### PR TITLE
mgr/cephadm: Cephadm support for NFS-Ganesha TLS configuration

### DIFF
--- a/doc/cephadm/services/nfs.rst
+++ b/doc/cephadm/services/nfs.rst
@@ -79,6 +79,85 @@ address is not present and ``monitoring_networks`` is specified, an IP address
 that matches one of the specified networks will be used. If neither condition
 is met, the default binding will happen on all available network interfaces.
 
+TLS/SSL Example
+---------------
+
+Here's an example NFS service specification with TLS/SSL configuration:
+
+.. code-block:: yaml
+
+    service_type: nfs
+    service_id: mynfs
+    placement:
+      hosts:
+      - ceph-node-0
+    spec:
+      port: 12345
+      ssl: true
+      certificate_source: inline|reference|cephadm-signed
+      ssl_cert: |
+        -----BEGIN CERTIFICATE-----
+        (PEM cert contents here)
+        -----END CERTIFICATE-----
+      ssl_key: |
+        -----BEGIN PRIVATE KEY-----
+        (PEM key contents here)
+        -----END PRIVATE KEY-----
+      ssl_ca_cert:
+        -----BEGIN PRIVATE KEY-----
+        (PEM key contents here)
+        -----END PRIVATE KEY-----
+      tls_ktls: true
+      tls_debug: true
+      tls_min_version: TLSv1.3
+      tls_ciphers: AES-256
+
+This example configures an NFS service with TLS encryption enabled using
+inline certificates.
+
+TLS/SSL Parameters
+~~~~~~~~~~~~~~~~~~
+
+The following parameters can be used to configure TLS/SSL encryption for the NFS service:
+
+* ``ssl`` (boolean): Enable or disable SSL/TLS encryption. Default is ``false``.
+
+* ``certificate_source`` (string): Specifies the source of the TLS certificates.
+  Options include:
+
+  - ``cephadm-signed``: Use certificates signed by cephadm's internal CA
+  - ``inline``: Provide certificates directly in the specification using ``ssl_cert``, ``ssl_key``, and ``ssl_ca_cert`` fields
+  - ``reference``: Users can register their own certificate and key with certmgr and
+    set the ``certificate_source`` to ``reference`` in the spec.
+
+* ``ssl_cert`` (string): The SSL certificate in PEM format. Required when using
+  ``inline`` certificate source.
+
+* ``ssl_key`` (string): The SSL private key in PEM format. Required when using
+  ``inline`` certificate source.
+
+* ``ssl_ca_cert`` (string): The SSL CA certificate in PEM format. Required when
+  using ``inline`` certificate source.
+
+* ``custom_sans`` (list): List of custom Subject Alternative Names (SANs) to
+  include in the certificate.
+
+* ``tls_ktls`` (boolean): Enable kernel TLS (kTLS) for improved performance when
+  available. Default is ``false``.
+
+* ``tls_debug`` (boolean): Enable TLS debugging output. Useful for troubleshooting
+  TLS issues. Default is ``false``.
+
+* ``tls_min_version`` (string): Specify the minimum TLS version to accept.
+  Examples: TLSv1.3, TLSv1.2
+
+* ``tls_ciphers`` (string): Specify allowed cipher suites for TLS connections.
+  Example: :-CIPHER-ALL:+AES-256-GCM
+
+.. note:: When ``ssl`` is enabled, a ``certificate_source`` must be specified.
+   If using ``inline`` certificates, all three certificate fields (``ssl_cert``,
+   ``ssl_key``, ``ssl_ca_cert``) must be provided.
+
 The specification can then be applied by running the following command:
 
 .. prompt:: bash #

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -182,7 +182,7 @@ In order to modify cluster parameters (for example, the port or the placement),
 use the orchestrator interface to update the NFS service spec. The safest way
 to do that is to export the current spec, modify it, and then re-apply it. For
 example, to modify the ``nfs.foo`` service, run commands of the following
-forms: 
+forms:
 
 .. prompt:: bash #
 
@@ -318,7 +318,7 @@ value is ``no_root_squash``. See the `NFS-Ganesha Export Sample`_ for
 permissible values.
 
 ``<sectype>`` specifies which authentication methods will be used when
-connecting to the export. Valid values include "krb5p", "krb5i", "krb5", "sys",
+connecting to the export. Valid values include "krb5p", "krb5i", "krb5", "sys", "tls", "mtls"
 and "none". More than one value can be supplied. The flag may be specified
 multiple times (example: ``--sectype=krb5p --sectype=krb5i``) or multiple
 values may be separated by a comma (example: ``--sectype krb5p,krb5i``). The
@@ -350,7 +350,7 @@ There are two kinds of RGW exports:
 
 RGW bucket export
 ^^^^^^^^^^^^^^^^^
-  
+
 To export a *bucket*:
 
 .. prompt:: bash #

--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -177,10 +177,23 @@ class NFSGanesha(ContainerDaemonForm):
 
         # create the ganesha conf dir
         config_dir = os.path.join(data_dir, 'etc/ganesha')
+        tls_dir = os.path.join(data_dir, 'etc/ganesha/tls')
         makedirs(config_dir, uid, gid, 0o755)
+        makedirs(tls_dir, uid, gid, 0o755)
 
+        config_files = {
+            fname: content
+            for fname, content in self.files.items()
+            if fname in ['ganesha.conf', 'idmap.conf']
+        }
+        tls_files = {
+            fname: content
+            for fname, content in self.files.items()
+            if fname.startswith('tls')
+        }
         # populate files from the config-json
-        populate_files(config_dir, self.files, uid, gid)
+        populate_files(config_dir, config_files, uid, gid)
+        populate_files(tls_dir, tls_files, uid, gid)
 
         # write the RGW keyring
         if self.rgw:

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -24,7 +24,7 @@ from mgr_util import verify_tls_files
 import tempfile
 from cephadm.services.service_registry import service_registry
 from cephadm.services.cephadmservice import CephadmAgent
-from cephadm.tlsobject_types import CertKeyPair
+from cephadm.tlsobject_types import TLSCredentials
 
 from urllib.error import HTTPError, URLError
 from typing import Any, Dict, List, Set, TYPE_CHECKING, Optional, MutableMapping, IO
@@ -77,13 +77,13 @@ class AgentEndpoint:
         verify_tls_files(self.cert_file.name, self.key_file.name)
         server.ssl_certificate, server.ssl_private_key = self.cert_file.name, self.key_file.name
 
-    def _get_agent_certificates(self) -> CertKeyPair:
+    def _get_agent_certificates(self) -> TLSCredentials:
         host = self.mgr.get_hostname()
-        tls_pair = self.mgr.cert_mgr.get_self_signed_cert_key_pair(CephadmAgent.TYPE, host)
-        if not tls_pair:
-            tls_pair = self.mgr.cert_mgr.generate_cert(host, self.mgr.get_mgr_ip(), duration_in_days=CEPHADM_AGENT_CERT_DURATION)
-            self.mgr.cert_mgr.save_self_signed_cert_key_pair(CephadmAgent.TYPE, tls_pair, host=host)
-        return tls_pair
+        tls_creds = self.mgr.cert_mgr.get_self_signed_tls_credentials(CephadmAgent.TYPE, host)
+        if not tls_creds:
+            tls_creds = self.mgr.cert_mgr.generate_cert(host, self.mgr.get_mgr_ip(), duration_in_days=CEPHADM_AGENT_CERT_DURATION)
+            self.mgr.cert_mgr.save_self_signed_cert_key_pair(CephadmAgent.TYPE, tls_creds, host=host)
+        return tls_creds
 
     def find_free_port(self) -> None:
         max_port = self.server_port + 150

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -735,7 +735,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             if svc.allows_user_certificates:
                 if svc.SCOPE == TLSObjectScope.UNKNOWN:
                     OrchestratorError(f"Service {svc.TYPE} requieres certificates but it has not defined its svc.SCOPE field.")
-                self.cert_mgr.register_cert_key_pair(svc.TYPE, svc.cert_name, svc.key_name, svc.SCOPE)
+                self.cert_mgr.register_cert_key_pair(svc.TYPE, svc.cert_name, svc.key_name, svc.SCOPE, svc.ca_cert_name)
 
         self.cert_mgr.register_cert_key_pair('nvmeof', 'nvmeof_client_cert', 'nvmeof_client_key', TLSObjectScope.SERVICE)
         self.cert_mgr.register_cert('nvmeof', 'nvmeof_root_ca_cert', TLSObjectScope.SERVICE)
@@ -3282,8 +3282,8 @@ Then run the following:
         if module_name == 'dashboard':
             host_fqdns.append('dashboard_servers')
 
-        cert, key = self.cert_mgr.generate_cert(host_fqdns, self.get_mgr_ip())
-        return {'cert': cert, 'key': key}
+        tls_creds = self.cert_mgr.generate_cert(host_fqdns, self.get_mgr_ip())
+        return {'cert': tls_creds.cert, 'key': tls_creds.key}
 
     @handle_orch_error
     def set_prometheus_access_info(self, user: str, password: str) -> str:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1156,7 +1156,11 @@ class CephadmServe:
                     # the daemon is written, which we rewrite on redeploy, but not
                     # on reconfig.
                     action = 'redeploy'
-
+                elif dd.daemon_type == 'nfs':
+                    # check what has changed, based on that decide action
+                    only_kmip_updated = all(s.startswith('kmip') for s in list(sym_diff))
+                    if not only_kmip_updated:
+                        action = 'redeploy'
             elif spec is not None and hasattr(spec, 'extra_container_args') and dd.extra_container_args != spec.extra_container_args:
                 self.log.debug(
                     f'{dd.name()} container cli args {dd.extra_container_args} -> {spec.extra_container_args}')

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -10,6 +10,7 @@ from cephadm import utils
 from orchestrator import OrchestratorError, DaemonDescription
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
 from .service_registry import register_cephadm_service
+from cephadm.tlsobject_types import TLSCredentials
 
 if TYPE_CHECKING:
     from ..module import CephadmOrchestrator
@@ -270,8 +271,8 @@ class IngressService(CephService):
             config_files['files']['haproxy.pem'] = combined_pem
 
         if spec.monitor_ssl and spec.monitor_cert_source != MonitorCertSource.REUSE_SERVICE_CERT.value:
-            stats_cert, stats_key = self.get_stats_certs(spec, daemon_spec, monitor_ips)
-            monitor_ssl_cert = [stats_cert, stats_key]
+            tls_creds = self.get_stats_certs(spec, daemon_spec, monitor_ips)
+            monitor_ssl_cert = [tls_creds.cert, tls_creds.key]
             config_files['files']['stats_haproxy.pem'] = '\n'.join(monitor_ssl_cert)
 
         return config_files, self.get_haproxy_dependencies(self.mgr, spec)
@@ -281,7 +282,7 @@ class IngressService(CephService):
         svc_spec: IngressSpec,
         daemon_spec: CephadmDaemonDeploySpec,
         ips: Optional[List[str]] = None,
-    ) -> Tuple[str, str]:
+    ) -> TLSCredentials:
         return self.get_certificates_generic(
             svc_spec=svc_spec,
             daemon_spec=daemon_spec,

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -120,14 +120,14 @@ class MgmtGatewayService(CephadmService):
             'enable_oauth2_proxy': bool(oauth2_proxy_endpoints),
         }
 
-        internal_cert, internal_pkey = self.get_self_signed_certificates_with_label(svc_spec, daemon_spec, INTERNAL_CERT_LABEL)
+        tls_creds = self.get_self_signed_certificates_with_label(svc_spec, daemon_spec, INTERNAL_CERT_LABEL)
         daemon_config = {
             "files": {
                 "nginx.conf": self.mgr.template.render(self.SVC_TEMPLATE_PATH, main_context),
                 "nginx_external_server.conf": self.mgr.template.render(self.EXTERNAL_SVC_TEMPLATE_PATH, server_context),
                 "nginx_internal_server.conf": self.mgr.template.render(self.INTERNAL_SVC_TEMPLATE_PATH, server_context),
-                "nginx_internal.crt": internal_cert,
-                "nginx_internal.key": internal_pkey,
+                "nginx_internal.crt": tls_creds.cert,
+                "nginx_internal.key": tls_creds.key,
                 "ca.crt": self.mgr.cert_mgr.get_root_ca()
             }
         }

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -9,7 +9,7 @@ import requests
 from mgr_module import HandleCommandResult
 from .service_registry import register_cephadm_service
 from cephadm.services.service_registry import service_registry
-from cephadm.tlsobject_types import CertKeyPair
+from cephadm.tlsobject_types import TLSCredentials
 
 from orchestrator import DaemonDescription
 from ceph.deployment.service_spec import AlertManagerSpec, GrafanaSpec, ServiceSpec, \
@@ -144,7 +144,7 @@ class GrafanaService(CephadmService):
 
         return ''
 
-    def get_grafana_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> CertKeyPair:
+    def get_grafana_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> TLSCredentials:
         host_ips = [self.mgr.inventory.get_addr(daemon_spec.host)]
         host_fqdns = [self.mgr.get_fqdn(daemon_spec.host), 'grafana_servers']
         return self.get_certificates(daemon_spec, host_ips, host_fqdns)
@@ -286,7 +286,7 @@ class AlertmanagerService(CephadmService):
     def needs_monitoring(self) -> bool:
         return True
 
-    def get_alertmanager_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> CertKeyPair:
+    def get_alertmanager_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> TLSCredentials:
         host_ips = [self.mgr.inventory.get_addr(daemon_spec.host)]
         host_fqdns = [self.mgr.get_fqdn(daemon_spec.host), 'alertmanager_servers']
         return self.get_certificates(daemon_spec, host_ips, host_fqdns)
@@ -492,7 +492,7 @@ class PrometheusService(CephadmService):
             # we shouldn't get here (mon will tell the mgr to respawn), but no
             # harm done if we do.
 
-    def get_prometheus_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> CertKeyPair:
+    def get_prometheus_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> TLSCredentials:
         host_ips = [self.mgr.inventory.get_addr(daemon_spec.host)]
         host_fqdns = [self.mgr.get_fqdn(daemon_spec.host), 'prometheus_servers']
         return self.get_certificates(daemon_spec, host_ips, host_fqdns)

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -46,4 +46,25 @@ RGW {
         name = "client.{{ rgw_user }}";
 }
 
+{% if tls_add %}
+TLS_CONFIG{
+        Enable_TLS = {{ tls_add }};
+        TLS_Cert_File = /etc/ganesha/tls/tls_cert.pem;
+        TLS_Key_File = /etc/ganesha/tls/tls_key.pem;
+        TLS_CA_File = /etc/ganesha/tls/tls_ca_cert.pem;
+	{% if tls_ciphers %}
+        TLS_Ciphers = "{{ tls_ciphers }}";
+	{% endif %}
+	{% if tls_min_version %}
+        TLS_Min_Version = "{{ tls_min_version }}";
+	{% endif %}
+	{% if tls_ktls %}
+        Enable_KTLS = {{ tls_ktls }};
+	{% endif %}
+	{% if tls_debug %}
+        Enable_debug = {{ tls_debug }};
+	{% endif %}
+}
+
+{% endif %}
 %url    {{ url }}

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -5,7 +5,7 @@ import json
 from tests import mock
 import logging
 
-from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectException, TLSObjectProtocol, CertKeyPair
+from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectException, TLSObjectProtocol, TLSCredentials
 from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSObjectScope
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
@@ -493,7 +493,7 @@ class TestCertMgr(object):
         # Save (simulate cephadm-generated) cert/key at host target
         cm.save_self_signed_cert_key_pair(
             svc,
-            CertKeyPair(CEPHADM_SELF_GENERATED_CERT_1, CEPHADM_SELF_GENERATED_KEY_2048),
+            TLSCredentials(CEPHADM_SELF_GENERATED_CERT_1, CEPHADM_SELF_GENERATED_KEY_2048),
             host=host,
             label=cert_label,
         )

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -305,12 +305,16 @@ class TestCertMgr(object):
         nvmeof_root_ca_cert = 'fake-nvmeof-root-ca-cert'
         grafana_cert_host_1 = 'grafana-cert-host-1'
         grafana_cert_host_2 = 'grafana-cert-host-2'
+        nfs_ssl_cert = 'nfs-ssl-cert'
+        nfs_ssl_ca_cert = 'nfs-ssl-ca-cert'
         cephadm_module.cert_mgr.save_cert('rgw_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
         cephadm_module.cert_mgr.save_cert('nvmeof_ssl_cert', nvmeof_ssl_cert, service_name='nvmeof.self-signed.foo', user_made=False)
         cephadm_module.cert_mgr.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
         cephadm_module.cert_mgr.save_cert('nvmeof_root_ca_cert', nvmeof_root_ca_cert, service_name='nvmeof.foo', user_made=True)
         cephadm_module.cert_mgr.save_cert('grafana_ssl_cert', grafana_cert_host_1, host='host-1', user_made=True)
         cephadm_module.cert_mgr.save_cert('grafana_ssl_cert', grafana_cert_host_2, host='host-2', user_made=True)
+        cephadm_module.cert_mgr.save_cert('nfs_ssl_cert', nfs_ssl_cert, service_name='nfs.foo', user_made=True)
+        cephadm_module.cert_mgr.save_cert('nfs_ssl_ca_cert', nfs_ssl_ca_cert, service_name='nfs.foo', user_made=True)
 
         expected_calls = [
             mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}rgw_ssl_cert', json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})),
@@ -319,7 +323,9 @@ class TestCertMgr(object):
             mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}nvmeof_root_ca_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_root_ca_cert, True).to_json()})),
             mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}grafana_ssl_cert', json.dumps({'host-1': Cert(grafana_cert_host_1, True).to_json()})),
             mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}grafana_ssl_cert', json.dumps({'host-1': Cert(grafana_cert_host_1, True).to_json(),
-                                                                                    'host-2': Cert(grafana_cert_host_2, True).to_json()}))
+                                                                                    'host-2': Cert(grafana_cert_host_2, True).to_json()})),
+            mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}nfs_ssl_cert', json.dumps({'nfs.foo': Cert(nfs_ssl_cert, True).to_json()})),
+            mock.call(f'{TLSOBJECT_STORE_CERT_PREFIX}nfs_ssl_ca_cert', json.dumps({'nfs.foo': Cert(nfs_ssl_ca_cert, True).to_json()})),
         ]
         _set_store.assert_has_calls(expected_calls)
 
@@ -420,6 +426,24 @@ class TestCertMgr(object):
             "certificates": {
                 "rgw.foo": get_generated_cephadm_cert_info_1(),
                 "rgw.bar": get_generated_cephadm_cert_info_2(),
+            },
+        }
+        compare_certls_dicts(expected_ls)
+
+        cephadm_module.cert_mgr.save_cert('nfs_ssl_cert', CEPHADM_SELF_GENERATED_CERT_1, service_name='nfs.foo', user_made=True)
+        expected_ls["nfs_ssl_cert"] = {
+            "scope": "service",
+            "certificates": {
+                "nfs.foo": get_generated_cephadm_cert_info_1(),
+            },
+        }
+        compare_certls_dicts(expected_ls)
+
+        cephadm_module.cert_mgr.save_cert('nfs_ssl_ca_cert', CEPHADM_SELF_GENERATED_CERT_2, service_name='nfs.foo', user_made=True)
+        expected_ls["nfs_ssl_ca_cert"] = {
+            "scope": "service",
+            "certificates": {
+                "nfs.foo": get_generated_cephadm_cert_info_2(),
             },
         }
         compare_certls_dicts(expected_ls)
@@ -586,6 +610,8 @@ class TestCertMgr(object):
             'grafana_ssl_cert': ('host1', 'grafana-cert', TLSObjectScope.HOST),
             'oauth2_proxy_ssl_cert': ('host1', 'oauth2-proxy', TLSObjectScope.HOST),
             'mgmt_gateway_ssl_cert': ('mgmt-gateway', 'mgmt-gw-cert', TLSObjectScope.GLOBAL),
+            'nfs_ssl_cert': ('nfs.foo', 'nfs-ssl-cert', TLSObjectScope.SERVICE),
+            'nfs_ssl_ca_cert': ('nfs.foo', 'nfs-ssl-ca-cert', TLSObjectScope.SERVICE),
         }
         unknown_certs = {
             'unknown_per_service_cert': ('unknown-svc.foo', 'unknown-cert', TLSObjectScope.SERVICE),
@@ -602,6 +628,7 @@ class TestCertMgr(object):
             'oauth2_proxy_ssl_key': ('host1', 'oauth2-proxy', TLSObjectScope.HOST),
             'ingress_ssl_key': ('ingress', 'ingress-ssl-key', TLSObjectScope.SERVICE),
             'iscsi_ssl_key': ('iscsi', 'iscsi-ssl-key', TLSObjectScope.SERVICE),
+            'nfs_ssl_key': ('nfs.foo', 'nfs-ssl-key', TLSObjectScope.SERVICE),
         }
         unknown_keys = {
             'unknown_per_service_key': ('unknown-svc.foo', 'unknown-key', TLSObjectScope.SERVICE),
@@ -674,9 +701,12 @@ class TestCertMgr(object):
         good_certs = {
             'rgw_ssl_cert': ('rgw.foo', 'good-cert', TLSObjectScope.SERVICE),
             'mgmt_gateway_ssl_cert': ('mgmt-gateway', 'good-global-cert', TLSObjectScope.GLOBAL),
+            'nfs_ssl_cert': ('nfs.foo', 'nfs-ssl-cert', TLSObjectScope.SERVICE),
+            'nfs_ssl_ca_cert': ('nfs.foo', 'nfs-ssl-ca-cert', TLSObjectScope.SERVICE),
         }
         good_keys = {
             'rgw_ssl_key': ('rgw.foo', 'good-key', TLSObjectScope.SERVICE),
+            'nfs_ssl_key': ('nfs.foo', 'nfs-ssl-key', TLSObjectScope.SERVICE),
         }
 
         # Helpers to dump valid JSON structures
@@ -723,10 +753,16 @@ class TestCertMgr(object):
         # Good entries loaded correctly
         assert 'rgw_ssl_cert' in cert_store
         assert cert_store['rgw_ssl_cert']['rgw.foo'] == Cert('good-cert', True)
+        assert 'nfs_ssl_cert' in cert_store
+        assert cert_store['nfs_ssl_cert']['nfs.foo'] == Cert('nfs-ssl-cert', True)
+        assert 'nfs_ssl_ca_cert' in cert_store
+        assert cert_store['nfs_ssl_ca_cert']['nfs.foo'] == Cert('nfs-ssl-ca-cert', True)
         assert 'mgmt_gateway_ssl_cert' in cert_store
         assert cert_store['mgmt_gateway_ssl_cert'] == Cert('good-global-cert', True)
         assert 'rgw_ssl_key' in key_store
         assert key_store['rgw_ssl_key']['rgw.foo'] == PrivKey('good-key')
+        assert 'nfs_ssl_key' in key_store
+        assert key_store['nfs_ssl_key']['nfs.foo'] == PrivKey('nfs-ssl-key')
 
         # Bad ones: object names exist (pre-registered), but **no targets** were added
         # Service / Host scoped => dict should be empty

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -36,7 +36,7 @@ from ceph.deployment.service_spec import (
     OAuth2ProxySpec
 )
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm, async_side_effect, wait
-from cephadm.tlsobject_types import CertKeyPair
+from cephadm.tlsobject_types import TLSCredentials
 
 from ceph.utils import datetime_now
 
@@ -171,7 +171,7 @@ class TestISCSIService:
     mgr.spec_store.all_specs.get.return_value = iscsi_spec
 
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     def test_iscsi_client_caps(self):
 
         iscsi_daemon_spec = CephadmDaemonDeploySpec(
@@ -199,7 +199,7 @@ class TestISCSIService:
 
     @patch('cephadm.utils.resolve_ip')
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     def test_iscsi_dashboard_config(self, mock_resolve_ip):
 
         self.mgr.check_mon_command = MagicMock()
@@ -322,7 +322,7 @@ log_to_file = False"""
     @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
     @patch("cephadm.services.iscsi.get_trusted_ips")
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     def test_iscsi_config_with_security_enabled(self, _get_trusted_ips, _get_name, _run_cephadm, cephadm_module: CephadmOrchestrator):
 
         iscsi_daemon_id = 'testpool.test.qwert'
@@ -779,7 +779,7 @@ class TestMonitoring:
     @patch("cephadm.services.monitoring.password_hash", lambda password: 'alertmanager_password_hash')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair('mycert', 'mykey'))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
     def test_alertmanager_config_when_mgmt_gw_enabled(self, _get_fqdn, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 
@@ -890,7 +890,7 @@ class TestMonitoring:
     @patch("cephadm.services.monitoring.password_hash", lambda password: 'alertmanager_password_hash')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair('mycert', 'mykey'))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
     def test_alertmanager_config_security_enabled(self, _get_fqdn, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 
@@ -1101,7 +1101,7 @@ class TestMonitoring:
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair('mycert', 'mykey'))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
     @patch('cephadm.services.cephadmservice.CephExporterService.get_keyring_with_caps', Mock(return_value='[client.ceph-exporter.test]\nkey = fake-secret\n'))
     def test_ceph_exporter_config_security_enabled(self, _get_fqdn, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
@@ -1188,7 +1188,7 @@ class TestMonitoring:
                 )
 
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("socket.getfqdn")
@@ -1403,7 +1403,7 @@ class TestMonitoring:
     @patch("cephadm.services.monitoring.password_hash", lambda password: 'prometheus_password_hash')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair('mycert', 'mykey'))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
     def test_prometheus_config_security_enabled(self, _run_cephadm, _get_uname, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         _get_uname.return_value = 'test'
@@ -1803,7 +1803,7 @@ class TestMonitoring:
     @patch("cephadm.module.CephadmOrchestrator.get_fqdn", lambda a, b: 'host_fqdn')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     def test_grafana_config_with_mgmt_gw_and_ouath2_proxy(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
 
@@ -1965,7 +1965,7 @@ class TestMonitoring:
     @patch("cephadm.module.CephadmOrchestrator.get_fqdn", lambda a, b: 'host_fqdn')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     def test_grafana_config_with_mgmt_gw(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
 
@@ -2024,7 +2024,7 @@ class TestMonitoring:
                 cephadm_module, GrafanaSpec("grafana")
             ) as _:
                 cephadm_module.cert_mgr.save_self_signed_cert_key_pair('grafana',
-                                                                       CertKeyPair(ceph_generated_cert, ceph_generated_key),
+                                                                       TLSCredentials(ceph_generated_cert, ceph_generated_key),
                                                                        host='test')
                 files = {
                     'grafana.ini': dedent("""
@@ -2107,7 +2107,7 @@ class TestMonitoring:
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1::4')
     @patch("cephadm.module.CephadmOrchestrator.get_fqdn", lambda a, b: 'host_fqdn')
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     def test_grafana_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
 
@@ -2118,7 +2118,7 @@ class TestMonitoring:
                 cephadm_module, GrafanaSpec("grafana")
             ) as _:
                 cephadm_module.cert_mgr.save_self_signed_cert_key_pair('grafana',
-                                                                       CertKeyPair(ceph_generated_cert, ceph_generated_key),
+                                                                       TLSCredentials(ceph_generated_cert, ceph_generated_key),
                                                                        host='test')
                 files = {
                     'grafana.ini': dedent("""
@@ -4489,7 +4489,7 @@ class TestJaeger:
 class TestAgent:
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None, fqdns=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_deploy_cephadm_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
@@ -4823,9 +4823,9 @@ class TestMgmtGateway:
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_discovery_endpoints")
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
-           lambda instance, svc_spec, dspec, label: (ceph_generated_cert, ceph_generated_key))
+           lambda instance, svc_spec, dspec, label: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
@@ -5069,9 +5069,9 @@ class TestMgmtGateway:
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_discovery_endpoints")
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
-           lambda instance, svc_spec, dspec, label: (ceph_generated_cert, ceph_generated_key))
+           lambda instance, svc_spec, dspec, label: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
@@ -5412,9 +5412,9 @@ class TestMgmtGateway:
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
-           lambda instance, svc_spec, dspec, label: (ceph_generated_cert, ceph_generated_key))
+           lambda instance, svc_spec, dspec, label: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
@@ -5424,11 +5424,11 @@ class TestMgmtGateway:
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.services.oauth2_proxy.OAuth2ProxyService.get_certificates",
-           lambda instance, dspec, ips=None: CertKeyPair(ceph_generated_cert, ceph_generated_key))
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
-           lambda instance, svc_spec, dspec, label: (ceph_generated_cert, ceph_generated_key))
+           lambda instance, svc_spec, dspec, label: TLSCredentials(ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))

--- a/src/pybind/mgr/cephadm/tlsobject_types.py
+++ b/src/pybind/mgr/cephadm/tlsobject_types.py
@@ -33,9 +33,10 @@ class TLSObjectScope(str, Enum):
         return self.value
 
 
-class CertKeyPair(NamedTuple):
+class TLSCredentials(NamedTuple):
     cert: str
     key: str
+    ca_cert: Optional[str] = None
 
     def __bool__(self) -> bool:
         # Treat the pair as truthy only if both cert and key are non-empty
@@ -47,7 +48,7 @@ class TLSObjectTarget(NamedTuple):
     host: Optional[str]
 
 
-EMPTY_TLS_KEYPAIR = CertKeyPair('', '')
+EMPTY_TLS_CREDENTIALS = TLSCredentials('', '', '')
 
 
 class TLSObjectProtocol(Protocol):

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -65,6 +65,14 @@ class NFSCluster:
             virtual_ip: Optional[str] = None,
             ingress_mode: Optional[IngressType] = None,
             port: Optional[int] = None,
+            ssl: bool = False,
+            ssl_cert: Optional[str] = None,
+            ssl_key: Optional[str] = None,
+            ssl_ca_cert: Optional[str] = None,
+            tls_ktls: bool = False,
+            tls_debug: bool = False,
+            tls_min_version: Optional[str] = None,
+            tls_ciphers: Optional[str] = None,
     ) -> None:
         if not port:
             port = 2049   # default nfs port
@@ -98,7 +106,15 @@ class NFSCluster:
                                   # use non-default port so we don't conflict with ingress
                                   port=ganesha_port,
                                   virtual_ip=virtual_ip_for_ganesha,
-                                  enable_haproxy_protocol=enable_haproxy_protocol)
+                                  enable_haproxy_protocol=enable_haproxy_protocol,
+                                  ssl=ssl,
+                                  ssl_cert=ssl_cert,
+                                  ssl_key=ssl_key,
+                                  ssl_ca_cert=ssl_ca_cert,
+                                  tls_ktls=tls_ktls,
+                                  tls_debug=tls_debug,
+                                  tls_min_version=tls_min_version,
+                                  tls_ciphers=tls_ciphers)
             completion = self.mgr.apply_nfs(spec)
             orchestrator.raise_if_exception(completion)
             ispec = IngressSpec(service_type='ingress',
@@ -116,7 +132,15 @@ class NFSCluster:
             # standalone nfs
             spec = NFSServiceSpec(service_type='nfs', service_id=cluster_id,
                                   placement=PlacementSpec.from_string(placement),
-                                  port=port)
+                                  port=port,
+                                  ssl=ssl,
+                                  ssl_cert=ssl_cert,
+                                  ssl_key=ssl_key,
+                                  ssl_ca_cert=ssl_ca_cert,
+                                  tls_ktls=tls_ktls,
+                                  tls_debug=tls_debug,
+                                  tls_min_version=tls_min_version,
+                                  tls_ciphers=tls_ciphers)
             completion = self.mgr.apply_nfs(spec)
             orchestrator.raise_if_exception(completion)
         log.debug("Successfully deployed nfs daemons with cluster id %s and placement %s",
@@ -140,6 +164,14 @@ class NFSCluster:
             ingress: Optional[bool] = None,
             ingress_mode: Optional[IngressType] = None,
             port: Optional[int] = None,
+            ssl: bool = False,
+            ssl_cert: Optional[str] = None,
+            ssl_key: Optional[str] = None,
+            ssl_ca_cert: Optional[str] = None,
+            tls_ktls: bool = False,
+            tls_debug: bool = False,
+            tls_min_version: Optional[str] = None,
+            tls_ciphers: Optional[str] = None,
     ) -> None:
         try:
             if virtual_ip:
@@ -163,7 +195,9 @@ class NFSCluster:
             self.create_empty_rados_obj(cluster_id)
 
             if cluster_id not in available_clusters(self.mgr):
-                self._call_orch_apply_nfs(cluster_id, placement, virtual_ip, ingress_mode, port)
+                self._call_orch_apply_nfs(cluster_id, placement, virtual_ip, ingress_mode, port,
+                                          ssl, ssl_cert, ssl_key, ssl_ca_cert, tls_ktls, tls_debug,
+                                          tls_min_version, tls_ciphers)
                 return
             raise NonFatalError(f"{cluster_id} cluster already exists")
         except Exception as e:

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -47,7 +47,7 @@ def _validate_access_type(access_type: str) -> None:
 
 
 def _validate_sec_type(sec_type: str) -> None:
-    valid_sec_types = ["none", "sys", "krb5", "krb5i", "krb5p"]
+    valid_sec_types = ["none", "sys", "krb5", "krb5i", "krb5p", "tls", "mtls"]
     if not isinstance(sec_type, str) or sec_type not in valid_sec_types:
         raise NFSInvalidOperation(
             f"SecType {sec_type} invalid, valid types are {valid_sec_types}")

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 from typing import Tuple, Optional, List, Dict, Any
+import yaml
 
 from mgr_module import MgrModule, CLICommand, Option, CLICheckNonemptyFileInput
 import object_format
@@ -130,11 +131,33 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                 ingress: Optional[bool] = None,
                                 virtual_ip: Optional[str] = None,
                                 ingress_mode: Optional[IngressType] = None,
-                                port: Optional[int] = None) -> None:
+                                port: Optional[int] = None,
+                                inbuf: Optional[str] = None) -> None:
         """Create an NFS Cluster"""
+        ssl_cert = ssl_key = ssl_ca_cert = tls_min_version = tls_ciphers = None
+        ssl = tls_ktls = tls_debug = False
+        if inbuf:
+            config = yaml.safe_load(inbuf)
+            ssl = config.get('ssl')
+            ssl_cert = config.get('ssl_cert')
+            ssl_key = config.get('ssl_key')
+            ssl_ca_cert = config.get('ssl_ca_cert')
+            tls_min_version = config.get('tls_min_version')
+            tls_ktls = config.get('tls_ktls')
+            tls_debug = config.get('tls_debug')
+            tls_ciphers = config.get('tls_ciphers')
+
         return self.nfs.create_nfs_cluster(cluster_id=cluster_id, placement=placement,
                                            virtual_ip=virtual_ip, ingress=ingress,
-                                           ingress_mode=ingress_mode, port=port)
+                                           ingress_mode=ingress_mode, port=port,
+                                           ssl=ssl,
+                                           ssl_cert=ssl_cert,
+                                           ssl_key=ssl_key,
+                                           ssl_ca_cert=ssl_ca_cert,
+                                           tls_ktls=tls_ktls,
+                                           tls_debug=tls_debug,
+                                           tls_min_version=tls_min_version,
+                                           tls_ciphers=tls_ciphers)
 
     @CLICommand('nfs cluster rm', perm='rw')
     @object_format.EmptyResponder()

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -803,7 +803,7 @@ NFS_CORE_PARAM {
                 'access_type': None,
                 'squash': None
             }],
-            'sectype': ["krb5p", "krb5i", "sys"],
+            'sectype': ["krb5p", "krb5i", "sys", "mtls", "tls"],
             'fsal': {
                 'name': 'RGW',
                 'user_id': 'nfs.foo.bucket',
@@ -817,7 +817,7 @@ NFS_CORE_PARAM {
         info = conf._get_export_dict(self.cluster_id, "/rgw/bucket")
         assert info["export_id"] == 2
         assert info["path"] == "bucket"
-        assert info["sectype"] == ["krb5p", "krb5i", "sys"]
+        assert info["sectype"] == ["krb5p", "krb5i", "sys", "mtls", "tls"]
 
     def test_update_export_with_ganesha_conf(self):
         self._do_mock_test(self._do_test_update_export_with_ganesha_conf)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/73035
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

This PR adds TLS (Transport Layer Security) support for NFS-Ganesha services in Cephadm, enabling secure connections with client certificate authentication. 

Changes of PR:
1. Updates get_certificates method to support CA certs
2. Adds TLS certificate support (server cert, key, CA cert) to NFSServiceSpec
3. Updates NFS service deployment to handle TLS configuration and file placement
4. Extends security types to include "tls" and "mtls" for NFS exports

Testing logs:
```

Ganesha.conf: 

TLS_CONFIG{
        Enable_TLS = True;
        TLS_Cert_File = /etc/ganesha/tls/tls_cert.pem;
        TLS_Key_File = /etc/ganesha/tls/tls_key.pem;
        TLS_CA_File = /etc/ganesha/tls/tls_ca_cert.pem;
        TLS_Ciphers = "AES-256";
        TLS_Min_Version = "TLSv1.3";
        Enable_KTLS = True;
        Enable_debug = True;
}

Export:

  "path": "/",
  "protocols": [
    3,
    4
  ],
  "pseudo": "/export1",
  "sectype": [
    "mtls"
  ],
  "security_label": true,
  "squash": "none",

```

1. certificate_source - cephadm-signed 
```
[ceph: root@ceph-node-0 /]# cat nfs2.yml 
service_type: nfs
service_id: mynfs
placement:
  hosts:
  - ceph-node-0
spec:
  port: 12345
  certificate_source: cephadm-signed
  ssl: true
  tls_ktls: true
  tls_debug: true
  tls_min_version: 3.1
  tls_ciphers: AES-256

[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# ceph orch certmgr cert ls --include-cephadm-signed --filter-by "name=*nfs*"
cephadm-signed_nfs.mynfs_cert
  scope: host
  certificates
    ceph-node-0
      subject
        commonName: 192.168.100.100
      validity
        remaining_days: 1094
[ceph: root@ceph-node-0 /]# 

```
2. certificate_source - inline
```
service_type: nfs
service_id: mynfs
placement:
  hosts:
  - ceph-node-0
spec:
  port: 12345
  certificate_source: inline
  ssl: true
  ssl_cert: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
  ssl_key: |
    -----BEGIN CERTIFICATE-----
   ...
    -----END CERTIFICATE-----
  ssl_ca_cert: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
  tls_ktls: true
  tls_debug: true
  tls_min_version: TLSv1.3
  tls_ciphers: AES-256

[root@ceph-node-0 ~]# ls -ltrh /var/lib/ceph/e3fd9a86-9ac0-11f0-a312-525400b8dd0c/nfs.mynfs.0.0.ceph-node-0.zuvfls/etc/ganesha/tls/
total 12K
-rw-------. 1 167 167 1.4K Sep 26 10:27 tls_cert.pem
-rw-------. 1 167 167 1.4K Sep 26 10:27 tls_key.pem
-rw-------. 1 167 167 1.4K Sep 26 10:27 tls_ca_cert.pem
[root@ceph-node-0 ~]# 
```
3. certificate_source - reference
```
[ceph: root@ceph-node-0 /]# ceph orch certmgr bindings ls
service:
  rgw:
    certs:
    - rgw_ssl_cert
    keys:
    - rgw_ssl_key
  nfs:
    certs:
    - nfs_ssl_cert
    - nfs_ssl_ca_cert
    keys:
    - nfs_ssl_key

[ceph: root@ceph-node-0 /]# ceph orch certmgr cert set nfs_ssl_cert --service_name nfs.mynfs -i cert.pem 
Certificate for nfs_ssl_cert set correctly
[ceph: root@ceph-node-0 /]# ceph orch certmgr cert set nfs_ssl_ca_cert --service_name nfs.mynfs -i ca_cert.pem 
Certificate for nfs_ssl_ca_cert set correctly
[ceph: root@ceph-node-0 /]# ceph orch certmgr key set nfs_ssl_key --service_name nfs.mynfs -i key.pem 
Key for nfs_ssl_key set correctly
[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# cat nfs3.yml 
service_type: nfs
service_id: mynfs
placement:
  hosts:
  - ceph-node-0
spec:
  port: 12345
  certificate_source: reference
  ssl: true
  tls_ktls: true
  tls_debug: true
  tls_min_version: 3.1
  tls_ciphers: AES-256
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs3.yml 
Scheduled nfs.mynfs update...
[ceph: root@ceph-node-0 /]# 
[root@ceph-node-0 ~]# ls -ltrh /var/lib/ceph/e3fd9a86-9ac0-11f0-a312-525400b8dd0c/nfs.mynfs.0.0.ceph-node-0.mjoxkt/etc/ganesha/tls/
total 12K
-rw-------. 1 167 167 1.8K Sep 26 10:34 tls_cert.pem
-rw-------. 1 167 167 3.2K Sep 26 10:34 tls_key.pem
-rw-------. 1 167 167 1.9K Sep 26 10:34 tls_ca_cert.pem
[root@ceph-node-0 ~]# 

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
