### PR TITLE
tentacle: test/libcephfs: validate asynchronous write and fsync executing concurrently

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2287,6 +2287,7 @@ void Client::unregister_request(MetaRequest *req)
 
 void Client::put_request(MetaRequest *request)
 {
+  ceph_assert(request->ref >= 1);
   if (request->_put()) {
     int op = -1;
     if (request->success)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12120,6 +12120,8 @@ void Client::C_nonblocking_fsync_state::advance()
       ldout(clnt->cct, 10) << "no metadata needs to commit" << dendl;
     }
 
+    ldout(clnt->cct, 10) << __func__ <<": in->unsafe_ops=" << in->unsafe_ops.size() << dendl;
+
     if (!syncdataonly && !in->unsafe_ops.empty()) {
       waitfor_safe = true;
       clnt->flush_mdlog_sync(in);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12274,12 +12274,16 @@ void Client::C_nonblocking_fsync_state_advancer::finish(int r)
   state->advance();
 }
 
-void Client::nonblocking_fsync(Inode *in, bool syncdataonly, Context *onfinish)
+int64_t Client::nonblocking_fsync(Inode *in, bool syncdataonly, Context *onfinish)
 {
   C_nonblocking_fsync_state *state = new C_nonblocking_fsync_state(this, in, syncdataonly, onfinish);
 
+  ldout(cct, 10) << __func__ << dendl;
+
+  std::unique_lock cl(client_lock);
   // Kick fsync off...
   state->advance();
+  return 0;
 }
 
 int Client::_fsync(Inode *in, bool syncdataonly)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -424,6 +424,9 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
   caps_release_delay = cct->_conf.get_val<std::chrono::seconds>(
     "client_caps_release_delay");
 
+  injected_write_delay_secs = std::chrono::duration<int>(
+    cct->_conf.get_val<std::chrono::seconds>("client_inject_write_delay_secs")).count();
+
   if (cct->_conf->client_acl_type == "posix_acl")
     acl_type = POSIX_ACL;
 
@@ -11938,6 +11941,13 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
 
     get_cap_ref(in, CEPH_CAP_FILE_BUFFER);
 
+    auto delay = get_injected_write_delay_secs();
+    if (unlikely(delay > 0)) {
+      ldout(cct, 20) << __func__ << ": delaying write for " << delay << " seconds" << dendl;
+      client_lock.unlock();
+      sleep(delay);
+      client_lock.lock();
+    }
     filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
 		       offset, size, bl, ceph::real_clock::now(), 0,
 		       in->truncate_size, in->truncate_seq,
@@ -17541,6 +17551,7 @@ std::vector<std::string> Client::get_tracked_keys() const noexcept
     "client_caps_release_delay",
     "client_deleg_break_on_open",
     "client_deleg_timeout",
+    "client_inject_write_delay_secs",
     "client_mount_timeout",
     "client_oc_max_dirty",
     "client_oc_max_dirty_age",
@@ -17601,6 +17612,10 @@ void Client::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("client_mount_timeout")) {
     mount_timeout = cct->_conf.get_val<std::chrono::seconds>(
       "client_mount_timeout");
+  }
+  if (changed.count("client_inject_write_delay_secs")) {
+    injected_write_delay_secs = std::chrono::duration<int>(
+      cct->_conf.get_val<std::chrono::seconds>("client_inject_write_delay_secs")).count();
   }
 }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -680,6 +680,7 @@ public:
                             Context *onfinish = nullptr,
                             bufferlist *blp = nullptr,
                             bool do_fsync = false, bool syncdataonly = false);
+  int64_t nonblocking_fsync(Inode *in, bool syncdataonly, Context *onfinish);
   loff_t ll_lseek(Fh *fh, loff_t offset, int whence);
   int ll_flush(Fh *fh);
   int ll_fsync(Fh *fh, bool syncdataonly);
@@ -1770,7 +1771,7 @@ private:
                       int64_t offset, bool write, Context *onfinish = nullptr,
                       bufferlist *blp = nullptr);
   int _flush(Fh *fh);
-  void nonblocking_fsync(Inode *in, bool syncdataonly, Context *onfinish);
+
   int _fsync(Fh *fh, bool syncdataonly);
   int _fsync(Inode *in, bool syncdataonly);
   int _sync_fs();

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1345,6 +1345,10 @@ protected:
   struct mount_state_t mount_state;
   struct initialize_state_t initialize_state;
 
+  int get_injected_write_delay_secs() const {
+    return injected_write_delay_secs;
+  }
+
 private:
   class C_Read_Finisher : public Context {
   public:
@@ -1957,6 +1961,7 @@ private:
 
   ceph::coarse_mono_time last_auto_reconnect;
   std::chrono::seconds caps_release_delay, mount_timeout;
+  int injected_write_delay_secs;
   // trace generation
   std::ofstream traceout;
 

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -598,3 +598,12 @@ options:
   services:
   - mds_client
   min: 1
+- name: client_inject_write_delay_secs
+  type: secs
+  level: dev
+  desc: induce delay in write operation for testing
+  long_desc: Inject a delay in write operation after grabbing required cap references (Fb caps in this case). This config is disabled by default (value of 0) and is to be used for the purpose of validating a race case bug with concurrent fsync.
+  default: 0
+  services:
+  - mds_client
+  min: 0

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -2025,6 +2025,8 @@ int64_t ceph_ll_writev(struct ceph_mount_info *cmount, struct Fh *fh,
 		       const struct iovec *iov, int iovcnt, int64_t off);
 int64_t ceph_ll_nonblocking_readv_writev(struct ceph_mount_info *cmount,
 					 struct ceph_ll_io_info *io_info);
+int64_t ceph_ll_nonblocking_fsync(struct ceph_mount_info *cmount,
+				  Inode *in, struct ceph_ll_io_info *io_info);
 int ceph_ll_close(struct ceph_mount_info *cmount, struct Fh* filehandle);
 int ceph_ll_iclose(struct ceph_mount_info *cmount, struct Inode *in, int mode);
 /**

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2195,6 +2195,15 @@ private:
   }
 };
 
+extern "C" int64_t ceph_ll_nonblocking_fsync(class ceph_mount_info *cmount,
+					     Inode *in, struct ceph_ll_io_info *io_info)
+{
+  LL_Onfinish *onfinish = new LL_Onfinish(io_info);
+
+  return (cmount->get_client()->nonblocking_fsync(
+	                in, io_info->syncdataonly, onfinish));
+}
+
 extern "C" int64_t ceph_ll_nonblocking_readv_writev(class ceph_mount_info *cmount,
 						    struct ceph_ll_io_info *io_info)
 {

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -4154,6 +4154,7 @@ TEST(LibCephFS, SubdirLookupAfterReaddir_ll) {
 }
 
 static bool write_done = false;
+static bool fsync_done = false;
 static bool read_done = false;
 static std::mutex mtx;
 static std::condition_variable cond;
@@ -4256,90 +4257,134 @@ TEST(LibCephFS, AsyncReadAndWriteMultiClient) {
   ceph_shutdown(r_cmount);
 }
 
-TEST(LibCephFS, UmountHangAfterLlLookupFilePath) {
-  struct ceph_statx stx;
+void write_fsync_io_callback(struct ceph_ll_io_info *io_info) {
+  std::unique_lock lock(mtx);
+  if (io_info->write) {
+    std::cout << "written=" << io_info->result << std::endl;
+    write_done = true;
+  } else {
+    std::cout << "fsync" << std::endl;
+    fsync_done = true;
+  }
+  cond.notify_one();
+}
+
+static void writer_func(struct ceph_mount_info *cmount, Fh *fh) {
+  int iterations = 2;
+  uint8_t buf[131072];
+  struct ceph_ll_io_info io_info;
+  struct iovec iov;
+
+  io_info.callback = write_fsync_io_callback;
+  io_info.iov = &iov;
+  io_info.iovcnt = 1;
+  io_info.off = 0;
+  io_info.fh = fh;
+  io_info.write = true;
+  io_info.fsync = false;
+
+  while (--iterations > 0) {
+    iov.iov_base = buf;
+    iov.iov_len = sizeof(buf);
+    io_info.result = 0;
+    write_done = false;
+    ASSERT_EQ(ceph_ll_nonblocking_readv_writev(cmount, &io_info), 0);
+    std::cout << ": waiting for write to finish" << std::endl;
+    {
+      std::unique_lock lock(mtx);
+      cond.wait(lock, []{
+        return write_done;
+      });
+    }
+    std::cout << ": write finished" << std::endl;
+    ASSERT_EQ(io_info.result, sizeof(buf));
+  }
+}
+
+static void fsync_func(struct ceph_mount_info *cmount, Inode *in) {
+  int iterations = 1000;
+  struct ceph_ll_io_info io_info;
+
+  io_info.callback = write_fsync_io_callback;
+
+  std::cout << ": fsync thread sleeping" << std::endl;
+  sleep(3);
+  std::cout << ": fsync thread wokeup" << std::endl;
+
+  while (--iterations > 0) {
+    io_info.result = 0;
+    fsync_done = false;
+    ASSERT_EQ(ceph_ll_nonblocking_fsync(cmount, in, &io_info), 0);
+    std::cout << ": waiting for fsync to finish" << std::endl;
+    {
+      std::unique_lock lock(mtx);
+      cond.wait(lock, []{
+        return fsync_done;
+      });
+    }
+    std::cout << ": fsync finished" << std::endl;
+  }
+}
+
+static void do_unsafe_ops(struct ceph_mount_info *cmount, std::string path) {
+  int iterations = 200;
+
+  std::cout << ": setxattr thread sleeping" << std::endl;
+  sleep(2);
+  std::cout << ": setxattr thread wokeup" << std::endl;
+
+  while (--iterations > 0) {
+    ASSERT_EQ(0, ceph_setxattr(cmount, path.c_str(), "user.key1", "value1", 6, 0));
+    sleep(1);
+  }
+}
+
+TEST(LibCephFS, ConcurrentWriteAndFsync) {
+  pid_t mypid = getpid();
   struct ceph_mount_info *cmount;
-  UserPerm *perms;
-  Inode *root, *file, *tmp;
-  Fh *fh;
+  UserPerm *perms = NULL;
+  Inode *parent, *inode = NULL;
+  struct ceph_statx stx = {0};
+  struct Fh *fh;
+  char filename[PATH_MAX];
 
-  int mypid = getpid();
-  char filename[NAME_MAX];
+  // for now use a single thread for performing write and fsync (each).
+  // in the future if we need to increase operation concurrency adjust
+  // @nthreads as required.
+  const int nthreads = 2;
+  std::thread unsafe_ops;
+  std::thread threads[nthreads];
 
-  sprintf(filename, "test_umounthangafterlookup%u", mypid);
+  sprintf(filename, "/contest_%d", mypid);
 
   ASSERT_EQ(ceph_create(&cmount, NULL), 0);
   ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
   ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(0, ceph_conf_set(cmount, "client_oc", "0"));
+  ASSERT_EQ(0, ceph_conf_set(cmount, "client_inject_write_delay_secs", "10"));
   ASSERT_EQ(0, ceph_mount(cmount, NULL));
 
-  perms = ceph_userperm_new(0, 0, 0, NULL);
+  perms = ceph_mount_perms(cmount);
+  ASSERT_EQ(ceph_ll_lookup_root(cmount, &parent), 0);
 
-  ASSERT_EQ(ceph_ll_lookup_root(cmount, &root), 0);
+  ASSERT_EQ(ceph_ll_create(cmount, parent, filename, 0744,
+                           O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW,
+                           &inode, &fh, &stx, CEPH_STATX_INO, 0, perms), 0);
 
-  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0777,
-                 O_CREAT | O_TRUNC | O_RDWR, &file, &fh, &stx,
-                 CEPH_STATX_INO, 0, perms), 0);
-  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  unsafe_ops = std::thread(do_unsafe_ops, cmount, std::string(filename));
 
-  ASSERT_EQ(ceph_ll_lookup(cmount, file, ".", &tmp, &stx, CEPH_STATX_INO,
-            0 , perms), -ENOTDIR);
+  for (int i = 0; i < nthreads/2; ++i) {
+    threads[i] = std::thread(writer_func, cmount, fh);
+  }
+  for (int i = 1; i < nthreads; ++i) {
+    threads[i] = std::thread(fsync_func, cmount, inode);
+  }
 
-  ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
+  for (int i = 0; i < nthreads; ++i) {
+    threads[i].join();
+  }
+  unsafe_ops.join();
 
-  ceph_ll_put(cmount, file);
-  ceph_ll_put(cmount, root);
-
-  std::cout << "Before ceph_unmount()" << std::endl;
   ASSERT_EQ(0, ceph_unmount(cmount));
-  std::cout << "After ceph_unmount()" << std::endl;
-
-  ceph_release(cmount);
-  ceph_userperm_destroy(perms);
-}
-
-TEST(LibCephFS, UnmountHangAfterOpenatFilePath) {
-  pid_t mypid = getpid();
-  struct ceph_mount_info *cmount;
-  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
-  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
-  ASSERT_EQ(ceph_conf_parse_env(cmount, NULL), 0);
-  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
-
-  char c_rel_dir[64];
-  char c_dir[128];
-  sprintf(c_rel_dir, "open_test_%d", mypid);
-  sprintf(c_dir, "/%s", c_rel_dir);
-  ASSERT_EQ(ceph_mkdir(cmount, c_dir, 0777), 0);
-
-  int root_fd = ceph_open(cmount, "/", O_DIRECTORY, 0777);
-  ASSERT_GT(root_fd, 0);
-
-  int dir_fd = ceph_openat(cmount, root_fd, c_rel_dir, O_DIRECTORY, 0777);
-  ASSERT_GT(dir_fd, 0);
-
-  struct ceph_statx stx;
-  ASSERT_EQ(ceph_statxat(cmount, root_fd, c_rel_dir, &stx, 0, 0), 0);
-
-  char c_rel_path[PATH_MAX];
-  char c_path[PATH_MAX];
-  sprintf(c_rel_path, "created_file_%d", mypid);
-  sprintf(c_path, "%s/%s", c_dir, c_rel_path);
-  int file_fd = ceph_openat(cmount, dir_fd, c_rel_path, O_RDONLY | O_CREAT, 0777);
-  ASSERT_GT(file_fd, 0);
-  int fd = ceph_openat(cmount, file_fd, ".", O_RDONLY, 0777);
-  ASSERT_EQ(fd, -ENOTDIR);
-
-  ASSERT_EQ(ceph_close(cmount, file_fd), 0);
-  ASSERT_EQ(ceph_close(cmount, dir_fd), 0);
-  ASSERT_EQ(ceph_close(cmount, root_fd), 0);
-
-  ASSERT_EQ(0, ceph_unlink(cmount, c_path));
-  ASSERT_EQ(0, ceph_rmdir(cmount, c_dir));
-
-  std::cout << "Before ceph_unmount()" << std::endl;
-  ASSERT_EQ(0, ceph_unmount(cmount));
-  std::cout << "After ceph_unmount()" << std::endl;
-
-  ASSERT_EQ(0, ceph_release(cmount));
+  ceph_shutdown(cmount);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72931

---

backport of https://github.com/ceph/ceph/pull/63636
parent tracker: https://tracker.ceph.com/issues/71515

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh