### PR TITLE
Add Linux Foundation Health Score badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ See https://ceph.com/ for current information about Ceph.
 
 ## Status
 
+[![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=cephfoundation)](https://insights.linuxfoundation.org/project/cephfoundation)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/2220/badge)](https://www.bestpractices.dev/projects/2220)
 [![Issue Backporting](https://github.com/ceph/ceph/actions/workflows/create-backport-trackers.yml/badge.svg)](https://github.com/ceph/ceph/actions/workflows/create-backport-trackers.yml)
 


### PR DESCRIPTION
Linux Foundation's health score easily lets users get insights into a project's health.

Ceph is rated with the highest level: Excellent
