### PR TITLE
tentacle: qa: suppress OpenSSL valgrind leaks

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -1139,3 +1139,94 @@
    fun:_ZdaPvm
    ...
 }
+{
+   OpenSSL leak still reachable
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   ...
+   obj:/usr/lib64/libcrypto*
+   ...
+   fun:*ceph*crypto*onwire*create_handler_pair*
+   ...
+   fun:*ProtocolV2*
+   ...
+}
+{
+   RocksDB ObjectLibrary leak still reachable
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:*rocksdb*ObjectLibrary*DefaultEv*
+   fun:*static_initialization_and_destruction*
+}
+{  
+   static_initialization_and_destruction leak variation
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:*static_initialization_and_destruction*
+   fun:_sub_I*
+   ...
+}
+{
+   rocksdb leak variation - ObjectLibrary PatternEntry
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:UnknownInlinedFun
+   ...
+   fun:*rocksdb*ObjectLibrary*PatternEntry*
+   ...
+   fun:*static_initialization_and_destruction*
+   fun:_sub_I*
+   ...
+}
+{
+   OpenSSL leak variation - realloc create_handler_pair
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   fun:*ceph*crypto*onwire*create_handler_pair*
+   ...
+   fun:*ProtocolV2*
+   ...
+}
+{
+   OpenSSL leak variation - CryptoKeyHandler
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   ...
+   fun:*CryptoKeyHandler*
+   ...
+   fun:*ProtocolV2*
+   ...
+}
+{
+   OpenSSL leak variation - realloc CryptoKeyHandler
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   ...
+   fun:*CryptoKeyHandler*
+   ...
+   fun:*ProtocolV2*
+   ...
+}
+{
+   OpenSSL leak variation - posix_memalign
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:posix_memalign
+   fun:CRYPTO_aligned_alloc
+   ...
+   fun:*ceph*crypto*onwire*create_handler_pair*
+   ...
+   fun:*ProtocolV2*
+   ...
+}
+


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73243

---

backport of https://github.com/ceph/ceph/pull/65634
parent tracker: https://tracker.ceph.com/issues/71182

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh