### PR TITLE
tentacle: monitoring: fix "In" OSDs in Cluster-Advanced grafana panel. Also change units from decbytes to bytes wherever used in the panel

### DIFF
--- a/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
@@ -136,7 +136,7 @@ local g = import 'grafonnet/grafana.libsonnet';
 
       $.addStatPanel(
         title='Cluster Capacity',
-        unit='decbytes',
+        unit='bytes',
         datasource='$datasource',
         gridPosition={ x: 6, y: 1, w: 3, h: 3 },
         graphMode='area',
@@ -233,7 +233,6 @@ local g = import 'grafonnet/grafana.libsonnet';
       )
       .addThresholds([
         { color: 'green', value: null },
-        { color: 'red', value: 80 },
       ])
       .addTargets([
         $.addTargetSchema(
@@ -259,7 +258,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           displayValueWithAlias='When Alias Displayed',
           units='none',
           valueHandler='Number Threshold',
-          expr='count(ceph_osd_in{%(matchers)s})' % $.matchers(),
+          expr='sum(ceph_osd_in{%(matchers)s})' % $.matchers(),
           legendFormat='In',
           interval='$interval',
           datasource='$datasource',
@@ -308,6 +307,29 @@ local g = import 'grafonnet/grafana.libsonnet';
           warn=1,
           datasource='$datasource',
         ),
+      ])
+      .addOverrides([
+        { matcher: { id: 'byName', options: 'All' }, properties: [
+          { id: 'color', value: { mode: 'fixed' } },
+        ] },
+        { matcher: { id: 'byName', options: 'Out' }, properties: [
+          {
+            id: 'thresholds',
+            value: { mode: 'absolute', steps: [
+              { color: 'green', value: null },
+              { color: 'red', value: 1 },
+            ] },
+          },
+        ] },
+        { matcher: { id: 'byName', options: 'Down' }, properties: [
+          {
+            id: 'thresholds',
+            value: { mode: 'absolute', steps: [
+              { color: 'green', value: null },
+              { color: 'red', value: 1 },
+            ] },
+          },
+        ] },
       ]),
 
       $.addStatPanel(
@@ -453,7 +475,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         displayName='',
         maxDataPoints=100,
         colorMode='none',
-        unit='decbytes',
+        unit='bytes',
         pluginVersion='9.4.7',
       )
       .addMappings([
@@ -713,7 +735,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         pointSize=5,
         lineWidth=1,
         showPoints='never',
-        unit='decbytes',
+        unit='bytes',
         displayMode='table',
         tooltip={ mode: 'multi', sort: 'desc' },
         interval='$interval',
@@ -755,7 +777,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         pointSize=5,
         lineWidth=1,
         showPoints='never',
-        unit='decbytes',
+        unit='bytes',
         displayMode='table',
         tooltip={ mode: 'multi', sort: 'desc' },
         interval='$interval',

--- a/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
+++ b/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
@@ -290,7 +290,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             }
          },
          "gridPos": {
@@ -505,15 +505,75 @@
                      {
                         "color": "green",
                         "value": null
-                     },
-                     {
-                        "color": "red",
-                        "value": 80
                      }
                   ]
                },
                "unit": "none"
-            }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "All"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Out"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Down"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+            ]
          },
          "flipCard": false,
          "flipTime": 5,
@@ -571,7 +631,7 @@
                "displayAliasType": "Always",
                "displayType": "Regular",
                "displayValueWithAlias": "When Alias Displayed",
-               "expr": "count(ceph_osd_in{cluster=~\"$cluster\", })",
+               "expr": "sum(ceph_osd_in{cluster=~\"$cluster\", })",
                "format": "time_series",
                "interval": "$interval",
                "intervalFactor": 1,
@@ -913,7 +973,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             }
          },
          "gridPos": {
@@ -1483,7 +1543,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             },
             "overrides": [ ]
          },
@@ -1590,7 +1650,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             },
             "overrides": [ ]
          },


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73229

---

backport of https://github.com/ceph/ceph/pull/65561
parent tracker: https://tracker.ceph.com/issues/72810

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh