### PR TITLE
squid: monitoring: fix "In" OSDs in Cluster-Advanced grafana panel. Also change units from decbytes to bytes wherever used in the panel

### DIFF
--- a/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
@@ -123,7 +123,7 @@ local g = import 'grafonnet/grafana.libsonnet';
 
       $.addStatPanel(
         title='Cluster Capacity',
-        unit='decbytes',
+        unit='bytes',
         datasource='$datasource',
         gridPosition={ x: 6, y: 1, w: 3, h: 3 },
         graphMode='area',
@@ -220,7 +220,6 @@ local g = import 'grafonnet/grafana.libsonnet';
       )
       .addThresholds([
         { color: 'green', value: null },
-        { color: 'red', value: 80 },
       ])
       .addTargets([
         $.addTargetSchema(
@@ -246,7 +245,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           displayValueWithAlias='When Alias Displayed',
           units='none',
           valueHandler='Number Threshold',
-          expr='count(ceph_osd_in{%(matchers)s})' % $.matchers(),
+          expr='sum(ceph_osd_in{%(matchers)s})' % $.matchers(),
           legendFormat='In',
           interval='$interval',
           datasource='$datasource',
@@ -295,6 +294,29 @@ local g = import 'grafonnet/grafana.libsonnet';
           warn=1,
           datasource='$datasource',
         ),
+      ])
+      .addOverrides([
+        { matcher: { id: 'byName', options: 'All' }, properties: [
+          { id: 'color', value: { mode: 'fixed' } },
+        ] },
+        { matcher: { id: 'byName', options: 'Out' }, properties: [
+          {
+            id: 'thresholds',
+            value: { mode: 'absolute', steps: [
+              { color: 'green', value: null },
+              { color: 'red', value: 1 },
+            ] },
+          },
+        ] },
+        { matcher: { id: 'byName', options: 'Down' }, properties: [
+          {
+            id: 'thresholds',
+            value: { mode: 'absolute', steps: [
+              { color: 'green', value: null },
+              { color: 'red', value: 1 },
+            ] },
+          },
+        ] },
       ]),
 
       $.addStatPanel(
@@ -440,7 +462,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         displayName='',
         maxDataPoints=100,
         colorMode='none',
-        unit='decbytes',
+        unit='bytes',
         pluginVersion='9.4.7',
       )
       .addMappings([
@@ -700,7 +722,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         pointSize=5,
         lineWidth=1,
         showPoints='never',
-        unit='decbytes',
+        unit='bytes',
         displayMode='table',
         tooltip={ mode: 'multi', sort: 'desc' },
         interval='$interval',
@@ -742,7 +764,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         pointSize=5,
         lineWidth=1,
         showPoints='never',
-        unit='decbytes',
+        unit='bytes',
         displayMode='table',
         tooltip={ mode: 'multi', sort: 'desc' },
         interval='$interval',

--- a/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
+++ b/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
@@ -277,7 +277,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             }
          },
          "gridPos": {
@@ -492,15 +492,75 @@
                      {
                         "color": "green",
                         "value": null
-                     },
-                     {
-                        "color": "red",
-                        "value": 80
                      }
                   ]
                },
                "unit": "none"
-            }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "All"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Out"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Down"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+            ]
          },
          "flipCard": false,
          "flipTime": 5,
@@ -558,7 +618,7 @@
                "displayAliasType": "Always",
                "displayType": "Regular",
                "displayValueWithAlias": "When Alias Displayed",
-               "expr": "count(ceph_osd_in{cluster=~\"$cluster\", })",
+               "expr": "sum(ceph_osd_in{cluster=~\"$cluster\", })",
                "format": "time_series",
                "interval": "$interval",
                "intervalFactor": 1,
@@ -900,7 +960,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             }
          },
          "gridPos": {
@@ -1470,7 +1530,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             },
             "overrides": [ ]
          },
@@ -1577,7 +1637,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             },
             "overrides": [ ]
          },


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73231

---

backport of https://github.com/ceph/ceph/pull/65561
parent tracker: https://tracker.ceph.com/issues/72810

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh