### PR TITLE
tentacle: mgr/dashboard: add nsid param to ns add command

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -441,7 +441,10 @@ else:
                 "trash_image": Param(bool, "Trash the RBD image when namespace is removed"),
                 "block_size": Param(int, "NVMeoF namespace block size"),
                 "load_balancing_group": Param(int, "Load balancing group"),
+                "disable_auto_resize": Param(str, "Disable auto resize", True, None),
+                "read_only": Param(str, "Read only namespace", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "traddr": Param(str, "Target gateway address", True, None),
                 "force": Param(
                     bool,
                     "Force create namespace even it image is used by other namespace"
@@ -459,44 +462,7 @@ else:
             nqn: str,
             rbd_image_name: str,
             rbd_pool: str = "rbd",
-            create_image: Optional[bool] = False,
-            size: Optional[int] = 1024,
-            rbd_image_size: Optional[int] = None,
-            trash_image: Optional[bool] = False,
-            block_size: int = 512,
-            load_balancing_group: Optional[int] = None,
-            force: Optional[bool] = False,
-            no_auto_visible: Optional[bool] = False,
-            disable_auto_resize: Optional[bool] = False,
-            read_only: Optional[bool] = False,
-            gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
-        ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add(
-                NVMeoFClient.pb2.namespace_add_req(
-                    subsystem_nqn=nqn,
-                    rbd_image_name=rbd_image_name,
-                    rbd_pool_name=rbd_pool,
-                    block_size=block_size,
-                    create_image=create_image,
-                    size=rbd_image_size or size,
-                    trash_image=trash_image,
-                    anagrpid=load_balancing_group,
-                    force=force,
-                    no_auto_visible=no_auto_visible,
-                    disable_auto_resize=disable_auto_resize,
-                    read_only=read_only
-                )
-            )
-
-        @NvmeofCLICommand("nvmeof ns add", model.NamespaceCreation)
-        @convert_to_model(model.NamespaceCreation)
-        @handle_nvmeof_error
-        def create_cli(
-            self,
-            nqn: str,
-            rbd_image_name: str,
-            rbd_pool: str = "rbd",
+            nsid: Optional[str] = None,
             create_image: Optional[bool] = False,
             size: Optional[str] = None,
             rbd_image_size: Optional[str] = None,
@@ -518,6 +484,7 @@ else:
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add(
                 NVMeoFClient.pb2.namespace_add_req(
                     subsystem_nqn=nqn,
+                    nsid=int(nsid) if nsid else None,
                     rbd_image_name=rbd_image_name,
                     rbd_pool_name=rbd_pool,
                     block_size=block_size,

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9351,7 +9351,8 @@ paths:
                   type: boolean
                 disable_auto_resize:
                   default: false
-                  type: integer
+                  description: Disable auto resize
+                  type: string
                 force:
                   default: false
                   description: Force create namespace even it image is used by other
@@ -9367,6 +9368,8 @@ paths:
                   default: false
                   description: Namespace will be visible only for the allowed hosts
                   type: boolean
+                nsid:
+                  type: string
                 rbd_image_name:
                   description: RBD image name
                   type: string
@@ -9379,12 +9382,13 @@ paths:
                   type: string
                 read_only:
                   default: false
-                  type: boolean
+                  description: Read only namespace
+                  type: string
                 size:
-                  default: 1024
                   description: RBD image size
                   type: integer
                 traddr:
+                  description: Target gateway address
                   type: string
                 trash_image:
                   default: false


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73258

---

backport of https://github.com/ceph/ceph/pull/65503
parent tracker: https://tracker.ceph.com/issues/72681

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh