### PR TITLE
tentacle: mgr/dashboard: --no-group-append default value to False, aligned with old cli

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -195,15 +195,20 @@ else:
             "Create a new NVMeoF subsystem",
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "enable_ha": Param(bool, "Enable high availability", True, None),
                 "max_namespaces": Param(int, "Maximum number of namespaces", True, 4096),
-                "enable_ha": Param(bool, "Enable high availability"),
+                "no_group_append": Param(int, "Do not append gateway group name to the NQN",
+                                         True, False),
+                "serial_number": Param(int, "Subsystem serial number", True, None),
+                "dhchap_key": Param(int, "Subsystem DH-HMAC-CHAP key", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "traddr": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.SubsystemStatus)
         @handle_nvmeof_error
         def create(self, nqn: str, enable_ha: Optional[bool] = True,
-                   max_namespaces: Optional[int] = 4096, no_group_append: Optional[bool] = True,
+                   max_namespaces: Optional[int] = 4096, no_group_append: Optional[bool] = False,
                    serial_number: Optional[str] = None, dhchap_key: Optional[str] = None,
                    gw_group: Optional[str] = None, traddr: Optional[str] = None):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -8790,7 +8790,8 @@ paths:
             schema:
               properties:
                 dhchap_key:
-                  type: string
+                  description: Subsystem DH-HMAC-CHAP key
+                  type: integer
                 enable_ha:
                   default: true
                   description: Enable high availability
@@ -8803,14 +8804,17 @@ paths:
                   description: Maximum number of namespaces
                   type: integer
                 no_group_append:
-                  default: true
-                  type: boolean
+                  default: false
+                  description: Do not append gateway group name to the NQN
+                  type: integer
                 nqn:
                   description: NVMeoF subsystem NQN
                   type: string
                 serial_number:
+                  description: Subsystem serial number
                   type: integer
                 traddr:
+                  description: NVMeoF gateway address
                   type: string
               required:
               - nqn


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73257

---

backport of https://github.com/ceph/ceph/pull/65504
parent tracker: https://tracker.ceph.com/issues/72757

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh