### PR TITLE
tentacle: mgr/dashboard: fix None force param handling in ns add_host so it won't raise exceptions

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -708,7 +708,7 @@ else:
                 NVMeoFClient.pb2.namespace_add_host_req(subsystem_nqn=nqn,
                                                         nsid=int(nsid),
                                                         host_nqn=host_nqn,
-                                                        force=str_to_bool(force))
+                                                        force=str_to_bool(force) if force else None)
             )
 
         @ReadPermission


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73256

---

backport of https://github.com/ceph/ceph/pull/65519
parent tracker: https://tracker.ceph.com/issues/72927

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh