### PR TITLE
squid: cephadm: support custom distros by falling back to ID_LIKE

### DIFF
--- a/src/cephadm/tests/test_util_funcs.py
+++ b/src/cephadm/tests/test_util_funcs.py
@@ -541,6 +541,54 @@ VERSION_CODENAME=hpec nimda
             """,
             ("hpec", "33", "hpec nimda"),
         ),
+        (
+            """# Fallback: unknown distro with comma-separated ID_LIKE
+ID="custom-rhel"
+ID_LIKE="rhel,centos,fedora"
+VERSION_ID="8"
+            """,
+            ("rhel", "8", None),
+        ),
+        (
+            """# Fallback: unknown distro with space-separated ID_LIKE
+ID="custom-rhel"
+ID_LIKE="rhel centos fedora"
+VERSION_ID="8"
+            """,
+            ("rhel", "8", None),
+        ),
+        (
+            """# Fallback: picks first known distro from mixed ID_LIKE
+ID="custom-distro"
+ID_LIKE="unknown-distro,centos,fedora"
+VERSION_ID="8"
+            """,
+            ("centos", "8", None),
+        ),
+        (
+            """# No fallback: unknown distro with unknown ID_LIKE values
+ID="unknown-distro"
+ID_LIKE="also-unknown another-unknown"
+VERSION_ID="1.0"
+            """,
+            ("unknown-distro", "1.0", None),
+        ),
+        (
+            """# No fallback: unknown distro with empty ID_LIKE
+ID="unknown-distro"
+ID_LIKE=""
+VERSION_ID="1.0"
+            """,
+            ("unknown-distro", "1.0", None),
+        ),
+        (
+            """# No fallback: known distro stays unchanged
+ID="rocky"
+ID_LIKE="rhel centos fedora"
+VERSION_ID="8.5"
+            """,
+            ("rocky", "8.5", None),
+        ),
     ],
 )
 def test_get_distro(monkeypatch, content, expected):


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/65599

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
