### PR TITLE
mgr/dashboard: Rename side-nav panel items

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.ts
@@ -73,8 +73,8 @@ export class RgwBucketNotificationListComponent extends ListWithDetails implemen
         flexGrow: 2
       },
       {
-        name: $localize`Topic`,
-        prop: 'Topic',
+        name: $localize`Destination`,
+        prop: 'Destination',
         flexGrow: 1,
         cellTransformation: CellTemplate.copy
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.ts
@@ -285,7 +285,7 @@ export class RgwBucketTieringFormComponent extends CdForm implements OnInit {
   }
 
   goToCreateStorageClass() {
-    this.router.navigate(['rgw/tiering/create']);
+    this.router.navigate(['rgw/storage-class/create']);
     this.closeModal();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
@@ -134,8 +134,8 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
     private rgwZoneService: RgwZoneService
   ) {
     super();
-    this.resource = $localize`Tiering Storage Class`;
-    this.editing = this.router.url.startsWith(`/rgw/tiering/${URLVerbs.EDIT}`);
+    this.resource = $localize`Storage Class`;
+    this.editing = this.router.url.startsWith(`/rgw/storage-class/${URLVerbs.EDIT}`);
     this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
   }
 
@@ -619,7 +619,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
     }
   }
   goToListView() {
-    this.router.navigate([`rgw/tiering`]);
+    this.router.navigate([`rgw/storage-class`]);
   }
 
   getTierTargetByStorageClass(placementTargetInfo: PlacementTarget, storageClass: string) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-list/rgw-storage-class-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-list/rgw-storage-class-list.component.html
@@ -4,6 +4,7 @@
   </cd-help-text>
 </legend>
 <cd-table
+  #table
   [data]="storageClassList"
   columnMode="flex"
   [columns]="columns"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-details/rgw-topic-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-details/rgw-topic-details.component.html
@@ -13,16 +13,6 @@
           </tr>
           <tr>
             <td i18n
-                class="bold w-25">Push endpoint topic</td>
-            <td class="w-75">{{ selection?.dest?.push_endpoint_topic}}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold w-25">Push endpoint</td>
-            <td class="w-75">{{ selection?.dest?.push_endpoint }}</td>
-          </tr>
-          <tr>
-            <td i18n
                 class="bold w-25">Stored secret</td>
             <td class="w-75">{{ selection?.dest?.stored_secret}}</td>
           </tr>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.html
@@ -9,14 +9,14 @@
       {{ action | titlecase }} {{ resource | upperFirst }}
       <cd-help-text>
         <span i18n>
-            Configure the push endpoint parameters to send notifications. On successful creation, you'll receive the topic's unique Amazon Resource Name
+            Configure the push endpoint parameters to send notifications. On successful creation, you'll receive the destination's unique Amazon Resource Name
         </span>
       </cd-help-text>
     </div>
 
     <div class="form-item form-item-append"
          cdsRow>
-      <!-- Topic Type-->
+      <!-- Destination Type-->
       <div cdsCol>
         <cds-select formControlName="endpointType"
                     label="Type"
@@ -25,15 +25,13 @@
                     id="endpointType"
                     (change)="onEndpointTypeChange();"
                     [invalid]="topicForm.controls.endpointType.invalid && topicForm.controls.endpointType.dirty"
-                    [invalidText]="topicTypeError"
-                    helperText="This user will manage and configure the topic’s settings."
-                    i18n-helperText>
+                    [invalidText]="topicTypeError">
           <option i18n
                   *ngIf="endpointType === null"
                   value="null">Loading... </option>
           <option i18n
                   *ngIf="endpointType !== null"
-                  value="">-- Select a Topic type --</option>
+                  value="">-- Select a destination type --</option>
           <option *ngFor="let data of endpointType"
                   i18n>{{ data | upperFirst }} </option>
         </cds-select>
@@ -53,9 +51,7 @@
           cdRequiredField="Owner"
           [invalid]="topicForm.controls.owner.invalid && topicForm.controls.owner.dirty"
           id="owner"
-          helperText="This owner will define and control the topic’s settings"
-          [invalidText]="ownerError"
-          i18n-helperText>
+          [invalidText]="ownerError">
           <option i18n
                   *ngIf="owners === null"
                   value="null">Loading... </option>
@@ -78,7 +74,7 @@
       <div class="form-item form-item-append"
            cdsRow>
 
-        <!-- Topic Name -->
+        <!-- Destination Name -->
         <div cdsCol>
           <cds-text-label
             labelInputID="name"
@@ -86,8 +82,7 @@
             i18n-helperText
             cdRequiredField="Name"
             [invalid]="topicForm.controls.name.invalid && topicForm.controls.name.dirty"
-            [invalidText]="nameError"
-            helperText="Enter a Topic name">Name
+            [invalidText]="nameError">Name
 
           <input cdsText
                  type="text"
@@ -162,13 +157,13 @@
         <div cdsCol>
           <cds-text-label
             labelInputID="fqdn"
-            cdRequiredField="RGW Gateway Hostname"
+            cdRequiredField="Destination address"
             [invalid]="topicForm.controls.fqdn.invalid && topicForm.controls.fqdn.dirty"
             [invalidText]="fqdnError"
-            helperText="Enter the FQDN to configure the topic's settings and behavior"
+            helperText="Enter the FQDN/hostname/IP address for the push endpoint"
             i18n-helperText
             i18n>
-           RGW Gateway hostname
+           Destination address
           <input cdsText
                  type="text"
                  id="fqdn"
@@ -188,7 +183,7 @@
           <cds-number
             id="Port"
             formControlName="port"
-            cdRequiredField="Port"
+            cdRequiredField="Destination port"
             label="Port"
             i18n-label
             [min]="1"
@@ -424,7 +419,7 @@
                   cdsCol
                   class="cd-header">
             Additional common attributes
-            <cd-help-text>Configure additional attributes to customize the topic's behavior and settings</cd-help-text>
+            <cd-help-text>Configure additional attributes to customize the destination behavior and settings</cd-help-text>
           </legend>
 
           <!-- Persistent-->
@@ -445,7 +440,7 @@
             <cds-text-label labelInputID="opaque_data"
                             i18n
                             i18n-helperText
-                            helperText="A user-defined metadata added to all notifications that are triggered by the topic.">
+                            helperText="A user-defined metadata added to all notifications that are triggered by the destination.">
               Opaque data
               <input cdsText
                      type="text"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.ts
@@ -26,7 +26,7 @@ import {
   Endpoint
 } from '~/app/shared/models/topic.model';
 
-const BASE_URL = 'rgw/topic';
+const BASE_URL = 'rgw/destination';
 @Component({
   selector: 'cd-rgw-topic-form',
   templateUrl: './rgw-topic-form.component.html',
@@ -65,9 +65,9 @@ export class RgwTopicFormComponent extends CdForm implements OnInit, AfterViewCh
     private route: ActivatedRoute
   ) {
     super();
-    this.editing = this.router.url.startsWith(`/rgw/topic/${URLVerbs.EDIT}`);
+    this.editing = this.router.url.startsWith(`/${BASE_URL}/${URLVerbs.EDIT}`);
     this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
-    this.resource = $localize`topic`;
+    this.resource = $localize`notification destination`;
   }
 
   ngAfterViewChecked(): void {
@@ -397,8 +397,8 @@ export class RgwTopicFormComponent extends CdForm implements OnInit, AfterViewCh
       return this.topicForm.setErrors({ cdSubmitButton: true });
     }
     const notificationTitle = this.editing
-      ? $localize`Topic updated successfully`
-      : $localize`Topic created successfully`;
+      ? $localize`Notification destination updated successfully`
+      : $localize`Notification destination created successfully`;
     const formValue = this.topicForm.getRawValue();
     const topicPolicy = this.getTopicPolicy();
     const payload = this.generatePayload(formValue, topicPolicy);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.html
@@ -1,5 +1,7 @@
   <ng-container>
   <cd-table #table
+            headerTitle="Notification destination"
+            headerDescription="Delivers bucket and object change notifications to external services like Kafka or AMQP."
             [autoReload]="false"
             [data]="topics$ | async"
             [columns]="columns"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.ts
@@ -22,7 +22,7 @@ import { Topic } from '~/app/shared/models/topic.model';
 import { BehaviorSubject, Observable, of, Subscriber } from 'rxjs';
 import { catchError, shareReplay, switchMap } from 'rxjs/operators';
 
-const BASE_URL = 'rgw/topic';
+const BASE_URL = 'rgw/destination';
 @Component({
   selector: 'cd-rgw-topic-list',
   templateUrl: './rgw-topic-list.component.html',
@@ -129,13 +129,13 @@ export class RgwTopicListComponent extends ListWithDetails implements OnInit {
     const key = this.selection.first().key;
     const name = this.selection.first().name;
     this.modalService.show(DeleteConfirmationModalComponent, {
-      itemDescription: $localize`Topic`,
+      itemDescription: $localize`Notification destination`,
       itemNames: [name],
       submitActionObservable: () => {
         return new Observable((observer: Subscriber<any>) => {
           this.taskWrapper
             .wrapTaskAroundCall({
-              task: new FinishedTask('rgw/topic/delete', {
+              task: new FinishedTask(`${BASE_URL}/delete`, {
                 name: [name]
               }),
               call: this.rgwTopicService.delete(key)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -389,8 +389,8 @@ const routes: Routes = [
     ]
   },
   {
-    path: 'tiering',
-    data: { breadcrumbs: 'Tiering' },
+    path: 'storage-class',
+    data: { breadcrumbs: 'Storage class' },
     children: [
       { path: '', component: RgwStorageClassListComponent },
       {
@@ -438,8 +438,8 @@ const routes: Routes = [
     children: [{ path: '', component: RgwConfigurationPageComponent }]
   },
   {
-    path: 'topic',
-    data: { breadcrumbs: 'Topic' },
+    path: 'destination',
+    data: { breadcrumbs: 'Notification destination' },
     children: [
       { path: '', component: RgwTopicListComponent },
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -211,25 +211,25 @@
                             [useRouter]="true"
                             class="tc_submenuitem tc_submenuitem_rgw_overview"><span i18n>Overview</span></cds-sidenav-item>
           <cds-sidenav-item route="/rgw/user"
-                            title="Users"
+                            title="User management"
                             i18n-title
                             [useRouter]="true"
-                            class="tc_submenuitem tc_submenuitem_rgw_users"><span i18n>Users</span></cds-sidenav-item>
+                            class="tc_submenuitem tc_submenuitem_rgw_users"><span i18n>User management</span></cds-sidenav-item>
           <cds-sidenav-item route="/rgw/bucket"
                             title="Buckets"
                             i18n-title
                             [useRouter]="true"
                             class="tc_submenuitem tc_submenuitem_rgw_buckets"><span i18n>Buckets</span></cds-sidenav-item>
-          <cds-sidenav-item route="/rgw/topic"
+          <cds-sidenav-item route="/rgw/destination"
                             [useRouter]="true"
-                            title="Topics"
+                            title="Notification destination"
                             i18n-title
-                            class="tc_submenuitem tc_submenuitem_rgw_topics"><span i18n>Topics</span></cds-sidenav-item>
-          <cds-sidenav-item route="/rgw/tiering"
-                            title="Tiering"
+                            class="tc_submenuitem tc_submenuitem_rgw_notification"><span i18n>Notification destination</span></cds-sidenav-item>
+          <cds-sidenav-item route="/rgw/storage-class"
+                            title="Storage class"
                             i18n-title
                             [useRouter]="true"
-                            class="tc_submenuitem tc_submenuitem_rgw_tiering"><span i18n>Tiering</span></cds-sidenav-item>
+                            class="tc_submenuitem tc_submenuitem_rgw_storage_class"><span i18n>Storage class</span></cds-sidenav-item>
           <cds-sidenav-item route="/rgw/multisite"
                             title="Multi-site"
                             i18n-title

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
@@ -139,7 +139,7 @@ describe('NavigationComponent', () => {
           '.tc_submenuitem_rgw_daemons',
           '.tc_submenuitem_rgw_users',
           '.tc_submenuitem_rgw_buckets',
-          '.tc_submenuitem_rgw_topics'
+          '.tc_submenuitem_rgw_notification'
         ]
       ]
     ];
@@ -188,7 +188,7 @@ describe('NavigationComponent', () => {
           '.tc_submenuitem_rgw_daemons',
           '.tc_submenuitem_rgw_users',
           '.tc_submenuitem_rgw_buckets',
-          '.tc_submenuitem_rgw_topics'
+          '.tc_submenuitem_rgw_notification'
         ]
       ]
     ];
@@ -248,9 +248,9 @@ describe('NavigationComponent', () => {
         '.tc_submenuitem_block_iscsi': 'iSCSI',
         '.tc_submenuitem_block_nvme': 'NVMe/TCP',
         '.tc_submenuitem_rgw_overview': 'Overview',
-        '.tc_submenuitem_rgw_users': 'Users',
+        '.tc_submenuitem_rgw_users': 'User management',
         '.tc_submenuitem_rgw_buckets': 'Buckets',
-        '.tc_submenuitem_rgw_topics': 'Topics',
+        '.tc_submenuitem_rgw_notification': 'Notification destination',
         '.tc_submenuitem_rgw_multi-site': 'Multi-site',
         '.tc_submenuitem_rgw_daemons': 'Gateways',
         '.tc_submenuitem_rgw_nfs': 'NFS',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -410,8 +410,8 @@ export class TaskMessageService {
     'nfs/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
       this.nfs(metadata)
     ),
-    'rgw/topic/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
-      this.topic(metadata)
+    'rgw/destination/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
+      this.destination(metadata)
     ),
     // Grafana tasks
     'grafana/dashboards/update': this.newTaskMessage(
@@ -624,8 +624,8 @@ export class TaskMessageService {
     return $localize`SMB users and groups access resource '${metadata.usersGroupsId}'`;
   }
 
-  topic(metadata: any) {
-    return $localize`Topic  '${metadata.name}'`;
+  destination(metadata: any) {
+    return $localize`Notification destination  '${metadata.name}'`;
   }
   notification(metadata: any) {
     return $localize`Notification  '${metadata.name}'`;
@@ -635,7 +635,7 @@ export class TaskMessageService {
   }
 
   rgwStorageClass(metadata: any) {
-    return $localize`Tiering Storage Class  '${metadata.storage_class}'`;
+    return $localize`Storage Class  '${metadata.storage_class}'`;
   }
 
   crudMessage(metadata: any) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/73252

Commit includes changes:
1) Renaming Topic to Destination
2) Renaming Tiering to Storage class
3) Renaming Users to User Management
4) fix storage class table refresh after delete

https://github.com/user-attachments/assets/fe184048-f832-4139-be73-144ed1e0c359





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
