### PR TITLE
tentacle: mgr/dashboard: Blank entry for Storage Capacity in dashboard under Cluster > Expand Cluster > Review

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
@@ -58,14 +58,10 @@
 <ng-template #simpleDeploymentTextTpl>
   <tr>
     <td>
-      <dl>
-        <dt>
-          <p i18n>Storage Capacity</p>
-        </dt>
-        <dd>
-          <p i18n>{{deploymentDescText}}</p>
-        </dd>
-      </dl>
+      <span i18n>Storage Capacity</span>
+    </td>
+    <td>
+      <span i18n>{{deploymentDescText}}</span>
     </td>
   </tr>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
@@ -23,7 +23,7 @@ export class CreateClusterReviewComponent implements OnInit {
   services: Array<CephServiceSpec> = [];
   totalCPUs = 0;
   totalMemory = 0;
-  deploymentDescText: string;
+  deploymentDescText: string = '-';
   isSimpleDeployment = true;
 
   constructor(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73275

---

backport of https://github.com/ceph/ceph/pull/65652
parent tracker: https://tracker.ceph.com/issues/73220

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh