### PR TITLE
Bump required Cython version for rpmbuild

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -290,7 +290,7 @@ BuildRequires:  procps
 BuildRequires:	python%{python3_pkgversion}
 BuildRequires:	python%{python3_pkgversion}-devel
 BuildRequires:	python%{python3_pkgversion}-setuptools
-BuildRequires:	python%{python3_pkgversion}-Cython
+BuildRequires:	python%{python3_pkgversion}-Cython >= 3
 BuildRequires:	snappy-devel
 BuildRequires:	sqlite-devel
 BuildRequires:	sudo


### PR DESCRIPTION
Cython 0.2x fails with
Invalid Buildtime constant BUILD_DOC

the other problem is that the packages for rhel9 systems are all cython 0.2x, but that's another problem.