### PR TITLE
osd: Issue health warning if min_size of a pool is too low

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -294,6 +294,7 @@ by setting it in the ``[mon]`` section of the configuration file.
 .. confval:: mon_warn_on_slow_ping_ratio
 .. confval:: mon_warn_on_slow_ping_time
 .. confval:: mon_warn_on_pool_no_redundancy
+.. confval:: mon_warn_on_pool_min_size_too_low
 .. confval:: mon_cache_target_full_warn_ratio
 .. confval:: mon_health_to_clog
 .. confval:: mon_health_to_clog_tick_interval

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1306,6 +1306,30 @@ recommended amount, run a command of the following form:
 For more information, see :ref:`choosing-number-of-placement-groups` and
 :ref:`pg-autoscaler`.
 
+POOL_MIN_SIZE_TOO_LOW
+_____________________
+
+One or more pools have a ``min_size`` value that is too low, which means 
+the minimum number of OSD daemons per Placement Group required by that pool 
+is too low. 
+For replica pools, ``min_size`` should be greater than 1, and for erasure
+pools, ``min_size`` should be greater than or equal to k + 1.
+
+This warning alerts about the increased risk of data loss when using values
+this low.
+
+For detailed information about which pools are affected, 
+run the following command:
+
+.. prompt:: bash $
+
+   ceph health detail
+
+To manually set the min_size of a pool, run a command of the following form:
+
+.. prompt:: bash $
+
+   ceph osd pool set <pool-name> min_size <min-size>
 
 POOL_TARGET_SIZE_BYTES_OVERCOMMITTED
 ____________________________________

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1309,8 +1309,8 @@ For more information, see :ref:`choosing-number-of-placement-groups` and
 POOL_MIN_SIZE_TOO_LOW
 _____________________
 
-One or more pools have a ``min_size`` value that is too low, which means 
-the minimum number of OSD daemons per Placement Group required by that pool 
+One or more pools have a ``min_size`` value that is too low, which means
+the minimum number of OSD daemons per Placement Group required by that pool
 is too low. 
 For replica pools, ``min_size`` should be greater than 1, and for erasure
 pools, ``min_size`` should be greater than or equal to k + 1.
@@ -1318,7 +1318,7 @@ pools, ``min_size`` should be greater than or equal to k + 1.
 This warning alerts about the increased risk of data loss when using values
 this low.
 
-For detailed information about which pools are affected, 
+For detailed information about which pools are affected,
 run the following command:
 
 .. prompt:: bash $

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -30,6 +30,7 @@
 	mon warn on too few osds = false
 	mon_warn_on_pool_pg_num_not_power_of_two = false
         mon_warn_on_pool_no_redundancy = false
+	mon_warn_on_pool_min_size_too_low = false
 	mon_allow_pool_size_one = true
 
         osd pool default erasure code profile = "plugin=isa technique=reed_sol_van k=2 m=1 crush-failure-domain=osd"

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -570,6 +570,19 @@ options:
   see_also:
   - osd_pool_default_size
   - osd_pool_default_min_size
+- name: mon_warn_on_pool_min_size_too_low
+  type: bool
+  level: advanced
+  desc: Issue a health warning if any pool has a minimum size that is too low
+  fmt_desc: Raise ``HEALTH_WARN`` if any pool has a minimum size that is too low.
+  long_desc: Issue a health warning if any pool has a minimum number of osds per pg 
+    that is too low. A replicated pool must have ``min_size`` > 1. An erasure pool 
+    must have ``min_size`` >= k+1.
+  default: true
+  services:
+  - mon
+  see_also:
+  - osd_pool_default_min_size
 - name: mon_warn_on_osd_down_out_interval_zero
   type: bool
   level: advanced


### PR DESCRIPTION
This commit displays a health warning if the min_size (minimum required number of OSDs per PG) of one or more pools is too low. For replicated pools, a min_size <= 1 is too low, and for erasure pools, a min_size < k+1 is too low.
The documentation has been updated to include this new health warning.

Fixes: https://tracker.ceph.com/issues/66641
Signed-off-by: Matty Williams <Matty.Williams@ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
