### PR TITLE
qa: Add new task module template.py

### DIFF
--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/10-subsys-90-namespace-no_huge_pages.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/10-subsys-90-namespace-no_huge_pages.yaml
@@ -13,7 +13,7 @@ tasks:
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
 
-- cephadm.exec:
+- exec:
     host.a:
       - ceph orch ls nvmeof --export > /tmp/nvmeof-orig.yaml
       - cp /tmp/nvmeof-orig.yaml /tmp/nvmeof-no-huge-page.yaml 

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/2-nfs.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/2-nfs.yaml
@@ -1,7 +1,7 @@
 tasks:
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 
@@ -20,7 +20,7 @@ tasks:
       # we can't do wait_for_service here because with octopus it's nfs.ganesha-foo not nfs.foo
       - while ! ceph orch ls | grep nfs | grep 2/2 ; do sleep 1 ; done
 
-- vip.exec:
+- exec:
     host.a:
       - mkdir /mnt/foo
       - while ! mount -t nfs $(hostname):/fake /mnt/foo -o sync ; do sleep 5 ; done

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
@@ -3,7 +3,7 @@ overrides:
     log-ignorelist:
       - CEPHADM_REFRESH_FAILED
 tasks:
-- vip.exec:
+- exec:
     host.a:
       - umount /mnt/foo
 - cephadm.shell:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
@@ -78,7 +78,7 @@ tasks:
             - "client.smbdata"
   - cephadm.wait_for_service:
       service: smb.saserv1
-  - cephadm.exec:
+  - template.exec:
       host.b:
         - sleep 30
         - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U smbuser1%insecure321 //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
@@ -54,7 +54,7 @@ tasks:
     service: smb.modusr1
 
 # verify CTDB is healthy, cluster well formed
-- cephadm.exec:
+- template.exec:
     host.a:
       - sleep 30
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.modusr1\")))[-1].name' > /tmp/svcname"
@@ -82,7 +82,7 @@ tasks:
     service: smb.modusr1
 
 # verify CTDB status doesn't include the node that was removed
-- cephadm.exec:
+- template.exec:
     host.a:
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.modusr1\")))[-1].name' > /tmp/svcname"
       - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb listnodes > /tmp/ctdb_listnodes"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
@@ -89,7 +89,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.admem1
 
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
@@ -46,7 +46,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.modusr1
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
@@ -59,14 +59,14 @@ tasks:
     service: smb.modusr1
 
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- cephadm.exec:
+- template.exec:
     host.a:
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.modusr1\")))[-1].name' > /tmp/svcname"
       - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
@@ -78,7 +78,7 @@ tasks:
       - rm -rf /tmp/svcname /tmp/ctdb_status
 
 # Test the assigned VIP
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{VIP0}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
@@ -88,14 +88,14 @@ tasks:
       - cmd: rados --pool=.smb -N uctdb1 get cluster.meta.json /dev/stdout
 
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user2%t3stP4ss2 //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- cephadm.exec:
+- template.exec:
     host.a:
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.uctdb1\")))[-1].name' > /tmp/svcname"
       - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
@@ -107,7 +107,7 @@ tasks:
       - rm -rf /tmp/svcname /tmp/ctdb_status
 
 # Test a different host in the cluster
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.c'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
@@ -91,14 +91,14 @@ tasks:
       - cmd: rados --pool=.smb -N adctdb1 get cluster.meta.json /dev/stdout
 
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- cephadm.exec:
+- template.exec:
     host.a:
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.adctdb1\")))[-1].name' > /tmp/svcname"
       - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
@@ -110,7 +110,7 @@ tasks:
       - rm -rf /tmp/svcname /tmp/ctdb_status
 
 # Test a different host in the cluster
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.c'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
@@ -96,14 +96,14 @@ tasks:
       - cmd: rados --pool=.smb -N adipctdb get cluster.meta.json /dev/stdout
 
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- cephadm.exec:
+- template.exec:
     host.a:
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.adipctdb\")))[-1].name' > /tmp/svcname"
       - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
@@ -115,7 +115,7 @@ tasks:
       - rm -rf /tmp/svcname /tmp/ctdb_status
 
 # Test the two assigned VIPs
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP0}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ports2c.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ports2c.yaml
@@ -129,7 +129,7 @@ tasks:
       - cmd: rados --pool=.smb -N ac2 get cluster.meta.json /dev/stdout
 
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
@@ -137,7 +137,7 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -p4455 -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/s1ac2 -c ls"
 
 # verify CTDB is healthy, cluster 1 is well formed
-- cephadm.exec:
+- template.exec:
     host.a:
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.ac1\")))[-1].name' > /tmp/svcname"
       - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
@@ -148,7 +148,7 @@ tasks:
       - grep 'Number of nodes:3' /tmp/ctdb_status
       - rm -rf /tmp/svcname /tmp/ctdb_status
 # verify CTDB is healthy, cluster 2 is well formed
-- cephadm.exec:
+- template.exec:
     host.a:
       - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.ac2\")))[-1].name' > /tmp/svcname"
       - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
@@ -160,7 +160,7 @@ tasks:
       - rm -rf /tmp/svcname /tmp/ctdb_status
 
 # Test the two assigned VIPs on cluster 1
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP0}}/share1 -c ls"
@@ -168,7 +168,7 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP0}}/share2 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP1}}/share2 -c ls"
 # Test the assigned VIP on cluster 2
-- cephadm.exec:
+- template.exec:
     host.d:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -p4455 -U DOMAIN1\\\\ckent%1115Rose. //{{VIP2}}/s1ac2 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
@@ -47,7 +47,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.modtest1
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
@@ -73,7 +73,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.modusr1
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
@@ -76,7 +76,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.modtest1
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_ports.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_ports.yaml
@@ -79,7 +79,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.altports
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -p4455 -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_disabled.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_disabled.yaml
@@ -78,7 +78,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.modtest1
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_enabled.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_enabled.yaml
@@ -78,7 +78,7 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.modtest1
 # Check if shares exist
-- cephadm.exec:
+- template.exec:
     host.b:
       - sleep 30
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-haproxy-proto.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-haproxy-proto.yaml
@@ -26,7 +26,7 @@ tasks:
 
 # make sure mount can be reached over VIP, ensuring both that
 # keepalived is maintaining the VIP and that the nfs has bound to it
-- vip.exec:
+- template.exec:
     host.a:
       - mkdir /mnt/happy
       - sleep 1

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-haproxy-proto.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-haproxy-proto.yaml
@@ -7,7 +7,7 @@ tasks:
       - ceph orch device ls --refresh
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-bucket.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-bucket.yaml
@@ -49,7 +49,7 @@ tasks:
 
 ## export and mount
 
-- vip.exec:
+- template.exec:
     host.a:
       - mkdir /mnt/foo
       - sleep 5

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-bucket.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-bucket.yaml
@@ -7,7 +7,7 @@ tasks:
       - ceph orch device ls --refresh
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 
@@ -16,7 +16,7 @@ tasks:
       - ceph orch apply rgw foorgw --port 8800
       - ceph nfs cluster create foo --ingress --virtual-ip {{VIP0}}/{{VIPPREFIXLEN}}
 
-- vip.exec:
+- exec:
     host.a:
       - dnf install -y python3-boto3 || apt install -y python3-boto3
       - /home/ubuntu/cephtest/cephadm shell radosgw-admin user create --uid foouser --display-name foo > /tmp/user.json
@@ -79,7 +79,7 @@ tasks:
       print(data.getvalue())
       assert data.getvalue().decode() == 'test\n'
 
-- vip.exec:
+- exec:
     host.a:
       - umount /mnt/foo
 

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-user.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-user.yaml
@@ -49,7 +49,7 @@ tasks:
 
 ## export and mount
 
-- vip.exec:
+- template.exec:
     host.a:
       - mkdir /mnt/foo
       - sleep 5

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-user.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-user.yaml
@@ -7,7 +7,7 @@ tasks:
       - ceph orch device ls --refresh
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 
@@ -16,7 +16,7 @@ tasks:
       - ceph orch apply rgw foorgw --port 8800
       - ceph nfs cluster create foo --ingress --virtual-ip {{VIP0}}/{{VIPPREFIXLEN}}
 
-- vip.exec:
+- exec:
     host.a:
       - dnf install -y python3-boto3 || apt install -y python3-boto3
       - /home/ubuntu/cephtest/cephadm shell radosgw-admin user create --uid foouser --display-name foo > /tmp/user.json
@@ -80,7 +80,7 @@ tasks:
       print(data.getvalue())
       assert data.getvalue().decode() == 'test\n'
 
-- vip.exec:
+- exec:
     host.a:
       - umount /mnt/foo
 

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
@@ -7,7 +7,7 @@ tasks:
       - ceph orch device ls --refresh
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
@@ -42,7 +42,7 @@ tasks:
     host.a:
       - ceph nfs export create cephfs --fsname foofs --cluster-id foo --pseudo-path /fake
 
-- vip.exec:
+- template.exec:
     host.a:
       - mkdir /mnt/foo
       - sleep 5

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
@@ -24,7 +24,7 @@ tasks:
 
 ## export and mount
 
-- vip.exec:
+- template.exec:
     host.a:
       - mkdir /mnt/foo
       - sleep 5

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
@@ -7,7 +7,7 @@ tasks:
       - ceph orch device ls --refresh
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 
@@ -51,7 +51,7 @@ tasks:
 
 # take each ganesha down in turn.
 # simulate "failure" by deleting the container
-- vip.exec:
+- exec:
     all-hosts:
       - |
         echo "Check with $(hostname) ganesha(s) down..."

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-keepalive-only.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-keepalive-only.yaml
@@ -7,7 +7,7 @@ tasks:
       - ceph orch device ls --refresh
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-keepalive-only.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-keepalive-only.yaml
@@ -46,7 +46,7 @@ tasks:
 
 # make sure mount can be reached over VIP, ensuring both that
 # keepalived is maintaining the VIP and that the nfs has bound to it
-- vip.exec:
+- template.exec:
     host.a:
       - mkdir /mnt/foo
       - sleep 5

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs.yaml
@@ -1,7 +1,7 @@
 tasks:
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs2.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs2.yaml
@@ -1,7 +1,7 @@
 tasks:
 
 # stop kernel nfs server, if running
-- vip.exec:
+- exec:
     all-hosts:
       - systemctl stop nfs-server
 

--- a/qa/tasks/python.py
+++ b/qa/tasks/python.py
@@ -1,6 +1,6 @@
 import logging
 from teuthology import misc as teuthology
-from tasks.vip import subst_vip
+from tasks import template
 
 log = logging.getLogger(__name__)
 
@@ -41,5 +41,6 @@ def task(ctx, config):
         ]
         if sudo:
             args = ['sudo'] + args
-        remote.run(args=args, stdin=subst_vip(ctx, code))
+        code = template.transform(ctx, config, code)
+        remote.run(args=args, stdin=code)
 

--- a/qa/tasks/template.py
+++ b/qa/tasks/template.py
@@ -1,0 +1,163 @@
+"""
+General template support for teuthology tasks.
+
+Functions in this module allow tests to template strings. For example:
+```
+template.exec:
+  host.x:
+    - echo {{ctx.foo.bar}}
+```
+
+Functions like transform allow you to use this templating support
+as a building block in your own .py files as well.
+
+By default a template can access the variables `ctx` and `config` - these are
+mapped to the first two arguments of this function and should match the ctx and
+config passed to an individual task. Additional vars `cluster` and `VIP<N>`
+(eg. VIP0, VIP1), `VIPPREFIXLEN`, `VIPSUBNET` are available for convenience
+and/or backwards compatiblity with existing tests. Finally, keyword args may be
+passed (via `ctx_vars`) to transform to add specific top-level
+variables to extend the templating for specific use-cases.
+
+Templates can access filters that transform on value into another. Currently,
+the only filter, not part of the jinja2 default filters, available is
+`role_to_remote`. Given a role name (like 'host.a') this returns the
+teuthology remote object corresponding to the *first* matching role.
+A template can then access the remote's properties as needed, for example to get
+a host's IP address. Example:
+```
+template.exec:
+  host.x:
+    - pip install foobarbuzz
+    - fbbuzz quuxify -q --extended {{role|role_to_remote|attr('ip_address')}}
+```
+
+
+"""
+
+import functools
+import logging
+
+import jinja2
+from teuthology import misc as teuthology
+
+
+log = logging.getLogger(__name__)
+
+
+def _convert_strs_in(obj, conv):
+    """A function to walk the contents of a dict/list and recursively apply
+    a conversion function (`conv`) to the strings within.
+    """
+    if isinstance(obj, str):
+        return conv(obj)
+    if isinstance(obj, dict):
+        for k in obj:
+            obj[k] = _convert_strs_in(obj[k], conv)
+    if isinstance(obj, list):
+        obj[:] = [_convert_strs_in(v, conv) for v in obj]
+    return obj
+
+
+def _apply_template(jinja_env, rctx, template):
+    """Apply jinja2 templating to the template string `template` via the jinja
+    environment `jinja_env`, passing a dictionary containing top-level context
+    to render into the template.
+    """
+    if "{{" in template or "{%" in template:
+        return jinja_env.from_string(template).render(**rctx)
+    return template
+
+
+@jinja2.pass_context
+def _role_to_remote(rctx, role):
+    """Return the first remote matching the given role."""
+    ctx = rctx["ctx"]
+    for remote, roles in ctx.cluster.remotes.items():
+        if role in roles:
+            return remote
+    return None
+
+
+def _vip_vars(rctx):
+    """For backwards compat with the vip.subst_vip function."""
+    # Make it possible to replace subst_vip in vip.py.
+    ctx = rctx["ctx"]
+    if "vnet" in getattr(ctx, "vip", {}):
+        rctx["VIPPREFIXLEN"] = str(ctx.vip["vnet"].prefixlen)
+        rctx["VIPSUBNET"] = str(ctx.vip["vnet"].network_address)
+    if "vips" in getattr(ctx, "vip", {}):
+        vips = ctx.vip["vips"]
+        for idx, vip in enumerate(vips):
+            rctx[f"VIP{idx}"] = str(vip)
+
+
+def transform(ctx, config, target, **ctx_vars):
+    """Apply jinja2 based templates to strings within the target object,
+    returning a transformed target. Target objects may be a list or dict or
+    str.
+
+    Note that only string values in the list or dict objects are modified.
+    Therefore one can read & parse yaml or json that contain templates in
+    string values without the risk of changing the structure of the yaml/json.
+    """
+    jenv = getattr(ctx, "_jinja_env", None)
+    if jenv is None:
+        loader = jinja2.BaseLoader()
+        jenv = jinja2.Environment(loader=loader)
+        jenv.filters["role_to_remote"] = _role_to_remote
+        setattr(ctx, "_jinja_env", jenv)
+    rctx = dict(
+        ctx=ctx, config=config, cluster_name=config.get("cluster", "")
+    )
+    _vip_vars(rctx)
+    rctx.update(ctx_vars)
+    conv = functools.partial(_apply_template, jenv, rctx)
+    return _convert_strs_in(target, conv)
+
+
+def expand_roles(ctx, config):
+    """Given a context and a config dict containing a mapping of test roles
+    to role actions (typically commands to exec). Expand the special role
+    macros `all-roles` and `all-hosts` into role names that can be found
+    in the teuthology config.
+    """
+    if "all-roles" in config and len(config) == 1:
+        a = config["all-roles"]
+        roles = teuthology.all_roles(ctx.cluster)
+        config = dict(
+            (id_, a) for id_ in roles if not id_.startswith("host.")
+        )
+    elif "all-hosts" in config and len(config) == 1:
+        a = config["all-hosts"]
+        roles = teuthology.all_roles(ctx.cluster)
+        config = dict((id_, a) for id_ in roles if id_.startswith("host."))
+    elif "all-roles" in config or "all-hosts" in config:
+        raise ValueError(
+            "all-roles/all-hosts may not be combined with any other roles"
+        )
+    return config
+
+
+def exec(ctx, config):
+    """
+    This is similar to the standard 'exec' task, but does template substitutions.
+    """
+    assert isinstance(config, dict), "task exec got invalid config"
+    testdir = teuthology.get_testdir(ctx)
+    config = expand_roles(ctx, config)
+    for role, ls in config.items():
+        (remote,) = ctx.cluster.only(role).remotes.keys()
+        log.info("Running commands on role %s host %s", role, remote.name)
+        for c in ls:
+            c.replace("$TESTDIR", testdir)
+            remote.run(
+                args=[
+                    "sudo",
+                    "TESTDIR={tdir}".format(tdir=testdir),
+                    "bash",
+                    "-ex",
+                    "-c",
+                    transform(ctx, config, c, role=role),
+                ],
+            )


### PR DESCRIPTION
Extract the general templating functions that we had added to cephadm.py a while ago into a proper module that doesn't really have any functionality specific to cephadm.




## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Overdue Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Jiggles and juggles supporting test code

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
