### PR TITLE
ceph-volume: use udev data instead of LVM subprocess in get_devices()

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -802,9 +802,12 @@ def get_devices(_sys_block_path='/sys/block', device=''):
             continue
 
         # If the mapper device is a logical volume it gets excluded
-        if is_mapper_device(diskname):
-            if lvm.get_device_lvs(diskname):
+        try:
+            if UdevData(diskname).is_lvm:
                 continue
+        except RuntimeError as e:
+            logger.debug("get_devices(): device {} couldn't be found.".format(diskname))
+            continue
 
         # all facts that have no defaults
         # (<name>, <path relative to _sys_block_path>)


### PR DESCRIPTION
Replace the  check using `lvm.get_device_lvs(diskname)`, which spawned a `pvs` subprocess, with a direct check on `/run/udev/data` via `UdevData(diskname).is_lvm`.

This avoids spawning subprocesses while scanning devices. It improves performance on systems with many disks, and keeps the device filtering logic intact.

Fixes: https://tracker.ceph.com/issues/73334
