### PR TITLE
osd: Optimized EC missing list not updated on recovering shard

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -324,6 +324,7 @@ void PeeringState::query_unfound(Formatter *f, string state)
 void PeeringState::apply_pwlc(const std::pair<eversion_t, eversion_t> pwlc,
 			      const pg_shard_t &shard,
 			      pg_info_t &info,
+			      peering_stage_t stage,
 			      pg_log_t *log1,
 			      PGLog *log2)
 {
@@ -331,7 +332,9 @@ void PeeringState::apply_pwlc(const std::pair<eversion_t, eversion_t> pwlc,
   // knowledge of partial_writes
   const auto & [fromversion, toversion] = pwlc;
   if (toversion > info.last_update) {
-    if (fromversion <= info.last_update) {
+    if ((fromversion <= info.last_update) &&
+	((stage == AFTER_ACTIVATE) ||
+	 (info.last_complete == info.last_update))) {
       if (info.last_complete == info.last_update) {
 	psdout(10) << "osd." << shard << " has last_complete"
 		   << "=last_update " << info.last_update
@@ -364,7 +367,8 @@ void PeeringState::apply_pwlc(const std::pair<eversion_t, eversion_t> pwlc,
 }
 
 void PeeringState::update_peer_info(const pg_shard_t &from,
-				    const pg_info_t &oinfo)
+				    const pg_info_t &oinfo,
+				    peering_stage_t stage)
 {
   // Merge pwlc information from another shard into
   // info.partial_writes_last_complete keeping the newest
@@ -423,14 +427,15 @@ void PeeringState::update_peer_info(const pg_shard_t &from,
   if (is_primary()) {
     for (auto & [shard, peer] : peer_info) {
       if (info.partial_writes_last_complete.contains(shard.shard)) {
-	apply_pwlc(info.partial_writes_last_complete[shard.shard], shard, peer);
+	apply_pwlc(info.partial_writes_last_complete[shard.shard], shard, peer,
+		   stage);
       }
     }
   }
   // Non-primary shards might need to apply pwlc to update info
   if (info.partial_writes_last_complete.contains(pg_whoami.shard)) {
     apply_pwlc(info.partial_writes_last_complete[pg_whoami.shard], pg_whoami,
-	       info, &pg_log);
+	       info, stage, &pg_log);
   }
 }
 
@@ -455,7 +460,7 @@ bool PeeringState::proc_replica_notify(const pg_shard_t &from, const pg_notify_t
   psdout(10) << " got osd." << from << " " << oinfo << dendl;
   ceph_assert(is_primary());
   peer_info[from] = oinfo;
-  update_peer_info(from, oinfo);
+  update_peer_info(from, oinfo, BEFORE_ACTIVATE);
   might_have_unfound.insert(from);
 
   update_history(oinfo.history);
@@ -2748,8 +2753,16 @@ bool PeeringState::search_for_missing(
   PeeringCtxWrapper &ctx)
 {
   uint64_t num_unfound_before = missing_loc.num_unfound();
+  pg_info_t tinfo(oinfo);
+  tinfo.pgid.shard = pg_whoami.shard;
+  // add partial write from our info
+  tinfo.partial_writes_last_complete = info.partial_writes_last_complete;
+  tinfo.partial_writes_last_complete_epoch = info.partial_writes_last_complete_epoch;
+  if (info.partial_writes_last_complete.contains(from.shard)) {
+    apply_pwlc(info.partial_writes_last_complete[from.shard], from, tinfo, AFTER_ACTIVATE);
+  }
   bool found_missing = missing_loc.add_source_info(
-    from, oinfo, omissing, ctx.handle);
+    from, tinfo, omissing, ctx.handle);
   if (found_missing && num_unfound_before != missing_loc.num_unfound())
     pl->publish_stats_to_osd();
   // avoid doing this if the peer is empty.  This is abit of paranoia
@@ -2758,14 +2771,6 @@ bool PeeringState::search_for_missing(
   // last_update=0'0 that's impossible.)
   if (found_missing &&
       oinfo.last_update != eversion_t()) {
-    pg_info_t tinfo(oinfo);
-    tinfo.pgid.shard = pg_whoami.shard;
-    // add partial write from our info
-    tinfo.partial_writes_last_complete = info.partial_writes_last_complete;
-    tinfo.partial_writes_last_complete_epoch = info.partial_writes_last_complete_epoch;
-    if (info.partial_writes_last_complete.contains(from.shard)) {
-      apply_pwlc(info.partial_writes_last_complete[from.shard], from, tinfo);
-    }
     if (!tinfo.partial_writes_last_complete.empty()) {
       psdout(20) << "sending info to " << from
 		 << " pwlc=e" << tinfo.partial_writes_last_complete_epoch
@@ -3188,6 +3193,10 @@ void PeeringState::activate(
 	  ceph_assert(pi_it != peer_info.end());
 	  auto pm_it = peer_missing.find(*i);
 	  ceph_assert(pm_it != peer_missing.end());
+          if (info.partial_writes_last_complete.contains(i->shard)) {
+	    apply_pwlc(info.partial_writes_last_complete[i->shard], *i,
+		       pi_it->second, AFTER_ACTIVATE);
+	  }
 	  missing_loc.add_source_info(
 	    *i,
 	    pi_it->second,
@@ -3362,7 +3371,7 @@ void PeeringState::proc_master_log(
 
   if (info.partial_writes_last_complete.contains(from.shard)) {
     apply_pwlc(info.partial_writes_last_complete[from.shard], from, oinfo,
-	       &olog);
+	       BEFORE_ACTIVATE, &olog);
   }
 
   bool invalidate_stats = false;
@@ -3519,12 +3528,12 @@ void PeeringState::proc_replica_log(
 
   if (info.partial_writes_last_complete.contains(from.shard)) {
     apply_pwlc(info.partial_writes_last_complete[from.shard], from, oinfo,
-	       &olog);
+	       BEFORE_ACTIVATE, &olog);
   }
   pg_log.proc_replica_log(oinfo, olog, omissing, from, pool.info.allows_ecoptimizations());
 
   peer_info[from] = oinfo;
-  update_peer_info(from, oinfo);
+  update_peer_info(from, oinfo, BEFORE_ACTIVATE);
   psdout(10) << " peer osd." << from << " now "
 	     << oinfo << " " << omissing << dendl;
   might_have_unfound.insert(from);
@@ -7030,10 +7039,10 @@ boost::statechart::result PeeringState::ReplicaActive::react(const MLogRec& loge
   ObjectStore::Transaction &t = context<PeeringMachine>().get_cur_transaction();
   if (msg->info.partial_writes_last_complete.contains(ps->pg_whoami.shard)) {
     ps->apply_pwlc(msg->info.partial_writes_last_complete[ps->pg_whoami.shard],
-		   ps->pg_whoami, ps->info, &ps->pg_log);
+		   ps->pg_whoami, ps->info, AFTER_ACTIVATE, &ps->pg_log);
   }
   ps->merge_log(t, logevt.msg->info, std::move(logevt.msg->log), logevt.from);
-  ps->update_peer_info(logevt.from, logevt.msg->info);
+  ps->update_peer_info(logevt.from, logevt.msg->info, AFTER_ACTIVATE);
   ceph_assert(ps->pg_log.get_head() == ps->info.last_update);
   if (logevt.msg->lease) {
     ps->proc_lease(*logevt.msg->lease);
@@ -7155,10 +7164,10 @@ boost::statechart::result PeeringState::Stray::react(const MLogRec& logevt)
   } else {
     if (msg->info.partial_writes_last_complete.contains(ps->pg_whoami.shard)) {
       ps->apply_pwlc(msg->info.partial_writes_last_complete[ps->pg_whoami.shard],
-		     ps->pg_whoami, ps->info, &ps->pg_log);
+		     ps->pg_whoami, ps->info, AFTER_ACTIVATE, &ps->pg_log);
     }
     ps->merge_log(t, msg->info, std::move(msg->log), logevt.from);
-    ps->update_peer_info(logevt.from, msg->info);
+    ps->update_peer_info(logevt.from, msg->info, AFTER_ACTIVATE);
   }
   if (logevt.msg->lease) {
     ps->proc_lease(*logevt.msg->lease);
@@ -7218,7 +7227,7 @@ boost::statechart::result PeeringState::Stray::react(const MInfoRec& infoevt)
   // Log must be consistent with info
   ceph_assert(ps->pg_log.get_head() == ps->info.last_update);
   // Update pwlc
-  ps->update_peer_info(infoevt.from, infoevt.info);
+  ps->update_peer_info(infoevt.from, infoevt.info, AFTER_ACTIVATE);
   post_event(Activate(infoevt.info.last_epoch_started));
   return transit<ReplicaActive>();
 }
@@ -8069,7 +8078,7 @@ boost::statechart::result PeeringState::WaitUpThru::react(const MLogRec& logevt)
   psdout(10) << "Noting missing from osd." << logevt.from << dendl;
   ps->peer_missing[logevt.from].claim(std::move(logevt.msg->missing));
   ps->peer_info[logevt.from] = logevt.msg->info;
-  ps->update_peer_info(logevt.from, logevt.msg->info);
+  ps->update_peer_info(logevt.from, logevt.msg->info, BEFORE_ACTIVATE);
   return discard_event();
 }
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1587,26 +1587,35 @@ public:
 
   void update_heartbeat_peers();
   void query_unfound(Formatter *f, std::string state);
+
+  enum peering_stage_t {
+    BEFORE_ACTIVATE,
+    AFTER_ACTIVATE
+  };
+
   void apply_pwlc(const std::pair<eversion_t, eversion_t> pwlc,
 		  const pg_shard_t &shard,
 		  pg_info_t &info,
+		  peering_stage_t stage,
 		  pg_log_t *log1,
 		  PGLog *log2);
   void apply_pwlc(const std::pair<eversion_t, eversion_t> pwlc,
 		  const pg_shard_t &shard,
 		  pg_info_t &info,
+		  peering_stage_t stage,
 		  pg_log_t *log)
   {
-    apply_pwlc(pwlc, shard, info, log, nullptr);
+    apply_pwlc(pwlc, shard, info, stage, log, nullptr);
   }
   void apply_pwlc(const std::pair<eversion_t, eversion_t> pwlc,
 		  const pg_shard_t &shard,
 		  pg_info_t &info,
+		  peering_stage_t stage,
 		  PGLog *log = nullptr)
   {
-    apply_pwlc(pwlc, shard, info, nullptr, log);
+    apply_pwlc(pwlc, shard, info, stage, nullptr, log);
   }
-  void update_peer_info(const pg_shard_t &from, const pg_info_t &oinfo);
+  void update_peer_info(const pg_shard_t &from, const pg_info_t &oinfo, peering_stage_t stage);
   bool proc_replica_notify(const pg_shard_t &from, const pg_notify_t &notify);
   void remove_down_peer_info(const OSDMapRef &osdmap);
   void check_recovery_sources(const OSDMapRef& map);


### PR DESCRIPTION
Shards that are recovering (last_complete != last_update) are using pwlc to advance last_update for writes that did not effect the shard. However simply incrementing last_update means that the primary doesnt send the shard log entries that it missed and consequently it cannot update its missing list.

If the shard is already missing object X at version V1 and there was a partial write at V2 that did not update the shard, it does not need to retain the log entry, but it does need to update the missing list to say it needs V2 rather than V1. This ensures all shards report a need for an object at the same version and avoids an assert in MissingLoc::add_active_missing when the primary is trying to combine the missing lists from all the shards to work out what has to be recovered.

The fix is to avoid applying pwlc when last_complete != last_update, this forces the primary to send the log to the recovering shard which can then update its missing list (and discarding the log entries as they are partial writes).

Fixes: https://tracker.ceph.com/issues/73249





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
