### PR TITLE
RGW - Posix Test - initialize "existed" bools

### DIFF
--- a/src/test/rgw/test_rgw_posix_driver.cc
+++ b/src/test/rgw/test_rgw_posix_driver.cc
@@ -148,7 +148,7 @@ TEST(FSEnt, DirCreate)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testdir->create(env->dpp, &existed);
 
   EXPECT_EQ(ret, 0);
@@ -165,7 +165,7 @@ TEST(FSEnt, DirBase)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testdir->create(env->dpp, &existed);
 
   EXPECT_EQ(ret, 0);
@@ -280,7 +280,7 @@ TEST(FSEnt, DirBase)
 
 TEST(FSEnt, DirAddDir)
 {
-  bool existed;
+  bool existed{false};
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
   std::unique_ptr<Directory> testdir = std::make_unique<Directory>(dirname, root.get(), env->cct.get());
@@ -314,7 +314,7 @@ TEST(FSEnt, DirAddDir)
 
 TEST(FSEnt, DirRename)
 {
-  bool existed;
+  bool existed{false};
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
   std::unique_ptr<Directory> testdir = std::make_unique<Directory>(dirname, root.get(), env->cct.get());
@@ -357,7 +357,7 @@ TEST(FSEnt, FileCreateReal)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testfile.create(env->dpp, &existed);
 
   EXPECT_EQ(ret, 0);
@@ -374,7 +374,7 @@ TEST(FSEnt, FileCreateTemp)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testfile.create(env->dpp, &existed, true);
   EXPECT_EQ(ret, 0);
   EXPECT_FALSE(existed);
@@ -396,7 +396,7 @@ TEST(FSEnt, FileBase)
   EXPECT_FALSE(sf::exists(tp));
   EXPECT_EQ(testfile->get_fd(), -1);
 
-  bool existed;
+  bool existed{false};
   int ret = testfile->create(env->dpp, &existed);
 
   EXPECT_EQ(ret, 0);
@@ -530,7 +530,7 @@ TEST(FSEnt, SymlinkBase)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testlink->create(env->dpp, &existed);
 
   EXPECT_EQ(ret, 0);
@@ -562,7 +562,7 @@ TEST(FSEnt, MPDirBase)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testdir->create(env->dpp, &existed);
 
   EXPECT_EQ(ret, 0);
@@ -680,7 +680,7 @@ TEST(FSEnt, MPDirTemp)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testdir->create(env->dpp, &existed, true);
 
   EXPECT_EQ(ret, 0);
@@ -771,7 +771,7 @@ TEST(FSEnt, VerDirBase)
 
   EXPECT_FALSE(sf::exists(tp));
 
-  bool existed;
+  bool existed{false};
   int ret = testdir->create(env->dpp, &existed);
 
   EXPECT_EQ(ret, 0);


### PR DESCRIPTION
Theoretically, the "existed" bools in the test could have had junk in them.  Since the driver only writes to them when writing "true", this could have had a false positive return.  Initialize them all.

Fixes: https://tracker.ceph.com/issues/73327





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
