### PR TITLE
tentacle: mgr/dashboard: fix command alias help message

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -234,6 +234,7 @@ class NvmeofCLICommand(CLICommand):
         self._output_formatter = AnnotatedDataTextOutputFormatter()
         self._model = model
         self._alias = alias
+        self._alias_cmd: Optional[NvmeofCLICommand] = None
 
     def _use_api_endpoint_desc_if_available(self, func):
         if not self.desc and hasattr(func, 'doc_info'):
@@ -241,7 +242,9 @@ class NvmeofCLICommand(CLICommand):
 
     def __call__(self, func) -> HandlerFuncType:  # type: ignore
         if self._alias:
-            NvmeofCLICommand(self._alias, model=self._model)._register_handler(func)
+            self._alias_cmd = NvmeofCLICommand(self._alias, model=self._model)
+            assert self._alias_cmd is not None
+            self._alias_cmd(func)
 
         resp = super().__call__(func)
         self._use_api_endpoint_desc_if_available(func)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73341

---

backport of https://github.com/ceph/ceph/pull/65612
parent tracker: https://tracker.ceph.com/issues/72680

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh