### PR TITLE
osd/snap_mapper: optimize dealing with std::map/set

### DIFF
--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -192,7 +192,7 @@ public:
       vptrs.insert(ip);
     }
     t->set_keys(keys);
-    t->add_callback(new TransHolder(vptrs));
+    t->add_callback(new TransHolder(std::move(vptrs)));
   }
 
   /// Adds operation removing keys to Transaction
@@ -208,7 +208,7 @@ public:
       vptrs.insert(ip);
     }
     t->remove_keys(keys);
-    t->add_callback(new TransHolder(vptrs));
+    t->add_callback(new TransHolder(std::move(vptrs)));
   }
 
   /// Gets keys, uses cached values for unstable keys

--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -133,6 +133,7 @@ class ContainerContext : public Context {
   T obj;
 public:
   ContainerContext(T &obj) : obj(obj) {}
+  ContainerContext(T&& obj) : obj(std::move(obj)) {}
   void finish(int r) override {}
 };
 template <typename T>

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -343,8 +343,7 @@ void PG::update_object_snap_mapping(
     ceph_abort();
   }
   snap_mapper.add_oid(
-    soid,
-    snaps,
+    SnapMapper::object_snaps(soid, snaps),
     &_t);
 }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4725,12 +4725,10 @@ int PrimaryLogPG::trim_object(
 
   set<snapid_t> new_snaps;
   const OSDMapRef& osdmap = get_osdmap();
-  for (set<snapid_t>::iterator i = old_snaps.begin();
-       i != old_snaps.end();
-       ++i) {
-    if (!osdmap->in_removed_snaps_queue(info.pgid.pgid.pool(), *i) &&
-	*i != snap_to_trim) {
-      new_snaps.insert(*i);
+  for (auto& s : old_snaps) {
+    if (!osdmap->in_removed_snaps_queue(info.pgid.pgid.pool(), s) &&
+	s != snap_to_trim) {
+      new_snaps.emplace_hint(new_snaps.cend(), s);
     }
   }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -420,8 +420,7 @@ void PrimaryLogPG::on_local_recover(
       snaps.insert(p->second.begin(), p->second.end());
       dout(20) << " snaps " << snaps << dendl;
       snap_mapper.add_oid(
-	recovery_info.soid,
-	snaps,
+	SnapMapper::object_snaps(recovery_info.soid, snaps),
 	&_t);
     } else {
       derr << __func__ << " " << hoid << " had no clone_snaps" << dendl;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1668,7 +1668,7 @@ private:
       boost::statechart::transition< Reset, NotTrimming >
       > reactions;
 
-    std::set<hobject_t> in_flight;
+    size_t in_flight_ops = 0;
     snapid_t snap_to_trim;
 
     explicit Trimming(my_context ctx)
@@ -1676,7 +1676,7 @@ private:
 	NamedState(nullptr, "Trimming") {
       context< SnapTrimmer >().log_enter(state_name);
       ceph_assert(context< SnapTrimmer >().permit_trim());
-      ceph_assert(in_flight.empty());
+      ceph_assert(in_flight_ops == 0);
     }
     void exit() {
       context< SnapTrimmer >().log_exit(state_name, enter_time);
@@ -1700,7 +1700,7 @@ private:
       : my_base(ctx),
 	NamedState(nullptr, "Trimming/WaitTrimTimer") {
       context< SnapTrimmer >().log_enter(state_name);
-      ceph_assert(context<Trimming>().in_flight.empty());
+      ceph_assert(context<Trimming>().in_flight_ops == 0);
       struct OnTimer : Context {
 	PrimaryLogPGRef pg;
 	epoch_t epoch;
@@ -1751,7 +1751,7 @@ private:
       : my_base(ctx),
 	NamedState(nullptr, "Trimming/WaitRWLock") {
       context< SnapTrimmer >().log_enter(state_name);
-      ceph_assert(context<Trimming>().in_flight.empty());
+      ceph_assert(context<Trimming>().in_flight_ops == 0);
     }
     void exit() {
       context< SnapTrimmer >().log_exit(state_name, enter_time);
@@ -1774,7 +1774,7 @@ private:
       : my_base(ctx),
 	NamedState(nullptr, "Trimming/WaitRepops") {
       context< SnapTrimmer >().log_enter(state_name);
-      ceph_assert(!context<Trimming>().in_flight.empty());
+      ceph_assert(!context<Trimming>().in_flight_ops == 0);
     }
     void exit() {
       context< SnapTrimmer >().log_exit(state_name, enter_time);
@@ -1828,7 +1828,7 @@ private:
       : my_base(ctx),
 	NamedState(nullptr, "Trimming/WaitReservation") {
       context< SnapTrimmer >().log_enter(state_name);
-      ceph_assert(context<Trimming>().in_flight.empty());
+      ceph_assert(context<Trimming>().in_flight_ops == 0);
       auto *pg = context< SnapTrimmer >().pg;
       pending = new ReservationCB(pg);
       pg->osd->snap_reserver.request_reservation(

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1576,7 +1576,7 @@ public:
   void handle_backoff(OpRequestRef& op);
 
   int trim_object(bool first, const hobject_t &coid, snapid_t snap_to_trim,
-		  OpContextUPtr *ctxp);
+		  OpContextUPtr *ctxp, OSDMap::removed_snaps_queue_ctx_t *rsq_ctx);
   void snap_trimmer(epoch_t e) override;
   void kick_snap_trim() override;
   void snap_trimmer_scrub_complete() override;

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -130,8 +130,11 @@ public:
   struct object_snaps {
     hobject_t oid;
     std::set<snapid_t> snaps;
-    object_snaps(hobject_t oid, const std::set<snapid_t> &snaps)
-      : oid(oid), snaps(snaps) {}
+    object_snaps(hobject_t oid, const std::set<snapid_t> &_snaps)
+      : oid(oid), snaps(_snaps) {}
+    object_snaps(hobject_t oid, const std::vector<snapid_t> &_snaps)
+      : oid(oid), snaps(_snaps.begin(), _snaps.end()) {
+    }
     object_snaps() {}
     void encode(ceph::buffer::list &bl) const;
     void decode(ceph::buffer::list::const_iterator &bp);
@@ -334,16 +337,14 @@ private:
 
   /// Update snaps for oid, empty new_snaps removes the mapping
   int update_snaps(
-    const hobject_t &oid,       ///< [in] oid to update
-    const std::set<snapid_t> &new_snaps, ///< [in] new snap std::set
+    const object_snaps& new_snaps,       ///< [in] oid + new snaps
     const std::set<snapid_t> *old_snaps, ///< [in] old snaps (for debugging)
     MapCacher::Transaction<std::string, ceph::buffer::list> *t ///< [out] transaction
     ); ///@ return error, 0 on success
 
   /// Add mapping for oid, must not already be mapped
   void add_oid(
-    const hobject_t &oid,       ///< [in] oid to add
-    const std::set<snapid_t>& new_snaps, ///< [in] snaps
+    const object_snaps& new_snaps, ///< [in] oid + new snaps
     MapCacher::Transaction<std::string, ceph::buffer::list> *t ///< [out] transaction
     );
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1475,7 +1475,7 @@ void PgScrubber::apply_snap_mapper_fixes(
     }
 
     // now - insert the correct snap-set
-    m_pg->snap_mapper.add_oid(hoid, snaps, &t_drv);
+    m_pg->snap_mapper.add_oid(SnapMapper::object_snaps(hoid, snaps), &t_drv);
   }
 
   // wait for repair to apply to avoid confusing other bits of the system.

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -512,7 +512,7 @@ public:
     }
     {
       PausyAsyncMap::Transaction t;
-      mapper->add_oid(obj, snaps, &t);
+      mapper->add_oid(SnapMapper::object_snaps(obj, snaps), &t);
       driver->submit(&t);
     }
   }
@@ -572,8 +572,7 @@ public:
 	{
 	  PausyAsyncMap::Transaction t;
 	  mapper->update_snaps(
-	    hoid,
-	    j->second,
+	    SnapMapper::object_snaps(hoid, j->second),
 	    &old_snaps,
 	    &t);
 	  driver->submit(&t);
@@ -1062,7 +1061,7 @@ public:
   void create_object(const hobject_t& obj, const set<snapid_t> &snaps) {
     std::lock_guard l{lock};
       PausyAsyncMap::Transaction t;
-      mapper->add_oid(obj, snaps, &t);
+      mapper->add_oid(SnapMapper::object_snaps(obj, snaps), &t);
       driver->submit(&t);
   }
 
@@ -1147,9 +1146,9 @@ TEST_F(DirectMapperTest, CorruptedSnaRecord)
   set<snapid_t> cln2_snaps{100, 200};
 
   PausyAsyncMap::Transaction t;
-  direct->mapper->add_oid(head, head_snaps, &t);
-  direct->mapper->add_oid(cln1, cln1_snaps, &t);
-  direct->mapper->add_oid(cln2, cln2_snaps, &t);
+  direct->mapper->add_oid(SnapMapper::object_snaps(head, head_snaps), &t);
+  direct->mapper->add_oid(SnapMapper::object_snaps(cln1, cln1_snaps), &t);
+  direct->mapper->add_oid(SnapMapper::object_snaps(cln2, cln2_snaps), &t);
   direct->driver->submit(&t);
   direct->driver->flush();
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1446,7 +1446,8 @@ int get_attrs(
 	       << std::endl;
 	OSDriver::OSTransaction _t(driver.get_transaction(t));
 	ceph_assert(!snaps.empty());
-	snap_mapper.add_oid(clone.hobj, snaps, &_t);
+	SnapMapper::object_snaps obj_snaps(clone.hobj, snaps);
+	snap_mapper.add_oid(obj_snaps, &_t);
       }
     } else {
       cerr << "missing SS_ATTR on " << hoid << std::endl;


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
