### PR TITLE
osd/scrub: scanning the rollbacks not mandating a reschedule

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1742,7 +1742,7 @@ void PG::unreserve_recovery_space() {
   local_num_bytes.store(0);
 }
 
-void PG::_scan_rollback_obs(const vector<ghobject_t> &rollback_obs)
+bool PG::_scan_rollback_obs(const vector<ghobject_t> &rollback_obs)
 {
   ObjectStore::Transaction t;
   eversion_t trimmed_to = recovery_state.get_last_rollback_info_trimmed_to_applied();
@@ -1763,7 +1763,9 @@ void PG::_scan_rollback_obs(const vector<ghobject_t> &rollback_obs)
     derr << __func__ << ": queueing trans to clean up obsolete rollback objs"
 	 << dendl;
     osd->store->queue_transaction(ch, std::move(t), NULL);
+    return true; // a transaction was queued
   }
+  return false;
 }
 
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1227,7 +1227,15 @@ protected:
   [[nodiscard]] bool ops_blocked_by_scrub() const;
   [[nodiscard]] Scrub::scrub_prio_t is_scrub_blocking_ops() const;
 
-  void _scan_rollback_obs(const std::vector<ghobject_t> &rollback_obs);
+
+  /**
+   * Scan the given list of rollback objects for obsolete entries.
+   * If found - the obsolete entries are removed.
+   *
+   * @return 'true' if a transaction was issued.
+   */
+  bool _scan_rollback_obs(const std::vector<ghobject_t> &rollback_obs);
+
   /**
    * returns true if [begin, end) is good to scrub at this time
    * a false return value obliges the implementer to requeue scrub when the

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1376,9 +1376,13 @@ int PgScrubber::build_scrub_map_chunk(ScrubMap& map,
     if (pos.ls.empty()) {
       break;
     }
-    m_pg->_scan_rollback_obs(rollback_obs);
     pos.pos = 0;
-    return -EINPROGRESS;
+    if (m_pg->_scan_rollback_obs(rollback_obs)) {
+      // we had to perform some real work (queue a transaction
+      // to discard obsolete rollback versions of objects in the
+      // selected range). Let's reschedule the scrub.
+      return -EINPROGRESS;
+    }
   }
 
   // scan objects


### PR DESCRIPTION
The scrubber calls PG::_scan_rollback_obs() to clean up obsolete rollback objects. This function may queue a transaction to delete such objects.

The commit modifies the scrubber, so that no rescheduling of the scrub is mandated if no transaction was queued.


