### PR TITLE
doc/cephfs: Typos and small improvements in scrub.rst

### DIFF
--- a/doc/cephfs/scrub.rst
+++ b/doc/cephfs/scrub.rst
@@ -8,7 +8,7 @@ CephFS provides the cluster admin (operator) to check consistency of a file syst
 via a set of scrub commands. Scrub can be classified into two parts:
 
 #. Forward Scrub: In which the scrub operation starts at the root of the file system
-   (or a sub directory) and looks at everything that can be touched in the hierarchy
+   (or a subdirectory) and looks at everything that can be touched in the hierarchy
    to ensure consistency.
 
 #. Backward Scrub: In which the scrub operation looks at every RADOS object in the
@@ -25,7 +25,7 @@ scrub thereafter).
 Initiate File System Scrub
 ==========================
 
-To start a scrub operation for a directory tree use the following command::
+To start a scrub operation for a directory tree, run a command of the following form::
 
    ceph tell mds.<fsname>:0 scrub start <path> [scrubopts] [tag]
 
@@ -57,7 +57,7 @@ rank 0 and distributed across MDS as appropriate.
 Monitor (ongoing) File System Scrubs
 ====================================
 
-Status of ongoing scrubs can be monitored and polled using in `scrub status`
+Status of ongoing scrubs can be monitored and polled using the ``scrub status``
 command. This commands lists out ongoing scrubs (identified by the tag) along
 with the path and options used to initiate the scrub::
 
@@ -72,10 +72,10 @@ with the path and options used to initiate the scrub::
        }
    }
 
-`status` shows the number of inodes that are scheduled to be scrubbed at any point in time,
-hence, can change on subsequent `scrub status` invocations. Also, a high level summary of
+``status`` shows the number of inodes that are scheduled to be scrubbed at any point in time.
+Hence, it can change on subsequent ``scrub status`` invocations. Also, a high level summary of
 scrub operation (which includes the operation state and paths on which scrub is triggered)
-gets displayed in `ceph status`::
+gets displayed in ``ceph status``::
 
    ceph status
    [...]
@@ -87,7 +87,8 @@ gets displayed in `ceph status`::
    [...]
 
 A scrub is complete when it no longer shows up in this list (although that may
-change in future releases). Any damage will be reported via cluster health warnings.
+change in future releases). Any damage will be reported via
+:ref:`cluster health warnings <cephfs-health-messages>`.
 
 Control (ongoing) File System Scrubs
 ====================================
@@ -116,7 +117,7 @@ Control (ongoing) File System Scrubs
        }
    }
 
-- Resume: Resuming kick starts a paused scrub operation::
+- Resume: Resuming kick-starts a paused scrub operation::
 
    ceph tell mds.cephfs:0 scrub resume
    {
@@ -143,32 +144,32 @@ The types of damage that can be reported and repaired by File System Scrub are:
 
 * BACKTRACE : Inode's backtrace in the data pool is corrupted.
 
-These above named MDS damages can be repaired by using the following command::
+These above named MDS damage types can be repaired by running a command of the following form::
 
     ceph tell mds.<fsname>:0 scrub start /path recursive, repair, force
 
 If scrub is able to repair the damage, the corresponding entry is automatically
 removed from the damage table.
 
-Note: A scrub invoked with the ``repair`` option can identify an damaged hard link but not repair it.
+.. note:: A scrub invoked with the ``repair`` option can identify a damaged hard link but not repair it.
 
 
-Evaluate strays using recursive scrub
+Evaluate Strays Using Recursive Scrub
 =====================================
 
-- In order to evaluate strays i.e. purge stray directories in ``~mdsdir`` use the following command::
+To evaluate strays i.e. purge stray directories in ``~mdsdir``, run a command of the following form::
 
     ceph tell mds.<fsname>:0 scrub start ~mdsdir recursive
 
-- ``~mdsdir`` is not enqueued by default when scrubbing at the CephFS root. In order to perform stray evaluation
-  at root, run scrub with flags ``scrub_mdsdir`` and ``recursive``::
+``~mdsdir`` is not enqueued by default when scrubbing at the CephFS root. To perform stray evaluation
+at root, run scrub with flags ``scrub_mdsdir`` and ``recursive``::
 
     ceph tell mds.<fsname>:0 scrub start / recursive,scrub_mdsdir
 
-Dump stray folder content
-=====================================
+Dump Stray Folder Content
+=========================
 
-- In order to dump stray folder content on a specific MDS, use the following command::
+To dump stray folder content on a specific MDS, run a command of the following form::
 
     ceph tell mds.<fsname>:0 dump stray
     {


### PR DESCRIPTION
Don't use a space in "subdirectory" or "kick-start".

Change command syntax introduction text to the common "To [...], run a command of the following form:" when the syntax has placeholders.

Use double backticks consistently (same as sections in the beginning) for CLI commands, parameters etc.

Linkify "cluster health warnings" to the CephFS health warnings doc.

Use admonition and fix two articles.

Use title case for section titles and trim overly long underline.

Minor improvements to language.

Don't use unordered lists in two cases when there's no real need, especially when there is only a single item in the latter case.

- Before: https://docs.ceph.com/en/latest/cephfs/scrub/
- Rendered PR: https://ceph--65809.org.readthedocs.build/en/65809/cephfs/scrub/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
