### PR TITLE
tentacle: pybind/cephfs, mgr/volumes: introduce non-recursive rmtree(), refactor purge() to use it and add MDS optimizations

### DIFF
--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -1,6 +1,4 @@
 #!/bin/sh -ex
 
-# Running as root because the filesystem root directory will be
-# owned by uid 0, and that's where we're writing.
-sudo python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
+python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
 exit 0

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7688,7 +7688,10 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, InodeRef *end
   return rc;
 }
 
-int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options)
+int Client::path_walk(InodeRef dirinode, const filepath& origpath,
+		      walk_dentry_result* result, const UserPerm& perms,
+		      const PathWalk_ExtraOptions& extra_options,
+		      std::string trimmed_path)
 {
   int rc = 0;
   filepath path = origpath;
@@ -7712,7 +7715,11 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
   int symlinks = 0;
   unsigned i = 0;
 
-  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << path << dendl;
+  if (trimmed_path == "") {
+    std::string trimmed_path = path.get_trimmed_path();
+  }
+
+  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << trimmed_path << dendl;
 
   if (path.depth() == 0) {
     /* diri/dname can also be used as a filepath; or target */
@@ -7726,7 +7733,7 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
     int caps = 0;
     dname = path[i];
     ldout(cct, 10) << " " << i << " " << *diri << " " << dname << dendl;
-    ldout(cct, 20) << "  (path is " << path << ")" << dendl;
+    ldout(cct, 20) << "  (path is " << trimmed_path << ")" << dendl;
     InodeRef next;
     if (!diri.get()->is_dir()) {
       ldout(cct, 20) << diri.get() << " is not a dir inode, name " << dname.c_str() << dendl;
@@ -15400,11 +15407,12 @@ int Client::ll_unlink(Inode *in, const char *name, const UserPerm& perm)
 
 int Client::_rmdir(Inode *dir, const char *name, const UserPerm& perms, bool check_perms)
 {
-  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << name << " uid "
+  std::string trimmed_path = filepath(name).get_trimmed_path();
+  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << trimmed_path << " uid "
 		<< perms.uid() << " gid " << perms.gid() << ")" << dendl;
 
   walk_dentry_result wdr;
-  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}); rc < 0) {
+  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}, trimmed_path); rc < 0) {
     return rc;
   }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1069,7 +1069,7 @@ protected:
     bool is_rename = false;
     bool require_target = true;
   };
-  int path_walk(InodeRef dirinode, const filepath& fp, struct walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options);
+  int path_walk(InodeRef dirinode, const filepath& fp, struct walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options, std::string trimmed_path=std::string());
   int path_walk(InodeRef dirinode, const filepath& fp, InodeRef *end, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options);
 
   // fake inode number for 32-bits ino_t

--- a/src/common/strescape.h
+++ b/src/common/strescape.h
@@ -34,4 +34,21 @@ inline std::string binstrprint(std::string_view sv, size_t maxlen=0)
   return s;
 }
 
+inline std::string get_trimmed_path_str(const std::string& path)
+{
+  // index of '/' before 10th component (count from end of the path).
+  size_t n = 0;
+
+  for (int i = 1; i <= 10; ++i) {
+    n = path.rfind("/", n - 1);
+    if (n == std::string::npos) {
+      // path doesn't contain 10 components, return path as it is.
+      return path;
+      break;
+    }
+  }
+
+  return std::string("..." + path.substr(n, -1));
+}
+
 #endif

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -104,6 +104,21 @@ class filepath {
     trimmed = true;
   }
 
+  /* Trim given path to final 10 components and return it by prefixing it with
+   * "..."  to indicate that the path has been trimmed. */
+  std::string get_trimmed_path() const
+  {
+    std::size_t n = 0;
+    for (int i = 1; i <= 10; ++i) {
+      n = path.rfind("/", n - 1);
+      if (n == std::string::npos) {
+	return std::string(path);
+      }
+    }
+
+    return std::string("..." + path.substr(n, -1));
+  }
+
   void set_path(std::string_view s, inodeno_t b) {
     path = s;
     ino = b;

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -39,6 +39,9 @@
 class filepath {
   inodeno_t ino = 0;   // base inode.  ino=0 implies pure relative path.
   std::string path;     // relative path.
+  // tells get_path() whether it should prefix path with "..." to indicate that
+  // it was shortened.
+  bool trimmed = false;
 
   /** bits - path segments
    * this is ['a', 'b', 'c'] for both the aboslute and relative case.
@@ -92,6 +95,14 @@ class filepath {
    */
   filepath(std::string_view s) { set_path(s); }
   filepath(const char* s) { set_path(s); }
+
+  void set_trimmed() {
+    if (trimmed)
+      return;
+    // indicates that the path has been shortened.
+    path += "...";
+    trimmed = true;
+  }
 
   void set_path(std::string_view s, inodeno_t b) {
     path = s;

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -84,7 +84,7 @@ const LockType CDentry::versionlock_type(CEPH_LOCK_DVERSION);
 ostream& operator<<(ostream& out, const CDentry& dn)
 {
   filepath path;
-  dn.make_path(path);
+  dn.make_trimmed_path(path);
   
   out << "[dentry " << path;
   
@@ -291,13 +291,44 @@ void CDentry::make_path_string(string& s, bool projected,
   s.append(name.data(), name.length());
 }
 
-void CDentry::make_path(filepath& fp, bool projected) const
+/* path_comp_count = path component count. default value is -1 which implies
+ * generate entire path.
+ */
+void CDentry::make_path(filepath& fp, bool projected,
+		        int path_comp_count) const
 {
-  ceph_assert(dir);
-  dir->inode->make_path(fp, projected);
-  fp.push_dentry(get_name());
+  fp.set_trimmed();
+
+  if (path_comp_count == -1) {
+    ceph_assert(dir);
+    dir->inode->make_path(fp, projected, path_comp_count);
+    fp.push_dentry(get_name());
+  } else if (path_comp_count >= 1) {
+    --path_comp_count;
+
+    ceph_assert(dir);
+    dir->inode->make_path(fp, projected, path_comp_count);
+    fp.push_dentry(get_name());
+  }
 }
 
+/* path_comp_count = path component count. default value is 10 which implies
+ * generate entire path.
+ *
+ * XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ */
+void CDentry::make_trimmed_path(filepath& fp, bool projected,
+				int path_comp_count) const
+{
+  make_path(fp, projected, path_comp_count);
+}
 /*
  * we only add ourselves to remote_parents when the linkage is
  * active (no longer projected).  if the passed dnl is projected,

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -291,6 +291,24 @@ void CDentry::make_path_string(string& s, bool projected,
   s.append(name.data(), name.length());
 }
 
+/* path_comp_count = path component count. default value is 10 which implies
+ * generate entire path.
+ *
+ * XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ */
+void CDentry::make_trimmed_path_string(string& s, bool projected,
+				       int path_comp_count) const
+{
+  make_path_string(s, projected, path_comp_count);
+}
+
 /* path_comp_count = path component count. default value is -1 which implies
  * generate entire path.
  */

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -279,10 +279,11 @@ void CDentry::clear_auth()
   }
 }
 
-void CDentry::make_path_string(string& s, bool projected) const
+void CDentry::make_path_string(string& s, bool projected,
+			       int path_comp_count) const
 {
   if (dir) {
-    dir->inode->make_path_string(s, projected);
+    dir->inode->make_path_string(s, projected, NULL, path_comp_count);
   } else {
     s = "???";
   }

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -245,6 +245,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
+  void make_trimmed_path_string(std::string& s, bool projected,
+				int path_comp_count=10) const;
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false,

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -245,7 +245,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
-  void make_path_string(std::string& s, bool projected=false) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false) const;
 
   // -- version --

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -247,7 +247,10 @@ public:
   // misc
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& fp, bool projected=false) const;
+  void make_path(filepath& fp, bool projected=false,
+		 int path_comp_count=-1) const;
+  void make_trimmed_path(filepath& fp, bool projected=false,
+			 int path_comp_count=10) const;
 
   // -- version --
   version_t get_version() const { return version; }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -91,7 +91,7 @@ public:
 
 ostream& operator<<(ostream& out, const CDir& dir)
 {
-  out << "[dir " << dir.dirfrag() << " " << dir.get_path() << "/"
+  out << "[dir " << dir.dirfrag() << " " << dir.get_trimmed_path() << "/"
       << " [" << dir.first << ",head]";
   if (dir.is_auth()) {
     out << " auth";
@@ -2026,7 +2026,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
     dout(0) << "_fetched missing object for " << *this << dendl;
 
     clog->error() << "dir " << dirfrag() << " object missing on disk; some "
-                     "files may be lost (" << get_path() << ")";
+                     "files may be lost (" << get_trimmed_path() << ")";
 
     go_bad(complete);
     return;
@@ -2041,14 +2041,14 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
       derr << "Corrupt fnode in dirfrag " << dirfrag()
 	   << ": " << err.what() << dendl;
       clog->warn() << "Corrupt fnode header in " << dirfrag() << ": "
-		   << err.what() << " (" << get_path() << ")";
+		   << err.what() << " (" << get_trimmed_path() << ")";
       go_bad(complete);
       return;
     }
     if (!p.end()) {
       clog->warn() << "header buffer of dir " << dirfrag() << " has "
 		  << hdrbl.length() - p.get_off() << " extra bytes ("
-                  << get_path() << ")";
+                  << get_trimmed_path() << ")";
       go_bad(complete);
       return;
     }
@@ -2166,7 +2166,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
     } catch (const buffer::error &err) {
       mdcache->mds->clog->warn() << "Corrupt dentry '" << key.name << "' in "
                                   "dir frag " << dirfrag() << ": "
-                               << err.what() << "(" << get_path() << ")";
+                               << err.what() << "(" << get_trimmed_path() << ")";
 
       // Remember that this dentry is damaged.  Subsequent operations
       // that try to act directly on it will get their EIOs, but this
@@ -3790,7 +3790,22 @@ bool CDir::scrub_local()
   return good;
 }
 
-std::string CDir::get_path() const
+/* XXX: Return string containing only final 10 components of the path. This
+ * shortened path is to be used usually for only logging. This prevents the
+ * unnecessary generation of full version of a very long path (imagine a path
+ * with 2000 components) from inode because not only repeatedly printing long
+ * path in logs is unnecessary and unreadable but more importantly because it
+ * is an expensive process (since it's done for more or less individual log
+ * entries).
+ */
+std::string CDir::get_trimmed_path() const
+{
+  std::string path;
+  get_inode()->make_trimmed_path_string(path, true);
+  return path;
+}
+
+std::string CDir::get_path(bool trim_path) const
 {
   std::string path;
   get_inode()->make_path_string(path, true);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -783,7 +783,8 @@ private:
   void steal_dentry(CDentry *dn);  // from another dir.  used by merge/split.
   void finish_old_fragment(std::vector<MDSContext*>& waiters, bool replay);
   void init_fragment_pins();
-  std::string get_path() const;
+  std::string get_trimmed_path() const;
+  std::string get_path(bool trim_path=false) const;
 
   // -- authority --
   /*

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -170,7 +170,7 @@ int num_cinode_locks = sizeof(cinode_lock_info) / sizeof(cinode_lock_info[0]);
 ostream& operator<<(ostream& out, const CInode& in)
 {
   string path;
-  in.make_path_string(path, true);
+  in.make_trimmed_path_string(path);
 
   out << "[inode " << in.ino();
   out << " [" 
@@ -1086,15 +1086,29 @@ bool CInode::is_projected_ancestor_of(const CInode *other) const
  * use_parent is NULL and projected is true, the primary parent's projected
  * inode is used all the way up the path chain. Otherwise the primary parent
  * stable inode is used.
+ *
+ * path_comp_count = path components count. default value is -1, which implies
+ * generate full path.
  */
-void CInode::make_path_string(string& s, bool projected, const CDentry *use_parent) const
+void CInode::make_path_string(string& s, bool projected,
+			      const CDentry *use_parent,
+			      int path_comp_count) const
 {
   if (!use_parent) {
     use_parent = projected ? get_projected_parent_dn() : parent;
   }
 
   if (use_parent) {
-    use_parent->make_path_string(s, projected);
+    if (path_comp_count == -1) {
+      use_parent->make_path_string(s, projected, path_comp_count);
+    } else if (path_comp_count >= 1) {
+      --path_comp_count;
+      use_parent->make_path_string(s, projected, path_comp_count);
+    } else if (path_comp_count == 0) {
+      // this indicates that path has been shortened.
+      s = "...";
+      return;
+    }
   } else if (is_root()) {
     s = "";
   } else if (is_mdsdir()) {
@@ -1109,6 +1123,25 @@ void CInode::make_path_string(string& s, bool projected, const CDentry *use_pare
     snprintf(n, sizeof(n), "#%" PRIx64, eino);
     s += n;
   }
+}
+
+/* XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ *
+ * path_comp_count = path components count. default value is 10, which implies
+ * generate full path.
+ */
+void CInode::make_trimmed_path_string(string& s, bool projected,
+				      const CDentry* use_parent,
+				      int path_comp_count) const
+{
+  make_path_string(s, projected, use_parent, path_comp_count);
 }
 
 void CInode::make_path(filepath& fp, bool projected) const
@@ -2679,7 +2712,7 @@ void CInode::finish_scatter_gather_update(int type, MutationRef& mut)
 
       if (pi->dirstat.nfiles < 0 || pi->dirstat.nsubdirs < 0) {
         std::string path;
-        make_path_string(path);
+	make_trimmed_path_string(path);
 	clog->error() << "Inconsistent statistics detected: fragstat on inode "
                       << ino() << " (" << path << "), inode has " << pi->dirstat;
 	ceph_assert(!"bad/negative fragstat" == g_conf()->mds_verify_scatter);
@@ -4948,7 +4981,7 @@ next:
 
       if (!results->backtrace.passed && in->scrub_infop->header->get_repair()) {
         std::string path;
-        in->make_path_string(path);
+	in->make_trimmed_path_string(path);
         in->mdcache->mds->clog->warn() << "bad backtrace on inode " << in->ino()
                                        << "(" << path << "), rewriting it";
         in->mark_dirty_parent(in->mdcache->mds->mdlog->get_current_segment(),

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1144,12 +1144,12 @@ void CInode::make_trimmed_path_string(string& s, bool projected,
   make_path_string(s, projected, use_parent, path_comp_count);
 }
 
-void CInode::make_path(filepath& fp, bool projected) const
+void CInode::make_path(filepath& fp, bool projected, int path_comp_count) const
 {
   const CDentry *use_parent = projected ? get_projected_parent_dn() : parent;
   if (use_parent) {
     ceph_assert(!is_base());
-    use_parent->make_path(fp, projected);
+    use_parent->make_path(fp, projected, path_comp_count);
   } else {
     fp = filepath(ino());
   }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -723,8 +723,15 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool is_ancestor_of(const CInode *other, std::unordered_map<CInode const*,bool>* visited=nullptr) const;
   bool is_projected_ancestor_of(const CInode *other) const;
 
-  void make_path_string(std::string& s, bool projected=false, const CDentry *use_parent=NULL) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        const CDentry *use_parent=NULL,
+		        int path_comp_count=-1) const;
   void make_path(filepath& s, bool projected=false) const;
+  void make_trimmed_path_string(std::string& s, bool projected=false,
+				const CDentry *use_parent=NULL,
+				int path_comp_count=10) const;
+  void make_path(filepath& s, bool projected=false,
+		 int path_comp_count=-1) const;
   void name_stray_dentry(std::string& dname);
   
   // -- dirtyness --

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -726,7 +726,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void make_path_string(std::string& s, bool projected=false,
 		        const CDentry *use_parent=NULL,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& s, bool projected=false) const;
   void make_trimmed_path_string(std::string& s, bool projected=false,
 				const CDentry *use_parent=NULL,
 				int path_comp_count=10) const;

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -234,9 +234,10 @@ bool MDSAuthCaps::is_capable(string_view fs_name,
 			     const vector<uint64_t> *caller_gid_list,
 			     unsigned mask,
 			     uid_t new_uid, gid_t new_gid,
-			     const entity_addr_t& addr) const
+			     const entity_addr_t& addr,
+			     string_view trimmed_inode_path) const
 {
-  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name << " inode(path /" << inode_path
+  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name << " inode(path /" << trimmed_inode_path
 		 << " owner " << inode_uid << ":" << inode_gid
 		 << " mode 0" << std::oct << inode_mode << std::dec
 		 << ") by caller " << caller_uid << ":" << caller_gid

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -272,7 +272,7 @@ public:
 		  uid_t inode_uid, gid_t inode_gid, unsigned inode_mode,
 		  uid_t uid, gid_t gid, const std::vector<uint64_t> *caller_gid_list,
 		  unsigned mask, uid_t new_uid, gid_t new_gid,
-		  const entity_addr_t& addr) const;
+		  const entity_addr_t& addr, std::string_view trimmed_inode_path) const;
   bool path_capable(std::string_view inode_path) const;
 
   bool fs_name_capable(std::string_view fs_name, unsigned mask) const {

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -508,8 +508,6 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
       ++it; /* trim (in the future) may remove dentry */
 
       if (dn->scrub(next_seq)) {
-        std::string path;
-        dir->get_inode()->make_path_string(path, true);
         clog->warn() << "Scrub error on dentry " << *dn
                      << " see " << g_conf()->name
                      << " log and `damage ls` output for details";

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -61,6 +61,7 @@
 
 #include "include/stringify.h"
 #include "include/filepath.h"
+#include "common/strescape.h"
 #include "common/ceph_json.h"
 #include "common/debug.h"
 #include "common/Timer.h"
@@ -9817,7 +9818,10 @@ void Server::_rename_prepare(const MDRequestRef& mdr,
       {
         std::string t;
         destdn->make_path_string(t, true);
-        dout(20) << " stray_prior_path = " << t << dendl;
+
+	/* Log only 10 final components fo the path to since logging entire
+	 * path is not useful and also reduces readability. */
+        dout(20) << " stray_prior_path = " << get_trimmed_path_str(t) << dendl;
         tpi->stray_prior_path = std::move(t);
       }
       tpi->nlink--;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8964,7 +8964,7 @@ void Server::_rmdir_rollback_finish(const MDRequestRef& mdr, metareqid_t reqid, 
  */
 bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
 {
-  dout(10) << "dir_is_nonempty_unlocked " << *in << dendl;
+  dout(10) << __func__ << " " << *in << dendl;
   ceph_assert(in->is_auth());
 
   if (in->filelock.is_cached())
@@ -8977,7 +8977,7 @@ bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
     // is the frag obviously non-empty?
     if (dir->is_auth()) {
       if (dir->get_projected_fnode()->fragstat.size()) {
-	dout(10) << "dir_is_nonempty_unlocked dirstat has " 
+	dout(10) << __func__ << " dirstat has "
 		 << dir->get_projected_fnode()->fragstat.size() << " items " << *dir << dendl;
 	return true;
       }

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -28,6 +28,7 @@
 #include "common/errno.h"
 #include "common/DecayCounter.h"
 #include "common/perf_counters.h"
+#include "common/strescape.h" // for get_trimmed_path()
 #include "include/ceph_assert.h"
 #include "include/stringify.h"
 
@@ -1120,11 +1121,14 @@ int Session::check_access(std::string_view fs_name, CInode *in, unsigned mask,
     }
   }
 
+  string trimmed_path = "";
   if (!path.empty()) {
     dout(20) << __func__ << " stray_prior_path " << path << dendl;
   } else {
     in->make_path_string(path, true);
-    dout(20) << __func__ << " path " << path << dendl;
+    /* Log only 10 final components fo the path to since logging entire
+     * path is not useful and also reduces readability. */
+    dout(20) << __func__ << " path " << get_trimmed_path_str(path) << dendl;
   }
   if (path.length())
     path = path.substr(1);    // drop leading /
@@ -1140,8 +1144,7 @@ int Session::check_access(std::string_view fs_name, CInode *in, unsigned mask,
 
   if (!auth_caps.is_capable(fs_name, path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
-			    new_uid, new_gid,
-			    info.inst.addr)) {
+			    new_uid, new_gid, info.inst.addr, trimmed_path)) {
     return -EACCES;
   }
   return 0;

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -184,7 +184,7 @@ TEST(MDSAuthCaps, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable(fsname, "foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo/bar"));
 }
 
 TEST(MDSAuthCaps, AllowUid) {
@@ -193,11 +193,11 @@ TEST(MDSAuthCaps, AllowUid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowUidGid) {
@@ -206,24 +206,24 @@ TEST(MDSAuthCaps, AllowUidGid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // user
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // group
   vector<uint64_t> glist10;
@@ -235,59 +235,59 @@ TEST(MDSAuthCaps, AllowUidGid) {
   glist11.push_back(11);
   vector<uint64_t> glist12;
   glist12.push_back(12);
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > group
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // group > other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPath) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * path=/sandbox", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPathChars) {
   MDSAuthCaps unquo_cap;
   ASSERT_TRUE(unquo_cap.parse("allow * path=/sandbox-._foo", NULL));
   ASSERT_FALSE(unquo_cap.allow_all());
-  ASSERT_TRUE(unquo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(unquo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 
@@ -295,21 +295,21 @@ TEST(MDSAuthCaps, AllowPathCharsQuoted) {
   MDSAuthCaps quo_cap;
   ASSERT_TRUE(quo_cap.parse("allow * path=\"/sandbox-._foo\"", NULL));
   ASSERT_FALSE(quo_cap.allow_all());
-  ASSERT_TRUE(quo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(quo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, RootSquash) {
   MDSAuthCaps rs_cap;
   ASSERT_TRUE(rs_cap.parse("allow rw root_squash, allow rw path=/sandbox", NULL));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, OutputParsed) {
@@ -371,7 +371,7 @@ TEST(MDSAuthCaps, network) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
 
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c, "foo"));
 }

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -12,13 +12,26 @@ import stat
 import uuid
 import json
 from datetime import datetime
+from subprocess import getoutput as get_cmd_output
+
 
 cephfs = None
+
 
 def setup_module():
     global cephfs
     cephfs = libcephfs.LibCephFS(conffile='')
+
+    username = get_cmd_output('id -un')
+    uid = get_cmd_output(f'id -u {username}')
+    gid = get_cmd_output(f'id -g {username}')
+    cephfs.conf_set('client_mount_uid', uid)
+    cephfs.conf_set('client_mount_gid', gid)
     cephfs.mount()
+
+    cephfs.conf_set('client_permissions' , 'false')
+    cephfs.chown('/', int(uid), int(gid))
+    cephfs.conf_set('client_permissions' , 'true')
 
 def teardown_module():
     global cephfs
@@ -569,23 +582,6 @@ def test_fchmod(testdir):
     cephfs.close(fd)
     cephfs.unlink(b'/file-fchmod')
 
-def test_fchown(testdir):
-    fd = cephfs.open(b'/file-fchown', 'w', 0o655)
-    uid = os.getuid()
-    gid = os.getgid()
-    assert_raises(TypeError, cephfs.fchown, b'/file-fchown', uid, gid)
-    assert_raises(TypeError, cephfs.fchown, fd, "uid", "gid")
-    cephfs.fchown(fd, uid, gid)
-    st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
-    assert_equal(st["uid"], uid)
-    assert_equal(st["gid"], gid)
-    cephfs.fchown(fd, 9999, 9999)
-    st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
-    assert_equal(st["uid"], 9999)
-    assert_equal(st["gid"], 9999)
-    cephfs.close(fd)
-    cephfs.unlink(b'/file-fchown')
-
 def test_truncate(testdir):
     fd = cephfs.open(b'/file-truncate', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
@@ -720,80 +716,6 @@ def test_preadv_pwritev():
     assert_equal([b"asdf", b"zxcvb"], list(buf))
     cephfs.close(fd)
     cephfs.unlink(b'file-1')
-
-def test_setattrx(testdir):
-    fd = cephfs.open(b'file-setattrx', 'w', 0o655)
-    cephfs.write(fd, b"1111", 0)
-    cephfs.close(fd)
-    st = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE, 0)
-    mode = st["mode"] | stat.S_IXUSR
-    assert_raises(TypeError, cephfs.setattrx, b'file-setattrx', "dict", 0, 0)
-
-    time.sleep(1)
-    statx_dict = dict()
-    statx_dict["mode"] = mode
-    statx_dict["uid"] = 9999
-    statx_dict["gid"] = 9999
-    dt = datetime.now()
-    statx_dict["mtime"] = dt
-    statx_dict["atime"] = dt
-    statx_dict["ctime"] = dt
-    statx_dict["size"] = 10
-    statx_dict["btime"] = dt
-    cephfs.setattrx(b'file-setattrx', statx_dict, libcephfs.CEPH_SETATTR_MODE | libcephfs.CEPH_SETATTR_UID |
-                                                  libcephfs.CEPH_SETATTR_GID | libcephfs.CEPH_SETATTR_MTIME |
-                                                  libcephfs.CEPH_SETATTR_ATIME | libcephfs.CEPH_SETATTR_CTIME |
-                                                  libcephfs.CEPH_SETATTR_SIZE | libcephfs.CEPH_SETATTR_BTIME, 0)
-    st1 = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE | libcephfs.CEPH_STATX_UID |
-                                         libcephfs.CEPH_STATX_GID | libcephfs.CEPH_STATX_MTIME |
-                                         libcephfs.CEPH_STATX_ATIME | libcephfs.CEPH_STATX_CTIME |
-                                         libcephfs.CEPH_STATX_SIZE | libcephfs.CEPH_STATX_BTIME, 0)
-    assert_equal(mode, st1["mode"])
-    assert_equal(9999, st1["uid"])
-    assert_equal(9999, st1["gid"])
-    assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
-    assert_equal(10, st1["size"])
-    cephfs.unlink(b'file-setattrx')
-
-def test_fsetattrx(testdir):
-    fd = cephfs.open(b'file-fsetattrx', 'w', 0o655)
-    cephfs.write(fd, b"1111", 0)
-    st = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE, 0)
-    mode = st["mode"] | stat.S_IXUSR
-    assert_raises(TypeError, cephfs.fsetattrx, fd, "dict", 0, 0)
-
-    time.sleep(1)
-    statx_dict = dict()
-    statx_dict["mode"] = mode
-    statx_dict["uid"] = 9999
-    statx_dict["gid"] = 9999
-    dt = datetime.now()
-    statx_dict["mtime"] = dt
-    statx_dict["atime"] = dt
-    statx_dict["ctime"] = dt
-    statx_dict["size"] = 10
-    statx_dict["btime"] = dt
-    cephfs.fsetattrx(fd, statx_dict, libcephfs.CEPH_SETATTR_MODE | libcephfs.CEPH_SETATTR_UID |
-                                                  libcephfs.CEPH_SETATTR_GID | libcephfs.CEPH_SETATTR_MTIME |
-                                                  libcephfs.CEPH_SETATTR_ATIME | libcephfs.CEPH_SETATTR_CTIME |
-                                                  libcephfs.CEPH_SETATTR_SIZE | libcephfs.CEPH_SETATTR_BTIME)
-    st1 = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE | libcephfs.CEPH_STATX_UID |
-                                         libcephfs.CEPH_STATX_GID | libcephfs.CEPH_STATX_MTIME |
-                                         libcephfs.CEPH_STATX_ATIME | libcephfs.CEPH_STATX_CTIME |
-                                         libcephfs.CEPH_STATX_SIZE | libcephfs.CEPH_STATX_BTIME, 0)
-    assert_equal(mode, st1["mode"])
-    assert_equal(9999, st1["uid"])
-    assert_equal(9999, st1["gid"])
-    assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
-    assert_equal(10, st1["size"])
-    cephfs.close(fd)
-    cephfs.unlink(b'file-fsetattrx')
 
 def test_get_layout(testdir):
     fd = cephfs.open(b'file-get-layout', 'w', 0o755)
@@ -940,6 +862,260 @@ def test_multi_target_command():
     if isinstance(mds_status, list): # if multi target command result
         for mds_sessions in session_map:
             assert(list(mds_sessions.keys())[0].startswith('mds.'))
+
+
+class TestWithRootUser:
+
+    def setup_method(self):
+        cephfs.unmount()
+        cephfs.conf_set('client_mount_uid', '0')
+        cephfs.conf_set('client_mount_gid', '0')
+        cephfs.mount()
+
+        cephfs.conf_set('client_permissions' , 'false')
+        cephfs.chown('/', 0, 0)
+        cephfs.conf_set('client_permissions' , 'true')
+
+    def teardown_method(self):
+        cephfs.unmount()
+
+        username = get_cmd_output('id -un')
+        uid = get_cmd_output(f'id -u {username}')
+        gid = get_cmd_output(f'id -g {username}')
+
+        cephfs.conf_set('client_mount_uid', uid)
+        cephfs.conf_set('client_mount_gid', gid)
+        cephfs.mount()
+
+        cephfs.conf_set('client_permissions' , 'false')
+        cephfs.chown('/', int(uid), int(gid))
+        cephfs.conf_set('client_permissions' , 'true')
+
+    def test_chown(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        uid = 1012
+        gid = 1012
+        cephfs.chown('file1', uid, gid)
+        st = cephfs.stat(b'/file1')
+        assert_equal(st.st_uid, uid)
+        assert_equal(st.st_gid, gid)
+
+    def test_chown_change_uid_but_not_gid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        st1 = cephfs.stat(b'/file1')
+
+        uid = 1012
+        cephfs.chown('file1', uid, -1)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_uid, uid)
+
+        # ensure that gid is unchaged.
+        assert_equal(st1.st_gid, st2.st_gid)
+
+    def test_chown_change_gid_but_not_uid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        st1 = cephfs.stat(b'/file1')
+
+        gid = 1012
+        cephfs.chown('file1', -1, gid)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_gid, gid)
+
+        # ensure that uid is unchaged.
+        assert_equal(st1.st_uid, st2.st_uid)
+
+    def test_lchown(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file1', 'slink1')
+
+        uid = 1012
+        gid = 1012
+        cephfs.lchown('slink1', uid, gid)
+        st = cephfs.lstat(b'/slink1')
+        assert_equal(st.st_uid, uid)
+        assert_equal(st.st_gid, gid)
+
+    def test_lchown_change_uid_but_not_gid(testdir):
+        fd = cephfs.open('file2', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file2', 'slink2')
+
+        st1 = cephfs.lstat(b'slink2')
+
+        uid = 1012
+        cephfs.lchown('slink2', uid, -1)
+        st2 = cephfs.lstat(b'/slink2')
+        assert_equal(st2.st_uid, uid)
+
+        # ensure that gid is unchaged.
+        assert_equal(st1.st_gid, st2.st_gid)
+
+    def test_lchown_change_gid_but_not_uid(testdir):
+        fd = cephfs.open('file3', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file3', 'slink3')
+
+        st1 = cephfs.lstat(b'slink3')
+
+        gid = 1012
+        cephfs.lchown('slink3', -1, gid)
+        st2 = cephfs.lstat(b'/slink3')
+        assert_equal(st2.st_gid, gid)
+
+        # ensure that uid is unchaged.
+        assert_equal(st1.st_uid, st2.st_uid)
+
+    def test_fchown(testdir):
+        fd = cephfs.open(b'/file-fchown', 'w', 0o655)
+        uid = os.getuid()
+        gid = os.getgid()
+        assert_raises(TypeError, cephfs.fchown, b'/file-fchown', uid, gid)
+        assert_raises(TypeError, cephfs.fchown, fd, "uid", "gid")
+        cephfs.fchown(fd, uid, gid)
+        st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
+        assert_equal(st["uid"], uid)
+        assert_equal(st["gid"], gid)
+        cephfs.fchown(fd, 9999, 9999)
+        st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
+        assert_equal(st["uid"], 9999)
+        assert_equal(st["gid"], 9999)
+        cephfs.close(fd)
+        cephfs.unlink(b'/file-fchown')
+
+    def test_fchown_change_uid_but_not_gid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+
+        st1 = cephfs.stat(b'/file1')
+
+        uid = 1012
+        cephfs.fchown(fd, uid, -1)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_uid, uid)
+
+        # ensure that uid is unchanged.
+        assert_equal(st1.st_gid, st2.st_gid)
+
+        cephfs.close(fd)
+
+    def test_fchown_change_gid_but_not_uid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+
+        st1 = cephfs.stat(b'/file1')
+
+        gid = 1012
+        cephfs.chown('file1', -1, gid)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_gid, gid)
+
+        # ensure that gid is unchanged.
+        assert_equal(st1.st_uid, st2.st_uid)
+
+        cephfs.close(fd)
+
+    def test_setattrx(testdir):
+        fd = cephfs.open(b'file-setattrx', 'w', 0o655)
+        cephfs.write(fd, b"1111", 0)
+        cephfs.close(fd)
+        st = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE, 0)
+        mode = st["mode"] | stat.S_IXUSR
+        assert_raises(TypeError, cephfs.setattrx, b'file-setattrx', "dict", 0, 0)
+
+        time.sleep(1)
+        statx_dict = dict()
+        statx_dict["mode"] = mode
+        statx_dict["uid"] = 9999
+        statx_dict["gid"] = 9999
+        dt = datetime.now()
+        statx_dict["mtime"] = dt
+        statx_dict["atime"] = dt
+        statx_dict["ctime"] = dt
+        statx_dict["size"] = 10
+        statx_dict["btime"] = dt
+        cephfs.setattrx(b'file-setattrx', statx_dict, libcephfs.CEPH_SETATTR_MODE |
+                                                      libcephfs.CEPH_SETATTR_UID |
+                                                      libcephfs.CEPH_SETATTR_GID |
+                                                      libcephfs.CEPH_SETATTR_MTIME |
+                                                      libcephfs.CEPH_SETATTR_ATIME |
+                                                      libcephfs.CEPH_SETATTR_CTIME |
+                                                      libcephfs.CEPH_SETATTR_SIZE |
+                                                      libcephfs.CEPH_SETATTR_BTIME, 0)
+        st1 = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE |
+                                             libcephfs.CEPH_STATX_UID |
+                                             libcephfs.CEPH_STATX_GID |
+                                             libcephfs.CEPH_STATX_MTIME |
+                                             libcephfs.CEPH_STATX_ATIME |
+                                             libcephfs.CEPH_STATX_CTIME |
+                                             libcephfs.CEPH_STATX_SIZE |
+                                             libcephfs.CEPH_STATX_BTIME, 0)
+        assert_equal(mode, st1["mode"])
+        assert_equal(9999, st1["uid"])
+        assert_equal(9999, st1["gid"])
+        assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
+        assert_equal(10, st1["size"])
+        cephfs.unlink(b'file-setattrx')
+
+    def test_fsetattrx(testdir):
+        fd = cephfs.open(b'file-fsetattrx', 'w', 0o655)
+        cephfs.write(fd, b"1111", 0)
+        st = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE, 0)
+        mode = st["mode"] | stat.S_IXUSR
+        assert_raises(TypeError, cephfs.fsetattrx, fd, "dict", 0, 0)
+
+        time.sleep(1)
+        statx_dict = dict()
+        statx_dict["mode"] = mode
+        statx_dict["uid"] = 9999
+        statx_dict["gid"] = 9999
+        dt = datetime.now()
+        statx_dict["mtime"] = dt
+        statx_dict["atime"] = dt
+        statx_dict["ctime"] = dt
+        statx_dict["size"] = 10
+        statx_dict["btime"] = dt
+        cephfs.fsetattrx(fd, statx_dict, libcephfs.CEPH_SETATTR_MODE |
+                                         libcephfs.CEPH_SETATTR_UID |
+                                         libcephfs.CEPH_SETATTR_GID |
+                                         libcephfs.CEPH_SETATTR_MTIME |
+                                         libcephfs.CEPH_SETATTR_ATIME |
+                                         libcephfs.CEPH_SETATTR_CTIME |
+                                         libcephfs.CEPH_SETATTR_SIZE |
+                                         libcephfs.CEPH_SETATTR_BTIME)
+        st1 = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE |
+                                              libcephfs.CEPH_STATX_UID |
+                                              libcephfs.CEPH_STATX_GID |
+                                              libcephfs.CEPH_STATX_MTIME |
+                                              libcephfs.CEPH_STATX_ATIME |
+                                              libcephfs.CEPH_STATX_CTIME |
+                                              libcephfs.CEPH_STATX_SIZE |
+                                              libcephfs.CEPH_STATX_BTIME, 0)
+        assert_equal(mode, st1["mode"])
+        assert_equal(9999, st1["uid"])
+        assert_equal(9999, st1["gid"])
+        assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
+        assert_equal(10, st1["size"])
+        cephfs.close(fd)
+        cephfs.unlink(b'file-fsetattrx')
 
 
 class TestRmtree:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73391, https://tracker.ceph.com/issues/73399, https://tracker.ceph.com/issues/73396

---

backport of https://github.com/ceph/ceph/pull/63917
parent tracker: https://tracker.ceph.com/issues/71648, https://tracker.ceph.com/issues/72779, https://tracker.ceph.com/issues/72993

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh