### PR TITLE
tentacle: mgr/dashboard: raise exception if both size and rbd_image_size are being passed in ns add

### DIFF
--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9389,7 +9389,7 @@ paths:
                   description: Read only namespace
                   type: string
                 size:
-                  description: RBD image size
+                  description: Deprecated. Use `rbd_image_size` instead
                   type: integer
                 traddr:
                   description: Target gateway address
@@ -9423,7 +9423,7 @@ paths:
             trace.
       security:
       - jwt: []
-      summary: Create a new NVMeoF namespace
+      summary: Create a new NVMeoF namespace.
       tags:
       - NVMe-oF Subsystem Namespace
   /api/nvmeof/subsystem/{nqn}/namespace/{nsid}:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73400

---

backport of https://github.com/ceph/ceph/pull/65676
parent tracker: https://tracker.ceph.com/issues/72679

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh