### PR TITLE
squid: pybind/cephfs, mgr/volumes: introduce non-recursive rmtree(), refactor purge() to use it and add MDS optimizations

### DIFF
--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -1,6 +1,4 @@
 #!/bin/sh -ex
 
-# Running as root because the filesystem root directory will be
-# owned by uid 0, and that's where we're writing.
-sudo python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
+python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
 exit 0

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7663,7 +7663,10 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, InodeRef *end
   return rc;
 }
 
-int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options)
+int Client::path_walk(InodeRef dirinode, const filepath& origpath,
+		      walk_dentry_result* result, const UserPerm& perms,
+		      const PathWalk_ExtraOptions& extra_options,
+		      std::string trimmed_path)
 {
   int rc = 0;
   filepath path = origpath;
@@ -7687,7 +7690,11 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
   int symlinks = 0;
   unsigned i = 0;
 
-  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << path << dendl;
+  if (trimmed_path == "") {
+    std::string trimmed_path = path.get_trimmed_path();
+  }
+
+  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << trimmed_path << dendl;
 
   if (path.depth() == 0) {
     /* diri/dname can also be used as a filepath; or target */
@@ -7701,7 +7708,7 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
     int caps = 0;
     dname = path[i];
     ldout(cct, 10) << " " << i << " " << *diri << " " << dname << dendl;
-    ldout(cct, 20) << "  (path is " << path << ")" << dendl;
+    ldout(cct, 20) << "  (path is " << trimmed_path << ")" << dendl;
     InodeRef next;
     if (should_check_perms()) {
       int r = may_lookup(diri.get(), perms);
@@ -15305,11 +15312,12 @@ int Client::ll_unlink(Inode *in, const char *name, const UserPerm& perm)
 
 int Client::_rmdir(Inode *dir, const char *name, const UserPerm& perms, bool check_perms)
 {
-  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << name << " uid "
+  std::string trimmed_path = filepath(name).get_trimmed_path();
+  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << trimmed_path << " uid "
 		<< perms.uid() << " gid " << perms.gid() << ")" << dendl;
 
   walk_dentry_result wdr;
-  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}); rc < 0) {
+  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}, trimmed_path); rc < 0) {
     return rc;
   }
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7672,7 +7672,10 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, InodeRef *end
   return rc;
 }
 
-int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options)
+int Client::path_walk(InodeRef dirinode, const filepath& origpath,
+		      walk_dentry_result* result, const UserPerm& perms,
+		      const PathWalk_ExtraOptions& extra_options,
+		      std::string trimmed_path)
 {
   int rc = 0;
   filepath path = origpath;
@@ -7696,7 +7699,11 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
   int symlinks = 0;
   unsigned i = 0;
 
-  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << path << dendl;
+  if (trimmed_path == "") {
+    std::string trimmed_path = path.get_trimmed_path();
+  }
+
+  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << trimmed_path << dendl;
 
   if (path.depth() == 0) {
     /* diri/dname can also be used as a filepath; or target */
@@ -7710,7 +7717,7 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
     int caps = 0;
     dname = path[i];
     ldout(cct, 10) << " " << i << " " << *diri << " " << dname << dendl;
-    ldout(cct, 20) << "  (path is " << path << ")" << dendl;
+    ldout(cct, 20) << "  (path is " << trimmed_path << ")" << dendl;
     InodeRef next;
     if (!diri.get()->is_dir()) {
       ldout(cct, 20) << diri.get() << " is not a dir inode, name " << dname.c_str() << dendl;
@@ -15338,11 +15345,12 @@ int Client::ll_unlink(Inode *in, const char *name, const UserPerm& perm)
 
 int Client::_rmdir(Inode *dir, const char *name, const UserPerm& perms, bool check_perms)
 {
-  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << name << " uid "
+  std::string trimmed_path = filepath(name).get_trimmed_path();
+  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << trimmed_path << " uid "
 		<< perms.uid() << " gid " << perms.gid() << ")" << dendl;
 
   walk_dentry_result wdr;
-  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}); rc < 0) {
+  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}, trimmed_path); rc < 0) {
     return rc;
   }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1062,7 +1062,7 @@ protected:
     bool is_rename = false;
     bool require_target = true;
   };
-  int path_walk(InodeRef dirinode, const filepath& fp, struct walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options);
+  int path_walk(InodeRef dirinode, const filepath& fp, struct walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options, std::string trimmed_path=std::string());
   int path_walk(InodeRef dirinode, const filepath& fp, InodeRef *end, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options);
 
   // fake inode number for 32-bits ino_t

--- a/src/common/strescape.h
+++ b/src/common/strescape.h
@@ -34,4 +34,21 @@ inline std::string binstrprint(std::string_view sv, size_t maxlen=0)
   return s;
 }
 
+inline std::string get_trimmed_path_str(const std::string& path)
+{
+  // index of '/' before 10th component (count from end of the path).
+  size_t n = 0;
+
+  for (int i = 1; i <= 10; ++i) {
+    n = path.rfind("/", n - 1);
+    if (n == std::string::npos) {
+      // path doesn't contain 10 components, return path as it is.
+      return path;
+      break;
+    }
+  }
+
+  return std::string("..." + path.substr(n, -1));
+}
+
 #endif

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -104,6 +104,21 @@ class filepath {
     trimmed = true;
   }
 
+  /* Trim given path to final 10 components and return it by prefixing it with
+   * "..."  to indicate that the path has been trimmed. */
+  std::string get_trimmed_path() const
+  {
+    std::size_t n = 0;
+    for (int i = 1; i <= 10; ++i) {
+      n = path.rfind("/", n - 1);
+      if (n == std::string::npos) {
+	return std::string(path);
+      }
+    }
+
+    return std::string("..." + path.substr(n, -1));
+  }
+
   void set_path(std::string_view s, inodeno_t b) {
     path = s;
     ino = b;

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -39,6 +39,9 @@
 class filepath {
   inodeno_t ino = 0;   // base inode.  ino=0 implies pure relative path.
   std::string path;     // relative path.
+  // tells get_path() whether it should prefix path with "..." to indicate that
+  // it was shortened.
+  bool trimmed = false;
 
   /** bits - path segments
    * this is ['a', 'b', 'c'] for both the aboslute and relative case.
@@ -92,6 +95,14 @@ class filepath {
    */
   filepath(std::string_view s) { set_path(s); }
   filepath(const char* s) { set_path(s); }
+
+  void set_trimmed() {
+    if (trimmed)
+      return;
+    // indicates that the path has been shortened.
+    path += "...";
+    trimmed = true;
+  }
 
   void set_path(std::string_view s, inodeno_t b) {
     path = s;

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -254,6 +254,24 @@ void CDentry::make_path_string(string& s, bool projected,
   s.append(name.data(), name.length());
 }
 
+/* path_comp_count = path component count. default value is 10 which implies
+ * generate entire path.
+ *
+ * XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ */
+void CDentry::make_trimmed_path_string(string& s, bool projected,
+				       int path_comp_count) const
+{
+  make_path_string(s, projected, path_comp_count);
+}
+
 /* path_comp_count = path component count. default value is -1 which implies
  * generate entire path.
  */

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -47,7 +47,7 @@ const LockType CDentry::versionlock_type(CEPH_LOCK_DVERSION);
 ostream& operator<<(ostream& out, const CDentry& dn)
 {
   filepath path;
-  dn.make_path(path);
+  dn.make_trimmed_path(path);
   
   out << "[dentry " << path;
   
@@ -254,13 +254,44 @@ void CDentry::make_path_string(string& s, bool projected,
   s.append(name.data(), name.length());
 }
 
-void CDentry::make_path(filepath& fp, bool projected) const
+/* path_comp_count = path component count. default value is -1 which implies
+ * generate entire path.
+ */
+void CDentry::make_path(filepath& fp, bool projected,
+		        int path_comp_count) const
 {
-  ceph_assert(dir);
-  dir->inode->make_path(fp, projected);
-  fp.push_dentry(get_name());
+  fp.set_trimmed();
+
+  if (path_comp_count == -1) {
+    ceph_assert(dir);
+    dir->inode->make_path(fp, projected, path_comp_count);
+    fp.push_dentry(get_name());
+  } else if (path_comp_count >= 1) {
+    --path_comp_count;
+
+    ceph_assert(dir);
+    dir->inode->make_path(fp, projected, path_comp_count);
+    fp.push_dentry(get_name());
+  }
 }
 
+/* path_comp_count = path component count. default value is 10 which implies
+ * generate entire path.
+ *
+ * XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ */
+void CDentry::make_trimmed_path(filepath& fp, bool projected,
+				int path_comp_count) const
+{
+  make_path(fp, projected, path_comp_count);
+}
 /*
  * we only add ourselves to remote_parents when the linkage is
  * active (no longer projected).  if the passed dnl is projected,

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -242,10 +242,11 @@ void CDentry::clear_auth()
   }
 }
 
-void CDentry::make_path_string(string& s, bool projected) const
+void CDentry::make_path_string(string& s, bool projected,
+			       int path_comp_count) const
 {
   if (dir) {
-    dir->inode->make_path_string(s, projected);
+    dir->inode->make_path_string(s, projected, NULL, path_comp_count);
   } else {
     s = "???";
   }

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -239,6 +239,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
+  void make_trimmed_path_string(std::string& s, bool projected,
+				int path_comp_count=10) const;
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false,

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -239,7 +239,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
-  void make_path_string(std::string& s, bool projected=false) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false) const;
 
   // -- version --

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -240,7 +240,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
-  void make_path_string(std::string& s, bool projected=false) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false) const;
 
   // -- version --

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -241,7 +241,10 @@ public:
   // misc
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& fp, bool projected=false) const;
+  void make_path(filepath& fp, bool projected=false,
+		 int path_comp_count=-1) const;
+  void make_trimmed_path(filepath& fp, bool projected=false,
+			 int path_comp_count=10) const;
 
   // -- version --
   version_t get_version() const { return version; }

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -240,6 +240,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
+  void make_trimmed_path_string(std::string& s, bool projected,
+				int path_comp_count=10) const;
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false,

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -242,7 +242,10 @@ public:
   // misc
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& fp, bool projected=false) const;
+  void make_path(filepath& fp, bool projected=false,
+		 int path_comp_count=-1) const;
+  void make_trimmed_path(filepath& fp, bool projected=false,
+			 int path_comp_count=10) const;
 
   // -- version --
   version_t get_version() const { return version; }

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -783,7 +783,8 @@ private:
   void steal_dentry(CDentry *dn);  // from another dir.  used by merge/split.
   void finish_old_fragment(MDSContext::vec& waiters, bool replay);
   void init_fragment_pins();
-  std::string get_path() const;
+  std::string get_trimmed_path() const;
+  std::string get_path(bool trim_path=false) const;
 
   // -- authority --
   /*

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -785,7 +785,8 @@ private:
   void steal_dentry(CDentry *dn);  // from another dir.  used by merge/split.
   void finish_old_fragment(MDSContext::vec& waiters, bool replay);
   void init_fragment_pins();
-  std::string get_path() const;
+  std::string get_trimmed_path() const;
+  std::string get_path(bool trim_path=false) const;
 
   // -- authority --
   /*

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -151,7 +151,7 @@ int num_cinode_locks = sizeof(cinode_lock_info) / sizeof(cinode_lock_info[0]);
 ostream& operator<<(ostream& out, const CInode& in)
 {
   string path;
-  in.make_path_string(path, true);
+  in.make_trimmed_path_string(path);
 
   out << "[inode " << in.ino();
   out << " [" 
@@ -1031,15 +1031,29 @@ bool CInode::is_projected_ancestor_of(const CInode *other) const
  * use_parent is NULL and projected is true, the primary parent's projected
  * inode is used all the way up the path chain. Otherwise the primary parent
  * stable inode is used.
+ *
+ * path_comp_count = path components count. default value is -1, which implies
+ * generate full path.
  */
-void CInode::make_path_string(string& s, bool projected, const CDentry *use_parent) const
+void CInode::make_path_string(string& s, bool projected,
+			      const CDentry *use_parent,
+			      int path_comp_count) const
 {
   if (!use_parent) {
     use_parent = projected ? get_projected_parent_dn() : parent;
   }
 
   if (use_parent) {
-    use_parent->make_path_string(s, projected);
+    if (path_comp_count == -1) {
+      use_parent->make_path_string(s, projected, path_comp_count);
+    } else if (path_comp_count >= 1) {
+      --path_comp_count;
+      use_parent->make_path_string(s, projected, path_comp_count);
+    } else if (path_comp_count == 0) {
+      // this indicates that path has been shortened.
+      s = "...";
+      return;
+    }
   } else if (is_root()) {
     s = "";
   } else if (is_mdsdir()) {
@@ -1054,6 +1068,25 @@ void CInode::make_path_string(string& s, bool projected, const CDentry *use_pare
     snprintf(n, sizeof(n), "#%" PRIx64, eino);
     s += n;
   }
+}
+
+/* XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ *
+ * path_comp_count = path components count. default value is 10, which implies
+ * generate full path.
+ */
+void CInode::make_trimmed_path_string(string& s, bool projected,
+				      const CDentry* use_parent,
+				      int path_comp_count) const
+{
+  make_path_string(s, projected, use_parent, path_comp_count);
 }
 
 void CInode::make_path(filepath& fp, bool projected) const
@@ -2624,7 +2657,7 @@ void CInode::finish_scatter_gather_update(int type, MutationRef& mut)
 
       if (pi->dirstat.nfiles < 0 || pi->dirstat.nsubdirs < 0) {
         std::string path;
-        make_path_string(path);
+	make_trimmed_path_string(path);
 	clog->error() << "Inconsistent statistics detected: fragstat on inode "
                       << ino() << " (" << path << "), inode has " << pi->dirstat;
 	ceph_assert(!"bad/negative fragstat" == g_conf()->mds_verify_scatter);
@@ -4879,7 +4912,7 @@ next:
 
       if (!results->backtrace.passed && in->scrub_infop->header->get_repair()) {
         std::string path;
-        in->make_path_string(path);
+	in->make_trimmed_path_string(path);
         in->mdcache->mds->clog->warn() << "bad backtrace on inode " << in->ino()
                                        << "(" << path << "), rewriting it";
         in->mark_dirty_parent(in->mdcache->mds->mdlog->get_current_segment(),

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1089,12 +1089,12 @@ void CInode::make_trimmed_path_string(string& s, bool projected,
   make_path_string(s, projected, use_parent, path_comp_count);
 }
 
-void CInode::make_path(filepath& fp, bool projected) const
+void CInode::make_path(filepath& fp, bool projected, int path_comp_count) const
 {
   const CDentry *use_parent = projected ? get_projected_parent_dn() : parent;
   if (use_parent) {
     ceph_assert(!is_base());
-    use_parent->make_path(fp, projected);
+    use_parent->make_path(fp, projected, path_comp_count);
   } else {
     fp = filepath(ino());
   }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -721,7 +721,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void make_path_string(std::string& s, bool projected=false,
 		        const CDentry *use_parent=NULL,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& s, bool projected=false) const;
   void make_trimmed_path_string(std::string& s, bool projected=false,
 				const CDentry *use_parent=NULL,
 				int path_comp_count=10) const;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -718,8 +718,15 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool is_ancestor_of(const CInode *other, std::unordered_map<CInode const*,bool>* visited=nullptr) const;
   bool is_projected_ancestor_of(const CInode *other) const;
 
-  void make_path_string(std::string& s, bool projected=false, const CDentry *use_parent=NULL) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        const CDentry *use_parent=NULL,
+		        int path_comp_count=-1) const;
   void make_path(filepath& s, bool projected=false) const;
+  void make_trimmed_path_string(std::string& s, bool projected=false,
+				const CDentry *use_parent=NULL,
+				int path_comp_count=10) const;
+  void make_path(filepath& s, bool projected=false,
+		 int path_comp_count=-1) const;
   void name_stray_dentry(std::string& dname);
   
   // -- dirtyness --

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -722,7 +722,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void make_path_string(std::string& s, bool projected=false,
 		        const CDentry *use_parent=NULL,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& s, bool projected=false) const;
   void make_trimmed_path_string(std::string& s, bool projected=false,
 				const CDentry *use_parent=NULL,
 				int path_comp_count=10) const;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -719,8 +719,15 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool is_ancestor_of(const CInode *other, std::unordered_map<CInode const*,bool>* visited=nullptr) const;
   bool is_projected_ancestor_of(const CInode *other) const;
 
-  void make_path_string(std::string& s, bool projected=false, const CDentry *use_parent=NULL) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        const CDentry *use_parent=NULL,
+		        int path_comp_count=-1) const;
   void make_path(filepath& s, bool projected=false) const;
+  void make_trimmed_path_string(std::string& s, bool projected=false,
+				const CDentry *use_parent=NULL,
+				int path_comp_count=10) const;
+  void make_path(filepath& s, bool projected=false,
+		 int path_comp_count=-1) const;
   void name_stray_dentry(std::string& dname);
   
   // -- dirtyness --

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -231,9 +231,10 @@ bool MDSAuthCaps::is_capable(string_view inode_path,
 			     const vector<uint64_t> *caller_gid_list,
 			     unsigned mask,
 			     uid_t new_uid, gid_t new_gid,
-			     const entity_addr_t& addr) const
+			     const entity_addr_t& addr,
+			     string_view trimmed_inode_path) const
 {
-  ldout(g_ceph_context, 10) << __func__ << " inode(path /" << inode_path
+  ldout(g_ceph_context, 10) << __func__ << " inode(path /" << trimmed_inode_path
 		 << " owner " << inode_uid << ":" << inode_gid
 		 << " mode 0" << std::oct << inode_mode << std::dec
 		 << ") by caller " << caller_uid << ":" << caller_gid

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -237,9 +237,11 @@ bool MDSAuthCaps::is_capable(string_view fs_name,
 			     const vector<uint64_t> *caller_gid_list,
 			     unsigned mask,
 			     uid_t new_uid, gid_t new_gid,
-			     const entity_addr_t& addr) const
+			     const entity_addr_t& addr,
+			     string_view trimmed_inode_path) const
 {
-  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name << " inode(path /" << inode_path
+  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name
+                 << " inode(path /" << trimmed_inode_path
 		 << " owner " << inode_uid << ":" << inode_gid
 		 << " mode 0" << std::oct << inode_mode << std::dec
 		 << ") by caller " << caller_uid << ":" << caller_gid

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -271,7 +271,7 @@ public:
 		  uid_t inode_uid, gid_t inode_gid, unsigned inode_mode,
 		  uid_t uid, gid_t gid, const std::vector<uint64_t> *caller_gid_list,
 		  unsigned mask, uid_t new_uid, gid_t new_gid,
-		  const entity_addr_t& addr) const;
+		  const entity_addr_t& addr, std::string_view trimmed_inode_path) const;
   bool path_capable(std::string_view inode_path) const;
 
   bool fs_name_capable(std::string_view fs_name, unsigned mask) const {

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -273,7 +273,7 @@ public:
 		  uid_t inode_uid, gid_t inode_gid, unsigned inode_mode,
 		  uid_t uid, gid_t gid, const std::vector<uint64_t> *caller_gid_list,
 		  unsigned mask, uid_t new_uid, gid_t new_gid,
-		  const entity_addr_t& addr) const;
+		  const entity_addr_t& addr, std::string_view trimmed_inode_path) const;
   bool path_capable(std::string_view inode_path) const;
 
   bool fs_name_capable(std::string_view fs_name, unsigned mask) const {

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -435,8 +435,6 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *done)
       ++it; /* trim (in the future) may remove dentry */
 
       if (dn->scrub(next_seq)) {
-        std::string path;
-        dir->get_inode()->make_path_string(path, true);
         clog->warn() << "Scrub error on dentry " << *dn
                      << " see " << g_conf()->name
                      << " log and `damage ls` output for details";

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8886,7 +8886,7 @@ void Server::_rmdir_rollback_finish(const MDRequestRef& mdr, metareqid_t reqid, 
  */
 bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
 {
-  dout(10) << "dir_is_nonempty_unlocked " << *in << dendl;
+  dout(10) << __func__ << " " << *in << dendl;
   ceph_assert(in->is_auth());
 
   if (in->filelock.is_cached())
@@ -8899,7 +8899,7 @@ bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
     // is the frag obviously non-empty?
     if (dir->is_auth()) {
       if (dir->get_projected_fnode()->fragstat.size()) {
-	dout(10) << "dir_is_nonempty_unlocked dirstat has " 
+	dout(10) << __func__ << " dirstat has "
 		 << dir->get_projected_fnode()->fragstat.size() << " items " << *dir << dendl;
 	return true;
       }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -47,6 +47,7 @@
 #include "include/stringify.h"
 #include "include/filepath.h"
 #include "common/errno.h"
+#include "common/strescape.h"
 #include "common/Timer.h"
 #include "common/perf_counters.h"
 #include "include/compat.h"
@@ -9739,7 +9740,10 @@ void Server::_rename_prepare(const MDRequestRef& mdr,
       {
         std::string t;
         destdn->make_path_string(t, true);
-        dout(20) << " stray_prior_path = " << t << dendl;
+
+	/* Log only 10 final components fo the path to since logging entire
+	 * path is not useful and also reduces readability. */
+        dout(20) << " stray_prior_path = " << get_trimmed_path_str(t) << dendl;
         tpi->stray_prior_path = std::move(t);
       }
       tpi->nlink--;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -47,6 +47,7 @@
 #include "include/stringify.h"
 #include "include/filepath.h"
 #include "common/errno.h"
+#include "common/strescape.h"
 #include "common/Timer.h"
 #include "common/perf_counters.h"
 #include "include/compat.h"
@@ -9775,7 +9776,10 @@ void Server::_rename_prepare(const MDRequestRef& mdr,
       {
         std::string t;
         destdn->make_path_string(t, true);
-        dout(20) << " stray_prior_path = " << t << dendl;
+
+	/* Log only 10 final components fo the path to since logging entire
+	 * path is not useful and also reduces readability. */
+        dout(20) << " stray_prior_path = " << get_trimmed_path_str(t) << dendl;
         tpi->stray_prior_path = std::move(t);
       }
       tpi->nlink--;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8920,7 +8920,7 @@ void Server::_rmdir_rollback_finish(const MDRequestRef& mdr, metareqid_t reqid, 
  */
 bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
 {
-  dout(10) << "dir_is_nonempty_unlocked " << *in << dendl;
+  dout(10) << __func__ << " " << *in << dendl;
   ceph_assert(in->is_auth());
 
   if (in->filelock.is_cached())
@@ -8933,7 +8933,7 @@ bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
     // is the frag obviously non-empty?
     if (dir->is_auth()) {
       if (dir->get_projected_fnode()->fragstat.size()) {
-	dout(10) << "dir_is_nonempty_unlocked dirstat has " 
+	dout(10) << __func__ << " dirstat has "
 		 << dir->get_projected_fnode()->fragstat.size() << " items " << *dir << dendl;
 	return true;
       }

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -22,6 +22,7 @@
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/DecayCounter.h"
+#include "common/strescape.h" // for get_trimmed_path()
 #include "include/ceph_assert.h"
 #include "include/stringify.h"
 
@@ -1068,11 +1069,14 @@ int Session::check_access(CInode *in, unsigned mask,
     }
   }
 
+  string trimmed_path = "";
   if (!path.empty()) {
     dout(20) << __func__ << " stray_prior_path " << path << dendl;
   } else {
     in->make_path_string(path, true);
-    dout(20) << __func__ << " path " << path << dendl;
+    /* Log only 10 final components fo the path to since logging entire
+     * path is not useful and also reduces readability. */
+    dout(20) << __func__ << " path " << get_trimmed_path_str(path) << dendl;
   }
   if (path.length())
     path = path.substr(1);    // drop leading /
@@ -1088,8 +1092,7 @@ int Session::check_access(CInode *in, unsigned mask,
 
   if (!auth_caps.is_capable(path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
-			    new_uid, new_gid,
-			    info.inst.addr)) {
+			    new_uid, new_gid, info.inst.addr, trimmed_path)) {
     return -EACCES;
   }
   return 0;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -22,6 +22,7 @@
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/DecayCounter.h"
+#include "common/strescape.h" // for get_trimmed_path()
 #include "include/ceph_assert.h"
 #include "include/stringify.h"
 
@@ -1070,11 +1071,14 @@ int Session::check_access(std::string_view fs_name, CInode *in, unsigned mask,
     }
   }
 
+  string trimmed_path = "";
   if (!path.empty()) {
     dout(20) << __func__ << " stray_prior_path " << path << dendl;
   } else {
     in->make_path_string(path, true);
-    dout(20) << __func__ << " path " << path << dendl;
+    /* Log only 10 final components fo the path to since logging entire
+     * path is not useful and also reduces readability. */
+    dout(20) << __func__ << " path " << get_trimmed_path_str(path) << dendl;
   }
   if (path.length())
     path = path.substr(1);    // drop leading /
@@ -1090,8 +1094,7 @@ int Session::check_access(std::string_view fs_name, CInode *in, unsigned mask,
 
   if (!auth_caps.is_capable(fs_name, path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
-			    new_uid, new_gid,
-			    info.inst.addr)) {
+			    new_uid, new_gid, info.inst.addr, trimmed_path)) {
     return -EACCES;
   }
   return 0;

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -183,7 +183,7 @@ TEST(MDSAuthCaps, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowUid) {
@@ -192,11 +192,11 @@ TEST(MDSAuthCaps, AllowUid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowUidGid) {
@@ -205,24 +205,24 @@ TEST(MDSAuthCaps, AllowUidGid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // user
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // group
   vector<uint64_t> glist10;
@@ -234,59 +234,59 @@ TEST(MDSAuthCaps, AllowUidGid) {
   glist11.push_back(11);
   vector<uint64_t> glist12;
   glist12.push_back(12);
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > group
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // group > other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPath) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * path=/sandbox", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPathChars) {
   MDSAuthCaps unquo_cap;
   ASSERT_TRUE(unquo_cap.parse("allow * path=/sandbox-._foo", NULL));
   ASSERT_FALSE(unquo_cap.allow_all());
-  ASSERT_TRUE(unquo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(unquo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 
@@ -294,21 +294,21 @@ TEST(MDSAuthCaps, AllowPathCharsQuoted) {
   MDSAuthCaps quo_cap;
   ASSERT_TRUE(quo_cap.parse("allow * path=\"/sandbox-._foo\"", NULL));
   ASSERT_FALSE(quo_cap.allow_all());
-  ASSERT_TRUE(quo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(quo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, RootSquash) {
   MDSAuthCaps rs_cap;
   ASSERT_TRUE(rs_cap.parse("allow rw root_squash, allow rw path=/sandbox", NULL));
-  ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable("sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, OutputParsed) {
@@ -370,7 +370,7 @@ TEST(MDSAuthCaps, network) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a, "foo"));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b, "foo"));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c, "foo"));
 }

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -184,7 +184,7 @@ TEST(MDSAuthCaps, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable(fsname, "foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowUid) {
@@ -193,11 +193,11 @@ TEST(MDSAuthCaps, AllowUid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowUidGid) {
@@ -206,24 +206,24 @@ TEST(MDSAuthCaps, AllowUidGid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // user
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // group
   vector<uint64_t> glist10;
@@ -235,59 +235,59 @@ TEST(MDSAuthCaps, AllowUidGid) {
   glist11.push_back(11);
   vector<uint64_t> glist12;
   glist12.push_back(12);
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > group
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // group > other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPath) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * path=/sandbox", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPathChars) {
   MDSAuthCaps unquo_cap;
   ASSERT_TRUE(unquo_cap.parse("allow * path=/sandbox-._foo", NULL));
   ASSERT_FALSE(unquo_cap.allow_all());
-  ASSERT_TRUE(unquo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(unquo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 
@@ -295,21 +295,21 @@ TEST(MDSAuthCaps, AllowPathCharsQuoted) {
   MDSAuthCaps quo_cap;
   ASSERT_TRUE(quo_cap.parse("allow * path=\"/sandbox-._foo\"", NULL));
   ASSERT_FALSE(quo_cap.allow_all());
-  ASSERT_TRUE(quo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(quo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, RootSquash) {
   MDSAuthCaps rs_cap;
   ASSERT_TRUE(rs_cap.parse("allow rw root_squash, allow rw path=/sandbox", NULL));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, OutputParsed) {
@@ -371,7 +371,7 @@ TEST(MDSAuthCaps, network) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
 
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c, "foo"));
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73392, https://tracker.ceph.com/issues/73395, https://tracker.ceph.com/issues/73398

---

backport of https://github.com/ceph/ceph/pull/63917
parent tracker: https://tracker.ceph.com/issues/71648, https://tracker.ceph.com/issues/72779, https://tracker.ceph.com/issues/72993

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh