### PR TITLE
squid: mds: Return ceph.dir.subvolume vxattr

### DIFF
--- a/qa/tasks/cephfs/test_subvolume.py
+++ b/qa/tasks/cephfs/test_subvolume.py
@@ -198,6 +198,27 @@ class TestSubvolume(CephFSTestCase):
         self.mount_a.run_shell(['rmdir', 'group/subvol2/dir/.snap/s2'])
 
 
+    def test_subvolume_vxattr_retrieval(self):
+        """
+        To verify that the ceph.dir.subvolume vxattr can be acquired using getfattr
+        """
+        # create subvolume dir
+        subvol_dir:str = 'group/subvol5'
+        self.mount_a.run_shell(['mkdir', subvol_dir])
+        mkdir_fattr = self.mount_a.getfattr(subvol_dir, 'ceph.dir.subvolume')
+        self.assertEqual('0', mkdir_fattr)
+
+        self.mount_a.setfattr(subvol_dir, 'ceph.dir.subvolume', '1')
+        new_fattr:str = self.mount_a.getfattr(subvol_dir, 'ceph.dir.subvolume')
+        self.assertEqual('1', new_fattr)
+
+        # clear subvolume flag
+        self.mount_a.removexattr(subvol_dir, 'ceph.dir.subvolume')
+
+        # cleanup
+        self.mount_a.run_shell(['rm', '-rf', subvol_dir])
+
+
 class TestSubvolumeReplicated(CephFSTestCase):
     CLIENTS_REQUIRED = 1
     MDSS_REQUIRED = 2

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7168,6 +7168,9 @@ void Server::handle_client_getvxattr(const MDRequestRef& mdr)
       // since we only handle ceph vxattrs here
       r = -ENODATA; // no such attribute
     }
+  } else if (xattr_name == "ceph.dir.subvolume"sv) {
+    const auto* srnode = cur->get_projected_srnode();
+    *css << (srnode && srnode->is_subvolume() ? "1"sv : "0"sv);
   } else {
     // otherwise respond as invalid request
     // since we only handle ceph vxattrs here

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -466,21 +466,22 @@ private:
 
   static bool is_ceph_dir_vxattr(std::string_view xattr_name) {
     return xattr_name == "ceph.dir.layout" ||
-	    xattr_name == "ceph.dir.layout.json" ||
-	    xattr_name == "ceph.dir.layout.object_size" ||
-	    xattr_name == "ceph.dir.layout.stripe_unit" ||
-	    xattr_name == "ceph.dir.layout.stripe_count" ||
-	    xattr_name == "ceph.dir.layout.pool" ||
-	    xattr_name == "ceph.dir.layout.pool_name" ||
-	    xattr_name == "ceph.dir.layout.pool_id" ||
-	    xattr_name == "ceph.dir.layout.pool_namespace" ||
-	    xattr_name == "ceph.dir.pin" ||
-	    xattr_name == "ceph.dir.pin.random" ||
-	    xattr_name == "ceph.dir.pin.distributed" ||
-            xattr_name == "ceph.dir.charmap"sv ||
-            xattr_name == "ceph.dir.normalization"sv ||
-            xattr_name == "ceph.dir.encoding"sv ||
-            xattr_name == "ceph.dir.casesensitive"sv;
+	   xattr_name == "ceph.dir.layout.json" ||
+	   xattr_name == "ceph.dir.layout.object_size" ||
+	   xattr_name == "ceph.dir.layout.stripe_unit" ||
+	   xattr_name == "ceph.dir.layout.stripe_count" ||
+	   xattr_name == "ceph.dir.layout.pool" ||
+	   xattr_name == "ceph.dir.layout.pool_name" ||
+	   xattr_name == "ceph.dir.layout.pool_id" ||
+	   xattr_name == "ceph.dir.layout.pool_namespace" ||
+	   xattr_name == "ceph.dir.pin" ||
+	   xattr_name == "ceph.dir.pin.random" ||
+	   xattr_name == "ceph.dir.pin.distributed" ||
+	   xattr_name == "ceph.dir.charmap"sv ||
+	   xattr_name == "ceph.dir.normalization"sv ||
+	   xattr_name == "ceph.dir.encoding"sv ||
+	   xattr_name == "ceph.dir.casesensitive"sv ||
+	   xattr_name == "ceph.dir.subvolume"sv;
   }
 
   static bool is_ceph_file_vxattr(std::string_view xattr_name) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73351

---

backport of https://github.com/ceph/ceph/pull/65104
parent tracker: https://tracker.ceph.com/issues/72556

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh