### PR TITLE
squid: mds/FSMap: fix join_fscid being incorrectly reset for active MDS during filesystem removal

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -1220,7 +1220,7 @@ void FSMap::erase_filesystem(fs_cluster_id_t fscid)
       });
     }
   }
-  for ([[maybe_unused]] auto& [fscid, fs] : filesystems) {
+  for ([[maybe_unused]] auto& [remaining_fscid, fs] : filesystems) {
     for (auto& [gid, info] : fs.mds_map.get_mds_info()) {
       if (info.join_fscid == fscid) {
         modify_daemon(gid, [](auto& info) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73349

---

backport of https://github.com/ceph/ceph/pull/65640
parent tracker: https://tracker.ceph.com/issues/73183

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh