### PR TITLE
squid:  mds: wrong snap check for directory with parent snaps

### DIFF
--- a/qa/tasks/cephfs/test_dir_charmap.py
+++ b/qa/tasks/cephfs/test_dir_charmap.py
@@ -280,6 +280,28 @@ class TestCharMapVxattr(CephFSTestCase, CharMapMixin):
             else:
                 self.fail("should fail")
 
+    def test_cs_no_parent_snaps_set_insensitive(self):
+        """
+        That setting a charmap succeeds for an empty directory with first beyond parent snaps.
+        """
+
+        attrs = {
+          "ceph.dir.casesensitive": False,
+          "ceph.dir.normalization": "nfc",
+          "ceph.dir.encoding": "utf8",
+        }
+
+        self.mount_a.run_shell_payload("mkdir -p foo/bar; mkdir foo/.snap/one; rmdir foo/bar; mkdir foo/bar")
+        for attr, v in attrs.items():
+            try:
+                self.mount_a.setfattr("foo/bar", attr, v, helpfulexception=True)
+            except DirectoryNotEmptyError:
+                self.fail("should not fail")
+        try:
+            self.check_cs("foo/bar", casesensitive=False, normalization="nfc")
+        except DirectoryNotEmptyError:
+            self.fail("should not fail")
+
     def test_cs_remount(self):
         """
         That a remount continues to see the charmap.

--- a/qa/tasks/cephfs/test_dir_charmap.py
+++ b/qa/tasks/cephfs/test_dir_charmap.py
@@ -265,7 +265,7 @@ class TestCharMapVxattr(CephFSTestCase, CharMapMixin):
           "ceph.dir.encoding": "utf8",
         }
 
-        self.mount_a.run_shell_payload("mkdir -p foo/{trash,bar}; mkdir foo/.snap/one; rmdir foo/trash;")
+        self.mount_a.run_shell_payload("mkdir -p foo/bar; mkdir foo/.snap/one;")
         for attr, v in attrs.items():
             try:
                 self.mount_a.setfattr("foo/bar", attr, v, helpfulexception=True)

--- a/qa/tasks/cephfs/test_dir_charmap.py
+++ b/qa/tasks/cephfs/test_dir_charmap.py
@@ -256,7 +256,7 @@ class TestCharMapVxattr(CephFSTestCase, CharMapMixin):
 
     def test_cs_parent_snaps_set_insensitive(self):
         """
-        That setting a charmap succeeds for an empty directory with parent snaps.
+        That setting a charmap fails for an empty directory with parent snaps.
         """
 
         attrs = {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8915,7 +8915,9 @@ bool Server::_dir_has_snaps(const MDRequestRef& mdr, CInode *diri)
   ceph_assert(diri->snaplock.can_read(mdr->get_client()));
 
   SnapRealm *realm = diri->find_snaprealm();
-  return !realm->get_snaps().empty();
+  auto& snaps = realm->get_snaps();
+  auto it = snaps.lower_bound(diri->get_oldest_snap());
+  return it != snaps.end();
 }
 
 bool Server::_dir_is_nonempty(const MDRequestRef& mdr, CInode *in)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72283

---

backport of https://github.com/ceph/ceph/pull/63524
parent tracker: https://tracker.ceph.com/issues/71462

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh