### PR TITLE
squid: libcephfs: convert ceph errno to host-based errno

### DIFF
--- a/qa/workunits/libcephfs/test.sh
+++ b/qa/workunits/libcephfs/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
 ceph_test_libcephfs
 ceph_test_libcephfs_access

--- a/src/include/platform_errno.h
+++ b/src/include/platform_errno.h
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+/* XXX: This definitions are placed here so that it's easy to import them into
+ * CephFS python bindings. Otherwise, entire src/include/types.h would needed to
+ * be imported, which is unneccessary and also complicated.
+ */
+
+#pragma once
+
+#if defined(__sun) || defined(_AIX) || defined(__APPLE__) || \
+    defined(__FreeBSD__) || defined(_WIN32)
+extern "C" {
+__s32  ceph_to_hostos_errno(__s32 e);
+__s32  hostos_to_ceph_errno(__s32 e);
+}
+#else
+#define  ceph_to_hostos_errno(e) (e)
+#define  hostos_to_ceph_errno(e) (e)
+#endif
+
+

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -17,6 +17,7 @@
 // this is needed for ceph_fs to compile in userland
 #include "int_types.h"
 #include "byteorder.h"
+#include "platform_errno.h"
 
 #include "uuid.h"
 
@@ -550,17 +551,6 @@ struct shard_id_t {
 };
 WRITE_CLASS_ENCODER(shard_id_t)
 std::ostream &operator<<(std::ostream &lhs, const shard_id_t &rhs);
-
-#if defined(__sun) || defined(_AIX) || defined(__APPLE__) || \
-    defined(__FreeBSD__) || defined(_WIN32)
-extern "C" {
-__s32  ceph_to_hostos_errno(__s32 e);
-__s32  hostos_to_ceph_errno(__s32 e);
-}
-#else
-#define  ceph_to_hostos_errno(e) (e)
-#define  hostos_to_ceph_errno(e) (e)
-#endif
 
 struct errorcode32_t {
   using code_t = __s32;

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -4,6 +4,10 @@
 from libc.stdint cimport *
 from types cimport *
 
+cdef extern from "../include/platform_errno.h":
+    ctypedef signed int int32_t;
+    int32_t ceph_to_hostos_errno(int32_t e)
+
 cdef extern from "cephfs/ceph_ll_client.h":
     cdef struct statx "ceph_statx":
         uint32_t    stx_mask

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -62,47 +62,47 @@ CEPH_SETATTR_BTIME = 0x200
 
 CEPH_NOSNAP = -2
 
-# errno definitions
-cdef enum:
-    EBLOCKLISTED = 108
-    EPERM = 1
-    ESTALE = 116
-    ENOSPC = 28
-    ETIMEDOUT = 110
-    EIO = 5
-    ENOTCONN = 107
-    EEXIST = 17
-    EINTR = 4
-    EINVAL = 22
-    EBADF = 9
-    EROFS = 30
-    EAGAIN = 11
-    EACCES = 13
-    ELOOP = 40
-    EISDIR = 21
-    ENOENT = 2
-    ENOTDIR = 20
-    ENAMETOOLONG = 36
-    EBUSY = 16
-    EDQUOT = 122
-    EFBIG = 27
-    ERANGE = 34
-    ENXIO = 6
-    ECANCELED = 125
-    ENODATA = 61
-    EOPNOTSUPP = 95
-    EXDEV = 18
-    ENOMEM = 12
-    ENOTRECOVERABLE = 131
-    ENOSYS = 38
-    EWOULDBLOCK = EAGAIN
-    ENOTEMPTY = 39
-    EDEADLK = 35
-    EDEADLOCK = EDEADLK
-    EDOM = 33
-    EMLINK = 31
-    ETIME = 62
-    EOLDSNAPC = 85
+# XXX: errno definitions, hard-coded numbers here are errnos defined by Linux
+# that are used for the Ceph on-the-wire status codes.
+EBLOCKLISTED = ceph_to_hostos_errno(108)
+EPERM = ceph_to_hostos_errno(1)
+ESTALE = ceph_to_hostos_errno(116)
+ENOSPC = ceph_to_hostos_errno(28)
+ETIMEDOUT = ceph_to_hostos_errno(110)
+EIO = ceph_to_hostos_errno(5)
+ENOTCONN = ceph_to_hostos_errno(107)
+EEXIST = ceph_to_hostos_errno(17)
+EINTR = ceph_to_hostos_errno(4)
+EINVAL = ceph_to_hostos_errno(22)
+EBADF = ceph_to_hostos_errno(9)
+EROFS = ceph_to_hostos_errno(30)
+EAGAIN = ceph_to_hostos_errno(11)
+EWOULDBLOCK = EAGAIN
+EACCES = ceph_to_hostos_errno(13)
+ELOOP = ceph_to_hostos_errno(40)
+EISDIR = ceph_to_hostos_errno(21)
+ENOENT = ceph_to_hostos_errno(2)
+ENOTDIR = ceph_to_hostos_errno(20)
+ENAMETOOLONG = ceph_to_hostos_errno(36)
+EBUSY = ceph_to_hostos_errno(16)
+EDQUOT = ceph_to_hostos_errno(122)
+EFBIG = ceph_to_hostos_errno(27)
+ERANGE = ceph_to_hostos_errno(34)
+ENXIO = ceph_to_hostos_errno(6)
+ECANCELED = ceph_to_hostos_errno(125)
+ENODATA = ceph_to_hostos_errno(61)
+EOPNOTSUPP = ceph_to_hostos_errno(95)
+EXDEV = ceph_to_hostos_errno(18)
+ENOMEM = ceph_to_hostos_errno(12)
+ENOTRECOVERABLE = ceph_to_hostos_errno(131)
+ENOSYS = ceph_to_hostos_errno(38)
+ENOTEMPTY = ceph_to_hostos_errno(39)
+EDEADLK = ceph_to_hostos_errno(35)
+EDEADLOCK = EDEADLK
+EDOM = ceph_to_hostos_errno(33)
+EMLINK = ceph_to_hostos_errno(31)
+ETIME = ceph_to_hostos_errno(62)
+EOLDSNAPC = ceph_to_hostos_errno(85)
 
 cdef extern from "Python.h":
     # These are in cpython/string.pxd, but use "object" types instead of
@@ -512,7 +512,7 @@ cdef class LibCephFS(object):
         with nogil:
             ret = ceph_create_from_rados(&self.cluster, rados_inst.cluster)
         if ret != 0:
-            raise Error("libcephfs_initialize failed with error code: %d" % ret)
+            raise Error(f"libcephfs_initialize failed with error code: {ret}")
         self.state = "configuring"
 
     NO_CONF_FILE = -1
@@ -541,7 +541,7 @@ cdef class LibCephFS(object):
         with nogil:
             ret = ceph_create(&self.cluster, <const char*>_auth_id)
         if ret != 0:
-            raise Error("libcephfs_initialize failed with error code: %d" % ret)
+            raise Error(f"libcephfs_initialize failed with error code: {ret}")
 
         self.state = "configuring"
         if conffile in (self.NO_CONF_FILE, None):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -5,6 +5,11 @@ from types cimport timespec
 
 
 cdef:
+    int32_t ceph_to_hostos_errno(int32_t e):
+        pass
+
+
+cdef:
     cdef struct statx "ceph_statx":
         uint32_t    stx_mask
         uint32_t    stx_blksize

--- a/src/pybind/cephfs/types.pxd
+++ b/src/pybind/cephfs/types.pxd
@@ -53,3 +53,7 @@ ELSE:
             unsigned short int d_reclen
             unsigned char d_type
             char d_name[256]
+
+cdef extern from "../../include/platform_errno.h":
+    ctypedef signed int int32_t;
+    int32_t ceph_to_hostos_errno(int32_t e)

--- a/src/pybind/cephfs/types.pxd
+++ b/src/pybind/cephfs/types.pxd
@@ -53,7 +53,3 @@ ELSE:
             unsigned short int d_reclen
             unsigned char d_type
             char d_name[256]
-
-cdef extern from "../../include/platform_errno.h":
-    ctypedef signed int int32_t;
-    int32_t ceph_to_hostos_errno(int32_t e)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73403, https://tracker.ceph.com/issues/73493

---

backport of https://github.com/ceph/ceph/pull/65135, https://github.com/ceph/ceph/pull/65839
parent tracker: https://tracker.ceph.com/issues/72401, https://tracker.ceph.com/issues/73435

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh