### PR TITLE
osd/scrub: fix blocked scrub accounting

### DIFF
--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -383,7 +383,6 @@ RangeBlocked::RangeBlocked(my_context ctx)
     m_timeout_token = machine.schedule_timer_event_after<RangeBlockedAlarm>(
       grace);
   }
-  context<Session>().m_perf_set->inc(scrbcnt_blocked);
 }
 
 sc::result RangeBlocked::react(const RangeBlockedAlarm&)
@@ -402,6 +401,7 @@ sc::result RangeBlocked::react(const RangeBlockedAlarm&)
     << ")";
 
   scrbr->set_scrub_blocked(utime_t{now_c, 0});
+  context<Session>().m_perf_set->inc(scrbcnt_blocked);
   return discard_event();
 }
 


### PR DESCRIPTION
The labeled perf counter `<label>_chunk_busy` is incremented whenever the selected scrub chunk range is not available, and the scrubber must wait for ongoing I/O to complete. This is as it should be.

`<label>_locked_object` should not be incremented in parallel, serving no purpose. Instead - it should count the times the 'wait for chunk to be free' takes longer than the configured grace period.

Fixes: https://tracker.ceph.com/issues/73415
