### PR TITLE
tentacle: sync build-with-container patches from main

### DIFF
--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -109,7 +109,7 @@ class DistroKind(StrEnum):
     ROCKY10 = "rocky10"
     UBUNTU2204 = "ubuntu22.04"
     UBUNTU2404 = "ubuntu24.04"
-    BOOKWORM = "bookworm"
+    DEBIAN12 = "debian12"
 
     @classmethod
     def uses_dnf(cls):
@@ -148,7 +148,9 @@ class DistroKind(StrEnum):
             str(cls.UBUNTU2404): cls.UBUNTU2404,
             "ubuntu-noble": cls.UBUNTU2404,
             "noble": cls.UBUNTU2404,
-            str(cls.BOOKWORM): cls.BOOKWORM,
+            str(cls.DEBIAN12): cls.DEBIAN12,
+            "debian-bookworm": cls.DEBIAN12,
+            "bookworm": cls.DEBIAN12,
         }
 
     @classmethod
@@ -165,7 +167,7 @@ class DefaultImage(StrEnum):
     ROCKY10 = "docker.io/rockylinux/rockylinux:10"
     UBUNTU2204 = "docker.io/ubuntu:22.04"
     UBUNTU2404 = "docker.io/ubuntu:24.04"
-    BOOKWORM = "docker.io/debian:bookworm"
+    DEBIAN12 = "docker.io/debian:bookworm"
 
 
 class CommandFailed(Exception):

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -105,6 +105,8 @@ class DistroKind(StrEnum):
     CENTOS8 = "centos8"
     CENTOS9 = "centos9"
     FEDORA41 = "fedora41"
+    FEDORA42 = "fedora42"
+    FEDORA43 = "fedora43"
     ROCKY9 = "rocky9"
     ROCKY10 = "rocky10"
     UBUNTU2204 = "ubuntu22.04"
@@ -144,6 +146,10 @@ class DistroKind(StrEnum):
             # fedora
             str(cls.FEDORA41): cls.FEDORA41,
             "fc41": cls.FEDORA41,
+            str(cls.FEDORA42): cls.FEDORA42,
+            "fc42": cls.FEDORA42,
+            str(cls.FEDORA43): cls.FEDORA43,
+            "fc43": cls.FEDORA43,
             # ubuntu
             str(cls.UBUNTU2204): cls.UBUNTU2204,
             "ubuntu-jammy": cls.UBUNTU2204,
@@ -171,6 +177,8 @@ class DefaultImage(StrEnum):
     ROCKY10 = "docker.io/rockylinux/rockylinux:10"
     # fedora
     FEDORA41 = "registry.fedoraproject.org/fedora:41"
+    FEDORA42 = "registry.fedoraproject.org/fedora:42"
+    FEDORA43 = "registry.fedoraproject.org/fedora:43"
     # ubuntu
     UBUNTU2204 = "docker.io/ubuntu:22.04"
     UBUNTU2404 = "docker.io/ubuntu:24.04"

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -109,6 +109,7 @@ class DistroKind(StrEnum):
     ROCKY10 = "rocky10"
     UBUNTU2204 = "ubuntu22.04"
     UBUNTU2404 = "ubuntu24.04"
+    BOOKWORM = "bookworm"
 
     @classmethod
     def uses_dnf(cls):
@@ -147,6 +148,7 @@ class DistroKind(StrEnum):
             str(cls.UBUNTU2404): cls.UBUNTU2404,
             "ubuntu-noble": cls.UBUNTU2404,
             "noble": cls.UBUNTU2404,
+            str(cls.BOOKWORM): cls.BOOKWORM,
         }
 
     @classmethod
@@ -163,6 +165,7 @@ class DefaultImage(StrEnum):
     ROCKY10 = "docker.io/rockylinux/rockylinux:10"
     UBUNTU2204 = "docker.io/ubuntu:22.04"
     UBUNTU2404 = "docker.io/ubuntu:24.04"
+    BOOKWORM = "docker.io/debian:bookworm"
 
 
 class CommandFailed(Exception):

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -109,6 +109,7 @@ class DistroKind(StrEnum):
     FEDORA43 = "fedora43"
     ROCKY9 = "rocky9"
     ROCKY10 = "rocky10"
+    UBUNTU2004 = "ubuntu20.04"
     UBUNTU2204 = "ubuntu22.04"
     UBUNTU2404 = "ubuntu24.04"
     DEBIAN12 = "debian12"
@@ -151,6 +152,9 @@ class DistroKind(StrEnum):
             str(cls.FEDORA43): cls.FEDORA43,
             "fc43": cls.FEDORA43,
             # ubuntu
+            str(cls.UBUNTU2004): cls.UBUNTU2004,
+            "ubuntu-focal": cls.UBUNTU2004,
+            "focal": cls.UBUNTU2004,
             str(cls.UBUNTU2204): cls.UBUNTU2204,
             "ubuntu-jammy": cls.UBUNTU2204,
             "jammy": cls.UBUNTU2204,
@@ -180,6 +184,7 @@ class DefaultImage(StrEnum):
     FEDORA42 = "registry.fedoraproject.org/fedora:42"
     FEDORA43 = "registry.fedoraproject.org/fedora:43"
     # ubuntu
+    UBUNTU2004 = "docker.io/ubuntu:20.04"
     UBUNTU2204 = "docker.io/ubuntu:22.04"
     UBUNTU2404 = "docker.io/ubuntu:24.04"
     # debian

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -173,7 +173,12 @@ class DistroKind(StrEnum):
 
     @classmethod
     def from_alias(cls, value):
-        return cls.aliases()[value]
+        try:
+            return cls.aliases()[value]
+        except KeyError:
+            valid = ", ".join(sorted(cls.aliases()))
+            msg = f"unknown distro: {value!r} not in {valid}"
+            raise argparse.ArgumentTypeError(msg)
 
 
 class DefaultImage(StrEnum):

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -131,23 +131,27 @@ class DistroKind(StrEnum):
     @classmethod
     def aliases(cls):
         return {
+            # EL distros
             str(cls.CENTOS10): cls.CENTOS10,
             "centos10stream": cls.CENTOS10,
             str(cls.CENTOS8): cls.CENTOS8,
             str(cls.CENTOS9): cls.CENTOS9,
             "centos9stream": cls.CENTOS9,
-            str(cls.FEDORA41): cls.FEDORA41,
-            "fc41": cls.FEDORA41,
             str(cls.ROCKY9): cls.ROCKY9,
             'rockylinux9': cls.ROCKY9,
             str(cls.ROCKY10): cls.ROCKY10,
             'rockylinux10': cls.ROCKY10,
+            # fedora
+            str(cls.FEDORA41): cls.FEDORA41,
+            "fc41": cls.FEDORA41,
+            # ubuntu
             str(cls.UBUNTU2204): cls.UBUNTU2204,
             "ubuntu-jammy": cls.UBUNTU2204,
             "jammy": cls.UBUNTU2204,
             str(cls.UBUNTU2404): cls.UBUNTU2404,
             "ubuntu-noble": cls.UBUNTU2404,
             "noble": cls.UBUNTU2404,
+            # debian
             str(cls.DEBIAN12): cls.DEBIAN12,
             "debian-bookworm": cls.DEBIAN12,
             "bookworm": cls.DEBIAN12,
@@ -159,14 +163,18 @@ class DistroKind(StrEnum):
 
 
 class DefaultImage(StrEnum):
+    # EL distros
     CENTOS10 = "quay.io/centos/centos:stream10"
     CENTOS8 = "quay.io/centos/centos:stream8"
     CENTOS9 = "quay.io/centos/centos:stream9"
-    FEDORA41 = "registry.fedoraproject.org/fedora:41"
     ROCKY9 = "docker.io/rockylinux/rockylinux:9"
     ROCKY10 = "docker.io/rockylinux/rockylinux:10"
+    # fedora
+    FEDORA41 = "registry.fedoraproject.org/fedora:41"
+    # ubuntu
     UBUNTU2204 = "docker.io/ubuntu:22.04"
     UBUNTU2404 = "docker.io/ubuntu:24.04"
+    # debian
     DEBIAN12 = "docker.io/debian:bookworm"
 
 

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -113,6 +113,7 @@ class DistroKind(StrEnum):
     UBUNTU2204 = "ubuntu22.04"
     UBUNTU2404 = "ubuntu24.04"
     DEBIAN12 = "debian12"
+    DEBIAN13 = "debian13"
 
     @classmethod
     def uses_dnf(cls):
@@ -165,6 +166,9 @@ class DistroKind(StrEnum):
             str(cls.DEBIAN12): cls.DEBIAN12,
             "debian-bookworm": cls.DEBIAN12,
             "bookworm": cls.DEBIAN12,
+            str(cls.DEBIAN13): cls.DEBIAN13,
+            "debian-trixie": cls.DEBIAN13,
+            "trixie": cls.DEBIAN13,
         }
 
     @classmethod
@@ -189,6 +193,7 @@ class DefaultImage(StrEnum):
     UBUNTU2404 = "docker.io/ubuntu:24.04"
     # debian
     DEBIAN12 = "docker.io/debian:bookworm"
+    DEBIAN13 = "docker.io/debian:trixie"
 
 
 class CommandFailed(Exception):

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -648,6 +648,7 @@ def get_container(ctx):
 def bc_configure(ctx):
     """Configure the build"""
     ctx.build.wants(Steps.CONTAINER, ctx)
+    ctx.build.wants(Steps.NPM_CACHE, ctx)
     cmd = _container_cmd(
         ctx,
         [

--- a/src/script/buildcontainer-setup.sh
+++ b/src/script/buildcontainer-setup.sh
@@ -41,7 +41,7 @@ case "${CEPH_BASE_BRANCH}~${DISTRO_KIND}" in
         install_container_deps
         dnf_clean
     ;;
-    *~*ubuntu*)
+    *~*ubuntu*|*~*debian*)
         apt-get update
         apt-get install -y wget reprepro curl software-properties-common lksctp-tools libsctp-dev protobuf-compiler ragel libc-ares-dev
         install_container_deps


### PR DESCRIPTION
Sync bwc state on `main` to tentacle. Changes from #65376,  #65804 &  #65835 
```
$ git rev-parse --abbrev-ref HEAD
jjm-bwc-backports-t
$ git diff origin/main -- src/script/build-with-container.py
$
```
No outstanding differences between branches outside these patches.
 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
  - [x] Something clever
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
  - [x] Something profound
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
  - [x] Something funny
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] Something to satisfy the checklist bot

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
