### PR TITLE
extend mTLS support to Dashboard

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2321,15 +2321,18 @@ def prepare_dashboard(
         if cert_key:
             cert_file = write_tmp(cert_key['cert'], uid, gid)
             key_file = write_tmp(cert_key['key'], uid, gid)
+            root_ca_file = write_tmp(cert_key['root_ca'], uid, gid)
             mounts = {
                 cert_file.name: '/tmp/dashboard.crt:z',
-                key_file.name: '/tmp/dashboard.key:z'
+                key_file.name: '/tmp/dashboard.key:z',
+                root_ca_file.name: '/tmp/root_ca.crt:z'
             }
         else:
             logger.error('Cannot generate certificates for Ceph dashboard.')
 
     cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
     cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
+    cli(['dashboard', 'set-ssl-root-ca-cert', '-i', '/tmp/root_ca.crt'], extra_mounts=mounts)
 
     logger.info('Creating initial admin user...')
     password = ctx.initial_dashboard_password or generate_password()

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3271,8 +3271,7 @@ Then run the following:
             self.set_store(PrometheusService.PASS_CFG_KEY, password)
         return (user, password)
 
-    @handle_orch_error
-    def generate_certificates(self, module_name: str) -> Optional[Dict[str, str]]:
+    def _generate_certificates(self, module_name: str) -> Dict[str, str]:
         supported_moduels = ['dashboard', 'prometheus']
         if module_name not in supported_moduels:
             raise OrchestratorError(f'Unsupported modlue {module_name}. Supported moduels are: {supported_moduels}')
@@ -3287,10 +3286,14 @@ Then run the following:
 
         tls_creds = self.cert_mgr.generate_cert(host_fqdns, self.get_mgr_ip())
         _, mgmt_gw_enabled, _ = self._get_security_config()
-        return {'mtls': mgmt_gw_enabled,
+        return {'mtls': str(mgmt_gw_enabled),
                 'cert': tls_creds.cert,
                 'key': tls_creds.key,
                 'root_ca': self.cert_mgr.get_root_ca()}
+
+    @handle_orch_error
+    def generate_certificates(self, module_name: str) -> Optional[Dict[str, str]]:
+        return self._generate_certificates(module_name)
 
     @handle_orch_error
     def set_prometheus_access_info(self, user: str, password: str) -> str:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3286,7 +3286,11 @@ Then run the following:
             host_fqdns.append('dashboard_servers')
 
         tls_creds = self.cert_mgr.generate_cert(host_fqdns, self.get_mgr_ip())
-        return {'cert': tls_creds.cert, 'key': tls_creds.key}
+        _, mgmt_gw_enabled, _ = self._get_security_config()
+        return {'mtls': mgmt_gw_enabled,
+                'cert': tls_creds.cert,
+                'key': tls_creds.key,
+                'root_ca': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
     def set_prometheus_access_info(self, user: str, password: str) -> str:

--- a/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
@@ -78,6 +78,12 @@ server {
     location / {
         proxy_pass {{ dashboard_scheme }}://dashboard_servers;
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+
+        proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+        proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+        proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth 2;
         {% if enable_oauth2_proxy %}
         auth_request /oauth2/auth;
         error_page 401 = /oauth2/sign_in;

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -192,7 +192,7 @@ class CherryPyConfig(object):
 
 
 if TYPE_CHECKING:
-    SslConfigKey = Literal['crt', 'key']
+    SslConfigKey = Literal['crt', 'key', 'root_ca']
 
 
 class Module(MgrModule, CherryPyConfig):
@@ -235,6 +235,7 @@ class Module(MgrModule, CherryPyConfig):
         Option(name='url_prefix', type='str', default=''),
         Option(name='key_file', type='str', default=''),
         Option(name='crt_file', type='str', default=''),
+        Option(name='root_ca_file', type='str', default=''),
         Option(name='ssl', type='bool', default=True),
         Option(name='standby_behaviour', type='str', default='redirect',
                enum_allowed=['redirect', 'error']),
@@ -355,8 +356,10 @@ class Module(MgrModule, CherryPyConfig):
         logger.info('Stopping engine...')
         self.shutdown_event.set()
 
-    def _set_ssl_item(self, item_label: str, item_key: 'SslConfigKey' = 'crt',
-                      mgr_id: Optional[str] = None, inbuf: Optional[str] = None):
+    def _set_ssl_item(self, item_label: str,
+                      item_key: 'SslConfigKey' = 'crt',
+                      mgr_id: Optional[str] = None,
+                      inbuf: Optional[str] = None):
         if inbuf is None:
             return -errno.EINVAL, '', f'Please specify the {item_label} with "-i" option'
 
@@ -382,6 +385,10 @@ class Module(MgrModule, CherryPyConfig):
     @CLIWriteCommand("dashboard set-ssl-root-ca-cert")
     def set_ssl_root_ca_certificate(self, mgr_id: Optional[str] = None, inbuf: Optional[str] = None):
         return self._set_ssl_item('root CA certificate', 'root_ca', mgr_id, inbuf)
+
+    @CLIWriteCommand("dashboard remove-ssl-root-ca-cert")
+    def remove_ssl_root_ca_certificate(self, mgr_id: Optional[str] = None):
+        return self._set_ssl_item('root CA certificate', 'root_ca', mgr_id, '')
 
     @CLIWriteCommand("dashboard create-self-signed-cert")
     def set_mgr_created_self_signed_cert(self):

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -7,9 +7,7 @@ import errno
 import logging
 import os
 import socket
-import ssl
 import sys
-import tempfile
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -26,8 +24,7 @@ if TYPE_CHECKING:
 from ceph.cryptotools.select import choose_crypto_caller
 from mgr_module import CLIReadCommand, CLIWriteCommand, HandleCommandResult, \
     MgrModule, MgrStandbyModule, NotifyType, Option, _get_localized_key
-from mgr_util import ServerConfigException, build_url, \
-    create_self_signed_cert, get_default_addr, verify_tls_files
+from mgr_util import ServerConfigException, build_url, create_self_signed_cert, get_default_addr
 
 from . import mgr
 from .controllers import nvmeof  # noqa # pylint: disable=unused-import
@@ -40,7 +37,7 @@ from .services.service import RgwServiceManager
 from .services.sso import SSO_COMMANDS, handle_sso_command
 from .settings import handle_option_command, options_command_list, options_schema_list
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
-    configure_cors, prepare_url_prefix, str_to_bool
+    configure_cors, configure_ssl_certs, prepare_url_prefix, str_to_bool
 
 try:
     import cherrypy
@@ -156,50 +153,7 @@ class CherryPyConfig(object):
         }
 
         if use_ssl:
-            # SSL initialization
-            cert = self.get_localized_store("crt")  # type: ignore
-            if cert is not None:
-                self.cert_tmp = tempfile.NamedTemporaryFile()
-                self.cert_tmp.write(cert.encode('utf-8'))
-                self.cert_tmp.flush()  # cert_tmp must not be gc'ed
-                cert_fname = self.cert_tmp.name
-            else:
-                cert_fname = self.get_localized_module_option('crt_file')  # type: ignore
-
-            pkey = self.get_localized_store("key")  # type: ignore
-            if pkey is not None:
-                self.pkey_tmp = tempfile.NamedTemporaryFile()
-                self.pkey_tmp.write(pkey.encode('utf-8'))
-                self.pkey_tmp.flush()  # pkey_tmp must not be gc'ed
-                pkey_fname = self.pkey_tmp.name
-            else:
-                pkey_fname = self.get_localized_module_option('key_file')  # type: ignore
-
-            verify_tls_files(cert_fname, pkey_fname)
-
-            # Create custom SSL context to disable TLS 1.0 and 1.1.
-            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-            context.load_cert_chain(cert_fname, pkey_fname)
-
-            root_ca = self.get_localized_store("root_ca")  # type: ignore
-            if root_ca is not None:
-                self.root_ca_tmp = tempfile.NamedTemporaryFile()
-                self.root_ca_tmp.write(root_ca.encode('utf-8'))
-                self.root_ca_tmp.flush()  # root_ca_tmp must not be gc'ed
-                root_ca_fname = self.root_ca_tmp.name
-                # enforce mTLS check
-                context.verify_mode = ssl.CERT_REQUIRED
-                context.load_verify_locations(root_ca_fname)
-
-            if sys.version_info >= (3, 7):
-                context.minimum_version = ssl.TLSVersion.TLSv1_3
-            else:
-                context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
-
-            config['server.ssl_module'] = 'builtin'
-            config['server.ssl_certificate'] = cert_fname
-            config['server.ssl_private_key'] = pkey_fname
-            config['server.ssl_context'] = context
+            configure_ssl_certs()
 
         self.update_cherrypy_config(config)
 
@@ -517,6 +471,11 @@ class Module(MgrModule, CherryPyConfig):
         self.set_module_option('cross_origin_url', ','.join(cross_origin_urls_list))
         configure_cors()
         return 0, 'Cross-origin URL set', ''
+
+    @CLIWriteCommand("dashboard refresh-ssl-certificates")
+    def refresh_ssl_certificates(self):
+        configure_ssl_certs(restart_engine=True)
+        return 0, 'SSL certificates refreshed', ''
 
     @CLIReadCommand("dashboard get-cross-origin-url")
     def get_cross_origin_url(self):

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -5,6 +5,10 @@ import fnmatch
 import inspect
 import json
 import logging
+import os
+import ssl
+import sys
+import tempfile
 import threading
 import time
 import urllib
@@ -12,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 
 import cherrypy
 from ceph.utils import strtobool
-from mgr_util import build_url
+from mgr_util import build_url, verify_tls_files
 
 from . import mgr
 from .exceptions import ViewCacheNoDataException
@@ -24,6 +28,10 @@ try:
         Optional, Set, Tuple, Union
 except ImportError:
     pass  # For typing only
+
+
+_cert_tmp = None
+_key_tmp = None
 
 
 class RequestLoggingTool(cherrypy.Tool):
@@ -907,3 +915,79 @@ def cors_tool():
         if cherrypy.request.config.get('tools.sessions.on', False):
             cherrypy.session['token'] = True
         return True
+
+
+def configure_ssl_certs(restart_engine=False):
+    logger = logging.getLogger('dashboard.tools.ssl')
+    global _cert_tmp, _key_tmp, _root_ca_fname
+
+    if _cert_tmp and os.path.exists(_cert_tmp):
+        os.remove(_cert_tmp)
+    if _key_tmp and os.path.exists(_key_tmp):
+        os.remove(_key_tmp)
+
+    # SSL initialization
+    config = {}
+    cert = mgr.get_localized_store("crt")  # type: ignore
+    if cert is not None:
+        cert_tmp = tempfile.NamedTemporaryFile(delete=False)
+        cert_tmp.write(cert.encode('utf-8'))
+        cert_tmp.close()
+        _cert_tmp = cert_tmp.name
+    else:
+        _cert_tmp = mgr.get_localized_module_option('crt_file')  # type: ignore
+
+    pkey = mgr.get_localized_store("key")  # type: ignore
+    if pkey is not None:
+        key_tmp = tempfile.NamedTemporaryFile(delete=False)
+        key_tmp.write(pkey.encode('utf-8'))
+        key_tmp.close()
+        _key_tmp = key_tmp.name
+    else:
+        _key_tmp = mgr.get_localized_module_option('key_file')  # type: ignore
+
+    verify_tls_files(_cert_tmp, _key_tmp)
+
+    # Create custom SSL context to disable TLS 1.0 and 1.1.
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(_cert_tmp, _key_tmp)
+
+    root_ca = mgr.get_localized_store("root_ca")  # type: ignore
+    if root_ca is not None:
+        root_ca_tmp = tempfile.NamedTemporaryFile()
+        root_ca_tmp.write(root_ca.encode('utf-8'))
+        root_ca_tmp.flush()  # root_ca_tmp must not be gc'ed
+        _root_ca_fname = root_ca_tmp.name
+        # enforce mTLS check
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.load_verify_locations(_root_ca_fname)
+
+    if sys.version_info >= (3, 7):
+        context.minimum_version = ssl.TLSVersion.TLSv1_3
+    else:
+        context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
+
+    config['server.ssl_module'] = 'builtin'
+    config['server.ssl_certificate'] = _cert_tmp
+    config['server.ssl_private_key'] = _key_tmp
+    config['server.ssl_context'] = context
+
+    cherrypy.config.update(config)
+
+    # trying to restart the ssl adapter without restarting
+    # the engine. this is to avoid dropping connections.
+    # incase it fails we fallback to restarting the engine.
+    if restart_engine:
+        try:
+            httpserver = cherrypy.server.httpserver
+
+            if hasattr(httpserver, 'ssl_adapter') and httpserver.ssl_adapter:
+                httpserver.ssl_adapter.context = context
+                httpserver.ssl_adapter.certificate = _cert_tmp
+                httpserver.ssl_adapter.private_key = _key_tmp
+            else:
+                cherrypy.engine.restart()
+
+        except Exception as e:
+            logger.error(f"Restarting SSL adapter failed: {e}. Restarting engine.")
+            cherrypy.engine.restart()

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -9,7 +9,7 @@ import time
 import enum
 from collections import namedtuple
 from collections import OrderedDict
-from tempfile import NamedTemporaryFile
+import tempfile
 import ssl
 
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, CLIWriteCommand


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
