### PR TITLE
Introduce ceph_codechecker.py script

### DIFF
--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -50,14 +50,41 @@ struct assert_data {
   const char *function;
 };
 
-extern void __ceph_assert_fail(const char *assertion, const char *file, int line, const char *function);
-extern void __ceph_assert_fail(const assert_data &ctx);
+#ifndef CEPH_ASSERT_NORETURN
+#ifdef __clang_analyzer__
+#define CEPH_ASSERT_NORETURN 1
+#else
+#define CEPH_ASSERT_NORETURN 0
+#endif
+#endif
+
+#if CEPH_ASSERT_NORETURN
+[[noreturn]]
+#endif
+extern void __ceph_assert_fail(
+    const char* assertion,
+    const char* file,
+    int line,
+    const char* function);
+#if CEPH_ASSERT_NORETURN
+[[noreturn]]
+#endif
+extern void __ceph_assert_fail(const assert_data& ctx);
 template <const assert_data* AssertCtxV>
 [[gnu::noinline, gnu::cold]] static void __ceph_assert_fail()  {
   __ceph_assert_fail(*AssertCtxV);
 }
 
-extern void __ceph_assertf_fail(const char *assertion, const char *file, int line, const char *function, const char* msg, ...);
+#if CEPH_ASSERT_NORETURN
+[[noreturn]]
+#endif
+extern void __ceph_assertf_fail(
+    const char* assertion,
+    const char* file,
+    int line,
+    const char* function,
+    const char* msg,
+    ...);
 extern void __ceph_assert_warn(const char *assertion, const char *file, int line, const char *function);
 
 [[noreturn]] void __ceph_abort(const char *file, int line, const char *func,

--- a/src/script/ceph_codechecker.py
+++ b/src/script/ceph_codechecker.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+
+"""
+ceph_codechecker.py
+-------------------
+
+Wrapper script to run CodeChecker analyzers against a Ceph build.
+
+This script prepares small configuration snippets (skip lists and
+analyzer option files), invokes CodeChecker to analyze a compilation
+database (compile_commands.json), parses the resulting plist files into
+the requested export format, and optionally stores the result to a
+CodeChecker server.
+
+Key features:
+- Prepares skipfile, cppcheck, clang-tidy and clang static analyzer
+    option files next to the provided output directory.
+- Supports analysis modes: 'fast', 'full', 'clangsa', 'cppcheck', and
+    'clang-tidy'.
+- Exports results in formats: html, json, codeclimate, gerrit, or
+    baseline and can upload to a running CodeChecker server via --url.
+
+Usage (short):
+    ceph_codechecker.py [--verbose {info,debug_analyzer,debug}] \
+                                            [--codechecker {full,fast,clangsa,cppcheck,clang-tidy}] \
+                                            [--export {html,json,codeclimate,gerrit,baseline}] \
+                                            [--url URL] [-o OUTPUT_DIR] COMPILE_COMMANDS
+
+Requirements:
+- Python 3
+- CodeChecker installed in the environment (pip3 install codechecker)
+- cppcheck:
+  - RPM-based distros (Fedora/RHEL/CentOS): sudo dnf install cppcheck
+  - DEB-based distros (Debian/Ubuntu): sudo apt-get install cppcheck
+- clang-tidy:
+  - RPM-based distros (Fedora/RHEL/CentOS): sudo dnf install clang-tools-extra
+  - DEB-based distros (Debian/Ubuntu): sudo apt-get install clang-tidy
+- Clang Static Analyzer:
+  - RPM-based distros (Fedora/RHEL/CentOS): sudo dnf install clang-analyzer
+  - DEB-based distros (Debian/Ubuntu): sudo apt-get install clang-tools
+- Create compile_commands.py file:
+  - Run './do_cmake.sh -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++' to generate a compilation database.
+  - Run 'cmake --build build' to compile the project.
+  - Run './src/script/ceph_codechecker.py --codechecker [full|fast|clangsa|cppcheck|clang-tidy] -o ./build ./compile_commands.json' to analyze the project
+    database to the output directory.
+Notes:
+- The script intentionally unsets OPENSSL_CONF for subprocesses to
+    avoid OpenSSL md5 configuration issues when running CodeChecker.
+"""
+
+import copy
+import os
+import argparse
+import datetime
+import subprocess
+import sys
+
+
+def search_plist_files(search_dir):
+    result = []
+    if os.path.isdir(search_dir):
+        for root, dirs, files in os.walk(search_dir):
+            for file in files:
+                filename, file_extension = os.path.splitext(file)
+                if file_extension == ".plist":
+                    result.extend([os.path.join(root, file)])
+    return result
+
+
+def build_codechecker(
+    compile_commands: str,
+    workspace_path: str,
+    analysis_type: str,
+    export: str,
+    url: str,
+    verbose: str,
+    include_boost: bool,
+):
+    print("Building with codechecker")
+    output_dir = f"csa-output-{os.environ.get('USER', 'unknown')}-{datetime.datetime.today().strftime('%Y%m%d-%H%M%S')}"
+
+    environ = copy.deepcopy(os.environ)
+
+    # Ensure the workspace_path directory exists
+    os.makedirs(workspace_path, exist_ok=True)
+
+    with open(os.path.join(workspace_path, "skipfile.cfg"), "w") as text_file:
+        if not include_boost:
+            text_file.write("-*/build/boost/*\n")
+        text_file.write("-*/build/_deps/*\n")
+
+    with open(os.path.join(workspace_path, "cppcheck.cfg"), "w") as text_file:
+        text_file.write("--check-level=exhaustive\n-D__clang_analyzer__\n")
+
+    with open(os.path.join(workspace_path, "tidyargs.cfg"), "w") as text_file:
+        text_file.write("-p " + compile_commands)
+
+    with open(os.path.join(workspace_path, "clangsa.cfg"), "w") as text_file:
+        text_file.write("-Xclang\n-analyzer-disable-checker=deadcode.DeadStores\n")
+
+    codechecker_default_options = [
+        # severity: LOW, CRITICAL, MEDIUM, UNSPECIFIED, HIGH, STYLE
+        "--disable",
+        "severity:LOW",
+        "--disable",
+        "severity:STYLE",
+        "-i",
+        os.path.join(workspace_path, "skipfile.cfg"),
+    ]
+
+    codechecker_cppcheck_options = [
+        "--analyzer-config",
+        f"cppcheck:cc-verbatim-args-file={os.path.join(workspace_path, 'cppcheck.cfg')}",
+    ]
+
+    codechecker_clangtidy_options = [
+        "--analyzer-config",
+        f"clang-tidy:cc-verbatim-args-file={os.path.join(workspace_path, 'tidyargs.cfg')}",
+        "--disable",
+        "bugprone-unused-return-value",
+        "--disable",
+        "cert-err33-c",
+        "--disable",
+        "clang-diagnostic-unused-parameter",
+        "--disable",
+        "clang-diagnostic-double-promotion",
+        "--disable",
+        "clang-diagnostic-mismatched-tags",
+        "--disable",
+        "clang-diagnostic-float-conversion",
+        "--disable",
+        "clang-diagnostic-reserved-identifier",
+        "--disable",
+        "clang-diagnostic-reserved-macro-identifier",
+        "--disable",
+        "clang-diagnostic-unused-private-field",
+        "--disable",
+        "misc-confusable-identifiers",
+    ]
+
+    codechecker_clangsa_options = [
+        "--analyzer-config",
+        f"clangsa:cc-verbatim-args-file={os.path.join(workspace_path, 'clangsa.cfg')}",
+    ]
+
+    codechecker_fast_options = [
+        "-e",
+        "alpha.cplusplus",
+        "-e",
+        "alpha.core.BoolAssignment",
+        "-e",
+        "alpha.core.CastSize",
+        "-e",
+        "alpha.security",
+        "-e",
+        "core",
+        "-e",
+        "cplusplus",
+        "-e",
+        "unix",
+        "-d",
+        "optin",
+        "-d",
+        "optin.cplusplus",
+        "-d",
+        "nullability",
+        "-d",
+        "valist",
+        "-d",
+        "alpha.security",
+        "-d",
+        "deadcode.DeadStores",
+        "--z3",
+        "off",
+        "--z3-refutation",
+        "off",
+        "--analyze-headers",
+        "off",
+        "--expand-macros",
+        "off",
+    ]
+    # Unset OPENSSL_CONF to avoid issues with OpenSSL configuration in subprocesses
+    environ["OPENSSL_CONF"] = ""
+    codechecker_cmd = ["CodeChecker", "analyze"]
+
+    if verbose:
+        codechecker_cmd.extend(["--verbose", verbose])
+
+    codechecker_cmd.extend(codechecker_default_options)
+
+    if analysis_type == "fast":
+        codechecker_cmd.extend(codechecker_fast_options)
+        codechecker_cmd.extend(["--analyzers", "clangsa"])
+        codechecker_cmd.extend(["--analyze-headers", "off", "--expand-macros", "off"])
+    elif analysis_type == "full":
+        codechecker_cmd.extend(["--analyzers", "clang-tidy", "cppcheck", "clangsa"])
+        codechecker_cmd.extend(codechecker_clangtidy_options)
+        codechecker_cmd.extend(codechecker_cppcheck_options)
+        codechecker_cmd.extend(codechecker_clangsa_options)
+    elif analysis_type == "clangsa":
+        codechecker_cmd.extend(["--analyzers", "clangsa"])
+        codechecker_cmd.extend(codechecker_clangsa_options)
+    elif analysis_type == "cppcheck":
+        codechecker_cmd.extend(["--analyzers", "cppcheck"])
+        codechecker_cmd.extend(codechecker_cppcheck_options)
+    elif analysis_type == "clang-tidy":
+        codechecker_cmd.extend(["--analyzers", "clang-tidy"])
+        codechecker_cmd.extend(codechecker_clangtidy_options)
+
+    codechecker_cmd.extend(
+        [
+            "-o",
+            os.path.join(workspace_path, output_dir),
+            compile_commands,
+        ]
+    )
+
+    try:
+        print('Running "' + " ".join(codechecker_cmd) + '"')
+        subprocess.run(codechecker_cmd, check=True, text=True, env=environ)
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 3:
+            pass
+        else:
+            raise e
+
+    plist_files = search_plist_files(os.path.join(workspace_path, output_dir))
+
+    codechecker_cmd = [
+        "CodeChecker",
+        "parse",
+        *plist_files,
+        "-e",
+        f"{export}",
+        "-o",
+        os.path.join(workspace_path, output_dir),
+    ]
+    try:
+        print('Running "' + " ".join(codechecker_cmd) + '"')
+        subprocess.run(codechecker_cmd, check=True, text=True, env=environ)
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 2:
+            pass
+        else:
+            raise e
+
+    if url:
+        codechecker_cmd = [
+            "CodeChecker",
+            "store",
+            os.path.join(workspace_path, output_dir),
+            "-n",
+            output_dir,
+            "--url",
+            url,
+        ]
+        try:
+            print('Running "' + " ".join(codechecker_cmd) + '"')
+            subprocess.run(codechecker_cmd, check=True, text=True, env=environ)
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 2:
+                pass
+            else:
+                raise e
+
+
+#
+# Start the script
+#
+if __name__ == "__main__":
+    # Usage must be:
+    # "ceph_codechecker.py  [--verbose] [--codechecker <type>] [--url <url>] [--export <format>]"
+    # Optional arguments include:
+    # --verbose (-v): Enable verbose reporting.
+    # --codechecker: Enable codechecker analysis with options like 'full', 'fast', 'clangsa', 'cppcheck', or 'clang-tidy'.
+    # --url: Upload codechecker report to a specified URL.
+    # --export (-e): Specify extra output format type (e.g., 'html', 'json', 'codeclimate', etc.).
+
+    arg_parser = argparse.ArgumentParser()
+
+    arg_parser.add_argument(
+        "--verbose",
+        type=str,
+        dest="verbose",
+        choices=["info", "debug_analyzer", "debug"],
+        help="Set verbosity level. If the value is 'debug' or "
+        "'debug_analyzer' it will create a "
+        "'codechecker.logger.debug' debug log file "
+        "beside the given output file. It will contain "
+        "debug information of compilation database "
+        "generation. You can override the location of "
+        "this file if you set the 'CC_LOGGER_DEBUG_FILE' "
+        "environment variable to a different file path.",
+    )
+
+    arg_parser.add_argument(
+        "--codechecker",
+        type=str,
+        choices=["full", "fast", "clangsa", "cppcheck", "clang-tidy"],
+        help="Enable codechecker analysis",
+    )
+    arg_parser.add_argument(
+        "--include-boost",
+        action="store_true",
+        default=False,
+        help="Include boost headers in the analysis (by default boost headers are skipped)",
+    )
+    arg_parser.add_argument(
+        "--url",
+        type=str,
+        default=None,
+        help=(
+            "Upload codechecker report to url, for example "
+            + '"http://codechecker.ceph.org:8001/Default"'
+        ),
+    )
+    arg_parser.add_argument(
+        "--export",
+        "-e",
+        type=str,
+        default="html",
+        choices=["html", "json", "codeclimate", "gerrit", "baseline"],
+        help="""
+Specify extra output format type.
+'codeclimate' format can be used for Code Climate and for GitLab integration. For more information see:
+https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
+'baseline' output can be used to integrate CodeChecker into your local workflow without using a CodeChecker server.
+""",
+    )
+
+    arg_parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default=os.path.abspath("codechecker_output"),
+        help="Base output directory path (default: ./codechecker_output). The actual results will be written to a subdirectory named 'csa-output-<user>-<timestamp>' inside this directory.",
+    )
+    arg_parser.add_argument(
+        "compile_commands",
+        type=str,
+        nargs="?",
+        metavar="COMPILE_COMMANDS",
+        help="(Required) Path to compile_commands.json file generated by your build system. This file is needed for CodeChecker analysis.",
+    )
+    args = arg_parser.parse_args()
+    if not args.compile_commands:
+        print(
+            "Error: Path to compile_commands.json must be provided as a positional argument."
+        )
+        sys.exit(1)
+
+    build_codechecker(
+        compile_commands=args.compile_commands,
+        workspace_path=args.output,
+        analysis_type=args.codechecker,
+        export=args.export,
+        url=args.url,
+        verbose=args.verbose,
+        include_boost=args.include_boost,
+    )

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -166,7 +166,7 @@ TEST_P(CompressorTest, big_round_trip_file)
 }
 #endif
 
-
+#ifndef __clang_analyzer__
 TEST_P(CompressorTest, round_trip_osdmap)
 {
 #include "osdmaps/osdmap.2982809.h"
@@ -205,6 +205,7 @@ TEST_P(CompressorTest, round_trip_osdmap)
   }
   delete o;
 }
+#endif // __clang_analyzer__
 
 TEST_P(CompressorTest, compress_decompress)
 {

--- a/src/test/objectstore/Allocator_aging_fragmentation.cc
+++ b/src/test/objectstore/Allocator_aging_fragmentation.cc
@@ -5,21 +5,23 @@
  * Bitmap allocator fragmentation benchmarks.
  * Author: Adam Kupczyk, akupczyk@redhat.com
  */
+#include <gtest/gtest.h>
+
 #include <bit>
 #include <iostream>
-#include <boost/scoped_ptr.hpp>
-#include <gtest/gtest.h>
-#include <boost/random/triangle_distribution.hpp>
 
-#include "common/ceph_mutex.h"
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/triangle_distribution.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/scoped_ptr.hpp>
+
 #include "common/Cond.h"
+#include "common/ceph_mutex.h"
 #include "common/errno.h"
 #include "global/global_init.h"
-#include "include/stringify.h"
 #include "include/Context.h"
+#include "include/stringify.h"
 #include "os/bluestore/Allocator.h"
-
-#include <boost/random/uniform_int.hpp>
 
 typedef boost::mt11213b gen_type;
 
@@ -293,7 +295,7 @@ void AllocTest::doAgingTest(
     cnt++;
     sum+=len;
   };
-  alloc->dump(list_free);
+  alloc->foreach (list_free);
   ASSERT_EQ(sum, capacity);
   if (verbose)
     std::cout << "free chunks sum=" << sum << " free chunks count=" << cnt << std::endl;
@@ -309,7 +311,7 @@ void AllocTest::doAgingTest(
 
 void AllocTest::SetUpTestSuite()
 {
-  vector<const char*> args;
+  std::vector<const char*> args;
   cct = global_init(NULL, args,
 		    CEPH_ENTITY_TYPE_CLIENT,
 		    CODE_ENVIRONMENT_UTILITY,


### PR DESCRIPTION
Support CodeChecker static analysis tools clang-tidy, cppcheck and clang static analyzer

Refactor assert handling and add noreturn attribute; to
  avoid static analysis false positives
Cleanup Allocator_aging_fragmentation includes

Fixes: https://tracker.ceph.com/issues/73486





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
