### PR TITLE
test: Add option to not delete created objects

### DIFF
--- a/src/common/io_exerciser/Model.cc
+++ b/src/common/io_exerciser/Model.cc
@@ -5,8 +5,11 @@
 
 using Model = ceph::io_exerciser::Model;
 
-Model::Model(const std::string& primary_oid, const std::string& secondary_oid, uint64_t block_size)
-    : num_io(0), primary_oid(primary_oid), secondary_oid(secondary_oid), block_size(block_size) {}
+Model::Model(const std::string& primary_oid, const std::string& secondary_oid,
+             uint64_t block_size, bool delete_objects)
+    : num_io(0), primary_oid_base(primary_oid), primary_oid(primary_oid), secondary_oid(secondary_oid),
+      block_size(block_size), delete_objects(delete_objects)
+{}
 
 const std::string Model::get_primary_oid() const { return primary_oid; }
 

--- a/src/common/io_exerciser/Model.h
+++ b/src/common/io_exerciser/Model.h
@@ -29,12 +29,16 @@ class IoOp;
 class Model {
  protected:
   int num_io{0};
+  std::string primary_oid_base;
   std::string primary_oid;
   std::string secondary_oid;
   uint64_t block_size;
+  bool delete_objects;
+  int num_objects{0};
 
  public:
-  Model(const std::string& primary_oid, const std::string& secondary_oid, uint64_t block_size);
+  Model(const std::string& primary_oid, const std::string& secondary_oid,
+        uint64_t block_size, bool delete_objects);
   virtual ~Model() = default;
 
   virtual bool readyForIoOp(IoOp& op) = 0;

--- a/src/common/io_exerciser/Model.h
+++ b/src/common/io_exerciser/Model.h
@@ -33,9 +33,6 @@ class Model {
   std::string secondary_oid;
   uint64_t block_size;
 
-  void set_primary_oid(const std::string& new_oid);
-  void set_secondary_oid(const std::string& new_oid);
-
  public:
   Model(const std::string& primary_oid, const std::string& secondary_oid, uint64_t block_size);
   virtual ~Model() = default;
@@ -43,6 +40,8 @@ class Model {
   virtual bool readyForIoOp(IoOp& op) = 0;
   virtual void applyIoOp(IoOp& op) = 0;
 
+  virtual void set_primary_oid(const std::string& new_oid);
+  virtual void set_secondary_oid(const std::string& new_oid);
   const std::string get_primary_oid() const;
   const std::string get_secondary_oid() const;
   void swap_primary_secondary_oid();

--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -12,6 +12,18 @@ ObjectModel::ObjectModel(const std::string& primary_oid, const std::string& seco
   rng.seed(seed);
 }
 
+void ObjectModel::set_primary_oid(const std::string& new_oid) {
+  Model::set_primary_oid(new_oid);
+  primary_created = false;
+  primary_contents.resize(0);
+}
+
+void ObjectModel::set_secondary_oid(const std::string& new_oid) {
+  Model::set_secondary_oid(new_oid);
+  secondary_created = false;
+  secondary_contents.resize(0);
+}
+
 int ObjectModel::get_seed(uint64_t offset) const {
   ceph_assert(offset < primary_contents.size());
   return primary_contents[offset];

--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -7,21 +7,10 @@
 
 using ObjectModel = ceph::io_exerciser::ObjectModel;
 
-ObjectModel::ObjectModel(const std::string& primary_oid, const std::string& secondary_oid, uint64_t block_size, int seed)
-    : Model(primary_oid, secondary_oid, block_size), primary_created(false), secondary_created(false) {
+ObjectModel::ObjectModel(const std::string& primary_oid, const std::string& secondary_oid,
+                         uint64_t block_size, int seed, bool delete_objects)
+    : Model(primary_oid, secondary_oid, block_size, delete_objects), primary_created(false), secondary_created(false) {
   rng.seed(seed);
-}
-
-void ObjectModel::set_primary_oid(const std::string& new_oid) {
-  Model::set_primary_oid(new_oid);
-  primary_created = false;
-  primary_contents.resize(0);
-}
-
-void ObjectModel::set_secondary_oid(const std::string& new_oid) {
-  Model::set_secondary_oid(new_oid);
-  secondary_created = false;
-  secondary_contents.resize(0);
 }
 
 int ObjectModel::get_seed(uint64_t offset) const {
@@ -171,13 +160,17 @@ void ObjectModel::applyIoOp(IoOp& op) {
       }
     } break;
 
-    case OpType::Remove:
+    case OpType::Remove: {
       ceph_assert(primary_created);
       ceph_assert(reads.empty());
       ceph_assert(writes.empty());
+      if (!delete_objects) {
+        const std::string new_primary_oid = primary_oid_base + "_" + std::to_string(++num_objects);
+        set_primary_oid(new_primary_oid);
+      }
       primary_created = false;
       primary_contents.resize(0);
-      break;
+    } break;
       
     case OpType::Read: {
       SingleReadOp& readOp = static_cast<SingleReadOp&>(op);

--- a/src/common/io_exerciser/ObjectModel.h
+++ b/src/common/io_exerciser/ObjectModel.h
@@ -47,6 +47,9 @@ class ObjectModel : public Model {
  public:
   ObjectModel(const std::string& primary_oid, const std::string& secondary_oid, uint64_t block_size, int seed);
 
+  void set_primary_oid(const std::string& new_oid) override;
+  void set_secondary_oid(const std::string& new_oid) override;
+
   int get_seed(uint64_t offset) const;
   std::vector<int> get_seed_offsets(int seed) const;
 

--- a/src/common/io_exerciser/ObjectModel.h
+++ b/src/common/io_exerciser/ObjectModel.h
@@ -45,10 +45,8 @@ class ObjectModel : public Model {
   interval_set<uint64_t> writes;
 
  public:
-  ObjectModel(const std::string& primary_oid, const std::string& secondary_oid, uint64_t block_size, int seed);
-
-  void set_primary_oid(const std::string& new_oid) override;
-  void set_secondary_oid(const std::string& new_oid) override;
+  ObjectModel(const std::string& primary_oid, const std::string& secondary_oid,
+              uint64_t block_size, int seed, bool delete_objects = true);
 
   int get_seed(uint64_t offset) const;
   std::vector<int> get_seed_offsets(int seed) const;

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -68,6 +68,16 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
 
 RadosIo::~RadosIo() {}
 
+void RadosIo::set_primary_oid(const std::string& new_oid) {
+  Model::set_primary_oid(new_oid);
+  om->set_primary_oid(new_oid);
+}
+
+void RadosIo::set_secondary_oid(const std::string& new_oid) {
+  Model::set_secondary_oid(new_oid);
+  om->set_secondary_oid(new_oid);
+}
+
 void RadosIo::start_io() {
   std::lock_guard l(lock);
   outstanding_io++;

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -47,12 +47,9 @@ class RadosIo : public Model {
           const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
           uint64_t block_size, int seed, int threads, ceph::mutex& lock,
           ceph::condition_variable& cond, bool is_replicated_pool,
-          bool ec_optimizations);
+          bool ec_optimizations, bool delete_objects = true);
 
   ~RadosIo();
-
-  void set_primary_oid(const std::string& new_oid) override;
-  void set_secondary_oid(const std::string& new_oid) override;
 
   void allow_ec_overwrites(bool allow);
   void allow_ec_optimizations();

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -51,6 +51,9 @@ class RadosIo : public Model {
 
   ~RadosIo();
 
+  void set_primary_oid(const std::string& new_oid) override;
+  void set_secondary_oid(const std::string& new_oid) override;
+
   void allow_ec_overwrites(bool allow);
   void allow_ec_optimizations();
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -1026,12 +1026,12 @@ ceph::io_sequence::tester::TestObject::TestObject(
     SelectObjectSize& sos, SelectNumThreads& snt, SelectSeqRange& ssr,
     ceph::util::random_number_generator<int>& rng, ceph::mutex& lock,
     ceph::condition_variable& cond, bool dryrun, bool verbose,
-    std::optional<int> seqseed, bool testrecovery, bool checkconsistency, bool dontdeleteobjects)
-    : rng(rng), verbose(verbose), seqseed(seqseed), primary_oid(primary_oid), secondary_oid(secondary_oid),
-      testrecovery(testrecovery), checkconsistency(checkconsistency), dontdeleteobjects(dontdeleteobjects) {
+    std::optional<int> seqseed, bool testrecovery, bool checkconsistency, bool delete_objects)
+    : rng(rng), verbose(verbose), seqseed(seqseed), testrecovery(testrecovery), checkconsistency(checkconsistency),
+      delete_objects(delete_objects) {
   if (dryrun) {
     exerciser_model = std::make_unique<ceph::io_exerciser::ObjectModel>(
-        primary_oid, secondary_oid, sbs.select(), rng());
+        primary_oid, secondary_oid, sbs.select(), rng(), delete_objects);
   } else {
     const std::string pool = spo.select();
     if (!dryrun) {
@@ -1053,7 +1053,7 @@ ceph::io_sequence::tester::TestObject::TestObject(
     exerciser_model = std::make_unique<ceph::io_exerciser::RadosIo>(
         rados, asio, pool, primary_oid, secondary_oid, sbs.select(), rng(),
         threads, lock, cond, spo.is_replicated_pool(),
-        spo.get_allow_pool_ec_optimizations());
+        spo.get_allow_pool_ec_optimizations(), delete_objects);
     dout(0) << "= " << primary_oid << " pool=" << pool << " threads=" << threads
             << " blocksize=" << exerciser_model->get_block_size() << " ="
             << dendl;
@@ -1061,9 +1061,6 @@ ceph::io_sequence::tester::TestObject::TestObject(
   obj_size_range = sos.select();
   seq_range = ssr.select();
   curseq = seq_range.first;
-
-  object_counter = 0;
-  primary_oid_base = primary_oid;
 
   if (testrecovery) {
     seq = ceph::io_exerciser::EcIoSequence::generate_sequence(
@@ -1095,13 +1092,7 @@ bool ceph::io_sequence::tester::TestObject::next() {
               << ": " << op->to_string(exerciser_model->get_block_size())
               << dendl;
     }
-    if (dontdeleteobjects && op->getOpType() == ceph::io_exerciser::OpType::Remove) {
-      // Change the primary_oid so that the next object will be created with a different name
-      primary_oid = primary_oid_base + "_" + std::to_string(object_counter++);
-      exerciser_model->set_primary_oid(primary_oid);
-    } else {
-      exerciser_model->applyIoOp(*op);
-    }
+    exerciser_model->applyIoOp(*op);
     if (op->getOpType() == ceph::io_exerciser::OpType::Done) {
       curseq = seq->getNextSupportedSequenceId();
       if (curseq >= seq_range.second) {
@@ -1163,7 +1154,7 @@ ceph::io_sequence::tester::TestRunner::TestRunner(
 
   verbose = vm.contains("verbose");
   dryrun = vm.contains("dryrun");
-  dont_delete_objects = vm.contains("dont_delete_objects");
+  delete_objects = !vm.contains("dont_delete_objects");
 
   seqseed = std::nullopt;
   if (vm.contains("seqseed")) {
@@ -1486,7 +1477,7 @@ bool ceph::io_sequence::tester::TestRunner::run_automated_test() {
       test_objects.push_back(
           std::make_shared<ceph::io_sequence::tester::TestObject>(
               primary_name, secondary_name, rados, asio, sbs, spo, sos, snt, ssr, rng, lock, cond,
-              dryrun, verbose, seqseed, testrecovery, checkconsistency, dont_delete_objects));
+              dryrun, verbose, seqseed, testrecovery, checkconsistency, delete_objects));
     }
     catch (const std::runtime_error &e) {
       std::cerr << "Error: " << e.what() << std::endl;

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -1063,6 +1063,7 @@ ceph::io_sequence::tester::TestObject::TestObject(
   curseq = seq_range.first;
 
   object_counter = 0;
+  primary_oid_base = primary_oid;
 
   if (testrecovery) {
     seq = ceph::io_exerciser::EcIoSequence::generate_sequence(
@@ -1096,8 +1097,8 @@ bool ceph::io_sequence::tester::TestObject::next() {
     }
     if (dontdeleteobjects && op->getOpType() == ceph::io_exerciser::OpType::Remove) {
       // Change the primary_oid so that the next object will be created with a different name
-      std::string new_oid = primary_oid + "_" + std::to_string(object_counter++);
-      exerciser_model->set_primary_oid(new_oid);
+      primary_oid = primary_oid_base + "_" + std::to_string(object_counter++);
+      exerciser_model->set_primary_oid(primary_oid);
     } else {
       exerciser_model->applyIoOp(*op);
     }

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -461,7 +461,7 @@ class TestObject {
              std::optional<int> seqseed,
              bool testRecovery,
              bool checkConsistency,
-             bool dontDeleteObjects);
+             bool delete_objects);
 
   int get_num_io();
   bool readyForIo();
@@ -485,11 +485,7 @@ class TestObject {
       pool_mappinglayers;
   bool testrecovery;
   bool checkconsistency;
-  bool dontdeleteobjects;
-  std::string primary_oid_base;
-  std::string primary_oid;
-  std::string secondary_oid;
-  int object_counter;
+  bool delete_objects;
 };
 
 class TestRunner {
@@ -524,7 +520,7 @@ class TestRunner {
 
   bool verbose;
   bool dryrun;
-  bool dont_delete_objects;
+  bool delete_objects;
   std::optional<int> seqseed;
   bool interactive;
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -460,7 +460,8 @@ class TestObject {
              bool verbose,
              std::optional<int> seqseed,
              bool testRecovery,
-             bool checkConsistency);
+             bool checkConsistency,
+             bool dontDeleteObjects);
 
   int get_num_io();
   bool readyForIo();
@@ -484,6 +485,10 @@ class TestObject {
       pool_mappinglayers;
   bool testrecovery;
   bool checkconsistency;
+  bool dontdeleteobjects;
+  std::string primary_oid;
+  std::string secondary_oid;
+  int object_counter;
 };
 
 class TestRunner {
@@ -518,6 +523,7 @@ class TestRunner {
 
   bool verbose;
   bool dryrun;
+  bool dont_delete_objects;
   std::optional<int> seqseed;
   bool interactive;
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -486,6 +486,7 @@ class TestObject {
   bool testrecovery;
   bool checkconsistency;
   bool dontdeleteobjects;
+  std::string primary_oid_base;
   std::string primary_oid;
   std::string secondary_oid;
   int object_counter;


### PR DESCRIPTION
This commit:
- Adds a command line option '--dont_delete_objects' for the 'ceph_test_rados_io_sequence' command that a user can add if they want to retain objects for testing purposes.
- When this option is on, and a 'Remove' operation is scheduled, the primary_oid of the exerciser_model is modified using the set_primary_oid method. This method ensures that primary_created and primary_contents inside the ObjectModel are consistent with the state after an object has been removed. Changing the primary_oid means that the next object created will not use the same name, and therefore, will not override the previous object.

Fixes: https://tracker.ceph.com/issues/73520
Signed-off-by: Matty Williams <Matty.Williams@ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
