### PR TITLE
test: Add option to select data generation type

### DIFF
--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -17,6 +17,8 @@
 using RadosIo = ceph::io_exerciser::RadosIo;
 using ConsistencyChecker = ceph::consistency::ConsistencyChecker;
 
+using GenerationType = ceph::io_exerciser::data_generation::GenerationType;
+
 namespace {
 template <typename S>
 int send_osd_command(int osd, S& s, librados::Rados& rados, const char* name,
@@ -47,14 +49,14 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
                  const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
                  uint64_t block_size, int seed, int threads, ceph::mutex& lock,
                  ceph::condition_variable& cond, bool is_replicated_pool,
-                 bool ec_optimizations, std::shared_ptr<ceph::io_exerciser::IoSequence> seq,
-                 bool delete_objects)
+                 bool ec_optimizations, GenerationType data_generation_type,
+                 std::shared_ptr<ceph::io_exerciser::IoSequence> seq, bool delete_objects)
     : Model(primary_oid, secondary_oid, block_size, delete_objects),
       rados(rados),
       asio(asio),
       om(std::make_unique<ObjectModel>(primary_oid, secondary_oid, block_size, seed, delete_objects)),
       db(data_generation::DataGenerator::create_generator(
-          data_generation::GenerationType::HeaderedSeededRandom, *om)),
+          data_generation_type, *om)),
       pool(pool),
       threads(threads),
       lock(lock),

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -23,6 +23,7 @@ namespace ceph {
 namespace io_exerciser {
 namespace data_generation {
 class DataGenerator;
+enum class GenerationType;
 }
 
 class RadosIo : public Model {
@@ -49,8 +50,8 @@ class RadosIo : public Model {
           const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
           uint64_t block_size, int seed, int threads, ceph::mutex& lock,
           ceph::condition_variable& cond, bool is_replicated_pool,
-          bool ec_optimizations, std::shared_ptr<ceph::io_exerciser::IoSequence> seq = nullptr,
-          bool delete_objects = true);
+          bool ec_optimizations, ceph::io_exerciser::data_generation::GenerationType data_generation_type,
+          std::shared_ptr<ceph::io_exerciser::IoSequence> seq = nullptr, bool delete_objects = true);
 
   ~RadosIo();
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -55,6 +55,8 @@ using SingleFailedWriteOp = ceph::io_exerciser::SingleFailedWriteOp;
 using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
 
+using GenerationType = ceph::io_exerciser::data_generation::GenerationType;
+
 namespace {
 struct Size {};
 void validate(boost::any& v, const std::vector<std::string>& values,
@@ -222,9 +224,28 @@ po::options_description get_options_description() {
       " may be removed. at a later date. Disabled by default if ec optimized")(
       "dont_delete_objects",
       "Stops the IO exerciser from deleting the object it was running the test "
-      "against once the test finishes. Does not affect interactive mode");
+      "against once the test finishes. Does not affect interactive mode")(
+      "data_generation_type", po::value<std::string>(),
+      "Data generation type to use for write IOs. Default is HeaderedSeededRandom");
 
   return desc;
+}
+
+GenerationType parse_data_generation_type(po::variables_map& vm) {
+  if (!vm.contains("data_generation_type")) {
+    // Default value
+    return GenerationType::HeaderedSeededRandom;
+  }
+
+  std::string data_generation_type = vm["data_generation_type"].as<std::string>();
+  if (data_generation_type == "HeaderedSeededRandom") {
+    return GenerationType::HeaderedSeededRandom;
+  } else if (data_generation_type == "SeededRandom") {
+    return GenerationType::SeededRandom;
+  } else {
+    throw std::invalid_argument(
+      fmt::format("Unrecognised data generation type: {}", data_generation_type));
+  }
 }
 
 int parse_io_seq_options(po::variables_map& vm, int argc, char** argv) {
@@ -1039,9 +1060,11 @@ ceph::io_sequence::tester::TestObject::TestObject(
     SelectObjectSize& sos, SelectNumThreads& snt, SelectSeqRange& ssr,
     std::mt19937_64& rng, ceph::mutex& lock,
     ceph::condition_variable& cond, bool dryrun, bool verbose,
-    std::optional<int> seqseed, bool testrecovery, bool checkconsistency, bool delete_objects)
-    : rng(rng), verbose(verbose), seqseed(seqseed), testrecovery(testrecovery), checkconsistency(checkconsistency),
-      delete_objects(delete_objects) {
+    std::optional<int> seqseed, bool testrecovery, bool checkconsistency,
+    bool delete_objects, GenerationType data_generation_type)
+    : rng(rng), verbose(verbose), seqseed(seqseed), testrecovery(testrecovery),
+      checkconsistency(checkconsistency), delete_objects(delete_objects),
+      data_generation_type(data_generation_type) {
   if (dryrun) {
     int model_seed = rng();
     exerciser_model = std::make_unique<ceph::io_exerciser::ObjectModel>(
@@ -1067,7 +1090,7 @@ ceph::io_sequence::tester::TestObject::TestObject(
     exerciser_model = std::make_unique<ceph::io_exerciser::RadosIo>(
         rados, asio, pool, primary_oid, secondary_oid, sbs.select(), model_seed,
         threads, lock, cond, spo.is_replicated_pool(),
-        spo.get_allow_pool_ec_optimizations(), seq, delete_objects);
+        spo.get_allow_pool_ec_optimizations(), data_generation_type, seq, delete_objects);
     dout(0) << "= " << primary_oid << " pool=" << pool << " threads=" << threads
             << " blocksize=" << exerciser_model->get_block_size() << " ="
             << dendl;
@@ -1169,6 +1192,8 @@ ceph::io_sequence::tester::TestRunner::TestRunner(
   verbose = vm.contains("verbose");
   dryrun = vm.contains("dryrun");
   delete_objects = !vm.contains("dont_delete_objects");
+
+  data_generation_type = parse_data_generation_type(vm);
 
   seqseed = std::nullopt;
   if (vm.contains("seqseed")) {
@@ -1337,7 +1362,8 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
         rados, asio, pool, primary_object_name, secondary_object_name, sbs.select(), model_seed,
         1,  // 1 thread
         lock, cond, spo.is_replicated_pool(),
-        spo.get_allow_pool_ec_optimizations());
+        spo.get_allow_pool_ec_optimizations(),
+        data_generation_type);
   }
 
   while (!done) {
@@ -1493,7 +1519,8 @@ bool ceph::io_sequence::tester::TestRunner::run_automated_test() {
       test_objects.push_back(
           std::make_shared<ceph::io_sequence::tester::TestObject>(
               primary_name, secondary_name, rados, asio, sbs, spo, sos, snt, ssr, rng, lock, cond,
-              dryrun, verbose, seqseed, testrecovery, checkconsistency, delete_objects));
+              dryrun, verbose, seqseed, testrecovery, checkconsistency,
+              delete_objects, data_generation_type));
     }
     catch (const std::runtime_error &e) {
       std::cerr << "Error: " << e.what() << std::endl;

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "ProgramOptionReader.h"
+#include "common/io_exerciser/DataGenerator.h"
 #include "common/io_exerciser/IoOp.h"
 #include "common/io_exerciser/IoSequence.h"
 #include "common/io_exerciser/Model.h"
@@ -15,6 +16,8 @@
 #include "global/global_init.h"
 #include "include/random.h"
 #include "librados/librados_asio.h"
+
+using GenerationType = ceph::io_exerciser::data_generation::GenerationType;
 
 /* Overview
  *
@@ -462,7 +465,8 @@ class TestObject {
              std::optional<int> seqseed,
              bool testRecovery,
              bool checkConsistency,
-             bool delete_objects);
+             bool delete_objects,
+             GenerationType data_generation_type);
 
   int get_num_io();
   bool readyForIo();
@@ -487,6 +491,7 @@ class TestObject {
   bool testrecovery;
   bool checkconsistency;
   bool delete_objects;
+  GenerationType data_generation_type;
 };
 
 class TestRunner {
@@ -539,6 +544,8 @@ class TestRunner {
   int num_object_pairs;
   std::string primary_object_name;
   std::string secondary_object_name;
+
+  GenerationType data_generation_type;
 
   std::string line;
   ceph::split split = ceph::split("");


### PR DESCRIPTION
This commit:
- Adds a new command line argument '--data_generation_type' for 'ceph_test_rados_io_sequence' allowing the user to specify the DataGenerator implementation that they wish to use to generate data for write IOs.
- The two current options are HeaderedSeededRandom and SeededRandom. The default is HeaderedSeededRandom.
- If an unrecognised string is entered, an invalid argument exception will be thrown.

Fixes: https://tracker.ceph.com/issues/73525
Signed-off-by: Matty Williams <Matty.Williams@ibm.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
