### PR TITLE
IO Generator: Add debug to DataGeneration validation failure output

### DIFF
--- a/src/common/io_exerciser/DataGenerator.cc
+++ b/src/common/io_exerciser/DataGenerator.cc
@@ -52,8 +52,7 @@ bufferlist DataGenerator::generate_wrong_data(uint64_t offset,
 
 bool DataGenerator::validate(bufferlist& bufferlist, uint64_t offset,
                              uint64_t length, std::string_view pool,
-                             ceph::io_exerciser::Sequence curseq,
-                             std::unique_ptr<ceph::io_exerciser::IoSequence> seq) {
+                             ceph::io_exerciser::Sequence curseq, int step) {
   return bufferlist.contents_equal(generate_data(offset, length));
 }
 
@@ -218,7 +217,7 @@ HeaderedSeededRandomGenerator::readDateTime(uint64_t block_offset,
 bool HeaderedSeededRandomGenerator::validate(bufferlist& bufferlist, uint64_t offset, 
                                              uint64_t length, std::string_view pool,
                                              ceph::io_exerciser::Sequence curseq,
-                                             std::unique_ptr<ceph::io_exerciser::IoSequence> seq) {
+                                             int step) {
   std::vector<uint64_t> invalid_block_offsets;
 
   for (uint64_t block_offset = offset; block_offset < offset + length;
@@ -232,9 +231,9 @@ bool HeaderedSeededRandomGenerator::validate(bufferlist& bufferlist, uint64_t of
   }
 
   if (!invalid_block_offsets.empty()) {
-    dout(0) << "Miscompare for read of " << m_model.get_primary_oid() <<
-      " offset=" << offset << " length=" << length << " in pool " << pool << 
-      ". This occured in test " << curseq << " step " << seq->get_step() << dendl;
+    dout(0) << "Miscompare for read of oid=" << m_model.get_primary_oid() <<
+      " offset=" << offset << " length=" << length << " pool=" << pool << 
+      ". This occured in test=" << curseq << " step=" << step << dendl;
     printDebugInformationForOffsets(offset, invalid_block_offsets, bufferlist);
   }
 

--- a/src/common/io_exerciser/DataGenerator.h
+++ b/src/common/io_exerciser/DataGenerator.h
@@ -48,7 +48,7 @@ class DataGenerator {
   virtual bufferlist generate_data(uint64_t length, uint64_t offset) = 0;
   virtual bool validate(bufferlist& bufferlist, uint64_t offset,
                         uint64_t length, std::string_view pool,
-                        ceph::io_exerciser::Sequence curseq, int step);
+                        ceph::io_exerciser::Sequence seq, int step);
 
   // Used for testing debug outputs from data generation
   virtual bufferlist generate_wrong_data(uint64_t offset, uint64_t length);
@@ -82,7 +82,7 @@ class HeaderedSeededRandomGenerator : public SeededRandomGenerator {
   bufferptr generate_wrong_block(uint64_t offset) override;
   bool validate(bufferlist& bufferlist, uint64_t offset,
                 uint64_t length, std::string_view pool, 
-                ceph::io_exerciser::Sequence curseq, int step) override;
+                ceph::io_exerciser::Sequence seq, int step) override;
 
  private:
   using UniqueIdBytes = uint64_t;

--- a/src/common/io_exerciser/DataGenerator.h
+++ b/src/common/io_exerciser/DataGenerator.h
@@ -48,8 +48,7 @@ class DataGenerator {
   virtual bufferlist generate_data(uint64_t length, uint64_t offset) = 0;
   virtual bool validate(bufferlist& bufferlist, uint64_t offset,
                         uint64_t length, std::string_view pool,
-                        ceph::io_exerciser::Sequence curseq,
-                        std::unique_ptr<ceph::io_exerciser::IoSequence> seq);
+                        ceph::io_exerciser::Sequence curseq, int step);
 
   // Used for testing debug outputs from data generation
   virtual bufferlist generate_wrong_data(uint64_t offset, uint64_t length);
@@ -82,8 +81,8 @@ class HeaderedSeededRandomGenerator : public SeededRandomGenerator {
   bufferptr generate_block(uint64_t offset) override;
   bufferptr generate_wrong_block(uint64_t offset) override;
   bool validate(bufferlist& bufferlist, uint64_t offset,
-                uint64_t length, std::string_view pool, ceph::io_exerciser::Sequence curseq,
-                std::unique_ptr<ceph::io_exerciser::IoSequence> seq) override;
+                uint64_t length, std::string_view pool, 
+                ceph::io_exerciser::Sequence curseq, int step) override;
 
  private:
   using UniqueIdBytes = uint64_t;

--- a/src/common/io_exerciser/DataGenerator.h
+++ b/src/common/io_exerciser/DataGenerator.h
@@ -4,6 +4,7 @@
 #include <random>
 
 #include "ObjectModel.h"
+#include "IoSequence.h"
 #include "include/buffer.h"
 
 /* Overview
@@ -46,7 +47,9 @@ class DataGenerator {
       GenerationType generatorType, const ObjectModel& model);
   virtual bufferlist generate_data(uint64_t length, uint64_t offset) = 0;
   virtual bool validate(bufferlist& bufferlist, uint64_t offset,
-                        uint64_t length);
+                        uint64_t length, std::string_view pool,
+                        ceph::io_exerciser::Sequence curseq,
+                        std::unique_ptr<ceph::io_exerciser::IoSequence> seq);
 
   // Used for testing debug outputs from data generation
   virtual bufferlist generate_wrong_data(uint64_t offset, uint64_t length);
@@ -79,7 +82,8 @@ class HeaderedSeededRandomGenerator : public SeededRandomGenerator {
   bufferptr generate_block(uint64_t offset) override;
   bufferptr generate_wrong_block(uint64_t offset) override;
   bool validate(bufferlist& bufferlist, uint64_t offset,
-                uint64_t length) override;
+                uint64_t length, std::string_view pool, ceph::io_exerciser::Sequence curseq,
+                std::unique_ptr<ceph::io_exerciser::IoSequence> seq) override;
 
  private:
   using UniqueIdBytes = uint64_t;

--- a/src/common/io_exerciser/Model.cc
+++ b/src/common/io_exerciser/Model.cc
@@ -33,3 +33,8 @@ void Model::swap_primary_secondary_oid() {
 const uint64_t Model::get_block_size() const { return block_size; }
 
 int Model::get_num_io() const { return num_io; }
+
+void Model::set_test_step(ceph::io_exerciser::Sequence new_seq, int new_step) {
+  curseq = new_seq;
+  step = new_step;
+}

--- a/src/common/io_exerciser/Model.cc
+++ b/src/common/io_exerciser/Model.cc
@@ -33,8 +33,3 @@ void Model::swap_primary_secondary_oid() {
 const uint64_t Model::get_block_size() const { return block_size; }
 
 int Model::get_num_io() const { return num_io; }
-
-void Model::set_test_step(ceph::io_exerciser::Sequence new_seq, int new_step) {
-  curseq = new_seq;
-  step = new_step;
-}

--- a/src/common/io_exerciser/Model.h
+++ b/src/common/io_exerciser/Model.h
@@ -34,8 +34,6 @@ class Model {
   std::string primary_oid;
   std::string secondary_oid;
   uint64_t block_size;
-  ceph::io_exerciser::Sequence curseq;
-  int step;
   bool delete_objects;
   int num_objects{0};
 
@@ -49,10 +47,6 @@ class Model {
 
   virtual bool readyForIoOp(IoOp& op) = 0;
   virtual void applyIoOp(IoOp& op) = 0;
-  void set_test_step(ceph::io_exerciser::Sequence new_seq, int new_step);
-
-  virtual void set_primary_oid(const std::string& new_oid);
-  virtual void set_secondary_oid(const std::string& new_oid);
   const std::string get_primary_oid() const;
   const std::string get_secondary_oid() const;
   void swap_primary_secondary_oid();

--- a/src/common/io_exerciser/Model.h
+++ b/src/common/io_exerciser/Model.h
@@ -6,6 +6,7 @@
 #include <boost/asio/io_context.hpp>
 
 #include "IoOp.h"
+#include "common/io_exerciser/IoSequence.h"
 #include "common/Thread.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
@@ -33,8 +34,13 @@ class Model {
   std::string primary_oid;
   std::string secondary_oid;
   uint64_t block_size;
+  ceph::io_exerciser::Sequence curseq;
+  int step;
   bool delete_objects;
   int num_objects{0};
+
+  void set_primary_oid(const std::string& new_oid);
+  void set_secondary_oid(const std::string& new_oid);
 
  public:
   Model(const std::string& primary_oid, const std::string& secondary_oid,
@@ -43,6 +49,7 @@ class Model {
 
   virtual bool readyForIoOp(IoOp& op) = 0;
   virtual void applyIoOp(IoOp& op) = 0;
+  void set_test_step(ceph::io_exerciser::Sequence new_seq, int new_step);
 
   virtual void set_primary_oid(const std::string& new_oid);
   virtual void set_secondary_oid(const std::string& new_oid);

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -47,7 +47,8 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
                  const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
                  uint64_t block_size, int seed, int threads, ceph::mutex& lock,
                  ceph::condition_variable& cond, bool is_replicated_pool,
-                 bool ec_optimizations, bool delete_objects)
+                 bool ec_optimizations, std::shared_ptr<ceph::io_exerciser::IoSequence> seq,
+                 bool delete_objects)
     : Model(primary_oid, secondary_oid, block_size, delete_objects),
       rados(rados),
       asio(asio),
@@ -58,7 +59,8 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
       threads(threads),
       lock(lock),
       cond(cond),
-      outstanding_io(0) {
+      outstanding_io(0),
+      seq(seq) {
   int rc;
   rc = rados.ioctx_create(pool.c_str(), io);
   ceph_assert(rc == 0);
@@ -261,7 +263,9 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
       ceph_assert(ec == boost::system::errc::success);
       for (int i = 0; i < N; i++) {
         ceph_assert(db->validate(op_info->bufferlist[i], op_info->offset[i],
-                                 op_info->length[i], pool, curseq, step));
+                                 op_info->length[i], pool,
+                                 seq ? seq->get_id() : Sequence::SEQUENCE_END,
+                                 seq ? seq->get_step() : -1));
       }
       finish_io();
     };

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -47,8 +47,7 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
                  const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
                  uint64_t block_size, int seed, int threads, ceph::mutex& lock,
                  ceph::condition_variable& cond, bool is_replicated_pool,
-                 bool ec_optimizations, ceph::io_exerciser::Sequence curseq,
-                 std::unique_ptr<ceph::io_exerciser::IoSequence> seq, bool delete_objects)
+                 bool ec_optimizations, bool delete_objects)
     : Model(primary_oid, secondary_oid, block_size, delete_objects),
       rados(rados),
       asio(asio),
@@ -59,9 +58,7 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
       threads(threads),
       lock(lock),
       cond(cond),
-      outstanding_io(0),
-      curseq(curseq),
-      seq(seq) {
+      outstanding_io(0) {
   int rc;
   rc = rados.ioctx_create(pool.c_str(), io);
   ceph_assert(rc == 0);
@@ -264,7 +261,7 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
       ceph_assert(ec == boost::system::errc::success);
       for (int i = 0; i < N; i++) {
         ceph_assert(db->validate(op_info->bufferlist[i], op_info->offset[i],
-                                 op_info->length[i], pool, curseq, seq));
+                                 op_info->length[i], pool, curseq, step));
       }
       finish_io();
     };

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -8,6 +8,7 @@
 #include "DataGenerator.h"
 #include "IoOp.h"
 #include "common/ceph_json.h"
+#include "common/io_exerciser/IoSequence.h"
 #include "common/json/OSDStructures.h"
 #include "librados/librados_asio.h"
 
@@ -46,7 +47,8 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
                  const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
                  uint64_t block_size, int seed, int threads, ceph::mutex& lock,
                  ceph::condition_variable& cond, bool is_replicated_pool,
-                 bool ec_optimizations, bool delete_objects)
+                 bool ec_optimizations, ceph::io_exerciser::Sequence curseq,
+                 std::unique_ptr<ceph::io_exerciser::IoSequence> seq, bool delete_objects)
     : Model(primary_oid, secondary_oid, block_size, delete_objects),
       rados(rados),
       asio(asio),
@@ -57,7 +59,9 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
       threads(threads),
       lock(lock),
       cond(cond),
-      outstanding_io(0) {
+      outstanding_io(0),
+      curseq(curseq),
+      seq(seq) {
   int rc;
   rc = rados.ioctx_create(pool.c_str(), io);
   ceph_assert(rc == 0);
@@ -260,7 +264,7 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
       ceph_assert(ec == boost::system::errc::success);
       for (int i = 0; i < N; i++) {
         ceph_assert(db->validate(op_info->bufferlist[i], op_info->offset[i],
-                                 op_info->length[i]));
+                                 op_info->length[i], pool, curseq, seq));
       }
       finish_io();
     };

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ObjectModel.h"
+#include "common/io_exerciser/IoSequence.h"
 #include "erasure-code/consistency/ConsistencyChecker.h"
 #include "librados/AioCompletionImpl.h"
 #include "common/ceph_mutex.h"
@@ -37,6 +38,8 @@ class RadosIo : public Model {
   ceph::condition_variable& cond;
   librados::IoCtx io;
   int outstanding_io;
+  ceph::io_exerciser::Sequence curseq;
+  std::unique_ptr<ceph::io_exerciser::IoSequence> seq;
 
   void start_io();
   void finish_io();
@@ -47,7 +50,8 @@ class RadosIo : public Model {
           const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
           uint64_t block_size, int seed, int threads, ceph::mutex& lock,
           ceph::condition_variable& cond, bool is_replicated_pool,
-          bool ec_optimizations, bool delete_objects = true);
+          bool ec_optimizations, ceph::io_exerciser::Sequence curseq,
+          std::unique_ptr<ceph::io_exerciser::IoSequence> seq, bool delete_objects = true);
 
   ~RadosIo();
 

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -38,6 +38,7 @@ class RadosIo : public Model {
   ceph::condition_variable& cond;
   librados::IoCtx io;
   int outstanding_io;
+  std::shared_ptr<ceph::io_exerciser::IoSequence> seq;
 
   void start_io();
   void finish_io();
@@ -48,7 +49,8 @@ class RadosIo : public Model {
           const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
           uint64_t block_size, int seed, int threads, ceph::mutex& lock,
           ceph::condition_variable& cond, bool is_replicated_pool,
-          bool ec_optimizations, bool delete_objects = true);
+          bool ec_optimizations, std::shared_ptr<ceph::io_exerciser::IoSequence> seq = nullptr,
+          bool delete_objects = true);
 
   ~RadosIo();
 

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -38,8 +38,6 @@ class RadosIo : public Model {
   ceph::condition_variable& cond;
   librados::IoCtx io;
   int outstanding_io;
-  ceph::io_exerciser::Sequence curseq;
-  std::unique_ptr<ceph::io_exerciser::IoSequence> seq;
 
   void start_io();
   void finish_io();
@@ -50,8 +48,7 @@ class RadosIo : public Model {
           const std::string& pool, const std::string& primary_oid, const std::string& secondary_oid,
           uint64_t block_size, int seed, int threads, ceph::mutex& lock,
           ceph::condition_variable& cond, bool is_replicated_pool,
-          bool ec_optimizations, ceph::io_exerciser::Sequence curseq,
-          std::unique_ptr<ceph::io_exerciser::IoSequence> seq, bool delete_objects = true);
+          bool ec_optimizations, bool delete_objects = true);
 
   ~RadosIo();
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -1053,7 +1053,7 @@ ceph::io_sequence::tester::TestObject::TestObject(
     exerciser_model = std::make_unique<ceph::io_exerciser::RadosIo>(
         rados, asio, pool, primary_oid, secondary_oid, sbs.select(), rng(),
         threads, lock, cond, spo.is_replicated_pool(),
-        spo.get_allow_pool_ec_optimizations(), delete_objects);
+        spo.get_allow_pool_ec_optimizations(), seq, delete_objects);
     dout(0) << "= " << primary_oid << " pool=" << pool << " threads=" << threads
             << " blocksize=" << exerciser_model->get_block_size() << " ="
             << dendl;
@@ -1072,7 +1072,6 @@ ceph::io_sequence::tester::TestObject::TestObject(
   }
 
   op = seq->next();
-  exerciser_model->set_test_step(curseq, seq->get_step());
   done = false;
   dout(0) << "== " << exerciser_model->get_primary_oid() << " " << curseq << " "
           << seq->get_name_with_seqseed() << " ==" << dendl;
@@ -1119,7 +1118,6 @@ bool ceph::io_sequence::tester::TestObject::next() {
       op = seq->next();
     }
   }
-  exerciser_model->set_test_step(curseq, seq->get_step());
   return done;
 }
 
@@ -1208,7 +1206,7 @@ void ceph::io_sequence::tester::TestRunner::list_sequence(bool testrecovery) {
   // List sequences
   std::pair<int, int> obj_size_range = sos.select();
   ceph::io_exerciser::Sequence s = ceph::io_exerciser::Sequence::SEQUENCE_BEGIN;
-  std::unique_ptr<ceph::io_exerciser::IoSequence> seq;
+  std::shared_ptr<ceph::io_exerciser::IoSequence> seq;
   std::optional<std::pair<int, int>> km;
   std::optional<std::pair<std::string_view, std::string_view>> mappinglayers;
   if (testrecovery) {

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -1072,6 +1072,7 @@ ceph::io_sequence::tester::TestObject::TestObject(
   }
 
   op = seq->next();
+  exerciser_model->set_test_step(curseq, seq->get_step());
   done = false;
   dout(0) << "== " << exerciser_model->get_primary_oid() << " " << curseq << " "
           << seq->get_name_with_seqseed() << " ==" << dendl;
@@ -1118,6 +1119,7 @@ bool ceph::io_sequence::tester::TestObject::next() {
       op = seq->next();
     }
   }
+  exerciser_model->set_test_step(curseq, seq->get_step());
   return done;
 }
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -474,7 +474,7 @@ class TestObject {
   std::pair<ceph::io_exerciser::Sequence, ceph::io_exerciser::Sequence>
       seq_range;
   ceph::io_exerciser::Sequence curseq;
-  std::unique_ptr<ceph::io_exerciser::IoSequence> seq;
+  std::shared_ptr<ceph::io_exerciser::IoSequence> seq;
   std::unique_ptr<ceph::io_exerciser::IoOp> op;
   bool done;
   ceph::util::random_number_generator<int>& rng;


### PR DESCRIPTION
Adds the pool, test and test step to the error message that is output when DataGeneration validation fails.

Fixes: https://tracker.ceph.com/issues/73534
Signed-off-by: Matty Williams <Matty.Williams@ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
