### PR TITLE
tentacle: build-with-container: build image variants

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -17,13 +17,13 @@ COPY \
 
 
 FROM $DISTRO
-ENV FOR_MAKE_CHECK=1
 ARG DISTRO
 ARG CEPH_CTR_SRC=/usr/local/src/ceph
 ARG CLEAN_DNF=yes
 ARG CEPH_BASE_BRANCH=main
 ARG SCCACHE_VERSION=0.8.2
 ARG WITH_CRIMSON=true
+ARG FOR_MAKE_CHECK=1
 COPY --from=bootstrap ${CEPH_CTR_SRC} ${CEPH_CTR_SRC}
 # Note that we do not use ENV for the following. This is because we do not
 # want them permamently stored in the container's layer.
@@ -32,6 +32,7 @@ RUN DISTRO=$DISTRO \
     CLEAN_DNF=$CLEAN_DNF \
     CEPH_CTR_SRC=${CEPH_CTR_SRC} \
     WITH_CRIMSON=${WITH_CRIMSON} \
+    FOR_MAKE_CHECK=${FOR_MAKE_CHECK} \
     bash -x ${CEPH_CTR_SRC}/buildcontainer-setup.sh
 RUN \
     SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz"; \

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -320,13 +320,22 @@ function preload_wheels_for_tox() {
 }
 
 for_make_check=false
-if tty -s; then
+if [ "$FOR_MAKE_CHECK" ]; then
+    case "$FOR_MAKE_CHECK" in
+        true|1|yes)
+            for_make_check=true
+        ;;
+        false|0|no)
+            for_make_check=false
+        ;;
+        *)
+            echo "error: unexpected FOR_MAKE_CHECK value: ${FOR_MAKE_CHECK}"
+            exit 2
+        ;;
+    esac
+elif tty -s; then
     # interactive
     for_make_check=true
-elif [ $FOR_MAKE_CHECK ]; then
-    for_make_check=true
-else
-    for_make_check=false
 fi
 
 if [ x$(uname)x = xFreeBSDx ]; then

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -237,7 +237,9 @@ def _run(cmd, *args, **kwargs):
     return subprocess.run(cmd, *args, **kwargs)
 
 
-def _container_cmd(ctx, args, *, workdir=None, interactive=False):
+def _container_cmd(
+    ctx, args, *, workdir=None, interactive=False, extra_args=None
+):
     rm_container = not ctx.cli.keep_container
     cmd = [
         ctx.container_engine,
@@ -277,8 +279,8 @@ def _container_cmd(ctx, args, *, workdir=None, interactive=False):
         )
         cmd.append(f"-eCCACHE_DIR={ccdir}")
         cmd.append(f"-eCCACHE_BASEDIR={ctx.cli.homedir}")
-    for extra_arg in ctx.cli.extra or []:
-        cmd.append(extra_arg)
+    cmd.extend(extra_args or [])
+    cmd.extend(ctx.cli.extra or [])
     if ctx.npm_cache_dir:
         # use :z so that other builds can use the cache
         cmd.extend([
@@ -367,6 +369,11 @@ class ImageSource(StrEnum):
         return ", ".join(s.value for s in cls)
 
 
+class ImageVariant(StrEnum):
+    DEFAULT = 'default'  # build everything + make check
+    PACKAGES = 'packages'  # test deps. ignored, only for packages
+
+
 class Context:
     """Command context."""
 
@@ -409,6 +416,8 @@ class Context:
                 branch = _git_current_branch(self).replace("/", "-")
             except subprocess.CalledProcessError:
                 branch = "UNKNOWN"
+        if self.cli.image_variant is not ImageVariant.DEFAULT:
+            suffix = f".{self.cli.image_variant}{suffix}"
         return f"{branch}.{self.cli.distro}{suffix}"
 
     def base_branch(self):
@@ -614,6 +623,8 @@ def build_container(ctx):
             f"--volume={ctx.dnf_cache_dir}:/var/cache/dnf:Z",
             "--build-arg=CLEAN_DNF=no",
         ]
+    if ctx.cli.image_variant is ImageVariant.PACKAGES:
+        cmd.append("--build-arg=FOR_MAKE_CHECK=false")
     if ctx.cli.build_args:
         cmd.extend([f"--build-arg={v}" for v in ctx.cli.build_args])
     cmd += ["-f", ctx.cli.containerfile, ctx.cli.containerdir]
@@ -726,6 +737,9 @@ def bc_build_tests(ctx):
             "-c",
             f"cd {ctx.cli.homedir} && source ./src/script/run-make.sh && build tests",
         ],
+        # for compatibility with earlier versions that baked this env var
+        # into the build images
+        extra_args=['-eFOR_MAKE_CHECK=1'],
     )
     with ctx.user_command():
         _run(cmd, check=True, ctx=ctx)
@@ -1077,6 +1091,13 @@ def parse_cli(build_step_names):
         type=ImageSource.argument,
         help="Specify a set of valid image sources. "
         f"May be a comma separated list of {ImageSource.hint()}",
+    )
+    g_image.add_argument(
+        "--image-variant",
+        type=ImageVariant,
+        choices=sorted(v.value for v in ImageVariant),
+        default=ImageVariant.DEFAULT.value,
+        help="Specify the variant of the build image desired.",
     )
     g_image.add_argument(
         "--base-image",


### PR DESCRIPTION
Backport patches from #65919





## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
