### PR TITLE
IO Generator: Change random number generator to be compiler independent

### DIFF
--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -5,6 +5,12 @@
 #include <execution>
 #include <iterator>
 
+#include "common/debug.h"
+#include "common/dout.h"
+
+#define dout_subsys ceph_subsys_rados
+#define dout_context g_ceph_context
+
 using ObjectModel = ceph::io_exerciser::ObjectModel;
 
 ObjectModel::ObjectModel(const std::string& primary_oid, const std::string& secondary_oid,
@@ -48,8 +54,14 @@ bool ObjectModel::readyForIoOp(IoOp& op) { return true; }
 
 void ObjectModel::applyIoOp(IoOp& op) {
   auto generate_random = [&rng = rng]() {
-    std::uniform_int_distribution<long long> distMax(1, std::numeric_limits<int>::max());
-    return distMax(rng);
+    constexpr int64_t min = 1;
+    constexpr int64_t max = static_cast<int64_t>(std::numeric_limits<int>::max());
+    constexpr uint64_t range = static_cast<uint64_t>(max - min + 1);
+    uint64_t rand_value = rng();
+    int64_t result = static_cast<int64_t>(rand_value % range + min);
+    dout(0) << "S1 rand_value: " << rand_value << " range: " 
+            << range << " result: " << result  << " addr: " << &rng << dendl;
+    return result;
   };
 
   auto verify_and_record_read_op =

--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -4,20 +4,14 @@
 #include <algorithm>
 #include <execution>
 #include <iterator>
-
-#include "common/debug.h"
-#include "common/dout.h"
-
-#define dout_subsys ceph_subsys_rados
-#define dout_context g_ceph_context
+#include <random>
 
 using ObjectModel = ceph::io_exerciser::ObjectModel;
 
 ObjectModel::ObjectModel(const std::string& primary_oid, const std::string& secondary_oid,
                          uint64_t block_size, int seed, bool delete_objects)
-    : Model(primary_oid, secondary_oid, block_size, delete_objects), primary_created(false), secondary_created(false) {
-  rng.seed(seed);
-}
+    : Model(primary_oid, secondary_oid, block_size, delete_objects),
+      primary_created(false), secondary_created(false), rng(seed) {}
 
 int ObjectModel::get_seed(uint64_t offset) const {
   ceph_assert(offset < primary_contents.size());
@@ -58,10 +52,7 @@ void ObjectModel::applyIoOp(IoOp& op) {
     constexpr int64_t max = static_cast<int64_t>(std::numeric_limits<int>::max());
     constexpr uint64_t range = static_cast<uint64_t>(max - min + 1);
     uint64_t rand_value = rng();
-    int64_t result = static_cast<int64_t>(rand_value % range + min);
-    dout(0) << "S1 rand_value: " << rand_value << " range: " 
-            << range << " result: " << result  << " addr: " << &rng << dendl;
-    return result;
+    return static_cast<int64_t>(rand_value % range + min);
   };
 
   auto verify_and_record_read_op =

--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -48,7 +48,8 @@ bool ObjectModel::readyForIoOp(IoOp& op) { return true; }
 
 void ObjectModel::applyIoOp(IoOp& op) {
   auto generate_random = [&rng = rng]() {
-    return rng(1, std::numeric_limits<int>::max());
+    std::uniform_int_distribution<long long> distMax(1, std::numeric_limits<int>::max());
+    return distMax(rng);
   };
 
   auto verify_and_record_read_op =

--- a/src/common/io_exerciser/ObjectModel.h
+++ b/src/common/io_exerciser/ObjectModel.h
@@ -29,8 +29,8 @@ class ObjectModel : public Model {
   bool secondary_created;
   std::vector<int> primary_contents;
   std::vector<int> secondary_contents;
-  ceph::util::random_number_generator<int> rng =
-      ceph::util::random_number_generator<int>();
+  std::mt19937_64 rng =
+      std::mt19937_64();
 
   // Track read and write I/Os that can be submitted in
   // parallel to detect violations:

--- a/src/common/io_exerciser/ObjectModel.h
+++ b/src/common/io_exerciser/ObjectModel.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <random>
 
 /* Overview
  *
@@ -29,8 +30,7 @@ class ObjectModel : public Model {
   bool secondary_created;
   std::vector<int> primary_contents;
   std::vector<int> secondary_contents;
-  std::mt19937_64 rng =
-      std::mt19937_64();
+  std::mt19937_64 rng;
 
   // Track read and write I/Os that can be submitted in
   // parallel to detect violations:

--- a/src/test/osd/ceph_test_rados_io_sequence/ProgramOptionReader.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ProgramOptionReader.h
@@ -5,13 +5,8 @@
 #include <random>
 #include <string>
 
-#include "common/debug.h"
-#include "common/dout.h"
 #include "include/ceph_assert.h"
 #include "include/random.h"
-
-#define dout_subsys ceph_subsys_rados
-#define dout_context g_ceph_context
 
 /* Overview
  *
@@ -114,8 +109,6 @@ class ProgramOptionSelector : public ProgramOptionReader<option_type> {
       uint64_t range = static_cast<uint64_t>(num_selections);
       uint64_t rand_value = rng();
       size_t index = static_cast<size_t>(rand_value % range);
-      dout(0) << "S4 rand_value: " << rand_value << " range: " 
-            << range << " index: " << index  << " addr: " << &rng << dendl;
       return selections_array[index];
     }
   }
@@ -165,15 +158,11 @@ public:
       uint64_t range = static_cast<uint64_t>(num_selections_stable);
       uint64_t rand_value = rng();
       size_t index = static_cast<size_t>(rand_value % range);
-      dout(0) << "S2 rand_value: " << rand_value << " range: " 
-            << range << " index: " << index << " addr: " << &rng << dendl;
       return selections_array_stable[index];
     } else {
       uint64_t range = static_cast<uint64_t>(num_selections);
       uint64_t rand_value = rng();
       size_t index = static_cast<size_t>(rand_value % range);
-      dout(0) << "S6 rand_value: " << rand_value << " range: " 
-            << range << " index: " << index << " addr: " << &rng << dendl;
       return selections_array[index];
     }
   }
@@ -223,8 +212,6 @@ class ProgramOptionGeneratedSelector
       uint64_t range = static_cast<uint64_t>(selection.size());
       uint64_t rand_value = rng();
       size_t index = static_cast<size_t>(rand_value % range);
-      dout(0) << "S3 rand_value: " << rand_value << " range: " 
-            << range << " index: " << index  << " addr: " << &rng << dendl;
       return selection[index];
     } else {
       return std::nullopt;

--- a/src/test/osd/ceph_test_rados_io_sequence/ProgramOptionReader.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ProgramOptionReader.h
@@ -2,6 +2,7 @@
 
 #include <boost/program_options.hpp>
 #include <optional>
+#include <random>
 #include <string>
 
 #include "include/ceph_assert.h"
@@ -86,7 +87,7 @@ template <typename option_type,
                             num_selections>& selections_array>
 class ProgramOptionSelector : public ProgramOptionReader<option_type> {
  public:
-  ProgramOptionSelector(ceph::util::random_number_generator<int>& rng,
+  ProgramOptionSelector(std::mt19937_64& rng,
                         po::variables_map& vm,
                         const std::string& option_name,
                         bool select_first)
@@ -105,12 +106,13 @@ class ProgramOptionSelector : public ProgramOptionReader<option_type> {
     } else if (first_value.has_value()) {
       return *std::exchange(first_value, std::nullopt);
     } else {
-      return selections_array[rng(num_selections - 1)];
+      std::uniform_int_distribution<long long> dist_selections(0, num_selections - 1);
+      return selections_array[dist_selections(rng)];
     }
   }
 
  protected:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   std::optional<option_type> first_value;
 };
@@ -124,7 +126,7 @@ template <typename option_type,
                             num_selections_stable>& elections_array_stable>
 class StableOptionSelector : public ProgramOptionReader<option_type> {
 public:
-  StableOptionSelector(ceph::util::random_number_generator<int>& rng,
+  StableOptionSelector(std::mt19937_64& rng,
                         po::variables_map& vm,
                         const std::string& option_name,
                         bool select_first)
@@ -150,14 +152,16 @@ public:
     } else if (first_value.has_value()) {
       return *std::exchange(first_value, std::nullopt);
     } else if (stable) {
-      return elections_array_stable[rng(num_selections_stable - 1)];
+      std::uniform_int_distribution<long long> dist_selections_stable(0, num_selections_stable - 1);
+      return elections_array_stable[dist_selections_stable(rng)];
     } else {
-      return selections_array[rng(num_selections - 1)];
+      std::uniform_int_distribution<long long> dist_selections(0, num_selections - 1);
+      return selections_array[dist_selections(rng)];
     }
   }
 
 protected:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
   std::optional<option_type> first_value;
   bool stable;
 };
@@ -166,7 +170,7 @@ template <typename option_type>
 class ProgramOptionGeneratedSelector
     : public OptionalProgramOptionReader<option_type> {
  public:
-  ProgramOptionGeneratedSelector(ceph::util::random_number_generator<int>& rng,
+  ProgramOptionGeneratedSelector(std::mt19937_64& rng,
                                  po::variables_map& vm,
                                  const std::string& option_name,
                                  bool first_use)
@@ -196,16 +200,18 @@ class ProgramOptionGeneratedSelector
 
   virtual const std::optional<option_type> selectRandom() {
     std::vector<option_type> selection = generate_selections();
-    if (selection.size() > 0)
-      return selection[rng(selection.size() - 1)];
-    else
+    if (selection.size() > 0) {
+      std::uniform_int_distribution<long long> dist_selection(0, selection.size() - 1);
+      return selection[dist_selection(rng)];
+    } else {
       return std::nullopt;
+    }
   }
 
   bool is_first_use() { return first_use; }
 
  private:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   bool first_use;
 };

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -2,6 +2,7 @@
 
 #include <boost/asio/io_context.hpp>
 #include <iostream>
+#include <random>
 #include <vector>
 
 #include "common/Formatter.h"
@@ -301,7 +302,7 @@ ceph::io_sequence::tester::SelectSeqRange::select() {
 }
 
 ceph::io_sequence::tester::SelectErasureTechnique::SelectErasureTechnique(
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     std::string_view plugin,
     bool first_use)
@@ -339,7 +340,7 @@ ceph::io_sequence::tester::SelectErasureTechnique::generate_selections() {
 }
 
 ceph::io_sequence::tester::lrc::SelectMappingAndLayers::SelectMappingAndLayers(
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     bool first_use)
     : rng_seed(rng()),
@@ -366,7 +367,7 @@ ceph::io_sequence::tester::lrc::SelectMappingAndLayers::select() {
 }
 
 ceph::io_sequence::tester::SelectErasureKM::SelectErasureKM(
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     std::string_view plugin,
     const std::optional<std::string>& technique,
@@ -416,7 +417,7 @@ ceph::io_sequence::tester::SelectErasureKM::generate_selections() {
 }
 
 ceph::io_sequence::tester::jerasure::SelectErasureW::SelectErasureW(
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     std::string_view plugin,
     const std::optional<std::string_view>& technique,
@@ -457,7 +458,7 @@ ceph::io_sequence::tester::jerasure::SelectErasureW::generate_selections() {
 }
 
 ceph::io_sequence::tester::shec::SelectErasureC::SelectErasureC(
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     std::string_view plugin,
     const std::optional<std::pair<int, int>>& km,
@@ -484,7 +485,7 @@ ceph::io_sequence::tester::shec::SelectErasureC::generate_selections() {
 }
 
 ceph::io_sequence::tester::jerasure::SelectErasurePacketSize::
-    SelectErasurePacketSize(ceph::util::random_number_generator<int>& rng,
+    SelectErasurePacketSize(std::mt19937_64& rng,
                             po::variables_map& vm,
                             std::string_view plugin,
                             const std::optional<std::string_view>& technique,
@@ -532,7 +533,7 @@ const std::vector<uint64_t> ceph::io_sequence::tester::jerasure::
 }
 
 ceph::io_sequence::tester::SelectErasureChunkSize::SelectErasureChunkSize(
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     ErasureCodeInterfaceRef ec_impl,
     bool first_use)
@@ -552,19 +553,22 @@ ceph::io_sequence::tester::SelectErasureChunkSize::generate_selections() {
   if (4096 % minimum_chunksize == 0) {
     choices.push_back(4096);
   } else {
-    choices.push_back(minimum_chunksize * (rng(4) + 1));
+    std::uniform_int_distribution<long long> dist4(0, 3);
+    choices.push_back(minimum_chunksize * (dist4(rng) + 1));
   }
 
   if ((64 * 1024) % minimum_chunksize == 0) {
     choices.push_back(64 * 1024);
   } else {
-    choices.push_back(minimum_chunksize * (rng(64) + 1));
+    std::uniform_int_distribution<long long> dist64(0, 63);
+    choices.push_back(minimum_chunksize * (dist64(rng) + 1));
   }
 
   if ((256 * 1024) % minimum_chunksize == 0) {
     choices.push_back(256 * 1024);
   } else {
-    choices.push_back(minimum_chunksize * (rng(256) + 1));
+    std::uniform_int_distribution<long long> dist256(0, 255);
+    choices.push_back(minimum_chunksize * (dist256(rng) + 1));
   }
 
   return choices;
@@ -572,7 +576,7 @@ ceph::io_sequence::tester::SelectErasureChunkSize::generate_selections() {
 
 ceph::io_sequence::tester::SelectErasureProfile::SelectErasureProfile(
     boost::intrusive_ptr<CephContext> cct,
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     librados::Rados& rados,
     bool dry_run,
@@ -795,7 +799,7 @@ ceph::io_sequence::tester::SelectErasureProfile::selectExistingProfile(
 
 ceph::io_sequence::tester::SelectErasurePool::SelectErasurePool(
     boost::intrusive_ptr<CephContext> cct,
-    ceph::util::random_number_generator<int>& rng,
+    std::mt19937_64& rng,
     po::variables_map& vm,
     librados::Rados& rados,
     bool dry_run,
@@ -1024,7 +1028,7 @@ ceph::io_sequence::tester::TestObject::TestObject(
     const std::string primary_oid, const std::string secondary_oid, librados::Rados& rados,
     boost::asio::io_context& asio, SelectBlockSize& sbs, SelectErasurePool& spo,
     SelectObjectSize& sos, SelectNumThreads& snt, SelectSeqRange& ssr,
-    ceph::util::random_number_generator<int>& rng, ceph::mutex& lock,
+    std::mt19937_64& rng, ceph::mutex& lock,
     ceph::condition_variable& cond, bool dryrun, bool verbose,
     std::optional<int> seqseed, bool testrecovery, bool checkconsistency, bool delete_objects)
     : rng(rng), verbose(verbose), seqseed(seqseed), testrecovery(testrecovery), checkconsistency(checkconsistency),
@@ -1133,7 +1137,7 @@ ceph::io_sequence::tester::TestRunner::TestRunner(
     librados::Rados& rados)
     : rados(rados),
       seed(vm.contains("seed") ? vm["seed"].as<int>() : time(nullptr)),
-      rng(ceph::util::random_number_generator<int>(seed)),
+      rng(seed),
       sbs{rng, vm, "blocksize", true},
       sos{rng, vm, "objectsize", true},
       spo{cct,
@@ -1316,6 +1320,7 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
         primary_object_name, secondary_object_name, sbs.select(), rng());
   } else {
     const std::string pool = spo.select();
+    dout(0) << "Pool name: " << pool << dendl;
 
     model = std::make_unique<ceph::io_exerciser::RadosIo>(
         rados, asio, pool, primary_object_name, secondary_object_name, sbs.select(), rng(),

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -552,30 +552,27 @@ ceph::io_sequence::tester::SelectErasureChunkSize::generate_selections() {
 
   auto generate_random_int = [this](uint64_t range) -> uint64_t {
     uint64_t rand_value = rng();
-    uint64_t index = rand_value % range;
-    dout(0) << "S5 rand_value: " << rand_value << " range: " 
-            << range << " index: " << index  << " addr: " << &rng << dendl;
-    return index;
+    return rand_value % range;;
   };
 
   if (4096 % minimum_chunksize == 0) {
     choices.push_back(4096);
   } else {
-    uint64_t r = generate_random_int(4); // 0–3
+    uint64_t r = generate_random_int(4); // [0–3]
     choices.push_back(minimum_chunksize * (r + 1));
   }
 
   if ((64 * 1024) % minimum_chunksize == 0) {
     choices.push_back(64 * 1024);
   } else {
-    uint64_t r = generate_random_int(64); // 0–63
+    uint64_t r = generate_random_int(64); // [0–63]
     choices.push_back(minimum_chunksize * (r + 1));
   }
 
   if ((256 * 1024) % minimum_chunksize == 0) {
     choices.push_back(256 * 1024);
   } else {
-    uint64_t r = generate_random_int(256); // 0–255
+    uint64_t r = generate_random_int(256); // [0–255]
     choices.push_back(minimum_chunksize * (r + 1));
   }
 
@@ -1042,8 +1039,9 @@ ceph::io_sequence::tester::TestObject::TestObject(
     : rng(rng), verbose(verbose), seqseed(seqseed), testrecovery(testrecovery), checkconsistency(checkconsistency),
       delete_objects(delete_objects) {
   if (dryrun) {
+    int model_seed = rng();
     exerciser_model = std::make_unique<ceph::io_exerciser::ObjectModel>(
-        primary_oid, secondary_oid, sbs.select(), rng(), delete_objects);
+        primary_oid, secondary_oid, sbs.select(), model_seed, delete_objects);
   } else {
     const std::string pool = spo.select();
     if (!dryrun) {
@@ -1061,9 +1059,9 @@ ceph::io_sequence::tester::TestObject::TestObject(
 
     bufferlist outbl;
     auto formatter = std::make_unique<JSONFormatter>(false);
-
+    int model_seed = rng();
     exerciser_model = std::make_unique<ceph::io_exerciser::RadosIo>(
-        rados, asio, pool, primary_oid, secondary_oid, sbs.select(), rng(),
+        rados, asio, pool, primary_oid, secondary_oid, sbs.select(), model_seed,
         threads, lock, cond, spo.is_replicated_pool(),
         spo.get_allow_pool_ec_optimizations(), delete_objects);
     dout(0) << "= " << primary_oid << " pool=" << pool << " threads=" << threads
@@ -1324,14 +1322,15 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
   std::unique_ptr<ceph::io_exerciser::Model> model;
 
   if (dryrun) {
+    int model_seed = rng();
     model = std::make_unique<ceph::io_exerciser::ObjectModel>(
-        primary_object_name, secondary_object_name, sbs.select(), rng());
+        primary_object_name, secondary_object_name, sbs.select(), model_seed);
   } else {
     const std::string pool = spo.select();
     dout(0) << "Pool name: " << pool << dendl;
-
+    int model_seed = rng();
     model = std::make_unique<ceph::io_exerciser::RadosIo>(
-        rados, asio, pool, primary_object_name, secondary_object_name, sbs.select(), rng(),
+        rados, asio, pool, primary_object_name, secondary_object_name, sbs.select(), model_seed,
         1,  // 1 thread
         lock, cond, spo.is_replicated_pool(),
         spo.get_allow_pool_ec_optimizations());

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -550,25 +550,33 @@ ceph::io_sequence::tester::SelectErasureChunkSize::generate_selections() {
 
   std::vector<uint64_t> choices = {};
 
+  auto generate_random_int = [this](uint64_t range) -> uint64_t {
+    uint64_t rand_value = rng();
+    uint64_t index = rand_value % range;
+    dout(0) << "S5 rand_value: " << rand_value << " range: " 
+            << range << " index: " << index  << " addr: " << &rng << dendl;
+    return index;
+  };
+
   if (4096 % minimum_chunksize == 0) {
     choices.push_back(4096);
   } else {
-    std::uniform_int_distribution<long long> dist4(0, 3);
-    choices.push_back(minimum_chunksize * (dist4(rng) + 1));
+    uint64_t r = generate_random_int(4); // 0–3
+    choices.push_back(minimum_chunksize * (r + 1));
   }
 
   if ((64 * 1024) % minimum_chunksize == 0) {
     choices.push_back(64 * 1024);
   } else {
-    std::uniform_int_distribution<long long> dist64(0, 63);
-    choices.push_back(minimum_chunksize * (dist64(rng) + 1));
+    uint64_t r = generate_random_int(64); // 0–63
+    choices.push_back(minimum_chunksize * (r + 1));
   }
 
   if ((256 * 1024) % minimum_chunksize == 0) {
     choices.push_back(256 * 1024);
   } else {
-    std::uniform_int_distribution<long long> dist256(0, 255);
-    choices.push_back(minimum_chunksize * (dist256(rng) + 1));
+    uint64_t r = generate_random_int(256); // 0–255
+    choices.push_back(minimum_chunksize * (r + 1));
   }
 
   return choices;

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -1,6 +1,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/program_options.hpp>
 #include <optional>
+#include <random>
 #include <string>
 #include <utility>
 
@@ -161,7 +162,7 @@ using SelectErasurePlugin =
 class SelectErasureKM
     : public ProgramOptionGeneratedSelector<std::pair<int, int>> {
  public:
-  SelectErasureKM(ceph::util::random_number_generator<int>& rng,
+  SelectErasureKM(std::mt19937_64& rng,
                   po::variables_map& vm,
                   std::string_view plugin,
                   const std::optional<std::string>& technique,
@@ -170,7 +171,7 @@ class SelectErasureKM
   const std::vector<std::pair<int, int>> generate_selections() override;
 
  private:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   std::string_view plugin;
   std::optional<std::string> technique;
@@ -179,7 +180,7 @@ class SelectErasureKM
 namespace shec {
 class SelectErasureC : public ProgramOptionGeneratedSelector<uint64_t> {
  public:
-  SelectErasureC(ceph::util::random_number_generator<int>& rng,
+  SelectErasureC(std::mt19937_64& rng,
                  po::variables_map& vm,
                  std::string_view plugin,
                  const std::optional<std::pair<int, int>>& km,
@@ -188,7 +189,7 @@ class SelectErasureC : public ProgramOptionGeneratedSelector<uint64_t> {
   const std::vector<uint64_t> generate_selections() override;
 
  private:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   std::string_view plugin;
   std::optional<std::pair<int, int>> km;
@@ -198,7 +199,7 @@ class SelectErasureC : public ProgramOptionGeneratedSelector<uint64_t> {
 namespace jerasure {
 class SelectErasureW : public ProgramOptionGeneratedSelector<uint64_t> {
  public:
-  SelectErasureW(ceph::util::random_number_generator<int>& rng,
+  SelectErasureW(std::mt19937_64& rng,
                  po::variables_map& vm,
                  std::string_view plugin,
                  const std::optional<std::string_view>& technique,
@@ -209,7 +210,7 @@ class SelectErasureW : public ProgramOptionGeneratedSelector<uint64_t> {
   const std::vector<uint64_t> generate_selections() override;
 
  private:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   std::string_view plugin;
   std::optional<std::string_view> technique;
@@ -220,7 +221,7 @@ class SelectErasureW : public ProgramOptionGeneratedSelector<uint64_t> {
 class SelectErasurePacketSize
     : public ProgramOptionGeneratedSelector<uint64_t> {
  public:
-  SelectErasurePacketSize(ceph::util::random_number_generator<int>& rng,
+  SelectErasurePacketSize(std::mt19937_64& rng,
                           po::variables_map& vm,
                           std::string_view plugin,
                           const std::optional<std::string_view>& technique,
@@ -230,7 +231,7 @@ class SelectErasurePacketSize
   const std::vector<uint64_t> generate_selections() override;
 
  private:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   std::string_view plugin;
   std::optional<std::string_view> technique;
@@ -291,7 +292,7 @@ using SelectLayers =
 
 class SelectMappingAndLayers {
  public:
-  SelectMappingAndLayers(ceph::util::random_number_generator<int>& rng,
+  SelectMappingAndLayers(std::mt19937_64& rng,
                          po::variables_map& vm,
                          bool first_use);
   const std::pair<std::string, std::string> select();
@@ -299,8 +300,8 @@ class SelectMappingAndLayers {
  private:
   uint64_t rng_seed;
 
-  ceph::util::random_number_generator<int> mapping_rng;
-  ceph::util::random_number_generator<int> layers_rng;
+  std::mt19937_64 mapping_rng;
+  std::mt19937_64 layers_rng;
 
   SelectMapping sma;
   SelectLayers sly;
@@ -310,7 +311,7 @@ class SelectMappingAndLayers {
 class SelectErasureTechnique
     : public ProgramOptionGeneratedSelector<std::string> {
  public:
-  SelectErasureTechnique(ceph::util::random_number_generator<int>& rng,
+  SelectErasureTechnique(std::mt19937_64& rng,
                          po::variables_map& vm,
                          std::string_view plugin,
                          bool first_use);
@@ -318,7 +319,7 @@ class SelectErasureTechnique
   const std::vector<std::string> generate_selections() override;
 
  private:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   std::string_view plugin;
   bool stable;
@@ -326,14 +327,14 @@ class SelectErasureTechnique
 
 class SelectErasureChunkSize : public ProgramOptionGeneratedSelector<uint64_t> {
  public:
-  SelectErasureChunkSize(ceph::util::random_number_generator<int>& rng,
+  SelectErasureChunkSize(std::mt19937_64& rng,
                          po::variables_map& vm,
                          ErasureCodeInterfaceRef ec_impl,
                          bool first_use);
   const std::vector<uint64_t> generate_selections() override;
 
  private:
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
 
   ErasureCodeInterfaceRef ec_impl;
 };
@@ -355,7 +356,7 @@ struct Profile {
 class SelectErasureProfile : public ProgramOptionReader<Profile> {
  public:
   SelectErasureProfile(boost::intrusive_ptr<CephContext> cct,
-                       ceph::util::random_number_generator<int>& rng,
+                       std::mt19937_64& rng,
                        po::variables_map& vm, librados::Rados& rados,
                        bool dry_run, bool first_use);
   const Profile select() override;
@@ -366,7 +367,7 @@ class SelectErasureProfile : public ProgramOptionReader<Profile> {
   boost::intrusive_ptr<CephContext> cct;
   librados::Rados& rados;
   bool dry_run;
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
   po::variables_map& vm;
 
   bool first_use;
@@ -380,7 +381,7 @@ class SelectErasureProfile : public ProgramOptionReader<Profile> {
 class SelectErasurePool : public ProgramOptionReader<std::string> {
  public:
   SelectErasurePool(boost::intrusive_ptr<CephContext> cct,
-                    ceph::util::random_number_generator<int>& rng,
+                    std::mt19937_64& rng,
                     po::variables_map& vm,
                     librados::Rados& rados,
                     bool dry_run,
@@ -453,7 +454,7 @@ class TestObject {
              ceph::io_sequence::tester::SelectObjectSize& sos,
              ceph::io_sequence::tester::SelectNumThreads& snt,
              ceph::io_sequence::tester::SelectSeqRange& ssr,
-             ceph::util::random_number_generator<int>& rng,
+             std::mt19937_64& rng,
              ceph::mutex& lock,
              ceph::condition_variable& cond,
              bool dryrun,
@@ -477,7 +478,7 @@ class TestObject {
   std::unique_ptr<ceph::io_exerciser::IoSequence> seq;
   std::unique_ptr<ceph::io_exerciser::IoOp> op;
   bool done;
-  ceph::util::random_number_generator<int>& rng;
+  std::mt19937_64& rng;
   bool verbose;
   std::optional<int> seqseed;
   std::optional<std::pair<int, int>> pool_km;
@@ -500,7 +501,7 @@ class TestRunner {
  private:
   librados::Rados& rados;
   int seed;
-  ceph::util::random_number_generator<int> rng;
+  std::mt19937_64 rng;
 
   ceph::io_sequence::tester::SelectBlockSize sbs;
   ceph::io_sequence::tester::SelectObjectSize sos;


### PR DESCRIPTION
This commit:
- Replaces the use of ceph::util::random_number_generator<int> with std::mt19937_64, which is compiler independent.
- Removes the rng() operator from the ObjectModel and RadosIo constructors to ensure consistent behaviour across compilers.

Fixes: https://tracker.ceph.com/issues/73553
Signed-off-by: Matty Williams <Matty.Williams@ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
