### PR TITLE
tentacle: backports variants improvements and Dockerfile.build changes

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -13,7 +13,7 @@ COPY \
     install-deps.sh \
     run-make-check.sh \
     src/script/buildcontainer-setup.sh \
-    ${CEPH_CTR_SRC}
+    ${CEPH_CTR_SRC}/
 
 
 FROM $DISTRO

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -21,7 +21,8 @@ ARG DISTRO
 ARG CEPH_CTR_SRC=/usr/local/src/ceph
 ARG CLEAN_DNF=yes
 ARG CEPH_BASE_BRANCH=main
-ARG SCCACHE_VERSION=0.8.2
+ARG SCCACHE_VERSION=v0.8.2
+ARG SCCACHE_REPO=https://github.com/mozilla/sccache
 ARG WITH_CRIMSON=true
 ARG FOR_MAKE_CHECK=1
 COPY --from=bootstrap ${CEPH_CTR_SRC} ${CEPH_CTR_SRC}
@@ -35,5 +36,6 @@ RUN DISTRO=$DISTRO \
     FOR_MAKE_CHECK=${FOR_MAKE_CHECK} \
     bash -x ${CEPH_CTR_SRC}/buildcontainer-setup.sh
 RUN \
-    SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz"; \
-    curl -L $SCCACHE_URL | tar --no-anchored --strip-components=1 -C /usr/local/bin/ -xzf - sccache
+    SCCACHE_URL="${SCCACHE_REPO}/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz"; \
+    echo "${SCCACHE_URL}"; \
+    curl -sS -L $SCCACHE_URL | tar --no-anchored --strip-components=1 -C /usr/local/bin/ -xzf - sccache

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -371,7 +371,13 @@ class ImageSource(StrEnum):
 
 class ImageVariant(StrEnum):
     DEFAULT = 'default'  # build everything + make check
-    PACKAGES = 'packages'  # test deps. ignored, only for packages
+    # test dependencies will not be instaled, other parameters
+    # are automatically pulled from the environment (etc)
+    PACKAGES_AUTO = 'packages'
+    # test dependencies will not be installed nor crimson deps
+    PACKAGES_MINIMAL = 'packages.minimal'
+    # test dependencies skipped but crimson deps are included
+    PACKAGES_AND_CRIMSON = 'packages.crimson'
 
 
 class Context:
@@ -404,6 +410,39 @@ class Context:
         base = self.cli.image_repo or "ceph-build"
         return f"{base}:{self.target_tag()}"
 
+    def packages_build(self):
+        """Return true if only packages will be build (not make check)."""
+        return self.cli.image_variant in {
+            ImageVariant.PACKAGES_AUTO,
+            ImageVariant.PACKAGES_MINIMAL,
+            ImageVariant.PACKAGES_AND_CRIMSON,
+        }
+
+    def variant(self):
+        """Return calculated variant. Checks env vars to select between
+        packages with or without crimson.
+        """
+        with_crimson = os.environ.get('WITH_CRIMSON')
+        if (
+            self.cli.image_variant is ImageVariant.PACKAGES_AUTO
+            and with_crimson
+        ):
+            return ImageVariant.PACKAGES_AND_CRIMSON
+        elif self.cli.image_variant is ImageVariant.PACKAGES_AUTO:
+            return ImageVariant.PACKAGES_MINIMAL
+        return self.cli.image_variant
+
+    def crimson_build(self):
+        """Detects if crimson deps should be installed in the build image.
+        Returns True/False if build flag is known or None for default.
+        """
+        if self.variant() is ImageVariant.PACKAGES_AND_CRIMSON:
+            return True
+        if self.variant() is ImageVariant.DEFAULT:
+            with_crimson = os.environ.get('WITH_CRIMSON')
+            return None if with_crimson is None else bool(with_crimson)
+        return False
+
     def target_tag(self):
         suffix = ""
         if self.cli.tag and self.cli.tag.startswith("+"):
@@ -416,8 +455,9 @@ class Context:
                 branch = _git_current_branch(self).replace("/", "-")
             except subprocess.CalledProcessError:
                 branch = "UNKNOWN"
-        if self.cli.image_variant is not ImageVariant.DEFAULT:
-            suffix = f".{self.cli.image_variant}{suffix}"
+        variant = self.variant()
+        if variant is not ImageVariant.DEFAULT:
+            suffix = f".{variant}{suffix}"
         return f"{branch}.{self.cli.distro}{suffix}"
 
     def base_branch(self):
@@ -609,6 +649,7 @@ def build_container(ctx):
         "-t",
         ctx.image_name,
         f"--label=io.ceph.build-with-container.src={_hash_sources()}",
+        f"--label=io.ceph.build-with-container.image-variant={ctx.variant()}",
         f"--build-arg=CEPH_BASE_BRANCH={ctx.base_branch()}",
     ]
     if ctx.cli.distro:
@@ -623,8 +664,13 @@ def build_container(ctx):
             f"--volume={ctx.dnf_cache_dir}:/var/cache/dnf:Z",
             "--build-arg=CLEAN_DNF=no",
         ]
-    if ctx.cli.image_variant is ImageVariant.PACKAGES:
+    if ctx.packages_build():
         cmd.append("--build-arg=FOR_MAKE_CHECK=false")
+    crimson_build = ctx.crimson_build()
+    if crimson_build is not None:
+        # the WITH_CRIMSON var is false only when empty (in install-deps)
+        with_crimson = '1' if crimson_build else ''
+        cmd.append(f"--build-arg=WITH_CRIMSON={with_crimson}")
     if ctx.cli.build_args:
         cmd.extend([f"--build-arg={v}" for v in ctx.cli.build_args])
     cmd += ["-f", ctx.cli.containerfile, ctx.cli.containerdir]


### PR DESCRIPTION
Backports of PR #65994, #65803, and #65760.



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
