### PR TITLE
squid: rgw: Check if `HTTP_X_AMZ_COPY_SOURCE` header is empty

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5341,6 +5341,9 @@ bool RGWCopyObj::parse_copy_location(const std::string_view& url_src,
     params_str = url_src.substr(pos + 1);
   }
 
+  if (name_str.empty()) {
+    return false;
+  }
   if (name_str[0] == '/') // trim leading slash
     name_str.remove_prefix(1);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73606

---

backport of https://github.com/ceph/ceph/pull/65159
parent tracker: https://tracker.ceph.com/issues/72669

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh