### PR TITLE
mon: stretch-cluster (3AZ) – add netsplit auto-resolver (Bron–Kerbosch + heuristics)

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -96,6 +96,94 @@ configuration across the entire cluster. Conversely, opt for a stretch pool
 when you need only a particular pool to be replicated across more than two data centers,
 providing a more granular level of control.
 
+3 Zones Stretch Clusters
+========================
+
+<Insert description here>
+
+Automatic Resolution of Netsplits in 3-Zone Stretch Clusters
+------------------------------------------------------------
+
+``mon_netsplit_auto_resolve`` is a configuration option that is `true` by default.
+When enabled, this option allows the cluster to automatically resolve netsplits.
+This can be disabled by setting the option to `false`.
+
+.. prompt:: bash $
+
+   ceph config set mon mon_netsplit_auto_resolve false
+
+**Important:** Automatic netsplit resolution is only triggered when Ceph detects that at least
+one pool in the cluster is configured as a stretch pool. Without stretch pools, the cluster
+will not automatically resolve netsplits.
+
+Netsplit Zone Preferences
+-------------------------
+
+When a netsplit occurs in a 3-zone (or more) stretch cluster with ``mon_netsplit_auto_resolve``
+enabled, the cluster must decide which partition should remain operational. If there are
+multiple partitions of equal size (called "largest cliques"), the cluster uses zone preferences
+and heuristics to choose the winning partition.
+
+**Setting Zone Preferences**
+
+You can specify an ordered list of preferred zones/buckets that the cluster should favor during
+netsplit resolution. The first zone in the list has the highest priority.
+
+.. prompt:: bash $
+
+   ceph mon set netsplit_zone_preferences dc1 dc2 dc3
+
+**Example:** Consider a 3-zone cluster with zones ``dc1``, ``dc2``, and ``dc3``, where a network
+failure causes ``dc1`` and ``dc2`` to lose connectivity to each other, but both zones can
+still communicate with ``dc3``. This creates two equal-sized partitions (largest cliques):
+
+- Partition 1: ``dc1`` and ``dc3``
+- Partition 2: ``dc2`` and ``dc3``
+
+With the preferences set as shown above (``dc1`` highest priority, then ``dc2``, then ``dc3``),
+the cluster will choose Partition 1 (``dc1`` + ``dc3``) because ``dc1`` has higher priority
+than ``dc2``. The priority is calculated by summing the preference rankings: zones earlier
+in the list have higher priority values.
+
+To view current preferences (included in ``ceph mon dump``):
+
+.. prompt:: bash $
+
+   ceph mon dump
+
+To clear zone preferences:
+
+.. prompt:: bash $
+
+   ceph mon clear netsplit_zone_preferences
+
+**Important:** Zone names in the preference list must exist as bucket names in the CRUSH map.
+The cluster validates this when you set preferences and will reject invalid bucket names.
+
+Netsplit Resolution Heuristics
+------------------------------
+
+When zone preferences are not set, or when the preferences do not match any of the largest
+cliques, the cluster uses automatic heuristics to select the surviving partition:
+
+1. **OSD Weight Distribution**: The cluster calculates the total CRUSH weight of OSDs in each
+   partition. The partition with the higher total OSD weight is chosen, as it likely represents
+   more storage capacity and can continue serving more data.
+
+2. **Monitor Count**: If OSD weights are equal, the partition with more Monitors
+   is preferred, as it is more likely to maintain stronger quorum.
+
+3. **Connection Scores**: The cluster evaluates the connectivity between the partitions. 
+   The partition with better connectivity wins.
+
+4. **Lexicographical Order**: As a final tiebreaker, if all other metrics are equal, the
+   partition with the lexicographically smallest bucket name is chosen to ensure deterministic
+   behavior.
+
+These heuristics run automatically and do not require configuration. The cluster logs its
+decisions to the monitor log when resolving netsplits, indicating whether
+zone preferences or heuristics were used.
+
 Limitations
 -----------
 

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1451,6 +1451,13 @@ options:
     should trigger a panic if it does not receive the initial map from the monitor
   default: 30
   services:
+- name: lift_fencing_threshold
+  type: secs
+  level: advanced
+  desc: Time (in seconds) to wait before lifting the netsplit fence 
+  default: 90
+  services :
+  - mon
 - name: mon_netsplit_grace_period
   type: secs
   level: advanced

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1459,6 +1459,13 @@ options:
   default: 9
   services :
   - mon
+- name: mon_netsplit_auto_resolve
+  type: bool
+  level: advanced
+  desc: flag to enable resolving a netsplit automatically after detection.
+  default: true
+  services:
+  - mon
 - name: pool_availability_update_interval
   type: float
   level: advanced

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -582,3 +582,8 @@ bool ElectionLogic::receive_victory_claim(int from, epoch_t from_epoch)
   // they win
   return true;
 }
+
+double ElectionLogic::get_connectivity_election_score(int rank)
+{
+  return connectivity_election_score(rank);
+}

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -352,6 +352,7 @@ public:
    */
   epoch_t get_epoch() const { return epoch; }
   int get_election_winner() { return last_election_winner; }
+  double get_connectivity_election_score(int rank);
 
 private:
   /**

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -891,3 +891,10 @@ void Elector::notify_strategy_maybe_changed(int strategy)
 {
   logic.set_election_strategy(static_cast<ElectionLogic::election_strategy>(strategy));
 }
+
+double Elector::get_connection_score_by_rank(int rank) {
+  if (is_current_member(rank)) {
+    return logic.get_connectivity_election_score(rank);
+  }
+  return 0.0;
+}

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -428,6 +428,7 @@ class Elector : public ElectionOwner, RankProvider {
     peer_tracker.dump(f);
     f->close_section();
   }
+  double get_connection_score_by_rank(int rank);
   /**
    * @}
    */

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -1023,10 +1023,30 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
     pending_location_netsplits.clear();
     current_mon_netsplits.clear();
     current_location_netsplits.clear();
+    auto now = ceph::coarse_mono_clock::now();
+    if (no_netsplit_since == ceph::coarse_mono_clock::time_point()) {
+      no_netsplit_since = now;
+    } else {
+      auto elapsed = now - no_netsplit_since;
+      auto lift_fencing_threshold =
+        g_conf().get_val<std::chrono::seconds>("lift_fencing_threshold");
+      if (elapsed >= lift_fencing_threshold) {
+        dout(10) << __func__ << " no netsplit for " << elapsed
+                 << " >= lift_fencing_threshold " << lift_fencing_threshold
+                 << ", requesting fencing lift" << dendl;
+        mon.osdmon()->lift_fencing();
+        // prevent repeated triggers until a netsplit happens again
+        no_netsplit_since = ceph::coarse_mono_clock::time_point();
+      }
+    }
     dout(30) << "No netsplit pairs found, clearing"
       << " pending_mon_netsplits, pending_location_netsplits"
       << " current_mon_netsplits, current_location_netsplits" << dendl;
+    
     return;
+  } else {
+    // Reset no_netsplit_since since we have detected a netsplit
+    no_netsplit_since = ceph::coarse_mono_clock::time_point();
   }
   // Pre-populate mon_loc_map & location_to_mons for each monitor, discarding monitors that are down,
   // and sort the crush location highest to lowest by type id in the cluster topology.

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -1039,6 +1039,8 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
   // Space Complexity: O(m)
   std::map<std::string, std::set<std::string>> location_to_mons;
   std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> mon_loc_map;
+  // Track distinct CRUSH locations per type across all monitors, e.g. {"datacenter": {"dc1","dc2"}}
+  std::map<std::string, std::set<std::string>> distinct_crush_locations;
   for (auto &mon_info : mon.monmap->mon_info) {
       // Create a vector of pairs
       std::vector<std::pair<std::string, std::string>> sorted_crush_loc_vec;
@@ -1075,6 +1077,7 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
       if (!sorted_crush_loc_vec.empty()) {
         if (!mons_down.count(mon_name)) {
           auto& highest_loc = sorted_crush_loc_vec.front();
+          distinct_crush_locations[highest_loc.first].insert(highest_loc.second);
           location_to_mons[highest_loc.second].insert(mon_name);
         } else {
           dout(30) << "mon: " << mon_name << " is down" << dendl;
@@ -1155,15 +1158,15 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
   // Check for location-level netsplits and remove individual-level netsplits
   for (auto& kv : location_disconnects) {
     auto& loc_pair = kv.first; // {dc1,dc2}
-    int disconnect_count = kv.second; // Number of disconnects between dc1 and dc2
+    int disconnects_count = kv.second; // Number of disconnects between dc1 and dc2
 
     // The expected number of disconnects between two locations
     // is the product of the number of monitors in each location
     int expected_disconnects = location_to_mons[loc_pair.first].size() *
                                 location_to_mons[loc_pair.second].size();
 
-    // Report location-level netsplits
-    if (disconnect_count == expected_disconnects) {
+    // Update detected_location_netsplits and remove individual monitor disconnects
+    if (disconnects_count == expected_disconnects) {
       detected_location_netsplits.insert(loc_pair);
       // Remove individual monitor disconnects between these locations
       for (const auto& mon1 : location_to_mons[loc_pair.first]) {
@@ -1175,14 +1178,16 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
     }
 
   }
-  // Report individual-level netsplits
+  // Update individual-level netsplits, add remaining monitor disconnects.
   for (auto& mon_pair : mon_disconnects) {
     detected_mon_netsplits.insert(mon_pair);
   }
-  
+
+  // Now we workout which netsplits are new, ongoing, or resolved.
   // update/add/erase to pending_mon_netsplits and pending_location_netsplits
   auto now = ceph::coarse_mono_clock::now();
   auto mon_netsplit_grace_period = g_conf().get_val<std::chrono::seconds>("mon_netsplit_grace_period");
+  auto mon_netsplit_auto_resolve = g_conf().get_val<bool>("mon_netsplit_auto_resolve");
   auto pending_location_netsplits_end = pending_location_netsplits.end();
   auto pending_mon_netsplits_end = pending_mon_netsplits.end();
   list<string> details;
@@ -1323,6 +1328,22 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
     }
     *_dout << " }" << dendl;
 
+    dout(30) << "distinct_crush_locations: {";
+    bool outer_first = true;
+    for (const auto& loc_pair : distinct_crush_locations) {
+      if (!outer_first) *_dout << ", ";
+      outer_first = false;
+      *_dout << loc_pair.first << ": {";
+      bool inner_first = true;
+      for (const auto& location : loc_pair.second) {
+        if (!inner_first) *_dout << ", ";
+        inner_first = false;
+        *_dout << location;
+      }
+      *_dout << "}";
+    }
+    *_dout << "}" << dendl;
+
     dout(30) << "detected_location_netsplits: {";
     bool first = true;
     for (const auto& netsplit : detected_location_netsplits) {
@@ -1360,6 +1381,34 @@ void HealthMonitor::check_netsplit(health_check_map_t *checks, std::set<std::str
       first = false;
     }
     *_dout << "}" << dendl;
+  }
+    // Netsplit auto-resolve for stretch clusters (excluding stretch mode)
+  if (current_location_netsplits.size() > 0
+      && mon_netsplit_auto_resolve
+      && !mon.monmap->stretch_mode_enabled) {
+      // Identify if at least one pool is stretched. if so get its failure domain,
+      // this is to ensure we are handling the correct location level.
+      std::string failure_domain = mon.osdmon()->get_stretch_pool_failure_domain();
+      if (!failure_domain.empty()) {
+        dout(20) << "Auto-resolving netsplits for stretch cluster"
+                 << " with failure domain: " << failure_domain << dendl;
+        // check if the failure domain exists in distinct_crush_locations
+        if (distinct_crush_locations.find(failure_domain) != distinct_crush_locations.end()) {
+          std::set<std::string> vertices = distinct_crush_locations[failure_domain];
+          std::set<std::pair<std::string, std::string>> cut_off_edges;
+          // add the netsplit locations to cut_off_edges
+          for (const auto& [cut_off_pair, _] : current_location_netsplits) {
+              if (vertices.find(cut_off_pair.first) != vertices.end() &&
+                vertices.find(cut_off_pair.second) != vertices.end()) {
+                cut_off_edges.insert(cut_off_pair);
+              }
+          }
+          mon.osdmon()->resolve_netsplit_stretch_cluster(vertices, cut_off_edges);
+        } else {
+          dout(5) << "No distinct CRUSH locations found for failure domain "
+                   << failure_domain << dendl;
+        }
+      }
   }
 }
 

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -36,6 +36,8 @@ class HealthMonitor : public PaxosService
   // currently active monitor netsplits with their elapsed time
   std::map<std::pair<std::string, std::string>, ceph::coarse_mono_clock::time_point> current_mon_netsplits;
   std::map<std::string,health_mute_t> pending_mutes;
+  // elapsed time since no netsplit detected
+  ceph::coarse_mono_clock::time_point no_netsplit_since;
 
 public:
   HealthMonitor(Monitor &m, Paxos &p, const std::string& service_name);

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -546,6 +546,13 @@ COMMAND("mon rm disallowed_leader " \
 	"name=name,type=CephString", \
 	"allow the named mon to be a leader again", \
 	"mon", "rw")
+COMMAND("mon set netsplit_zone_preferences " \
+	"name=zones,type=CephString,n=N,goodchars=[A-Za-z0-9-_.]", \
+	"set ordered list of preferred CRUSH zones/buckets for netsplit resolution (highest priority first)", \
+	"mon", "rw")
+COMMAND("mon clear netsplit_zone_preferences", \
+	"clear netsplit zone preferences", \
+	"mon", "rw")
 COMMAND("mon set_location " \
 	"name=name,type=CephString "
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]",

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -250,7 +250,7 @@ void MonMap::encode(ceph::buffer::list& blist, uint64_t con_features) const
     return;
   }
 
-  ENCODE_START(9, 6, blist);
+  ENCODE_START(10, 6, blist);
   ceph::encode_raw(fsid, blist);
   encode(epoch, blist);
   encode(last_changed, blist);
@@ -267,13 +267,14 @@ void MonMap::encode(ceph::buffer::list& blist, uint64_t con_features) const
   encode(stretch_mode_enabled, blist);
   encode(tiebreaker_mon, blist);
   encode(stretch_marked_down_mons, blist);
+  encode(netsplit_zone_preferences, blist);
   ENCODE_FINISH(blist);
 }
 
 void MonMap::decode(ceph::buffer::list::const_iterator& p)
 {
   map<string,entity_addr_t> mon_addr;
-  DECODE_START_LEGACY_COMPAT_LEN_16(9, 3, 3, p);
+  DECODE_START_LEGACY_COMPAT_LEN_16(10, 3, 3, p);
   ceph::decode_raw(fsid, p);
   decode(epoch, p);
   if (struct_v == 1) {
@@ -330,6 +331,11 @@ void MonMap::decode(ceph::buffer::list::const_iterator& p)
     stretch_mode_enabled = false;
     tiebreaker_mon = "";
     stretch_marked_down_mons.clear();
+  }
+  if (struct_v >= 10) {
+    decode(netsplit_zone_preferences, p);
+  } else {
+    netsplit_zone_preferences.clear();
   }
   calc_addr_mons();
   DECODE_FINISH(p);
@@ -488,6 +494,7 @@ void MonMap::dump(Formatter *f) const
   f->dump_stream("disallowed_leaders") << disallowed_leaders;
   f->dump_bool("stretch_mode", stretch_mode_enabled);
   f->dump_string("tiebreaker_mon", tiebreaker_mon);
+  f->dump_stream("netsplit_zone_preferences") << netsplit_zone_preferences;
   f->dump_stream("removed_ranks") << removed_ranks;
   f->open_object_section("features");
   persistent_features.dump(f, "persistent");

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -168,6 +168,7 @@ class MonMap {
   std::string tiebreaker_mon;
   std::set<std::string> stretch_marked_down_mons; // can't be leader or taken proposal in CONNECTIVITY 
                                                   // seriously until fully recovered
+  std::vector<std::string> netsplit_zone_preferences; // ordered list of preferred zones for netsplit resolution (index 0 = highest priority)
 
 public:
   void calc_legacy_ranks();
@@ -415,6 +416,11 @@ public:
     auto it = mon_info.find(n);
     ceph_assert(it != mon_info.end());
     it->second.weight = v;
+  }
+  std::map<std::string,std::string> get_crush_location_by_name(const std::string& n) const {
+    auto it = mon_info.find(n);
+    ceph_assert(it != mon_info.end());
+    return it->second.crush_loc;
   }
 
   void encode(ceph::buffer::list& blist, uint64_t con_features) const;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -7168,3 +7168,57 @@ void Monitor::disconnect_disallowed_stretch_sessions()
     session_stretch_allowed(*j, blank);
   }
 }
+
+int Monitor::get_total_up_mons_by_bucket_name(const std::string& bucket_name)
+{
+  /**
+   * Get the total number of up monitors in the specified bucket.
+   * @param bucket_name The name of the bucket to check.
+   * @return The total number of up monitors in the specified bucket.
+   */
+  int total = 0;
+  // loop through monmap for mons.
+  for (const auto& mon_info : monmap->mon_info) {
+    // get crush loc for this mon, see if it matches bucket_name
+    auto crush_loc = monmap->get_crush_location_by_name(mon_info.first);
+    for (const auto& [_ , value] : crush_loc) {
+      if (value == bucket_name) {
+        // check if mon is up (in quorum)
+        int mon_rank = monmap->get_rank(mon_info.first);
+        if (quorum.count(mon_rank)) {
+          total++;
+        }
+      }
+    }
+  }
+  dout(20) << __func__ << " " << bucket_name
+           << ": " << total << dendl;
+  return total;
+}
+
+double Monitor::get_total_mon_connection_score_by_bucket_name(const std::string& bucket_name)
+{
+  /**
+   * Get the total connection score of up monitors in the specified bucket.
+   * @param bucket_name The name of the bucket to check.
+   * @return The total connection score of up monitors in the specified bucket.
+   */
+  double total = 0.0;
+  // loop through monmap for mons.
+  for (const auto& mon_info : monmap->mon_info) {
+    // get crush loc for this mon, see if it matches bucket_name
+    auto crush_loc = monmap->get_crush_location_by_name(mon_info.first);
+    for (const auto& [_ , value] : crush_loc) {
+      if (value == bucket_name) {
+        int mon_rank = monmap->get_rank(mon_info.first);
+        // check if mon is up (in quorum)
+        if (quorum.count(mon_rank)) {
+          total += elector.get_connection_score_by_rank(mon_rank);
+        }
+      }
+    }
+  }
+  dout(20) << __func__ << " " << bucket_name
+           << ": " << total << dendl;
+  return total;
+}

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -766,6 +766,8 @@ public:
   int get_mon_metadata(int mon, ceph::Formatter *f, std::ostream& err);
   int print_nodes(ceph::Formatter *f, std::ostream& err);
 
+  int get_total_up_mons_by_bucket_name(const std::string& bucket_name);
+  double get_total_mon_connection_score_by_bucket_name(const std::string& bucket_name);
   // track metadata reported by win_election()
   std::map<int, Metadata> mon_metadata;
   std::map<int, Metadata> pending_metadata;

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -1024,6 +1024,58 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     }
     pending_map.disallowed_leaders.erase(name);
     pending_map.last_changed = ceph_clock_now();
+  } else if (prefix == "mon set netsplit_zone_preferences") {
+    vector<string> zones;
+    if (!cmd_getval(cmdmap, "zones", zones)) {
+      err = -EINVAL;
+      ss << "must specify zone names";
+      goto reply_no_propose;
+    }
+    
+    // Wait for OSDMonitor to be readable so we can validate against CRUSH map
+    if (!mon.osdmon()->is_readable()) {
+      dout(10) << __func__
+               << ": waiting for osdmon readable to validate zone preferences"
+               << dendl;
+      mon.osdmon()->wait_for_readable(op, new Monitor::C_RetryMessage(&mon, op));
+      return false;
+    }
+    
+    // Validate that all zones exist in the CRUSH map
+    const CrushWrapper& crush = *mon.osdmon()->osdmap.crush;
+    vector<string> invalid_zones;
+    for (const auto& zone : zones) {
+      if (!crush.name_exists(zone)) {
+        invalid_zones.push_back(zone);
+      }
+    }
+    
+    if (!invalid_zones.empty()) {
+      ss << "The following zones do not exist in the CRUSH map: ";
+      for (size_t i = 0; i < invalid_zones.size(); ++i) {
+        if (i > 0) ss << ", ";
+        ss << "'" << invalid_zones[i] << "'";
+      }
+      err = -ENOENT;
+      goto reply_no_propose;
+    }
+    
+    pending_map.netsplit_zone_preferences = zones;
+    pending_map.last_changed = ceph_clock_now();
+    ss << "set netsplit zone preferences to: ";
+    for (size_t i = 0; i < zones.size(); ++i) {
+      if (i > 0) ss << ", ";
+      ss << zones[i];
+    }
+  } else if (prefix == "mon clear netsplit_zone_preferences") {
+    if (pending_map.netsplit_zone_preferences.empty()) {
+      ss << "netsplit zone preferences are already empty";
+      err = 0;
+      goto reply_no_propose;
+    }
+    pending_map.netsplit_zone_preferences.clear();
+    pending_map.last_changed = ceph_clock_now();
+    ss << "cleared netsplit zone preferences";
   } else if (prefix == "mon set_location") {
     if (!mon.get_quorum_mon_features().contains_all(
 				        ceph::features::mon::FEATURE_PINGING)) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2907,6 +2907,20 @@ bool OSDMonitor::preprocess_failure(MonOpRequestRef op)
     }
   }
 
+  // is from a fenced osd?
+  if (osdmap.is_osd_in_fenced_bucket(m->get_orig_source().num(), cct)) {
+    dout(5) << "preprocess_failure: from fenced osd." << m->get_orig_source().num()
+	    << ", ignoring" << dendl;
+    send_incremental(op, m->get_epoch()+1);
+    goto didit;
+  }
+  // is targeting a fenced osd?
+  if (osdmap.is_osd_in_fenced_bucket(badboy, cct)) {
+    dout(5) << "preprocess_failure failure message about fenced osd."
+	    << badboy << ", ignoring" << dendl;
+    send_incremental(op, m->get_epoch()+1);
+    goto didit;
+  }
 
   // weird?
   if (osdmap.is_down(badboy)) {
@@ -8210,9 +8224,8 @@ void OSDMonitor::resolve_netsplit_stretch_cluster(
   *    choose the "best" clique (prioritizing OSD weights, then MONs,
   *    then connection scores, then lexicographical as tiebreaker).
   *  - Compute the set of fence_buckets = (vertices – best_clique),
-  *    which identifies buckets to fence (mark OSDs down) so
-  *    that only the surviving clique continues to serve I/O.
   */
+  
   dout(20) << __func__ << " vertices: {" << vertices << "}"
            << " cut_off_edges: {" << cut_off_edges << "}" << dendl;
   // Construct the adjacency list by adding

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7906,6 +7906,424 @@ int OSDMonitor::get_replicated_stretch_crush_rule()
   return most_used_rule;
 }
 
+std::string OSDMonitor::get_stretch_pool_failure_domain()
+{
+ // Return the failure domain of a stretch pool if any exists.
+  for (const auto& pooli : osdmap.pools) {
+    const pg_pool_t& p = pooli.second;
+    if (p.is_stretch_pool()) {
+      std::string failure_domain = osdmap.crush->get_type_name(p.peering_crush_bucket_barrier);
+      return failure_domain;
+    }
+  }
+  return "";
+}
+std::set<std::string> OSDMonitor::run_zone_preference(
+  const std::vector<std::set<std::string>>& largest_cliques,
+  const std::vector<std::string>& zone_preferences) {
+  /**
+  * Select the best clique based on user-defined zone preferences.
+  *
+  * Priority rules:
+  *   1. Prefer clique containing zones with the HIGHEST priority (lowest index)
+  *   2. If tied, use total priority sum as tiebreaker
+  *   3. Only consider zones that exist in the largest_cliques
+  *   4. Return empty set if no preferred zones found (fallback to heuristics)
+  */
+  
+  // Build set of all zones present in largest_cliques for validation
+  std::set<std::string> available_zones;
+  for (const auto& clique : largest_cliques) {
+    available_zones.insert(clique.begin(), clique.end());
+  }
+  
+  // Filter zone preferences to only include zones in the current cliques
+  std::vector<std::string> zone_priority;
+  std::vector<std::string> unavailable_zones;
+
+  for (const auto& zone : zone_preferences) {
+    // Check if zone exists in any of the largest cliques
+    if (available_zones.find(zone) == available_zones.end()) {
+      dout(10) << __func__ << " Preferred zone '" << zone
+               << "' not found in any largest clique, ignoring" << dendl;
+      unavailable_zones.push_back(zone);
+      continue;
+    }
+    
+    zone_priority.push_back(zone);
+  }
+  
+  // Warn if none of the preferences match
+  if (zone_priority.empty() && !unavailable_zones.empty()) {
+    dout(5) << __func__ << " no preferred zones found in current netsplit partitions, "
+            << "falling back to heuristics" << dendl;
+    mon.clog->warn() << "Netsplit zone preferences do not match any partition, "
+                     << "falling back to default heuristics";
+    return {};
+  }
+  
+  if (zone_priority.empty()) {
+    return {};
+  }
+  
+  dout(10) << __func__ << " using zone preferences: " << zone_priority << dendl;
+  
+  // Convert to set for efficient lookup
+  std::set<std::string> zone_pref_set(zone_priority.begin(), zone_priority.end());
+  
+  // Score each clique by summing priorities
+  // Only consider cliques where ALL zones are in the preference list
+  std::set<std::string> best_clique;
+  int best_total_priority = -1;
+  
+  for (const auto& clique : largest_cliques) {
+    // Check if ALL zones in this clique are in preferences
+    bool all_in_prefs = std::includes(
+      zone_pref_set.begin(), zone_pref_set.end(),
+      clique.begin(), clique.end());
+    
+    if (!all_in_prefs) {
+      dout(20) << __func__ << " skipping clique " << clique
+               << " (contains zones not in preferences)" << dendl;
+      continue;
+    }
+    
+    // All zones are in preferences, sum their priorities
+    int total_priority = 0;
+    for (const auto& bucket : clique) {
+      auto it = std::find(zone_priority.begin(), zone_priority.end(), bucket);
+      // Priority: index 0 is highest, so invert: size - distance
+      int priority = zone_priority.size() - std::distance(zone_priority.begin(), it);
+      total_priority += priority;
+    }
+    
+    // Pick clique with highest total priority
+    // If tied, use lexicographical order for deterministic tiebreaker
+    if (total_priority > best_total_priority ||
+        (total_priority == best_total_priority &&
+         (best_clique.empty() || std::lexicographical_compare(
+           clique.begin(), clique.end(),
+           best_clique.begin(), best_clique.end())))) {
+      best_total_priority = total_priority;
+      best_clique = clique;
+      
+      dout(20) << __func__ << " new best clique: " << clique
+               << " total_priority=" << total_priority << dendl;
+    }
+  }
+  
+  if (best_total_priority > 0) {
+    dout(10) << __func__ << " zone preference selected clique: " << best_clique
+             << " with total priority score: " << best_total_priority << dendl;
+    mon.clog->info() << "Netsplit resolved using zone preferences, "
+                     << "selected partition: " << best_clique;
+    return best_clique;
+  }
+  
+  // No cliques where all zones are in preferences
+  dout(10) << __func__ << " no cliques with all zones in preferences, "
+           << "falling back to heuristics" << dendl;
+  mon.clog->warn() << "Netsplit zone preferences did not match any partition "
+                   << "(all zones in partition must be in preference list), "
+                   << "falling back to default heuristics";
+  return {};
+}
+
+std::set<std::string> OSDMonitor::run_heuristics_on_largest_cliques(
+  const std::vector<std::set<std::string>>& largest_cliques,
+  const std::set<std::string>& vertices) {
+  /**
+  * Given multiple largest cliques discovered during a netsplit in a stretch
+  * cluster, select the "best" clique to survive. Each clique is scored based
+  * on aggregate bucket metrics:
+  *
+  *   1. Effective OSD weight (higher is better)
+  *   2. Number of up MONs
+  *   3. MON connection score
+  *   4. Lexicographical order of bucket names (deterministic tiebreaker)
+  *
+  * Workflow:
+  *  For each vertex (bucket) we precompute a Score {osd, mon, conn}.
+  *  Each clique's score is the sum of its buckets' scores. The function
+  *  iterates over all candidate cliques and applies the scoring priority
+  *  until a strict winner is found. If scores are tied, the lexicographically
+  *  smallest clique is chosen to ensure deterministic behavior.
+  */
+
+  // Only call this function when there is more than 1 clique
+  ceph_assert(largest_cliques.size() > 1);
+
+  struct Score {
+    float osd = 0.0;
+    int mon = 0;
+    double conn = 0.0;
+  };
+  std::unordered_map<std::string, Score> bucket_score;
+
+  for (const auto& bucket : vertices) {
+    Score s{};
+    s.osd = osdmap.get_total_effective_osd_weight_by_bucket_name(cct, bucket);
+    s.mon = mon.get_total_up_mons_by_bucket_name(bucket);
+    s.conn = mon.get_total_mon_connection_score_by_bucket_name(bucket);
+    bucket_score.emplace(bucket, s);
+  }
+
+  // compare two clique scores by priority (OSD, then MON).
+  auto better = [](
+    const std::set<std::string>& clique_a,
+    const Score& score_a,
+    const std::set<std::string>& clique_b,
+    const Score& score_b,
+    bool& win_on_tie_breaker) {
+    if (score_a.osd != score_b.osd) return score_a.osd > score_b.osd;  // higher effective OSD weights first
+    if (score_a.mon != score_b.mon) return score_a.mon > score_b.mon;  // then higher MON up count
+    if (score_a.conn != score_b.conn) return score_a.conn > score_b.conn;  // then higher MON connection score
+    // tie -> lexicographical compare to see which one lexicographically smaller
+    win_on_tie_breaker = true;
+    return std::lexicographical_compare(
+      clique_a.begin(), clique_a.end(),
+      clique_b.begin(), clique_b.end());
+  };
+
+
+  std::set<std::string> best_clique;
+  Score best_score{
+    -std::numeric_limits<float>::infinity(),
+    std::numeric_limits<int>::min(),
+    -std::numeric_limits<double>::infinity()
+  };
+  bool win_on_tie_breaker = false;
+  for (const auto& clique : largest_cliques) {
+    // Inner loop gets the sum score of the clique
+    // we keep track of the best clique and score.
+    Score current_score{};
+    for (const auto& bucket : clique) {
+      if (auto it = bucket_score.find(bucket); it != bucket_score.end()) {
+        current_score.osd  += it->second.osd;
+        current_score.mon  += it->second.mon;
+        current_score.conn += it->second.conn;
+      }
+      else {
+        derr << __func__ << " bucket " << bucket
+          << " not found in bucket_score map!" << dendl;
+      }
+    }
+    // Debug output of current clique and its score
+    if (mon.cct->_conf->subsys.should_gather(ceph_subsys_mon, 30)) {
+      dout(30) << __func__ << " clique with buckets {";
+      bool first = true;
+      for (const auto& v : clique) {
+          if (!first) *_dout << ", ";
+          first = false;
+          *_dout << v;
+      }
+      *_dout << "} osd score: " << current_score.osd
+            << " mon up score: " << current_score.mon
+            << " mon conn score: " << current_score.conn << dendl;
+    }
+
+    win_on_tie_breaker = false;
+    if (better(clique, current_score, best_clique, best_score, win_on_tie_breaker)) {
+      best_score = current_score;
+      best_clique = clique;
+    }
+    if (win_on_tie_breaker) {
+      dout(5) << __func__ << " found a tie; picking lexicographically smaller clique: " << best_clique << dendl;
+    }
+  }
+  dout(20) << __func__ << "; best clique osd score: "
+           << best_score.osd << "; mon up score: " << best_score.mon
+           << "; mon conn score: " << best_score.conn << dendl;
+  return best_clique;
+}
+
+std::vector<std::set<std::string>> OSDMonitor::get_largest_cliques(
+  const std::vector<std::set<std::string>>& maximal_cliques) {
+  
+  std::vector<std::set<std::string>> largest_cliques;
+  size_t max_size = 0;
+  for (const auto& clique : maximal_cliques) {
+    // found bigger one; replace.
+    if (clique.size() > max_size) {
+      largest_cliques.clear();
+      largest_cliques.push_back(clique);
+      max_size = clique.size();
+    // found same size; append.
+    } else if (clique.size() == max_size) {
+      largest_cliques.push_back(clique);
+    }
+  }
+  return largest_cliques;
+}
+
+static std::set<std::string> intersect_sets(const std::set<std::string>& a,
+                                            const std::set<std::string>& b) {
+  std::set<std::string> out;
+  std::set_intersection(a.begin(), a.end(), b.begin(), b.end(),
+                        std::inserter(out, out.begin()));
+  return out;
+}
+
+void OSDMonitor::bronKerbose(
+  std::set<std::string> current_clique, // we trying to build this
+  std::set<std::string> candidates_set, // {dc1, dc2, dc3}
+  std::set<std::string> excluded_set,
+  std::map<std::string, std::set<std::string>> adj_list,
+  std::vector<std::set<std::string>> &maximal_cliques)
+{
+  if (candidates_set.empty() && excluded_set.empty()) {
+    // current_clique is a maximal clique
+    maximal_cliques.push_back(std::move(current_clique));
+    return;
+  }
+
+  auto snapshot = candidates_set; // iterate over a copy; mutate originals
+  for (const auto& v : snapshot) {
+    auto next_clique = current_clique;
+    next_clique.insert(v);
+
+    const auto& neighbors = adj_list.at(v);
+    auto next_candidates = intersect_sets(candidates_set, neighbors);
+    auto next_excluded   = intersect_sets(excluded_set,   neighbors);
+
+    bronKerbose(next_clique, next_candidates, next_excluded, adj_list, maximal_cliques);
+    // move v from candidates_set -> excluded_set
+    candidates_set.erase(v);
+    excluded_set.insert(v);
+
+  }
+}
+
+void OSDMonitor::resolve_netsplit_stretch_cluster(
+  std::set<std::string> vertices,
+  std::set<std::pair<std::string, std::string>> cut_off_edges) {
+  /*
+  *
+  * This function handles netsplit resolution for a N-AZ stretch cluster
+  * by analyzing the connectivity between "bucket" vertices (datacenters/zones).
+  *
+  * Workflow:
+  *  - Build an adjacency list of all vertices (buckets).
+  *  - Remove cut_off_edges to represent the netsplit.
+  *  - Run the Bron–Kerbosch algorithm to find all maximal cliques.
+  *  - If more than one largest clique exists, apply heuristics to
+  *    choose the "best" clique (prioritizing OSD weights, then MONs,
+  *    then connection scores, then lexicographical as tiebreaker).
+  *  - Compute the set of fence_buckets = (vertices – best_clique),
+  *    which identifies buckets to fence (mark OSDs down) so
+  *    that only the surviving clique continues to serve I/O.
+  */
+  dout(20) << __func__ << " vertices: {" << vertices << "}"
+           << " cut_off_edges: {" << cut_off_edges << "}" << dendl;
+  // Construct the adjacency list by adding
+  // all other vertices as neighbors.
+  std::map<std::string, std::set<std::string>> adj_list;
+  for (const auto& v1 : vertices) {
+    auto& v1_neighbors = adj_list[v1];
+    for (const auto& v2 : vertices) {
+      if (v1 != v2) v1_neighbors.insert(v2);
+    }
+  }
+
+  // Remove the edges that experiences netsplit
+  for (const auto& [v1, v2] : cut_off_edges) {
+    adj_list[v1].erase(v2);
+    adj_list[v2].erase(v1);
+  }
+
+  // execute bronKerbose algorithm to find maximal cliques
+  std::set<std::string> current_clique;
+  std::set<std::string> excluded_set;
+  std::vector<std::set<std::string>> maximal_cliques;
+  bronKerbose(current_clique, vertices, excluded_set, adj_list, maximal_cliques);
+  dout(10) << "bronKerbose" << " found " << maximal_cliques.size()
+    << " maximal cliques." << dendl;
+
+  // Debug output of maximal cliques found from bronKerbose
+  if (mon.cct->_conf->subsys.should_gather(ceph_subsys_mon, 20)) {
+    dout(20) << "maximal cliques: {";
+    bool outer_first = true;
+    for (const auto& clique : maximal_cliques) {
+      if (!outer_first) *_dout << ", ";
+      outer_first = false;
+      *_dout << "{";
+      bool inner_first = true;
+      for (const auto& vertex : clique) {
+          if (!inner_first) *_dout << ", ";
+          inner_first = false;
+          *_dout << vertex;
+      }
+      *_dout << "}";
+    }
+    *_dout << " }" << dendl;
+  }
+
+  // pick the largest clique or cliques as the surviving stretch cluster
+  // determine best clique via zone preferences or heuristics
+  // if multiple largest cliques found.
+  std::set<std::string> best_clique;
+  const std::vector<std::string>& zone_preferences = mon.monmap->netsplit_zone_preferences;
+  std::vector<std::set<std::string>> largest_cliques = get_largest_cliques(maximal_cliques);
+  if (largest_cliques.size() > 1) {
+    dout(10) << __func__ << " found multiple largest cliques of size "
+             << largest_cliques[0].size() << "; Running Heuristics."
+             << dendl;
+    if (!zone_preferences.empty()) {
+      dout(10) << __func__ << " zone preferences set; applying preferences: "
+               << zone_preferences << dendl;
+      best_clique = run_zone_preference(largest_cliques, zone_preferences);
+    }
+    // Fallback to heuristics if preferences not set or didn't match
+    if (best_clique.empty()) {
+      dout(10) << __func__ << " using default heuristics." << dendl;
+      best_clique = run_heuristics_on_largest_cliques(largest_cliques, vertices);
+    }
+  } else {
+    dout(10) << __func__ << " found 1 largest clique of size "
+             << largest_cliques[0].size() << dendl;
+    best_clique = largest_cliques[0];
+  }
+
+  dout(10) << __func__ << " best clique: {" << best_clique << "}" << dendl;
+
+  // Workout the fence buckets
+  std::set<std::string> fenced_buckets;
+  // Sanity check: best_clique should be a subset of vertices
+  if (!std::includes(vertices.begin(), vertices.end(),
+    best_clique.begin(), best_clique.end())) {
+    derr << __func__ << " best_clique is not a subset of vertices! Abort!" << dendl;
+    return;
+  }
+
+  std::set_difference(vertices.begin(), vertices.end(),
+                      best_clique.begin(), best_clique.end(),
+                      std::inserter(fenced_buckets, fenced_buckets.begin()));
+
+  if (fenced_buckets.empty()) {
+    dout(5) << __func__ << " Weird! best_clique has every vertex; No fencing needed." << dendl;
+    return;
+  }
+  dout(10) << __func__ << " fenced_buckets: {" << fenced_buckets << "}" << dendl;
+  // Update OSDMap with the latest fenced buckets and active_buckets
+  pending_inc.change_fenced_buckets = true;
+  pending_inc.new_fenced_buckets = fenced_buckets;
+  // if no ongoing fence yet, we execute immediately
+  
+
+  // if there is on going fence and new fenced_buckets matches, refresh Up timer & exit
+
+  // Other wise, the new computation proposes a different fence_buckets
+  // Don't change our decision immediately. Enforce a decision-min-duration
+}
+
+void OSDMonitor::lift_fencing() {
+  // Clear any existing fenced buckets
+  dout(10) << __func__ << " lifting fencing; clearing fenced_buckets" << dendl;
+  pending_inc.change_fenced_buckets = true;
+  pending_inc.new_fenced_buckets.clear();
+}
+
+
 int OSDMonitor::prepare_pool_crush_rule(const unsigned pool_type,
 					const string &erasure_code_profile,
 					const string &rule_name,

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -920,6 +920,60 @@ public:
    * @return the crush rule ID, or a negative errno
    */
   int get_replicated_stretch_crush_rule();
+  /**
+   * Run heuristics on the largest cliques found in the stretch
+   * cluster graph to try to resolve netsplit.
+   * @param largest_cliques The largest cliques found in the graph
+   * @param vertices The set of all vertices in the graph
+   */
+  std::set<std::string> run_zone_preference(
+    const std::vector<std::set<std::string>>& largest_cliques,
+    const std::vector<std::string>& zone_preferences);
+  /**
+   * Apply heuristics (OSD weight, MON count, connection scores) to pick best
+   * clique when multiple largest cliques are found during netsplit resolution.
+   * @param largest_cliques The largest cliques found in the graph
+   * @param vertices The set of all vertices in the graph
+   */
+  std::set<std::string> run_heuristics_on_largest_cliques(
+    const std::vector<std::set<std::string>>& largest_cliques,
+    const std::set<std::string>& vertices);
+  /**
+   * From a vector of maximal cliques, obtain the largest ones.
+   * @param maximal_cliques The input vector of maximal cliques
+   * @return A vector of the largest maximal cliques
+   */
+  std::vector<std::set<std::string>> get_largest_cliques(
+    const std::vector<std::set<std::string>>& maximal_cliques);
+  /**
+   * Bron-Kerbose algorithm to find maximal cliques in an undirected graph.
+   * Used to find maximal clique when trying to resolve netsplit.
+   * @param current_clique The current clique being built
+   * @param candidates_set The candidate vertices that can be added to the clique
+   * @param excluded_set The vertices that have already been processed
+   * @param adj_list The adjacency list representing the graph
+   * @param maximal_cliques The output vector of maximal cliques found
+   */
+  void bronKerbose(std::set<std::string> current_clique,
+    std::set<std::string> candidates_set,
+    std::set<std::string> excluded_set,
+    std::map<std::string, std::set<std::string>> adj_list,
+    std::vector<std::set<std::string>> &maximal_cliques);
+  /**
+   * Automatically resolve netsplit for stretch clusters, excluding stretch mode.
+   */
+  void resolve_netsplit_stretch_cluster(
+    std::set<std::string> vertices,
+    std::set<std::pair<std::string, std::string>> cut_off_edges);
+  /**
+   * Get the failure domain used for stretch pools.
+   * @return the failure domain string
+   */
+  std::string get_stretch_pool_failure_domain();
+  /**
+   * Lift fencing, returning to normal operation.
+   */
+  void lift_fencing();
 private:
   utime_t stretch_recovery_triggered; // what time we committed a switch to recovery mode
 };

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -666,7 +666,7 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
   }
 
   {
-    uint8_t target_v = 9; // if bumping this, be aware of allow_crimson 12
+    uint8_t target_v = 9; // if bumping this, be aware of fenced_bucket 13
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 2;
     } else if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
@@ -681,6 +681,9 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
     }
     if (mutate_allow_crimson != mutate_allow_crimson_t::NONE) {
       target_v = std::max((uint8_t)12, target_v);
+    }
+    if (change_fenced_buckets) {
+      target_v = std::max((uint8_t)13, target_v);
     }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data
     if (target_v < 7) {
@@ -737,6 +740,11 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
     }
     if (target_v >= 12) {
       encode(mutate_allow_crimson, bl);
+    }
+    if (target_v >= 13) {
+      // NEW: encode fenced_buckets change marker + full set
+      encode(change_fenced_buckets, bl);
+      encode(new_fenced_buckets, bl);
     }
     ENCODE_FINISH(bl); // osd-only data
   }
@@ -951,7 +959,7 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(12, bl); // extended, osd-only data
+    DECODE_START(13, bl); // extended, osd-only data
     decode(new_hb_back_up, bl);
     decode(new_up_thru, bl);
     decode(new_last_clean_interval, bl);
@@ -1022,6 +1030,13 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
     }
     if (struct_v >= 12) {
       decode(mutate_allow_crimson, bl);
+    }
+    if (struct_v >= 13) {
+      decode(change_fenced_buckets, bl);
+      decode(new_fenced_buckets, bl);
+    } else {
+      change_fenced_buckets = false;
+      new_fenced_buckets.clear();
     }
     DECODE_FINISH(bl); // osd-only data
   }
@@ -1389,6 +1404,11 @@ void OSDMap::Incremental::dump(Formatter *f) const
     f->dump_int("new_stretch_mode_bucket", new_stretch_mode_bucket);
   }
   f->close_section();
+  f->dump_bool("change_fenced_buckets", change_fenced_buckets);
+  f->open_array_section("new_fenced_buckets");
+  for (const auto &bucket : new_fenced_buckets) {
+    f->dump_string("bucket", bucket);
+  }
   f->close_section();
 }
 
@@ -2701,6 +2721,10 @@ int OSDMap::apply_incremental(const Incremental &inc)
     break;
   }
 
+  if (inc.change_fenced_buckets) {
+    fenced_buckets = inc.new_fenced_buckets;
+  }
+
   calc_num_osds();
   _calc_up_osd_features();
   return 0;
@@ -3531,6 +3555,9 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     if (allow_crimson) {
       target_v = std::max((uint8_t)12, target_v);
     }
+    if (!fenced_buckets.empty()) {
+      target_v = std::max((uint8_t)13, target_v);
+    }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data
     if (target_v < 7) {
       encode_addrvec_pvec_as_addr(osd_addrs->hb_back_addrs, bl, features);
@@ -3591,6 +3618,9 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     }
     if (target_v >= 12) {
       ::encode(allow_crimson, bl);
+    }
+    if (target_v >= 13) {
+      encode(fenced_buckets, bl);
     }
     ENCODE_FINISH(bl); // osd-only data
   }
@@ -3857,7 +3887,7 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(12, bl); // extended, osd-only data
+    DECODE_START(13, bl); // extended, osd-only data
     decode(osd_addrs->hb_back_addrs, bl);
     decode(osd_info, bl);
     decode(blocklist, bl);
@@ -3945,6 +3975,11 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
     }
     if (struct_v >= 12) {
       decode(allow_crimson, bl);
+    }
+    if (struct_v >= 13) {
+      decode(fenced_buckets, bl);
+    } else {
+      fenced_buckets.clear();
     }
     DECODE_FINISH(bl); // osd-only data
   }
@@ -4337,8 +4372,12 @@ void OSDMap::dump(Formatter *f, CephContext *cct) const
     f->dump_int("stretch_mode_bucket", stretch_mode_bucket);
   }
   f->close_section();
+  f->open_array_section("fenced_buckets");
+  for (auto& bucket : fenced_buckets) {
+    f->dump_string("bucket", bucket);
+  }
+  f->close_section();
 }
-
 list<OSDMap> OSDMap::generate_test_instances()
 {
   list<OSDMap> o;
@@ -4517,6 +4556,13 @@ void OSDMap::print(CephContext *cct, ostream& out) const
     out << "cluster_snapshot " << get_cluster_snapshot() << "\n";
   if (allow_crimson) {
     out << "allow_crimson=true\n";
+  }
+  if (!fenced_buckets.empty()) {
+    out << "fenced_buckets ";
+    for (const auto& bucket : fenced_buckets) {
+      out << bucket << " ";
+    }
+    out << "\n";
   }
   out << "\n";
 
@@ -6966,6 +7012,75 @@ int OSDMap::calc_read_balance_score(CephContext *cct, int64_t pool_id,
 int OSDMap::get_osds_by_bucket_name(const string &name, set<int> *osds) const
 {
   return crush->get_leaves(name, osds);
+}
+
+bool OSDMap::is_osd_in_fenced_bucket(int osd, CephContext *cct) const
+{
+  set<int> osds;
+  for (const auto &bucket_name : fenced_buckets) {
+    if (get_osds_by_bucket_name(bucket_name, &osds) < 0) {
+      if (cct) {
+        ldout(cct, 5) << __func__ << " get_osds_by_bucket_name("
+          << bucket_name << ") failed" << dendl;
+      }
+      continue;
+    }
+    if (osds.count(osd) > 0) {
+      if (cct) {
+        ldout(cct, 30) << __func__ << " osd " << osd << " is in fenced bucket " << bucket_name << dendl;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+float OSDMap::get_total_effective_osd_weight_by_bucket_name(CephContext *cct,
+                                           const std::string &bucket_name) const
+{
+  /*
+  * Calculate total effective weight of all OSDs in the given bucket.
+  * Only include OSDs that are UP and IN.
+  * effective weight = crush weight * osdmap weight
+  */
+  set<int> leaves;
+  if (crush->get_leaves(bucket_name, &leaves) < 0) {
+    ldout(cct, 10) << __func__ << " crush->get_leaves(" << bucket_name << ") failed" << dendl;
+    return 0.0f;
+  } else {
+    ldout(cct, 30) << __func__ << " bucket_name=" << bucket_name << " leaves=" << leaves << dendl;
+  }
+  float total = 0.0f;
+  for (int item : leaves) {
+    if (!exists(item)) {
+      ldout(cct, 30) << __func__ << " skipping item " << item << " does not exist" << dendl;
+      continue;
+    }
+    if (is_down(item)) {
+      ldout(cct, 30) << __func__ << " skipping item " << item << " is down" << dendl;
+      continue;
+    }
+    if (is_out(item)) {
+      ldout(cct, 30) << __func__ << " skipping item " << item << " is out" << dendl;
+      continue;
+    }
+    // get osdmap item weight
+    float osdmap_weight = get_weightf(item);
+    ldout(cct, 30) << __func__ << " item " << item << " osdmap_weight=" << osdmap_weight << dendl;
+    // get crush item weight
+    float crush_weight = crush->get_item_weightf(item);
+    ldout(cct, 30) << __func__ << " item " << item << " crush_weight=" << crush_weight << dendl;
+    // calculate effective weight
+    float eff = crush_weight * osdmap_weight;
+    ldout(cct, 30) << __func__
+      << " osd." << item
+      << " crush_weight=" << crush_weight
+      << " osdmap_weight=" << osdmap_weight
+      << " effective=" << eff << dendl;
+    total += eff;
+  }
+  ldout(cct, 20) << __func__ << " " << bucket_name << " total_effective_weight=" << total << dendl;
+  return total;
 }
 
 // get pools whose crush rules might reference the given osd

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -112,6 +112,20 @@ WRITE_CLASS_ENCODER_FEATURES(osd_xinfo_t)
 
 std::ostream& operator<<(std::ostream& out, const osd_xinfo_t& xi);
 
+// struct NetsplitFence {
+//   std::set<std::string> fenced_buckets;
+//   std::set<std::string> active_buckets;
+//   std::set<std::string> last_active_buckets;
+//   utime_t last_fence_decision_ts; // when we last made a fencing decision
+//   utime_t last_lift_attempt_ts; // when we last attempted to lift fencing
+//   void dump(ceph::Formatter *f) const;
+//   void encode(ceph::buffer::list& bl) const;
+//   void decode(ceph::buffer::list::const_iterator& bl);
+//   static std::list<NetsplitFence> generate_test_instances();
+// };
+// WRITE_CLASS_ENCODER_FEATURES(NetsplitFence)
+
+// std::ostream& operator<<(std::ostream& out, const NetsplitFence& f);
 
 struct PGTempMap {
 #if 1
@@ -390,6 +404,9 @@ public:
       // Monitor won't allow CLEAR to be set currently, but we may allow it later
       CLEAR = 2
     } mutate_allow_crimson = mutate_allow_crimson_t::NONE;
+
+    bool change_fenced_buckets{false};
+    std::set<std::string> new_fenced_buckets;
 
     // full (rare)
     ceph::buffer::list fullmap;  // in lieu of below.
@@ -679,6 +696,7 @@ private:
   uint32_t recovering_stretch_mode; // 0 if not recovering; else 1
   int32_t stretch_mode_bucket; // the bucket type we're stretched across
   bool allow_crimson{false};
+  std::set<std::string> fenced_buckets;
 private:
   uint32_t crush_version = 1;
 
@@ -1105,6 +1123,17 @@ public:
     return -1;
   }
 
+  /**
+   * check if an osd is in a fenced bucket
+   */
+  bool is_osd_in_fenced_bucket(int osd, CephContext *cct = nullptr) const;
+
+  /**
+   * get total effective osd weight for a given bucket
+   */
+  float get_total_effective_osd_weight_by_bucket_name(
+    CephContext *cct,
+    const std::string& bucket_name) const;
 
   void get_random_up_osds_by_subtree(int n,     // whoami
                                      std::string &subtree,

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1708,7 +1708,12 @@ map<pg_shard_t, pg_info_t>::const_iterator PeeringState::find_best_info(
   // if there are multiples, prefer
   //  - a longer tail, if it brings another peer into log contiguity
   //  - the current primary
+  const OSDMapRef osdmap = get_osdmap();
   for (auto p = infos.begin(); p != infos.end(); ++p) {
+    if (osdmap && osdmap->is_osd_in_fenced_bucket(p->first.osd, cct)) {
+      psdout(10) << "find_best_info: skipping fenced osd." << p->first.osd << dendl;
+      continue;
+    }
     if (restrict_to_up_acting && !is_up(p->first) &&
 	!is_acting(p->first))
       continue;
@@ -1791,6 +1796,7 @@ void PeeringState::calc_ec_acting(
   vector<int> *_want,
   set<pg_shard_t> *backfill,
   set<pg_shard_t> *acting_backfill,
+  const OSDMapRef osdmap,
   ostream &ss)
 {
   vector<int> want(size, CRUSH_ITEM_NONE);
@@ -1802,6 +1808,10 @@ void PeeringState::calc_ec_acting(
   }
   for (uint8_t i = 0; i < want.size(); ++i) {
     ss << "For position " << (unsigned)i << ": ";
+    if (osdmap->is_osd_in_fenced_bucket(up[i], nullptr)) {
+          ss << " skipping fenced up[" << (unsigned)i << "] osd." << up[i] << std::endl;
+          continue;
+    }
     if (up.size() > (unsigned)i && up[i] != CRUSH_ITEM_NONE &&
 	!all_info.find(pg_shard_t(up[i], shard_id_t(i)))->second.is_incomplete() &&
 	all_info.find(pg_shard_t(up[i], shard_id_t(i)))->second.last_update >=
@@ -1815,7 +1825,10 @@ void PeeringState::calc_ec_acting(
 	 << " and ";
       backfill->insert(pg_shard_t(up[i], shard_id_t(i)));
     }
-
+    if (osdmap->is_osd_in_fenced_bucket(acting[i], nullptr)) {
+      ss << " skipping fenced acting[" << (unsigned)i << "] osd." << acting[i] << std::endl;
+      continue;
+    }
     if (acting.size() > (unsigned)i && acting[i] != CRUSH_ITEM_NONE &&
 	!all_info.find(pg_shard_t(acting[i], shard_id_t(i)))->second.is_incomplete() &&
 	all_info.find(pg_shard_t(acting[i], shard_id_t(i)))->second.last_update >=
@@ -1826,6 +1839,9 @@ void PeeringState::calc_ec_acting(
       for (auto j = all_info_by_shard[shard_id_t(i)].begin();
 	   j != all_info_by_shard[shard_id_t(i)].end();
 	   ++j) {
+      if (osdmap->is_osd_in_fenced_bucket(j->osd, nullptr)) {
+          continue;
+      }
 	ceph_assert(static_cast<int>(j->shard) == i);
 	if (!all_info.find(*j)->second.is_incomplete() &&
 	    all_info.find(*j)->second.last_update >=
@@ -1940,9 +1956,13 @@ void PeeringState::calc_replicated_acting(
 {
   ss << __func__ << (restrict_to_up_acting ? " restrict_to_up_acting" : "")
      << std::endl;
-
-  want->push_back(primary->first.osd);
-  acting_backfill->insert(primary->first);
+  // select primary
+  if (osdmap->is_osd_in_fenced_bucket(primary->first.osd, nullptr)) {
+      ss << " osd." << primary->first.osd << " (primary) is fenced, skipping" << std::endl;
+  } else {
+    want->push_back(primary->first.osd);
+    acting_backfill->insert(primary->first);
+  }
 
   // select replicas that have log contiguity with primary.
   // prefer up, then acting, then any peer_info osds
@@ -1950,6 +1970,10 @@ void PeeringState::calc_replicated_acting(
     pg_shard_t up_cand = pg_shard_t(i, shard_id_t::NO_SHARD);
     if (up_cand == primary->first)
       continue;
+    if (osdmap->is_osd_in_fenced_bucket(i, nullptr)) {
+      ss << " osd." << i << " (up) is fenced, skipping" << std::endl;
+      continue;
+    }
     const pg_info_t &cur_info = all_info.find(up_cand)->second;
     if (cur_info.is_incomplete() ||
         cur_info.last_update < oldest_auth_log_entry) {
@@ -1971,6 +1995,10 @@ void PeeringState::calc_replicated_acting(
   candidate_by_last_update.reserve(acting.size());
   // This no longer has backfill OSDs, but they are covered above.
   for (auto i : acting) {
+    if (osdmap->is_osd_in_fenced_bucket(i, nullptr)) {
+      ss << " osd." << i << " (acting) is fenced, skipping" << std::endl;
+      continue;
+    }
     pg_shard_t acting_cand(i, shard_id_t::NO_SHARD);
     // skip up osds we already considered above
     if (acting_cand == primary->first)
@@ -1997,6 +2025,10 @@ void PeeringState::calc_replicated_acting(
   std::sort(candidate_by_last_update.begin(),
             candidate_by_last_update.end(), sort_by_eversion);
   for (auto &p: candidate_by_last_update) {
+    if (osdmap->is_osd_in_fenced_bucket(p.second, nullptr)) {
+      ss << " osd." << p.second << " (candidate_by_last_update) is fenced, skipping" << std::endl;
+      continue;
+    }
     ceph_assert(want->size() < size);
     want->push_back(p.second);
     pg_shard_t s = pg_shard_t(p.second, shard_id_t::NO_SHARD);
@@ -2015,6 +2047,10 @@ void PeeringState::calc_replicated_acting(
   candidate_by_last_update.reserve(all_info.size()); // overestimate but fine
   // continue to search stray to find more suitable peers
   for (auto &i : all_info) {
+    if (osdmap->is_osd_in_fenced_bucket(i.first.osd, nullptr)) {
+      ss << " osd." << i.first.osd << " (all_info) is fenced, skipping" << std::endl;
+      continue;
+    }
     // skip up osds we already considered above
     if (i.first == primary->first)
       continue;
@@ -2215,12 +2251,22 @@ void PeeringState::calc_replicated_acting_stretch(
       get_ancestor(osd)->inc_selected();
     }
   };
-  add_required(primary->first.osd);
-  ss << " osd " << primary->first.osd << " primary accepted "
+  if (osdmap->is_osd_in_fenced_bucket(primary->first.osd, nullptr)) {
+    ss << __func__ << " osd."
+      << primary->first.osd << " is fenced, skipping" << std::endl;
+  } else {
+    add_required(primary->first.osd);
+    ss << " osd " << primary->first.osd << " primary accepted "
      << osd_info(primary->first.osd) << std::endl;
+  }
   for (auto upcand: up) {
     auto upshard = pg_shard_t(upcand, shard_id_t::NO_SHARD);
     auto &curinfo = osd_info(upcand);
+    if (osdmap->is_osd_in_fenced_bucket(upcand, nullptr)) {
+      ss << __func__ << " osd."
+        << upcand << " is fenced, skipping" << std::endl;
+      continue;
+    }
     if (usable_osd(upcand)) {
       ss << " osd " << upcand << " (up) accepted " << curinfo << std::endl;
       add_required(upcand);
@@ -2252,6 +2298,11 @@ void PeeringState::calc_replicated_acting_stretch(
 	info.last_update);
     };
     for (auto &cand : acting) {
+        if (osdmap->is_osd_in_fenced_bucket(cand, nullptr)) {
+        ss << __func__ << " osd."
+          << cand << " is fenced, skipping" << std::endl;
+      continue;
+      }
       auto &cand_info = osd_info(cand);
       if (!used(cand) && usable_info(cand_info)) {
 	ss << " acting candidate " << cand << " " << cand_info << std::endl;
@@ -2260,6 +2311,11 @@ void PeeringState::calc_replicated_acting_stretch(
     }
     if (!restrict_to_up_acting) {
       for (auto &[cand, info] : all_info) {
+        if (osdmap->is_osd_in_fenced_bucket(cand.osd, nullptr)) {
+          ss << __func__ << " osd."
+            << cand.osd << " is fenced, skipping" << std::endl;
+          continue;
+        }
 	if (!used(cand.osd) && usable_info(info) &&
 	    (std::find(acting.begin(), acting.end(), cand.osd)
 	     == acting.end())) {
@@ -2631,6 +2687,7 @@ bool PeeringState::choose_acting(pg_shard_t &get_log_shard_id,
       &want,
       &want_backfill,
       &want_acting_backfill,
+      get_osdmap(),
       ss);
   }
   psdout(10) << ss.str() << dendl;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1711,6 +1711,7 @@ private:
     std::vector<int> *want,
     std::set<pg_shard_t> *backfill,
     std::set<pg_shard_t> *acting_backfill,
+    const OSDMapRef osdmap,
     std::ostream &ss);
 
   static std::pair<std::map<pg_shard_t, pg_info_t>::const_iterator, eversion_t>


### PR DESCRIPTION
This introduces an automatic netsplit resolver for stretch clusters. When a
netsplit is detected, the monitor computes maximal cliques of reachable
zones/datacenters and selects the surviving clique deterministically.

What’s added
- Maximal clique detection via Bron–Kerbosch to enumerate candidate cliques.
- Heuristic chooser `run_heuristics_on_largest_cliques()` to pick among equal-size
cliques using:
1) sum of effective OSD weight,
2) MON up count,
3) MON connection score,
4) lexicographic tiebreak (deterministic).
- Fencing set computation: `fence_buckets = vertices - best_clique`.
- `fenced_buckets` persists in OSDMap
- PeeringState only choose OSDs that don't belong in fenced_buckets
- OSDMonitor will drop OSD failures messages that are from or to OSDs fenced_buckets
- Lifting the fence when it is viable

    
New tunable
- `mon_netsplit_auto_resolve` (bool, default: true)
Controls whether the monitor will attempt automatic netsplit resolution in
stretch-cluster deployments.

Notes
- “Effective OSD weight” = CRUSH weight × OSDMap (re)weight.

Fixes: https://tracker.ceph.com/issues/73589
    
Signed-off-by: Kamoltat Sirivadhna <ksirivad@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
