### PR TITLE
mgr/cephadm: Stop NFS service/daemon from starting automatically after reboot, cephadm to manage startup

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1175,12 +1175,15 @@ def deploy_daemon(
             cephadm_agent.deploy_daemon_unit(config_js)
         else:
             if c:
+                # Disable automatic startup for NFS daemons
+                enable_daemon = daemon_type != 'nfs'
                 deploy_daemon_units(
                     ctx,
                     ident,
                     uid,
                     gid,
                     c,
+                    enable=enable_daemon,
                     osd_fsid=osd_fsid,
                     endpoints=endpoints,
                     init_containers=init_containers,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1175,8 +1175,9 @@ def deploy_daemon(
             cephadm_agent.deploy_daemon_unit(config_js)
         else:
             if c:
-                # Disable automatic startup for NFS daemons
-                enable_daemon = daemon_type != 'nfs'
+                # Disable automatic systemd enable for NFS and keepalived; the mgr
+                # starts them when appropriate (see cephadm serve / DISABLED_SERVICES).
+                enable_daemon = daemon_type not in ('nfs', 'keepalived')
                 deploy_daemon_units(
                     ctx,
                     ident,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3147,11 +3147,11 @@ Then run the following:
 
         # Track user-initiated stop/start actions
         if action == 'stop':
-            d.user_stopped = True
-            self.cache.update_host_daemons(d.hostname, {d.name(): d})
+            d.update_user_stopped_status(True)
+            self.cache.save_host(d.hostname)
         elif action in ['start', 'restart']:
-            d.user_stopped = False
-            self.cache.update_host_daemons(d.hostname, {d.name(): d})
+            d.update_user_stopped_status(False)
+            self.cache.save_host(d.hostname)
 
         self._daemon_action_set_image(action, image, d.daemon_type, d.daemon_id)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -47,7 +47,7 @@ from ceph.deployment.service_spec import (
 from ceph.deployment.drive_group import DeviceSelection
 from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
 from ceph.cryptotools.select import choose_crypto_caller
-from cephadm.serve import CephadmServe, REQUIRES_POST_ACTIONS
+from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.http_server import CephadmHttpServer
 from cephadm.agent import CephadmAgentHelpers
@@ -1126,6 +1126,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                     'unknown': DaemonDescriptionStatus.error,
                 }[d['state']]
 
+            cached_dd = None
+            try:
+                cached_dd = self.cache.get_daemon(d['name'], host)
+            except OrchestratorError:
+                self.log.debug(f'Could not find daemon {d["name"]} in cache')
+
             sd = orchestrator.DaemonDescription(
                 daemon_type=daemon_type,
                 daemon_id='.'.join(d['name'].split('.')[1:]),
@@ -1155,15 +1161,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 rank_generation=rank_generation,
                 extra_container_args=d.get('extra_container_args'),
                 extra_entrypoint_args=d.get('extra_entrypoint_args'),
+                pending_daemon_config=cached_dd.pending_daemon_config if cached_dd else False,
+                user_stopped=cached_dd.user_stopped if cached_dd else False,
             )
-
-            if daemon_type in REQUIRES_POST_ACTIONS:
-                # If post action is required for daemon, then restore value of pending_daemon_config
-                try:
-                    cached_dd = self.cache.get_daemon(sd.name(), host)
-                    sd.update_pending_daemon_config(cached_dd.pending_daemon_config)
-                except orchestrator.OrchestratorError:
-                    pass
 
             dm[sd.name()] = sd
         self.log.debug('Refreshed host %s daemons (%d)' % (host, len(dm)))
@@ -1180,6 +1180,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def offline_hosts_remove(self, host: str) -> None:
         if host in self.offline_hosts:
             self.offline_hosts.remove(host)
+            self._invalidate_all_host_metadata_and_kick_serve(host)
 
     def update_failed_daemon_health_check(self) -> None:
         failed_daemons = []
@@ -3088,8 +3089,12 @@ Then run the following:
                     out, err, code = self.wait_async(CephadmServe(self)._run_cephadm(
                         daemon_spec.host, name, 'unit',
                         ['--name', name, a]))
-            except Exception:
-                self.log.exception(f'`{daemon_spec.host}: cephadm unit {name} {a}` failed')
+            except Exception as exp:
+                if a == 'reset-failed' and daemon_spec.daemon_type in ['nfs'] and 'not loaded' in str(exp):
+                    # Don't log exception if reset-failed fails because the unit is not loaded
+                    pass
+                else:
+                    self.log.exception(f'`{daemon_spec.host}: cephadm unit {name} {a}` failed')
         self.cache.invalidate_host_daemons(daemon_spec.host)
         msg = "{} {} from host '{}'".format(action, name, daemon_spec.host)
         self.events.for_daemon(name, 'INFO', msg)
@@ -3120,6 +3125,7 @@ Then run the following:
         d = self.cache.get_daemon(daemon_name)
         assert d.daemon_type is not None
         assert d.daemon_id is not None
+        assert d.hostname
 
         if (action == 'redeploy' or action == 'restart') and self.daemon_is_self(d.daemon_type, d.daemon_id) \
                 and not self.mgr_service.mgr_map_has_standby():
@@ -3138,6 +3144,14 @@ Then run the following:
                 raise OrchestratorError(
                     f'key rotation not supported for {d.daemon_type}'
                 )
+
+        # Track user-initiated stop/start actions
+        if action == 'stop':
+            d.user_stopped = True
+            self.cache.update_host_daemons(d.hostname, {d.name(): d})
+        elif action in ['start', 'restart']:
+            d.user_stopped = False
+            self.cache.update_host_daemons(d.hostname, {d.name(): d})
 
         self._daemon_action_set_image(action, image, d.daemon_type, d.daemon_id)
 

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -340,6 +340,7 @@ class HostAssignment(object):
 
         # get candidate hosts based on [hosts, label, host_pattern]
         candidates = self.get_candidates()  # type: List[DaemonPlacement]
+        all_candidates = candidates
         if self.primary_daemon_type in RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES:
             # remove unreachable hosts that are not in maintenance so daemons
             # on these hosts will be rescheduled
@@ -400,7 +401,7 @@ class HostAssignment(object):
         existing_slots: List[DaemonPlacement] = []
         to_add: List[DaemonPlacement] = []
         to_remove: List[orchestrator.DaemonDescription] = []
-        ranks: List[int] = list(range(len(candidates)))
+        ranks: List[int] = list(range(len(all_candidates)))
         others: List[DaemonPlacement] = candidates.copy()
         for dd in daemons:
             found = False

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -401,7 +401,7 @@ class HostAssignment(object):
         existing_slots: List[DaemonPlacement] = []
         to_add: List[DaemonPlacement] = []
         to_remove: List[orchestrator.DaemonDescription] = []
-        ranks: List[int] = list(range(len(all_candidates)))
+        ranks: List[int] = list(range(len(all_candidates if len(all_candidates) > len(candidates) else candidates)))
         others: List[DaemonPlacement] = candidates.copy()
         for dd in daemons:
             found = False

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -219,6 +219,7 @@ class HostAssignment(object):
                  draining_hosts: List[orchestrator.HostSpec],
                  daemons: List[orchestrator.DaemonDescription],
                  related_service_daemons: Optional[List[DaemonDescription]] = None,
+                 related_service_required_count: Optional[int] = None,
                  networks: Dict[str, Dict[str, Dict[str, List[str]]]] = {},
                  filter_new_host: Optional[Callable[[str, ServiceSpec], bool]] = None,
                  allow_colo: bool = False,
@@ -240,6 +241,7 @@ class HostAssignment(object):
         self.service_name = spec.service_name()
         self.daemons = daemons
         self.related_service_daemons = related_service_daemons
+        self.related_service_required_count = related_service_required_count
         self.networks = networks
         self.allow_colo = allow_colo
         self.per_host_daemon_type = per_host_daemon_type
@@ -473,8 +475,27 @@ class HostAssignment(object):
                     # If we still need to remove more, remove from hosts with related services
                     remaining_needed = total_excess - len(to_delete)
                     if remaining_needed > 0:
-                        remaining = [dd for dd in existing if dd not in to_delete]
-                        to_delete.extend(remaining[count:])
+                        # Restrict defer-removal behavior to ingress only.
+                        should_defer_related_removal = False
+                        if self.spec.service_type == 'ingress':
+                            related_service_count = len(self.related_service_daemons)
+                            related_service_required_count = (
+                                self.related_service_required_count or count
+                            )
+                            related_service_is_ranked = any(
+                                dd.rank is not None
+                                for dd in self.related_service_daemons
+                            )
+                            # For ingress with ranked backends (e.g. NFS), if backend
+                            # scale-down is still pending, defer deleting co-located
+                            # ingress daemons until a later iteration.
+                            should_defer_related_removal = (
+                                related_service_is_ranked
+                                and related_service_count > related_service_required_count
+                            )
+                        if not should_defer_related_removal:
+                            remaining = [dd for dd in existing if dd not in to_delete]
+                            to_delete.extend(remaining[count:])
 
                     non_matching_daemons = to_delete
                 else:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -870,6 +870,17 @@ class CephadmServe:
         rank_map = None
         if svc.ranked(spec):
             rank_map = self.mgr.spec_store[spec.service_name()].rank_map or {}
+        related_service_required_count = None
+        if service_type == 'ingress':
+            ingress_spec = cast(IngressSpec, spec)
+            assert ingress_spec.backend_service
+            backend_spec = self.mgr.spec_store.active_specs.get(
+                ingress_spec.backend_service
+            )
+            if backend_spec and backend_spec.placement:
+                related_service_required_count = backend_spec.placement.get_target_count(
+                    self.mgr.cache.get_schedulable_hosts()
+                )
         host_selector = _host_selector(svc)
         ha = HostAssignment(
             spec=spec,
@@ -880,6 +891,7 @@ class CephadmServe:
             blocking_daemon_hosts=blocking_daemon_hosts,
             daemons=daemons,
             related_service_daemons=related_service_daemons,
+            related_service_required_count=related_service_required_count,
             networks=self.mgr.cache.networks,
             filter_new_host=host_filters.get(service_type, None),
             allow_colo=svc.allow_colo(),

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -34,6 +34,7 @@ from mgr_module import MonCommandFailed
 from mgr_util import format_bytes
 from cephadm.services.service_registry import service_registry
 from cephadm.services.nfs import NFSService
+from cephadm.services.ingress import IngressService
 
 from . import utils
 from . import exchange
@@ -45,7 +46,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 REQUIRES_POST_ACTIONS = ['grafana', 'iscsi', 'prometheus', 'alertmanager', 'rgw', 'nvmeof', 'mgmt-gateway']
-DISABLED_SERVICES = ['nfs']
+# Daemons not systemd-enabled on deploy, mgr start them when not user stopped
+DISABLED_SERVICES = ['nfs', 'keepalived']
 
 CEPHADM_EXE = ssh.RemoteExecutable('/usr/bin/cephadm')
 
@@ -1263,6 +1265,10 @@ class CephadmServe:
                             highest_gen_daemon = max(same_rank_daemons,
                                                      key=lambda d: d.rank_generation or 0)
                             should_start = (dd == highest_gen_daemon)
+                    elif dd.daemon_type == 'keepalived' and spec is not None:
+                        should_start = IngressService.keepalived_should_auto_start(
+                            self.mgr, dd, spec
+                        )
                     else:
                         should_start = True
                     if should_start:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 REQUIRES_POST_ACTIONS = ['grafana', 'iscsi', 'prometheus', 'alertmanager', 'rgw', 'nvmeof', 'mgmt-gateway']
+DISABLED_SERVICES = ['nfs']
 
 CEPHADM_EXE = ssh.RemoteExecutable('/usr/bin/cephadm')
 
@@ -978,10 +979,11 @@ class CephadmServe:
                 for d in daemons_to_remove:
                     assert d.hostname is not None
                     self._remove_daemon(d.name(), d.hostname)
-                daemons_to_remove = []
 
                 # fence them
-                svc.fence_old_ranks(spec, rank_map, len(all_slots))
+                if daemons_to_remove:
+                    svc.fence_old_ranks(spec, rank_map, len(all_slots))
+                daemons_to_remove = []
 
             # create daemons
             daemon_place_fails = []
@@ -1240,6 +1242,12 @@ class CephadmServe:
             action = _ceph_service_next_action(
                 action, dd.daemon_type, dd.name(), self.mgr, last_config
             )
+
+            # If no action is specified, check whether we need to start the daemon
+            if not action and dd.daemon_type in DISABLED_SERVICES:
+                if dd.status == 0 and not dd.user_stopped:
+                    self.log.debug(f'Starting daemon {dd.name()}')
+                    action = 'start'
 
             if action:
                 if scheduled_action == 'redeploy' and action == 'reconfig':

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1246,8 +1246,28 @@ class CephadmServe:
             # If no action is specified, check whether we need to start the daemon
             if not action and dd.daemon_type in DISABLED_SERVICES:
                 if dd.status == 0 and not dd.user_stopped:
-                    self.log.debug(f'Starting daemon {dd.name()}')
-                    action = 'start'
+                    should_start = False
+                    if spec and service_registry.get_service(daemon_type_to_service(dd.daemon_type)).ranked(spec):
+                        # For ranked services, check if we should start this daemon
+                        same_rank_daemons = [
+                            d for d in self.mgr.cache.get_daemons_by_service(dd.service_name())
+                            if d.rank == dd.rank and d.daemon_type == dd.daemon_type
+                        ]
+                        self.log.debug(
+                            f'Start hightest rank_gen daemon of same rank daemons {same_rank_daemons}'
+                        )
+                        if len(same_rank_daemons) == 1:
+                            should_start = True
+                        else:
+                            # Multiple daemons exist for this rank, only start the highest generation
+                            highest_gen_daemon = max(same_rank_daemons,
+                                                     key=lambda d: d.rank_generation or 0)
+                            should_start = (dd == highest_gen_daemon)
+                    else:
+                        should_start = True
+                    if should_start:
+                        self.log.debug(f'Starting daemon {dd.name()}')
+                        action = 'start'
 
             if action:
                 if scheduled_action == 'redeploy' and action == 'reconfig':

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1236,6 +1236,7 @@ class CephadmServe:
                     spec,
                     curr_deps=deps,
                     last_deps=last_deps,
+                    daemon=dd,
                 )
                 if _step.action is not _scheduled_action:
                     self.log.info(

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -969,6 +969,7 @@ class CephadmService(metaclass=ABCMeta):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that
@@ -1997,6 +1998,7 @@ class CephExporterService(CephService):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -8,7 +8,7 @@ from ceph.deployment.service_spec import ServiceSpec, IngressSpec, MonitorCertSo
 from ceph.deployment.utils import is_ipv6
 from mgr_util import build_url
 from cephadm import utils
-from orchestrator import OrchestratorError, DaemonDescription
+from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService, CephadmService
 from .service_registry import register_cephadm_service
 from cephadm.tlsobject_types import TLSCredentials
@@ -327,6 +327,56 @@ class IngressService(CephService):
         daemon_spec.final_config, daemon_spec.deps = self.keepalived_generate_config(daemon_spec)
 
         return daemon_spec
+
+    @staticmethod
+    def _ingress_keepalived_required_count(
+        mgr: "CephadmOrchestrator",
+        ispec: IngressSpec,
+    ) -> int:
+        """
+        get keepalived slot count from ingress placement only
+        """
+        return ispec.placement.get_target_count(mgr.cache.get_schedulable_hosts())
+
+    @staticmethod
+    def keepalived_should_auto_start(
+        mgr: "CephadmOrchestrator",
+        dd: DaemonDescription,
+        spec: ServiceSpec,
+    ) -> bool:
+        """
+        Whether a stopped keepalived unit should be started by the serve loop.
+        Does not auto-start while more keepalived daemons exist than the placement target
+        """
+        ispec = cast(IngressSpec, spec)
+        ingress_daemons = mgr.cache.get_daemons_by_service(ispec.service_name())
+        keepalived_total = len(
+            [d for d in ingress_daemons if d.daemon_type == 'keepalived']
+        )
+        required = IngressService._ingress_keepalived_required_count(mgr, ispec)
+        if keepalived_total > required:
+            return False
+        if ispec.keepalive_only:
+            if not ispec.backend_service:
+                return False
+            for d in mgr.cache.get_daemons_by_service(ispec.backend_service):
+                if d.hostname != dd.hostname:
+                    continue
+                if d.status in (
+                    DaemonDescriptionStatus.running,
+                    DaemonDescriptionStatus.starting,
+                ):
+                    return True
+            return False
+        for d in mgr.cache.get_daemons_by_service(spec.service_name()):
+            if d.daemon_type != 'haproxy' or d.hostname != dd.hostname:
+                continue
+            if d.status in (
+                DaemonDescriptionStatus.running,
+                DaemonDescriptionStatus.starting,
+            ):
+                return True
+        return False
 
     @staticmethod
     def get_keepalived_dependencies(mgr: "CephadmOrchestrator", spec: Optional[ServiceSpec]) -> List[str]:

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -605,6 +605,7 @@ class IngressService(CephService):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that
@@ -614,6 +615,20 @@ class IngressService(CephService):
             scheduled_action, daemon_type, spec, curr_deps, last_deps
         )
         action = step.action
+        # keepalived is not systemd-enabled; when stopped, redeploy rewrites
+        # the unit and container so the serve loop can start the daemon again.
+        if (
+            daemon_type == 'keepalived'
+            and action is utils.Action.RECONFIG
+            and daemon is not None
+            and daemon.status == DaemonDescriptionStatus.stopped
+        ):
+            logger.debug(
+                'Redeploy wanted %s: keepalived deps changed (daemon stopped)',
+                spec.service_name() if spec else daemon_type,
+            )
+            return utils.NextDaemonStep(utils.Action.REDEPLOY)
+
         if (
             action is not utils.Action.REDEPLOY
             and daemon_type == 'haproxy'

--- a/src/pybind/mgr/cephadm/services/jaeger.py
+++ b/src/pybind/mgr/cephadm/services/jaeger.py
@@ -2,6 +2,7 @@ from dataclasses import replace
 from typing import List, cast, Optional, TYPE_CHECKING
 from cephadm.services.cephadmservice import CephadmService, CephadmDaemonDeploySpec
 from ceph.deployment.service_spec import TracingSpec, ServiceSpec
+from orchestrator import DaemonDescription
 from .service_registry import register_cephadm_service
 from mgr_util import build_url
 from cephadm import utils
@@ -58,6 +59,7 @@ class JaegerAgentService(CephadmService):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -491,6 +491,7 @@ class AlertmanagerService(CephadmService):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that
@@ -824,6 +825,7 @@ class PrometheusService(CephadmService):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that
@@ -891,6 +893,7 @@ class NodeExporterService(CephadmService):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -578,6 +578,7 @@ class NFSService(CephService):
         spec: Optional[ServiceSpec],
         curr_deps: List[str],
         last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
     ) -> utils.NextDaemonStep:
         """Given the scheduled_action, service spec, daemon_type, and
         current and previous dependency lists return the next action that

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -14,7 +14,9 @@ from ceph.deployment.service_spec import (
 from cephadm.tests.fixtures import with_host, with_service, async_side_effect
 
 from ceph.utils import datetime_now
-from orchestrator._interface import DaemonDescription
+from orchestrator._interface import DaemonDescription, DaemonDescriptionStatus
+from orchestrator import HostSpec
+from cephadm.services.ingress import IngressService
 
 
 class TestIngressService:
@@ -1455,3 +1457,144 @@ class TestIngressService:
         )
         ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
         assert "Bind_addr = 10.10.2.20" in ganesha_conf
+
+
+def test_keepalived_should_auto_start_colocated_haproxy():
+    mgr = MagicMock()
+    mgr.cache.get_schedulable_hosts.return_value = [HostSpec('host-a')]
+    spec = IngressSpec(
+        service_id='test',
+        backend_service='rgw.foo',
+        frontend_port=8080,
+        monitor_port=8999,
+        virtual_ip='192.168.1.50/24',
+        placement=PlacementSpec(hosts=['host-a']),
+    )
+    k = DaemonDescription(
+        daemon_type='keepalived',
+        daemon_id='test',
+        hostname='host-a',
+        service_name='ingress.test',
+    )
+    hp = DaemonDescription(
+        daemon_type='haproxy',
+        daemon_id='test',
+        hostname='host-a',
+        service_name='ingress.test',
+        status=DaemonDescriptionStatus.running,
+        ports=[8080, 8999],
+    )
+    hp_stopped = DaemonDescription(
+        daemon_type='haproxy',
+        daemon_id='test',
+        hostname='host-a',
+        service_name='ingress.test',
+        status=DaemonDescriptionStatus.stopped,
+        ports=[8080, 8999],
+    )
+
+    mgr.cache.get_daemons_by_service.side_effect = lambda n: [] if n == 'ingress.test' else []
+    assert not IngressService.keepalived_should_auto_start(mgr, k, spec)
+
+    mgr.cache.get_daemons_by_service.side_effect = lambda n: [hp, k] if n == 'ingress.test' else []
+    assert IngressService.keepalived_should_auto_start(mgr, k, spec)
+
+    mgr.cache.get_daemons_by_service.side_effect = (
+        lambda n: [hp_stopped, k] if n == 'ingress.test' else []
+    )
+    assert not IngressService.keepalived_should_auto_start(mgr, k, spec)
+
+
+def test_keepalived_should_auto_start_false_when_more_kv_than_required():
+    mgr = MagicMock()
+    mgr.cache.get_schedulable_hosts.return_value = [
+        HostSpec('host-a'),
+        HostSpec('host-b'),
+        HostSpec('host-c'),
+    ]
+    spec = IngressSpec(
+        service_id='test',
+        backend_service='rgw.foo',
+        frontend_port=8080,
+        monitor_port=8999,
+        virtual_ip='192.168.1.50/24',
+        placement=PlacementSpec(hosts=['host-a', 'host-b']),
+    )
+    hp_a = DaemonDescription(
+        daemon_type='haproxy',
+        daemon_id='test',
+        hostname='host-a',
+        service_name='ingress.test',
+        status=DaemonDescriptionStatus.running,
+        ports=[8080, 8999],
+    )
+    hp_b = DaemonDescription(
+        daemon_type='haproxy',
+        daemon_id='test',
+        hostname='host-b',
+        service_name='ingress.test',
+        status=DaemonDescriptionStatus.running,
+        ports=[8080, 8999],
+    )
+    kv_a = DaemonDescription(
+        daemon_type='keepalived',
+        daemon_id='test',
+        hostname='host-a',
+        service_name='ingress.test',
+    )
+    kv_b = DaemonDescription(
+        daemon_type='keepalived',
+        daemon_id='test',
+        hostname='host-b',
+        service_name='ingress.test',
+    )
+    kv_extra = DaemonDescription(
+        daemon_type='keepalived',
+        daemon_id='test',
+        hostname='host-c',
+        service_name='ingress.test',
+    )
+    mgr.cache.get_daemons_by_service.side_effect = (
+        lambda n: [hp_a, hp_b, kv_a, kv_b, kv_extra] if n == 'ingress.test' else []
+    )
+    assert not IngressService.keepalived_should_auto_start(mgr, kv_extra, spec)
+
+
+def test_keepalived_should_auto_start_keepalive_only_backend():
+    mgr = MagicMock()
+    mgr.cache.get_schedulable_hosts.return_value = [HostSpec('host1')]
+    spec = IngressSpec(
+        service_id='test',
+        backend_service='nfs.foo',
+        frontend_port=2049,
+        monitor_port=9049,
+        virtual_ip='192.168.122.100/24',
+        keepalive_only=True,
+        placement=PlacementSpec(hosts=['host1']),
+    )
+    k = DaemonDescription(
+        daemon_type='keepalived',
+        daemon_id='keepalived.test',
+        hostname='host1',
+        service_name='ingress.test',
+    )
+    nfs_d = DaemonDescription(
+        daemon_type='nfs',
+        daemon_id='foo.host1',
+        hostname='host1',
+        service_name='nfs.foo',
+        status=DaemonDescriptionStatus.starting,
+    )
+
+    mgr.cache.get_daemons_by_service.side_effect = lambda n: []
+    assert not IngressService.keepalived_should_auto_start(mgr, k, spec)
+
+    def _with_nfs(name: str):
+        if name == 'ingress.test':
+            return [k]
+        if name == 'nfs.foo':
+            return [nfs_d]
+        return []
+
+    mgr.cache.get_daemons_by_service.side_effect = _with_nfs
+    assert IngressService.keepalived_should_auto_start(mgr, k, spec)

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -16,6 +16,7 @@ from cephadm.tests.fixtures import with_host, with_service, async_side_effect
 from ceph.utils import datetime_now
 from orchestrator._interface import DaemonDescription, DaemonDescriptionStatus
 from orchestrator import HostSpec
+from cephadm import utils
 from cephadm.services.ingress import IngressService
 
 
@@ -1457,6 +1458,86 @@ class TestIngressService:
         )
         ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
         assert "Bind_addr = 10.10.2.20" in ganesha_conf
+
+
+def test_keepalived_choose_next_action_redeploy_on_deps_change_when_stopped():
+    mgr = MagicMock()
+    svc = IngressService(mgr)
+    spec = IngressSpec(
+        service_id='test',
+        backend_service='nfs.foo',
+        frontend_port=2049,
+        monitor_port=9049,
+        virtual_ip='192.168.122.100/24',
+        placement=PlacementSpec(hosts=['host1']),
+    )
+    daemon = DaemonDescription(
+        daemon_type='keepalived',
+        daemon_id='test',
+        hostname='host1',
+        service_name='ingress.test',
+        status=DaemonDescriptionStatus.stopped,
+    )
+    next_step = svc.choose_next_action(
+        utils.Action.NO_ACTION,
+        'keepalived',
+        spec,
+        curr_deps=['haproxy.test'],
+        last_deps=['haproxy.old'],
+        daemon=daemon,
+    )
+    assert next_step.action is utils.Action.REDEPLOY
+
+
+def test_keepalived_choose_next_action_reconfig_when_running():
+    mgr = MagicMock()
+    svc = IngressService(mgr)
+    spec = IngressSpec(
+        service_id='test',
+        backend_service='nfs.foo',
+        frontend_port=2049,
+        monitor_port=9049,
+        virtual_ip='192.168.122.100/24',
+        placement=PlacementSpec(hosts=['host1']),
+    )
+    daemon = DaemonDescription(
+        daemon_type='keepalived',
+        daemon_id='test',
+        hostname='host1',
+        service_name='ingress.test',
+        status=DaemonDescriptionStatus.running,
+    )
+    next_step = svc.choose_next_action(
+        utils.Action.NO_ACTION,
+        'keepalived',
+        spec,
+        curr_deps=['haproxy.test'],
+        last_deps=['haproxy.old'],
+        daemon=daemon,
+    )
+    assert next_step.action is utils.Action.RECONFIG
+
+
+def test_keepalived_choose_next_action_scheduled_when_deps_unchanged():
+    mgr = MagicMock()
+    svc = IngressService(mgr)
+    spec = IngressSpec(
+        service_id='test',
+        backend_service='nfs.foo',
+        frontend_port=2049,
+        monitor_port=9049,
+        virtual_ip='192.168.122.100/24',
+        placement=PlacementSpec(hosts=['host1']),
+    )
+    deps = ['haproxy.test']
+    next_step = svc.choose_next_action(
+        utils.Action.NO_ACTION,
+        'keepalived',
+        spec,
+        curr_deps=deps,
+        last_deps=deps,
+    )
+    assert next_step.action is utils.Action.NO_ACTION
 
 
 def test_keepalived_should_auto_start_colocated_haproxy():

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -1,8 +1,13 @@
 import contextlib
+from typing import cast
 from unittest.mock import MagicMock, patch, ANY
 
 import pytest
 
+from ceph.utils import datetime_now
+from orchestrator import DaemonDescriptionStatus
+
+from cephadm.serve import CephadmServe
 from cephadm.services.service_registry import service_registry
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.module import CephadmOrchestrator
@@ -740,3 +745,68 @@ def test_ingress_for_nfs_choose_next_action(cephadm_module, mock_cephadm):
         # _daemon_action so we can check what action was chosen
         mock_cephadm.serve(cephadm_module)._check_daemons()
         mock_cephadm._daemon_action.assert_called_with(ANY, action="redeploy")
+
+
+@patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+@patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+@patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+def test_check_daemons_starts_keepalived_when_stopped_and_haproxy_running(
+    cephadm_module, mock_cephadm
+):
+    """Regression: serve loop must issue 'start' for keepalived when deps are ok
+    and colocated haproxy is running (keepalived is not systemd-enabled)."""
+    nfs_spec = NFSServiceSpec(
+        service_id="foo",
+        placement=PlacementSpec(hosts=['test']),
+        port=8765,
+    )
+    ingress_spec = IngressSpec(
+        service_id='bar',
+        backend_service='nfs.foo',
+        frontend_port=2468,
+        monitor_port=8642,
+        virtual_ip='1.2.3.0/24',
+        placement=PlacementSpec(hosts=['test']),
+        keepalived_password='abcde',
+    )
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(with_host(cephadm_module, "test"))
+        cephadm_module.cache.update_host_networks(
+            'test',
+            {
+                '1.2.3.0/24': {
+                    'if0': [
+                        '1.2.3.4',
+                        '1.2.3.1',
+                    ]
+                }
+            },
+        )
+        stack.enter_context(with_service(cephadm_module, nfs_spec))
+        stack.enter_context(with_service(cephadm_module, ingress_spec))
+
+        ingress_svc = service_registry.get_service('ingress')
+        ispec = cast(IngressSpec, cephadm_module.spec_store[ingress_spec.service_name()].spec)
+
+        for dd in list(cephadm_module.cache.get_daemons_by_service(ingress_spec.service_name())):
+            if dd.daemon_type == 'haproxy' and dd.hostname == 'test':
+                dd.status = DaemonDescriptionStatus.running
+            elif dd.daemon_type == 'keepalived' and dd.hostname == 'test':
+                dd.status = DaemonDescriptionStatus.stopped
+                assert dd.hostname is not None
+                deps = ingress_svc.sorted_dependencies(
+                    cephadm_module, ispec, 'keepalived'
+                )
+                cephadm_module.cache.update_daemon_config_deps(
+                    dd.hostname, dd.name(), deps, datetime_now()
+                )
+
+        mock_cephadm._daemon_action.reset_mock()
+        CephadmServe(cephadm_module)._check_daemons()
+
+        keepalived_started = any(
+            getattr(c.args[0], 'daemon_type', None) == 'keepalived'
+            and (len(c.args) > 1 and c.args[1] == 'start' or c.kwargs.get('action') == 'start')
+            for c in mock_cephadm._daemon_action.call_args_list
+        )
+        assert keepalived_started

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -284,6 +284,7 @@ class TestCephadm(object):
                         'is_active': False,
                         'ports': [],
                         'pending_daemon_config': False,
+                        'user_stopped': False
                     }
                 ]
 

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -2082,3 +2082,58 @@ def test_related_service_downsize(service_type, placement, hosts, daemons, relat
     assert sorted(got_add) == sorted(expected_add)
 
     assert sorted([d.name() for d in to_remove]) == sorted(expected_remove)
+
+
+def test_ingress_scale_down_defers_related_when_ranked_backend_exceeds_required():
+    """
+    With ingress count below current daemons, ranked NFS backends still above
+    placement target (related_service_required_count), remove only ingress on
+    hosts without NFS first; defer removing co-located ingress until NFS scales
+    down (next iteration).
+    """
+    spec = IngressSpec(
+        service_type='ingress',
+        service_id='nfs.test',
+        frontend_port=443,
+        monitor_port=8888,
+        virtual_ip='10.0.0.20/8',
+        backend_service='nfs.test',
+        placement=PlacementSpec(count=1),
+    )
+    hosts = [HostSpec(h) for h in 'host1 host2 host3'.split()]
+    daemons = [
+        DaemonDescription('haproxy', 'ingress1', 'host1'),
+        DaemonDescription('keepalived', 'ingress1', 'host1'),
+        DaemonDescription('haproxy', 'ingress2', 'host2'),
+        DaemonDescription('keepalived', 'ingress2', 'host2'),
+        DaemonDescription('haproxy', 'ingress3', 'host3'),
+        DaemonDescription('keepalived', 'ingress3', 'host3'),
+    ]
+    related_service_daemons = [
+        DaemonDescription('nfs', 'nfs1', 'host1', rank=0, rank_generation=0),
+        DaemonDescription('nfs', 'nfs2', 'host2', rank=1, rank_generation=0),
+    ]
+    all_slots, to_add, to_remove = HostAssignment(
+        spec=spec,
+        hosts=hosts,
+        unreachable_hosts=[],
+        draining_hosts=[],
+        daemons=daemons,
+        related_service_daemons=related_service_daemons,
+        related_service_required_count=1,
+        primary_daemon_type='haproxy',
+        per_host_daemon_type='keepalived',
+        rank_map=None,
+    ).place()
+
+    assert sorted(str(p) for p in all_slots) == sorted([
+        'haproxy:host1(*:443,8888,1024)',
+        'haproxy:host2(*:443,8888,1024)',
+        'keepalived:host1',
+        'keepalived:host2',
+    ])
+    assert to_add == []
+    assert sorted(d.name() for d in to_remove) == sorted([
+        'haproxy.ingress3',
+        'keepalived.ingress3',
+    ])

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -300,7 +300,7 @@ def test_dd_octopus(dd_json):
         del j['daemon_name']
         return j
 
-    dd_json.update({'pending_daemon_config': False})
+    dd_json.update({'pending_daemon_config': False, 'user_stopped': False})
     assert dd_json == convert_to_old_style_json(
         DaemonDescription.from_json(dd_json).to_json())
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1226,7 +1226,8 @@ class DaemonDescription(object):
                  rank_generation: Optional[int] = None,
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
-                 pending_daemon_config: bool = False
+                 pending_daemon_config: bool = False,
+                 user_stopped: bool = False
                  ) -> None:
 
         #: Host is at the same granularity as InventoryHost
@@ -1302,6 +1303,7 @@ class DaemonDescription(object):
             self.extra_entrypoint_args = ArgumentSpec.from_general_args(
                 extra_entrypoint_args)
         self.pending_daemon_config = pending_daemon_config
+        self.user_stopped = user_stopped
 
     def __setattr__(self, name: str, value: Any) -> None:
         if value is not None and name in ('extra_container_args', 'extra_entrypoint_args'):
@@ -1460,6 +1462,7 @@ class DaemonDescription(object):
         out['rank_generation'] = self.rank_generation
         out['systemd_unit'] = self.systemd_unit
         out['pending_daemon_config'] = self.pending_daemon_config
+        out['user_stopped'] = self.user_stopped
 
         for k in ['last_refresh', 'created', 'started', 'last_deployed',
                   'last_configured']:
@@ -1498,6 +1501,7 @@ class DaemonDescription(object):
         out['ip'] = self.ip
         out['systemd_unit'] = self.systemd_unit
         out['pending_daemon_config'] = self.pending_daemon_config
+        out['user_stopped'] = self.user_stopped
 
         for k in ['last_refresh', 'created', 'started', 'last_deployed',
                   'last_configured']:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1428,6 +1428,9 @@ class DaemonDescription(object):
     def update_pending_daemon_config(self, value: bool) -> None:
         self.pending_daemon_config = value
 
+    def update_user_stopped_status(self, value: bool) -> None:
+        self.user_stopped = value
+
     def __repr__(self) -> str:
         return "<DaemonDescription>({type}.{id})".format(type=self.daemon_type,
                                                          id=self.daemon_id)

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -93,6 +93,7 @@ status: 1
 status_desc: starting
 is_active: false
 pending_daemon_config: false
+user_stopped: false
 events:
 - 2020-06-10T10:08:22.933241Z daemon:crash.ubuntu [INFO] "Deployed crash.ubuntu on
   host 'ubuntu'"


### PR DESCRIPTION
PR fixes:
1. Disable NFS daemon service, so that daemon will not start automatically after reboot. And serve loops '_check_daemons' method will start the daemon. If service is configured in active-passive mode (placement count < hosts), then the daemon will not start on rebooted node (as failed over to another node) and it will directly get removed. Daemon will be only started if they needs to be started (If same rank daemon exists then only start highest rank generation daemon).
2. Since the server loop is now starting the NFS daemons, we must ensure that daemons stopped by the user are not restarted. Added user_stopped field in DaemonDescription to track it.
3. For one NFS instance case, as fence_old_rank was happening in every loop, the down node's rank map was getting removed and daemon was getting redeployed once node is up.
4. The case where NFS is deployed with just placement hosts, when node with low rank was getting down, the node with high rank was getting redeployed with the rank of down daemon.
 

Fixes: https://tracker.ceph.com/issues/73442
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
