### PR TITLE
tentacle: doc/radosgw: deprecate STS Lite for tentacle

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -43,6 +43,7 @@
   normalized directory entry names. This is an inheritable configuration making
   it apply to an entire directory tree. For more information, see
   https://docs.ceph.com/en/latest/cephfs/charmap/
+* RGW: "STS Lite" and the sts:GetSessionToken operation are now deprecated.
 * Based on tests performed at scale on an HDD based Ceph cluster, it was found
   that scheduling with mClock was not optimal with multiple OSD shards. For
   example, in the test cluster with multiple OSD node failures, the client

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -328,6 +328,7 @@
   normalized directory entry names. This is an inheritable configuration making
   it apply to an entire directory tree. For more information, see
   https://docs.ceph.com/en/latest/cephfs/charmap/
+* RGW: "STS Lite" and the sts:GetSessionToken operation are now deprecated.
 * Based on tests performed at scale on an HDD based Ceph cluster, it was found
   that scheduling with mClock was not optimal with multiple OSD shards. For
   example, in the test cluster with multiple OSD node failures, the client

--- a/doc/radosgw/STSLite.rst
+++ b/doc/radosgw/STSLite.rst
@@ -2,6 +2,8 @@
 STS Lite
 =========
 
+.. deprecated:: Tentacle
+
 Ceph Object Gateway provides support for a subset of Amazon Secure Token Service
 (STS) APIs. STS Lite is an extension of STS and builds upon one of its APIs to
 decrease the load on external IDPs like Keystone and LDAP.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73642

---

backport of https://github.com/ceph/ceph/pull/66053
parent tracker: https://tracker.ceph.com/issues/73641

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh