### PR TITLE
cephfs_mirror: update recovery from failure in ServiceDaemon

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1842,3 +1842,51 @@ class TestMirroring(CephFSTestCase):
 
         self.config_set('client.mirror', 'cephfs_mirror_distribute_datasync_threads', 'true')
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_mirroring_recovery_from_failure_in_service_daemon(self):
+        """Test mirror daemon updates recovery from failure in ServiceDaemon"""
+
+        def get_mirroring_failed(data):
+            for key, value in data["cephfs-mirror"].items():
+                status_json = json.loads(value["status"]["status_json"])
+                for item in status_json.values():
+                    if "mirroring_failed" in item:
+                        return item["mirroring_failed"]
+            return None
+
+        # disable mgr mirroring plugin as it would try to load dir map on
+        # on mirroring enabled for a filesystem (an throw up errors in
+        # the logs)
+        self.disable_mirroring_module()
+
+        # enable mirroring through mon interface -- this should result in the mirror daemon
+        # failing to enable mirroring due to absence of `cephfs_mirror` index object.
+        self.run_ceph_cmd("fs", "mirror", "enable", self.primary_fs_name)
+
+        with safe_while(sleep=5, tries=10, action='wait for mirror_failed=true') as proceed:
+            while proceed():
+                try:
+                    service_status = json.loads(self.get_ceph_cmd_stdout("service", "status"))
+                    log.debug(f'service_status={service_status}')
+                    mirror_failed = get_mirroring_failed(service_status)
+                    break
+                except KeyError:
+                    pass
+        log.debug(f'mirror_failed={mirror_failed}')
+        self.assertTrue(mirror_failed)
+
+        # check if mirror_failed is returning to False
+        self.run_ceph_cmd("fs", "mirror", "disable", self.primary_fs_name)
+        self.enable_mirroring_module()
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        with safe_while(sleep=5, tries=10, action='wait for mirror_failed=false') as proceed:
+            while proceed():
+                try:
+                    service_status = json.loads(self.get_ceph_cmd_stdout("service", "status"))
+                    log.debug(f'service_status={service_status}')
+                    mirror_failed = get_mirroring_failed(service_status)
+                    break
+                except KeyError:
+                    pass
+        log.debug(f'mirror_failed={mirror_failed}')
+        self.assertFalse(mirror_failed)

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -431,6 +431,7 @@ void FSMirror::add_peer(const Peer &peer) {
   }
   m_peer_replayers.emplace(peer, std::move(replayer));
   ceph_assert(m_peer_replayers.size() == 1); // support only a single peer
+  m_service_daemon->remove_peer_attribute(m_filesystem.fscid, peer, SERVICE_DAEMON_PEER_INIT_FAILED_KEY);
   if (m_perf_counters) {
     m_perf_counters->inc(l_cephfs_mirror_fs_mirror_peers);
   }

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -375,6 +375,7 @@ void Mirror::handle_enable_mirroring(const Filesystem &filesystem,
   }
 
   dout(10) << ": Initialized FSMirror for filesystem=" << filesystem << dendl;
+  m_service_daemon->remove_fs_attribute(filesystem.fscid, SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY);
   if (m_perf_counters) {
     m_perf_counters->inc(l_cephfs_mirror_file_systems_mirrorred);
   }
@@ -407,6 +408,7 @@ void Mirror::handle_enable_mirroring(const Filesystem &filesystem, int r) {
   m_cond.notify_all();
 
   dout(10) << ": Initialized FSMirror for filesystem=" << filesystem << dendl;
+  m_service_daemon->remove_fs_attribute(filesystem.fscid, SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY);
   if (m_perf_counters) {
     m_perf_counters->inc(l_cephfs_mirror_file_systems_mirrorred);
   }

--- a/src/tools/cephfs_mirror/ServiceDaemon.cc
+++ b/src/tools/cephfs_mirror/ServiceDaemon.cc
@@ -145,6 +145,20 @@ void ServiceDaemon::add_or_update_fs_attribute(fs_cluster_id_t fscid, std::strin
   schedule_update_status();
 }
 
+void ServiceDaemon::remove_fs_attribute(fs_cluster_id_t fscid, std::string_view key) {
+  dout(10) << ": fscid=" << fscid << dendl;
+  {
+    std::scoped_lock locker(m_lock);
+    auto fs_it = m_filesystems.find(fscid);
+    if (fs_it == m_filesystems.end()) {
+      return;
+    }
+
+    fs_it->second.fs_attributes.erase(std::string(key));
+  }
+  schedule_update_status();
+}
+
 void ServiceDaemon::add_or_update_peer_attribute(fs_cluster_id_t fscid, const Peer &peer,
                                                  std::string_view key, AttributeValue value) {
   dout(10) << ": fscid=" << fscid << dendl;
@@ -162,6 +176,25 @@ void ServiceDaemon::add_or_update_peer_attribute(fs_cluster_id_t fscid, const Pe
     }
 
     peer_it->second[std::string(key)] = value;
+  }
+  schedule_update_status();
+}
+
+void ServiceDaemon::remove_peer_attribute(fs_cluster_id_t fscid, const Peer &peer, std::string_view key) {
+  dout(10) << ": fscid=" << fscid << dendl;
+  {
+    std::scoped_lock locker(m_lock);
+    auto fs_it = m_filesystems.find(fscid);
+    if (fs_it == m_filesystems.end()) {
+      return;
+    }
+
+    auto peer_it = fs_it->second.peer_attributes.find(peer);
+    if (peer_it == fs_it->second.peer_attributes.end()) {
+      return;
+    }
+
+    peer_it->second.erase(std::string(key));
   }
   schedule_update_status();
 }

--- a/src/tools/cephfs_mirror/ServiceDaemon.h
+++ b/src/tools/cephfs_mirror/ServiceDaemon.h
@@ -27,8 +27,10 @@ public:
 
   void add_or_update_fs_attribute(fs_cluster_id_t fscid, std::string_view key,
                                   AttributeValue value);
+  void remove_fs_attribute(fs_cluster_id_t fscid, std::string_view key);
   void add_or_update_peer_attribute(fs_cluster_id_t fscid, const Peer &peer,
                                     std::string_view key, AttributeValue value);
+  void remove_peer_attribute(fs_cluster_id_t fscid, const Peer &peer, std::string_view key);
 
 private:
   struct Filesystem {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/73648






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>