### PR TITLE
squid: client: adjust `Fb` cap ref count check during synchronous fsync()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12277,9 +12277,13 @@ int Client::_fsync(Inode *in, bool syncdataonly)
     ldout(cct, 15) << "got " << r << " from flush writeback" << dendl;
   } else {
     // FIXME: this can starve
-    while (in->cap_refs[CEPH_CAP_FILE_BUFFER] > 0) {
+    int nr_refs = 0;
+    if (in->is_write_delegated()) {
+      ++nr_refs;
+    }
+    while (in->cap_refs[CEPH_CAP_FILE_BUFFER] > nr_refs) {
       ldout(cct, 10) << "ino " << in->ino << " has " << in->cap_refs[CEPH_CAP_FILE_BUFFER]
-		     << " uncommitted, waiting" << dendl;
+		     << " uncommitted (nrefs: " << nr_refs << "), waiting" << dendl;
       wait_on_context_list(in->waitfor_commit);
     }
   }

--- a/src/client/Delegation.h
+++ b/src/client/Delegation.h
@@ -28,6 +28,9 @@ public:
   Fh *get_fh() { return fh; }
   unsigned get_type() { return type; }
   bool is_recalled() { return !recall_time.is_zero(); }
+  bool is_write_delegated() {
+    return type == CEPH_DELEGATION_WR;
+  }
 
   void reinit(unsigned _type, ceph_deleg_cb_t _recall_cb, void *_priv);
   void recall(bool skip_read);

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -640,6 +640,21 @@ bool Inode::has_recalled_deleg()
   return deleg.is_recalled();
 }
 
+bool Inode::is_write_delegated()
+{
+  if (delegations.empty()) {
+    return false;
+  }
+
+  for (auto& deleg : delegations) {
+    if (deleg.is_write_delegated() && !deleg.is_recalled()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void Inode::recall_deleg(bool skip_read)
 {
   if (delegations.empty())

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -349,6 +349,7 @@ struct Inode : RefCountedObject {
 
   void recall_deleg(bool skip_read);
   bool has_recalled_deleg();
+  bool is_write_delegated();
   int set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv);
   void unset_deleg(Fh *fh);
 

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -408,3 +408,41 @@ TEST(LibCephFS, RecalledGetattr) {
   ceph_unmount(cmount1);
   ceph_release(cmount1);
 }
+
+TEST(LibCephFS, DelegTestWithWrite) {
+  struct ceph_mount_info *cmount1;
+  ASSERT_EQ(ceph_create(&cmount1, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount1, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount1, NULL));
+  ASSERT_EQ(0, ceph_conf_set(cmount1, "client_oc", "0"));
+  ASSERT_EQ(ceph_mount(cmount1, "/"), 0);
+  ASSERT_EQ(set_default_deleg_timeout(cmount1), 0);
+
+  Inode *root, *file;
+  ASSERT_EQ(ceph_ll_lookup_root(cmount1, &root), 0);
+
+  char filename[32];
+  sprintf(filename, "delegtestwrite%x", getpid());
+
+  Fh *fh;
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount1);
+
+  ASSERT_EQ(ceph_ll_create(cmount1, root, filename, 0666,
+			   O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_write(cmount1, fh, 0, sizeof(filename), filename),
+	    static_cast<int>(sizeof(filename)));
+  ASSERT_EQ(ceph_ll_close(cmount1, fh), 0);
+
+  std::atomic_bool recalled(false);
+  ASSERT_EQ(ceph_ll_lookup(cmount1, root, filename, &file, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_open(cmount1, file, O_WRONLY, &fh, perms), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount1, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_write(cmount1, fh, 0, sizeof(filename), filename),
+	    static_cast<int>(sizeof(filename)));
+  ASSERT_EQ(0, ceph_ll_fsync(cmount1, fh, false));
+  ASSERT_EQ(ceph_ll_close(cmount1, fh), 0);
+
+  ceph_unmount(cmount1);
+  ceph_release(cmount1);
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73465

---

backport of https://github.com/ceph/ceph/pull/65713
parent tracker: https://tracker.ceph.com/issues/73298

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh