### PR TITLE
os/bluestore: User-space cache for BlueFS

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4290,16 +4290,18 @@ options:
     that this recommendation may change in the future however.
   default: true
   with_legacy: true
-- name: bluefs_enable_cache
+- name: bluefs_cache_enable
   type: bool
   level: advanced
-  desc: Enables caching for bluefs reads to improve performance by reducing disk reads
+  desc: Enables caching for bluefs reads hence reducing disk reads
+  long_desc: Enabling caching is mutually exclusive of `bluefs_buffered_io` set to true. The cache size 
+    is configured with `bluefs_cache_size` option.
   default: false
   with_legacy: true
 - name: bluefs_cache_size
   type: size
   level: advanced
-  desc: Cache size for bluefs reads, considered only when bluefs_enable_cache is set to true
+  desc: Cache size for bluefs reads, considered only when bluefs_cache_enable is set to true
   default: 16_M
   with_legacy: true
 - name: bluefs_cache_evict_size

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4290,6 +4290,24 @@ options:
     that this recommendation may change in the future however.
   default: true
   with_legacy: true
+- name: bluefs_enable_cache
+  type: bool
+  level: advanced
+  desc: Enables caching for bluefs reads to improve performance by reducing disk reads
+  default: false
+  with_legacy: true
+- name: bluefs_cache_size
+  type: size
+  level: advanced
+  desc: Cache size for bluefs reads, considered only when bluefs_enable_cache is set to true
+  default: 16_M
+  with_legacy: true
+- name: bluefs_cache_evict_size
+  type: size
+  level: advanced
+  desc: Cache evict size for bluefs reads, when the cache is exceeding configured bluefs_cache_size
+  default: 4_M
+  with_legacy: true
 - name: bluefs_sync_write
   type: bool
   level: advanced

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -15,7 +15,6 @@
 #include "boost/algorithm/string.hpp" 
 #include "bluestore_common.h"
 #include "BlueFS.h"
-#include "BlueFSCache.h"
 
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/debug.h"

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -216,12 +216,12 @@ BlueFS::BlueFS(CephContext* cct)
 
 BlueFS::BlueFS(CephContext* cct, std::shared_ptr<LRUCache> bluefscache)
   : cct(cct),
+    bluefscache(bluefscache),
     bdev(MAX_BDEV),
     ioc(MAX_BDEV),
     alloc(MAX_BDEV),
     alloc_size(MAX_BDEV, 0),
-    locked_alloc(MAX_BDEV),
-    bluefscache(bluefscache)
+    locked_alloc(MAX_BDEV)
 {
   dirty.pending_release.resize(MAX_BDEV);
   discard_cb[BDEV_WAL] = wal_discard_cb;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -552,7 +552,7 @@ public:
   };
 private:
   PerfCounters *logger = nullptr;
-  std::shared_ptr<LRUCache> bluefscache;
+  std::shared_ptr<BlueFSLRUCache> bluefscache;
 
   uint64_t max_bytes[MAX_BDEV] = {0};
   uint64_t max_bytes_pcounters[MAX_BDEV] = {
@@ -795,7 +795,7 @@ private:
 
 public:
   BlueFS(CephContext* cct);
-  BlueFS(CephContext* cct, std::shared_ptr<LRUCache> bluefscache);
+  BlueFS(CephContext* cct, std::shared_ptr<BlueFSLRUCache> bluefscache);
   ~BlueFS();
 
   // the super is always stored on bdev 0

--- a/src/os/bluestore/BlueFSCache.cc
+++ b/src/os/bluestore/BlueFSCache.cc
@@ -1,0 +1,203 @@
+#include "BlueFSCache.h"
+#include "bluestore_common.h"
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include "common/errno.h"
+#include "common/dout.h"
+#include "common/debug.h"
+#include "include/buffer_fwd.h"
+#include "common/ceph_context.h"
+#include "include/denc.h"
+#include "tools/cephfs/EventOutput.h"
+
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_bluefs
+#undef dout_prefix
+#define dout_prefix *_dout << "bluefs "
+
+LRUCache::LRUCache(size_t cache_capacity, size_t evict_bytes, CephContext* cct)
+        : cache_capacity(cache_capacity), evict_bytes(evict_bytes), current_bytes(0), cct(cct) {}
+
+cache_bufferlist LRUCache::get_nearest_offset(uint64_t inode, uint64_t offset,
+                                              uint64_t *buffer_offset) {
+
+  dout(20) << __func__ << " inode " << inode << std::hex << " offset 0x" << offset << std::dec << dendl;
+  std::shared_lock lock(mutex);
+  inode_offset_pair key = {inode, offset};
+  auto it = kv.find(key);
+  if (it != kv.end()) {
+    dout(20) << __func__ << " inode " << inode << std::hex << " offset 0x" << offset << " exists in cache" << std::dec << dendl;
+    lock.unlock();
+    *buffer_offset = 0;
+    update_recency(key);
+    return it->second;
+  }
+  it = kv.upper_bound({inode, offset});
+  --it;
+  if (it != kv.end() && it->first.first == inode &&
+      (offset >= it->first.second &&
+       offset < (it->first.second + it->second->length()))) {
+    key = it->first;
+    lock.unlock();
+    update_recency(key);
+    *buffer_offset = offset - it->first.second;
+    dout(20) << __func__ << " inode " << inode << std::hex << " offset 0x" << offset << " exists within offset 0x" << it->first.second  << " at buffer offset 0x" << buffer_offset << std::dec <<  dendl;
+    return it->second;
+  }
+  return NULL;
+}
+
+int LRUCache::put(uint64_t inode, uint64_t offset, cache_bufferlist value) {
+  size_t new_size = value->length();
+
+  std::unique_lock lock(mutex);
+
+  auto it = kv.find({inode, offset});
+
+  if (it != kv.end()) {
+    size_t old_size = it->second->length();
+    // if the bufferlist value is less than the existing bufferlist, no need to
+    // update the map
+    if (new_size < old_size) {
+      dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " is less than the already existing bufferlist size 0x" << old_size << std::dec << dendl;
+      return 0;
+    }
+
+    if (new_size > cache_capacity) {
+      dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " is greater than the cache capacity 0x" << cache_capacity << std::dec << dendl;
+      return -EINVAL;
+    }
+
+    if (current_bytes + new_size - old_size > cache_capacity) {
+      dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " evict cache necessary" << std::dec << dendl;
+      evict(std::max(evict_bytes, new_size));
+      // while evicting, the key could be deleted, hence not using the iterator
+      // to update the map
+      it = kv.find({inode, offset});
+      if (it == kv.end()) {
+        dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " adding new entry to cache" << std::dec << dendl;
+        kv[{inode, offset}] = value;
+        current_bytes += new_size;
+        update_recency({inode, offset});
+        dout(20) << __func__ << " current cache size 0x" << std::hex << current_bytes << " and cache capacity 0x" << cache_capacity << std::dec << dendl;
+        return 0;
+      }
+    }
+
+    it->second->clear();
+    it->second->claim_append(*value);
+    current_bytes -= old_size;
+    current_bytes += new_size;
+    dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " updating existing entry in cache" << std::dec << dendl;
+    dout(20) << __func__ << " current cache size 0x" << std::hex << current_bytes << " and cache capacity 0x" << cache_capacity << std::dec << dendl;
+    update_recency({inode, offset});
+    return 0;
+  }
+
+  // New insertion: check space
+  if (new_size > cache_capacity) {
+    dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " is greater than the cache capacity 0x" << cache_capacity << std::dec << dendl;
+    return -EINVAL;
+  }
+
+  // Evict until enough space
+  if (current_bytes + new_size > cache_capacity) {
+    dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " evict cache necessary" << std::dec << dendl;
+    evict(std::max(evict_bytes, cache_capacity));
+  }
+
+  dout(20) << __func__ << " inode " << inode << std::hex << " 0x" << offset << "~" << new_size << " adding new entry to cache" << std::dec << dendl;
+  std::unique_lock lockIter(mutex_iter);
+  kv[{inode, offset}] = value;
+  access_order.push_front({inode, offset});
+  key_iter[{inode, offset}] = access_order.begin();
+  current_bytes += new_size;
+  dout(20) << __func__ << " current cache size 0x" << std::hex << current_bytes << " and cache capacity 0x" << cache_capacity << std::dec << dendl;
+  return 0;
+}
+
+void LRUCache::remove(std::pair<uint64_t, uint64_t> key) {
+  // Move key to front (most recently used)
+
+  dout(20) << __func__ << " removing key from cache for inode " << key.first << std::hex << " 0x" << key.second << std::dec << dendl;
+  {
+    std::unique_lock lock(mutex);
+    auto kv_it = kv.find(key);
+    if (kv_it != kv.end()) {
+      kv_it->second->clear();
+      kv.erase(key);
+      dout(20) << __func__ << " removed key from cache for inode " << key.first << std::hex << " 0x" << key.second << std::dec << dendl;
+    }
+  }
+
+  {
+    std::unique_lock lock_iter(mutex_iter);
+    auto list_it = key_iter.find(key);
+    if (list_it != key_iter.end()) {
+      key_iter.erase(key);
+      access_order.remove(key);
+      dout(20) << __func__ << " removed key from LRU list " << key.first << std::hex << " 0x" << key.second << std::dec << dendl;
+    }
+  }
+}
+
+void LRUCache::print_cache() {
+  dout(30) << __func__ << "Cache Contents (Total Bytes: 0x" << std::hex << current_bytes << std::dec << ")" << dendl;
+  for (auto key : access_order) {
+    auto &val = kv[key];
+    dout(30) << __func__ << std::hex << " inode " << key.first << " and offset 0x" << key.second << std::dec << dendl;
+  }
+}
+
+void LRUCache::update_recency(std::pair<uint64_t, uint64_t> key) {
+  // Move key to front (most recently used)
+
+  dout(20) << __func__ << " updating recency for inode " << key.first << " and offset 0x" << std::hex << key.second << std::dec << dendl;
+  std::unique_lock lock(mutex_iter);
+  auto it = key_iter.find(key);
+  if (it != key_iter.end()) {
+    access_order.erase(key_iter[key]);
+  }
+  access_order.push_front(key);
+  key_iter[key] = access_order.begin();
+}
+
+void LRUCache::evict(size_t target_free_bytes) {
+  dout(20) << __func__ << " evicting to free the cache 0x" << std::hex << target_free_bytes << std::dec << " bytes" << dendl;
+  size_t freed = 0;
+  std::unique_lock lockIter(mutex_iter);
+  std::map<std::pair<uint64_t, uint64_t>, cache_bufferlist>::iterator it;
+
+  while (!access_order.empty() && freed < target_free_bytes) {
+    std::pair key_to_remove = access_order.back();
+    dout(20) << __func__ << " evicted inode " <<  key_to_remove.first << " offset 0x" << std::hex << key_to_remove.second << std::dec << " from cache" << dendl;
+    access_order.pop_back();
+
+    it = kv.find(key_to_remove);
+    freed += it->second->length();
+    current_bytes -= it->second->length();
+
+    it->second->clear();
+    kv.erase(key_to_remove);
+    key_iter.erase(key_to_remove);
+  }
+
+  dout(20) << __func__ << " Evicted to free the cache 0x" << std::hex << freed << std::dec << " bytes" << dendl;
+}
+
+bool LRUCache::is_empty() {
+  std::shared_lock lock(mutex);
+  return kv.empty();
+}
+
+cache_bufferlist LRUCache::create_bufferlist() {
+  return std::make_shared<bufferlist>();
+}

--- a/src/os/bluestore/BlueFSCache.cc
+++ b/src/os/bluestore/BlueFSCache.cc
@@ -152,7 +152,6 @@ void LRUCache::remove(std::pair<uint64_t, uint64_t> key) {
 void LRUCache::print_cache() {
   dout(30) << __func__ << "Cache Contents (Total Bytes: 0x" << std::hex << current_bytes << std::dec << ")" << dendl;
   for (auto key : access_order) {
-    auto &val = kv[key];
     dout(30) << __func__ << std::hex << " inode " << key.first << " and offset 0x" << key.second << std::dec << dendl;
   }
 }

--- a/src/os/bluestore/BlueFSCache.h
+++ b/src/os/bluestore/BlueFSCache.h
@@ -23,10 +23,10 @@ namespace std {
     };
 }
 
-class LRUCache
+class BlueFSLRUCache
 {
 public:
-    LRUCache(size_t cache_capacity, size_t evict_bytes, CephContext* cct);
+    BlueFSLRUCache(size_t cache_capacity, size_t evict_bytes, CephContext* cct);
 
     /*
     bufferlist* get(uint64_t inode, uint64_t offset)

--- a/src/os/bluestore/BlueFSCache.h
+++ b/src/os/bluestore/BlueFSCache.h
@@ -1,0 +1,75 @@
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <functional>
+#include <unordered_map>
+#include "bluestore_common.h"
+#include "include/buffer_fwd.h"
+#include "tools/cephfs/EventOutput.h"
+
+
+using cache_bufferlist = std::shared_ptr<bufferlist>;
+// Hash function for std::pair<uint64_t, uint64_t>
+namespace std {
+    template <>
+    struct hash<std::pair<uint64_t, uint64_t>> {
+        size_t operator()(const std::pair<uint64_t, uint64_t>& p) const {
+            return std::hash<uint64_t>()(p.first) ^ (std::hash<uint64_t>()(p.second) << 1);
+        }
+    };
+}
+
+class LRUCache
+{
+public:
+    LRUCache(size_t cache_capacity, size_t evict_bytes, CephContext* cct);
+
+    /*
+    bufferlist* get(uint64_t inode, uint64_t offset)
+    {
+        std::shared_lock lock(mutex);
+        auto it = kv.find({inode, offset});
+        if (it == kv.end())
+        {
+            return nullptr;
+        }
+
+        updateRecency({inode, offset});
+        return it->second;
+    }*/
+
+    cache_bufferlist get_nearest_offset(uint64_t inode, uint64_t offset, uint64_t *buffer_offset);
+
+    int put(uint64_t inode, uint64_t offset, cache_bufferlist value);
+
+    void remove(std::pair<uint64_t, uint64_t> key);
+
+    bool is_empty();
+
+    cache_bufferlist create_bufferlist();
+
+private:
+    size_t cache_capacity;
+    size_t evict_bytes;
+    size_t current_bytes;
+    CephContext* cct;
+
+    using inode_offset_pair = std::pair<uint64_t, uint64_t>;
+
+    std::map<inode_offset_pair,cache_bufferlist> kv;                                   // key -> value
+    std::shared_mutex mutex;
+
+    std::list<inode_offset_pair> access_order;                                     // most recent at front
+    std::unordered_map<inode_offset_pair, std::list<inode_offset_pair>::iterator> key_iter; // key -> position in the list
+    std::shared_mutex mutex_iter;
+
+    void print_cache();
+
+    void update_recency(std::pair<uint64_t, uint64_t> key);
+
+    void evict(size_t target_free_bytes);
+};

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -6,6 +6,7 @@
 #include "include/stringify.h"
 #include "kv/RocksDBStore.h"
 #include "string.h"
+#include <cstdint>
 
 using std::string_view;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -62,7 +62,6 @@
 #include "Writer.h"
 #include "Compression.h"
 #include "BlueAdmin.h"
-#include "BlueFSCache.h"
 
 #if defined(WITH_LTTNG)
 #define TRACEPOINT_DEFINE

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -62,6 +62,7 @@
 #include "Writer.h"
 #include "Compression.h"
 #include "BlueAdmin.h"
+#include "BlueFSCache.h"
 
 #if defined(WITH_LTTNG)
 #define TRACEPOINT_DEFINE
@@ -5758,8 +5759,8 @@ BlueStore::BlueStore(CephContext *cct,
   _init_logger();
   cct->_conf.add_observer(this);
   set_cache_shards(1);
-  if (cct->_conf->bluefs_enable_cache) {
-    bluefscache = std::make_shared<LRUCache>(cct->_conf->bluefs_cache_size, cct->_conf->bluefs_cache_evict_size, cct);
+  if (cct->_conf->bluefs_cache_enable) {
+    bluefscache = std::make_shared<BlueFSLRUCache>(cct->_conf->bluefs_cache_size, cct->_conf->bluefs_cache_evict_size, cct);
   }
   bluestore_bdev_label_require_all = cct->_conf.get_val<bool>("bluestore_bdev_label_require_all");
   asok_hook = new SocketHook(*this);
@@ -7632,11 +7633,8 @@ int BlueStore::_minimal_open_bluefs(bool create)
 {
   int r;
 
-  if (cct->_conf->bluefs_enable_cache) {
-    bluefs = new BlueFS(cct, bluefscache);
-  } else {
-    bluefs = new BlueFS(cct);
-  }
+  bluefs = new BlueFS(cct, bluefscache);
+
   string bfn;
   struct stat st;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2334,6 +2334,7 @@ public:
   // members
 private:
   BlueFS *bluefs = nullptr;
+  std::shared_ptr<LRUCache> bluefscache = nullptr;
   bluefs_layout_t bluefs_layout;
   utime_t next_dump_on_bluefs_alloc_failure;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -57,7 +57,6 @@
 
 #include "bluestore_types.h"
 #include "bluestore_common.h"
-#include "BlueFSCache.h"
 #include "BlueFS.h"
 #include "common/EventTrace.h"
 #include "common/admin_socket.h"
@@ -2335,7 +2334,7 @@ public:
   // members
 private:
   BlueFS *bluefs = nullptr;
-  std::shared_ptr<LRUCache> bluefscache = nullptr;
+  std::shared_ptr<BlueFSLRUCache> bluefscache = nullptr;
   bluefs_layout_t bluefs_layout;
   utime_t next_dump_on_bluefs_alloc_failure;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -57,6 +57,7 @@
 
 #include "bluestore_types.h"
 #include "bluestore_common.h"
+#include "BlueFSCache.h"
 #include "BlueFS.h"
 #include "common/EventTrace.h"
 #include "common/admin_socket.h"

--- a/src/os/bluestore/CMakeLists.txt
+++ b/src/os/bluestore/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(bluestore OBJECT
   bluefs_types.cc
   BlueRocksEnv.cc
   BlueStore.cc
+  BlueFSCache.cc
   BlueStore_debug.cc
   simple_bitmap.cc
   bluestore_types.cc

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -318,6 +318,141 @@ TEST(BlueFS, very_large_write2) {
   g_ceph_context->_conf.set_val("bluefs_buffered_io", stringify((int)old));
 }
 
+TEST(BlueFS, cache_test) {
+  SKIP_JENKINS();
+  // we'll write a ~5G file, so allocate more than that for the whole fs
+  uint64_t size = 1048576 * 1024 * 6ull;
+  TempBdev bdev{size};
+  BlueFS fs(g_ceph_context);
+
+  bool old = g_ceph_context->_conf.get_val<bool>("bluefs_buffered_io");
+  g_ceph_context->_conf.set_val("bluefs_buffered_io", "false");
+  bool old_cache_enabled = g_ceph_context->_conf.get_val<bool>("bluefs_enable_cache");
+  g_ceph_context->_conf.set_val("bluefs_enable_cache", "true");
+  uint64_t total_written = 0;
+
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
+  char buf[1048571]; // this is biggish, but intentionally not evenly aligned
+  for (unsigned i = 0; i < sizeof(buf); ++i) {
+    buf[i] = i;
+  }
+  {
+    BlueFS::FileWriter *h;
+    ASSERT_EQ(0, fs.mkdir("dir"));
+    ASSERT_EQ(0, fs.open_for_write("dir", "bigfile", &h, false));
+    for (unsigned i = 0; i < 3*1024*1048576ull / sizeof(buf); ++i) {
+      h->append(buf, sizeof(buf));
+      total_written += sizeof(buf);
+    }
+    fs.fsync(h);
+    for (unsigned i = 0; i < 2*1024*1048576ull / sizeof(buf); ++i) {
+      h->append(buf, sizeof(buf));
+      total_written += sizeof(buf);
+    }
+    fs.fsync(h);
+    fs.close_writer(h);
+  }
+  {
+    BlueFS::FileReader *h;
+    ASSERT_EQ(0, fs.open_for_read("dir", "bigfile", &h));
+    bufferlist bl;
+    ASSERT_EQ(h->file->fnode.size, total_written);
+    for (unsigned i = 0; i < 3*1024*1048576ull / sizeof(buf); ++i) {
+      bl.clear();
+      fs.read(h, i * sizeof(buf), sizeof(buf), &bl, NULL);
+      int r = memcmp(buf, bl.c_str(), sizeof(buf));
+      if (r) {
+	cerr << "read got mismatch at offset " << i*sizeof(buf) << " r " << r
+	     << std::endl;
+      }
+      ASSERT_EQ(0, r);
+    }
+    for (unsigned i = 0; i < 2*1024*1048576ull / sizeof(buf); ++i) {
+      bl.clear();
+      fs.read(h, i * sizeof(buf), sizeof(buf), &bl, NULL);
+      int r = memcmp(buf, bl.c_str(), sizeof(buf));
+      if (r) {
+	cerr << "read got mismatch at offset " << i*sizeof(buf) << " r " << r
+	     << std::endl;
+      }
+      ASSERT_EQ(0, r);
+    }
+    delete h;
+    ASSERT_EQ(0, fs.open_for_read("dir", "bigfile", &h));
+    ASSERT_EQ(h->file->fnode.size, total_written);
+    auto huge_buf = std::make_unique<char[]>(h->file->fnode.size);
+    auto l = h->file->fnode.size;
+    int64_t r = fs.read(h, 0, l, NULL, huge_buf.get());
+    ASSERT_EQ(r, l);
+    delete h;
+  }
+  fs.umount();
+
+  g_ceph_context->_conf.set_val("bluefs_buffered_io", stringify((int)old));
+  g_ceph_context->_conf.set_val("bluefs_enable_cache", stringify((int)old_cache_enabled));
+}
+
+TEST(BlueFS, cache_test2) {
+  SKIP_JENKINS();
+  // we'll write a ~5G file, so allocate more than that for the whole fs
+  uint64_t size_full = 1048576 * 1024 * 6ull;
+  uint64_t size = 1048576 * 1024 * 5ull;
+  TempBdev bdev{ size_full };
+  BlueFS fs(g_ceph_context);
+
+  bool old = g_ceph_context->_conf.get_val<bool>("bluefs_buffered_io");
+  g_ceph_context->_conf.set_val("bluefs_buffered_io", "false");
+  bool old_cache_enabled = g_ceph_context->_conf.get_val<bool>("bluefs_enable_cache");
+  g_ceph_context->_conf.set_val("bluefs_enable_cache", "true");
+  uint64_t total_written = 0;
+
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
+
+  char fill_arr[1 << 20]; // 1M
+  for (size_t i = 0; i < sizeof(fill_arr); ++i) {
+    fill_arr[i] = (char)i;
+  }
+  std::unique_ptr<char[]> buf;
+  buf.reset(new char[size]);
+  for (size_t i = 0; i < size; i += sizeof(fill_arr)) {
+    memcpy(buf.get() + i, fill_arr, sizeof(fill_arr));
+  }
+  {
+    BlueFS::FileWriter* h;
+    ASSERT_EQ(0, fs.mkdir("dir"));
+    ASSERT_EQ(0, fs.open_for_write("dir", "bigfile", &h, false));
+    fs.append_try_flush(h, buf.get(), size);
+    total_written = size;
+    fs.fsync(h);
+    fs.close_writer(h);
+  }
+  memset(buf.get(), 0, size);
+  {
+    BlueFS::FileReader* h;
+    ASSERT_EQ(0, fs.open_for_read("dir", "bigfile", &h));
+    ASSERT_EQ(h->file->fnode.size, total_written);
+    auto l = h->file->fnode.size;
+    int64_t r = fs.read(h, 0, l, NULL, buf.get());
+    ASSERT_EQ(r, l);
+    for (size_t i = 0; i < size; i += sizeof(fill_arr)) {
+      ceph_assert(memcmp(buf.get() + i, fill_arr, sizeof(fill_arr)) == 0);
+    }
+    delete h;
+  }
+  fs.umount();
+
+  g_ceph_context->_conf.set_val("bluefs_buffered_io", stringify((int)old));
+  g_ceph_context->_conf.set_val("bluefs_enable_cache", stringify((int)old_cache_enabled));
+}
+
 #define ALLOC_SIZE 4096
 
 void write_data(BlueFS &fs, uint64_t rationed_bytes)

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -319,7 +319,6 @@ TEST(BlueFS, very_large_write2) {
 }
 
 TEST(BlueFS, cache_test) {
-  SKIP_JENKINS();
   // we'll write a ~5G file, so allocate more than that for the whole fs
   uint64_t size = 1048576 * 1024 * 6ull;
   TempBdev bdev{size};
@@ -327,8 +326,8 @@ TEST(BlueFS, cache_test) {
 
   bool old = g_ceph_context->_conf.get_val<bool>("bluefs_buffered_io");
   g_ceph_context->_conf.set_val("bluefs_buffered_io", "false");
-  bool old_cache_enabled = g_ceph_context->_conf.get_val<bool>("bluefs_enable_cache");
-  g_ceph_context->_conf.set_val("bluefs_enable_cache", "true");
+  bool old_cache_enabled = g_ceph_context->_conf.get_val<bool>("bluefs_cache_enable");
+  g_ceph_context->_conf.set_val("bluefs_cache_enable", "true");
   uint64_t total_written = 0;
 
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev.path, false));
@@ -393,11 +392,10 @@ TEST(BlueFS, cache_test) {
   fs.umount();
 
   g_ceph_context->_conf.set_val("bluefs_buffered_io", stringify((int)old));
-  g_ceph_context->_conf.set_val("bluefs_enable_cache", stringify((int)old_cache_enabled));
+  g_ceph_context->_conf.set_val("bluefs_cache_enable", stringify((int)old_cache_enabled));
 }
 
 TEST(BlueFS, cache_test2) {
-  SKIP_JENKINS();
   // we'll write a ~5G file, so allocate more than that for the whole fs
   uint64_t size_full = 1048576 * 1024 * 6ull;
   uint64_t size = 1048576 * 1024 * 5ull;
@@ -406,8 +404,8 @@ TEST(BlueFS, cache_test2) {
 
   bool old = g_ceph_context->_conf.get_val<bool>("bluefs_buffered_io");
   g_ceph_context->_conf.set_val("bluefs_buffered_io", "false");
-  bool old_cache_enabled = g_ceph_context->_conf.get_val<bool>("bluefs_enable_cache");
-  g_ceph_context->_conf.set_val("bluefs_enable_cache", "true");
+  bool old_cache_enabled = g_ceph_context->_conf.get_val<bool>("bluefs_cache_enable");
+  g_ceph_context->_conf.set_val("bluefs_cache_enable", "true");
   uint64_t total_written = 0;
 
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev.path, false));
@@ -450,7 +448,7 @@ TEST(BlueFS, cache_test2) {
   fs.umount();
 
   g_ceph_context->_conf.set_val("bluefs_buffered_io", stringify((int)old));
-  g_ceph_context->_conf.set_val("bluefs_enable_cache", stringify((int)old_cache_enabled));
+  g_ceph_context->_conf.set_val("bluefs_cache_enable", stringify((int)old_cache_enabled));
 }
 
 #define ALLOC_SIZE 4096


### PR DESCRIPTION
Tracker: https://tracker.ceph.com/issues/70627

**Issues addressed by this feature**

1. Config `bluefs_buffered_io` is set to `true`. With buffered_io and direct_io happening asynchronously (hence resulting in a mix of buffered and direct I/O ), the page flush resulting from buffered write could overwrite the data written via direct write, **when the kernel page size differs from the physical block size.** Hence this PR is more intended as a bug fix rather than a performance improvement
2. It also reduces the number of reads on the disk.

**Overview**

This cache provides a configurable BlueFS cache, mapping `(file, offset)` ranges to `bufferlist` data.

**Details**

- Enable/disable via `bluefs_cache_enabled` config option, this is mutually exclusive with `bluefs_buffered_io=true`
- Maximum cache size set by `bluefs_cache_size` (in bytes).
- Falls back to the original buffering mode (`FileReaderBuffer` + `bluefs_buffered_io`) if disabled.
- Caches data per file and offset range, not by disk location.


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

Signed-off-by:  Guna K Kambalimath Guna.Kambalimath@ibm.com
