### PR TITLE
common: enable AVX512+VPCLMULQDQ for crc32c performance on x86

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,7 +239,8 @@ if(HAVE_INTEL)
     check_nasm_support(${object_format}
       HAVE_NASM_X64
       HAVE_NASM_X64_AVX2
-      HAVE_NASM_X64_AVX512)
+      HAVE_NASM_X64_AVX512
+      HAVE_NASM_X64_AVX512_VPCLMUL)
   endif()
 endif()
 

--- a/src/arch/intel.c
+++ b/src/arch/intel.c
@@ -16,6 +16,7 @@
 #include "arch/probe.h"
 
 /* flags we export */
+int ceph_arch_intel_avx512_vpclmul = 0;
 int ceph_arch_intel_pclmul = 0;
 int ceph_arch_intel_sse42 = 0;
 int ceph_arch_intel_sse41 = 0;
@@ -26,6 +27,7 @@ int ceph_arch_intel_aesni = 0;
 
 #ifdef __x86_64__
 #include <cpuid.h>
+#include <x86intrin.h>
 
 /* http://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits */
 
@@ -35,7 +37,22 @@ int ceph_arch_intel_aesni = 0;
 #define CPUID_SSSE3	(1 << 9)
 #define CPUID_SSE3	(1)
 #define CPUID_SSE2	(1 << 26)
-#define CPUID_AESNI (1 << 25)
+#define CPUID_AESNI 	(1 << 25)
+#define CPUID_OSXSAVE	(1 << 27)
+
+/* SSE:[1] AVX:[2] Opmask:[5] ZMM_HI256:[6] ZMM16-31:[7]*/
+#define XCR0_AVX512		(0x000000E6ULL)
+
+/* Match ISA-L requirements since we call into it. May be stricter than necessary. */
+/* AVX512F:[16] DQ:[17] CD:[28] BW:[30] VL:[31] */
+#define CPUID7_0_AVX512_EBX	(0xD0030000UL)
+/* AVX512VBMI2:[6] GFNI:[8] VAES:[9] VPCLMULQDQ:[10] VNNI:[11] BITALG:[12] VPOPCNTDQ:[14] */
+#define CPUID7_0_AVX512_ECX	(0x00005F40UL)
+
+__attribute__((__target__("xsave")))
+unsigned long long ceph_xgetbv(unsigned int xcr_index) {
+	return _xgetbv(xcr_index);
+}
 
 int ceph_arch_intel_probe(void)
 {
@@ -62,10 +79,25 @@ int ceph_arch_intel_probe(void)
 	if ((edx & CPUID_SSE2) != 0) {
 	        ceph_arch_intel_sse2 = 1;
 	}
-  if ((ecx & CPUID_AESNI) != 0) {
-          ceph_arch_intel_aesni = 1;
-  }
+	if ((ecx & CPUID_AESNI) != 0) {
+	        ceph_arch_intel_aesni = 1;
+	}
 
+	/*
+	 * AVX512 feature: check these conditions IN ORDER
+	 *     a. OSXSAVE/XGETBV is available
+	 *     b. AVX512 state is enabled in XCR0
+	 *     c. CPUID leaf 7 exists
+	 *     d. required AVX512 features present
+	 */
+	unsigned int eax_7_0 = 0, ebx_7_0 = 0, ecx_7_0 = 0, edx_7_0 = 0;
+	if ((ecx & CPUID_OSXSAVE) &&
+	    ((ceph_xgetbv(0) & XCR0_AVX512) == XCR0_AVX512) &&
+	    (__get_cpuid_count(7, 0, &eax_7_0, &ebx_7_0, &ecx_7_0, &edx_7_0)) &&
+	    ((ebx_7_0 & CPUID7_0_AVX512_EBX) == CPUID7_0_AVX512_EBX) &&
+	    ((ecx_7_0 & CPUID7_0_AVX512_ECX) == CPUID7_0_AVX512_ECX)) {
+		ceph_arch_intel_avx512_vpclmul = 1;
+	}
 	return 0;
 }
 

--- a/src/arch/intel.h
+++ b/src/arch/intel.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+extern int ceph_arch_intel_avx512_vpclmul; /* true if we have AVX512+VPCLMUL features */
 extern int ceph_arch_intel_pclmul; /* true if we have PCLMUL features */
 extern int ceph_arch_intel_sse42;  /* true if we have sse 4.2 features */
 extern int ceph_arch_intel_sse41;  /* true if we have sse 4.1 features */

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -237,6 +237,10 @@ if(HAVE_INTEL)
       ${PROJECT_SOURCE_DIR}/src/isa-l/crc/crc32_iscsi_01.asm
       crc32c_intel_fast_zero_asm.s)
   endif(HAVE_NASM_X64)
+  if(HAVE_NASM_X64_AVX512_VPCLMUL)
+    set(CMAKE_ASM_FLAGS "-DAS_FEATURE_LEVEL=10 ${CMAKE_ASM_FLAGS}")
+    list(APPEND crc32_srcs ${PROJECT_SOURCE_DIR}/src/isa-l/crc/crc32_iscsi_by16_10.asm)
+  endif(HAVE_NASM_X64_AVX512_VPCLMUL)
 elseif(HAVE_POWER8)
   list(APPEND crc32_srcs
     crc32c_ppc.c)

--- a/src/common/crc32c.cc
+++ b/src/common/crc32c.cc
@@ -27,6 +27,9 @@ ceph_crc32c_func_t ceph_choose_crc32(void)
   // if the CPU supports it, *and* the fast version is compiled in,
   // use that.
 #if defined(__i386__) || defined(__x86_64__)
+  if (ceph_arch_intel_avx512_vpclmul && ceph_crc32c_intel_fast_avx512_vpclmul_exists()) {
+    return ceph_crc32c_intel_fast_avx512_vpclmul;
+  }
   if (ceph_arch_intel_sse42 && ceph_crc32c_intel_fast_exists()) {
     if (ceph_arch_intel_pclmul) {
       return ceph_crc32c_intel_fast_pclmul;

--- a/src/common/crc32c_intel_fast.c
+++ b/src/common/crc32c_intel_fast.c
@@ -2,7 +2,38 @@
 #include "common/crc32c_intel_baseline.h"
 
 extern unsigned int crc32_iscsi_01(unsigned char const *buffer, uint64_t len, uint64_t crc) asm("crc32_iscsi_01");
+extern unsigned int crc32_iscsi_by16_10(unsigned char const *buffer, uint64_t len, uint64_t crc) asm("crc32_iscsi_by16_10");
 extern unsigned int crc32_iscsi_zero_00(unsigned char const *buffer, uint64_t len, uint64_t crc) asm("crc32_iscsi_zero_00");
+
+#ifdef HAVE_NASM_X64_AVX512_VPCLMUL
+
+uint32_t ceph_crc32c_intel_fast_avx512_vpclmul(uint32_t crc, unsigned char const *buffer, unsigned len)
+{
+	if (!buffer)
+	{
+		return crc32_iscsi_zero_00(buffer, len, crc);
+	}
+	return crc32_iscsi_by16_10(buffer, len, crc);
+}
+
+int ceph_crc32c_intel_fast_avx512_vpclmul_exists(void)
+{
+	return 1;
+}
+
+#else
+
+uint32_t ceph_crc32c_intel_fast_avx512_vpclmul(uint32_t crc, unsigned char const *buffer, unsigned len)
+{
+	return 0;
+}
+
+int ceph_crc32c_intel_fast_avx512_vpclmul_exists(void)
+{
+	return 0;
+}
+
+#endif
 
 #ifdef HAVE_NASM_X64
 

--- a/src/common/crc32c_intel_fast.h
+++ b/src/common/crc32c_intel_fast.h
@@ -7,13 +7,20 @@ extern "C" {
 
 /* is the fast version compiled in */
 extern int ceph_crc32c_intel_fast_exists(void);
+extern int ceph_crc32c_intel_fast_avx512_vpclmul_exists(void);
 
 #ifdef __x86_64__
 
+extern uint32_t ceph_crc32c_intel_fast_avx512_vpclmul(uint32_t crc, unsigned char const *buffer, unsigned len);
 extern uint32_t ceph_crc32c_intel_fast_pclmul(uint32_t crc, unsigned char const *buffer, unsigned len);
 extern uint32_t ceph_crc32c_intel_fast(uint32_t crc, unsigned char const *buffer, unsigned len);
 
 #else
+
+static inline uint32_t ceph_crc32c_intel_fast_avx512_vpclmul(uint32_t crc, unsigned char const *buffer, unsigned len)
+{
+	return 0;
+}
 
 static inline uint32_t ceph_crc32c_intel_fast_pclmul(uint32_t crc, unsigned char const *buffer, unsigned len)
 {

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -256,6 +256,9 @@
 /* nasm can also build the isa-l:avx512 */
 #cmakedefine HAVE_NASM_X64_AVX512
 
+/* nasm can also build the isa-l:avx512 & vpclmulqdq */
+#cmakedefine HAVE_NASM_X64_AVX512_VPCLMUL
+
 /* Define if the erasure code isa-l plugin is compiled */
 #cmakedefine WITH_EC_ISA_PLUGIN
 


### PR DESCRIPTION
Improving crc32c performance on x86 platform with AVX512 & VPCLMULQDQ features:

- Add crc32_iscsi_by16_10 in src/isa-l into candidates for ceph_crc32c
- Add hardware capability check for AVX512 instr before register
- Add NASM feature check to ensure compatibility and to enable AS_FEATURE_LEVEL in crc32_iscsi_by16_10.asm

AVX512+VPCLMULQDQ (crc32_iscsi_by16_10) can perform much faster than CRC32 (crc32_iscsi_01) if the hardware has coresponding features. On our Hygon platform, it shows over 174% improvement than crc32_iscsi_01 (current best choice), tested with unittest_crc32c.

By the way, crc32_iscsi_by16_10.asm in src/isa-l submodule is quite an old version (about 5 years old one). It is good, but not good enought. It does not have any software prefetch mechanism. So when ISA-L release a new verion in the future, we would also like to update src/isa-l submodule. That will be a further help for crc32c calculation. Erasure code can also gain improvement from it.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
