### PR TITLE
squid: client: fix dump_mds_requests to valid json format

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1977,6 +1977,7 @@ void Client::dump_mds_sessions(Formatter *f, bool cap_dump)
 
 void Client::dump_mds_requests(Formatter *f)
 {
+  f->open_array_section("requests");
   for (map<ceph_tid_t, MetaRequest*>::iterator p = mds_requests.begin();
        p != mds_requests.end();
        ++p) {
@@ -1984,6 +1985,7 @@ void Client::dump_mds_requests(Formatter *f)
     p->second->dump(f);
     f->close_section();
   }
+  f->close_section();
 }
 
 int Client::verify_reply_trace(int r, MetaSession *session,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73742

---

backport of https://github.com/ceph/ceph/pull/66025
parent tracker: https://tracker.ceph.com/issues/73639

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh