### PR TITLE
rgw/account: Support backward compatibility for s3:PutAcls calls for users migrated to account.

### DIFF
--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -288,6 +288,8 @@ Request Entities
 | ``Permission``            | String      | The permission given to the ``Grantee`` bucket.                                              |
 +---------------------------+-------------+----------------------------------------------------------------------------------------------+
 
+.. note:: For accounts users, the ``Owner`` and ``ID`` in ``AccessControlPolicy`` may be set to either the legacy user ID or the new account ID. Both are accepted for backward compatibility.
+
 List Bucket Multipart Uploads
 -----------------------------
 

--- a/doc/radosgw/s3/objectops.rst
+++ b/doc/radosgw/s3/objectops.rst
@@ -234,6 +234,7 @@ Request Entities
 | ``Permission``            | String      | The permission given to the ``Grantee`` object.                                              |
 +---------------------------+-------------+----------------------------------------------------------------------------------------------+
 
+.. note:: For accounts users, the ``Owner`` and ``ID`` in ``AccessControlPolicy`` may be set to either the legacy user ID or the new account ID. Both are accepted for backward compatibility.
 
 
 Initiate Multi-part Upload

--- a/qa/workunits/rgw/test_account_migration.sh
+++ b/qa/workunits/rgw/test_account_migration.sh
@@ -34,12 +34,24 @@ export AWS_SECRET_ACCESS_KEY=$(echo $userinfo | jq -r .keys[0].secret_key)
 aws s3 mb s3://testmigrate
 aws s3api put-object --bucket testmigrate --key obj
 
+# put bucket and object acls before migration
+aws s3api put-bucket-acl --bucket testmigrate --acl private
+aws s3api put-object-acl --bucket testmigrate --key obj --acl private
+
 # create an account and migrate the user as account root
 accountid=$(radosgw-admin account create | jq -r .id)
 radosgw-admin user modify --uid test-account-migration --account-root --account-id=$accountid
 
 # verify the migrated user still has access
 aws s3api head-object --bucket testmigrate --key obj
+
+# verify get/put acl backward compatibility after migration.
+# the bucket/object acl owner is still the old user id, but the
+# requester now authenticates as the account id. both should work.
+aws s3api get-bucket-acl --bucket testmigrate
+aws s3api get-object-acl --bucket testmigrate --key obj
+aws s3api put-bucket-acl --bucket testmigrate --acl private
+aws s3api put-object-acl --bucket testmigrate --key obj --acl private
 
 # replace account-root flag with managed policy
 aws iam attach-user-policy --region us-east-1 --user-name MigratedUser \

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -74,6 +74,22 @@ static bool match_owner(const rgw_owner& owner, const rgw_user& uid,
       }), owner);
 }
 
+static bool match_owner(const rgw_owner& owner, const rgw_user& uid)
+{
+  return std::visit(fu2::overload(
+      [&uid] (const rgw_user& u) { return u == uid; },
+      [] (const rgw_account_id&) { return false; }), owner);
+}
+
+static bool match_owner(const rgw_owner& owner, const RGWAccountInfo& account)
+{
+  return std::visit(fu2::overload(
+      [] (const rgw_user&) { return false; },
+      [&account] (const rgw_account_id& a) {
+        return a == account.id;
+      }), owner);
+}
+
 static bool match_account_or_tenant(const std::optional<RGWAccountInfo>& account,
                                     std::string_view tenant,
                                     std::string_view expected)
@@ -595,7 +611,11 @@ ACLOwner rgw::auth::WebIdentityApplier::get_aclowner() const
 
 bool rgw::auth::WebIdentityApplier::is_owner_of(const rgw_owner& o) const
 {
-  return match_owner(o, rgw_user{role_tenant, sub, "oidc"}, account);
+  if (account) {
+    return match_owner(o, *account);
+  } else {
+    return match_owner(o, rgw_user{role_tenant, sub, "oidc"});
+  }
 }
 
 void rgw::auth::WebIdentityApplier::to_str(std::ostream& out) const
@@ -1206,7 +1226,11 @@ ACLOwner rgw::auth::RoleApplier::get_aclowner() const
 
 bool rgw::auth::RoleApplier::is_owner_of(const rgw_owner& o) const
 {
-  return match_owner(o, token_attrs.user_id, role.account);
+  if (role.account) {
+    return match_owner(o, *role.account);
+  } else {
+    return match_owner(o, token_attrs.user_id);
+  }
 }
 
 void rgw::auth::RoleApplier::to_str(std::ostream& out) const {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6691,8 +6691,12 @@ void RGWPutACLs::execute(optional_yield y)
   if (op_ret < 0)
     return;
 
+  // only allow acl owner to change if the requester views them as equivalent.
+  // the requester may change between their user id and account id.
   if (!existing_owner.empty() &&
-      existing_owner.id != new_policy.get_owner().id) {
+      existing_owner.id != new_policy.get_owner().id &&
+      !(s->auth.identity->is_owner_of(existing_owner.id) &&
+        s->auth.identity->is_owner_of(new_policy.get_owner().id))) {
     s->err.message = "Cannot modify ACL Owner";
     op_ret = -EPERM;
     return;


### PR DESCRIPTION



Fixes: https://tracker.ceph.com/issues/73759. 

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
