### PR TITLE
mgr/cephadm: mon public network updating

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2666,6 +2666,36 @@ Then run the following:
 
         return f'Rotated key for {daemon_spec.name()}'
 
+    def _mon_public_network_changed(self, daemon_spec: CephadmDaemonDeploySpec) -> bool:
+        if daemon_spec.daemon_type != 'mon':
+            return False
+
+        rc_get, out_get, err_get = self.mon_command({
+                    'prefix': 'config get',
+                    'who': f'{daemon_spec.service_name}.{daemon_spec.daemon_id}',
+                    'key': 'public_network'
+                })
+
+        if rc_get:
+            self.log.error(f'cmd: config get failed with: {err_get}, (errno:{rc_get})')
+            return False
+
+        rc_show, out_show, err_show = self.mon_command({
+                    'prefix': 'config show',
+                    'who': f'{daemon_spec.service_name}.{daemon_spec.daemon_id}',
+                    'key': 'public_network'
+                })
+
+        if rc_show:
+            self.log.error(f'cmd: config get failed with: {err_show}, (errno:{rc_show})')
+            return False
+
+        if out_get == out_show:
+            return False
+
+        self.log.debug(f'{daemon_spec.service_name}.{daemon_spec.daemon_id} public network changed, redeploy instead of restart')
+        return True
+
     def _daemon_action(self,
                        daemon_spec: CephadmDaemonDeploySpec,
                        action: str,
@@ -2681,7 +2711,7 @@ Then run the following:
         if action == 'rotate-key':
             return self._rotate_daemon_key(daemon_spec)
 
-        if action == 'redeploy' or action == 'reconfig':
+        if action == 'redeploy' or action == 'reconfig' or (action == 'restart' and self._mon_public_network_changed(daemon_spec)):
             if daemon_spec.daemon_type != 'osd':
                 daemon_spec = service_registry.get_service(daemon_type_to_service(
                     daemon_spec.daemon_type)).prepare_create(daemon_spec)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2671,29 +2671,29 @@ Then run the following:
             return False
 
         rc_get, out_get, err_get = self.mon_command({
-                    'prefix': 'config get',
-                    'who': f'{daemon_spec.service_name}.{daemon_spec.daemon_id}',
-                    'key': 'public_network'
-                })
+            'prefix': 'config get',
+            'who': f'mon.{daemon_spec.daemon_id}',
+            'key': 'public_network'
+        })
 
         if rc_get:
             self.log.error(f'cmd: config get failed with: {err_get}, (errno:{rc_get})')
             return False
 
         rc_show, out_show, err_show = self.mon_command({
-                    'prefix': 'config show',
-                    'who': f'{daemon_spec.service_name}.{daemon_spec.daemon_id}',
-                    'key': 'public_network'
-                })
+            'prefix': 'config show',
+            'who': f'mon.{daemon_spec.daemon_id}',
+            'key': 'public_network'
+        })
 
         if rc_show:
-            self.log.error(f'cmd: config get failed with: {err_show}, (errno:{rc_show})')
+            self.log.error(f'cmd: config show failed with: {err_show}, (errno:{rc_show})')
             return False
 
         if out_get == out_show:
             return False
 
-        self.log.debug(f'{daemon_spec.service_name}.{daemon_spec.daemon_id} public network changed, redeploy instead of restart')
+        self.log.debug(f'mon.{daemon_spec.daemon_id} public network changed, redeploy instead of restart')
         return True
 
     def _daemon_action(self,
@@ -2712,6 +2712,8 @@ Then run the following:
             return self._rotate_daemon_key(daemon_spec)
 
         if action == 'redeploy' or action == 'reconfig' or (action == 'restart' and self._mon_public_network_changed(daemon_spec)):
+            if action == 'restart':
+                action = 'redeploy'  # to ensure proper behavior since we want redeploy
             if daemon_spec.daemon_type != 'osd':
                 daemon_spec = service_registry.get_service(daemon_type_to_service(
                     daemon_spec.daemon_type)).prepare_create(daemon_spec)


### PR DESCRIPTION
Currently when a new public network is set for mon daemons and the mon daemons are restarted, the new public network is still not applied. This is because the public network config doesn't update dynamically and it requires the mon daemon to be redeployed for the change to take effect. People assume that restarting the mon daemon should apply the change so my code adds a function to check if the mon daemon public network config has been changed and has not been applied yet. This function is then called in _daemon_action to reroute a restart request to the redeploy request process, essentially turning the restart into a redeploy to update the public network.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2400397

Upstream Tracker: https://tracker.ceph.com/issues/73775

Signed-off-by: Timothy Q Nguyen <timqn22@gmail.com>