### PR TITLE
CephFS: support read_from_replica

### DIFF
--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -83,6 +83,21 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
    Pass the name of Ceph FS to be mounted. Not passing this option mounts the
    default Ceph FS on the Ceph cluster.
 
+.. option:: --read_from_replica <no|balance|localize>
+
+    - ``no``: Disable replica reads, always pick the primary OSD (default).
+
+    - ``balance``: When a replicated pool receives a read request, pick a random
+      OSD from the PG's acting set to serve it.
+
+    - ``localize``: When a replicated pool receives a read request, pick the most
+      local OSD to serve it. The locality metric is calculated against
+      the location of the client given with ``crush_location``; a match with the
+      lowest-valued bucket type wins. For example, an OSD in a matching rack
+      is closer than an OSD in a matching data center, which in turn is closer
+      than an OSD in a matching region.
+
+
 Availability
 ============
 

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -115,12 +115,22 @@ int main(int argc, const char **argv, const char *envp[]) {
 			 CODE_ENVIRONMENT_DAEMON,
 			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
 
+  std::string val;
   for (auto i = args.begin(); i != args.end();) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "--localize-reads", (char*)nullptr)) {
-      cerr << "setting CEPH_OSD_FLAG_LOCALIZE_READS" << std::endl;
-      filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
+    } else if (ceph_argparse_witharg(args, i, &val, "--read-from-replica", (char*)nullptr)) {
+      if (val == "no") {
+        cerr << "setting 0, disabling replica reads" << std::endl;
+        filer_flags = 0;
+      }
+      else if (val == "balance") {
+        cerr << "setting CEPH_OSD_FLAG_BALANCE_READS" << std::endl;
+        filer_flags |= CEPH_OSD_FLAG_BALANCE_READS;
+      } else if (val == "localize") {
+        cerr << "setting CEPH_OSD_FLAG_LOCALIZE_READS" << std::endl;
+        filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
+      }
     } else if (ceph_argparse_flag(args, i, "-V", (char*)nullptr)) {
       const char* tmpargv[] = {
 	"ceph-fuse",

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -18438,14 +18438,16 @@ void Client::set_filer_flags(int flags)
 {
   std::scoped_lock l(client_lock);
   ceph_assert(flags == 0 ||
-	 flags == CEPH_OSD_FLAG_LOCALIZE_READS);
+              flags == CEPH_OSD_FLAG_LOCALIZE_READS ||
+              flags == CEPH_OSD_FLAG_BALANCE_READS);
   objecter->add_global_op_flags(flags);
 }
 
 void Client::clear_filer_flags(int flags)
 {
   std::scoped_lock l(client_lock);
-  ceph_assert(flags == CEPH_OSD_FLAG_LOCALIZE_READS);
+  ceph_assert(flags == CEPH_OSD_FLAG_LOCALIZE_READS ||
+              flags == CEPH_OSD_FLAG_BALANCE_READS);
   objecter->clear_global_op_flag(flags);
 }
 

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -258,6 +258,9 @@ void parse_syn_options(vector<const char*>& args)
     else if (strcmp(args[i], "localize_reads") == 0) {
       cerr << "set CEPH_OSD_FLAG_LOCALIZE_READS" << std::endl;
       syn_filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
+    } else if (strcmp(args[i], "balance_reads") == 0) {
+      cerr << "set CEPH_OSD_FLAG_BALANCE_READS" << std::endl;
+      syn_filer_flags |= CEPH_OSD_FLAG_BALANCE_READS;
     }
     else {
       nargs.push_back(args[i]);

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1812,3 +1812,15 @@ options:
   min: 30
   services:
   - mds
+- name: mds_read_from_replica
+  type: str
+  level: advanced
+  desc: read from the nearest replica
+  long_desc: set read from replica preference - no/balance/localize
+  default: 'no'
+  enum_values:
+  - 'no'
+  - 'balance'
+  - 'localize'
+  services:
+  - mds

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1972,6 +1972,16 @@ int ceph_set_default_file_replication(struct ceph_mount_info *cmount, int replic
 int ceph_localize_reads(struct ceph_mount_info *cmount, int val);
 
 /**
+ * Read from local replicas when possible.
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param val a boolean to set (1) or clear (0) the option to favor balance objects
+ *     for reads.
+ * @returns 0
+ */
+int ceph_balance_reads(struct ceph_mount_info *cmount, int val);
+
+/**
  * Get the osd id of the local osd (if any)
  *
  * @param cmount the ceph mount handle to use.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -1961,6 +1961,17 @@ extern "C" int ceph_localize_reads(struct ceph_mount_info *cmount, int val)
   return 0;
 }
 
+extern "C" int ceph_balance_reads(struct ceph_mount_info *cmount, int val)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+  if (!val)
+    cmount->get_client()->clear_filer_flags(CEPH_OSD_FLAG_BALANCE_READS);
+  else
+    cmount->get_client()->set_filer_flags(CEPH_OSD_FLAG_BALANCE_READS);
+  return 0;
+}
+
 extern "C" CephContext *ceph_get_mount_context(struct ceph_mount_info *cmount)
 {
   return cmount->get_ceph_context();

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1872,6 +1872,7 @@ void CDir::_omap_fetch(std::set<string> *keys, MDSContext *c)
     fin->ret3 = -ECANCELED;
   }
 
+  mdcache->mds->objecter->add_global_op_flags(mdcache->mds->get_filer_flags());
   mdcache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
 			     new C_OnFinisher(fin, mdcache->mds->finisher));
 }
@@ -1892,6 +1893,7 @@ void CDir::_omap_fetch_more(version_t omap_version, bufferlist& hdrbl,
 		   &fin->omap_more,
 		   &fin->more,
 		   &fin->ret);
+  mdcache->mds->objecter->add_global_op_flags(mdcache->mds->get_filer_flags());
   mdcache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
 			     new C_OnFinisher(fin, mdcache->mds->finisher));
 }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1364,6 +1364,7 @@ void CInode::fetch(MDSContext *fin)
   object_t oid = CInode::get_object_name(ino(), frag_t(), "");
   object_locator_t oloc(mdcache->mds->get_metadata_pool());
 
+  mdcache->mds->objecter->add_global_op_flags(mdcache->mds->get_filer_flags());
   // Old on-disk format: inode stored in xattr of a dirfrag
   ObjectOperation rd;
   rd.getxattr("inode", &c->bl, NULL);
@@ -4902,6 +4903,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       const int64_t pool = in->get_backtrace_pool();
       object_t oid = CInode::get_object_name(in->ino(), frag_t(), "");
 
+      in->mdcache->mds->objecter->add_global_op_flags(in->mdcache->mds->get_filer_flags());
       ObjectOperation fetch;
       fetch.getxattr("parent", bt, bt_r);
       in->mdcache->mds->objecter->read(oid, object_locator_t(pool), fetch, CEPH_NOSNAP,

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -424,6 +424,7 @@ int MDBalancer::localize_balancer()
   /* we assume that balancer is in the metadata pool */
   object_t oid = object_t(mds->mdsmap->get_balancer());
   object_locator_t oloc(mds->get_metadata_pool());
+  mds->objecter->add_global_op_flags(mds->get_filer_flags());
   ceph_tid_t tid = mds->objecter->read(oid, oloc, 0, 0, CEPH_NOSNAP, &lua_src, 0,
                                        new C_SafeCond(lock, cond, &ack, &r));
   dout(15) << "launched non-blocking read tid=" << tid

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14916,6 +14916,7 @@ void MDCache::file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, ui
   C_ListSnapsAggregator *on_finish = new C_ListSnapsAggregator(mds, in1, in2, block_diff, ctx);
   MDSGatherBuilder gather_ctx(g_ceph_context, on_finish);
 
+  mds->objecter->add_global_op_flags(mds->get_filer_flags());
   while (scans > 0) {
     ObjectOperation op;
     std::unique_ptr<SnapSetContext> ssc(new SnapSetContext());

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -4349,3 +4349,16 @@ void MDSRank::reset_event_flags() {
   beacon.missed_beacon_ack_dump = false;
   beacon.missed_internal_heartbeat_dump = false;
 }
+
+int MDSRank::get_filer_flags() {
+  std::string val = g_conf().get_val<std::string>("mds_read_from_replica");
+  int filer_flags = 0;
+  if (val == "no") {
+    filer_flags = 0;
+  } else if (val == "balance") {
+    filer_flags |= CEPH_OSD_FLAG_BALANCE_READS;
+  } else if (val == "localize") {
+    filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
+  }
+  return filer_flags;
+}

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -396,6 +396,7 @@ class MDSRank {
 
     std::string get_path(inodeno_t ino);
     uint64_t get_inode_rbytes(inodeno_t ino);
+    int get_filer_flags();
 
     // Reference to global MDS::mds_lock, so that users of MDSRank don't
     // carry around references to the outer MDS, and we can substitute

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -760,6 +760,7 @@ void OpenFileTable::_read_omap_values(const std::string& key, unsigned idx,
       op.omap_get_header(&c->header_bl, &c->header_r);
     op.omap_get_vals(key, "", uint64_t(-1),
 		     &c->values, &c->more, &c->values_r);
+    mds->objecter->add_global_op_flags(mds->get_filer_flags());
     mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, nullptr, 0,
 			new C_OnFinisher(c, mds->finisher));
 }

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -284,6 +284,7 @@ void SessionMap::_load_finish(
     const std::string last_key = session_vals.rbegin()->first;
     dout(10) << __func__ << ": continue omap load from '"
              << last_key << "'" << dendl;
+    mds->objecter->add_global_op_flags(mds->get_filer_flags());
     object_t oid = get_object_name();
     object_locator_t oloc(mds->get_metadata_pool());
     C_IO_SM_Load *c = new C_IO_SM_Load(this, false);
@@ -323,7 +324,7 @@ void SessionMap::load(MDSContext *onload)
 
   if (onload)
     waiting_for_load.push_back(onload);
-  
+  mds->objecter->add_global_op_flags(mds->get_filer_flags());
   C_IO_SM_Load *c = new C_IO_SM_Load(this, true);
   object_t oid = get_object_name();
   object_locator_t oloc(mds->get_metadata_pool());
@@ -360,7 +361,7 @@ public:
 void SessionMap::load_legacy()
 {
   dout(10) << __func__ << dendl;
-
+  mds->objecter->add_global_op_flags(mds->get_filer_flags());
   C_IO_SM_LoadLegacy *c = new C_IO_SM_LoadLegacy(this);
   object_t oid = get_object_name();
   object_locator_t oloc(mds->get_metadata_pool());

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -607,7 +607,19 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi,
 			if (!cmi->cmi_mons)
 				return -ENOMEM;
 			mon_addr_specified = true;
-		} else {
+		} else if (strcmp(data, "read_from_replica") == 0) {
+          if (!value || !*value) {
+            fprintf(stderr, "mount option read_from_replica requires a value.\n");
+            return -EINVAL;
+          }
+          if (strcmp(value, "no") == 0) {
+            cmi->cmi_flags |= 0;
+          } else if (strcmp(value, "balance") == 0) {
+            cmi->cmi_flags |= CEPH_FLAG_BALANCE_READS;
+          } else if (strcmp (value, "localize") == 0) {
+            cmi->cmi_flags |= CEPH_FLAG_LOCALIZE_READS;
+          }
+        } else {
 			/* unrecognized mount options, passing to kernel */
 			skip = false;
 		}

--- a/src/mount/mount.ceph.h
+++ b/src/mount/mount.ceph.h
@@ -26,6 +26,11 @@ extern "C" {
 
 #define CLUSTER_FSID_LEN        37
 
+enum {
+  CEPH_FLAG_BALANCE_READS =  0x0100,
+  CEPH_FLAG_LOCALIZE_READS = 0x2000,
+};
+
 void mount_ceph_debug(const char *fmt, ...);
 
 struct ceph_config_info {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/64846






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>