### PR TITLE
[WIP] src/script: add script to store pool availability status

### DIFF
--- a/src/script/pool-status-check.sh
+++ b/src/script/pool-status-check.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+LOG_DIR="/var/log/ceph_pool_status"
+PID_FILE="/var/run/ceph_pool_status.pid"
+
+mkdir -p "$LOG_DIR"
+
+# Handle stop flag
+if [[ "$1" == "--stop" ]]; then
+    if [[ -f "$PID_FILE" ]]; then
+        PID=$(cat "$PID_FILE")
+        echo "Stopping ceph_pool_status process with PID $PID..."
+        kill "$PID" 2>/dev/null
+
+        # Force-kill if still running
+        sleep 1
+        if kill -0 "$PID" 2>/dev/null; then
+            echo "Force killing..."
+            kill -9 "$PID"
+        fi
+
+        rm -f "$PID_FILE"
+        echo "Stopped."
+    else
+        echo "No PID file found. Script is not running."
+    fi
+    exit 0
+fi
+
+# Prevent multiple instances
+if [[ -f "$PID_FILE" ]]; then
+    echo "Script already running (PID $(cat "$PID_FILE")). Exiting."
+    exit 1
+fi
+
+# Save current PID
+echo $$ > "$PID_FILE"
+
+# Main loop
+while true
+do
+    LOG_FILE="$LOG_DIR/pool_status_$(date +%Y-%m-%d).log"
+
+    {
+        echo "===== $(date '+%Y-%m-%d %H:%M:%S') ====="
+        ceph -s --format json
+        ceph osd pool availability-status --format json-pretty
+        echo ""
+    } >> "$LOG_FILE" 2>&1
+
+    sleep 600
+done


### PR DESCRIPTION
This commit adds a script, pool-status-check.sh, to enable testing of the data availability feature. The script specifically stores the ceph status output and pool's data availability output in a log file every 10 mins to a log file. This log file can be used to analyse the reliability of the feature. The script ensures multiple instances of the same script are not run.

Before running the script make sure it has appropriate permissions: 
```
chmod u+rwx pool_status_check.sh
```

Command to run the script such that the terminal is not blocked and losing SSH connection will not interrupt the script:

```
nohup ./pool_status_check.sh &
```

Command to stop the script:
```
./pool_status_check.sh --stop
```
Output: 
```
[root@ceph-node-0 ~]# cat nohup.out 
Script already running (PID 1215533). Exiting.
[root@ceph-node-0 ~]# ./pool_status_check.sh --stop
Stopping ceph_pool_status process with PID 1215533...
Stopped.
[1]+  Terminated              nohup ./pool_status_check.sh
[root@ceph-node-0 ~]# ll /var/log/ceph_pool_status/
total 4
```

Each entry in the log file will look like this: 
```
===== 2025-12-11 10:56:54 =====

{"fsid":"c77ef51e-c60b-11f0-8a2c-525400c5fe66","health":{"status":"HEALTH_OK","checks":{},"mutes":[]},"election_epoch":20,"quorum":[0,1,2],"quorum_names":["ceph-node-0","ceph-node-1","ceph-node-2"],"quorum_age":474954,"monmap":{"epoch":3,"min_mon_release_name":"tentacle","num_mons":3},"osdmap":{"epoch":65,"num_osds":3,"num_up_osds":3,"osd_up_since":1763642069,"num_in_osds":3,"osd_in_since":1763641983,"num_remapped_pgs":0},"pgmap":{"pgs_by_state":[{"state_name":"active+clean","count":1}],"num_pgs":1,"num_pools":1,"num_objects":2,"data_bytes":459280,"bytes_used":196313088,"bytes_avail":32003358720,"bytes_total":32199671808},"fsmap":{"epoch":1,"btime":"2025-11-20T12:24:29:402878+0000","by_rank":[],"up:standby":0},"mgrmap":{"available":true,"num_standbys":1,"modules":["cephadm","iostat","nfs"],"services":{}},"servicemap":{"epoch":9139,"modified":"2025-12-11T10:56:29.638153+0000","services":{}},"progress_events":{}}

POOL  UPTIME  DOWNTIME  NUMFAILURES  MTBF  MTTR  SCORE  AVAILABLE
.mgr     13m        0s            0    0s    0s      1          1
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
