### PR TITLE
mgr: add config to load modules in main interpreter instead of subinterpreter

### DIFF
--- a/src/common/options/CMakeLists.txt
+++ b/src/common/options/CMakeLists.txt
@@ -82,6 +82,8 @@ if(WITH_MGR)
   endif()
 endif()
 
+set(mgr_subinterpreter_modules "")
+
 add_options(global)
 add_options(cephfs-mirror)
 add_options(crimson)

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -145,6 +145,19 @@ options:
   - mgr_module_path
   flags:
   - startup
+- name: mgr_subinterpreter_modules
+  type: str
+  level: advanced
+  desc: List of manager modules to load in independent subinterpreters
+  long_desc: A comma delimited list of module names. This list is read by manager
+    when it starts. By default, manager loads each module into the main interpreter.
+    Modules in this list will instead be loaded into independent subinterpreters.
+    Specifying '*' will cause all modules to be run in independent subinterpreters.
+  default: @mgr_subinterpreter_modules@
+  services:
+  - mgr
+  flags:
+  - startup
 - name: mgr_initial_modules
   type: str
   level: basic

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -67,10 +67,10 @@ public:
 
   bool method_exists(const std::string &method) const;
 
-  PyObject *dispatch_remote(
+  std::optional<std::vector<std::byte>> dispatch_remote(
       const std::string &method,
-      PyObject *args,
-      PyObject *kwargs,
+      std::span<std::byte const> pickled_args,
+      std::span<std::byte const> pickled_kwargs,
       std::string *err);
 
   int handle_command(

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -625,18 +625,20 @@ bool ActivePyModules::get_store(const std::string &module_name,
   }
 }
 
-PyObject *ActivePyModules::dispatch_remote(
+std::optional<std::vector<std::byte>> ActivePyModules::dispatch_remote(
     const std::string &other_module,
     const std::string &method,
-    PyObject *args,
-    PyObject *kwargs,
+    std::span<std::byte const> pickled_args,
+    std::span<std::byte const> pickled_kwargs,
     std::string *err)
 {
   auto mod_iter = modules.find(other_module);
   ceph_assert(mod_iter != modules.end());
 
-  return mod_iter->second->dispatch_remote(method, args, kwargs, err);
+  return mod_iter->second->dispatch_remote(
+    method, pickled_args, pickled_kwargs, err);
 }
+
 
 bool ActivePyModules::get_config(const std::string &module_name,
     const std::string &key, std::string *val) const

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -233,11 +233,11 @@ public:
     return modules.at(module_name)->method_exists(method_name);
   }
 
-  PyObject *dispatch_remote(
+  std::optional<std::vector<std::byte>> dispatch_remote(
       const std::string &other_module,
       const std::string &method,
-      PyObject *args,
-      PyObject *kwargs,
+      std::span<std::byte const> pickled_args,
+      std::span<std::byte const> pickled_kwargs,
       std::string *err);
 
   int init();

--- a/src/mgr/Gil.cc
+++ b/src/mgr/Gil.cc
@@ -25,6 +25,30 @@
 
 #include "Gil.h"
 
+static void assert_gil()
+{
+  /* Using PyGILState_Check() isn't appropriate:
+   *
+   * https://docs.python.org/3/c-api/init.html#c.PyGILState_Check
+   *
+   * "Only if it has had its thread state initialized via PyGILState_Ensure()
+   * will it return 1."
+   *
+   * We got away with it for a while due to:
+   *
+   * "Note: If the current Python process has ever created a subinterpreter,
+   * this function will always return 1."
+   *
+   * Instead, use PyThreadState_Get() and use ts->thread_id to confirm that it's
+   * the right thread (ts->thread_id isn't necessarily stable, and may need to
+   * change in the future).  Once we no longer need to support python versions
+   * prior to 3.13, this can be PyThreadState_GetUnchecked().
+   */
+  auto *ts = PyThreadState_Get();
+  ceph_assert(ts != nullptr);
+  ceph_assert(ts->thread_id == PyThread_get_thread_ident());
+}
+
 SafeThreadState::SafeThreadState(PyThreadState *ts_)
     : ts(ts_)
 {
@@ -80,7 +104,7 @@ Gil::~Gil()
 
 without_gil_t::without_gil_t()
 {
-  assert(PyGILState_Check());
+  assert_gil();
   release_gil();
 }
 

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -156,6 +156,48 @@ std::string peek_pyerror()
   return exc_msg;
 }
 
+std::span<std::byte const> py_bytes_as_span(PyObject *bytes)
+{
+  assert(bytes);
+  assert(PyBytes_CheckExact(bytes));
+  Py_ssize_t length;
+  char *buf;
+  int r = PyBytes_AsStringAndSize(
+    bytes, &buf, &length);
+  assert(r == 0);
+  return std::span<std::byte const>((const std::byte*)buf, size_t(length));
+}
+
+PyObject *py_bytes_from_span(std::span<std::byte const> s)
+{
+  auto ret = PyBytes_FromStringAndSize(
+    reinterpret_cast<const char*>(s.data()), s.size_bytes());
+  assert(ret);
+  return ret;
+}
+
+std::vector<std::byte> py_bytes_as_vec(PyObject *bytes)
+{
+  assert(bytes);
+  assert(PyBytes_CheckExact(bytes));
+  Py_ssize_t length;
+  char *buf;
+  int r = PyBytes_AsStringAndSize(
+    bytes, &buf, &length);
+  assert(r == 0);
+  return std::vector<std::byte>{
+    reinterpret_cast<const std::byte*>(buf),
+    reinterpret_cast<const std::byte*>(buf) + size_t(length)};
+}
+
+PyObject *py_bytes_from_vec(const std::vector<std::byte> &s)
+{
+  auto ret = PyBytes_FromStringAndSize(
+    reinterpret_cast<const char *>(s.data()), s.size());
+  assert(ret);
+  return ret;
+}
+
 
 namespace {
   PyObject* log_write(PyObject*, PyObject* args) {
@@ -311,6 +353,13 @@ int PyModule::load(PyThreadState *pMainThreadState)
     Gil gil(pMyThreadState);
 
     int r;
+
+    pPickleModule = PyImport_ImportModuleNoBlock("pickle");
+    if (!pPickleModule) {
+      derr << "Unable to load pickle" << dendl;
+      return -EINVAL;
+    }
+
     r = load_subclass_of("MgrModule", &pClass);
     if (r) {
       derr << "Class not found in module '" << module_name << "'" << dendl;
@@ -718,6 +767,7 @@ PyModule::~PyModule()
     Gil gil(pMyThreadState, true);
     Py_XDECREF(pClass);
     Py_XDECREF(pStandbyClass);
+    Py_XDECREF(pPickleModule);
     Py_EndInterpreter(pMyThreadState.ts);
     pMyThreadState.ts = nullptr;
   }

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -105,6 +105,9 @@ public:
   PyObject *pStandbyClass = nullptr;
   PyObject *pPickleModule = nullptr;
 
+  // true unless module in mgr_subinterpreter_modules
+  bool use_main_interpreter = true;
+
   explicit PyModule(const std::string &module_name_)
     : module_name(module_name_)
   {

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -33,6 +33,13 @@ std::string handle_pyerror(bool generate_crash_dump = false,
 
 std::string peek_pyerror();
 
+std::span<std::byte const> py_bytes_as_span(PyObject*);
+PyObject *py_bytes_from_span(std::span<std::byte const>);
+
+std::vector<std::byte> py_bytes_as_vec(PyObject*);
+PyObject *py_bytes_from_vec(const std::vector<std::byte> &);
+
+
 /**
  * A Ceph CLI command description provided from a Python module
  */
@@ -96,6 +103,7 @@ public:
   SafeThreadState pMyThreadState;
   PyObject *pClass = nullptr;
   PyObject *pStandbyClass = nullptr;
+  PyObject *pPickleModule = nullptr;
 
   explicit PyModule(const std::string &module_name_)
     : module_name(module_name_)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -933,6 +933,14 @@ class ServiceSpec(object):
         sub_cls: Any = cls._cls(service_type)
         return object.__new__(sub_cls)
 
+    def __getnewargs__(self):
+        """
+        Pickle will pass the return of this function to __new__ upon
+        unpickle.  We need to ensure it gets service_type in order
+        to get the right subtype.
+        """
+        return (self.service_type,)
+
     def __init__(self,
                  service_type: str,
                  service_id: Optional[str] = None,


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
