### PR TITLE
tentacle: messages: MOSDOpReply encode and decode errorcode32_t with PGID64 fea…

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -635,8 +635,8 @@ struct errorcode32_t {
     return hostos_to_ceph_errno(code);
   }
 
-  inline void set_wire_to_host(code_t host_code) {
-    code = ceph_to_hostos_errno(host_code);
+  inline void set_wire_to_host(code_t wire_code) {
+    code = ceph_to_hostos_errno(wire_code);
   }
 
   void encode(ceph::buffer::list &bl) const {

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -267,6 +267,7 @@ public:
       pgid = pg_t(head.layout.ol_pgid);
       result.set_wire_to_host((int32_t)head.result);
       flags = head.flags;
+      bad_replay_version = head.reassert_version;
       replay_version = head.reassert_version;
       user_version = replay_version.version;
       osdmap_epoch = head.osdmap_epoch;

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -183,7 +183,7 @@ public:
       head.flags = flags;
       head.osdmap_epoch = osdmap_epoch;
       head.reassert_version = bad_replay_version;
-      head.result = result;
+      head.result = result.get_host_to_wire();
       head.num_ops = ops.size();
       head.object_len = oid.name.length();
       encode(head, payload);
@@ -265,7 +265,7 @@ public:
       }
       ceph::decode_nohead(head.object_len, oid.name, p);
       pgid = pg_t(head.layout.ol_pgid);
-      result = (int32_t)head.result;
+      result.set_wire_to_host((int32_t)head.result);
       flags = head.flags;
       replay_version = head.reassert_version;
       user_version = replay_version.version;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73849

---

backport of https://github.com/ceph/ceph/pull/65962
parent tracker: https://tracker.ceph.com/issues/69814

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh