### PR TITLE
os/bluestore: asok command to expand block device and Bluestore while OSD is running

### DIFF
--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -487,6 +487,87 @@ function TEST_bluestore_expand() {
     ceph-bluestore-tool --log-file $dir/bluestore_tool.log --path $dir/0 qfsck || return 1
 }
 
+function TEST_bluestore_expand_online() {
+    local dir=$1
+
+    local flimit=$(ulimit -n)
+    if [ $flimit -lt 1536 ]; then
+        echo "Low open file limit ($flimit), test may fail. Increase to 1536 or higher and retry if that happens."
+    fi
+    export CEPH_MON="127.0.0.1:7146" # git grep '\<7146\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--bluestore_block_size=2147483648 "
+    CEPH_ARGS+="--bluestore_block_db_create=true "
+    CEPH_ARGS+="--bluestore_block_db_size=536870912 "
+    CEPH_ARGS+="--bluestore_block_wal_create=true "
+    CEPH_ARGS+="--bluestore_block_wal_size=268435456 "
+    CEPH_ARGS+="--bluestore_fsck_on_mount=true "
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    osd_pid0=$(cat $dir/osd.0.pid)
+    run_osd $dir 1 || return 1
+    osd_pid1=$(cat $dir/osd.1.pid)
+    run_osd $dir 2 || return 1
+    osd_pid2=$(cat $dir/osd.2.pid)
+    run_osd $dir 3 || return 1
+    osd_pid3=$(cat $dir/osd.3.pid)
+
+    sleep 5
+    create_pool foo 16
+
+    timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
+
+    # expand slow devices while OSDs are running
+    truncate $dir/0/block -s 4294967296 # 4GB
+    ceph tell osd.0 bluestore bluefs-bdev-expand || return 1
+
+    truncate $dir/1/block -s 11811160064 # 11GB
+    ceph tell osd.1 bluestore bluefs-bdev-expand || return 1
+
+    truncate $dir/2/block -s 4295099392 # 4GB + 129KB
+    ceph tell osd.2 bluestore bluefs-bdev-expand || return 1
+
+    truncate $dir/3/block -s 4293918720 # 4GB - 1MB
+    ceph tell osd.3 bluestore bluefs-bdev-expand || return 1
+
+    # expand DB devices while OSDs are running
+    truncate $dir/0/block.db -s 1073741824 # 1GB
+    ceph tell osd.0 bluestore bluefs-bdev-expand || return 1
+
+    truncate $dir/1/block.db -s 1073741824 # 1GB
+    ceph tell osd.1 bluestore bluefs-bdev-expand || return 1
+
+    # write more objects to use the new space
+    timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
+
+    wait_for_clean || return 1
+
+    ceph tell osd.0 bluestore bluefs device info
+    ceph tell osd.1 bluestore bluefs device info
+    ceph tell osd.2 bluestore bluefs device info
+    ceph tell osd.3 bluestore bluefs device info
+
+    # kill and verify with fsck
+    while kill $osd_pid0; do sleep 1 ; done
+    ceph osd down 0
+    while kill $osd_pid1; do sleep 1 ; done
+    ceph osd down 1
+    while kill $osd_pid2; do sleep 1 ; done
+    ceph osd down 2
+    while kill $osd_pid3; do sleep 1 ; done
+    ceph osd down 3
+
+    ceph-bluestore-tool --path $dir/0 fsck || return 1
+    ceph-bluestore-tool --path $dir/1 fsck || return 1
+    ceph-bluestore-tool --path $dir/2 fsck || return 1
+    ceph-bluestore-tool --path $dir/3 fsck || return 1
+
+}
+
 main osd-bluefs-volume-ops "$@"
 
 # Local Variables:

--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -519,6 +519,12 @@ function TEST_bluestore_expand_online() {
     sleep 5
     create_pool foo 16
 
+    # no device expansion sanity check
+    ceph tell osd.0 bluestore bluefs-bdev-expand || return 1
+    ceph tell osd.1 bluestore bluefs-bdev-expand || return 1
+    ceph tell osd.2 bluestore bluefs-bdev-expand || return 1
+    ceph tell osd.3 bluestore bluefs-bdev-expand || return 1
+
     timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
 
     # expand slow devices while OSDs are running

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -241,6 +241,7 @@ public:
   }
   
   uint64_t get_size() const { return size; }
+  virtual int refresh_size() { return 0; }
   uint64_t get_block_size() const { return block_size; }
   uint64_t get_optimal_io_size() const { return optimal_io_size; }
   bool is_discard_supported() const { return support_discard; }

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -179,7 +179,7 @@ private:
     void *cbpriv, aio_callback_t d_cb, void *d_cbpriv, const char* dev_name);
 
 protected:
-  uint64_t size = 0;
+  std::atomic<uint64_t> size = 0;
   uint64_t block_size = 0;
   uint64_t optimal_io_size = 0;
   bool support_discard = false;

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -13,6 +13,7 @@
  *
  */
 
+#include <cerrno>
 #include <limits>
 #include <unistd.h>
 #include <stdlib.h>
@@ -38,6 +39,7 @@
 #include "common/buffer_instrumentation.h"
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/errno.h"
+#include "BlockDevice.h"
 #if defined(__FreeBSD__)
 #include "bsm/audit_errno.h"
 #endif
@@ -351,6 +353,37 @@ int KernelDevice::get_devices(std::set<std::string> *ls) const
     return 0;
   }
   get_raw_devices(devname, ls);
+  return 0;
+}
+
+int KernelDevice::refresh_size()
+{
+  if (fd_directs.empty() || fd_directs[WRITE_LIFE_NOT_SET] < 0) {
+    return -ENODEV;
+  }
+
+  struct stat st;
+  int r = ::fstat(fd_directs[WRITE_LIFE_NOT_SET], &st);
+  if (r < 0) {
+    r = -errno;
+    derr << __func__ << " fstat failed: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // logic taken from open() for block vs file
+  int64_t new_size;
+  if (S_ISBLK(st.st_mode)) {
+    BlkDev blkdev(fd_directs[WRITE_LIFE_NOT_SET]);
+    r = blkdev.get_size(&new_size);
+    if (r < 0) {
+      derr << __func__ << " ioctl failed: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  } else {
+    new_size = st.st_size;
+  }
+
+  size = new_size;
   return 0;
 }
 

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -146,6 +146,7 @@ public:
     return 0;
   }
   int get_devices(std::set<std::string> *ls) const override;
+  int refresh_size() override;
 
   int get_ebd_state(ExtBlkDevState &state) const override;
   int detect_ebd(std::string& id) override;

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -90,9 +90,13 @@ public:
   {
     return block_size;
   }
+  virtual void expand(int64_t new_size){
+    ceph_assert(new_size >= device_size);
+    device_size = new_size;
+  }
 
 protected:
-  const int64_t device_size = 0;
+  int64_t device_size = 0;
   const int64_t block_size = 0;
 };
 

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -13,6 +13,7 @@
 #ifndef CEPH_OS_BLUESTORE_ALLOCATOR_H
 #define CEPH_OS_BLUESTORE_ALLOCATOR_H
 
+#include <atomic>
 #include <functional>
 #include <ostream>
 #include "include/ceph_assert.h"
@@ -84,19 +85,19 @@ public:
   virtual const std::string& get_name() const = 0;
   int64_t get_capacity() const
   {
-    return device_size;
+    return device_size.load();
   }
   int64_t get_block_size() const
   {
     return block_size;
   }
   virtual void expand(int64_t new_size){
-    ceph_assert(new_size >= device_size);
-    device_size = new_size;
+    ceph_assert(new_size >= device_size.load());
+    device_size.store(new_size);
   }
 
 protected:
-  int64_t device_size = 0;
+  std::atomic<int64_t> device_size{0};
   const int64_t block_size = 0;
 };
 

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "BitmapAllocator.h"
+#include <cstdint>
 #include "include/types.h" // for byte_u_t
 
 #define dout_context cct
@@ -87,6 +88,25 @@ void BitmapAllocator::init_rm_free(uint64_t offset, uint64_t length)
   ceph_assert(offs + l <= (uint64_t)device_size);
   _mark_allocated(offs, l);
   ldout(cct, 10) << __func__ << " done" << dendl;
+}
+
+void BitmapAllocator::expand(int64_t new_size)
+{
+  int64_t old_size = get_capacity();
+  ceph_assert(new_size >= old_size);
+
+  if (new_size == old_size) {
+    return;
+  }
+
+  ldout(cct, 1) << __func__ << " expanding from 0x" << std::hex << old_size
+                << " to 0x" << new_size << std::dec << dendl;
+
+  Allocator::expand(new_size);
+  AllocatorLevel02::expand(new_size, old_size);
+
+  ldout(cct, 1) << __func__ << " expansion complete, available=0x"
+                << std::hex << get_available() << std::dec << dendl;
 }
 
 void BitmapAllocator::shutdown()

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -57,7 +57,7 @@ void BitmapAllocator::release(
     for (auto& [offset, len] : release_set) {
       ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << len
                      << std::dec << dendl;
-      ceph_assert(offset + len <= (uint64_t)device_size);
+      ceph_assert(offset + len <= (uint64_t)device_size.load());
     }
   }
   _free_l2(release_set);
@@ -73,7 +73,7 @@ void BitmapAllocator::init_add_free(uint64_t offset, uint64_t length)
   auto mas = get_min_alloc_size();
   uint64_t offs = round_up_to(offset, mas);
   uint64_t l = p2align(offset + length - offs, mas);
-  ceph_assert(offs + l <= (uint64_t)device_size);
+  ceph_assert(offs + l <= (uint64_t)device_size.load());
 
   _mark_free(offs, l);
   ldout(cct, 10) << __func__ << " done" << dendl;
@@ -85,13 +85,14 @@ void BitmapAllocator::init_rm_free(uint64_t offset, uint64_t length)
   auto mas = get_min_alloc_size();
   uint64_t offs = round_up_to(offset, mas);
   uint64_t l = p2align(offset + length - offs, mas);
-  ceph_assert(offs + l <= (uint64_t)device_size);
+  ceph_assert(offs + l <= (uint64_t)device_size.load());
   _mark_allocated(offs, l);
   ldout(cct, 10) << __func__ << " done" << dendl;
 }
 
 void BitmapAllocator::expand(int64_t new_size)
 {
+  std::lock_guard l(expand_lock);
   int64_t old_size = get_capacity();
   ceph_assert(new_size >= old_size);
 

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -56,6 +56,8 @@ public:
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
 
+  void expand(int64_t new_size) override;
+
   void shutdown() override;
 };
 

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -16,6 +16,7 @@
 class BitmapAllocator : public AllocatorBase,
   public AllocatorLevel02<AllocatorLevel01Loose> {
   CephContext* cct;
+  ceph::mutex expand_lock = ceph::make_mutex("BitmapAllocator::expand_lock");
 public:
   BitmapAllocator(CephContext* _cct, int64_t capacity, int64_t alloc_unit,
 		  std::string_view name);

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -163,6 +163,12 @@ int BitmapFreelistManager::_expand(uint64_t old_size, KeyValueDB* db)
   return 0;
 }
 
+int BitmapFreelistManager::expand(uint64_t new_size, KeyValueDB* db){
+  uint64_t old_size = size;
+  size = new_size;
+  return _expand(old_size ,db);
+}
+
 int BitmapFreelistManager::read_size_meta_from_db(KeyValueDB* kvdb,
   uint64_t* res)
 {

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -164,6 +164,9 @@ int BitmapFreelistManager::_expand(uint64_t old_size, KeyValueDB* db)
 }
 
 int BitmapFreelistManager::expand(uint64_t new_size, KeyValueDB* db){
+  if (new_size == size){
+    return 0;
+  }
   uint64_t old_size = size;
   size = new_size;
   return _expand(old_size ,db);

--- a/src/os/bluestore/BitmapFreelistManager.h
+++ b/src/os/bluestore/BitmapFreelistManager.h
@@ -96,6 +96,7 @@ public:
     std::vector<std::pair<std::string, std::string>>*) const override;
 
   bool validate(uint64_t min_alloc_size) const override;
+  int expand(uint64_t new_size, KeyValueDB* db) override;
 };
 
 #endif

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -3,9 +3,13 @@
 
 #include "BlueAdmin.h"
 #include "Compression.h"
+#include "common/errno.h"
 #include "common/pretty_binary.h"
+#include "os/bluestore/BlueStore.h"
 #include "common/debug.h"
 #include <asm-generic/errno-base.h>
+#include <iostream>
+#include <sstream>
 #include <vector>
 #include <limits>
 
@@ -77,6 +81,11 @@ BlueStore::SocketHook::SocketHook(BlueStore& store)
       "bluestore show sharding ",
       this,
       "print RocksDB sharding");
+    ceph_assert(r == 0);
+    r = admin_socket->register_command("bluestore bluefs-bdev-expand",
+                                       this,
+                                       "Instruct BlueFS to check the size of its block devices"
+                                       " and, if they have expanded, make use of the additional space.");
     ceph_assert(r == 0);
   }
 }
@@ -287,6 +296,15 @@ int BlueStore::SocketHook::call(
       }
     }
     return 0;
+  } else if (command == "bluestore bluefs-bdev-expand"){
+    std::stringstream result;
+    int ret = store.expand_devices(result);
+    if (ret < 0) {
+      ss << "expand device failed: " << cpp_strerror(ret) << std::endl;
+    } else {
+      out.append(result.str());
+    }
+    return ret;
   } else {
     ss << "Invalid command" << std::endl;
     r = -ENOSYS;

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -298,7 +298,7 @@ int BlueStore::SocketHook::call(
     return 0;
   } else if (command == "bluestore bluefs-bdev-expand"){
     std::stringstream result;
-    int ret = store.expand_devices(result);
+    int ret = store.expand_devices_online(result);
     if (ret < 0) {
       ss << "expand device failed: " << cpp_strerror(ret) << std::endl;
     } else {

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -298,7 +298,7 @@ int BlueStore::SocketHook::call(
     return 0;
   } else if (command == "bluestore bluefs-bdev-expand"){
     std::stringstream result;
-    int ret = store.expand_devices_online(result);
+    int ret = store.expand_devices(result);
     if (ret < 0) {
       ss << "expand device failed: " << cpp_strerror(ret) << std::endl;
     } else {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -950,8 +950,8 @@ void BlueFS::expand_device(unsigned devid, uint64_t new_size, uint64_t old_size)
   ceph_assert(total > total - free);
 
   dout(10) << __func__ << " dev " << devid
-           << " added free space: 0x" << std::hex << old_size
-           << "~0x" << (aligned_size - old_size) << std::dec << dendl;
+           << " added free space: 0x" << std::hex << aligned_old_size
+           << "~0x" << (aligned_size - aligned_old_size) << std::dec << dendl;
 }
 
 int BlueFS::_read_and_check(uint8_t ndev, uint64_t off, uint64_t len,

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -924,6 +924,29 @@ void BlueFS::_stop_alloc()
   }
 }
 
+void BlueFS::expand_device(unsigned devid, uint64_t new_size, uint64_t old_size)
+{
+  dout(10) << __func__ << " dev " << devid
+           << " from 0x" << std::hex << old_size
+           << " to 0x" << new_size << std::dec << dendl;
+
+  ceph_assert(devid < alloc.size());
+  ceph_assert(alloc[devid]);
+  ceph_assert(new_size > old_size);
+
+  alloc[devid]->expand(new_size);
+  auto aligned_size = p2align(new_size, alloc_size[devid]);
+  alloc[devid]->init_add_free(old_size, aligned_size - old_size);
+
+  uint64_t total = get_block_device_size(devid);
+  uint64_t free = get_free(devid);
+  ceph_assert(total > total - free);
+
+  dout(10) << __func__ << " dev " << devid
+           << " added free space: 0x" << std::hex << old_size
+           << "~0x" << (aligned_size - old_size) << std::dec << dendl;
+}
+
 int BlueFS::_read_and_check(uint8_t ndev, uint64_t off, uint64_t len,
 			    ceph::buffer::list *pbl, IOContext *ioc, bool buffered)
 {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -16,6 +16,7 @@
 #include "Allocator.h"
 #include "include/buffer_fwd.h"
 #include "include/ceph_assert.h"
+#include "include/intarith.h"
 #include "include/stringify.h"
 #include "common/admin_socket.h"
 #include "os/bluestore/bluefs_types.h"
@@ -936,7 +937,8 @@ void BlueFS::expand_device(unsigned devid, uint64_t new_size, uint64_t old_size)
 
   alloc[devid]->expand(new_size);
   auto aligned_size = p2align(new_size, alloc_size[devid]);
-  alloc[devid]->init_add_free(old_size, aligned_size - old_size);
+  auto aligned_old_size = p2roundup(old_size, alloc_size[devid]);
+  alloc[devid]->init_add_free(aligned_old_size, aligned_size - aligned_old_size);
 
   if (vselector) {
     vselector->expand_device(devid, aligned_size);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -938,6 +938,11 @@ void BlueFS::expand_device(unsigned devid, uint64_t new_size, uint64_t old_size)
   auto aligned_size = p2align(new_size, alloc_size[devid]);
   alloc[devid]->init_add_free(old_size, aligned_size - old_size);
 
+  if (vselector) {
+    vselector->expand_device(devid, aligned_size);
+    vselector->update_from_config(cct);
+  }
+
   uint64_t total = get_block_device_size(devid);
   uint64_t free = get_free(devid);
   ceph_assert(total > total - free);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -901,6 +901,8 @@ public:
   bool bdev_support_label(unsigned id);
   BlockDevice* get_block_device(unsigned bdev) const;
 
+  void expand_device(unsigned devid, uint64_t new_size, uint64_t old_size);
+
   // handler for discard event
   void handle_discard(unsigned dev, interval_set<uint64_t>& to_release);
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -211,6 +211,15 @@ public:
   /* used for sanity checking of vselector */
   virtual BlueFSVolumeSelector* clone_empty() const { return nullptr; }
   virtual bool compare(BlueFSVolumeSelector* other) { return true; };
+
+  /**
+  *  Update device total size after online expansion
+  *  Parameters:
+  *    dev_id: BlueFS device id (BDEV_WAL, BDEV_DB, BDEV_SLOW)
+  *    new_size: new total size of the device
+  *
+  */
+  virtual void expand_device(uint8_t dev_id, uint64_t new_size) = 0;
 };
 
 struct bluefs_shared_alloc_context_t {
@@ -1010,6 +1019,22 @@ public:
     // do nothing
     return;
   }
+
+  void expand_device(uint8_t dev_id, uint64_t new_size) override {
+    switch (dev_id) {
+    case BlueFS::BDEV_WAL:
+      wal_total = new_size;
+      break;
+    case BlueFS::BDEV_DB:
+      db_total = new_size;
+      break;
+    case BlueFS::BDEV_SLOW:
+      slow_total = new_size;
+      break;
+    default:
+      break;
+    }
+  }
 };
 
 class FitToFastVolumeSelector : public OriginalVolumeSelector {
@@ -1259,6 +1284,22 @@ public:
   void dump(std::ostream& sout) override;
   BlueFSVolumeSelector* clone_empty() const override;
   bool compare(BlueFSVolumeSelector* other) override;
+
+  void expand_device(uint8_t dev_id, uint64_t new_size) override {
+    switch (dev_id) {
+    case BlueFS::BDEV_WAL:
+      l_totals[LEVEL_WAL - LEVEL_FIRST] = new_size;
+      break;
+    case BlueFS::BDEV_DB:
+      l_totals[LEVEL_DB - LEVEL_FIRST] = new_size;
+      break;
+    case BlueFS::BDEV_SLOW:
+      l_totals[LEVEL_SLOW - LEVEL_FIRST] = new_size;
+      break;
+    default:
+      break;
+    }
+  }
 };
 
 /**

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9184,135 +9184,6 @@ string BlueStore::get_device_path(unsigned id)
   return res;
 }
 
-int BlueStore::expand_devices(ostream& out)
-{
-  // let's open in read-only mode first to be able to recover
-  // from the out-of-space state at DB/shared volume(s)
-  // Opening in R/W mode might cause extra space allocation
-  // which is effectively a show stopper for volume expansion.
-  int r = _open_db_and_around(true);
-  ceph_assert(r == 0);
-  bluefs->dump_block_extents(out);
-  out << "Expanding DB/WAL..." << std::endl;
-  // updating dedicated devices first
-  for (auto devid : { BlueFS::BDEV_WAL, BlueFS::BDEV_DB}) {
-    if (devid == bluefs_layout.shared_bdev) {
-      continue;
-    }
-    auto my_bdev = bluefs->get_block_device(devid);
-    uint64_t size = my_bdev ? my_bdev->get_size() : 0;
-    if (size == 0) {
-      // no bdev
-      continue;
-    }
-    if (my_bdev->supported_bdev_label()) {
-      string my_path = get_device_path(devid);
-      bluestore_bdev_label_t my_label;
-      int r = _read_bdev_label(cct, my_bdev, my_path, &my_label);
-      if (r < 0) {
-        derr << "unable to read label for " << my_path << ": "
-              << cpp_strerror(r) << dendl;
-        continue;
-      } else {
-        if (size == my_label.size) {
-          // no need to expand
-          out << devid
-	      << " : nothing to do, skipped"
-	      << std::endl;
-          continue;
-        } else if (size < my_label.size) {
-          // something weird in bdev label
-          out << devid
-	      <<" : ERROR: bdev label is above device size, skipped"
-	      << std::endl;
-          continue;
-        } else {
-          my_label.size = size;
-          out << devid
-	      << " : Expanding to 0x" << std::hex << size
-	      << std::dec << "(" << byte_u_t(size) << ")"
-	      << std::endl;
-          r = _write_bdev_label(cct, my_bdev, my_path, my_label);
-          if (r < 0) {
-            derr << "unable to write label for " << my_path << ": "
-                  << cpp_strerror(r) << dendl;
-          } else {
-            out << devid
-                << " : size updated to 0x" << std::hex << size
-                << std::dec << "(" << byte_u_t(size) << ")"
-                << std::endl;
-          }
-        }
-      }
-    }
-  }
-  // now proceed with a shared device
-  uint64_t size0 = fm->get_size();
-  uint64_t size = bdev->get_size();
-  auto devid = bluefs_layout.shared_bdev;
-  auto aligned_size = p2align(size, min_alloc_size);
-  if (aligned_size == size0) {
-    // no need to expand
-    out << devid
-        << " : nothing to do, skipped"
-        << std::endl;
-  } else if (aligned_size < size0) {
-    // something weird in bdev label
-    out << devid
-        << " : ERROR: previous device size is above the current one, skipped"
-	<< std::endl;
-  } else {
-    auto my_path = get_device_path(devid);
-    out << devid
-	<<" : Expanding to 0x" << std::hex << size
-	<< std::dec << "(" << byte_u_t(size) << ")"
-	<< std::endl;  
-    r = _write_out_fm_meta(size);
-    if (r != 0) {
-      derr << "unable to write out fm meta for " << my_path << ": "
-           << cpp_strerror(r) << dendl;
-    } else if (bdev->supported_bdev_label()) {
-      bdev_label.size = size;
-      uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
-      for (uint64_t loc : bdev_label_positions) {
-        if ((loc >= size0) && (loc + lsize <= size)) {
-          bdev_label_valid_locations.push_back(loc);
-          if (!bdev_label_multi) {
-            break;
-          }
-        }
-      }
-      r = _write_bdev_label(cct, bdev, my_path,
-        bdev_label, bdev_label_valid_locations);
-      if (r != 0) {
-        derr << "unable to write label(s) for " << my_path << ": "
-             << cpp_strerror(r) << dendl;
-      }
-    }
-    if (r == 0) {
-      out << devid
-          << " : size updated to 0x" << std::hex << size
-          << std::dec << "(" << byte_u_t(size) << ")"
-          << std::endl;
-      _close_db_and_around();
-
-       //
-      // Mount in read/write to sync expansion changes
-      // and make sure everything is all right.
-      //
-      before_expansion_bdev_size = size0; // preserve orignal size to permit
-                                          // following _db_open_and_around()
-                                          // do some post-init stuff on opened
-                                          // allocator.
-
-      r = _open_db_and_around(false);
-      ceph_assert(r == 0);
-    }
-  }
-  _close_db_and_around();
-  return r;
-}
-
 bool BlueStore::get_db_sharding(std::string& res_sharding)
 {
   bool ret = false;
@@ -9323,8 +9194,24 @@ bool BlueStore::get_db_sharding(std::string& res_sharding)
   return ret;
 }
 
-int BlueStore::expand_devices_online(ostream& out)
+int BlueStore::expand_devices(ostream& out)
 {
+  bool need_to_close = false;
+  int r = 0;
+
+  if (!mounted) {
+    // let's open in read-only mode first to be able to recover
+    // from the out-of-space state at DB/shared volume(s)
+    // Opening in R/W mode might cause extra space allocation
+    // which is effectively a show stopper for volume expansion.
+    r = _open_db_and_around(false);
+    if (r < 0) {
+      derr << __func__ << " failed to open db: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    need_to_close = true;
+  }
+
   bluefs->dump_block_extents(out);
   out << "Expanding DB/WAL..." << std::endl;
 
@@ -9345,7 +9232,7 @@ int BlueStore::expand_devices_online(ostream& out)
     if (my_bdev->supported_bdev_label()) {
       string my_path = get_device_path(devid);
       bluestore_bdev_label_t my_label;
-      int r = _read_bdev_label(cct, my_bdev, my_path, &my_label);
+      r = _read_bdev_label(cct, my_bdev, my_path, &my_label);
       if (r < 0) {
         derr << "unable to read label for " << my_path << ": "
               << cpp_strerror(r) << dendl;
@@ -9380,7 +9267,9 @@ int BlueStore::expand_devices_online(ostream& out)
                 << std::dec << "(" << byte_u_t(size) << ")"
                 << std::endl;
           }
-          bluefs->expand_device(devid, size, old_size);
+          if (mounted) {
+            bluefs->expand_device(devid, size, old_size);
+          }
         }
       }
     }
@@ -9394,7 +9283,7 @@ int BlueStore::expand_devices_online(ostream& out)
   uint64_t size0 = fm->get_size();
   uint64_t size = bdev->get_size();
   auto aligned_size = p2align(size, min_alloc_size);
-  int r = 0;
+  r = 0;
   if (aligned_size == size0) {
     // no need to expand
     out << devid
@@ -9410,7 +9299,7 @@ int BlueStore::expand_devices_online(ostream& out)
     out << devid
 	<<" : Expanding to 0x" << std::hex << size
 	<< std::dec << "(" << byte_u_t(size) << ")"
-	<< std::endl;  
+	<< std::endl;
     r = _write_out_fm_meta(size);
     if (r != 0) {
       derr << "unable to write out fm meta for " << my_path << ": "
@@ -9428,6 +9317,10 @@ int BlueStore::expand_devices_online(ostream& out)
       }
       r = _write_bdev_label(cct, bdev, my_path,
         bdev_label, bdev_label_valid_locations);
+      if (r != 0) {
+        derr << "unable to write label(s) for " << my_path << ": "
+             << cpp_strerror(r) << dendl;
+      }
     }
     if (r == 0) {
       out << devid
@@ -9435,26 +9328,25 @@ int BlueStore::expand_devices_online(ostream& out)
           << std::dec << "(" << byte_u_t(size) << ")"
           << std::endl;
 
-      // since we are not relying on db open/close to update FM
-      // need to keep FM and the shared allocator in sync now
       fm->expand(aligned_size, db);
       alloc->expand(aligned_size);
       alloc->init_add_free(size0, aligned_size - size0);
-
-      need_to_destage_allocation_file = true;
-      before_expansion_bdev_size = 0;
 
       dout(1) << __func__
               << " : size updated to 0x" << std::hex << size
               << std::dec << "(" << byte_u_t(size) << ")"
               << ", allocator type " << alloc->get_type()
-              << ", capacity 0x" << alloc->get_capacity()
+              << ", capacity 0x" << std::hex << alloc->get_capacity()
               << ", block size 0x" << alloc->get_block_size()
               << ", free 0x" << alloc->get_free()
+              << std::dec
               << ", fragmentation " << alloc->get_fragmentation()
-              << std::dec << dendl;
-
+              << dendl;
     }
+  }
+
+  if (need_to_close) {
+    _close_db_and_around();
   }
   return r;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9323,6 +9323,142 @@ bool BlueStore::get_db_sharding(std::string& res_sharding)
   return ret;
 }
 
+int BlueStore::expand_devices_online(ostream& out)
+{
+  bluefs->dump_block_extents(out);
+  out << "Expanding DB/WAL..." << std::endl;
+
+  // updating dedicated devices first
+  for (auto devid : { BlueFS::BDEV_WAL, BlueFS::BDEV_DB}) {
+    if (devid == bluefs_layout.shared_bdev) {
+      continue;
+    }
+
+    auto my_bdev = bluefs->get_block_device(devid);
+    my_bdev->refresh_size();
+    uint64_t size = my_bdev ? my_bdev->get_size() : 0;
+
+    if (size == 0) {
+      // no bdev
+      continue;
+    }
+    if (my_bdev->supported_bdev_label()) {
+      string my_path = get_device_path(devid);
+      bluestore_bdev_label_t my_label;
+      int r = _read_bdev_label(cct, my_bdev, my_path, &my_label);
+      if (r < 0) {
+        derr << "unable to read label for " << my_path << ": "
+              << cpp_strerror(r) << dendl;
+        continue;
+      } else {
+        if (size == my_label.size) {
+          // no need to expand
+          out << devid
+	      << " : nothing to do, skipped"
+	      << std::endl;
+          continue;
+        } else if (size < my_label.size) {
+          // something weird in bdev label
+          out << devid
+	      <<" : ERROR: bdev label is above device size, skipped"
+	      << std::endl;
+          continue;
+        } else {
+          int64_t old_size = my_label.size;
+          my_label.size = size;
+          out << devid
+	      << " : Expanding to 0x" << std::hex << size
+	      << std::dec << "(" << byte_u_t(size) << ")"
+	      << std::endl;
+          r = _write_bdev_label(cct, my_bdev, my_path, my_label);
+          if (r < 0) {
+            derr << "unable to write label for " << my_path << ": "
+                  << cpp_strerror(r) << dendl;
+          } else {
+            out << devid
+                << " : size updated to 0x" << std::hex << size
+                << std::dec << "(" << byte_u_t(size) << ")"
+                << std::endl;
+          }
+          bluefs->expand_device(devid, size, old_size);
+        }
+      }
+    }
+  }
+  auto devid = bluefs_layout.shared_bdev;
+  // bluestore and bluefs hold separate instances so we need to
+  // refresh both to figure out if there is a new size
+  bluefs->get_block_device(devid)->refresh_size();
+  bdev->refresh_size();
+
+  uint64_t size0 = fm->get_size();
+  uint64_t size = bdev->get_size();
+  auto aligned_size = p2align(size, min_alloc_size);
+  int r = 0;
+  if (aligned_size == size0) {
+    // no need to expand
+    out << devid
+        << " : nothing to do, skipped"
+        << std::endl;
+  } else if (aligned_size < size0) {
+    // something weird in bdev label
+    out << devid
+        << " : ERROR: previous device size is above the current one, skipped"
+	<< std::endl;
+  } else {
+    auto my_path = get_device_path(devid);
+    out << devid
+	<<" : Expanding to 0x" << std::hex << size
+	<< std::dec << "(" << byte_u_t(size) << ")"
+	<< std::endl;  
+    r = _write_out_fm_meta(size);
+    if (r != 0) {
+      derr << "unable to write out fm meta for " << my_path << ": "
+           << cpp_strerror(r) << dendl;
+    } else if (bdev->supported_bdev_label()) {
+      bdev_label.size = size;
+      uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+      for (uint64_t loc : bdev_label_positions) {
+        if ((loc >= size0) && (loc + lsize <= size)) {
+          bdev_label_valid_locations.push_back(loc);
+          if (!bdev_label_multi) {
+            break;
+          }
+        }
+      }
+      r = _write_bdev_label(cct, bdev, my_path,
+        bdev_label, bdev_label_valid_locations);
+    }
+    if (r == 0) {
+      out << devid
+          << " : size updated to 0x" << std::hex << size
+          << std::dec << "(" << byte_u_t(size) << ")"
+          << std::endl;
+
+      // since we are not relying on db open/close to update FM
+      // need to keep FM and the shared allocator in sync now
+      fm->expand(aligned_size, db);
+      alloc->expand(aligned_size);
+      alloc->init_add_free(size0, aligned_size - size0);
+
+      need_to_destage_allocation_file = true;
+      before_expansion_bdev_size = 0;
+
+      dout(1) << __func__
+              << " : size updated to 0x" << std::hex << size
+              << std::dec << "(" << byte_u_t(size) << ")"
+              << ", allocator type " << alloc->get_type()
+              << ", capacity 0x" << alloc->get_capacity()
+              << ", block size 0x" << alloc->get_block_size()
+              << ", free 0x" << alloc->get_free()
+              << ", fragmentation " << alloc->get_fragmentation()
+              << std::dec << dendl;
+
+    }
+  }
+  return r;
+}
+
 int BlueStore::dump_bluefs_sizes(ostream& out)
 {
   int r = _open_db_and_around(true);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9204,11 +9204,8 @@ int BlueStore::expand_devices(ostream& out)
     // from the out-of-space state at DB/shared volume(s)
     // Opening in R/W mode might cause extra space allocation
     // which is effectively a show stopper for volume expansion.
-    r = _open_db_and_around(false);
-    if (r < 0) {
-      derr << __func__ << " failed to open db: " << cpp_strerror(r) << dendl;
-      return r;
-    }
+    r = _open_db_and_around(true);
+    ceph_assert(r == 0);
     need_to_close = true;
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9267,6 +9267,7 @@ int BlueStore::expand_devices(ostream& out)
                 << std::dec << "(" << byte_u_t(size) << ")"
                 << std::endl;
           }
+          ceph_assert(mounted);
           bluefs->expand_device(devid, size, old_size);
         }
       }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9222,6 +9222,9 @@ int BlueStore::expand_devices(ostream& out)
     }
 
     auto my_bdev = bluefs->get_block_device(devid);
+    if (!my_bdev) {
+      continue;
+    }
     my_bdev->refresh_size();
     uint64_t size = my_bdev ? my_bdev->get_size() : 0;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9251,7 +9251,7 @@ int BlueStore::expand_devices(ostream& out)
 	      << std::endl;
           continue;
         } else {
-          int64_t old_size = my_label.size;
+          uint64_t old_size = my_label.size;
           my_label.size = size;
           out << devid
 	      << " : Expanding to 0x" << std::hex << size
@@ -9266,9 +9266,12 @@ int BlueStore::expand_devices(ostream& out)
                 << " : size updated to 0x" << std::hex << size
                 << std::dec << "(" << byte_u_t(size) << ")"
                 << std::endl;
+            // online expand needs to update allocator now
+            // offline does not need this as update will happen
+            // on next open
+            if (!need_to_close)
+              bluefs->expand_device(devid, size, old_size);
           }
-          ceph_assert(mounted);
-          bluefs->expand_device(devid, size, old_size);
         }
       }
     }
@@ -9326,6 +9329,12 @@ int BlueStore::expand_devices(ostream& out)
           << " : size updated to 0x" << std::hex << size
           << std::dec << "(" << byte_u_t(size) << ")"
           << std::endl;
+
+      if (need_to_close) {
+        _close_db_and_around();
+        r = _open_db_and_around(false);
+        ceph_assert(r == 0);
+      }
 
       fm->expand(aligned_size, db);
       alloc->expand(aligned_size);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9328,7 +9328,8 @@ int BlueStore::expand_devices(ostream& out)
 
       fm->expand(aligned_size, db);
       alloc->expand(aligned_size);
-      alloc->init_add_free(size0, aligned_size - size0);
+      uint64_t aligned_size0 = p2roundup(size0, min_alloc_size);
+      alloc->init_add_free(aligned_size0, aligned_size - aligned_size0);
 
       dout(1) << __func__
               << " : size updated to 0x" << std::hex << size

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9267,9 +9267,7 @@ int BlueStore::expand_devices(ostream& out)
                 << std::dec << "(" << byte_u_t(size) << ")"
                 << std::endl;
           }
-          if (mounted) {
-            bluefs->expand_device(devid, size, old_size);
-          }
+          bluefs->expand_device(devid, size, old_size);
         }
       }
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9223,7 +9223,7 @@ int BlueStore::expand_devices(ostream& out)
       continue;
     }
     my_bdev->refresh_size();
-    uint64_t size = my_bdev ? my_bdev->get_size() : 0;
+    uint64_t size = my_bdev->get_size();
 
     if (size == 0) {
       // no bdev
@@ -9266,7 +9266,7 @@ int BlueStore::expand_devices(ostream& out)
                 << " : size updated to 0x" << std::hex << size
                 << std::dec << "(" << byte_u_t(size) << ")"
                 << std::endl;
-            // online expand needs to update allocator now
+            // online expand needs to update BlueFS allocator(s) now
             // offline does not need this as update will happen
             // on next open
             if (!need_to_close)
@@ -9332,14 +9332,22 @@ int BlueStore::expand_devices(ostream& out)
 
       if (need_to_close) {
         _close_db_and_around();
+        //
+        // Mount in read/write to sync expansion changes
+        // and make sure everything is all right.
+        //
+        before_expansion_bdev_size = size0; // preserve orignal size to permit
+                                            // following _db_open_and_around()
+                                            // do some post-init stuff on opened
+                                            // allocator.
         r = _open_db_and_around(false);
         ceph_assert(r == 0);
+      } else {
+        fm->expand(aligned_size, db);
+        alloc->expand(aligned_size);
+        uint64_t aligned_size0 = p2roundup(size0, min_alloc_size);
+        alloc->init_add_free(aligned_size0, aligned_size - aligned_size0);
       }
-
-      fm->expand(aligned_size, db);
-      alloc->expand(aligned_size);
-      uint64_t aligned_size0 = p2roundup(size0, min_alloc_size);
-      alloc->init_add_free(aligned_size0, aligned_size - aligned_size0);
 
       dout(1) << __func__
               << " : size updated to 0x" << std::hex << size

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3207,6 +3207,7 @@ public:
     int id,
     const std::string& path);
   int expand_devices(std::ostream& out);
+  int expand_devices_online(std::ostream& out);
   std::string get_device_path(unsigned id);
 
   bool get_db_sharding(std::string& res_sharding);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3207,7 +3207,6 @@ public:
     int id,
     const std::string& path);
   int expand_devices(std::ostream& out);
-  int expand_devices_online(std::ostream& out);
   std::string get_device_path(unsigned id);
 
   bool get_db_sharding(std::string& res_sharding);

--- a/src/os/bluestore/FreelistManager.h
+++ b/src/os/bluestore/FreelistManager.h
@@ -49,6 +49,7 @@ public:
   virtual uint64_t get_alloc_units() const = 0;
   virtual uint64_t get_alloc_size() const = 0;
 
+  virtual int expand(uint64_t new_size, KeyValueDB* db) = 0;
   virtual void get_meta(uint64_t target_size,
   std::vector<std::pair<std::string, std::string>>*) const = 0;
 

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -56,6 +56,22 @@ public:
     }
   }
   void init_rm_free(uint64_t offset, uint64_t length) override;
+
+  void expand(int64_t new_size) override {
+    std::lock_guard l(PrimaryAllocator::get_lock());
+    int64_t old_size = PrimaryAllocator::get_capacity();
+    ceph_assert(new_size >= old_size);
+
+    if (new_size == old_size) {
+      return;
+    }
+
+    PrimaryAllocator::expand(new_size);
+    if (bmap_alloc) {
+      bmap_alloc->expand(new_size);
+    }
+  }
+
   void shutdown() override {
     std::lock_guard l(PrimaryAllocator::get_lock());
     PrimaryAllocator::_shutdown();


### PR DESCRIPTION
implements support for expanding BlueStore block devices while the OSD is running. The implementation expands allocators and freelist managers in-place rather than recreating them.

ceph tell osd.X bluestore bluefs-bdev-expand

https://tracker.ceph.com/issues/68797


---

I didn't touch any of the tree allocators because I'm assuming I can just update device_size.
There is also a lot of redundant code that I copied from bluestore::expand_devices that I'm working to cleanup.


the way I was testing this locally, 
```
truncate -s 150G dev/osd0/block
truncate -s 50G dev/osd0/block.db

./bin/ceph tell osd.0 bluestore bluefs-bdev-expand
0 : device size 0x3e800000(1000 MiB) : using 0x1900000(25 MiB)
1 : device size 0x40000000(1 GiB) : using 0xe00000(14 MiB)
2 : device size 0x1900000000(100 GiB) : using 0xd9000(868 KiB) : bluefs used 0x0(0 B) : non-bluefs used 0xd9000(868 KiB)
Expanding DB/WAL...
0 : nothing to do, skipped
1 : Expanding to 0xc80000000(50 GiB)
1 : size updated to 0xc80000000(50 GiB)
2 : Expanding to 0x2580000000(150 GiB)
2 : size updated to 0x2580000000(150 GiB)


then checking outputs of 
./bin/ceph tell osd.0 bluestore bluefs device info
{
    "dev": {
        "device": "BDEV_WAL",
        "total": 1048576000,
        "free": 1022361600,
        "bluefs_used": 26214400
    },
    "dev": {
        "device": "BDEV_DB",
        "total": 53687091200,
        "free": 53672411136,
        "bluefs_used": 14680064
    },
    "dev": {
        "device": "BDEV_SLOW",
        "total": 161061273600,
        "free": 161060212736,
        "bluefs_used": 0,
        "bluefs max available": 161059897344
    }
}

./bin/ceph tell osd.0 bluestore bluefs-bdev-expand
```

separately I would run this
```
./bin/unittest_fastbmap_allocator --gtest_filter="TestAllocatorLevel02.test_expand*"
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
