### PR TITLE
doc: Update graphana cert keyname in cephadm/services/monitoring.rst

### DIFF
--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -566,12 +566,16 @@ key/value store. If no certificate is specified, ``cephadm`` generates a
 self-signed certificate during the deployment of the Grafana service. Each
 certificate is specific for the host it was generated on.
 
+. note::
+
+  The config keyname for the Grafana certificate has been changed from ``grafana_crt`` to ``grafana_cert``.
+
 A custom certificate can be configured using the following commands:
 
 .. prompt:: bash #
 
   ceph config-key set mgr/cephadm/{hostname}/grafana_key -i $PWD/key.pem
-  ceph config-key set mgr/cephadm/{hostname}/grafana_crt -i $PWD/certificate.pem
+  ceph config-key set mgr/cephadm/{hostname}/grafana_cert -i $PWD/certificate.pem
 
 Where `hostname` is the hostname for the host where grafana service is deployed.
 


### PR DESCRIPTION

doc: Update Grafana cert key in cephadm/services/monitoring.rst

This updates the documentation to reflect the change of the Grafana certificate config key name from `grafana_crt` to `grafana_cert`. Also adds a note to inform users about this change.

Signed-off-by: Manuel Oetiker <manuel@oetiker.ch>

    Doc update (no ticket needed)
    No impact that needs to be tracked
    Updates relevant documentation
    No tests (documentation only)
