### PR TITLE
mgr/orchestrator/rgw: Introduce dedicated parameter for secondary http frontend port.

### DIFF
--- a/doc/cephadm/services/rgw.rst
+++ b/doc/cephadm/services/rgw.rst
@@ -102,6 +102,42 @@ example spec file:
 	  ``rgw_frontend_extra_args`` into a single space-separated arguments list
 	  which is used to set the value of the ``rgw_frontends`` configuration parameter.
 
+Adding a second port to accept HTTP traffic
+-------------------------------------------
+
+The RGW service specification can be used to configure a second port on the frontend by
+using the ``rgw_frontend_secondary_port`` parameter. This port is defined as an integer
+value and can only be used to accept HTTP traffic when HTTPS traffic is enabled.
+
+Example spec file:
+
+.. code-block:: yaml
+
+    service_type: rgw
+    service_id: foo
+    placement:
+      label: rgw
+      count_per_host: 2
+    spec:
+      rgw_realm: myrealm
+      rgw_zone: myzone
+      rgw_frontend_type: "beast"
+      rgw_frontend_port: 443
+      rgw_frontend_secondary_port: 8080
+      ssl: true
+      generate_cert: true
+
+.. note::
+   ``cephadm`` combines the arguments from the ``spec`` section with those from
+   ``rgw_frontend_extra_args`` into a single space-separated argument list
+   which is used to set the value of the ``rgw_frontends`` configuration parameter.
+
+   If a TCP and an SSL port are also defined within the ``rgw_frontend_extra_args``,
+   the Beast frontend will accept HTTP traffic on both the ``rgw_frontend_secondary_port``
+   and the extra HTTP port defined there, as well as HTTPS traffic on both the
+   ``rgw_frontend_port`` and the extra SSL port defined there.
+
+
 Multisite zones
 ---------------
 
@@ -355,7 +391,7 @@ balancing on a floating virtual IP.
 
 If the RGW service is configured with SSL enabled, then the ingress service
 will use the `ssl` and `verify none` options in the backend configuration.
-Trust verification is disabled because the backends are accessed by IP 
+Trust verification is disabled because the backends are accessed by IP
 address instead of FQDN.
 
 .. image:: ../../images/HAProxy_for_RGW.svg

--- a/doc/cephadm/services/rgw.rst
+++ b/doc/cephadm/services/rgw.rst
@@ -102,6 +102,42 @@ example spec file:
 	  ``rgw_frontend_extra_args`` into a single space-separated arguments list
 	  which is used to set the value of the ``rgw_frontends`` configuration parameter.
 
+Adding a second port to accept HTTP traffic
+-------------------------------------------
+
+The RGW service specification can be used to configure a second port on the frontend by
+using the ``rgw_frontend_secondary_port`` parameter. This port is defined as an integer
+value and can only be used to accept HTTP traffic when HTTPS traffic is enabled.
+
+Example spec file:
+
+.. code-block:: yaml
+
+    service_type: rgw
+    service_id: foo
+    placement:
+      label: rgw
+      count_per_host: 2
+    spec:
+      rgw_realm: myrealm
+      rgw_zone: myzone
+      rgw_frontend_type: "beast"
+      rgw_frontend_port: 443
+      rgw_frontend_secondary_port: 8080
+      ssl: true
+      generate_cert: true
+
+.. note::
+   ``cephadm`` combines the arguments from the ``spec`` section with those from
+   ``rgw_frontend_extra_args`` into a single space-separated argument list
+   which is used to set the value of the ``rgw_frontends`` configuration parameter.
+
+   If a TCP and an SSL port are also defined within the ``rgw_frontend_extra_args``,
+   the Beast frontend will accept HTTP traffic on both the ``rgw_frontend_secondary_port``
+   and the extra HTTP port defined there, as well as HTTPS traffic on both the
+   ``rgw_frontend_port`` and the extra SSL port defined there.
+
+
 Multisite zones
 ---------------
 
@@ -363,7 +399,7 @@ balancing on a floating virtual IP.
 
 If the RGW service is configured with SSL enabled, then the ingress service
 will use the `ssl` and `verify none` options in the backend configuration.
-Trust verification is disabled because the backends are accessed by IP 
+Trust verification is disabled because the backends are accessed by IP
 address instead of FQDN.
 
 .. image:: ../../images/HAProxy_for_RGW.svg

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1553,17 +1553,8 @@ class RgwService(CephService):
 
         keyring = self.get_keyring(rgw_id)
 
-        if daemon_spec.ports:
-            port = daemon_spec.ports[0]
-        else:
-            # this is a redeploy of older instance that doesn't have an explicitly
-            # assigned port, in which case we can assume there is only 1 per host
-            # and it matches the spec.
-            ports = spec.get_port()
-            if spec.ssl:
-                port = ports[1] if len(ports) > 1 else ports[0]
-            else:
-                port = ports[0]
+        port = spec.rgw_frontend_port
+        secondary_port = spec.rgw_frontend_secondary_port
 
         if spec.ssl:
             san_list = spec.zonegroup_hostnames or []
@@ -1598,6 +1589,8 @@ class RgwService(CephService):
             ip_to_bind_to = self.mgr.get_first_matching_network_ip(daemon_spec.host, spec) or ''
             if ip_to_bind_to:
                 daemon_spec.port_ips = {str(port): ip_to_bind_to}
+                if secondary_port is not None:
+                    daemon_spec.port_ips[str(secondary_port)] = ip_to_bind_to
             else:
                 logger.warning(
                     f'Failed to find ip in {spec.networks} for host {daemon_spec.host}. '
@@ -1611,8 +1604,13 @@ class RgwService(CephService):
                 if ip_to_bind_to:
                     args.append(
                         f"ssl_endpoint={build_url(host=ip_to_bind_to, port=port).lstrip('/')}")
+                    if secondary_port is not None:
+                        args.append(
+                            f"endpoint={build_url(host=ip_to_bind_to, port=secondary_port).lstrip('/')}")
                 else:
                     args.append(f"ssl_port={port}")
+                    if secondary_port is not None:
+                        args.append(f"port={secondary_port}")
                 if spec.generate_cert:
                     args.append(f"ssl_certificate=config://rgw/cert/{daemon_spec.name()}")
                 elif not extra_ssl_cert_provided:
@@ -1627,8 +1625,12 @@ class RgwService(CephService):
                 if ip_to_bind_to:
                     # note the 's' suffix on port
                     args.append(f"port={build_url(host=ip_to_bind_to, port=port).lstrip('/')}s")
+                    if secondary_port is not None:
+                        args.append(f"port={build_url(host=ip_to_bind_to, port=secondary_port).lstrip('/')}")
                 else:
                     args.append(f"port={port}s")  # note the 's' suffix on port
+                    if secondary_port is not None:
+                        args.append(f"port={secondary_port}")
                 if spec.generate_cert:
                     args.append(f"ssl_certificate=config://rgw/cert/{daemon_spec.name()}")
                 elif not extra_ssl_cert_provided:
@@ -1883,7 +1885,7 @@ class RgwService(CephService):
 
         ports = set()
         for val in frontend_str.split():
-            if val.startswith("port="):
+            if val.startswith("port=") or val.startswith("ssl_port="):
                 ports.add(int(val.split("=")[1]))
 
         return ports

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1612,17 +1612,9 @@ class RgwService(CephService):
 
         keyring = self.get_keyring(rgw_id)
 
-        if daemon_spec.ports:
-            port = daemon_spec.ports[0]
-        else:
-            # this is a redeploy of older instance that doesn't have an explicitly
-            # assigned port, in which case we can assume there is only 1 per host
-            # and it matches the spec.
-            ports = spec.get_port()
-            if spec.ssl:
-                port = ports[1] if len(ports) > 1 else ports[0]
-            else:
-                port = ports[0]
+        port = spec.rgw_frontend_port
+        secondary_port = spec.rgw_frontend_secondary_port
+
 
         if spec.ssl:
 
@@ -1670,6 +1662,8 @@ class RgwService(CephService):
                 # back to 0.0.0.0 and can false-conflict with listeners on
                 # other addresses.
                 daemon_spec.port_ips.update({str(port): ip_to_bind_to})
+                if secondary_port is not None:
+                    daemon_spec.port_ips.update({str(secondary_port): ip_to_bind_to})
             else:
                 logger.warning(
                     f'Failed to find ip in {spec.networks} for host {daemon_spec.host}. '
@@ -1686,8 +1680,13 @@ class RgwService(CephService):
                 if ip_to_bind_to:
                     args.append(
                         f"ssl_endpoint={build_url(host=ip_to_bind_to, port=port).lstrip('/')}")
+                    if secondary_port is not None:
+                        args.append(
+                            f"endpoint={build_url(host=ip_to_bind_to, port=secondary_port).lstrip('/')}")
                 else:
                     args.append(f"ssl_port={port}")
+                    if secondary_port is not None:
+                        args.append(f"port={secondary_port}")
                 if spec.generate_cert:
                     args.append(f"ssl_certificate=config://rgw/cert/{daemon_spec.name()}")
                 elif not extra_ssl_cert_provided:
@@ -1702,8 +1701,12 @@ class RgwService(CephService):
                 if ip_to_bind_to:
                     # note the 's' suffix on port
                     args.append(f"port={build_url(host=ip_to_bind_to, port=port).lstrip('/')}s")
+                    if secondary_port is not None:
+                        args.append(f"port={build_url(host=ip_to_bind_to, port=secondary_port).lstrip('/')}")
                 else:
                     args.append(f"port={port}s")  # note the 's' suffix on port
+                    if secondary_port is not None:
+                        args.append(f"port={secondary_port}")
                 if spec.generate_cert:
                     args.append(f"ssl_certificate=config://rgw/cert/{daemon_spec.name()}")
                 elif not extra_ssl_cert_provided:
@@ -1964,10 +1967,23 @@ class RgwService(CephService):
 
     def _extract_ports_from_frontend(self, frontend_str: str) -> set[int]:
 
+        ssl_port_match_patterns = [
+            r"(?:ssl_)?port=(\d+)",
+            r"(?:ssl_)?endpoint=\S+:(\d+)",
+        ]
+        port_match_patterns = [
+            r"(?<!ssl_)port=(\d+)",
+            r"(?<!ssl_)endpoint=\S+:(\d+)",
+        ]
         ports = set()
-        for val in frontend_str.split():
-            if val.startswith("port="):
-                ports.add(int(val.split("=")[1]))
+
+        for pattern in ssl_port_match_patterns:
+            for port_str in re.findall(pattern, frontend_str):
+                ports.add(int(port_str))
+
+        for pattern in port_match_patterns:
+            for port_str in re.findall(pattern, frontend_str):
+                ports.add(int(port_str))
 
         return ports
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -311,7 +311,8 @@ class TestCephadm(object):
                             'service_id': 'r.z',
                             'service_name': 'rgw.r.z',
                             'service_type': 'rgw',
-                            'spec': {'rgw_exit_timeout_secs': 120},
+                            'spec': {'rgw_exit_timeout_secs': 120,
+                                     'rgw_frontend_port': 80},
                             'status': {'created': mock.ANY, 'running': 1, 'size': 1,
                                        'ports': [80]},
                         }

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -346,7 +346,8 @@ class TestCephadm(object):
                             'service_id': 'r.z',
                             'service_name': 'rgw.r.z',
                             'service_type': 'rgw',
-                            'spec': {'rgw_exit_timeout_secs': 120},
+                            'spec': {'rgw_exit_timeout_secs': 120,
+                                     'rgw_frontend_port': 80},
                             'status': {'created': mock.ANY, 'running': 1, 'size': 1,
                                        'ports': [80]},
                         }

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -128,6 +128,8 @@ def test_spec_octopus(spec_json):
         j_c.pop('filter_logic', None)
         j_c.pop('anonymous_access', None)
         j_c.pop('rgw_exit_timeout_secs', None)
+        j_c.pop('rgw_frontend_port', None)
+        j_c.pop('rgw_frontend_secondary_port', None)
         return j_c
 
     converted = convert_to_old_style_json(spec.to_json())

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -44,6 +44,7 @@ RGW_DAEMON_SCHEMA = {
     "zonegroup_name": (str, "Zone Group"),
     "zone_name": (str, "Zone"),
     "port": (int, "Port"),
+    "secondary_port": (int, "Secondary Port")
 }
 
 RGW_USER_SCHEMA = {
@@ -325,14 +326,22 @@ class RgwDaemon(RESTController):
                 metadata = service['metadata']
 
                 frontend_config = metadata['frontend_config#0']
-                port_match = re.search(r"port=(\d+)", frontend_config)
+
+                port_match = re.search(r"(?<!ssl_)port=(\d+)", frontend_config) or \
+                    re.search(r"(?<!ssl_)endpoint=\S+:(\d+)", frontend_config)
+
+                ssl_port_match = re.search(r"ssl_port=(\d+)", frontend_config) or \
+                    re.search(r"ssl_endpoint=\S+:(\d+)", frontend_config)
+
                 port = None
-                if port_match:
-                    port = port_match.group(1)
-                else:
-                    match_from_endpoint = re.search(r"endpoint=\S+:(\d+)", frontend_config)
-                    if match_from_endpoint:
-                        port = match_from_endpoint.group(1)
+                secondary_port = None
+
+                if m_ssl := ssl_port_match:
+                    port = m_ssl.group(1)
+                    if m_port := port_match:
+                        secondary_port = m_port.group(1)
+                elif m_port := port_match:
+                    port = m_port.group(1)
 
                 # extract per-daemon service data and health
                 daemon = {
@@ -345,7 +354,8 @@ class RgwDaemon(RESTController):
                     'zonegroup_id': metadata['zonegroup_id'],
                     'zone_name': metadata['zone_name'],
                     'default': instance.daemon.name == metadata['id'],
-                    'port': int(port) if port else None
+                    'port': int(port) if port else None,
+                    'secondary_port': int(secondary_port) if secondary_port else None,
                 }
 
                 daemons.append(daemon)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -481,80 +481,92 @@
       }
 
       <!-- RGW -->
-      @if (
-        !serviceForm.controls.unmanaged.value && serviceForm.controls.service_type.value === 'rgw'
-      ) {
-        <!-- rgw_frontend_port -->
+      @if (!serviceForm.controls.unmanaged.value && serviceForm.controls.service_type.value === 'rgw') {
+      <!-- rgw_frontend_port -->
+      <div class="form-item">
+        <cds-number label="Port"
+                    formControlName="rgw_frontend_port"
+                    id="rgw_frontend_port"
+                    min="1"
+                    max="65535"
+                    helperText="Number of deamons that will be deployed"
+                    i18n-helperText
+                    [invalid]="serviceForm.controls.rgw_frontend_port.invalid && serviceForm.controls.rgw_frontend_port.dirty"
+                    [invalidText]="invalidRgwFrontendPortError">
+        </cds-number>
+        <ng-template #invalidRgwFrontendPortError>
+          @if (serviceForm.showError('rgw_frontend_port', frm, 'min')) {
+          <span class="invalid-feedback"
+                i18n>The value must be at least 1.</span>
+          }
+          @if (serviceForm.showError('rgw_frontend_port', frm, 'max')) {
+          <span class="invalid-feedback"
+                i18n>The value cannot exceed 65535.</span>
+          }
+        </ng-template>
+      </div>
+        @if (serviceForm.controls.ssl.value) {
+        <!-- rgw_frontend_secondary_port -->
         <div class="form-item">
-          <cds-number
-            label="Port"
-            formControlName="rgw_frontend_port"
-            id="rgw_frontend_port"
-            min="1"
-            max="65535"
-            helperText="Number of deamons that will be deployed"
-            i18n-helperText
-            [invalid]="
-              serviceForm.controls.rgw_frontend_port.invalid &&
-              serviceForm.controls.rgw_frontend_port.dirty
-            "
-            [invalidText]="invalidRgwFrontendPortError"
-          >
+          <cds-number label="Secondary port"
+                      formControlName="rgw_frontend_secondary_port"
+                      id="rgw_frontend_secondary_port"
+                      min="1"
+                      max="65535"
+                      [invalid]="serviceForm.controls.rgw_frontend_secondary_port.invalid && serviceForm.controls.rgw_frontend_secondary_port.dirty"
+                      [invalidText]="invalidRgwFrontendSecondaryPortError">
           </cds-number>
-          <ng-template #invalidRgwFrontendPortError>
-            @if (serviceForm.showError('rgw_frontend_port', frm, 'min')) {
-              <span
-                class="invalid-feedback"
-                i18n
-                >The value must be at least 1.</span
-              >
+          <ng-template #invalidRgwFrontendSecondaryPortError>
+            @if (serviceForm.showError('rgw_frontend_secondary_port', frm, 'pattern')) {
+            <span class="invalid-feedback"
+                  i18n>The entered value needs to be a number.</span>
             }
-            @if (serviceForm.showError('rgw_frontend_port', frm, 'max')) {
-              <span
-                class="invalid-feedback"
-                i18n
-                >The value cannot exceed 65535.</span
-              >
+            @if (serviceForm.showError('rgw_frontend_secondary_port', frm, 'min')) {
+            <span class="invalid-feedback"
+                  i18n>The value must be at least 1.</span>
+            }
+            @if (serviceForm.showError('rgw_frontend_secondary_port', frm, 'max')) {
+            <span class="invalid-feedback"
+                  i18n>The value cannot exceed 65535.</span>
+            }
+            @if (serviceForm.showError('rgw_frontend_secondary_port', frm, 'donotmatch')) {
+            <span class="invalid-feedback"
+                  i18n>Port and Secondary port cannot have the same value.</span>
             }
           </ng-template>
         </div>
+        }
+      }
 
-        @if (!rgwModuleEnabled) {
-          <cd-alert-panel
-            type="warning"
-            spacingClass="mb-3"
-            actionName="Enable"
-            (action)="enableRgwModule()"
-            i18n-actionName
-            i18n
-          >
-            The RGW mgr module must be enabled to configure S3 hostnames. Enabling the module will
-            cause temporary manager downtime while it loads.
-          </cd-alert-panel>
-        }
-        <div class="form-item">
-          <cds-checkbox
-            i18n-label
-            formControlName="virtual_host_enabled"
-          >
-            Enable virtual-host style bucket access
-            <cd-help-text i18n>
-              Allows bucket access via hostnames such as mybucket.s3.example.com.
-            </cd-help-text>
-          </cds-checkbox>
-        </div>
-        @if (serviceForm.controls.virtual_host_enabled.value) {
-          <div class="form-item">
-            <cd-text-label-list
-              formControlName="zonegroup_hostnames"
-              label="S3 hostname"
-              i18n-label
-              helperText="Domain names for S3 virtual-host bucket access (e.g., s3.example.com). Enables bucket URLs like bucket.s3.example.com instead of s3.example.com/bucket."
-              i18n-helperText
-            >
-            </cd-text-label-list>
-          </div>
-        }
+      @if (!rgwModuleEnabled) {
+      <cd-alert-panel type="warning"
+                      spacingClass="mb-3"
+                      actionName="Enable"
+                      (action)="enableRgwModule()"
+                      i18n-actionName
+                      i18n>
+        The RGW mgr module must be enabled to configure S3 hostnames.
+        Enabling the module will cause temporary manager downtime while it loads.
+      </cd-alert-panel>
+      }
+      <div class="form-item">
+        <cds-checkbox i18n-label
+                      formControlName="virtual_host_enabled">
+          Enable virtual-host style bucket access
+          <cd-help-text i18n>
+            Allows bucket access via hostnames such as mybucket.s3.example.com.
+          </cd-help-text>
+        </cds-checkbox>
+      </div>
+      @if (serviceForm.controls.virtual_host_enabled.value) {
+      <div class="form-item">
+        <cd-text-label-list formControlName="zonegroup_hostnames"
+                            label="S3 hostname"
+                            i18n-label
+                            helperText="Domain names for S3 virtual-host bucket access (e.g., s3.example.com). Enables bucket URLs like bucket.s3.example.com instead of s3.example.com/bucket."
+                            i18n-helperText>
+        </cd-text-label-list>
+      </div>
       }
 
       <!-- iSCSI -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -493,7 +493,7 @@
             id="rgw_frontend_port"
             min="1"
             max="65535"
-            helperText="Port on which the service listens for client requests."
+            helperText="Port on which the service listens for HTTP or HTTPS client requests."
             i18n-helperText
             [invalid]="
               serviceForm.controls.rgw_frontend_port.invalid &&
@@ -520,51 +520,84 @@
           </ng-template>
         </div>
 
-        @if (!rgwModuleEnabled) {
-          <cd-alert-panel
-            type="warning"
-            spacingClass="mb-3"
-            actionName="Enable"
-            (action)="enableRgwModule()"
-            i18n-actionName
-            i18n
-          >
-            The RGW mgr module must be enabled to configure S3 hostnames. Enabling the module will
-            cause temporary manager downtime while it loads.
-          </cd-alert-panel>
-        }
-        <div class="form-item">
-          <cds-checkbox
-            i18n-label
-            formControlName="virtual_host_enabled"
-          >
-            Enable virtual-host style bucket access
-            @if (realmList.length === 0) {
-              <cd-help-text i18n>
-                Requires a multisite realm, zonegroup, and zone. Create a realm to enable
-                virtual-host style bucket access.
-              </cd-help-text>
-            } @else {
-              <cd-help-text i18n>
-                Allows bucket access via hostnames such as mybucket.s3.example.com.
-              </cd-help-text>
-            }
-          </cds-checkbox>
-        </div>
-        @if (serviceForm.controls.virtual_host_enabled.value) {
+        @if (serviceForm.controls.ssl.value) {
+          <!-- rgw_frontend_secondary_port -->
           <div class="form-item">
-            <cd-text-label-list
-              formControlName="zonegroup_hostnames"
-              label="S3 hostname"
-              i18n-label
-              helperText="Domain names for S3 virtual-host bucket access (e.g., s3.example.com). Enables bucket URLs like bucket.s3.example.com instead of s3.example.com/bucket."
+            <cds-number
+              label="Secondary Port"
+              formControlName="rgw_frontend_secondary_port"
+              id="rgw_frontend_secondary_port"
+              min="1"
+              max="65535"
+              helperText="Port on which the service listens for HTTP client requests."
               i18n-helperText
-            >
-            </cd-text-label-list>
+              [invalid]="
+                serviceForm.controls.rgw_frontend_secondary_port.invalid &&
+                serviceForm.controls.rgw_frontend_secondary_port.dirty
+              "
+              [invalidText]="invalidRgwFrontendSecondaryPortError">
+            </cds-number>
+            <ng-template #invalidRgwFrontendSecondaryPortError>
+              @if (serviceForm.showError('rgw_frontend_secondary_port', frm, 'min')) {
+              <span class="invalid-feedback"
+                    i18n>The value must be at least 1.</span>
+              }
+              @if (serviceForm.showError('rgw_frontend_secondary_port', frm, 'max')) {
+              <span class="invalid-feedback"
+                    i18n>The value cannot exceed 65535.</span>
+              }
+              @if (serviceForm.showError('rgw_frontend_secondary_port', frm, 'donotmatch')) {
+              <span class="invalid-feedback"
+                    i18n>Port and Secondary Port cannot have the same value.</span>
+              }
+            </ng-template>
           </div>
         }
-      }
 
+        @if (!rgwModuleEnabled) {
+         <cd-alert-panel
+           type="warning"
+           spacingClass="mb-3"
+           actionName="Enable"
+           (action)="enableRgwModule()"
+           i18n-actionName
+           i18n
+         >
+           The RGW mgr module must be enabled to configure S3 hostnames. Enabling the module will
+           cause temporary manager downtime while it loads.
+         </cd-alert-panel>
+         }
+      }
+      <div class="form-item">
+         <cds-checkbox
+          i18n-label
+          formControlName="virtual_host_enabled"
+        >
+          Enable virtual-host style bucket access
+          @if (realmList.length === 0) {
+            <cd-help-text i18n>
+              Requires a multisite realm, zonegroup, and zone. Create a realm to enable
+              virtual-host style bucket access.
+            </cd-help-text>
+          } @else {
+            <cd-help-text i18n>
+              Allows bucket access via hostnames such as mybucket.s3.example.com.
+            </cd-help-text>
+          }
+        </cds-checkbox>
+      </div>
+      @if (serviceForm.controls.virtual_host_enabled.value) {
+        <div class="form-item">
+          <cd-text-label-list
+            formControlName="zonegroup_hostnames"
+            label="S3 hostname"
+            i18n-label
+            helperText="Domain names for S3 virtual-host bucket access (e.g., s3.example.com). Enables bucket URLs like bucket.s3.example.com instead of s3.example.com/bucket."
+            i18n-helperText
+          >
+          </cd-text-label-list>
+        </div>
+      }
       <!-- iSCSI -->
       <!-- pool -->
       @if (serviceForm.controls.service_type.value === 'iscsi') {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -355,6 +355,64 @@ describe('ServiceFormComponent', () => {
         formHelper.expectError('rgw_frontend_port', 'pattern');
       });
 
+      it('should submit rgw with port, secondary port and ssl enabled', () => {
+        formHelper.setValue('rgw_frontend_port', 1234);
+        formHelper.setValue('rgw_frontend_secondary_port', 1235);
+        formHelper.setValue('ssl', true);
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'rgw',
+          service_id: 'svc',
+          rgw_realm: null,
+          rgw_zone: null,
+          rgw_zonegroup: null,
+          placement: {},
+          unmanaged: false,
+          rgw_frontend_port: 1234,
+          rgw_frontend_secondary_port: 1235,
+          certificate_source: 'cephadm-signed',
+          ssl: true
+        });
+      });
+
+      it('should submit valid rgw secondary port (1)', () => {
+        formHelper.setValue('rgw_frontend_secondary_port', 1);
+        component.onSubmit();
+        formHelper.expectValid('rgw_frontend_secondary_port');
+      });
+
+      it('should submit valid rgw secondary port (2)', () => {
+        formHelper.setValue('rgw_frontend_secondary_port', 65535);
+        component.onSubmit();
+        formHelper.expectValid('rgw_frontend_secondary_port');
+      });
+
+      it('should submit invalid rgw secondary port (1)', () => {
+        formHelper.setValue('rgw_frontend_secondary_port', 0);
+        fixture.detectChanges();
+        formHelper.expectError('rgw_frontend_secondary_port', 'min');
+      });
+
+      it('should submit invalid rgw secondary port (2)', () => {
+        formHelper.setValue('rgw_frontend_secondary_port', 65536);
+        fixture.detectChanges();
+        formHelper.expectError('rgw_frontend_secondary_port', 'max');
+      });
+
+      it('should submit invalid rgw secondary port (3)', () => {
+        formHelper.setValue('rgw_frontend_secondary_port', 'abc');
+        component.onSubmit();
+        formHelper.expectError('rgw_frontend_secondary_port', 'pattern');
+      });
+
+      it('should submit invalid rgw when ssl is enabled and frontend_port and secondary_port are the same', () => {
+        formHelper.setValue('rgw_frontend_port', 1234);
+        formHelper.setValue('rgw_frontend_secondary_port', 1234);
+        formHelper.setValue('ssl', true);
+        component.onSubmit();
+        formHelper.expectError('rgw_frontend_secondary_port', 'donotmatch');
+      });
+
       it('should submit rgw w/o port', () => {
         formHelper.setValue('ssl', false);
         component.onSubmit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -111,6 +111,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   smbFeaturesList = ['domain'];
   currentURL: string;
   port: number = 443;
+  secondary_port: number = 8080;
   sslProtocolsItems: Array<ListItem> = Object.values(SSL_PROTOCOLS).map((protocol) => ({
     content: protocol,
     selected: true
@@ -305,6 +306,10 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [CdValidators.number(false), Validators.min(1), Validators.max(65535)]
       ],
+      rgw_frontend_secondary_port: [
+        null,
+        [CdValidators.number(false), Validators.min(1), Validators.max(65535)]
+      ],
       realm_name: [null],
       zonegroup_name: [null],
       zone_name: [null],
@@ -353,29 +358,48 @@ export class ServiceFormComponent extends CdForm implements OnInit {
           CdValidators.composeIf(
             {
               service_type: 'smb'
-            },
-            [
-              Validators.required,
-              CdValidators.custom('configUriPattern', (value: string) => {
-                if (_.isEmpty(value)) {
-                  return false;
-                }
-                return !this.SMB_CONFIG_URI_PATTERN.test(value);
-              })
-            ]
-          )
-        ]
-      ],
-      custom_dns: [null],
-      join_sources: [null],
-      user_sources: [null],
-      include_ceph_users: [null],
-      // Ingress
-      backend_service: [
-        null,
-        [
+            }),
+            CdValidators.composeIf(
+              {
+                service_type: 'rgw'
+              },
+              [Validators.required]
+            ),
+            CdValidators.custom('uniqueName', (service_id: string) => {
+              return this.serviceIds && this.serviceIds.includes(service_id);
+            })
+          ]
+        ],
+        placement: ['hosts'],
+        label: [
+          null,
+          [
+            CdValidators.requiredIf({
+              placement: 'label',
+              unmanaged: false
+            })
+          ]
+        ],
+        hosts: [[]],
+        count: [null, [CdValidators.number(false), Validators.min(1)]],
+        unmanaged: [false],
+        // iSCSI
+        // NVMe/TCP
+        pool: [
+          null,
+          [
+            CdValidators.requiredIf({
+              service_type: 'iscsi'
+            }),
+            CdValidators.requiredIf({
+              service_type: 'nvmeof'
+            })
+          ]
+        ],
+        group: [
+          'default',
           CdValidators.requiredIf({
-            service_type: 'ingress'
+            service_type: 'nvmeof'
           })
         ]
       ],
@@ -561,119 +585,132 @@ export class ServiceFormComponent extends CdForm implements OnInit {
           validators: [
             CdValidators.requiredIf({
               service_type: 'snmp-gateway'
+            })
+          ]
+        ],
+        snmp_destination: [
+          null,
+          {
+            validators: [
+              CdValidators.requiredIf({
+                service_type: 'snmp-gateway'
+              }),
+              CdValidators.custom('snmpDestinationPattern', (value: string) => {
+                if (_.isEmpty(value)) {
+                  return false;
+                }
+                return !this.SNMP_DESTINATION_PATTERN.test(value);
+              })
+            ]
+          }
+        ],
+        engine_id: [
+          null,
+          [
+            CdValidators.requiredIf({
+              snmp_version: 'V3'
             }),
-            CdValidators.custom('snmpDestinationPattern', (value: string) => {
+            CdValidators.custom('snmpEngineIdPattern', (value: string) => {
               if (_.isEmpty(value)) {
                 return false;
               }
-              return !this.SNMP_DESTINATION_PATTERN.test(value);
+              return !this.SNMP_ENGINE_ID_PATTERN.test(value);
             })
           ]
-        }
-      ],
-      engine_id: [
-        null,
-        [
-          CdValidators.requiredIf({
-            snmp_version: 'V3'
-          }),
-          CdValidators.custom('snmpEngineIdPattern', (value: string) => {
-            if (_.isEmpty(value)) {
-              return false;
-            }
-            return !this.SNMP_ENGINE_ID_PATTERN.test(value);
-          })
-        ]
-      ],
-      auth_protocol: [
-        'SHA',
-        [
-          CdValidators.requiredIf({
-            snmp_version: 'V3'
-          })
-        ]
-      ],
-      privacy_protocol: [null],
-      snmp_community: [
-        null,
-        [
-          CdValidators.requiredIf({
-            snmp_version: 'V2c'
-          })
-        ]
-      ],
-      snmp_v3_auth_username: [
-        null,
-        [
-          CdValidators.requiredIf({
-            snmp_version: 'V3'
-          })
-        ]
-      ],
-      snmp_v3_auth_password: [
-        null,
-        [
-          CdValidators.requiredIf({
-            snmp_version: 'V3'
-          })
-        ]
-      ],
-      snmp_v3_priv_password: [
-        null,
-        [
-          CdValidators.requiredIf({
-            privacy_protocol: { op: '!empty' }
-          })
-        ]
-      ],
-      grafana_port: [null, [CdValidators.number(false)]],
-      grafana_admin_password: [null],
-      // oauth2-proxy
-      provider_display_name: [
-        'My OIDC provider',
-        [
-          CdValidators.requiredIf({
-            service_type: 'oauth2-proxy'
-          })
-        ]
-      ],
-      client_id: [
-        null,
-        [
-          CdValidators.requiredIf({
-            service_type: 'oauth2-proxy'
-          })
-        ]
-      ],
-      client_secret: [
-        null,
-        [
-          CdValidators.requiredIf({
-            service_type: 'oauth2-proxy'
-          })
-        ]
-      ],
-      oidc_issuer_url: [
-        null,
-        [
-          CdValidators.requiredIf({
-            service_type: 'oauth2-proxy'
-          }),
-          CdValidators.custom('validUrl', (url: string) => {
-            if (_.isEmpty(url)) {
-              return false;
-            }
-            return !this.OAUTH2_ISSUER_URL_PATTERN.test(url);
-          })
-        ]
-      ],
-      https_address: [null, [CdValidators.oauthAddressTest()]],
-      redirect_url: [null],
-      scope: [null],
-      email_domains: [null],
-      allowlist_domains: [null],
-      ssl_insecure_skip_verify: [false]
-    });
+        ],
+        auth_protocol: [
+          'SHA',
+          [
+            CdValidators.requiredIf({
+              snmp_version: 'V3'
+            })
+          ]
+        ],
+        privacy_protocol: [null],
+        snmp_community: [
+          null,
+          [
+            CdValidators.requiredIf({
+              snmp_version: 'V2c'
+            })
+          ]
+        ],
+        snmp_v3_auth_username: [
+          null,
+          [
+            CdValidators.requiredIf({
+              snmp_version: 'V3'
+            })
+          ]
+        ],
+        snmp_v3_auth_password: [
+          null,
+          [
+            CdValidators.requiredIf({
+              snmp_version: 'V3'
+            })
+          ]
+        ],
+        snmp_v3_priv_password: [
+          null,
+          [
+            CdValidators.requiredIf({
+              privacy_protocol: { op: '!empty' }
+            })
+          ]
+        ],
+        grafana_port: [null, [CdValidators.number(false)]],
+        grafana_admin_password: [null],
+        // oauth2-proxy
+        provider_display_name: [
+          'My OIDC provider',
+          [
+            CdValidators.requiredIf({
+              service_type: 'oauth2-proxy'
+            })
+          ]
+        ],
+        client_id: [
+          null,
+          [
+            CdValidators.requiredIf({
+              service_type: 'oauth2-proxy'
+            })
+          ]
+        ],
+        client_secret: [
+          null,
+          [
+            CdValidators.requiredIf({
+              service_type: 'oauth2-proxy'
+            })
+          ]
+        ],
+        oidc_issuer_url: [
+          null,
+          [
+            CdValidators.requiredIf({
+              service_type: 'oauth2-proxy'
+            }),
+            CdValidators.custom('validUrl', (url: string) => {
+              if (_.isEmpty(url)) {
+                return false;
+              }
+              return !this.OAUTH2_ISSUER_URL_PATTERN.test(url);
+            })
+          ]
+        ],
+        https_address: [null, [CdValidators.oauthAddressTest()]],
+        redirect_url: [null],
+        scope: [null],
+        email_domains: [null],
+        allowlist_domains: [null],
+        ssl_insecure_skip_verify: [false]
+      },
+      {
+        validators: [CdValidators.donotmatch('rgw_frontend_port', 'rgw_frontend_secondary_port')]
+      }
+    );
   }
 
   resolveRoute() {
@@ -818,6 +855,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               this.serviceForm
                 .get('rgw_frontend_port')
                 .setValue(response[0].spec?.rgw_frontend_port);
+              this.serviceForm
+                .get('rgw_frontend_secondary_port')
+                .setValue(response[0].spec?.rgw_frontend_secondary_port);
               this.setRgwFields(
                 response[0].spec?.rgw_realm,
                 response[0].spec?.rgw_zonegroup,
@@ -1630,6 +1670,12 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         case 'rgw':
           if (_.isNumber(values['rgw_frontend_port']) && values['rgw_frontend_port'] > 0) {
             serviceSpec['rgw_frontend_port'] = values['rgw_frontend_port'];
+          }
+          if (
+            _.isNumber(values['rgw_frontend_secondary_port']) &&
+            values['rgw_frontend_secondary_port'] > 0
+          ) {
+            serviceSpec['rgw_frontend_secondary_port'] = values['rgw_frontend_secondary_port'];
           }
           serviceSpec['ssl'] = values['ssl'];
           if (values['virtual_host_enabled'] && values['zonegroup_hostnames']?.length > 0) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -113,6 +113,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   smbFeaturesList = ['domain'];
   currentURL: string;
   port: number = 443;
+  secondary_port: number = 8080;
   sslProtocolsItems: Array<ListItem> = Object.values(SSL_PROTOCOLS).map((protocol) => ({
     content: protocol,
     selected: true
@@ -304,6 +305,10 @@ export class ServiceFormComponent extends CdForm implements OnInit {
       ],
       // RGW
       rgw_frontend_port: [
+        null,
+        [CdValidators.number(false), Validators.min(1), Validators.max(65535)]
+      ],
+      rgw_frontend_secondary_port: [
         null,
         [CdValidators.number(false), Validators.min(1), Validators.max(65535)]
       ],
@@ -675,6 +680,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
       email_domains: [null],
       allowlist_domains: [null],
       ssl_insecure_skip_verify: [false]
+    },
+    {
+        validators: [CdValidators.donotmatch('rgw_frontend_port', 'rgw_frontend_secondary_port')]
     });
   }
 
@@ -820,6 +828,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
               this.serviceForm
                 .get('rgw_frontend_port')
                 .setValue(response[0].spec?.rgw_frontend_port);
+              this.serviceForm
+                .get('rgw_frontend_secondary_port')
+                .setValue(response[0].spec?.rgw_frontend_secondary_port);
               this.setRgwFields(
                 response[0].spec?.rgw_realm,
                 response[0].spec?.rgw_zonegroup,
@@ -1638,6 +1649,12 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         case 'rgw':
           if (_.isNumber(values['rgw_frontend_port']) && values['rgw_frontend_port'] > 0) {
             serviceSpec['rgw_frontend_port'] = values['rgw_frontend_port'];
+          }
+          if (
+            _.isNumber(values['rgw_frontend_secondary_port']) &&
+            values['rgw_frontend_secondary_port'] > 0
+          ) {
+            serviceSpec['rgw_frontend_secondary_port'] = values['rgw_frontend_secondary_port'];
           }
           serviceSpec['ssl'] = values['ssl'];
           if (values['virtual_host_enabled'] && values['zonegroup_hostnames']?.length > 0) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
@@ -9,4 +9,5 @@ export class RgwDaemon {
   zone_name: string;
   default: boolean;
   port: number;
+  secondary_port?: number;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
@@ -9,6 +9,7 @@ export class RgwDaemon {
   zone_name: string;
   default: boolean;
   port: number;
+  secondary_port?: number;
 }
 
 export interface RgwDaemonDetailsResponse {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -346,7 +346,7 @@ export class CdValidators {
    *   on the `path2` control.
    */
   static match(path1: string, path2: string): ValidatorFn {
-    return (control: AbstractControl): { [key: string]: any } => {
+    return (control: AbstractControl): { [key: string]: any } | null => {
       const ctrl1 = control.get(path1);
       const ctrl2 = control.get(path2);
       if (!ctrl1 || !ctrl2) {
@@ -366,6 +366,69 @@ export class CdValidators {
           ctrl2.setErrors(_.isEmpty(_.keys(errors)) ? null : errors);
         }
       }
+      return null;
+    };
+  }
+
+  /**
+   * Validator factory that requires both specified controls to have different values.
+   * Errors will be added directly to the `path2` control instead of the parent group.
+   * @param {string} path1 A dot-delimited string that defines the path to the first control.
+   * @param {string} path2 A dot-delimited string that defines the path to the second control.
+   * @param {string} [serviceTypePath] Optional dot-delimited string that defines the path to the service type control.
+   * @param {string} [sslPath] Optional dot-delimited string that defines the path to the SSL control.
+   * @return {ValidatorFn} Returns an Angular ValidatorFn. The function itself evaluates to `null`
+   * for the target control group, while setting or clearing the `donotmatch` error map on `path2`.
+   */
+  static donotmatch(
+    path1: string,
+    path2: string,
+    serviceTypePath?: string,
+    sslPath?: string
+  ): ValidatorFn {
+    return (control: AbstractControl): { [key: string]: any } | null => {
+      const ctrl1 = control.get(path1);
+      const ctrl2 = control.get(path2);
+
+      if (!ctrl1 || !ctrl2) {
+        return null;
+      }
+
+      const clearDoNotMatchError = () => {
+         const hasError = ctrl2.hasError('donotmatch');
+         if (hasError) {
+            // Remove the 'donotmatch' error. If no more errors exist, then set
+            // the error value to 'null', otherwise the field is still marked
+            // as invalid.
+            const errors = ctrl2.errors;
+            _.unset(errors, 'donotmatch');
+            ctrl2.setErrors(_.isEmpty(_.keys(errors)) ? null : errors);
+          }
+        };
+
+      // Copilot Condition: Only evaluate if serviceTypePath and sslPath are provided.
+      // If the service is not RGW, or SSL is disabled, skip validation and clear stale errors.
+      if (serviceTypePath && sslPath) {
+        const serviceType = control.get(serviceTypePath)?.value;
+        const ssl = control.get(sslPath)?.value;
+
+        if (serviceType !== 'rgw' || !ssl) {
+          clearDoNotMatchError();
+          return null;
+        }
+      }
+
+      if (isEmptyInputValue(ctrl1.value) || isEmptyInputValue(ctrl2.value)) {
+         clearDoNotMatchError();
+         return null;
+       }
+
+      if (ctrl1.value === ctrl2.value) {
+        ctrl2.setErrors({ donotmatch: true });
+      } else {
+        clearDoNotMatchError();
+      }
+
       return null;
     };
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -415,7 +415,7 @@ export class CdValidators {
    *   on the `path2` control.
    */
   static match(path1: string, path2: string): ValidatorFn {
-    return (control: AbstractControl): { [key: string]: any } => {
+    return (control: AbstractControl): { [key: string]: any } | null => {
       const ctrl1 = control.get(path1);
       const ctrl2 = control.get(path2);
       if (!ctrl1 || !ctrl2) {
@@ -435,6 +435,69 @@ export class CdValidators {
           ctrl2.setErrors(_.isEmpty(_.keys(errors)) ? null : errors);
         }
       }
+      return null;
+    };
+  }
+
+  /**
+   * Validator factory that requires both specified controls to have different values.
+   * Errors will be added directly to the `path2` control instead of the parent group.
+   * @param {string} path1 A dot-delimited string that defines the path to the first control.
+   * @param {string} path2 A dot-delimited string that defines the path to the second control.
+   * @param {string} [serviceTypePath] Optional dot-delimited string that defines the path to the service type control.
+   * @param {string} [sslPath] Optional dot-delimited string that defines the path to the SSL control.
+   * @return {ValidatorFn} Returns an Angular ValidatorFn. The function itself evaluates to `null`
+   * for the target control group, while setting or clearing the `donotmatch` error map on `path2`.
+   */
+  static donotmatch(
+    path1: string,
+    path2: string,
+    serviceTypePath?: string,
+    sslPath?: string
+  ): ValidatorFn {
+    return (control: AbstractControl): { [key: string]: any } | null => {
+      const ctrl1 = control.get(path1);
+      const ctrl2 = control.get(path2);
+
+      if (!ctrl1 || !ctrl2) {
+        return null;
+      }
+
+      const clearDoNotMatchError = () => {
+         const hasError = ctrl2.hasError('donotmatch');
+         if (hasError) {
+            // Remove the 'donotmatch' error. If no more errors exist, then set
+            // the error value to 'null', otherwise the field is still marked
+            // as invalid.
+            const errors = ctrl2.errors;
+            _.unset(errors, 'donotmatch');
+            ctrl2.setErrors(_.isEmpty(_.keys(errors)) ? null : errors);
+          }
+        };
+
+      // Copilot Condition: Only evaluate if serviceTypePath and sslPath are provided.
+      // If the service is not RGW, or SSL is disabled, skip validation and clear stale errors.
+      if (serviceTypePath && sslPath) {
+        const serviceType = control.get(serviceTypePath)?.value;
+        const ssl = control.get(sslPath)?.value;
+
+        if (serviceType !== 'rgw' || !ssl) {
+          clearDoNotMatchError();
+          return null;
+        }
+      }
+
+      if (isEmptyInputValue(ctrl1.value) || isEmptyInputValue(ctrl2.value)) {
+         clearDoNotMatchError();
+         return null;
+       }
+
+      if (ctrl1.value === ctrl2.value) {
+        ctrl2.setErrors({ donotmatch: true });
+      } else {
+        clearDoNotMatchError();
+      }
+
       return null;
     };
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -70,6 +70,7 @@ export interface CephServiceAdditionalSpec {
   api_port: number;
   api_secure: boolean;
   rgw_frontend_port: number;
+  rgw_frontend_secondary_port: number;
   trusted_ip_list: string[];
   virtual_ip: string;
   frontend_port: number;

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -19527,6 +19527,9 @@ paths:
                     port:
                       description: Port
                       type: integer
+                    secondary_port:
+                      description: Secondary Port
+                      type: integer
                     server_hostname:
                       description: ''
                       type: string
@@ -19547,6 +19550,7 @@ paths:
                 - zonegroup_name
                 - zone_name
                 - port
+                - secondary_port
                 type: array
             application/vnd.ceph.api.v1.0+json:
               schema:
@@ -19557,6 +19561,9 @@ paths:
                       type: string
                     port:
                       description: Port
+                      type: integer
+                    secondary_port:
+                      description: Secondary Port
                       type: integer
                     server_hostname:
                       description: ''

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -20487,6 +20487,9 @@ paths:
                     port:
                       description: Port
                       type: integer
+                    secondary_port:
+                      description: Secondary Port
+                      type: integer
                     server_hostname:
                       description: ''
                       type: string
@@ -20507,6 +20510,7 @@ paths:
                 - zonegroup_name
                 - zone_name
                 - port
+                - secondary_port
                 type: array
             application/vnd.ceph.api.v1.0+json:
               schema:
@@ -20517,6 +20521,9 @@ paths:
                       type: string
                     port:
                       description: Port
+                      type: integer
+                    secondary_port:
+                      description: Secondary Port
                       type: integer
                     server_hostname:
                       description: ''

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -85,7 +85,8 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 {'id': '5356', 'type': 'rgw'},
                 {'id': '5357', 'type': 'rgw'},
                 {'id': '5358', 'type': 'rgw'},
-                {'id': '5359', 'type': 'rgw'}
+                {'id': '5359', 'type': 'rgw'},
+                {'id': '5360', 'type': 'rgw'}
             ]
         }]
         mgr.get_metadata.side_effect = [
@@ -135,6 +136,16 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'zone_name': 'zone5',
                 'frontend_config#0':
                     'beast endpoint=0.0.0.0:8445 ssl_certificate=config:/config'
+            },
+            {
+                'ceph_version': 'ceph version master (dev)',
+                'id': 'daemon6',
+                'realm_name': 'realm6',
+                'zonegroup_name': 'zg6',
+                'zonegroup_id': 'zg6-id',
+                'zone_name': 'zone6',
+                'frontend_config#0':
+                    'beast port=8081 ssl_port=8443 ssl_certificate=config:/config'
             }, ]
         self._get('/test/api/rgw/daemon')
         self.assertStatus(200)
@@ -147,7 +158,9 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zonegroup_name': 'zg1',
             'zonegroup_id': 'zg1-id',
             'zone_name': 'zone1', 'default': True,
-            'port': 80
+            'port': 80,
+            'secondary_port': None
+
         },
             {
             'id': 'daemon2',
@@ -160,6 +173,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zone_name': 'zone2',
             'default': False,
             'port': 443,
+            'secondary_port': None,
         },
             {
             'id': 'daemon3',
@@ -172,6 +186,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zone_name': 'zone3',
             'default': False,
             'port': 8080,
+            'secondary_port': None,
         },
             {
             'id': 'daemon4',
@@ -184,6 +199,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zone_name': 'zone4',
             'default': False,
             'port': None,
+            'secondary_port': None,
         },
             {
             'id': 'daemon5',
@@ -196,6 +212,20 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zone_name': 'zone5',
             'default': False,
             'port': 8445,
+            'secondary_port': None,
+        },
+            {
+            'id': 'daemon6',
+            'service_map_id': '5360',
+            'version': 'ceph version master (dev)',
+            'server_hostname': 'host1',
+            'realm_name': 'realm6',
+            'zonegroup_name': 'zg6',
+            'zonegroup_id': 'zg6-id',
+            'zone_name': 'zone6',
+            'default': False,
+            'port': 8443,
+            'secondary_port': 8081,
         }])
 
     def test_list_empty(self):
@@ -256,7 +286,8 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zonegroup_id': 'zg1-id',
             'zone_name': 'zone1',
             'default': False,
-            'port': 80
+            'port': 80,
+            'secondary_port': None
         },
             {
             'id': 'daemon2',
@@ -269,6 +300,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zone_name': 'zone2',
             'default': True,
             'port': 443,
+            'secondary_port': None
         }])
 
         # Change the default zonegroup and test if the correct daemon gets picked up
@@ -288,7 +320,8 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zonegroup_id': 'zg1-id',
             'zone_name': 'zone1',
             'default': True,
-            'port': 80
+            'port': 80,
+            'secondary_port': None
         },
             {
             'id': 'daemon2',
@@ -301,6 +334,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zone_name': 'zone2',
             'default': False,
             'port': 443,
+            'secondary_port': None,
         }])
 
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1742,6 +1742,7 @@ Usage:
                  placement: Optional[str] = None,
                  _end_positional_: int = 0,
                  port: Optional[int] = None,
+                 secondary_port: Optional[int] = None,
                  ssl: bool = False,
                  inbuf: Optional[str] = None) -> HandleCommandResult:
         """Start RGW daemon(s)"""
@@ -1751,6 +1752,7 @@ Usage:
         spec = RGWSpec(
             service_id=svc_id,
             rgw_frontend_port=port,
+            rgw_frontend_secondary_port=secondary_port,
             ssl=ssl,
             placement=PlacementSpec.from_string(placement),
         )
@@ -2061,6 +2063,7 @@ Usage:
                    zone: Optional[str] = None,
                    networks: Optional[List[str]] = None,
                    port: Optional[int] = None,
+                   secondary_port: Optional[int] = None,
                    ssl: bool = False,
                    dry_run: bool = False,
                    format: Format = Format.plain,
@@ -2085,6 +2088,7 @@ Usage:
             rgw_zone=zone,
             networks=networks,
             rgw_frontend_port=port,
+            rgw_frontend_secondary_port=secondary_port,
             ssl=ssl,
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1745,6 +1745,7 @@ Usage:
                  placement: Optional[str] = None,
                  _end_positional_: int = 0,
                  port: Optional[int] = None,
+                 secondary_port: Optional[int] = None,
                  ssl: bool = False,
                  inbuf: Optional[str] = None) -> HandleCommandResult:
         """Start RGW daemon(s)"""
@@ -1754,6 +1755,7 @@ Usage:
         spec = RGWSpec(
             service_id=svc_id,
             rgw_frontend_port=port,
+            rgw_frontend_secondary_port=secondary_port,
             ssl=ssl,
             placement=PlacementSpec.from_string(placement),
         )
@@ -2064,6 +2066,7 @@ Usage:
                    zone: Optional[str] = None,
                    networks: Optional[List[str]] = None,
                    port: Optional[int] = None,
+                   secondary_port: Optional[int] = None,
                    ssl: bool = False,
                    dry_run: bool = False,
                    format: Format = Format.plain,
@@ -2088,6 +2091,7 @@ Usage:
             rgw_zone=zone,
             networks=networks,
             rgw_frontend_port=port,
+            rgw_frontend_secondary_port=secondary_port,
             ssl=ssl,
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -183,6 +183,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                  zonegroup_name: Optional[str] = None,
                                  zone_name: Optional[str] = None,
                                  port: Optional[int] = None,
+                                 secondary_port: Optional[int] = None,
                                  placement: Optional[str] = None,
                                  zone_endpoints: Optional[str] = None,
                                  start_radosgw: Optional[bool] = True,
@@ -201,6 +202,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                  rgw_zonegroup=zonegroup_name,
                                  rgw_zone=zone_name,
                                  rgw_frontend_port=port,
+                                 rgw_frontend_secondary_port=secondary_port,
                                  placement=placement_spec,
                                  zone_endpoints=zone_endpoints)]
         else:
@@ -442,6 +444,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                              zone_name: Optional[str] = None,
                              realm_token: Optional[str] = None,
                              port: Optional[int] = None,
+                             secondary_port: Optional[int] = None,
                              placement: Optional[str] = None,
                              start_radosgw: Optional[bool] = True,
                              zone_endpoints: Optional[str] = None,
@@ -452,6 +455,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             created_zones = self.rgw_zone_create(zone_name=zone_name,
                                                  realm_token=realm_token,
                                                  port=port,
+                                                 secondary_port=secondary_port,
                                                  placement=placement,
                                                  start_radosgw=start_radosgw,
                                                  zone_endpoints=zone_endpoints,
@@ -465,6 +469,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                         zone_name: Optional[str] = None,
                         realm_token: Optional[str] = None,
                         port: Optional[int] = None,
+                        secondary_port: Optional[int] = None,
                         placement: Optional[Union[str, Dict[str, Any]]] = None,
                         tier_type: Optional[str] = None,
                         start_radosgw: Optional[bool] = True,
@@ -487,6 +492,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                  rgw_zone=zone_name,
                                  rgw_realm_token=realm_token,
                                  rgw_frontend_port=port,
+                                 rgw_frontend_secondary_port=secondary_port,
                                  placement=placement_spec,
                                  zone_endpoints=zone_endpoints)]
         else:
@@ -538,10 +544,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                            zone_name: Optional[str] = None,
                            realm_token: Optional[str] = None,
                            port: Optional[int] = None,
+                           secondary_port: Optional[int] = None,
                            placement: Optional[dict] = None,
                            tier_type: Optional[str] = None,
                            start_radosgw: Optional[bool] = True,
                            zone_endpoints: Optional[str] = None) -> None:
         placement_spec = placement.get('placement') if placement else None
-        self.rgw_zone_create(zone_name, realm_token, port, placement_spec, tier_type, start_radosgw,
+        self.rgw_zone_create(zone_name, realm_token, port, secondary_port, placement_spec, tier_type, start_radosgw,
                              zone_endpoints, secondary_zone_period_retry_limit=5)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1618,6 +1618,7 @@ class RGWSpec(ServiceSpec):
             rgw_zone: myzone
             ssl: true
             rgw_frontend_port: 1234
+            rgw_frontend_secondary_port: 4321
             rgw_frontend_type: beast
             rgw_frontend_ssl_certificate: ...
             # Optional: enable D3N (L1 datacache) for RGW
@@ -1649,6 +1650,7 @@ class RGWSpec(ServiceSpec):
                  rgw_zonegroup: Optional[str] = None,
                  rgw_zone: Optional[str] = None,
                  rgw_frontend_port: Optional[int] = None,
+                 rgw_frontend_secondary_port: Optional[int] = None,
                  rgw_frontend_ssl_certificate: Optional[Union[str, List[str]]] = None,
                  rgw_frontend_type: Optional[str] = None,
                  rgw_frontend_extra_args: Optional[List[str]] = None,
@@ -1714,6 +1716,8 @@ class RGWSpec(ServiceSpec):
         self.rgw_zone: Optional[str] = rgw_zone
         #: Port of the RGW daemons
         self.rgw_frontend_port: Optional[int] = rgw_frontend_port
+        #: Secondary RGW frontend port, intended for HTTP (unencrypted) traffic only.
+        self.rgw_frontend_secondary_port: Optional[int] = rgw_frontend_secondary_port
         #: List of SSL certificates
         self.rgw_frontend_ssl_certificate: Optional[Union[str, List[str]]] \
             = rgw_frontend_ssl_certificate
@@ -1721,6 +1725,8 @@ class RGWSpec(ServiceSpec):
         self.rgw_frontend_type: Optional[str] = rgw_frontend_type
         #: List of extra arguments for rgw_frontend in the form opt=value. See :ref:`rgw_frontends`
         self.rgw_frontend_extra_args: Optional[List[str]] = rgw_frontend_extra_args
+        self.rgw_frontend_extra_port: Optional[int] = None
+        self.rgw_frontend_extra_ssl_port: Optional[int] = None
         #: enable SSL
         self.ssl = ssl
         self.rgw_realm_token = rgw_realm_token
@@ -1751,32 +1757,56 @@ class RGWSpec(ServiceSpec):
         self.qat = qat or {}
         self.d3n_cache = d3n_cache or {}
 
+        if self.rgw_frontend_extra_args is not None:
+            for arg in self.rgw_frontend_extra_args[:]:
+                if "=" in arg:
+                    key, val = arg.split("=", 1)
+                    if key == "port":
+                        if not self.ssl and not self.rgw_frontend_port:
+                            self.rgw_frontend_port = int(val)
+                            self.rgw_frontend_extra_args.remove(arg)
+                        elif self.ssl and not self.rgw_frontend_secondary_port:
+                            self.rgw_frontend_secondary_port = int(val)
+                            self.rgw_frontend_extra_args.remove(arg)
+                        else:
+                            self.rgw_frontend_extra_port = int(val)
+                    elif key == "ssl_port":
+                        if self.ssl and not self.rgw_frontend_port:
+                            self.rgw_frontend_port = int(val)
+                            self.rgw_frontend_extra_args.remove(arg)
+                        else:
+                            self.rgw_frontend_extra_ssl_port = int(val)
+
+        if self.rgw_frontend_port is None:
+            self.rgw_frontend_port = 443 if self.ssl else 80
+
     def get_port_start(self) -> List[int]:
         ports = self.get_port()
         return ports
 
     def get_port(self) -> List[int]:
         ports = []
+
         if self.rgw_frontend_port:
             ports.append(self.rgw_frontend_port)
 
-        ssl_port = next(
-            (
-                int(arg.split('=')[1])
-                for arg in (self.rgw_frontend_extra_args or [])
-                if arg.startswith("ssl_port=")
-            ),
-            None,
-        )
+        if self.ssl and self.rgw_frontend_secondary_port:
+            ports.append(self.rgw_frontend_secondary_port)
 
-        if self.ssl and ssl_port:
-            ports.append(ssl_port)
+        if self.rgw_frontend_extra_port:
+            ports.append(self.rgw_frontend_extra_port)
+
+        if self.ssl and self.rgw_frontend_extra_ssl_port:
+            ports.append(self.rgw_frontend_extra_ssl_port)
+
         if not ports:
             ports.append(443 if self.ssl else 80)
 
         return ports
 
     def validate(self) -> None:
+
+        validate_unique_ports(self.get_port_start())
 
         if self.ssl:
             if not self.ssl_cert and self.rgw_frontend_ssl_certificate:
@@ -1788,6 +1818,14 @@ class RGWSpec(ServiceSpec):
                 self.rgw_frontend_ssl_certificate = None
                 if not (self.ssl_cert and self.ssl_key):
                     raise SpecValidationError("Failed to parse rgw_frontend_ssl_certificate field.")
+        elif self.rgw_frontend_secondary_port:
+            raise SpecValidationError(
+                'Invalid rgw_frontend_secondary_port: Only can be enabled with SSL'
+            )
+        elif self.rgw_frontend_extra_ssl_port:
+            raise SpecValidationError(
+                'Invalid use of ssl_port in rgw_frontend_extra_args : Only can be enabled with SSL'
+            )
 
         # This validation is done after adjusting the SSL field so when
         # RGW Spec is updated with the right fields before validation

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1647,6 +1647,7 @@ class RGWSpec(ServiceSpec):
             rgw_zone: myzone
             ssl: true
             rgw_frontend_port: 1234
+            rgw_frontend_secondary_port: 4321
             rgw_frontend_type: beast
             rgw_frontend_ssl_certificate: ...
             # Optional: enable D3N (L1 datacache) for RGW
@@ -1678,6 +1679,7 @@ class RGWSpec(ServiceSpec):
                  rgw_zonegroup: Optional[str] = None,
                  rgw_zone: Optional[str] = None,
                  rgw_frontend_port: Optional[int] = None,
+                 rgw_frontend_secondary_port: Optional[int] = None,
                  rgw_frontend_ssl_certificate: Optional[Union[str, List[str]]] = None,
                  rgw_frontend_type: Optional[str] = None,
                  rgw_frontend_extra_args: Optional[List[str]] = None,
@@ -1743,6 +1745,8 @@ class RGWSpec(ServiceSpec):
         self.rgw_zone: Optional[str] = rgw_zone
         #: Port of the RGW daemons
         self.rgw_frontend_port: Optional[int] = rgw_frontend_port
+        #: Secondary RGW frontend port, intended for HTTP (unencrypted) traffic only.
+        self.rgw_frontend_secondary_port: Optional[int] = rgw_frontend_secondary_port
         #: List of SSL certificates
         self.rgw_frontend_ssl_certificate: Optional[Union[str, List[str]]] \
             = rgw_frontend_ssl_certificate
@@ -1750,6 +1754,8 @@ class RGWSpec(ServiceSpec):
         self.rgw_frontend_type: Optional[str] = rgw_frontend_type
         #: List of extra arguments for rgw_frontend in the form opt=value. See :ref:`rgw_frontends`
         self.rgw_frontend_extra_args: Optional[List[str]] = rgw_frontend_extra_args
+        self.rgw_frontend_extra_port: Optional[int] = None
+        self.rgw_frontend_extra_ssl_port: Optional[int] = None
         #: enable SSL
         self.ssl = ssl
         self.rgw_realm_token = rgw_realm_token
@@ -1780,26 +1786,48 @@ class RGWSpec(ServiceSpec):
         self.qat = qat or {}
         self.d3n_cache = d3n_cache or {}
 
+        if self.rgw_frontend_extra_args is not None:
+            for arg in self.rgw_frontend_extra_args[:]:
+                if "=" in arg:
+                    key, val = arg.split("=", 1)
+                    if key == "port":
+                        if not self.ssl and not self.rgw_frontend_port:
+                            self.rgw_frontend_port = int(val)
+                            self.rgw_frontend_extra_args.remove(arg)
+                        elif self.ssl and not self.rgw_frontend_secondary_port:
+                            self.rgw_frontend_secondary_port = int(val)
+                            self.rgw_frontend_extra_args.remove(arg)
+                        else:
+                            self.rgw_frontend_extra_port = int(val)
+                    elif key == "ssl_port":
+                        if self.ssl and not self.rgw_frontend_port:
+                            self.rgw_frontend_port = int(val)
+                            self.rgw_frontend_extra_args.remove(arg)
+                        else:
+                            self.rgw_frontend_extra_ssl_port = int(val)
+
+        if self.rgw_frontend_port is None:
+            self.rgw_frontend_port = 443 if self.ssl else 80
+
     def get_port_start(self) -> List[int]:
         ports = self.get_port()
         return ports
 
     def get_port(self) -> List[int]:
         ports = []
+
         if self.rgw_frontend_port:
             ports.append(self.rgw_frontend_port)
 
-        ssl_port = next(
-            (
-                int(arg.split('=')[1])
-                for arg in (self.rgw_frontend_extra_args or [])
-                if arg.startswith("ssl_port=")
-            ),
-            None,
-        )
+        if self.ssl and self.rgw_frontend_secondary_port:
+            ports.append(self.rgw_frontend_secondary_port)
 
-        if self.ssl and ssl_port:
-            ports.append(ssl_port)
+        if self.rgw_frontend_extra_port:
+            ports.append(self.rgw_frontend_extra_port)
+
+        if self.ssl and self.rgw_frontend_extra_ssl_port:
+            ports.append(self.rgw_frontend_extra_ssl_port)
+
         if not ports:
             ports.append(443 if self.ssl else 80)
 
@@ -1836,8 +1864,19 @@ class RGWSpec(ServiceSpec):
 
     def validate(self) -> None:
 
-        if self.ssl and not self.ssl_cert and self.rgw_frontend_ssl_certificate:
-            self._migrate_legacy_rgw_frontend_ssl_certificate()
+        validate_unique_ports(self.get_port_start())
+
+        if self.ssl:
+            if not self.ssl_cert and self.rgw_frontend_ssl_certificate:
+                self._migrate_legacy_rgw_frontend_ssl_certificate()
+        elif self.rgw_frontend_secondary_port:
+            raise SpecValidationError(
+                'Invalid rgw_frontend_secondary_port: Only can be enabled with SSL'
+            )
+        elif self.rgw_frontend_extra_ssl_port:
+            raise SpecValidationError(
+                'Invalid use of ssl_port in rgw_frontend_extra_args : Only can be enabled with SSL'
+            )
 
         # This validation is done after adjusting the SSL field so when
         # RGW Spec is updated with the right fields before validation

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -579,6 +579,10 @@ def test_yaml(y):
         if key in obj_dict.get('spec', {}):
             obj_dict['spec'][key] = data['spec'][key]
 
+    """RGW spec may not have 'rgw_frontend_port' if it is not set, so we pop it from the dict before comparison if it's missing in the input data."""
+    if data.get('service_type') == 'rgw' and 'rgw_frontend_port' not in data.get('spec', {}):
+            obj_dict['spec'].pop('rgw_frontend_port', None)
+
     assert obj_dict == data
 
 def test_alertmanager_spec_1():
@@ -1476,9 +1480,9 @@ def test_extra_args_handling(y, ec_args, ee_args, ec_final_args, ee_final_args):
         for args in spec_obj.extra_entrypoint_args:
             ee_res.extend(args.to_args())
         assert ee_res == ee_final_args
-  
+
 def test_osd_has_default_termination_grace_when_missing():
-    
+
     spec_data = """
 service_type: osd
 service_id: osd_spec_default

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -630,6 +630,10 @@ def test_yaml(y):
         if key in obj_dict.get('spec', {}):
             obj_dict['spec'][key] = data['spec'][key]
 
+    """RGW spec may not have 'rgw_frontend_port' if it is not set, so we pop it from the dict before comparison if it's missing in the input data."""
+    if data.get('service_type') == 'rgw' and 'rgw_frontend_port' not in data.get('spec', {}):
+            obj_dict['spec'].pop('rgw_frontend_port', None)
+
     assert obj_dict == data
 
 def test_alertmanager_spec_1():
@@ -1631,9 +1635,9 @@ def test_extra_args_handling(y, ec_args, ee_args, ec_final_args, ee_final_args):
         for args in spec_obj.extra_entrypoint_args:
             ee_res.extend(args.to_args())
         assert ee_res == ee_final_args
-  
+
 def test_osd_has_default_termination_grace_when_missing():
-    
+
     spec_data = """
 service_type: osd
 service_id: osd_spec_default


### PR DESCRIPTION
**mgr/orchestrator/rgw:** Introduce dedicated parameter for secondary HTTP frontend port**

This Pull Request enhances the RGW service specification and the Ceph Dashboard by:

- **Adding a new service parameter**: rgw_frontend_secondary_port, specifically designed to handle unencrypted HTTP traffic.

- **Improving Visibility**: Updating ceph orch ls to display all configured ports (primary and secondary).

- **Dashboard Enhancement**: Adding a new input field in the RGW creation/edit form to configure the secondary port.

- **Logic Constraints**: Implemented validation to ensure the secondary port field is only displayed when SSL is enabled. Additionally, added logic to ensure that primary and secondary ports are unique to avoid port conflicts.

See-also: https://tracker.ceph.com/issues/73982

Code development assisted by Gemini 3.1 Pro.

## Testing Logs:
**Scenario: rgw with two ports defined as follows**
Expected: rgw daemon with attending HTTPS traffic, through port 443, and HTTP, through 8080.
```
[root@ceph-dev-node-0 ~]# ceph orch ls rgw --export
service_type: rgw
service_id: default
service_name: rgw.default
placement:
  count_per_host: 1
  label: rgw
spec:
  certificate_source: cephadm-signed
  generate_cert: true
  rgw_exit_timeout_secs: 120
  rgw_frontend_extra_args:
  - tcp_nodelay=1
  - max_header_size=65536
  rgw_frontend_port: 443
  rgw_frontend_secondary_port: 8080
  rgw_frontend_type: beast
  ssl: true
```
```
[root@ceph-dev-node-0 ~]# ceph orch ps --daemon_type rgw
NAME                                HOST             PORTS       STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
rgw.default.ceph-dev-node-1.rbuwwn  ceph-dev-node-1  *:443,8080  running (2h)     4m ago   2h     184M        -  21.0.0-1322-gf05320ab  961b5c502e9f  3082a2ba326e  
```
```
[root@ceph-dev-node-0 ~]# ceph config dump | grep rgw_frontends
client.rgw.default.ceph-dev-node-1.rbuwwn                        basic     rgw_frontends                              beast ssl_port=443 port=8080 ssl_certificate=config://rgw/cert/rgw.default.ceph-dev-node-1.rbuwwn tcp_nodelay=1 max_header_size=65536
```
```
[root@ceph-dev-node-0 ~]# ceph orch ls rgw
NAME         PORTS       RUNNING  REFRESHED  AGE  PLACEMENT                   
rgw.default  ?:443,8080      1/1  3m ago     2h   count-per-host:1;label:rgw  
```
```
[root@ceph-dev-node-1 ~]# netstat -tlnp | grep -E "443|8080"
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      7148/radosgw        
tcp        0      0 0.0.0.0:443             0.0.0.0:*               LISTEN      7148/radosgw        
tcp6       0      0 :::8080                 :::*                    LISTEN      7148/radosgw        
tcp6       0      0 :::443                  :::*                    LISTEN      7148/radosgw      
```

**Scenario: rgw with three ports defined as follows**
Expected: rgw daemon with attending HTTPS traffic, through port 443, and HTTP, through 8080 and 8081.
```
[root@ceph-dev-node-0 ~]# ceph orch ls rgw --export
service_type: rgw
service_id: default
service_name: rgw.default
placement:
  count_per_host: 1
  label: rgw
spec:
  certificate_source: cephadm-signed
  generate_cert: true
  rgw_exit_timeout_secs: 120
  rgw_frontend_extra_args:
  - tcp_nodelay=1
  - max_header_size=65536
  - port=8081
  rgw_frontend_port: 443
  rgw_frontend_secondary_port: 8080
  rgw_frontend_type: beast
  ssl: true
```
```
[root@ceph-dev-node-0 ~]# ceph orch ps --daemon_type rgw
NAME                                HOST             PORTS            STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
rgw.default.ceph-dev-node-1.srmxxo  ceph-dev-node-1  *:443,8080,8081  running (13m)     2m ago  13m     101M        -  21.0.0-1322-gf05320ab  961b5c502e9f  5ea009470f25 
```
```
[root@ceph-dev-node-0 ~]# ceph config dump | grep rgw_frontends
client.rgw.default.ceph-dev-node-1.srmxxo                        basic     rgw_frontends                              beast ssl_port=443 port=8080 ssl_certificate=config://rgw/cert/rgw.default.ceph-dev-node-1.srmxxo tcp_nodelay=1 max_header_size=65536 port=8081
```
```
[root@ceph-dev-node-0 ~]# ceph orch ls rgw
NAME         PORTS            RUNNING  REFRESHED  AGE  PLACEMENT                   
rgw.default  ?:443,8080,8081      1/1  3m ago     14m  count-per-host:1;label:rgw  
```
```
[root@ceph-dev-node-1 ~]# netstat -tlnp | grep -E "443|8080|8081"
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      51420/radosgw       
tcp        0      0 0.0.0.0:8081            0.0.0.0:*               LISTEN      51420/radosgw       
tcp        0      0 0.0.0.0:443             0.0.0.0:*               LISTEN      51420/radosgw       
tcp6       0      0 :::8080                 :::*                    LISTEN      51420/radosgw       
tcp6       0      0 :::8081                 :::*                    LISTEN      51420/radosgw       
tcp6       0      0 :::443                  :::*                    LISTEN      51420/radosgw       
```
**Scenario: rgw with four ports defined as follows**
Expected: Two ports, 443 and 444, serving HTTPS  and another two, 8080 and 8081, serving HTTP.
```
[root@ceph-dev-node-0 ~]# ceph orch ls rgw --export
service_type: rgw
service_id: default
service_name: rgw.default
placement:
  count_per_host: 1
  label: rgw
spec:
  certificate_source: cephadm-signed
  generate_cert: true
  rgw_exit_timeout_secs: 120
  rgw_frontend_extra_args:
  - tcp_nodelay=1
  - max_header_size=65536
  - port=8081
  - ssl_port=444
  rgw_frontend_port: 443
  rgw_frontend_secondary_port: 8080
  rgw_frontend_type: beast
  ssl: true
```
```
[root@ceph-dev-node-0 ~]# ceph orch ps --daemon_type rgw
NAME                                HOST             PORTS                STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
rgw.default.ceph-dev-node-1.cgjuox  ceph-dev-node-1  *:443,8080,8081,444  running (98s)    93s ago  98s    95.4M        -  21.0.0-1322-gf05320ab  961b5c502e9f  9d90f9455a9d 
```
```
[root@ceph-dev-node-0 ~]# ceph config dump | grep rgw_frontends
client.rgw.default.ceph-dev-node-1.cgjuox                        basic     rgw_frontends                              beast ssl_port=443 port=8080 ssl_certificate=config://rgw/cert/rgw.default.ceph-dev-node-1.cgjuox tcp_nodelay=1 max_header_size=65536 port=8081 ssl_port=444
```
```
[root@ceph-dev-node-0 ~]# ceph orch ls rgw
NAME         PORTS                RUNNING  REFRESHED  AGE  PLACEMENT                   
rgw.default  ?:443,444,8080,8081      1/1  2m ago     2m   count-per-host:1;label:rgw
```
```
[root@ceph-dev-node-1 ~]# netstat -tlnp | grep -E "443|444|8080|8081"
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      54890/radosgw       
tcp        0      0 0.0.0.0:8081            0.0.0.0:*               LISTEN      54890/radosgw       
tcp        0      0 0.0.0.0:443             0.0.0.0:*               LISTEN      54890/radosgw       
tcp        0      0 0.0.0.0:444             0.0.0.0:*               LISTEN      54890/radosgw       
tcp6       0      0 :::8080                 :::*                    LISTEN      54890/radosgw       
tcp6       0      0 :::8081                 :::*                    LISTEN      54890/radosgw       
tcp6       0      0 :::443                  :::*                    LISTEN      54890/radosgw       
tcp6       0      0 :::444                  :::*                    LISTEN      54890/radosgw   
```
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [X] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [X] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
