### PR TITLE
mgr/dashboard: fix rgw user creation for tenanted account

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -958,7 +958,7 @@ class RgwUser(RgwRESTController):
                system=None, suspended=None, generate_key=None, access_key=None,
                secret_key=None, daemon_name=None, account_id: Optional[str] = None,
                account_root_user: Optional[bool] = False,
-               account_policies: Optional[str] = None):
+               account_policies: Optional[str] = None, tenant=None):
         """Create a new RGW user."""
 
         params = {'uid': uid, 'display-name': display_name}
@@ -972,7 +972,8 @@ class RgwUser(RgwRESTController):
             'generate-key': generate_key,
             'access-key': access_key,
             'secret-key': secret_key,
-            'account-id': account_id
+            'account-id': account_id,
+            'tenant': tenant
         }
 
         # Add only non-None parameters
@@ -1013,7 +1014,7 @@ class RgwUser(RgwRESTController):
     def set(self, uid, display_name=None, email=None, max_buckets=None,
             system=None, suspended=None, daemon_name=None, account_id: Optional[str] = None,
             account_root_user: Optional[bool] = False,
-            account_policies: Optional[str] = None):
+            account_policies: Optional[str] = None, tenant=None):
         """Update an existing RGW user."""
 
         params = {'uid': uid}
@@ -1025,7 +1026,8 @@ class RgwUser(RgwRESTController):
             'max-buckets': max_buckets,
             'system': system,
             'suspended': suspended,
-            'account-id': account_id
+            'account-id': account_id,
+            'tenant': tenant
         }
 
         # Add only non-None parameters

--- a/src/pybind/mgr/dashboard/frontend/cypress.config.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress.config.ts
@@ -22,8 +22,8 @@ export default defineConfig({
 
   env: {
     LOGIN_USER: 'admin',
-    LOGIN_PWD: 'admin',
-    CEPH2_URL: 'https://localhost:4202/'
+    LOGIN_PWD: 'password',
+    CEPH2_URL: 'https://192.168.100.100:8443/'
   },
 
   chromeWebSecurity: false,
@@ -55,7 +55,7 @@ export default defineConfig({
       )
       return require('./cypress/plugins/index.js')(on, config);
     },
-    baseUrl: 'https://localhost:4200/',
+    baseUrl: 'https://192.168.100.100:8443/',
     excludeSpecPattern: ['*.po.ts', '**/orchestrator/**'],
     experimentalSessionAndOrigin: true,
     specPattern: 'cypress/e2e/**/*-spec.{js,jsx,ts,tsx,feature}'

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.e2e-spec.ts
@@ -96,4 +96,50 @@ describe('RGW users page', () => {
       accounts.delete(account.name, null, null, true, false, false, false);
     });
   });
+
+  describe('create user linked to tenanted account test', () => {
+    const account = {
+      name: `test_account`,
+      email: `test@test`,
+      tenant: `tenanted_acc`
+    };
+    const user_id = `tenanted_account_user`;
+
+    it('should create user linked to account in create form and pass tenant', () => {
+      accounts.navigateTo();
+
+      cy.get('cd-table').then(($table) => {
+        const hasExistingAccount = $table
+          .find('tbody tr td')
+          .toArray()
+          .some((cell) => cell.textContent?.trim() === account.name);
+
+        if (hasExistingAccount) {
+          accounts.delete(account.name, null, null, true, false, false, false);
+          accounts.navigateTo();
+        }
+      });
+
+      accounts.navigateTo('create');
+      accounts.create(account);
+
+      accounts.navigateTo();
+      accounts
+        .getTableRow(account.name)
+        .find('td')
+        .eq(3)
+        .invoke('text')
+        .then((account_id: string) => {
+          const trimmedAccountId = account_id.trim();
+          users.navigateTo();
+          users.navigateTo('create');
+          users.createLinkedAccountUser(trimmedAccountId, account.name, user_id, account.tenant);
+        });
+
+      users.navigateTo();
+      users.delete(`${account.tenant}$${user_id}`, null, null, true, false, false, true);
+      accounts.navigateTo();
+      accounts.delete(account.name, null, null, true, false, false, false);
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.po.ts
@@ -177,10 +177,12 @@ export class UsersPageHelper extends PageHelper {
 
     cy.get(`select[id=${selection_name}]`).should('exist');
     cy.get(`select[id=${selection_name}]`).select(account_id);
-    cy.get(`select[id=${selection_name}] option:checked`).should(
-      'have.text',
-      `${account_name} - ${tenant}`
-    );
+    cy.get(`select[id=${selection_name}] option:checked`)
+      .invoke('text')
+      .then((selectedText: string) => {
+        const normalized = selectedText.trim();
+        expect([`${tenant}$${account_name}`, `${account_name} - ${tenant}`]).to.include(normalized);
+      });
     cy.contains('button', 'Edit User').click();
 
     this.getTableRow(tenant + '$' + user_id).as('AccountUser');
@@ -230,10 +232,12 @@ export class UsersPageHelper extends PageHelper {
     const username = tenant + '$' + user_id;
     this.navigateEdit(username);
     cy.get(`select[id=${selection_name}]`).should('exist').should('be.disabled');
-    cy.get(`select[id=${selection_name}] option:checked`).should(
-      'have.text',
-      `${account_name} - ${tenant}`
-    );
+    cy.get(`select[id=${selection_name}] option:checked`)
+      .invoke('text')
+      .then((selectedText: string) => {
+        const normalized = selectedText.trim();
+        expect([`${tenant}$${account_name}`, `${account_name} - ${tenant}`]).to.include(normalized);
+      });
     cy.get('input#account_root_user_input').check({ force: true });
 
     cy.contains('button', 'Edit User').click();
@@ -253,6 +257,60 @@ export class UsersPageHelper extends PageHelper {
           cy.get('td').eq(0).should('have.text', 'User type');
           cy.get('td').eq(1).should('have.text', 'Account root user');
         });
+    });
+  }
+
+  @PageHelper.restrictTo(pages.create.url)
+  createLinkedAccountUser(
+    account_id: string,
+    account_name: string,
+    user_id: string,
+    tenant: string
+  ) {
+    const fullname = 'test_acc_user';
+    const username = `${tenant}$${user_id}`;
+
+    cy.intercept('POST', '/api/rgw/user**').as('createUserRequest');
+
+    cy.get('#user_id').type(user_id);
+    cy.get('select#link_account').should('exist').select(account_id);
+    cy.get('select#link_account option:checked')
+      .invoke('text')
+      .then((selectedText: string) => {
+        const normalized = selectedText.trim();
+        expect([`${tenant}$${account_name}`, `${account_name} - ${tenant}`]).to.include(normalized);
+      });
+
+    cy.get('#show_tenant').should('not.exist');
+    cy.get('input#tenant').should('not.exist');
+
+    cy.get('#display_name').click().type(fullname);
+    cy.get('#email').click().type('user@test');
+
+    this.selectOption('max_buckets_mode', 'Custom');
+    cy.get('input#max_buckets').should('exist').should('have.value', '1000');
+
+    cy.contains('button', 'Create User').should('be.enabled').click();
+
+    cy.wait('@createUserRequest').then((interception) => {
+      const queryString = interception.request.url.split('?')[1] || '';
+      const params = new URLSearchParams(queryString);
+      const statusCode = interception.response?.statusCode;
+
+      expect(statusCode).to.be.oneOf([200, 201]);
+
+      expect(params.get('account_id')).to.eq(account_id);
+      expect(params.get('tenant')).to.eq(tenant);
+      expect(params.get('uid')).to.eq(user_id);
+      expect(`${params.get('tenant')}$${params.get('uid')}`).to.eq(username);
+    });
+
+    cy.location('hash').should('eq', pages.index.url);
+    cy.get(pages.index.id).should('exist');
+
+    this.getTableRow(username).within(() => {
+      cy.get('td').eq(1).should('have.text', username);
+      cy.get('td').eq(3).should('have.text', account_name);
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -25,7 +25,7 @@
                   *ngIf="accounts !== null"
                   [value]="''">-- Select an Account --</option>
           <option *ngFor="let account of accounts"
-                  [value]="account.id">{{ account.name }} {{account.tenant ? '- '+account.tenant : ''}}</option>
+                  [value]="account.id">{{account.tenant ? account.tenant+'$' : ''}}{{ account.name }}</option>
         </cds-select>
         <ng-template #accountError>
           <span class="invalid-feedback"
@@ -79,7 +79,12 @@
       </ng-template>
     </div>
 
-    <!-- Show Tenant -->
+    <!--
+    Show Tenant, but when the user is selecting an account
+    we don't need to show this option as the tenant is inherited
+    from the selected account.
+    -->
+    @if (!userForm?.controls?.account_id?.value) {
     <div class="form-item">
       <cds-checkbox formControlName="show_tenant"
                     id="show_tenant"
@@ -87,6 +92,7 @@
                     (checkedChange)="updateFieldsWhenTenanted()">Show Tenant
       </cds-checkbox>
     </div>
+    }
 
     <!-- Tenant -->
     <div class="form-item"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -761,6 +761,8 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
     if (this.userForm.getValue('account_id')) {
       _.merge(result, {
         account_id: this.userForm.getValue('account_id'),
+        tenant: this.accounts.find((account) => account.id === this.userForm.getValue('account_id'))
+          ?.tenant,
         account_root_user: this.userForm.getValue('account_root_user')
       });
     }
@@ -777,12 +779,15 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
    */
   private _getUpdateArgs() {
     const result: Record<string, any> = {};
-    const keys = ['display_name', 'email', 'max_buckets', 'system', 'suspended'];
+    const keys = ['display_name', 'email', 'max_buckets', 'system', 'suspended', 'tenant'];
     for (const key of keys) {
       result[key] = this.userForm.getValue(key);
     }
     if (this.userForm.getValue('account_id')) {
       result['account_id'] = this.userForm.getValue('account_id');
+      result['tenant'] = this.accounts.find(
+        (account) => account.id === this.userForm.getValue('account_id')
+      )?.tenant;
       result['account_root_user'] = this.userForm.getValue('account_root_user');
     }
     const maxBucketsMode = parseInt(this.userForm.getValue('max_buckets_mode'), 10);

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -19907,6 +19907,8 @@ paths:
                   type: string
                 system:
                   type: string
+                tenant:
+                  type: string
                 uid:
                   type: string
               required:
@@ -20119,6 +20121,8 @@ paths:
                 suspended:
                   type: string
                 system:
+                  type: string
+                tenant:
                   type: string
               type: object
       responses:


### PR DESCRIPTION
when selecting a tenanted account, the rgw user creation is failing because the API is missing a `tenant` param.

when I tried from API without the `tenant` param for a tenanted account
```
./rgw_admin_curl.sh -a DiPt4V7WWvy2njL1z6aC -s xSZUdYky0bTctAdCEEW8ikhfBVKsBV5LFYL82vvh -e 172.20.0.2:8000 -r PUT -p user -q "uid=tsting-api&display-name=tenant-user&account-id=RGW00174313985613652"
{"Code":"InvalidArgument","Message":"","RequestId":"tx000001dda5d1cdec521a7-006926be17-4739-default","HostId":"4739-default-default"}
```

but when I tried with tenant it succesfully created the user
```
./rgw_admin_curl.sh -a DiPt4V7WWvy2njL1z6aC -s xSZUdYky0bTctAdCEEW8ikhfBVKsBV5LFYL82vvh -e 172.20.0.2:8000 -r PUT -p user -q "uid=tsting-api&display-name=tenant-user&account-id=RGW00174313985613652&tenant=mytenant"

{"full_user_id":"mytenant$tsting-api","tenant":"mytenant","user_id":"tsting-api","display_name":"tenant-user","email":"","suspended":0,"max_buckets":1000,"subusers":[],"keys":[{"user":"mytenant$tsting-api","access_key":"TH6JNLN1CY00CJQWZ73M","secret_key":"5SCKxoCXXrmb0DJwSGA1DxloNzDptdIoAHZtYm86","active":true}],"swift_keys":[],"caps":[],"op_mask":"read, write, delete","system":false,"admin":false,"default_placement":"","default_storage_class":"","placement_tags":[],"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1,"max_size_kb":0,"max_objects":-1},"user_quota":{"enabled":false,"check_on_raw":false,"max_size":-1,"max_size_kb":0,"max_objects":-1},"temp_url_keys":[],"type":"rgw","mfa_ids":[],"account_id":"RGW00174313985613652","path":"/","create_date":"2025-11-26T08:46:40.860688Z","tags":[],"group_ids":[]}

```

so fetching the tenant and passing it to the API.

Also in the dropdown of tenanted account users I am updating the format to make it consistent with the usual rgw tenanted id format which is `tenant$user_id` instead of the current `user_id - tenant`.

And I am disabling the user to add a tenant from the user form if he selects the account.

Fixes: https://tracker.ceph.com/issues/74000

**BEFORE**

[Ceph Dashboard_ Object _ Users _ Create.webm](https://github.com/user-attachments/assets/1e905a2d-4883-4dca-9b0c-e44b6c4e46ea)


**AFTER**

[Ceph Dashboard_ Object _ Users.webm](https://github.com/user-attachments/assets/56f3370b-5424-4a3a-b83d-327e1cd4f104)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
