### PR TITLE
aio_cxx: Fix mutual deadlock and resolve test unreliability

### DIFF
--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -2386,6 +2386,7 @@ ceph::mutex my_lock = ceph::make_mutex("my_lock");
 set<unsigned> inflight;
 unsigned max_success = 0;
 unsigned min_failed = 0;
+std::condition_variable_any cv_inflight;
 
 struct io_info {
   unsigned i;
@@ -2413,6 +2414,9 @@ void pool_io_callback(completion_t cb, void *arg /* Actually AioCompletion* */)
     if (!min_failed || i < min_failed) {
       min_failed = i;
     }
+    if (inflight.empty()) {
+      cv_inflight.notify_all();
+    }
   }
 }
 
@@ -2425,15 +2429,32 @@ TEST(LibRadosAio, PoolEIOFlag) {
   std::unique_ptr<std::thread> t;
   std::atomic<bool> missed_eio{false};
   
-  unsigned max = 1000;
-  unsigned timeout = max * 10;
+  auto start_time = std::chrono::steady_clock::now();
+  const int max_run_seconds = 30;
   unsigned long i = 1;
-  for (; min_failed == 0 && i <= timeout; ++i) {
+
+  while (true) {
+    {
+      std::unique_lock l(my_lock);
+      if (min_failed != 0) {
+            break;
+      }
+      inflight.insert(i);
+    }
     io_info *info = new io_info;
     info->i = i;
     info->c = Rados::aio_create_completion();
     info->c->set_complete_callback((void*)info, pool_io_callback);
     int r = test_data.m_ioctx.aio_write(test_data.m_oid, info->c, bl, bl.length(), 0);
+    if (r < 0) {
+      std::cout << "Race caught: aio_write returned " << r << " at index " << i << std::endl;
+      std::scoped_lock l(my_lock);
+      inflight.erase(i);
+      if (inflight.empty()) {
+        cv_inflight.notify_all();
+      }
+      break;
+    }
 
     // Trigger EIO after 100 ops have been submitted
     if (i == 100) {
@@ -2447,35 +2468,39 @@ TEST(LibRadosAio, PoolEIOFlag) {
             "val": "true"
             }})", test_data.m_pool_name),
           {}, nullptr, nullptr));
-
-        {
-          std::scoped_lock lk(my_lock);
-          missed_eio = (!min_failed && max_success == max);
-        }
       });
     }
 
-    std::this_thread::sleep_for(10ms);
-    my_lock.lock();
-    if (r < 0) {
-      inflight.erase(i);
-      break;
+    // Timeout to avoid infinite loop in case EIO never takes effect
+    // Check every 100 ops if we've exceeded max run time
+    if (i % 100 == 0) {
+      auto now = std::chrono::steady_clock::now();
+      if (std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count() > max_run_seconds) {
+        // Stop loop if EIO never happened (Cluster issue?)
+        std::cout << "Timed out waiting for EIO to take effect after " << i << " ops" << std::endl;
+        missed_eio = true;
+        break;
+      }
+    }
+    i++;
+  }
+
+  {
+    std::unique_lock l(my_lock);
+    std::cout << "waiting for inflight ios to complete, count=" << inflight.size() << std::endl;
+    bool finished = cv_inflight.wait_for(l, std::chrono::seconds(60), []{ 
+      return inflight.empty(); 
+    });
+    if (!finished) {
+      GTEST_FAIL() << "timeout waiting for inflight ios to complete";
     }
   }
   if (t && t->joinable()) {
     t->join();
   }
 
-  // wait for ios to finish
-  for (; !inflight.empty(); ++i) {
-    cout << "waiting for " << inflight.size() << std::endl;
-    my_lock.unlock();
-    sleep(1);
-    my_lock.lock();
-  }
-
-  if (!missed_eio) {
-    my_lock.unlock();
+  std::scoped_lock l(my_lock);
+  if (missed_eio) {
     GTEST_SKIP() << "eio flag missed all ios that already completed";
   }
   cout << "max_success " << max_success << ", min_failed " << min_failed << std::endl;

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -34,7 +34,7 @@ class AioTestDataPP
 {
 public:
   AioTestDataPP()
-    : m_init(false),    
+    : m_init(false),
       m_oid("foo")
   {
   }
@@ -2422,25 +2422,22 @@ TEST(LibRadosAio, PoolEIOFlag) {
 
   bufferlist bl;
   bl.append("some data");
-  std::thread *t = nullptr;
+  std::unique_ptr<std::thread> t;
   std::atomic<bool> missed_eio{false};
   
   unsigned max = 1000;
   unsigned timeout = max * 10;
   unsigned long i = 1;
-  my_lock.lock();
   for (; min_failed == 0 && i <= timeout; ++i) {
     io_info *info = new io_info;
     info->i = i;
     info->c = Rados::aio_create_completion();
     info->c->set_complete_callback((void*)info, pool_io_callback);
-    inflight.insert(i);
-    my_lock.unlock();
     int r = test_data.m_ioctx.aio_write(test_data.m_oid, info->c, bl, bl.length(), 0);
-    //cout << "start " << i << " r = " << r << std::endl;
 
-    if (i == max / 2) {
-      t = new std::thread([&] {
+    // Trigger EIO after 100 ops have been submitted
+    if (i == 100) {
+      t = std::make_unique<std::thread>([&] {
         cout << "sending pool EIO time: " << ceph_clock_now() << std::endl;
         ASSERT_EQ(0, test_data.m_cluster.mon_command(
           fmt::format(R"({{
@@ -2465,8 +2462,9 @@ TEST(LibRadosAio, PoolEIOFlag) {
       break;
     }
   }
-  t->join();
-  delete t;
+  if (t && t->joinable()) {
+    t->join();
+  }
 
   // wait for ios to finish
   for (; !inflight.empty(); ++i) {
@@ -2481,8 +2479,8 @@ TEST(LibRadosAio, PoolEIOFlag) {
     GTEST_SKIP() << "eio flag missed all ios that already completed";
   }
   cout << "max_success " << max_success << ", min_failed " << min_failed << std::endl;
+  ASSERT_TRUE(min_failed > 0) << "Did not catch any EIO errors";
   ASSERT_TRUE(max_success + 1 == min_failed);
-  my_lock.unlock();
 }
 
 // This test case reproduces https://tracker.ceph.com/issues/57152


### PR DESCRIPTION
The LibRadosAio.PoolEIOFlag test was unstable, hanging or skipping due to two distinct synchronization problems:

1. Deadlock: The main thread held the shared mutex ('my_lock') while calling thread join. This created a mutual deadlock.
    * Fix: Mutex is unlocked before thread join using RAII scopes.

2. Test Unreliability (Timing Dependency): The test used a fixed iteration count for IO submission and finished too quickly, missing the target error.
    * Fix: The submission loop now runs continuously (time-bounded) until the EIO error is reliably caught, eliminating the timing issue.

Fixes: https://tracker.ceph.com/issues/73946





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
