### PR TITLE
test/mgr: Improve unit-test coverage for ceph-mgr

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -786,11 +786,69 @@
 }
 
 {
+  Python marshal unicode allocations - direct
+  Memcheck:Leak
+  match-leak-kinds: all
+  fun:malloc
+  ...
+  fun:_PyUnicode_FromUCS1.part.0
+  ...
+}
+
+{
+  Python marshal unicode allocations - via r_object
+  Memcheck:Leak
+  match-leak-kinds: all
+  fun:malloc
+  ...
+  fun:r_object
+  ...
+}
+
+{
+  Python marshal loads
+  Memcheck:Leak
+  match-leak-kinds: all
+  fun:malloc
+  ...
+  fun:marshal_loads
+  ...
+}
+
+{
+  Python obmalloc allocations
+  Memcheck:Leak
+  match-leak-kinds: all
+  fun:malloc
+  obj:*/libpython*.so*
+  ...
+}
+
+{
+  Python eval frame
+  Memcheck:Leak
+  match-leak-kinds: all
+  fun:malloc
+  ...
+  fun:_PyEval_EvalFrameDefault
+  ...
+}
+
+{
   ignore *all* ceph-mgr python crap.  this is overkill, but better than nothing
   Memcheck:Leak
   match-leak-kinds: all
   ...
-  fun:Py*
+  fun:*Py*
+  ...
+}
+
+{
+  ignore *all* ceph-mgr python crap.  this is overkill, but better than nothing
+  Memcheck:Leak
+  match-leak-kinds: all
+  ...
+  fun:UnknownInlinedFun
   ...
 }
 

--- a/src/test/mgr/CMakeLists.txt
+++ b/src/test/mgr/CMakeLists.txt
@@ -1,9 +1,77 @@
+# unittest_mgr_clusterstate
+add_executable(unittest_mgr_clusterstate
+  test_clusterstate.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/ClusterState.cc
+)
+add_ceph_unittest(unittest_mgr_clusterstate)
+target_link_libraries(unittest_mgr_clusterstate
+  ceph-common
+  global
+  Python3::Python
+)
+
+# unittest_mgr_daemonkey
+add_executable(unittest_mgr_daemonkey
+  test_daemonkey.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonKey.cc
+)
+add_ceph_unittest(unittest_mgr_daemonkey)
+target_link_libraries(unittest_mgr_daemonkey
+  ceph-common
+)
+
+# unittest_mgr_daemonstate
+add_executable(unittest_mgr_daemonstate
+  test_daemonstate.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonState.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonKey.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonPerfCounters.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PerfCounterInstance.cc
+)
+add_ceph_unittest(unittest_mgr_daemonstate)
+target_link_libraries(unittest_mgr_daemonstate
+  ceph-common
+  Python3::Python
+)
+
 # unittest_mgr_mgrcap
 add_executable(unittest_mgr_mgrcap
   test_mgrcap.cc
   $<TARGET_OBJECTS:mgr_cap_obj>)
 add_ceph_unittest(unittest_mgr_mgrcap)
 target_link_libraries(unittest_mgr_mgrcap global)
+
+# unittest_mgr_pyformatter
+add_executable(unittest_mgr_pyformatter
+  test_pyformatter.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyFormatter.cc
+)
+add_ceph_unittest(unittest_mgr_pyformatter)
+target_link_libraries(unittest_mgr_pyformatter
+  ceph-common
+  Python3::Python
+)
+
+# unittest_mgr_pyutil
+add_executable(unittest_mgr_pyutil
+  test_pyutil.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyUtil.cc
+)
+add_ceph_unittest(unittest_mgr_pyutil)
+target_link_libraries(unittest_mgr_pyutil
+  ceph-common
+  Python3::Python
+)
+
+# unittest_mgr_servicemap
+add_executable(unittest_mgr_servicemap
+  test_servicemap.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/ServiceMap.cc
+)
+add_ceph_unittest(unittest_mgr_servicemap)
+target_link_libraries(unittest_mgr_servicemap
+  ceph-common
+)
 
 # unittest_mgr_ttlcache
 add_executable(unittest_mgr_ttlcache test_ttlcache.cc)

--- a/src/test/mgr/TestMgr.h
+++ b/src/test/mgr/TestMgr.h
@@ -1,0 +1,190 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <Python.h>
+
+#include <cassert>
+
+#include "common/async/context_pool.h"
+#include "global/global_context.h"
+#include "gtest/gtest.h"
+#include "messages/MPGStats.h"
+#include "mgr/ClusterState.h"
+#include "mgr/DaemonState.h"
+#include "mon/MgrMap.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+#include "osdc/Objecter.h"
+
+#define dout_subsys ceph_subsys_client
+
+namespace bs = boost::system;
+namespace ca = ceph::async;
+
+class ClusterStateTestHelper : public ClusterState {
+public:
+  ClusterStateTestHelper(
+      MonClient* mc_,
+      Objecter* objecter_,
+      const MgrMap& mgrmap_) :
+    ClusterState(mc_, objecter_, mgrmap_)
+  {}
+
+  const PGMap::Incremental&
+  test_get_pending_inc() const
+  {
+    return pending_inc;
+  }
+
+  const std::map<int64_t, unsigned>&
+  test_get_existing_pools() const
+  {
+    return existing_pools;
+  }
+
+  const PGMap&
+  test_get_pg_map() const
+  {
+    return pg_map;
+  }
+
+  Objecter*
+  test_get_objecter() const
+  {
+    return objecter;
+  }
+};
+
+class TestMgr : public ::testing::Test {
+public:
+  static void
+  SetUpTestSuite()
+  {
+    if (!cct) {
+      std::vector<const char*> args = {"unittest_mgr"};
+      cct = global_init(
+          nullptr, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+          CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+
+      cct->_conf.set_val("auth_client_required", "none");
+      cct->_conf.set_val("auth_cluster_required", "none");
+      cct->_conf.set_val("auth_service_required", "none");
+      cct->_conf.apply_changes(nullptr);
+
+      common_init_finish(cct.get());
+    }
+  }
+
+  void
+  SetUp() override
+  {
+    icp = std::make_unique<ca::io_context_pool>(1);
+    mc = std::make_unique<MonClient>(cct.get(), *icp);
+    messenger.reset(
+        Messenger::create_client_messenger(cct.get(), "unittest_mgr"));
+    objecter =
+        std::make_unique<Objecter>(cct.get(), messenger.get(), mc.get(), *icp);
+
+    ceph_assert(objecter != nullptr);
+    objecter->set_client_incarnation(0);
+    objecter->init();
+
+    cs = std::make_unique<ClusterStateTestHelper>(
+        mc.get(), objecter.get(), mgr_map);
+  }
+
+  void
+  TearDown() override
+  {
+    ceph_assert(objecter != nullptr);
+    ceph_assert(mc != nullptr);
+    objecter->shutdown();
+    mc->shutdown();
+    messenger->shutdown();
+    messenger->wait();
+
+    cs.reset();
+    objecter.reset();
+    mc.reset();
+    messenger.reset();
+    icp.reset();
+  }
+
+protected:
+  static inline boost::intrusive_ptr<CephContext> cct;
+  std::unique_ptr<ClusterStateTestHelper> cs;
+  std::unique_ptr<ca::io_context_pool> icp;
+  std::unique_ptr<Messenger> messenger;
+  std::unique_ptr<Objecter> objecter;
+  std::unique_ptr<MonClient> mc;
+  MgrMap mgr_map;
+  OSDMap osd_map;
+};
+
+class ClusterStateTest : public TestMgr {
+public:
+  ceph::ref_t<DeviceState> device;
+
+  void
+  SetUp() override
+  {
+    TestMgr::SetUp();
+
+    //Setup pools and notify osdmap
+    pool.set_pg_num(2);
+    osd_inc.new_pool_max = 1;
+    osd_inc.new_pools[1] = pool;
+    osd_map.apply_incremental(osd_inc);
+
+    cs->with_osdmap_and_pgmap([&](const OSDMap& old_map, const PGMap& pg_map) {
+      cs->notify_osdmap(osd_map);
+    });
+
+    stats->pool_stat[1] = store_statfs_t{};
+    stats->set_src(entity_name_t::OSD(0));
+    stats->osd_stat.seq = 1;
+    pgstat.state = PG_STATE_ACTIVE;
+    pgstat.reported_epoch = 1;
+    pgstat.reported_seq = 2;
+  }
+
+  void
+  ingest_and_pginc()
+  {
+    cs->ingest_pgstats(stats);
+    p_inc = cs->test_get_pending_inc();
+  }
+
+protected:
+  const mempool::osdmap::map<int64_t, pg_pool_t>& pools = osd_map.get_pools();
+  OSDMap::Incremental osd_inc = OSDMap::Incremental(osd_map.get_epoch() + 1);
+  ceph::ref_t<MPGStats> stats = ceph::make_ref<MPGStats>();
+  PGMap::Incremental p_inc;
+  pg_stat_t pgstat;
+  pg_pool_t pool;
+};
+
+class DeviceStateTest : public ::testing::Test {
+public:
+  ceph::ref_t<DeviceState> device;
+
+  void
+  SetUp() override
+  {
+    device = ceph::make_ref<DeviceState>("test_device_111");
+  }
+};
+
+struct PythonEnv : public ::testing::Environment {
+  void
+  SetUp() override
+  {
+    Py_Initialize();
+  }
+
+  void
+  TearDown() override
+  {
+    Py_Finalize();
+  }
+};

--- a/src/test/mgr/test_clusterstate.cc
+++ b/src/test/mgr/test_clusterstate.cc
@@ -1,0 +1,217 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <memory>
+
+#include "global/global_init.h"
+#include "gtest/gtest.h"
+#include "messages/MMgrDigest.h"
+#include "messages/MPGStats.h"
+#include "mgr/ClusterState.h"
+#include "mon/PGMap.h"
+#include "osd/osd_types.h"
+#include "test/mgr/TestMgr.h"
+
+TEST_F(TestMgr, ClusterState_Construct)
+{
+  cs->with_mgrmap([&](const MgrMap& m) { ASSERT_EQ(m.epoch, mgr_map.epoch); });
+
+  cs->with_osdmap([&](const OSDMap& o) { ASSERT_EQ(o.get_epoch(), 0); });
+
+  cs->with_fsmap([&](const FSMap& f) { ASSERT_EQ(f.get_epoch(), 0); });
+
+  cs->with_servicemap([&](const ServiceMap& sm) { ASSERT_EQ(sm.epoch, 0); });
+
+  cs->with_pgmap([&](const PGMap& pm) { ASSERT_EQ(pm.version, 0); });
+}
+
+TEST_F(TestMgr, ClusterState_Setters)
+{
+  Objecter new_objecter(cct.get(), messenger.get(), mc.get(), *icp);
+  cs->set_objecter(&new_objecter);
+  ASSERT_EQ(cs->test_get_objecter(), &new_objecter);
+  ASSERT_NE(cs->test_get_objecter(), objecter.get());
+
+  cs->with_osdmap_and_pgmap([&](const OSDMap& old_map, const PGMap& pg_map) {
+    cs->notify_osdmap(osd_map);
+  });
+  cs->with_osdmap([&](const OSDMap& o) {
+    ASSERT_EQ(o.get_epoch(), osd_map.get_epoch());
+  });
+
+  ASSERT_FALSE(cs->have_fsmap());
+  const FSMap fs_map = [] {
+    FSMap f;
+    f.inc_epoch();
+    f.inc_epoch();
+    return f;
+  }();
+  cs->set_fsmap(fs_map);
+  ASSERT_TRUE(cs->have_fsmap());
+  cs->with_fsmap([&](const FSMap& f) {
+    ASSERT_EQ(f.get_epoch(), fs_map.get_epoch());
+  });
+
+  const MgrMap new_mgr_map = [] {
+    MgrMap m;
+    m.epoch = 456;
+    return m;
+  }();
+  cs->set_mgr_map(new_mgr_map);
+  cs->with_mgrmap([&](const MgrMap& m) {
+    ASSERT_EQ(m.epoch, new_mgr_map.epoch);
+  });
+
+  const ServiceMap s_map = [] {
+    ServiceMap s;
+    s.epoch = 777;
+    return s;
+  }();
+  cs->set_service_map(s_map);
+  cs->with_servicemap([&](const ServiceMap& sm) {
+    ASSERT_EQ(sm.epoch, s_map.epoch);
+  });
+
+  //After notify_osdmap, pgmap version should be incremented from 0
+  cs->with_pgmap([&](const PGMap& pm) { ASSERT_EQ(pm.version, 1); });
+}
+
+TEST_F(TestMgr, ClusterState_LoadDigest)
+{
+  const bufferlist mon_status_bl = [] {
+    bufferlist bl;
+    bl.append("{\"monmap\":{\"epoch\":1}}");
+    return bl;
+  }();
+
+  const bufferlist health_bl = [] {
+    bufferlist bl;
+    bl.append("{\"status\":\"HEALTH_OK\"}");
+    return bl;
+  }();
+
+  auto digest = ceph::make_message<MMgrDigest>();
+  digest->mon_status_json = mon_status_bl;
+  digest->health_json = health_bl;
+
+  cs->load_digest(digest.get());
+
+  cs->with_mon_status([&](const bufferlist& monstat) {
+    ASSERT_EQ(monstat.length(), mon_status_bl.length());
+    ASSERT_EQ(monstat.to_str(), mon_status_bl.to_str());
+  });
+
+  cs->with_health([&](const bufferlist& health) {
+    ASSERT_EQ(health.length(), health_bl.length());
+    ASSERT_EQ(health.to_str(), health_bl.to_str());
+  });
+}
+
+TEST_F(ClusterStateTest, IngestPGStats_Valid)
+{
+  // Test 1: OSD is in the map, PG pool exists, in range, new version
+  pg_t pgid(0, 1);
+  stats->pg_stat[pgid] = pgstat;
+  ingest_and_pginc();
+
+  ASSERT_TRUE(p_inc.pg_stat_updates.contains(pgid));
+}
+
+TEST_F(ClusterStateTest, IngestPGStats_PoolDNE)
+{
+  //Test 2: OSD is in the map, PG pool does not exist
+  pg_t pgid(0, 2);
+  stats->pg_stat[pgid] = pgstat;
+  ingest_and_pginc();
+
+  ASSERT_FALSE(p_inc.pg_stat_updates.contains(pgid));
+}
+
+TEST_F(ClusterStateTest, IngestPGStats_OOR)
+{
+  //Test 3: OSD is in the map, PG pool exists, out of range
+  pg_t pgid_out_of_range(2, 1);
+  stats->pg_stat[pgid_out_of_range] = pgstat;
+  ingest_and_pginc();
+
+  ASSERT_FALSE(p_inc.pg_stat_updates.contains(pgid_out_of_range));
+}
+
+TEST_F(ClusterStateTest, IngestPGStats_oldReportedSeq)
+{
+  pg_t pgid_valid(0, 1);
+
+  stats->set_src(entity_name_t::OSD(0));
+  stats->pg_stat[pgid_valid] = pgstat;
+
+  cs->ingest_pgstats(stats);
+  cs->update_delta_stats();
+
+  //Test 4: OSD is in the map, PG pool exists, shard in range, old version
+  pgstat.reported_epoch = 1;
+  pgstat.reported_seq = 1;
+  stats->osd_stat.seq = 1;
+  pg_t pgid_old_version(0, 1);
+  stats->pg_stat[pgid_old_version] = pgstat;
+  ingest_and_pginc();
+
+  ASSERT_FALSE(p_inc.pg_stat_updates.contains(pgid_old_version));
+}
+
+TEST_F(ClusterStateTest, UpdateDeltaStats)
+{
+  pg_t pgid(0, 1);
+
+  pgstat.reported_seq = 1;
+  stats->pg_stat[pgid] = pgstat;
+
+  cs->ingest_pgstats(stats);
+  cs->update_delta_stats();
+
+  p_inc = cs->test_get_pending_inc();
+  PGMap pg_map = cs->test_get_pg_map();
+
+  ASSERT_TRUE(p_inc.pg_stat_updates.empty());
+  ASSERT_TRUE(pg_map.pg_stat.contains(pgid));
+  ASSERT_EQ(pg_map.pg_stat[pgid].reported_seq, pgstat.reported_seq);
+}
+
+TEST_F(ClusterStateTest, NotifyOSDMap)
+{
+  const pg_pool_t pool1 = [] {
+    pg_pool_t p;
+    p.set_pg_num(2);
+    return p;
+  }();
+
+  const pg_pool_t pool2 = [] {
+    pg_pool_t p;
+    p.set_pg_num(4);
+    return p;
+  }();
+
+  OSDMap::Incremental notify_inc(osd_map.get_epoch() + 1);
+  notify_inc.new_pool_max = 2;
+  notify_inc.new_pools.emplace(1, pool1);
+  notify_inc.new_pools.emplace(2, pool2);
+  osd_map.apply_incremental(notify_inc);
+
+  cs->with_osdmap_and_pgmap([&](const OSDMap& old_map, const PGMap& pg_map) {
+    cs->notify_osdmap(osd_map);
+  });
+
+  const auto& existing_pools = cs->test_get_existing_pools();
+
+  ASSERT_TRUE(existing_pools.contains(1));
+  ASSERT_TRUE(existing_pools.contains(2));
+  ASSERT_EQ(existing_pools.at(1), pool1.get_pg_num());
+  ASSERT_EQ(existing_pools.at(2), pool2.get_pg_num());
+}
+
+int
+main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/src/test/mgr/test_daemonkey.cc
+++ b/src/test/mgr/test_daemonkey.cc
@@ -1,0 +1,147 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "gtest/gtest.h"
+#include "mgr/DaemonKey.h"
+
+TEST(DaemonKey, Parse)
+{
+  auto [key, ok] = DaemonKey::parse("osd.1");
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(key.type, "osd");
+  EXPECT_EQ(key.name, "1");
+}
+
+TEST(DaemonKey, LessThan)
+{
+  DaemonKey a{"mon", "a"};
+  DaemonKey b{"osd", "1"};
+  DaemonKey c{"osd", "2"};
+
+  EXPECT_TRUE(a < b); // mon < osd
+  EXPECT_TRUE(b < c); // 1 < 2
+  EXPECT_FALSE(c < b); // 2 < 1
+  EXPECT_FALSE(b < a); // osd < mon
+}
+
+TEST(DaemonKey, Ostream)
+{
+  DaemonKey key{"osd", "1"};
+  std::ostringstream oss;
+  oss << key;
+
+  EXPECT_EQ(oss.str(), "osd.1");
+}
+
+TEST(DaemonKey, ToString)
+{
+  DaemonKey key{"osd", "1"};
+
+  EXPECT_EQ(ceph::to_string(key), "osd.1");
+}
+
+/* Start Negative Tests */
+
+TEST(DaemonKey, ParseWithEmptyString)
+{
+  auto [key, ok] = DaemonKey::parse("");
+  ASSERT_FALSE(ok);
+  EXPECT_EQ(key.type, "");
+  EXPECT_EQ(key.name, "");
+}
+
+TEST(DaemonKey, ParseWithoutDot)
+{
+  auto [key, ok] = DaemonKey::parse("osd1");
+  ASSERT_FALSE(ok);
+  EXPECT_EQ(key.type, "");
+  EXPECT_EQ(key.name, "");
+}
+
+TEST(DaemonKey, ParseExtraDot)
+{
+  auto [key, ok] = DaemonKey::parse("osd.1.extra");
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(key.type, "osd");
+  EXPECT_EQ(key.name, "1.extra");
+}
+
+TEST(DaemonKey, ParseStartDot)
+{
+  auto [key, ok] = DaemonKey::parse(".osd");
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(key.type, "");
+  EXPECT_EQ(key.name, "osd");
+}
+
+TEST(DaemonKey, ParseEndDot)
+{
+  auto [key, ok] = DaemonKey::parse("osd.");
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(key.type, "osd");
+  EXPECT_EQ(key.name, "");
+}
+
+TEST(DaemonKey, ParseDot)
+{
+  auto [key, ok] = DaemonKey::parse(".");
+  ASSERT_TRUE(ok);
+  EXPECT_EQ(key.type, "");
+  EXPECT_EQ(key.name, "");
+}
+
+TEST(DaemonKey, LessThanEmptyStr)
+{
+  DaemonKey a{"", ""};
+  DaemonKey b{"", ""};
+  DaemonKey c{"osd", "1"};
+
+  EXPECT_FALSE(a < b);
+  EXPECT_TRUE(a < c);
+  EXPECT_FALSE(c < a);
+}
+
+TEST(DaemonKey, LessThanEmptyType)
+{
+  DaemonKey a{"", "1"};
+  DaemonKey b{"", "2"};
+  DaemonKey c{"osd", "1"};
+
+  EXPECT_TRUE(a < b);
+  EXPECT_TRUE(a < c);
+}
+
+TEST(DaemonKey, LessThanEmptyName)
+{
+  DaemonKey a{"mon", ""};
+  DaemonKey b{"mon", "a"};
+  DaemonKey c{"osd", ""};
+
+  EXPECT_TRUE(a < b);
+  EXPECT_TRUE(a < c);
+}
+
+TEST(DaemonKey, OstreamEmpty)
+{
+  DaemonKey key{"", ""};
+  std::ostringstream oss;
+  oss << key;
+
+  EXPECT_EQ(oss.str(), ".");
+}
+
+TEST(DaemonKey, ToStringEmptyType)
+{
+  DaemonKey key{"", "1"};
+
+  EXPECT_EQ(ceph::to_string(key), ".1");
+}
+
+TEST(DaemonKey, ToStringEmptyName)
+{
+  DaemonKey key{"osd", ""};
+
+  EXPECT_EQ(ceph::to_string(key), "osd.");
+}
+
+/* End Negative Tests */

--- a/src/test/mgr/test_daemonstate.cc
+++ b/src/test/mgr/test_daemonstate.cc
@@ -1,0 +1,229 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <sstream>
+
+#include "common/Formatter.h"
+#include "global/global_init.h"
+#include "gtest/gtest.h"
+#include "include/utime.h"
+#include "mgr/DaemonState.h"
+#include "test/mgr/TestMgr.h"
+
+// Test macro for utime_t comparisons
+#define EXPECT_UTIME_EQ(actual, expected)                              \
+  do {                                                                 \
+    const utime_t& _a = (actual);                                      \
+    const utime_t& _e = (expected);                                    \
+    if (!(_a == _e)) {                                                 \
+      ADD_FAILURE() << "EXPECT_UTIME_EQ failed:\n"                     \
+                    << "  actual:   " << _a.sec() << "s " << _a.nsec() \
+                    << "ns\n"                                          \
+                    << "  expected: " << _e.sec() << "s " << _e.nsec() \
+                    << "ns\n";                                         \
+    }                                                                  \
+  } while (false);
+
+TEST_F(DeviceStateTest, SetMetadata)
+{
+  std::map<std::string, std::string> metadata = {
+      {"life_expectancy_min", "1111111111.000000"},
+      {"life_expectancy_max", "2222222222.000000"},
+      {"life_expectancy_stamp", "1234567890.000000"},
+      {"wear_level", "0.75"}};
+
+  device->set_metadata(std::move(metadata));
+
+  ASSERT_EQ(device->wear_level, 0.75f);
+  utime_t expected_min(1111111111, 0);
+  EXPECT_UTIME_EQ(device->life_expectancy.first, expected_min);
+  utime_t expected_max(2222222222, 0);
+  EXPECT_UTIME_EQ(device->life_expectancy.second, expected_max);
+  utime_t expected_stamp(1234567890, 0);
+  EXPECT_UTIME_EQ(device->life_expectancy_stamp, expected_stamp);
+}
+
+TEST_F(DeviceStateTest, SetLifeExpectancy)
+{
+  utime_t from(1000, 0);
+  utime_t to(2000, 0);
+  utime_t now(900, 0);
+
+  device->set_life_expectancy(from, to, now);
+
+  ASSERT_EQ(device->life_expectancy.first, from);
+  ASSERT_EQ(device->life_expectancy.second, to);
+  ASSERT_EQ(device->life_expectancy_stamp, now);
+  ASSERT_EQ(device->metadata["life_expectancy_min"], "1000.000000");
+  ASSERT_EQ(device->metadata["life_expectancy_max"], "2000.000000");
+  ASSERT_EQ(device->metadata["life_expectancy_stamp"], "900.000000");
+}
+
+TEST_F(DeviceStateTest, RemoveLifeExpectancy)
+{
+  utime_t from(1000, 0);
+  utime_t to(2000, 0);
+  utime_t now(900, 0);
+
+  device->set_life_expectancy(from, to, now);
+  device->rm_life_expectancy();
+
+  ASSERT_EQ(device->life_expectancy.first, utime_t());
+  ASSERT_EQ(device->life_expectancy.second, utime_t());
+  ASSERT_EQ(device->life_expectancy_stamp, utime_t());
+  ASSERT_FALSE(device->metadata.contains("life_expectancy_min"));
+  ASSERT_FALSE(device->metadata.contains("life_expectancy_max"));
+  ASSERT_FALSE(device->metadata.contains("life_expectancy_stamp"));
+}
+
+TEST_F(DeviceStateTest, SetWearLevel)
+{
+  device->set_wear_level(0.75f);
+
+  ASSERT_EQ(device->wear_level, 0.75f);
+  ASSERT_EQ(device->metadata["wear_level"], "0.75");
+
+  device->set_wear_level(-1.0f);
+
+  ASSERT_EQ(device->wear_level, -1.0f);
+  ASSERT_FALSE(device->metadata.contains("wear_level"));
+}
+
+TEST_F(DeviceStateTest, GetLifeExpectancyStr)
+{
+  utime_t now(1500, 0);
+  std::string result = device->get_life_expectancy_str(now);
+
+  ASSERT_EQ(result, "");
+
+  utime_t from(1000, 0);
+  utime_t to(1400, 0);
+  device->set_life_expectancy(from, to, now);
+  result = device->get_life_expectancy_str(now);
+
+  ASSERT_EQ(result, "now");
+
+  from = utime_t(2000, 0);
+  to = utime_t(3000, 0);
+  device->set_life_expectancy(from, to, now);
+  result = device->get_life_expectancy_str(now);
+
+  ASSERT_EQ(result, "8m to 25m");
+
+  from = utime_t(2500, 0);
+  to = utime_t();
+  device->set_life_expectancy(from, to, now);
+  result = device->get_life_expectancy_str(now);
+
+  ASSERT_EQ(result, ">16m");
+
+  from = utime_t(2000, 0);
+  to = utime_t(2000, 1000);
+  device->set_life_expectancy(from, to, now);
+  result = device->get_life_expectancy_str(now);
+
+  ASSERT_EQ(result, "8m");
+}
+
+/* Begin Negative Tests */
+
+TEST_F(DeviceStateTest, SetMetadataWithEmptyMap)
+{
+  std::map<std::string, std::string> empty_metadata;
+  device->set_metadata(std::move(empty_metadata));
+
+  ASSERT_EQ(device->wear_level, -1.0f);
+  ASSERT_EQ(device->life_expectancy.first, utime_t());
+  ASSERT_EQ(device->life_expectancy.second, utime_t());
+  ASSERT_EQ(device->life_expectancy_stamp, utime_t());
+}
+
+TEST_F(DeviceStateTest, SetMetadataWithInvalidValues)
+{
+  std::map<std::string, std::string> invalid_metadata = {
+      {"life_expectancy_min", "bad"},
+      {"life_expectancy_max", "test"},
+      {"life_expectancy_stamp", "input"},
+      {"wear_level", "zeropointsevenfive"}};
+  device->set_metadata(std::move(invalid_metadata));
+
+  ASSERT_EQ(device->wear_level, 0.0f);
+  ASSERT_EQ(device->life_expectancy.first, utime_t());
+  ASSERT_EQ(device->life_expectancy.second, utime_t());
+  ASSERT_EQ(device->life_expectancy_stamp, utime_t());
+}
+
+TEST_F(DeviceStateTest, SetMetadataWithEmptyStrings)
+{
+  std::map<std::string, std::string> empty_str_metadata = {
+      {"life_expectancy_min", ""},
+      {"life_expectancy_max", ""},
+      {"life_expectancy_stamp", ""},
+      {"wear_level", ""}};
+  device->set_metadata(std::move(empty_str_metadata));
+
+  ASSERT_EQ(device->wear_level, 0.0f);
+  ASSERT_EQ(device->life_expectancy.first, utime_t());
+  ASSERT_EQ(device->life_expectancy.second, utime_t());
+  ASSERT_EQ(device->life_expectancy_stamp, utime_t());
+}
+
+TEST_F(DeviceStateTest, SetLifeExpectancyInvalidTime)
+{
+  utime_t from(2000, 0);
+  utime_t to(1000, 0); // to > from
+  utime_t now(900, 0);
+
+  device->set_life_expectancy(from, to, now);
+
+  ASSERT_EQ(device->life_expectancy.first, from);
+  ASSERT_EQ(device->life_expectancy.second, to);
+  ASSERT_EQ(device->life_expectancy_stamp, now);
+  ASSERT_EQ(device->metadata["life_expectancy_min"], "2000.000000");
+  ASSERT_EQ(device->metadata["life_expectancy_max"], "1000.000000");
+  ASSERT_EQ(device->metadata["life_expectancy_stamp"], "900.000000");
+}
+
+TEST_F(DeviceStateTest, SetLifeExpectancyZeros)
+{
+  utime_t from(0, 0);
+  utime_t to(0, 0);
+  utime_t now(0, 0);
+
+  device->set_life_expectancy(from, to, now);
+
+  ASSERT_EQ(device->life_expectancy.first, from);
+  ASSERT_EQ(device->life_expectancy.second, to);
+  ASSERT_EQ(device->life_expectancy_stamp, now);
+  ASSERT_EQ(device->metadata["life_expectancy_min"], "");
+  ASSERT_EQ(device->metadata["life_expectancy_max"], "");
+  ASSERT_EQ(device->metadata["life_expectancy_stamp"], "");
+}
+
+TEST_F(DeviceStateTest, SetWearLevelInvalidRange)
+{
+  // > 1.0 (1.0 = 100% per conversion in DaemonServer.cc)
+  device->set_wear_level(1.5f);
+
+  ASSERT_EQ(device->wear_level, 1.5f);
+  ASSERT_EQ(device->metadata["wear_level"], "1.5");
+
+  device->set_wear_level(-1.5f); // < -1.0 which is used as not set / unknown
+
+  ASSERT_EQ(device->wear_level, -1.5f);
+  ASSERT_FALSE(device->metadata.contains("wear_level"));
+}
+
+TEST_F(DeviceStateTest, RemoveLifeExpectancyBeforeSet)
+{
+  device->rm_life_expectancy();
+
+  ASSERT_EQ(device->life_expectancy.first, utime_t());
+  ASSERT_EQ(device->life_expectancy.second, utime_t());
+  ASSERT_EQ(device->life_expectancy_stamp, utime_t());
+  ASSERT_FALSE(device->metadata.contains("life_expectancy_min"));
+  ASSERT_FALSE(device->metadata.contains("life_expectancy_max"));
+  ASSERT_FALSE(device->metadata.contains("life_expectancy_stamp"));
+}
+
+/* End Negative Tests */

--- a/src/test/mgr/test_mgrcap.cc
+++ b/src/test/mgr/test_mgrcap.cc
@@ -15,164 +15,173 @@
 
 #include <iostream>
 
+#include "gtest/gtest.h"
 #include "include/stringify.h"
 #include "mgr/MgrCap.h"
 
-#include "gtest/gtest.h"
-
 using namespace std;
 
-const char *parse_good[] = {
-
-  // MgrCapMatch
-  "allow *",
-  "allow r",
-  "allow rwx",
-  "allow  r",
-  " allow rwx",
-  "allow rwx ",
-  " allow rwx ",
-  " allow\t   rwx ",
-  "\tallow\nrwx\t",
-  "allow service=foo x",
-  "allow service=\"froo\" x",
-  "allow profile read-only",
-  "allow profile read-write",
-  "allow profile \"rbd-read-only\", allow *",
-  "allow command \"a b c\"",
-  "allow command abc",
-  "allow command abc with arg=foo",
-  "allow command abc with arg=foo arg2=bar",
-  "allow command abc with arg=foo arg2=bar",
-  "allow command abc with arg=foo arg2 prefix bar arg3 prefix baz",
-  "allow command abc with arg=foo arg2 prefix \"bar bingo\" arg3 prefix baz",
-  "allow command abc with arg regex \"^[0-9a-z.]*$\"",
-  "allow command abc with arg regex \"\(invaluid regex\"",
-  "allow service foo x",
-  "allow service foo x; allow service bar x",
-  "allow service foo w ;allow service bar x",
-  "allow service foo  w , allow service bar x",
-  "allow service foo r , allow service bar x",
-  "allow service foo_foo r, allow service bar r",
-  "allow service foo-foo r, allow service bar r",
-  "allow service \" foo \" w, allow service bar r",
-  "allow module foo x",
-  "allow module=foo x",
-  "allow module foo_foo r",
-  "allow module \" foo \" w",
-  "allow module foo with arg1=value1 x",
-  "allow command abc with arg=foo arg2=bar, allow service foo r",
-  "allow command abc.def with arg=foo arg2=bar, allow service foo r",
-  "allow command \"foo bar\" with arg=\"baz\"",
-  "allow command \"foo bar\" with arg=\"baz.xx\"",
-  "allow command \"foo bar\" with arg = \"baz.xx\"",
-  "profile crash",
-  "profile osd",
-  "profile mds",
-  "profile rbd pool=ABC namespace=NS",
-  "profile \"rbd-read-only\", profile crash",
-  "allow * network 1.2.3.4/24",
-  "allow * network ::1/128",
-  "allow * network [aa:bb::1]/128",
-  "allow service=foo x network 1.2.3.4/16",
-  "allow command abc network 1.2.3.4/8",
-  "profile crash network 1.2.3.4/32",
-  "allow profile crash network 1.2.3.4/32",
-  0
+const std::vector<std::string> parse_good = {
+    // MgrCapMatch
+    "allow *"s,
+    "allow r"s,
+    "allow rwx"s,
+    "allow  r"s,
+    " allow rwx"s,
+    "allow rwx "s,
+    " allow rwx "s,
+    " allow\t   rwx "s,
+    "\tallow\nrwx\t"s,
+    "allow service=foo x"s,
+    "allow service=\"froo\" x"s,
+    "allow profile read-only"s,
+    "allow profile read-write"s,
+    "allow profile \"rbd-read-only\", allow *"s,
+    "allow command \"a b c\""s,
+    "allow command abc"s,
+    "allow command abc with arg=foo"s,
+    "allow command abc with arg=foo arg2=bar"s,
+    "allow command abc with arg=foo arg2=bar"s,
+    "allow command abc with arg=foo arg2 prefix bar arg3 prefix baz"s,
+    "allow command abc with arg=foo arg2 prefix \"bar bingo\" arg3 prefix baz"s,
+    "allow command abc with arg regex \"^[0-9a-z.]*$\""s,
+    "allow command abc with arg regex \"\(invaluid regex\""s,
+    "allow service foo x"s,
+    "allow service foo x; allow service bar x"s,
+    "allow service foo w ;allow service bar x"s,
+    "allow service foo  w , allow service bar x"s,
+    "allow service foo r , allow service bar x"s,
+    "allow service foo_foo r, allow service bar r"s,
+    "allow service foo-foo r, allow service bar r"s,
+    "allow service \" foo \" w, allow service bar r"s,
+    "allow module foo x"s,
+    "allow module=foo x"s,
+    "allow module foo_foo r"s,
+    "allow module \" foo \" w"s,
+    "allow module foo with arg1=value1 x"s,
+    "allow command abc with arg=foo arg2=bar, allow service foo r"s,
+    "allow command abc.def with arg=foo arg2=bar, allow service foo r"s,
+    "allow command \"foo bar\" with arg=\"baz\""s,
+    "allow command \"foo bar\" with arg=\"baz.xx\""s,
+    "allow command \"foo bar\" with arg = \"baz.xx\""s,
+    "profile crash"s,
+    "profile osd"s,
+    "profile mds"s,
+    "profile rbd pool=ABC namespace=NS"s,
+    "profile \"rbd-read-only\", profile crash"s,
+    "allow * network 1.2.3.4/24"s,
+    "allow * network ::1/128"s,
+    "allow * network [aa:bb::1]/128"s,
+    "allow service=foo x network 1.2.3.4/16"s,
+    "allow command abc network 1.2.3.4/8"s,
+    "profile crash network 1.2.3.4/32"s,
+    "allow profile crash network 1.2.3.4/32"s,
 };
 
-TEST(MgrCap, ParseGood) {
-  for (int i=0; parse_good[i]; ++i) {
-    string str = parse_good[i];
+TEST(MgrCap, ParseGood)
+{
+  for (const auto& parseable : parse_good) {
     MgrCap cap;
-    std::cout << "Testing good input: '" << str << "'" << std::endl;
-    ASSERT_TRUE(cap.parse(str, &cout));
+    std::cout << "Testing good input: '" << parseable << "'" << std::endl;
+    ASSERT_TRUE(cap.parse(parseable, &cout));
     std::cout << "                                         -> " << cap
               << std::endl;
   }
 }
 
 // these should stringify to the input value
-const char *parse_identity[] = {
-  "allow *",
-  "allow r",
-  "allow rwx",
-  "allow service foo x",
-  "profile crash",
-  "profile rbd-read-only, allow *",
-  "profile rbd namespace=NS pool=ABC",
-  "allow command abc",
-  "allow command \"a b c\"",
-  "allow command abc with arg=foo",
-  "allow command abc with arg=foo arg2=bar",
-  "allow command abc with arg=foo arg2=bar",
-  "allow command abc with arg=foo arg2 prefix bar arg3 prefix baz",
-  "allow command abc with arg=foo arg2 prefix \"bar bingo\" arg3 prefix baz",
-  "allow service foo x",
-  "allow service foo x, allow service bar x",
-  "allow service foo w, allow service bar x",
-  "allow service foo r, allow service bar x",
-  "allow service foo_foo r, allow service bar r",
-  "allow service foo-foo r, allow service bar r",
-  "allow service \" foo \" w, allow service bar r",
-  "allow module foo x",
-  "allow module \" foo_foo \" r",
-  "allow module foo with arg1=value1 x",
-  "allow command abc with arg=foo arg2=bar, allow service foo r",
-  0
+const std::vector<std::string> parse_identity = {
+    "allow *"s,
+    "allow r"s,
+    "allow rwx"s,
+    "allow service foo x"s,
+    "profile crash"s,
+    "profile rbd-read-only, allow *"s,
+    "profile rbd namespace=NS pool=ABC"s,
+    "allow command abc"s,
+    "allow command \"a b c\""s,
+    "allow command abc with arg=foo"s,
+    "allow command abc with arg=foo arg2=bar"s,
+    "allow command abc with arg=foo arg2=bar"s,
+    "allow command abc with arg=foo arg2 prefix bar arg3 prefix baz"s,
+    "allow command abc with arg=foo arg2 prefix \"bar bingo\" arg3 prefix baz"s,
+    "allow service foo x"s,
+    "allow service foo x, allow service bar x"s,
+    "allow service foo w, allow service bar x"s,
+    "allow service foo r, allow service bar x"s,
+    "allow service foo_foo r, allow service bar r"s,
+    "allow service foo-foo r, allow service bar r"s,
+    "allow service \" foo \" w, allow service bar r"s,
+    "allow module foo x"s,
+    "allow module \" foo_foo \" r"s,
+    "allow module foo with arg1=value1 x"s,
+    "allow command abc with arg=foo arg2=bar, allow service foo r"s,
 };
 
 TEST(MgrCap, ParseIdentity)
 {
-  for (int i=0; parse_identity[i]; ++i) {
-    string str = parse_identity[i];
+  for (const auto& parseable : parse_identity) {
     MgrCap cap;
-    std::cout << "Testing good input: '" << str << "'" << std::endl;
-    ASSERT_TRUE(cap.parse(str, &cout));
+    std::cout << "Testing good input: '" << parseable << "'" << std::endl;
+    ASSERT_TRUE(cap.parse(parseable, &cout));
     string out = stringify(cap);
-    ASSERT_EQ(out, str);
+    ASSERT_EQ(out, parseable);
   }
 }
 
-const char *parse_bad[] = {
-  "allow r foo",
-  "allow*",
-  "foo allow *",
-  "profile foo rwx",
-  "profile",
-  "profile foo bar rwx",
-  "allow profile foo rwx",
-  "allow profile",
-  "allow profile foo bar rwx",
-  "allow service bar",
-  "allow command baz x",
-  "allow r w",
-  "ALLOW r",
-  "allow rwx,",
-  "allow rwx x",
-  "allow r pool foo r",
-  "allow wwx pool taco",
-  "allow wwx pool taco^funny&chars",
-  "allow rwx pool 'weird name''",
-  "allow rwx object_prefix \"beforepool\" pool weird",
-  "allow rwx auid 123 pool asdf",
-  "allow command foo a prefix b",
-  "allow command foo with a prefixb",
-  "allow command foo with a = prefix b",
-  "allow command foo with a prefix b c",
-  0
+const std::vector<std::string> parse_bad = {
+    "allow r foo"s,
+    "allow*"s,
+    "foo allow *"s,
+    "profile foo rwx"s,
+    "profile"s,
+    "profile foo bar rwx"s,
+    "allow profile foo rwx"s,
+    "allow profile"s,
+    "allow profile foo bar rwx"s,
+    "allow service bar"s,
+    "allow command baz x"s,
+    "allow r w"s,
+    "ALLOW r"s,
+    "allow rwx,"s,
+    "allow rwx x"s,
+    "allow r pool foo r"s,
+    "allow wwx pool taco"s,
+    "allow wwx pool taco^funny&chars"s,
+    "allow rwx pool 'weird name''"s,
+    "allow rwx object_prefix \"beforepool\" pool weird"s,
+    "allow rwx auid 123 pool asdf"s,
+    "allow command foo a prefix b"s,
+    "allow command foo with a prefixb"s,
+    "allow command foo with a = prefix b"s,
+    "allow command foo with a prefix b c"s,
+    // Empty and whitespace strings
+    ""s,
+    "   "s,
+    "\t\n"s,
+    // Empty names
+    "allow command \"\""s,
+    "allow service \"\" r"s,
+    "allow module \"\" r"s,
+    // Invalid profile parameters
+    "profile unknown"s,
+    "profile rbd invalid-key=value"s,
+    "profile rbd pool"s,
+    "profile rbd pool="s,
+    "profile rbd =value"s,
 };
 
-TEST(MgrCap, ParseBad) {
-  for (int i=0; parse_bad[i]; ++i) {
-    string str = parse_bad[i];
+TEST(MgrCap, ParseBad)
+{
+  for (const auto& unparseable : parse_bad) {
     MgrCap cap;
-    std::cout << "Testing bad input: '" << str << "'" << std::endl;
-    ASSERT_FALSE(cap.parse(str, &cout));
+    std::cout << "Testing bad input: '" << unparseable << "'" << std::endl;
+    ASSERT_FALSE(cap.parse(unparseable, &cout));
   }
 }
 
-TEST(MgrCap, AllowAll) {
+TEST(MgrCap, AllowAll)
+{
   MgrCap cap;
   ASSERT_FALSE(cap.is_allow_all());
 
@@ -206,8 +215,8 @@ TEST(MgrCap, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", nullptr));
   ASSERT_TRUE(cap.is_allow_all());
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true,
-                             true, {}));
+  ASSERT_TRUE(
+      cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true, true, {}));
 
   MgrCap cap2;
   ASSERT_FALSE(cap2.is_allow_all());
@@ -215,9 +224,11 @@ TEST(MgrCap, AllowAll) {
   ASSERT_TRUE(cap2.is_allow_all());
 }
 
-TEST(MgrCap, Network) {
+TEST(MgrCap, Network)
+{
   MgrCap cap;
-  bool r = cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", nullptr);
+  bool r = cap.parse(
+      "allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", nullptr);
   ASSERT_TRUE(r);
 
   entity_addr_t a, b, c;
@@ -225,48 +236,72 @@ TEST(MgrCap, Network) {
   b.parse("192.168.2.3");
   c.parse("192.167.2.3");
 
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true,
-                             true, a));
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true,
-                             true, b));
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true,
-                              true, c));
+  ASSERT_TRUE(
+      cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true, true, a));
+  ASSERT_TRUE(
+      cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true, true, b));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true, true, c));
 }
 
-TEST(MgrCap, CommandRegEx) {
+TEST(MgrCap, NetworkIPv6)
+{
+  MgrCap cap;
+  bool r = cap.parse(
+      "allow * network 2001:db8::/32, allow * network fe80::/10", nullptr);
+  ASSERT_TRUE(r);
+
+  entity_addr_t a, b, c;
+  a.parse("[2001:db8::1]");
+  b.parse("[fe80::1]");
+  c.parse("[2001:db9::1]");
+
+  ASSERT_TRUE(
+      cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true, true, a));
+  ASSERT_TRUE(
+      cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true, true, b));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "foo", "", "asdf", {}, true, true, true, c));
+}
+
+TEST(MgrCap, CommandRegEx)
+{
   MgrCap cap;
   ASSERT_FALSE(cap.is_allow_all());
-  ASSERT_TRUE(cap.parse("allow command abc with arg regex \"^[0-9a-z.]*$\"",
-                        nullptr));
+  ASSERT_TRUE(
+      cap.parse("allow command abc with arg regex \"^[0-9a-z.]*$\"", nullptr));
 
   EntityName name;
   name.from_str("osd.123");
-  ASSERT_TRUE(cap.is_capable(nullptr, name, "", "", "abc",
-                             {{"arg", "12345abcde"}}, true, true, true, {}));
-  ASSERT_FALSE(cap.is_capable(nullptr, name, "", "", "abc", {{"arg", "~!@#$"}},
-                              true, true, true, {}));
+  ASSERT_TRUE(cap.is_capable(
+      nullptr, name, "", "", "abc", {{"arg", "12345abcde"}}, true, true, true,
+      {}));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, name, "", "", "abc", {{"arg", "~!@#$"}}, true, true, true, {}));
 
   ASSERT_TRUE(cap.parse("allow command abc with arg regex \"[*\"", nullptr));
-  ASSERT_FALSE(cap.is_capable(nullptr, name, "", "", "abc", {{"arg", ""}}, true,
-                              true, true, {}));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, name, "", "", "abc", {{"arg", ""}}, true, true, true, {}));
 }
 
-TEST(MgrCap, Module) {
+TEST(MgrCap, Module)
+{
   MgrCap cap;
   ASSERT_FALSE(cap.is_allow_all());
   ASSERT_TRUE(cap.parse("allow module abc r, allow module bcd w", nullptr));
 
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "", "abc", "", {}, true, true, false,
-                              {}));
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "", "abc", "", {}, true, false, false,
-                             {}));
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "", "bcd", "", {}, true, true, false,
-                              {}));
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "", "bcd", "", {}, false, true, false,
-                             {}));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "abc", "", {}, true, true, false, {}));
+  ASSERT_TRUE(
+      cap.is_capable(nullptr, {}, "", "abc", "", {}, true, false, false, {}));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "bcd", "", {}, true, true, false, {}));
+  ASSERT_TRUE(
+      cap.is_capable(nullptr, {}, "", "bcd", "", {}, false, true, false, {}));
 }
 
-TEST(MgrCap, Profile) {
+TEST(MgrCap, Profile)
+{
   MgrCap cap;
   ASSERT_FALSE(cap.is_allow_all());
 
@@ -274,28 +309,93 @@ TEST(MgrCap, Profile) {
   ASSERT_FALSE(cap.parse("profile rbd invalid-key=value"));
 
   ASSERT_TRUE(cap.parse("profile rbd", nullptr));
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "", "abc", "", {}, true, false,
-                              false, {}));
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "", "rbd_support", "", {}, true,
-                             true, false, {}));
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "", "rbd_support", "", {}, true,
-                             false, false, {}));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "abc", "", {}, true, false, false, {}));
+  ASSERT_TRUE(cap.is_capable(
+      nullptr, {}, "", "rbd_support", "", {}, true, true, false, {}));
+  ASSERT_TRUE(cap.is_capable(
+      nullptr, {}, "", "rbd_support", "", {}, true, false, false, {}));
 
   ASSERT_TRUE(cap.parse("profile rbd pool=abc namespace prefix def", nullptr));
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "", "rbd_support", "", {},
-                              true, true, false, {}));
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "", "rbd_support", "",
-                              {{"pool", "abc"}},
-                              true, true, false, {}));
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "", "rbd_support", "",
-                             {{"pool", "abc"}, {"namespace", "defghi"}},
-                             true, true, false, {}));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, {}, "", "rbd_support", "", {}, true, true, false, {}));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, {}, "", "rbd_support", "", {{"pool", "abc"}}, true, true, false,
+      {}));
+  ASSERT_TRUE(cap.is_capable(
+      nullptr, {}, "", "rbd_support", "",
+      {{"pool", "abc"}, {"namespace", "defghi"}}, true, true, false, {}));
 
   ASSERT_TRUE(cap.parse("profile rbd-read-only", nullptr));
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "", "abc", "", {}, true, false,
-                              false, {}));
-  ASSERT_FALSE(cap.is_capable(nullptr, {}, "", "rbd_support", "", {}, true,
-                              true, false, {}));
-  ASSERT_TRUE(cap.is_capable(nullptr, {}, "", "rbd_support", "", {}, true,
-                             false, false, {}));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "abc", "", {}, true, false, false, {}));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, {}, "", "rbd_support", "", {}, true, true, false, {}));
+  ASSERT_TRUE(cap.is_capable(
+      nullptr, {}, "", "rbd_support", "", {}, true, false, false, {}));
 }
+
+/* Begin Negative Tests */
+
+TEST(MgrCap, IsCapableEmptyCommand)
+{
+  MgrCap cap;
+  ASSERT_TRUE(cap.parse("allow command abc", nullptr));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "", "", {}, true, false, false, {}));
+}
+
+TEST(MgrCap, IsCapableEmptyModule)
+{
+  MgrCap cap;
+  ASSERT_TRUE(cap.parse("allow module xyz r", nullptr));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "", "", {}, true, false, false, {}));
+}
+
+TEST(MgrCap, IsCapableEmptyService)
+{
+  MgrCap cap;
+  ASSERT_TRUE(cap.parse("allow service foo r", nullptr));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "", "", {}, true, false, false, {}));
+}
+
+TEST(MgrCap, CommandEmptyArguments)
+{
+  MgrCap cap;
+  ASSERT_TRUE(cap.parse("allow command abc with arg=foo", nullptr));
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "", "abc", {}, true, false, false, {}));
+}
+
+TEST(MgrCap, CommandMismatchedArguments)
+{
+  MgrCap cap;
+  ASSERT_TRUE(cap.parse("allow command abc with arg=foo arg2=bar", nullptr));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, {}, "", "", "abc", {{"arg", "foo"}}, true, false, false, {}));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, {}, "", "", "abc", {{"arg", "wrong"}, {"arg2", "bar"}}, true,
+      false, false, {}));
+}
+
+TEST(MgrCap, RegexWithInvalidPattern)
+{
+  MgrCap cap;
+  // Invalid regex should be accepted during parse but fail during matching
+  ASSERT_TRUE(cap.parse("allow command abc with arg regex \"[*\"", nullptr));
+  ASSERT_FALSE(cap.is_capable(
+      nullptr, {}, "", "", "abc", {{"arg", "test"}}, true, false, false, {}));
+}
+
+TEST(MgrCap, PermissionsWithNoCapability)
+{
+  MgrCap cap;
+  ASSERT_TRUE(cap.parse("allow r", nullptr));
+  // Asking for write when only read is granted
+  ASSERT_FALSE(
+      cap.is_capable(nullptr, {}, "", "", "", {}, false, true, false, {}));
+}
+
+/* End Negative Tests */

--- a/src/test/mgr/test_pyformatter.cc
+++ b/src/test/mgr/test_pyformatter.cc
@@ -1,0 +1,383 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <Python.h>
+
+#include "global/global_init.h"
+#include "gtest/gtest.h"
+#include "mgr/PyFormatter.h"
+
+#include "TestMgr.h"
+
+TEST(PyFormatter, CreateAndGet)
+{
+  PyFormatter py_f;
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, ArraySection)
+{
+  PyFormatter py_f;
+  py_f.open_array_section("items");
+  py_f.dump_int("item", 123);
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* items = PyDict_GetItemString(py_obj, "items");
+  ASSERT_NE(items, nullptr);
+  ASSERT_TRUE(PyList_Check(items));
+
+  Py_ssize_t list_size = PyList_Size(items);
+  ASSERT_EQ(list_size, 1);
+
+  PyObject* py_value = PyList_GetItem(items, 0);
+  ASSERT_NE(py_value, nullptr);
+  ASSERT_TRUE(PyLong_Check(py_value));
+  ASSERT_EQ(PyLong_AsLong(py_value), 123);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, ObjectSection)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_string("a", "b");
+  py_f.dump_int("abc", 123);
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_NE(temp, nullptr);
+  ASSERT_TRUE(PyDict_Check(temp));
+
+  PyObject* py_str_value = PyDict_GetItemString(temp, "a");
+  ASSERT_NE(py_str_value, nullptr);
+  ASSERT_TRUE(PyUnicode_Check(py_str_value));
+
+  const char* str_result = PyUnicode_AsUTF8(py_str_value);
+  ASSERT_NE(str_result, nullptr);
+  ASSERT_STREQ(str_result, "b");
+
+  PyObject* py_int_value = PyDict_GetItemString(temp, "abc");
+  ASSERT_NE(py_int_value, nullptr);
+  ASSERT_TRUE(PyLong_Check(py_int_value));
+  ASSERT_EQ(PyLong_AsLong(py_int_value), 123);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpNull)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_null("abc");
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_NE(temp, nullptr);
+  ASSERT_TRUE(PyDict_Check(temp));
+
+  PyObject* py_null_value = PyDict_GetItemString(temp, "abc");
+  ASSERT_NE(py_null_value, nullptr);
+  ASSERT_EQ(py_null_value, Py_None);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpUnsigned)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_unsigned("testUInt", 123u);
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "testUInt");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_TRUE(PyLong_Check(py_value));
+  ASSERT_EQ(PyLong_AsLong(py_value), 123);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpInt)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_int("testInt", -123);
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "testInt");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_TRUE(PyLong_Check(py_value));
+  ASSERT_EQ(PyLong_AsLong(py_value), -123);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpFloat)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_float("testFloat", 1.23);
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "testFloat");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_TRUE(PyFloat_Check(py_value));
+  ASSERT_DOUBLE_EQ(PyFloat_AsDouble(py_value), 1.23);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpString)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_string("testStr", "testing");
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "testStr");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_TRUE(PyUnicode_Check(py_value));
+  ASSERT_STREQ(PyUnicode_AsUTF8(py_value), "testing");
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpBool)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_bool("testFlag", true);
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "testFlag");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_TRUE(PyBool_Check(py_value));
+  ASSERT_EQ(py_value, Py_True);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpStream)
+{
+  PyFormatter py_f;
+  std::ostringstream oss;
+  oss << "test stream value";
+  py_f.open_object_section("temp");
+  py_f.dump_stream(oss.str());
+  py_f.close_section();
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpFormatVa)
+{
+  auto dump_format_va_helper = [](PyFormatter* py_formatter,
+                                  std::string_view name, const char* ns,
+                                  bool quoted, const char* py_formatstr, ...) {
+    va_list args;
+    va_start(args, py_formatstr);
+    py_formatter->dump_format_va(name, ns, quoted, py_formatstr, args);
+    va_end(args);
+  };
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  dump_format_va_helper(
+      &py_f, "testVa", nullptr, false, "testing %s %d", "abc", 123);
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "testVa");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_TRUE(PyUnicode_Check(py_value));
+  ASSERT_STREQ(PyUnicode_AsUTF8(py_value), "testing abc 123");
+
+  Py_DECREF(py_obj);
+}
+
+/* Begin Negative Tests */
+
+TEST(PyFormatter, DumpWithEmptyKey)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_string("", "value");
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_STREQ(PyUnicode_AsUTF8(py_value), "value");
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpWithEmptyString)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_string("key", "");
+  py_f.close_section();
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "key");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_STREQ(PyUnicode_AsUTF8(py_value), "");
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, OpenSectionWithoutClosing)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_int("key", 123);
+  //Not closing the section, testing that we handle incomplete nesting
+  //Should still return valid data from get()
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+  ASSERT_TRUE(PyDict_Check(temp));
+
+  PyObject* py_value = PyDict_GetItemString(temp, "key");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_TRUE(PyLong_Check(py_value));
+  ASSERT_EQ(PyLong_AsLong(py_value), 123);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, DumpExtremeInts)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("temp");
+  py_f.dump_int("max", INT_MAX);
+  py_f.dump_int("min", INT_MIN);
+  py_f.close_section();
+  //Testing for Integer overflow during conversion to/from Python objects
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "temp");
+  ASSERT_TRUE(temp != nullptr);
+  ASSERT_TRUE(PyDict_Check(temp));
+
+  PyObject* max_val = PyDict_GetItemString(temp, "max");
+  ASSERT_TRUE(max_val != nullptr);
+  ASSERT_TRUE(PyLong_Check(max_val));
+  ASSERT_EQ(PyLong_AsLong(max_val), INT_MAX);
+
+  PyObject* min_val = PyDict_GetItemString(temp, "min");
+  ASSERT_TRUE(min_val != nullptr);
+  ASSERT_TRUE(PyLong_Check(min_val));
+  ASSERT_EQ(PyLong_AsLong(min_val), INT_MIN);
+
+  Py_DECREF(py_obj);
+}
+
+TEST(PyFormatter, EmptySectionName)
+{
+  PyFormatter py_f;
+  py_f.open_object_section("");
+  py_f.dump_string("key", "test_val");
+  py_f.close_section();
+  //Test that "" is a valid key
+
+  PyObject* py_obj = py_f.get();
+  ASSERT_NE(py_obj, nullptr);
+  ASSERT_TRUE(PyDict_Check(py_obj));
+
+  PyObject* temp = PyDict_GetItemString(py_obj, "");
+  ASSERT_TRUE(temp != nullptr);
+
+  PyObject* py_value = PyDict_GetItemString(temp, "key");
+  ASSERT_TRUE(py_value != nullptr);
+  ASSERT_STREQ(PyUnicode_AsUTF8(py_value), "test_val");
+
+  Py_DECREF(py_obj);
+}
+
+/* End Negative Tests */
+
+int
+main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new PythonEnv);
+
+  return RUN_ALL_TESTS();
+}

--- a/src/test/mgr/test_pyutil.cc
+++ b/src/test/mgr/test_pyutil.cc
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <Python.h>
+
+#include "common/options.h"
+#include "global/global_init.h"
+#include "gtest/gtest.h"
+#include "mgr/PyUtil.h"
+
+#include "TestMgr.h"
+
+TEST(PyUtil, IntType)
+{
+  PyObject* int_obj = get_python_typed_option_value(Option::TYPE_INT, "11");
+  ASSERT_TRUE(PyLong_Check(int_obj));
+  EXPECT_EQ(PyLong_AsLong(int_obj), 11);
+  Py_DECREF(int_obj);
+}
+
+TEST(PyUtil, FloatType)
+{
+  PyObject* float_obj =
+      get_python_typed_option_value(Option::TYPE_FLOAT, "11.22");
+  ASSERT_TRUE(PyFloat_Check(float_obj));
+  EXPECT_DOUBLE_EQ(PyFloat_AsDouble(float_obj), 11.22);
+  Py_DECREF(float_obj);
+}
+
+TEST(PyUtil, BoolType)
+{
+  PyObject* bool_obj_true =
+      get_python_typed_option_value(Option::TYPE_BOOL, "true");
+  ASSERT_EQ(bool_obj_true, Py_True);
+  Py_DECREF(bool_obj_true);
+
+  PyObject* bool_obj_false =
+      get_python_typed_option_value(Option::TYPE_BOOL, "false");
+  ASSERT_EQ(bool_obj_false, Py_False);
+  Py_DECREF(bool_obj_false);
+}
+
+TEST(PyUtil, StringType)
+{
+  PyObject* string_obj = get_python_typed_option_value(Option::TYPE_STR, "test");
+  ASSERT_TRUE(PyUnicode_Check(string_obj));
+  EXPECT_STREQ(PyUnicode_AsUTF8(string_obj), "test");
+  Py_DECREF(string_obj);
+}
+
+/* Begin Negative Tests */
+
+TEST(PyUtil, BoolWithInvalidString)
+{
+  PyObject* bool_obj_false =
+      get_python_typed_option_value(Option::TYPE_BOOL, "maybe");
+  ASSERT_EQ(bool_obj_false, Py_False);
+  Py_DECREF(bool_obj_false);
+}
+
+TEST(PyUtil, StringTypeEmptyString)
+{
+  PyObject* string_obj = get_python_typed_option_value(Option::TYPE_STR, "");
+  ASSERT_TRUE(PyUnicode_Check(string_obj));
+  EXPECT_STREQ(PyUnicode_AsUTF8(string_obj), "");
+  Py_DECREF(string_obj);
+}
+
+TEST(PyUtil, IntTypeExtremes)
+{
+  PyObject* int_obj_max =
+      get_python_typed_option_value(Option::TYPE_INT, "2147483647");
+  ASSERT_TRUE(PyLong_Check(int_obj_max));
+  EXPECT_EQ(PyLong_AsLong(int_obj_max), 2147483647);
+  Py_DECREF(int_obj_max);
+
+  PyObject* int_obj_min =
+      get_python_typed_option_value(Option::TYPE_INT, "-2147483648");
+  ASSERT_TRUE(PyLong_Check(int_obj_min));
+  EXPECT_EQ(PyLong_AsLong(int_obj_min), -2147483648);
+  Py_DECREF(int_obj_min);
+}
+
+/*TODO: Also need to test/fix other type mismatches 
+  Commented out until Tracker 74181 is resolved
+  Causes a segfault since there is no guard against bad input
+TEST(PyUtil, IntTypeMismatch)
+{
+  PyObject* int_obj = get_python_typed_option_value(Option::TYPE_INT, "abc");
+  ASSERT_TRUE(PyLong_Check(int_obj));
+  Py_DECREF(int_obj);
+}
+*/
+/* End Negative Tests */
+
+int
+main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new PythonEnv);
+
+  return RUN_ALL_TESTS();
+}

--- a/src/test/mgr/test_servicemap.cc
+++ b/src/test/mgr/test_servicemap.cc
@@ -1,0 +1,299 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <fmt/format.h>
+
+#include <map>
+#include <sstream>
+#include <string>
+
+#include "common/Formatter.h"
+#include "common/JSONFormatter.h"
+#include "gtest/gtest.h"
+#include "include/buffer.h"
+#include "mgr/ServiceMap.h"
+#include "msg/msg_types.h"
+
+TEST(ServiceMapDaemon, EncodeDecode)
+{
+  ServiceMap::Daemon d_1;
+  d_1.gid = 123;
+  d_1.metadata["test"] = "ing";
+
+  bufferlist bl;
+  d_1.encode(bl, 0);
+  auto p = bl.cbegin();
+
+  ServiceMap::Daemon d_2;
+  d_2.decode(p);
+
+  EXPECT_EQ(d_2.gid, 123);
+  EXPECT_EQ(d_2.metadata["test"], "ing");
+}
+
+TEST(ServiceMapDaemon, Dump)
+{
+  ServiceMap::Daemon test_daemon;
+  test_daemon.gid = 11;
+
+  entity_addr_t addr;
+  addr.parse("127.0.0.1:1234", nullptr);
+  test_daemon.addr = addr;
+  test_daemon.start_epoch = 33;
+  test_daemon.start_stamp = utime_t(55, 5500000);
+
+  //dump_object will call ServiceMap::Daemon::dump wrapped in an open/close section
+  JSONFormatter f;
+  f.dump_object("daemon", test_daemon);
+
+  std::ostringstream oss;
+  f.flush(oss);
+
+  std::string json_str;
+  json_str = oss.str();
+
+  EXPECT_TRUE(json_str.contains("\"gid\":11"));
+  EXPECT_TRUE(json_str.contains("127.0.0.1:1234"));
+  EXPECT_TRUE(json_str.contains("\"start_epoch\":33"));
+  EXPECT_TRUE(json_str.contains("\"start_stamp\":\"55.005500\""));
+}
+
+TEST(ServiceMapService, GetSummary)
+{
+  ServiceMap::Service sms;
+  sms.summary = "test summary";
+
+  EXPECT_EQ(sms.get_summary(), "test summary");
+}
+
+TEST(ServiceMapService, HasRunningTasks)
+{
+  ServiceMap::Service sms;
+
+  EXPECT_FALSE(sms.has_running_tasks());
+
+  sms.daemons["test"].task_status["task"] = "running";
+
+  EXPECT_TRUE(sms.has_running_tasks());
+}
+
+TEST(ServiceMapService, GetTaskSummary)
+{
+  ServiceMap::Service sms;
+  sms.daemons["test"].task_status["task"] = "running";
+  sms.daemons["test2"].task_status["task"] = "idle";
+
+  const std::string expected =
+      "\n"
+      "    task:\n"
+      "        svc.test: running\n"
+      "        svc.test2: idle";
+  EXPECT_EQ(sms.get_task_summary("svc"), expected);
+}
+
+TEST(ServiceMapService, CountMetadata)
+{
+  ServiceMap::Service sms;
+  sms.daemons["daemon1"].metadata["test"] = "t1";
+  sms.daemons["daemon2"].metadata["test"] = "t2";
+  sms.daemons["daemon3"].task_status["abc"] = "xyz";
+
+  std::map<std::string, int> metadata_info;
+  sms.count_metadata("test", &metadata_info);
+
+  EXPECT_EQ(metadata_info["t1"], 1);
+  EXPECT_EQ(metadata_info["t2"], 1);
+  EXPECT_EQ(metadata_info["unknown"], 1);
+}
+
+TEST(ServiceMapService, EncodeDecode)
+{
+  ServiceMap::Service s_1;
+  s_1.summary = "summary";
+  s_1.daemons["d"].gid = 99;
+
+  bufferlist bl;
+  s_1.encode(bl, 0);
+  auto p = bl.cbegin();
+
+  ServiceMap::Service s_2;
+  s_2.decode(p);
+
+  EXPECT_EQ(s_2.summary, "summary");
+  EXPECT_EQ(s_2.daemons["d"].gid, 99);
+}
+
+TEST(ServiceMapService, Dump)
+{
+  entity_addr_t addr;
+  addr.parse("127.0.0.1:1234", nullptr);
+
+  ServiceMap::Service sms;
+  sms.summary = "testSummary";
+  sms.daemons["d123"].gid = 123;
+  sms.daemons["d123"].addr = addr;
+
+  JSONFormatter f;
+  f.dump_object("service", sms);
+
+  std::ostringstream oss;
+  f.flush(oss);
+
+  std::string json_str;
+  json_str = oss.str();
+
+  const std::string expected =
+      R"({"daemons":{"summary":"testSummary","d123":{"start_epoch":0,"start_stamp":"0.000000","gid":123,"addr":"127.0.0.1:1234/0","metadata":{},"task_status":{}}}})";
+  EXPECT_EQ(json_str, expected);
+}
+
+TEST(ServiceMapMap, EncodeDecode)
+{
+  ServiceMap m_1;
+  m_1.epoch = 123;
+  m_1.services["svc"].summary = "abc";
+
+  bufferlist bl;
+  m_1.encode(bl, 0);
+  auto p = bl.cbegin();
+
+  ServiceMap m_2;
+  m_2.decode(p);
+
+  EXPECT_EQ(m_2.epoch, 123);
+  EXPECT_EQ(m_2.services["svc"].summary, "abc");
+}
+
+TEST(ServiceMapMap, Dump)
+{
+  ServiceMap sm;
+  sm.epoch = 123;
+  sm.services["svc"].summary = "testSummary";
+
+  JSONFormatter f;
+  f.dump_object("servicemap", sm);
+
+  std::ostringstream oss;
+  f.flush(oss);
+
+  std::string json_str;
+  json_str = oss.str();
+
+  const std::string expected =
+      R"({"epoch":123,"modified":"0.000000","services":{"svc":{"daemons":{"summary":"testSummary"}}}})";
+  EXPECT_EQ(json_str, expected);
+}
+
+/* Begin Negative Tests */
+
+TEST(ServiceMapDaemon, EncodeDecodeWithEmptyMetadata)
+{
+  ServiceMap::Daemon d_1;
+
+  d_1.gid = 123;
+  bufferlist bl;
+  d_1.encode(bl, 0);
+  auto p = bl.cbegin();
+
+  ServiceMap::Daemon d_2;
+  d_2.decode(p);
+
+  EXPECT_EQ(d_2.gid, 123);
+  EXPECT_TRUE(d_2.metadata.empty());
+}
+
+TEST(ServiceMapDaemon, DumpWithEmptyMetadata)
+{
+  std::ostringstream oss;
+  JSONFormatter f(true);
+  ServiceMap::Daemon d;
+
+  d.gid = 123;
+  f.dump_object("daemon", d);
+  f.flush(oss);
+  const std::string output = oss.str();
+
+  EXPECT_TRUE(output.contains("\"gid\": 123"));
+  EXPECT_TRUE(output.contains("\"metadata\": {}"));
+}
+
+TEST(ServiceMapService, GetSummaryEmptyString)
+{
+  ServiceMap::Service s;
+
+  s.summary = "";
+
+  EXPECT_EQ(s.get_summary(), "no daemons active");
+}
+
+TEST(ServiceMapService, GetTaskSummaryEmptyDaemons)
+{
+  ServiceMap::Service s;
+  std::string summary = s.get_task_summary("svc");
+
+  EXPECT_EQ(summary, "");
+}
+
+TEST(ServiceMapService, GetTaskSummaryEmptyTaskStatus)
+{
+  ServiceMap::Service s;
+
+  s.daemons["d1"].gid = 1;
+  std::string summary = s.get_task_summary("svc");
+
+  EXPECT_EQ(summary, "");
+}
+
+TEST(ServiceMapService, CountMetadataEmptyKey)
+{
+  ServiceMap::Service s;
+  std::map<std::string, int> out;
+
+  s.daemons["d1"].metadata["zone"] = "z1";
+  s.count_metadata("", &out);
+
+  EXPECT_EQ(out["unknown"], 1);
+}
+
+TEST(ServiceMapService, CountMetadataDNEKey)
+{
+  ServiceMap::Service s;
+  std::map<std::string, int> out;
+
+  s.daemons["d1"].metadata["zone"] = "z1";
+  s.count_metadata("DNE", &out);
+
+  EXPECT_EQ(out["unknown"], 1);
+}
+
+TEST(ServiceMapService, EncodeDecodeEmptyDaemons)
+{
+  ServiceMap::Service s_1;
+  ServiceMap::Service s_2;
+  bufferlist bl;
+
+  s_1.summary = "summary";
+  s_1.encode(bl, 0);
+  auto p = bl.cbegin();
+  s_2.decode(p);
+
+  EXPECT_EQ(s_2.summary, "summary");
+  EXPECT_TRUE(s_2.daemons.empty());
+}
+
+TEST(ServiceMapMap, EncodeDecodeEmptyServices)
+{
+  ServiceMap m_1;
+  ServiceMap m_2;
+  bufferlist bl;
+
+  m_1.epoch = 123;
+  m_1.encode(bl, 0);
+  auto p = bl.cbegin();
+  m_2.decode(p);
+
+  EXPECT_EQ(m_2.epoch, 123);
+  EXPECT_TRUE(m_2.services.empty());
+}
+
+/* End Negative Tests*/

--- a/src/test/mgr/test_ttlcache.cc
+++ b/src/test/mgr/test_ttlcache.cc
@@ -1,24 +1,26 @@
 #include <iostream>
 
-#include "mgr/TTLCache.h"
 #include "gtest/gtest.h"
+#include "mgr/TTLCache.h"
 
 using namespace std;
 
-TEST(TTLCache, Get) {
-	TTLCache<string, int> c{100};
-	c.insert("foo", 1);
-	int foo = c.get("foo");
-	ASSERT_EQ(foo, 1);
+TEST(TTLCache, Get)
+{
+  TTLCache<string, int> c{100};
+  c.insert("foo", 1);
+  int foo = c.get("foo");
+  ASSERT_EQ(foo, 1);
 }
 
-TEST(TTLCache, Erase) {
-	TTLCache<string, int> c{100};
-	c.insert("foo", 1);
-	int foo = c.get("foo");
-	ASSERT_EQ(foo, 1);
-	c.erase("foo");
-  try{
+TEST(TTLCache, Erase)
+{
+  TTLCache<string, int> c{100};
+  c.insert("foo", 1);
+  int foo = c.get("foo");
+  ASSERT_EQ(foo, 1);
+  c.erase("foo");
+  try {
     foo = c.get("foo");
     FAIL();
   } catch (std::out_of_range& e) {
@@ -26,22 +28,24 @@ TEST(TTLCache, Erase) {
   }
 }
 
-TEST(TTLCache, Clear) {
-	TTLCache<string, int> c{100};
-	c.insert("foo", 1);
-	c.insert("foo2", 2);
-	c.clear();
-	ASSERT_FALSE(c.size());
+TEST(TTLCache, Clear)
+{
+  TTLCache<string, int> c{100};
+  c.insert("foo", 1);
+  c.insert("foo2", 2);
+  c.clear();
+  ASSERT_FALSE(c.size());
 }
 
-TEST(TTLCache, NoTTL) {
-	TTLCache<string, int> c{100};
-	c.insert("foo", 1);
-	int foo = c.get("foo");
-	ASSERT_EQ(foo, 1);
-	c.set_ttl(0);
-	c.insert("foo2", 2);
-  try{
+TEST(TTLCache, NoTTL)
+{
+  TTLCache<string, int> c{100};
+  c.insert("foo", 1);
+  int foo = c.get("foo");
+  ASSERT_EQ(foo, 1);
+  c.set_ttl(0);
+  c.insert("foo2", 2);
+  try {
     foo = c.get("foo2");
     FAIL();
   } catch (std::out_of_range& e) {
@@ -49,22 +53,24 @@ TEST(TTLCache, NoTTL) {
   }
 }
 
-TEST(TTLCache, SizeLimit) {
-	TTLCache<string, int> c{100, 2};
-	c.insert("foo", 1);
-	c.insert("foo2", 2);
-	c.insert("foo3", 3);
-	ASSERT_EQ(c.size(), 2);
+TEST(TTLCache, SizeLimit)
+{
+  TTLCache<string, int> c{100, 2};
+  c.insert("foo", 1);
+  c.insert("foo2", 2);
+  c.insert("foo3", 3);
+  ASSERT_EQ(c.size(), 2);
 }
 
-TEST(TTLCache, HitRatio) {
-	TTLCache<string, int> c{100};
-	c.insert("foo", 1);
-	c.insert("foo2", 2);
-	c.insert("foo3", 3);
-	c.get("foo2");
-	c.get("foo3");
-	std::pair<uint64_t, uint64_t> hit_miss_ratio = c.get_hit_miss_ratio();
-	ASSERT_EQ(std::get<1>(hit_miss_ratio), 3);
-	ASSERT_EQ(std::get<0>(hit_miss_ratio), 2);
+TEST(TTLCache, HitRatio)
+{
+  TTLCache<string, int> c{100};
+  c.insert("foo", 1);
+  c.insert("foo2", 2);
+  c.insert("foo3", 3);
+  c.get("foo2");
+  c.get("foo3");
+  std::pair<uint64_t, uint64_t> hit_miss_ratio = c.get_hit_miss_ratio();
+  ASSERT_EQ(std::get<1>(hit_miss_ratio), 3);
+  ASSERT_EQ(std::get<0>(hit_miss_ratio), 2);
 }


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

The current test coverage and the unit-test coverage for ceph-mgr are not enough; changes that have been made sometimes can break the core functions of the mgr
We need to expand the test coverage for classes under src/mgr directory and expand the tests for the mgr modules.

Fixes: https://tracker.ceph.com/issues/72938

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
