### PR TITLE
bluestore/bluefs: FileWriter simpler flush

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3901,7 +3901,7 @@ void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length)/*_WF*/
     // For envelope files disregard offset and length and just flush current envelope.
     _flush_envelope_F(h);
   } else {
-    _flush_range_F(h, offset, length);
+    _flush_range_F(h, offset + length);
   }
 }
 
@@ -3917,43 +3917,30 @@ int BlueFS::_flush_envelope_F(FileWriter *h)
   ceph_le64 flush_length_le(content_length);
   h->envelope_head_filler.copy_in(File::envelope_t::head_size(), (char*)&flush_length_le);
   uint64_t length = File::envelope_t::head_size() + content_length + File::envelope_t::tail_size();
-  return _flush_range_F(h, offset, length);
+  return _flush_range_F(h, offset + length);
 }
 
-int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
+int BlueFS::_flush_range_F(FileWriter *h, uint64_t end)
 {
   auto t0 = mono_clock::now();
   ceph_assert(ceph_mutex_is_locked(h->lock));
   ceph_assert(h->file->num_readers.load() == 0);
   ceph_assert(h->file->fnode.ino > 1);
 
-  uint64_t end = offset + length;
-
-  dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->get_pos()
-	   << " 0x" << offset << "~" << length << std::dec
-	   << " to " << h->file->fnode
-	   << " hint " << h->file->vselector_hint
-           << dendl;
+  dout(10) << __func__ << " " << h << std::hex
+           << " 0x" << h->get_pos() << ".." << end << std::dec
+           << " to " << h->file->fnode
+           << " hint " << h->file->vselector_hint << dendl;
 
   bool buffered = cct->_conf->bluefs_buffered_io;
 
   if (end <= h->get_pos())
     return 0;
-  if (offset < h->get_pos()) {
-    // NOTE: for envelope files we flush existing data
-    ceph_assert(!h->file->envelope_mode());
-    length -= h->get_pos() - offset;
-    offset = h->get_pos();
-    dout(10) << " still need 0x"
-             << std::hex << offset << "~" << length << std::dec
-             << dendl;
-  }
   std::lock_guard file_lock(h->file->lock);
   if (h->file->deleted) {
     dout(10) << __func__ << " deleted, no-op" << dendl;
     return 0;
   }
-  ceph_assert(offset <= h->file->fnode.size);
 
   uint64_t allocated = h->file->fnode.get_allocated();
   // do not bother to dirty the file if we are overwriting
@@ -3970,8 +3957,7 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 	              });
     if (r < 0) {
       derr << __func__ << " allocated: 0x" << std::hex << allocated
-           << " offset: 0x" << offset << " length: 0x" << length << std::dec
-           << dendl;
+           << " for " << h->file->fnode << " end: 0x" << end << std::dec << dendl;
       ceph_abort_msg("bluefs enospc");
       return r;
     }
@@ -3987,12 +3973,12 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
     }
   }
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
-  int res = _flush_data(h, offset, length, buffered);
+  int res = _flush_data(h, end, buffered);
   logger->tinc_with_max(l_bluefs_flush_lat, mono_clock::now() - t0);
   return res;
 }
 
-int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
+int BlueFS::_flush_data(FileWriter *h, uint64_t end, bool buffered)
 {
   if (h->file->fnode.ino > 1) {
     ceph_assert(ceph_mutex_is_locked(h->lock));
@@ -4008,8 +3994,8 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
     }
   }
   uint64_t write_offset = h->get_flush_offset();
-  bufferlist bl = h->get_flush_buffer(cct, offset + length);
-  length = bl.length();
+  bufferlist bl = h->get_flush_buffer(cct, end);
+  uint64_t length = bl.length();
 
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(write_offset, &x_off);
@@ -4176,15 +4162,16 @@ int BlueFS::_flush_F(FileWriter *h, bool force, bool *flushed)
 	     << h->file->fnode << dendl;
     return 0;
   }
+  uint64_t end = offset + length;
   dout(10) << __func__ << " " << h << " 0x"
-           << std::hex << offset << "~" << length << std::dec
+           << std::hex << offset << ".." << end << std::dec
 	   << " to " << h->file->fnode << dendl;
   ceph_assert(h->get_pos() <= h->file->fnode.size);
   int r;
   if (h->file->envelope_mode()) {
     r = _flush_envelope_F(h);
   } else {
-    r = _flush_range_F(h, offset, length);
+    r = _flush_range_F(h, end);
   }
   if (flushed) {
     *flushed = true;
@@ -4209,7 +4196,7 @@ uint64_t BlueFS::_flush_special(FileWriter *h)
     new_data = offset + length - h->file->fnode.size;
     h->file->fnode.size = offset + length;
   }
-  _flush_data(h, offset, length, false);
+  _flush_data(h, offset + length, false);
   return new_data;
 }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3812,45 +3812,32 @@ int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to)
   return 0;
 }
 
-ceph::bufferlist BlueFS::FileWriter::flush_buffer(
-  CephContext* const cct,
-  const bool partial,
-  const unsigned length,
-  const bluefs_super_t& super)
+ceph::bufferlist BlueFS::FileWriter::get_flush_buffer(
+  CephContext* cct,
+  uint64_t want_end)
 {
   ceph_assert(ceph_mutex_is_locked(this->lock) || file->fnode.ino <= 1);
-  ceph::bufferlist bl;
-  if (partial) {
-    tail_block.splice(0, tail_block.length(), &bl);
-  }
-  dout(20) << __func__ << " tail is" << std::hex << bl.length() << dendl;
-  ceph_assert(length >= bl.length());
-  const auto remaining_len = length - bl.length();
-  buffer.splice(0, remaining_len, &bl);
-  if (buffer.length()) {
-    dout(20) << " leaving 0x" << std::hex << buffer.length() << std::dec
-             << " unflushed" << dendl;
-  }
-  // Append padding to fill block
-  unsigned tail = bl.length() & ~super.block_mask();
-  if (tail) {
-    unsigned padding_len = super.block_size - tail;
-    dout(20) << __func__ << " caching tail of 0x"
-             << std::hex << tail
-             << " and padding block with 0x" << padding_len
-             << " buffer.length() " << buffer.length()
-             << std::dec << dendl;
+  ceph_assert(get_pos() < want_end);
+  ceph::bufferlist bl_to_disk;
+  uint64_t data_end = get_pos() + get_buffer_length();
+  uint64_t io_end = p2roundup<uint64_t>(
+    std::min(want_end, data_end), super_block_size);
+  uint64_t io_size = io_end - buffer_pos;
+  if (io_end <= data_end) {
+    // only partial flush
+    buffer.splice(0, io_size, &bl_to_disk);
+    pos = want_end;
+    buffer_pos += io_size;
+  } else {
+    // need to pad with zeros
+    ceph_assert(io_end - data_end < super_block_size);
+    uint64_t tail = p2phase<uint64_t>(data_end, super_block_size);
     // We need to go through the `buffer_appender` to get a chance to
     // preserve in-memory contiguity and not mess with the alignment.
     // Otherwise a costly rebuild could happen in e.g. `KernelDevice`.
-    buffer_appender.append_zero(padding_len);
-    buffer.splice(buffer.length() - padding_len, padding_len, &bl);
-    // Deep copy the tail here. This allows to avoid costlier copy on
-    // bufferlist rebuild in e.g. `KernelDevice` and minimizes number
-    // of memory allocations.
-    // The alternative approach would be to place the entire tail and
-    // padding on a dedicated, 4 KB long memory chunk. This shouldn't
-    // trigger the rebuild while still being less expensive.
+    buffer_appender.append_zero(super_block_size - tail);
+    // now aligned
+    buffer.splice(0, io_size, &bl_to_disk);
     if (file->envelope_mode() &&
       buffer.get_append_buffer_unused_tail_length() < tail + File::envelope_t::head_size()) {
       // Envelope mode header must completely fit in single buffer::ptr,
@@ -3862,12 +3849,14 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
       // pages. The size is min 2 * super.block_size so header will fit.
       buffer.clear();
     }
-    buffer_appender.substr_of(bl, bl.length() - padding_len - tail, tail);
-    buffer.splice(buffer.length() - tail, tail, &tail_block);
-  } else {
-    tail_block.clear();
+    // append (duplicate) tail for next flush
+    buffer_appender.substr_of(bl_to_disk, (data_end - tail) - buffer_pos, tail);
+
+    pos = want_end;
+    buffer_pos += io_size - super_block_size;
+    ceph_assert(buffer.length() < super_block_size);
   }
-  return bl;
+  return bl_to_disk;
 }
 
 int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
@@ -4009,19 +3998,8 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
     ceph_assert(ceph_mutex_is_locked(h->lock));
     ceph_assert(ceph_mutex_is_locked(h->file->lock));
   }
-  uint64_t x_off = 0;
-  auto p = h->file->fnode.seek(offset, &x_off);
-  ceph_assert(p != h->file->fnode.extents.end());
-  dout(20) << __func__ << " in " << *p << " x_off 0x"
-           << std::hex << x_off << std::dec << dendl;
 
-  unsigned partial = x_off & ~super.block_mask();
-  if (partial) {
-    dout(20) << __func__ << " using partial tail 0x"
-             << std::hex << partial << std::dec << dendl;
-    x_off -= partial;
-    offset -= partial;
-    length += partial;
+  if (h->has_flushed_data()) {
     dout(20) << __func__ << " waiting for previous aio to complete" << dendl;
     for (auto p : h->iocv) {
       if (p) {
@@ -4029,11 +4007,15 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
       }
     }
   }
-
-  auto bl = h->flush_buffer(cct, partial, length, super);
-  ceph_assert(bl.length() >= length);
-  h->set_pos(offset + length);
+  uint64_t write_offset = h->get_flush_offset();
+  bufferlist bl = h->get_flush_buffer(cct, offset + length);
   length = bl.length();
+
+  uint64_t x_off = 0;
+  auto p = h->file->fnode.seek(write_offset, &x_off);
+  ceph_assert(p != h->file->fnode.extents.end());
+  dout(20) << __func__ << " in " << *p << " x_off 0x"
+           << std::hex << x_off << std::dec << dendl;
 
   logger->inc(l_bluefs_write_count, 1);
   logger->inc(l_bluefs_write_bytes, length);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1177,10 +1177,10 @@ int BlueFS::mount()
   // set up the log for future writes
   log.writer = _create_writer(_get_file(1));
   ceph_assert(log.writer->file->fnode.ino == 1);
-  log.writer->pos = log.writer->file->fnode.size;
+  log.writer->set_pos(log.writer->file->fnode.size);
   log.writer->file->fnode.reset_delta();
   dout(10) << __func__ << " log write pos set to 0x"
-           << std::hex << log.writer->pos << std::dec
+           << std::hex << log.writer->get_pos() << std::dec
            << dendl;
   // update log size
   logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
@@ -3494,11 +3494,11 @@ void BlueFS::_compact_log_async_LD_LNF_D() //also locks FW for new_writer
   // Reconstruct actual log object from the new one.
   vselector->sub_usage(log_file->vselector_hint, log_file->fnode);
   log_file->fnode.size =
-    log.writer->pos - old_log_jump_to + starter_need + compacted_meta_need;
+    log.writer->get_pos() - old_log_jump_to + starter_need + compacted_meta_need;
   log_file->fnode.mtime = std::max(mtime, log_file->fnode.mtime);
   log_file->fnode.swap_extents(new_log->fnode);
   // update log's writer
-  log.writer->pos = log.writer->file->fnode.size;
+  log.writer->set_pos(log.writer->file->fnode.size);
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
   // and unlock
   log.lock.unlock();
@@ -3795,9 +3795,9 @@ int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to)
   _flush_and_sync_log_core();
 
   dout(10) << __func__ << " jumping log offset from 0x" << std::hex
-	   << log.writer->pos << " -> 0x" << jump_to << std::dec << dendl;
-  ceph_assert(log.writer->pos <= jump_to);
-  log.writer->pos = jump_to;
+           << log.writer->get_pos() << " -> 0x" << jump_to << std::dec << dendl;
+  ceph_assert(log.writer->get_pos() <= jump_to);
+  log.writer->set_pos(jump_to);
   vselector->sub_usage(log.writer->file->vselector_hint, log.writer->file->fnode.size);
   log.writer->file->fnode.size = jump_to;
   vselector->add_usage(log.writer->file->vselector_hint, log.writer->file->fnode.size);
@@ -3922,7 +3922,7 @@ int BlueFS::_flush_envelope_F(FileWriter *h)
   ceph_assert(h->file->envelope_mode());
   uint64_t content_length = h->get_buffer_length() - File::envelope_t::head_size();
   h->append((char*)&h->file->stamp.v[0], File::envelope_t::tail_size());
-  uint64_t offset = h->pos;
+  uint64_t offset = h->get_pos();
 
   h->file->fnode.content_size += content_length;
   ceph_le64 flush_length_le(content_length);
@@ -3940,7 +3940,7 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 
   uint64_t end = offset + length;
 
-  dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
+  dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->get_pos()
 	   << " 0x" << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode
 	   << " hint " << h->file->vselector_hint
@@ -3948,13 +3948,13 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 
   bool buffered = cct->_conf->bluefs_buffered_io;
 
-  if (end <= h->pos)
+  if (end <= h->get_pos())
     return 0;
-  if (offset < h->pos) {
+  if (offset < h->get_pos()) {
     // NOTE: for envelope files we flush existing data
     ceph_assert(!h->file->envelope_mode());
-    length -= h->pos - offset;
-    offset = h->pos;
+    length -= h->get_pos() - offset;
+    offset = h->get_pos();
     dout(10) << " still need 0x"
              << std::hex << offset << "~" << length << std::dec
              << dendl;
@@ -4032,7 +4032,7 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
 
   auto bl = h->flush_buffer(cct, partial, length, super);
   ceph_assert(bl.length() >= length);
-  h->pos = offset + length;
+  h->set_pos(offset + length);
   length = bl.length();
 
   logger->inc(l_bluefs_write_count, 1);
@@ -4088,7 +4088,7 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
   }
 
   dout(20) << __func__ << " h " << h << " pos now 0x"
-           << std::hex << h->pos << std::dec << dendl;
+           << std::hex << h->get_pos() << std::dec << dendl;
   return 0;
 }
 
@@ -4178,7 +4178,7 @@ int BlueFS::_flush_F(FileWriter *h, bool force, bool *flushed)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
   uint64_t length = h->get_buffer_length();
-  uint64_t offset = h->pos;
+  uint64_t offset = h->get_pos();
   if (flushed) {
     *flushed = false;
   }
@@ -4197,7 +4197,7 @@ int BlueFS::_flush_F(FileWriter *h, bool force, bool *flushed)
   dout(10) << __func__ << " " << h << " 0x"
            << std::hex << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode << dendl;
-  ceph_assert(h->pos <= h->file->fnode.size);
+  ceph_assert(h->get_pos() <= h->file->fnode.size);
   int r;
   if (h->file->envelope_mode()) {
     r = _flush_envelope_F(h);
@@ -4220,7 +4220,7 @@ uint64_t BlueFS::_flush_special(FileWriter *h)
 {
   ceph_assert(h->file->fnode.ino <= 1);
   uint64_t length = h->get_buffer_length();
-  uint64_t offset = h->pos;
+  uint64_t offset = h->get_pos();
   uint64_t new_data = 0;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
   if (h->file->fnode.size < offset + length) {
@@ -4244,9 +4244,9 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)/*_WF_L*/
            << " file " << fnode << dendl;
 
   // truncate off unflushed data?
-  if (h->pos < offset &&
-      h->pos + h->get_buffer_length() > offset) {
-    dout(20) << __func__ << " tossing out last " << offset - h->pos
+  if (h->get_pos() < offset &&
+      h->get_pos() + h->get_buffer_length() > offset) {
+    dout(20) << __func__ << " tossing out last " << offset - h->get_pos()
 	     << " unflushed bytes" << dendl;
     ceph_abort_msg("actually this shouldn't happen");
   }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -692,8 +692,8 @@ private:
 
   /* signal replay log to include h->file in nearest log flush */
   int _signal_dirty_to_log_D(FileWriter *h);
-  int _flush_range_F(FileWriter *h, uint64_t offset, uint64_t length);
-  int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
+  int _flush_range_F(FileWriter *h, uint64_t end); // flush up to offset 'end'
+  int _flush_data(FileWriter *h, uint64_t end, bool buffered);
   int _flush_F(FileWriter *h, bool force, bool *flushed = nullptr);
   int _flush_envelope_F(FileWriter *h);
   int _fsync(FileWriter *h, bool force_dirty);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -413,21 +413,34 @@ public:
       return pos;
     }
     void set_pos(uint64_t new_pos) {
+      ceph_assert(buffer.length() == 0);
+      ceph_assert(p2aligned<uint32_t>(new_pos, super_block_size));
       pos = new_pos;
+      buffer_pos = pos;
     }
   private:
-    uint64_t pos = 0;        ///< offset of data in file
-    ceph::buffer::list buffer;      ///< new data to write (at end of file)
-    ceph::buffer::list tail_block;  ///< existing partial block at end of file, if any
+    uint64_t pos = 0;          ///< offset of unflushed data
+    ceph::buffer::list buffer; ///< new data to write (at end of file)
+                               ///  includes unaligned tail from last flush
+    uint32_t super_block_size;
+    uint64_t buffer_pos = 0;   ///< offset of buffer in file
   public:
+    // does not take into account part of `buffer` already flushed to disk
     unsigned get_buffer_length() const {
-      return buffer.length();
+      return buffer.length() - (pos - buffer_pos);
     }
-    ceph::bufferlist flush_buffer(
+    // indicates that a part of buffer has already been flushed to disk
+    bool has_flushed_data() {
+      return pos != buffer_pos;
+    }
+    // offset (in file) of `buffer` to flush
+    uint64_t get_flush_offset() {
+      return buffer_pos;
+    }
+    // create bufferlist to write to disk, modify buffer
+    ceph::bufferlist get_flush_buffer(
       CephContext* cct,
-      const bool partial,
-      const unsigned length,
-      const bluefs_super_t& super);
+      uint64_t flush_end);
     ceph::buffer::list::page_aligned_appender buffer_appender;  //< for const char* only
     bufferlist::contiguous_filler envelope_head_filler;
   public:
@@ -440,6 +453,7 @@ public:
 
     FileWriter(FileRef f, unsigned super_block_size)
       : file(std::move(f))
+      , super_block_size(super_block_size)
       , buffer_appender(buffer.get_page_aligned_appender(
         std::max<uint64_t>(g_conf()->bluefs_alloc_size, 2 * super_block_size) / CEPH_PAGE_SIZE))
       , envelope_head_filler() {
@@ -494,7 +508,7 @@ public:
     }
 
     uint64_t get_effective_write_pos() {
-      return pos + buffer.length();
+      return buffer_pos + buffer.length();
     }
 
   };

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -466,7 +466,9 @@ public:
     }
     // NOTE: caller must call BlueFS::close_writer()
     ~FileWriter() {
-      --file->num_writers;
+      if (file) {
+        --file->num_writers;
+      }
       for (unsigned i = 0; i < MAX_BDEV; ++i) {
         delete iocv[i];
       }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -409,8 +409,14 @@ public:
     MEMPOOL_CLASS_HELPERS();
 
     FileRef file;
-    uint64_t pos = 0;       ///< start offset for buffer
+    uint64_t get_pos() {
+      return pos;
+    }
+    void set_pos(uint64_t new_pos) {
+      pos = new_pos;
+    }
   private:
+    uint64_t pos = 0;        ///< offset of data in file
     ceph::buffer::list buffer;      ///< new data to write (at end of file)
     ceph::buffer::list tail_block;  ///< existing partial block at end of file, if any
   public:

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -20424,12 +20424,12 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   }
 
   bluefs->fsync(p_handle);
-  bluefs->truncate(p_handle, p_handle->pos);
+  bluefs->truncate(p_handle, p_handle->get_pos());
   bluefs->fsync(p_handle);
 
   utime_t duration = ceph_clock_now() - start_time;
   dout(5) <<"WRITE-extent_count=" << extent_count << ", allocation_size=" << allocation_size << ", serial=" << s_serial << dendl;
-  dout(5) <<"p_handle->pos=" << p_handle->pos << " WRITE-duration=" << duration << " seconds" << dendl;
+  dout(5) <<"p_handle->pos=" << p_handle->get_pos() << " WRITE-duration=" << duration << " seconds" << dendl;
 
   bluefs->close_writer(p_handle);
   need_to_destage_allocation_file = false;

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -2511,6 +2511,156 @@ TEST(BlueFS, test_69481_truncate_asserts) {
   fs.umount();
 }
 
+TEST(FileWriter, get_flush_buffer) {
+  size_t block_size = 32;
+  BlueFS::FileRef file = ceph::make_ref<BlueFS::File>();
+  BlueFS::FileWriter fw(file, block_size);
+
+  bufferlist bl;
+
+  ASSERT_EQ(fw.get_flush_offset(), 0);
+  ASSERT_EQ(fw.get_pos(), 0);
+  ASSERT_EQ(fw.get_buffer_length(), 0);
+
+  // append and flush full page
+  bufferlist bl1;
+  bl1.append(std::string(block_size, 'a'));
+  bl = bl1;
+  fw.append(bl1);
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size);
+  ASSERT_EQ(fw.get_pos(), block_size);
+  ASSERT_EQ(fw.get_buffer_length(), 0);
+
+  // append and flush full page once again
+  bufferlist bl2;
+  bl2.append(std::string(block_size, 'b'));
+  bl = bl2;
+  fw.append(bl2);
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 2), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 2);
+  ASSERT_EQ(fw.get_pos(), block_size * 2);
+  ASSERT_EQ(fw.get_buffer_length(), 0);
+
+  // append full page and flush it in two pieces
+  bufferlist bl3;
+  bl3.append(std::string(block_size, 'c'));
+  bl = bl3;
+
+  fw.append(bl3);
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 2 + 1), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 3); // ?????
+  ASSERT_EQ(fw.get_pos(), block_size * 2 + 1);
+  ASSERT_EQ(fw.get_buffer_length(), block_size - 1);
+
+  bl.clear();
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 3), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 3);
+  ASSERT_EQ(fw.get_pos(), block_size * 3);
+  ASSERT_EQ(fw.get_buffer_length(), 0);
+
+  // append half page, flush 1 byte,
+  // append the remaining half and flush till the end
+  bufferlist bl4;
+  bl4.append(std::string(block_size / 2, 'd'));
+  bl = bl4;
+  bl.append_zero(block_size / 2);
+
+  fw.append(bl4);
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 3 + 1), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 3);
+  ASSERT_EQ(fw.get_pos(), block_size * 3 + 1);
+  ASSERT_EQ(fw.get_buffer_length(), block_size /2  - 1);
+
+  bl4.append(std::string(block_size / 2, 'd'));
+  bl.clear();
+  bl.append(std::string(block_size, 'd'));
+
+  fw.append(bl4);
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 4), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 4);
+  ASSERT_EQ(fw.get_pos(), block_size * 4);
+  ASSERT_EQ(fw.get_buffer_length(), 0);
+
+  // append 10 bytes, flush 2 bytes,
+  // append 12 bytes, flush 2 bytes,
+  // flush 18 bytes
+  // append 12 bytes, flush 9 bytes
+  // flush 2 bytes
+  // flush 1 bytes
+
+  bufferlist bl5;
+  bl5.append(std::string(10, 'e'));
+  bl = bl5;
+  bl.append_zero(block_size - bl5.length());
+
+  fw.append(bl5);
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 4 + 2), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 4);
+  ASSERT_EQ(fw.get_pos(), block_size * 4 + 2);
+  ASSERT_EQ(fw.get_buffer_length(), 8);
+
+  bl5.append(std::string(12, 'f'));
+  bl.clear();
+  bl.append(std::string(10, 'e'));
+  bl.append(std::string(12, 'f'));
+  bl.append_zero(block_size - bl.length());
+
+  fw.append(bl5);
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 4 + 4), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 4);
+  ASSERT_EQ(fw.get_pos(), block_size * 4 + 4);
+  ASSERT_EQ(fw.get_buffer_length(), 18);
+
+  bl.clear();
+  bl.append(std::string(10, 'e'));
+  bl.append(std::string(12, 'f'));
+  bl.append_zero(block_size - bl.length());
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 4 + 22), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 4);
+  ASSERT_EQ(fw.get_pos(), block_size * 4 + 22);
+  ASSERT_EQ(fw.get_buffer_length(), 0);
+
+  bl5.append(std::string(12, 'g'));
+  fw.append(bl5);
+
+  bl.clear();
+  bl.append(std::string(10, 'e'));
+  bl.append(std::string(12, 'f'));
+  bl.append(std::string(10, 'g'));
+
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 5 - 1), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 5);
+  ASSERT_EQ(fw.get_pos(), block_size * 5 - 1);
+  ASSERT_EQ(fw.get_buffer_length(), 3);
+
+  bl.clear();
+  bl.append(std::string(2, 'g'));
+  bl.append_zero(block_size - 2);
+
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 5 + 1), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 5);
+  ASSERT_EQ(fw.get_pos(), block_size * 5 + 1);
+  ASSERT_EQ(fw.get_buffer_length(), 1);
+
+  ASSERT_EQ(fw.get_flush_buffer(g_ceph_context, block_size * 5 + 2), bl);
+
+  ASSERT_EQ(fw.get_flush_offset(), block_size * 5);
+  ASSERT_EQ(fw.get_pos(), block_size * 5 + 2);
+  ASSERT_EQ(fw.get_buffer_length(), 0);
+}
+
 TEST(bluefs_locked_extents_t, basics) {
   const uint64_t M = 1 << 20;
   {


### PR DESCRIPTION
Replaced exising `FileWriter::flush_buffer` with more constrained, but simpler `FileWriter::get_write_data`.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
