### PR TITLE
tentacle: doc/cephfs: fix docs for pause_purging and pause_cloning

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -1027,13 +1027,13 @@ useful during cluster recovery scenarios:
 
 .. prompt:: bash #
 
-    ceph config set mgr/volumes/pause_purging true
+    ceph config set mgr mgr/volumes/pause_purging true
 
 To resume purging threads:
 
 .. prompt:: bash #
 
-    ceph config set mgr/volumes/pause_purging false
+    ceph config set mgr mgr/volumes/pause_purging false
 
 Pause the threads that asynchronously clone subvolume snapshots. This option is
 useful during cluster recovery scenarios:

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -1040,13 +1040,13 @@ useful during cluster recovery scenarios:
 
 .. prompt:: bash #
 
-    ceph config set mgr/volumes/pause_cloning true
+    ceph config set mgr mgr/volumes/pause_cloning true
 
 To resume cloning threads:
 
 .. prompt:: bash #
 
-    ceph config set mgr/volumes/pause_cloning false
+    ceph config set mgr mgr/volumes/pause_cloning false
 
 Configure the ``snapshot_clone_no_wait`` option:
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74020

---

backport of https://github.com/ceph/ceph/pull/66213
parent tracker: https://tracker.ceph.com/issues/73811

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh