### PR TITLE
Cephadm: Fix logrotate SELinux issues and ensure daemons reopen logs

### DIFF
--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -255,9 +255,7 @@ def _get_container_runtime_path(ctx: CephadmContext) -> str:
     if engine and getattr(engine, 'path', None):
         return engine.path
     return (
-        shutil.which('podman')
-        or shutil.which('docker')
-        or '/usr/bin/podman'
+        shutil.which('podman') or shutil.which('docker') or '/usr/bin/podman'
     )
 
 

--- a/src/cephadm/cephadmlib/systemd_unit.py
+++ b/src/cephadm/cephadmlib/systemd_unit.py
@@ -191,6 +191,9 @@ def _install_base_units(ctx: CephadmContext, fsid: str) -> None:
         call_throws(ctx, ['systemctl', 'start', 'ceph-%s.target' % fsid])
 
     logrotate_path = os.path.join(ctx.logrotate_dir, f'ceph-{fsid}')
+    # If a ceph-<fsid> logrotate file already exists, only update it when it was created by cephadm and
+    # hasn’t been migrated to the systemd-run helper format yet. This avoids touching admin-managed
+    # logrotate files and keeps the migration idempotent.
     if os.path.exists(logrotate_path):
         try:
             with open(logrotate_path, 'r') as existing:

--- a/src/cephadm/cephadmlib/templates/cluster.logrotate.config.j2
+++ b/src/cephadm/cephadmlib/templates/cluster.logrotate.config.j2
@@ -5,6 +5,7 @@
     compress
     sharedscripts
     postrotate
+        {{ systemd_run|shellquote }} --wait --collect --quiet {{ helper_script|shellquote }} || true
         killall -q -1 {{ targets|join(' ') }} || pkill -1 -x '{{ targets|join('|') }}' || true
     endscript
     missingok

--- a/src/cephadm/cephadmlib/templates/cluster.logrotate.helper.sh.j2
+++ b/src/cephadm/cephadmlib/templates/cluster.logrotate.helper.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+# created by cephadm
+set -euo pipefail
+
+mapfile -t containers < <({{ container_runtime|shellquote }} ps --filter "label=ceph=True" --format "{{ ('{' * 2) }}.Names{{ ('}' * 2) }}" | grep -E "^ceph-{{ fsid }}" || true)
+
+if [ "${containers[*]:-}" = "" ]; then
+    exit 0
+fi
+
+{{ container_runtime|shellquote }} kill --signal SIGHUP "${containers[@]}" || true
+exit 0
+

--- a/src/cephadm/cephadmlib/templating.py
+++ b/src/cephadm/cephadmlib/templating.py
@@ -26,6 +26,7 @@ class Templates(str, enum.Enum):
     init_ctr_service = 'init_ctr.service.j2'
     sidecar_service = 'sidecar.service.j2'
     cluster_logrotate_config = 'cluster.logrotate.config.j2'
+    cluster_logrotate_helper = 'cluster.logrotate.helper.sh.j2'
     cephadm_logrotate_config = 'cephadm.logrotate.config.j2'
     sidecar_run = 'sidecar.run.j2'
     init_ctr_run = 'init_containers.run.j2'

--- a/src/cephadm/tests/test_logrotate_config.py
+++ b/src/cephadm/tests/test_logrotate_config.py
@@ -1,8 +1,8 @@
-from unittest import mock
+import shutil
 
 import pytest
 
-from tests.fixtures import import_cephadm, cephadm_fs
+from tests.fixtures import import_cephadm, cephadm_fs, mock_podman
 
 from cephadmlib import logging
 
@@ -12,28 +12,51 @@ _cephadm = import_cephadm()
 def test_cluster_logrotate_config(cephadm_fs):
     ctx = _cephadm.CephadmContext()
     ctx.logrotate_dir = '/my/log/dir'
+    ctx.data_dir = '/my/data/dir'
+    ctx.container_engine = mock_podman()
     fsid = '5dcc9af0-7cd3-11ee-9e84-525400babd0a'
+    helper_script = f'{ctx.data_dir}/{fsid}/logrotate-reopen-logs.sh'
+    systemd_run_path = shutil.which('systemd-run') or '/usr/bin/systemd-run'
 
     cephadm_fs.create_dir(ctx.logrotate_dir)
+    cephadm_fs.create_dir(ctx.data_dir)
 
-    expected_cluster_logrotate_file = """# created by cephadm
-/var/log/ceph/5dcc9af0-7cd3-11ee-9e84-525400babd0a/*.log {
+    expected_cluster_logrotate_file = f"""# created by cephadm
+/var/log/ceph/{fsid}/*.log {{
     rotate 7
     daily
     compress
     sharedscripts
     postrotate
+        {systemd_run_path} --wait --collect --quiet {helper_script} || true
         killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror cephfs-mirror tcmu-runner || pkill -1 -x 'ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror|cephfs-mirror|tcmu-runner' || true
     endscript
     missingok
     notifempty
     su root root
-}"""
+}}"""
+
+    expected_helper_script = f"""#!/bin/bash
+# created by cephadm
+set -euo pipefail
+
+mapfile -t containers < <(/usr/bin/podman ps --filter "label=ceph=True" --format "{{{{.Names}}}}" | grep -E "^ceph-{fsid}" || true)
+
+if [ "${{containers[*]:-}}" = "" ]; then
+    exit 0
+fi
+
+/usr/bin/podman kill --signal SIGHUP "${{containers[@]}}" || true
+exit 0
+"""
 
     logging.write_cluster_logrotate_config(ctx, fsid)
 
     with open(ctx.logrotate_dir + f'/ceph-{fsid}', 'r') as f:
         assert f.read() == expected_cluster_logrotate_file
+    with open(helper_script, 'r') as helper_fd:
+        assert helper_fd.read() == expected_helper_script
+
 
 def test_cephadm_logrotate_config(cephadm_fs):
     ctx = _cephadm.CephadmContext()


### PR DESCRIPTION
Signed-off-by: Ujjawal Anand [Ujjawal.Anand@ibm.com]

### Issue: With file logging enabled, some Ceph daemons running in containers (RGW and ceph-exporter) would stop writing to their log files after log rotation

### Issue triaging:
It called podman kill directly from the logrotate script:
  ```
postrotate
      podman kill --signal S
```
This worked when logrotate was run manually as `root`, but when it was run automatically by the systemd timer under the logrotate_t SELinux domain, the KCS version hit AVC denials
```
type=AVC ... avc:  denied  { read } for  pid=... comm="sh" name="podman"
    scontext=system_u:system_r:logrotate_t:s0
    tcontext=system_u:object_r:container_runtime_exec_t:s0
```
As a result:
1. logrotate rotated the files on disk,
2. but the podman kill ... SIGHUP never actually executed from the container side,
3. so RGW / ceph-exporter never got SIGHUP and did not reopen their .log files.
4. After rotation, those log files remained empty while the daemons continued to run.

### Proposed fix:
Moved the “send SIGHUP to containers” part into a separate helper script, and we run that helper via systemd-run. This shifts the SELinux context from logrotate_t to systemd_t, which is allowed to execute the container runtime

### Testing:
1. Enable file logging
```
cephadm shell -- ceph config set global log_to_file true
cephadm shell -- ceph config set global log_to_stderr false
cephadm shell -- ceph config set global log_to_syslog false
FSID=$(cephadm shell -- ceph fsid)
```
Outcome:
Daemon logs present under /var/log/ceph/$FSID/*.log as expected.

2. Deploy ceph-exporter and confirm logging before
```
cephadm shell -- ceph orch apply ceph-exporter --placement='1 ceph-node-1'
cephadm shell -- ceph orch ps | grep ceph-exporter

ls -l /var/log/ceph/$FSID/ceph-client.ceph-exporter.ceph-node-1.log
tail -n 5 /var/log/ceph/$FSID/ceph-client.ceph-exporter.ceph-node-1.log
```

Outcome:
ceph-exporter.ceph-node-1 is running.
ceph-client.ceph-exporter.ceph-node-1.log exists and has periodic log entries. 

3. Force log rotation and verify exporter continues logging after rotation
# Before rotation
```
ls -l /var/log/ceph/$FSID/ceph-client.ceph-exporter.ceph-node-1.log
tail -n 5 /var/log/ceph/$FSID/ceph-client.ceph-exporter.ceph-node-1.log
```

# Rotate
`logrotate -vf /etc/logrotate.d/ceph-$FSID`

# Wait and check again
```
ls -l /var/log/ceph/$FSID/ceph-client.ceph-exporter.ceph-node-1.log*
tail -n 5 /var/log/ceph/$FSID/ceph-client.ceph-exporter.ceph-node-1.log
```

Outcome:
logrotate -vf output shows:
ceph-client.ceph-exporter.ceph-node-1.log is rotated to .log.1 and compressed.

```
  -rw-r--r--. 1 root root 849  ... ceph-client.ceph-exporter.ceph-node-1.log
  -rw-r--r--. 1 root root 362  ... ceph-client.ceph-exporter.ceph-node-1.log.1.gz
```
**And the new active log (.log) has fresh entries with later timestamps than the rotated file, showing the exporter reopened its log file and kept logging after rotation.**


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
