### PR TITLE
squid: mgr: fix PyObject* refcounting in TTLCache and cleanup logic

### DIFF
--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -42,6 +42,7 @@ Configuration
 .. confval:: standby_behaviour
 .. confval:: standby_error_status_code
 .. confval:: exclude_perf_counters
+.. confval:: healthcheck_history_max_entries
 
 By default the module will accept HTTP requests on port ``9283`` on all IPv4
 and IPv6 addresses on the host.  The port and listen address are
@@ -151,6 +152,13 @@ The metrics take the following form:
     ceph_health_detail{name="OSDMAP_FLAGS",severity="HEALTH_WARN"} 0.0
     ceph_health_detail{name="OSD_DOWN",severity="HEALTH_WARN"} 1.0
     ceph_health_detail{name="PG_DEGRADED",severity="HEALTH_WARN"} 1.0
+
+The module also maintains an in-memory history of health-check states.
+By default the history retains a maximum of 1000 entries. This limit is configurable via the following runtime option:
+
+  ``mgr/prometheus/healthcheck_history_max_entries`` - the maximum number of unique health check entries to track in memory (default: 1000).
+
+This setting helps avoid unbounded memory growth in large or long-lived clusters.
 
 The health check history may be retrieved and cleared by running the following commands:
 

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -200,7 +200,6 @@ PyObject *ActivePyModules::cacheable_get_python(const std::string &what)
   PyObject *obj = get_python(what);
   if(ttl_seconds && ttl_cache.is_cacheable(what)) {
     ttl_cache.insert(what, obj);
-    Py_INCREF(obj);
   }
   update_cache_metrics();
   return obj;

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -140,6 +140,6 @@ PyObject* PyJSONFormatter::get()
   std::ostringstream ss;
   flush(ss);
   std::string s = ss.str();
-  PyObject* obj = PyBytes_FromStringAndSize(std::move(s.c_str()), s.size());
+  PyObject* obj = PyBytes_FromStringAndSize(s.c_str(), s.size());
   return obj;
 }

--- a/src/mgr/TTLCache.h
+++ b/src/mgr/TTLCache.h
@@ -63,6 +63,14 @@ template <class Key, class Value> class Cache {
   }
   int size() { return content.size(); }
 
+  //return the keys vector
+  std::vector<Key> keys() {
+    std::vector<Key> keys;
+    for (auto const& [k, v] : content) {
+      keys.push_back(k);
+    }
+    return keys;
+  }
   ~Cache(){};
 };
 
@@ -110,12 +118,16 @@ class TTLCache<Key, PyObject*> : public TTLCacheBase<Key, PyObject*> {
  public:
   TTLCache(uint16_t ttl_ = 0, uint16_t size = UINT16_MAX, float spread = 0.25)
       : TTLCacheBase<Key, PyObject*>(ttl_, size, spread) {}
-  ~TTLCache(){};
+  ~TTLCache(){ clear(); };
+  void insert(Key key, PyObject* value);
   PyObject* get(Key key);
   void erase(Key key);
-
+  void clear();
+  PyObject* get_value(Key key, bool count_hit = true);
  private:
   using ttl_base = TTLCacheBase<Key, PyObject*>;
+  using value_type = std::pair<PyObject*, ttl_time_point>;
+  using cache = Cache<Key, value_type>;
 };
 
 #include "TTLCache.cc"

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -15,8 +15,7 @@ from mgr_util import get_default_addr, profile_method, build_url
 from orchestrator import OrchestratorClientMixin, raise_if_exception, OrchestratorError
 from rbd import RBD
 
-from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable, TypeVar, Generic
-
+from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable, TypeVar, Iterator
 LabelValues = Tuple[str, ...]
 Number = Union[int, float]
 MetricValue = Dict[LabelValues, Number]
@@ -137,8 +136,7 @@ K = TypeVar('K')
 V = TypeVar('V')
 
 
-class LRUCacheDict(OrderedDict[K, V], Generic[K, V]):
-    maxsize: int
+class LRUCacheDict(OrderedDict[K, V]):
 
     def __init__(self, maxsize: int, *args: Any, **kwargs: Any) -> None:
         self.maxsize = maxsize
@@ -159,9 +157,11 @@ class HealthHistory:
 
     def __init__(self, mgr: MgrModule):
         self.mgr = mgr
-        self.lock = threading.Lock()
-        self.max_entries = cast(int, self.mgr.get_localized_module_option('healthcheck_history_max_entries', 1000))
-        self.healthcheck: LRUCacheDict[str, HealthCheckEvent] = LRUCacheDict(maxsize=self.max_entries)
+        self.lock = threading.RLock()
+        self.max_entries = cast(int, self.mgr.get_localized_module_option(
+            'healthcheck_history_max_entries', 1000))
+        self.healthcheck: ThreadSafeLRUCacheDict[str, HealthCheckEvent] = ThreadSafeLRUCacheDict(
+            maxsize=self.max_entries)
         self._load()
 
     def _load(self) -> None:
@@ -304,6 +304,55 @@ class HealthHistory:
             str: YAML representation of the healthcheck history
         """
         return yaml.safe_dump(self.as_dict(), explicit_start=True, default_flow_style=False)
+
+
+class ThreadSafeLRUCacheDict(LRUCacheDict[K, V]):
+    maxsize: int
+
+    def __init__(self, maxsize: int, *args: Any, **kwargs: Any) -> None:
+        self.maxsize = maxsize
+        self._lock = threading.RLock()
+        super().__init__(maxsize, *args, **kwargs)
+
+    def __setitem__(self, key: K, value: V) -> None:
+        with self._lock:
+            super().__setitem__(key, value)
+
+    def __getitem__(self, key: Any) -> V:
+        with self._lock:
+            return super().__getitem__(key)
+
+    def __iter__(self) -> Iterator[K]:
+        with self._lock:
+            return iter(list(super().keys()))
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            return super().__contains__(key)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return super().__len__()
+
+    def get(self, key: K, default: Optional[V] = None) -> Optional[V]:  # type: ignore[override]
+        with self._lock:
+            return super().get(key, default)
+
+    def clear(self) -> None:
+        with self._lock:
+            super().clear()
+
+    def keys(self) -> List[K]:  # type: ignore[override]
+        with self._lock:
+            return list(super().keys())
+
+    def items(self) -> List[Tuple[K, V]]:  # type: ignore[override]
+        with self._lock:
+            return list(super().items())
+
+    def values(self) -> List[V]:  # type: ignore[override]
+        with self._lock:
+            return list(super().values())
 
 
 class Metric(object):
@@ -948,6 +997,7 @@ class Module(MgrModule, OrchestratorClientMixin):
                     self.metrics[path].set(0)
 
         self.health_history.check(health)
+
         for name, info in self.health_history.healthcheck.items():
             v = 1 if info.active else 0
             self.metrics['health_detail'].set(
@@ -1132,7 +1182,8 @@ class Module(MgrModule, OrchestratorClientMixin):
             host = cast(str, server.get('hostname', ''))
             for service in cast(List[ServiceInfoT], server.get('services', [])):
                 ret.update({(service['id'], service['type']): (host,
-                                                               service.get('ceph_version', 'unknown'),
+                                                               service.get(
+                                                                   'ceph_version', 'unknown'),
                                                                service.get('name', ''))})
         return ret
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -3,19 +3,19 @@ import yaml
 from collections import defaultdict
 import json
 import math
-import os
 import re
 import threading
 import time
 import enum
 from collections import namedtuple
+from collections import OrderedDict
 
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, CLIWriteCommand
 from mgr_util import get_default_addr, profile_method, build_url
 from orchestrator import OrchestratorClientMixin, raise_if_exception, OrchestratorError
 from rbd import RBD
 
-from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable
+from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable, TypeVar, Generic
 
 LabelValues = Tuple[str, ...]
 Number = Union[int, float]
@@ -26,14 +26,6 @@ MetricValue = Dict[LabelValues, Number]
 # for Prometheus exporter port registry
 
 DEFAULT_PORT = 9283
-
-
-# cherrypy likes to sys.exit on error.  don't let it take us down too!
-def os_exit_noop(status: int) -> None:
-    pass
-
-
-os._exit = os_exit_noop   # type: ignore
 
 # to access things in class Module from subclass Root.  Because
 # it's a dict, the writer doesn't need to declare 'global' for access
@@ -141,6 +133,25 @@ class HealthCheckEvent:
         return self.__dict__
 
 
+K = TypeVar('K')
+V = TypeVar('V')
+
+
+class LRUCacheDict(OrderedDict[K, V], Generic[K, V]):
+    maxsize: int
+
+    def __init__(self, maxsize: int, *args: Any, **kwargs: Any) -> None:
+        self.maxsize = maxsize
+        super().__init__(*args, **kwargs)
+
+    def __setitem__(self, key: K, value: V) -> None:
+        if key in self:
+            self.move_to_end(key)
+        elif len(self) >= self.maxsize:
+            self.popitem(last=False)  # drop oldest
+        super().__setitem__(key, value)
+
+
 class HealthHistory:
     kv_name = 'health_history'
     titles = "{healthcheck_name:<24}  {first_seen:<20}  {last_seen:<20}  {count:>5}  {active:^6}"
@@ -149,7 +160,8 @@ class HealthHistory:
     def __init__(self, mgr: MgrModule):
         self.mgr = mgr
         self.lock = threading.Lock()
-        self.healthcheck: Dict[str, HealthCheckEvent] = {}
+        self.max_entries = cast(int, self.mgr.get_localized_module_option('healthcheck_history_max_entries', 1000))
+        self.healthcheck: LRUCacheDict[str, HealthCheckEvent] = LRUCacheDict(maxsize=self.max_entries)
         self._load()
 
     def _load(self) -> None:
@@ -179,7 +191,7 @@ class HealthHistory:
         """Reset the healthcheck history."""
         with self.lock:
             self.mgr.set_store(self.kv_name, "{}")
-            self.healthcheck = {}
+            self.healthcheck.clear()
 
     def save(self) -> None:
         """Save the current in-memory healthcheck history to the KV store."""
@@ -194,43 +206,43 @@ class HealthHistory:
         """
 
         current_checks = health_checks.get('checks', {})
-        changes_made = False
-
-        # first turn off any active states we're tracking
-        for seen_check in self.healthcheck:
-            check = self.healthcheck[seen_check]
-            if check.active and seen_check not in current_checks:
-                check.active = False
-                changes_made = True
-
-        # now look for any additions to track
         now = time.time()
-        for name, info in current_checks.items():
-            if name not in self.healthcheck:
-                # this healthcheck is new, so start tracking it
-                changes_made = True
-                self.healthcheck[name] = HealthCheckEvent(
-                    name=name,
-                    severity=info.get('severity'),
-                    first_seen=now,
-                    last_seen=now,
-                    count=1,
-                    active=True
-                )
-            else:
-                # seen it before, so update its metadata
-                check = self.healthcheck[name]
-                if check.active:
-                    # check has been registered as active already, so skip
-                    continue
-                else:
-                    check.last_seen = now
-                    check.count += 1
-                    check.active = True
-                    changes_made = True
+        with self.lock:
+            changes_made = False
+            names = set(self.healthcheck) | set(current_checks)
 
-        if changes_made:
-            self.save()
+            for name in names:
+                present = name in current_checks
+                check = self.healthcheck.get(name)
+                if check is None:
+                    if present:
+                        info = current_checks[name]
+                        self.healthcheck[name] = HealthCheckEvent(
+                            name=name,
+                            severity=info.get('severity'),
+                            first_seen=now,
+                            last_seen=now,
+                            count=1,
+                            active=True
+                        )
+                        changes_made = True
+
+                    continue
+
+                if present:
+                    if not check.active:
+                        check.count += 1
+                        changes_made = True
+
+                    check.last_seen = now
+                    check.active = True
+                else:
+                    if check.active:
+                        check.active = False
+                        changes_made = True
+
+            if changes_made:
+                self.save()
 
     def __str__(self) -> str:
         """Print the healthcheck history.
@@ -592,7 +604,14 @@ class Module(MgrModule, OrchestratorClientMixin):
             desc='Do not include perf-counters in the metrics output',
             long_desc='Gathering perf-counters from a single Prometheus exporter can degrade ceph-mgr performance, especially in large clusters. Instead, Ceph-exporter daemons are now used by default for perf-counter gathering. This should only be disabled when no ceph-exporters are deployed.',
             runtime=True
-        )
+        ),
+        Option(
+            name='healthcheck_history_max_entries',
+            type='int',
+            default=1000,
+            desc='Maximum number of health check history entries to keep',
+            runtime=True
+        ),
     ]
 
     STALE_CACHE_FAIL = 'fail'
@@ -1768,6 +1787,13 @@ class Module(MgrModule, OrchestratorClientMixin):
             'server.ssl_module': None,
             'server.ssl_certificate': None,
             'server.ssl_private_key': None,
+            'tools.gzip.on': True,
+            'tools.gzip.mime_types': [
+                'text/plain',
+                'text/html',
+                'application/json',
+            ],
+            'tools.gzip.compress_level': 6,
         })
         # Publish the URI that others may use to access the service we're about to start serving
         self.set_uri(build_url(scheme='http', host=self.get_server_addr(),
@@ -1803,6 +1829,13 @@ class Module(MgrModule, OrchestratorClientMixin):
             'server.ssl_module': 'builtin',
             'server.ssl_certificate': cert_file_path,
             'server.ssl_private_key': key_file_path,
+            'tools.gzip.on': True,
+            'tools.gzip.mime_types': [
+                'text/plain',
+                'text/html',
+                'application/json',
+            ],
+            'tools.gzip.compress_level': 6,
         })
         # Publish the URI that others may use to access the service we're about to start serving
         self.set_uri(build_url(scheme='https', host=self.get_server_addr(),
@@ -1837,10 +1870,9 @@ class Module(MgrModule, OrchestratorClientMixin):
 
             @staticmethod
             def _metrics(instance: 'Module') -> Optional[str]:
-                if not self.cache:
-                    self.log.debug('Cache disabled, collecting and returning without cache')
-                    cherrypy.response.headers['Content-Type'] = 'text/plain'
-                    return self.collect()
+                if not instance.cache:
+                    instance.log.debug('Cache disabled, collecting and returning without cache')
+                    return instance.collect()
 
                 # Return cached data if available
                 if not instance.collect_cache:
@@ -1848,7 +1880,6 @@ class Module(MgrModule, OrchestratorClientMixin):
 
                 def respond() -> Optional[str]:
                     assert isinstance(instance, Module)
-                    cherrypy.response.headers['Content-Type'] = 'text/plain'
                     return instance.collect_cache
 
                 if instance.collect_time < instance.scrape_interval:
@@ -1906,7 +1937,11 @@ class Module(MgrModule, OrchestratorClientMixin):
 
         cherrypy.tree.mount(Root(), "/")
         self.log.info('Starting engine...')
-        cherrypy.engine.start()
+        try:
+            cherrypy.engine.start()
+        except Exception as e:
+            self.log.error(f'Failed to start engine: {e}')
+            return
         self.log.info('Engine started.')
 
         # wait for the shutdown event
@@ -2001,7 +2036,6 @@ class StandbyModule(MgrStandbyModule):
 
             @cherrypy.expose
             def metrics(self) -> str:
-                cherrypy.response.headers['Content-Type'] = 'text/plain'
                 return ''
 
         cherrypy.tree.mount(Root(), '/', {})

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1917,6 +1917,7 @@ class Module(MgrModule, OrchestratorClientMixin):
                 # Lock the function execution
                 assert isinstance(_global_instance, Module)
                 with _global_instance.collect_lock:
+                    cherrypy.response.headers['Content-Type'] = 'text/plain; charset=utf-8'
                     return self._metrics(_global_instance)
 
             @staticmethod
@@ -2087,6 +2088,7 @@ class StandbyModule(MgrStandbyModule):
 
             @cherrypy.expose
             def metrics(self) -> str:
+                cherrypy.response.headers['Content-Type'] = 'text/plain; charset=utf-8'
                 return ''
 
         cherrypy.tree.mount(Root(), '/', {})


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74057

---

backport of https://github.com/ceph/ceph/pull/65245
parent tracker: https://tracker.ceph.com/issues/68989

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh