### PR TITLE
rgw: add checksum type and algorithm in S3 APIs

### DIFF
--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -188,6 +188,8 @@ list<rgw_bucket_dir_entry_meta> rgw_bucket_dir_entry_meta::generate_test_instanc
   m.owner = "owner";
   m.owner_display_name = "display name";
   m.content_type = "content/type";
+  m.cksum_algo = 1;
+  m.cksum_flags = 1;
   o.push_back(std::move(m));
   o.emplace_back();
   return o;
@@ -209,6 +211,8 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
   encode_json("accounted_size", accounted_size, f);
   encode_json("user_data", user_data, f);
   encode_json("appendable", appendable, f);
+  encode_json("cksum_algo", (unsigned)cksum_algo, f);
+  encode_json("cksum_flags", (unsigned)cksum_flags, f);
 }
 
 void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
@@ -227,6 +231,10 @@ void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("accounted_size", accounted_size, obj);
   JSONDecoder::decode_json("user_data", user_data, obj);
   JSONDecoder::decode_json("appendable", appendable, obj);
+  JSONDecoder::decode_json("cksum_algo", val, obj);
+  cksum_algo = (uint16_t)val;
+  JSONDecoder::decode_json("cksum_flags", val, obj);
+  cksum_flags = (uint8_t)val;
 }
 
 list<rgw_bucket_dir_entry> rgw_bucket_dir_entry::generate_test_instances()

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -211,9 +211,11 @@ struct rgw_bucket_dir_entry_meta {
   std::string user_data;
   std::string storage_class;
   bool appendable = false;
+  uint16_t cksum_algo;
+  uint8_t cksum_flags;
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(7, 3, bl);
+    ENCODE_START(8, 3, bl);
     encode(category, bl);
     encode(size, bl);
     encode(mtime, bl);
@@ -225,6 +227,8 @@ struct rgw_bucket_dir_entry_meta {
     encode(user_data, bl);
     encode(storage_class, bl);
     encode(appendable, bl);
+    encode(cksum_algo, bl);
+    encode(cksum_flags, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -248,6 +252,10 @@ struct rgw_bucket_dir_entry_meta {
       decode(storage_class, bl);
     if (struct_v >= 7)
       decode(appendable, bl);
+    if (struct_v >= 8) {
+      decode(cksum_algo, bl);
+      decode(cksum_flags, bl);
+    }
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -211,8 +211,8 @@ struct rgw_bucket_dir_entry_meta {
   std::string user_data;
   std::string storage_class;
   bool appendable = false;
-  uint16_t cksum_algo;
-  uint8_t cksum_flags;
+  uint16_t cksum_algo = 0;
+  uint16_t cksum_flags = 0;
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(8, 3, bl);

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -419,7 +419,7 @@ int AtomicObjectProcessor::complete(
   obj_op.meta.modify_tail = true;
   if (cksum) {
     obj_op.meta.cksum_algo = static_cast<uint16_t>(cksum->type);
-    obj_op.meta.cksum_flags = static_cast<uint8_t>(cksum->flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+    obj_op.meta.cksum_flags = cksum->flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK;
   }
 
   r = read_cloudtier_info_from_attrs(attrs, obj_op.meta.category, obj_op.meta.olh_epoch, manifest);

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -417,6 +417,10 @@ int AtomicObjectProcessor::complete(
   obj_op.meta.user_data = user_data;
   obj_op.meta.zones_trace = zones_trace;
   obj_op.meta.modify_tail = true;
+  if (cksum) {
+    obj_op.meta.cksum_algo = static_cast<uint16_t>(cksum->type);
+    obj_op.meta.cksum_flags = static_cast<uint8_t>(cksum->flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+  }
 
   r = read_cloudtier_info_from_attrs(attrs, obj_op.meta.category, obj_op.meta.olh_epoch, manifest);
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4112,14 +4112,14 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
   }
 
   uint16_t cksum_algo = 0;
-  uint8_t cksum_flags = 0;
+  uint16_t cksum_flags = 0;
   if (found_cksum) {
     try {
       rgw::cksum::Cksum cksum;
       auto iter = cksum_bl.cbegin();
       cksum.decode(iter);
       cksum_algo = static_cast<uint16_t>(cksum.type);
-      cksum_flags = static_cast<uint8_t>(cksum.flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+      cksum_flags = cksum.flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK;
     } catch (buffer::error& err) {
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
 	": unable to decode Checksum for " << p(head_obj) << dendl;
@@ -7609,13 +7609,13 @@ int RGWRados::set_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* octx, RGWBu
         storage_class = rgw_bl_str(iter->second);
       }
       uint16_t cksum_algo = 0;
-      uint8_t cksum_flags = 0;
+      uint16_t cksum_flags = 0;
       if (iter = attrs.find(RGW_ATTR_CKSUM); iter != attrs.end()) {
         try {
           rgw::cksum::Cksum cksum;
           decode(cksum, iter->second);
           cksum_algo = static_cast<uint16_t>(cksum.type);
-          cksum_flags = static_cast<uint8_t>(cksum.flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+          cksum_flags = cksum.flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK;
         } catch (buffer::error& err) {
           ldpp_dout(dpp, 0) << "ERROR: failed to decode rgw::cksum::Cksum" << dendl;
         }
@@ -8082,7 +8082,7 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
                                             uint64_t size, uint64_t accounted_size,
                                             const ceph::real_time& ut, const string& etag,
                                             const string& content_type, const string& storage_class,
-                                            const uint16_t cksum_algo, const uint8_t cksum_flags,
+                                            const uint16_t cksum_algo, const uint16_t cksum_flags,
                                             const ACLOwner& owner,
                                             RGWObjCategory category,
                                             list<rgw_obj_index_key> *remove_objs,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3477,7 +3477,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   tracepoint(rgw_rados, complete_enter, req_id.c_str());
   r = index_op->complete(rctx.dpp, poolid, epoch, size, accounted_size,
                         meta.set_mtime, etag, content_type,
-                        storage_class, meta.owner,
+                        storage_class, meta.cksum_algo, meta.cksum_flags, meta.owner,
 			 meta.category, meta.remove_objs, rctx.y,
 			 meta.user_data, meta.appendable, log_op);
   tracepoint(rgw_rados, complete_exit, req_id.c_str());
@@ -4073,6 +4073,8 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
   bufferlist olh_info_bl;
   bool appendable { false };
   bufferlist part_num_bl;
+  bufferlist cksum_bl;
+  bool found_cksum { false };
 
   rgw::sal::Attrs& attr_set = head_state->attrset;
   read_attr(attr_set, RGW_ATTR_ETAG, etag);
@@ -4081,6 +4083,7 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
   read_attr(attr_set, RGW_ATTR_ACL, acl_bl, &found_acl);
   read_attr(attr_set, RGW_ATTR_OLH_INFO, olh_info_bl, &found_olh_info);
   read_attr(attr_set, RGW_ATTR_APPEND_PART_NUM, part_num_bl, &appendable);
+  read_attr(attr_set, RGW_ATTR_CKSUM, cksum_bl, &found_cksum);
 
   // check for a pure OLH object and if so exit early
   if (found_olh_info) {
@@ -4106,6 +4109,22 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
   ACLOwner owner;
   if (found_acl) {
     (void) decode_policy(dpp, acl_bl, &owner);
+  }
+
+  uint16_t cksum_algo = 0;
+  uint8_t cksum_flags = 0;
+  if (found_cksum) {
+    try {
+      rgw::cksum::Cksum cksum;
+      auto iter = cksum_bl.cbegin();
+      cksum.decode(iter);
+      cksum_algo = static_cast<uint16_t>(cksum.type);
+      cksum_flags = static_cast<uint8_t>(cksum.flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+    } catch (buffer::error& err) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+	": unable to decode Checksum for " << p(head_obj) << dendl;
+      return -EIO;
+    }
   }
 
   rgw_rados_ref bucket_ref;
@@ -4155,6 +4174,8 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
 			    etag,
 			    content_type,
 			    storage_class,
+			    cksum_algo,
+			    cksum_flags,
 			    owner,
 			    RGWObjCategory::Main, // RGWObjCategory category,
 			    nullptr, // remove_objs list
@@ -7587,6 +7608,19 @@ int RGWRados::set_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* octx, RGWBu
                  iter != state->attrset.end()) {
         storage_class = rgw_bl_str(iter->second);
       }
+      uint16_t cksum_algo = 0;
+      uint8_t cksum_flags = 0;
+      if (iter = attrs.find(RGW_ATTR_CKSUM); iter != attrs.end()) {
+        try {
+          rgw::cksum::Cksum cksum;
+          decode(cksum, iter->second);
+          cksum_algo = static_cast<uint16_t>(cksum.type);
+          cksum_flags = static_cast<uint8_t>(cksum.flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+        } catch (buffer::error& err) {
+          ldpp_dout(dpp, 0) << "ERROR: failed to decode rgw::cksum::Cksum" << dendl;
+        }
+      }
+
       int64_t poolid = ioctx.get_id();
 
       // Retain Object category as CloudTiered while restore is in
@@ -7625,7 +7659,7 @@ int RGWRados::set_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* octx, RGWBu
       }
 	    ldpp_dout(dpp, 20) << "Setting obj category:" << category << ", storage_class:" << storage_class << dendl;
       r = index_op.complete(dpp, poolid, epoch, state->size, state->accounted_size,
-                            mtime, etag, content_type, storage_class, owner,
+                            mtime, etag, content_type, storage_class, cksum_algo, cksum_flags, owner,
                             category, nullptr, y, nullptr, false, log_op);
     } else {
       int ret = index_op.cancel(dpp, nullptr, y, log_op);
@@ -8048,6 +8082,7 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
                                             uint64_t size, uint64_t accounted_size,
                                             const ceph::real_time& ut, const string& etag,
                                             const string& content_type, const string& storage_class,
+                                            const uint16_t cksum_algo, const uint8_t cksum_flags,
                                             const ACLOwner& owner,
                                             RGWObjCategory category,
                                             list<rgw_obj_index_key> *remove_objs,
@@ -8082,6 +8117,8 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
   ent.meta.owner_display_name = owner.display_name;
   ent.meta.content_type = content_type;
   ent.meta.appendable = appendable;
+  ent.meta.cksum_algo = cksum_algo;
+  ent.meta.cksum_flags = cksum_flags;
 
   bool add_log = log_op && store->svc.zone->need_to_log_data();
 

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -834,7 +834,7 @@ public:
         bool completeMultipart;
         bool appendable;
         uint16_t cksum_algo;
-        uint8_t cksum_flags;
+        uint16_t cksum_flags;
 
         MetaParams() : mtime(NULL), rmattrs(NULL), data(NULL), manifest(NULL), ptag(NULL),
                  remove_objs(NULL), category(RGWObjCategory::Main), flags(0),
@@ -1014,7 +1014,7 @@ public:
                    uint64_t accounted_size, const ceph::real_time& ut,
                    const std::string& etag, const std::string& content_type,
                    const std::string& storage_class,
-                   uint16_t cksum_algo, uint8_t cksum_flags,
+                   uint16_t cksum_algo, uint16_t cksum_flags,
                    const ACLOwner& owner, RGWObjCategory category,
 		   std::list<rgw_obj_index_key> *remove_objs,
 		   optional_yield y,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -833,6 +833,8 @@ public:
         bool keep_tail;
         bool completeMultipart;
         bool appendable;
+        uint16_t cksum_algo;
+        uint8_t cksum_flags;
 
         MetaParams() : mtime(NULL), rmattrs(NULL), data(NULL), manifest(NULL), ptag(NULL),
                  remove_objs(NULL), category(RGWObjCategory::Main), flags(0),
@@ -1012,6 +1014,7 @@ public:
                    uint64_t accounted_size, const ceph::real_time& ut,
                    const std::string& etag, const std::string& content_type,
                    const std::string& storage_class,
+                   uint16_t cksum_algo, uint8_t cksum_flags,
                    const ACLOwner& owner, RGWObjCategory category,
 		   std::list<rgw_obj_index_key> *remove_objs,
 		   optional_yield y,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -4518,7 +4518,7 @@ int RadosMultipartUpload::complete(const DoutPrefixProvider *dpp,
   obj_op.meta.if_nomatch = if_nomatch;
   if (cksum_type != rgw::cksum::Type::none) {
     obj_op.meta.cksum_algo = static_cast<uint16_t>(cksum_type);
-    obj_op.meta.cksum_flags = static_cast<uint8_t>(cksum_flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+    obj_op.meta.cksum_flags = cksum_flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK;
   }
 
   const req_context rctx{dpp, y, nullptr};

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -4516,6 +4516,10 @@ int RadosMultipartUpload::complete(const DoutPrefixProvider *dpp,
   obj_op.meta.olh_epoch = olh_epoch;
   obj_op.meta.if_match = if_match;
   obj_op.meta.if_nomatch = if_nomatch;
+  if (cksum_type != rgw::cksum::Type::none) {
+    obj_op.meta.cksum_algo = static_cast<uint16_t>(cksum_type);
+    obj_op.meta.cksum_flags = static_cast<uint8_t>(cksum_flags & rgw::cksum::Cksum::CKSUM_TYPE_MASK);
+  }
 
   const req_context rctx{dpp, y, nullptr};
   ret = obj_op.write_meta(ofs, accounted_size, attrs, rctx, get_trace());

--- a/src/rgw/rgw_cksum.h
+++ b/src/rgw/rgw_cksum.h
@@ -112,6 +112,8 @@ namespace rgw { namespace cksum {
       (FLAG_COMBINED|FLAG_COMPOSITE);
     static constexpr uint16_t FULL_OBJECT_MASK =
       (FLAG_COMBINED|FLAG_FULL_OBJECT);
+    static constexpr uint16_t CKSUM_TYPE_MASK =
+      (FLAG_COMPOSITE|FLAG_FULL_OBJECT);
 
     Type type;
     value_type digest;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4815,8 +4815,13 @@ void RGWListMultipart_ObjStore_S3::send_response()
     /* TODO: missing initiator:
        Container element that identifies who initiated the multipart upload. If the initiator is an AWS account, this element provides the same information as the Owner element. If the initiator is an IAM User, this element provides the user ARN and display name, see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html */
 
-    if (cksum && cksum->aws()) {
-      s->formatter->dump_string("ChecksumAlgorithm", cksum->uc_type_string());
+    if (upload->cksum_type != rgw::cksum::Type::none) {
+      s->formatter->dump_string("ChecksumAlgorithm", to_uc_string(upload->cksum_type));
+      if (upload->cksum_flags & rgw::cksum::Cksum::FLAG_COMPOSITE) {
+        s->formatter->dump_string("ChecksumType", "COMPOSITE");
+      } else {
+        s->formatter->dump_string("ChecksumType", "FULL_OBJECT");
+      }
     }
 
     for (; iter != upload->get_parts().end(); ++iter) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2100,6 +2100,15 @@ void RGWListBucket_ObjStore_S3::send_response()
 	} else {
 	s->formatter->dump_string("Type", "Normal");
       }
+      rgw::cksum::Type cksum_algo{iter->meta.cksum_algo};
+      if (cksum_algo != rgw::cksum::Type::none) {
+        s->formatter->dump_string("ChecksumAlgorithm", rgw::cksum::to_uc_string(cksum_algo));
+        if (iter->meta.cksum_flags & rgw::cksum::Cksum::FLAG_COMPOSITE) {
+          s->formatter->dump_string("ChecksumType", "COMPOSITE");
+        } else {
+          s->formatter->dump_string("ChecksumType", "FULL_OBJECT");
+        }
+      }
       // JSON has one extra section per element
       s->formatter->close_section();
     } // foreach obj
@@ -2245,6 +2254,15 @@ void RGWListBucket_ObjStore_S3v2::send_response()
         s->formatter->dump_string("Type", "Appendable");
       } else {
         s->formatter->dump_string("Type", "Normal");
+      }
+      rgw::cksum::Type cksum_algo{iter->meta.cksum_algo};
+      if (cksum_algo != rgw::cksum::Type::none) {
+        s->formatter->dump_string("ChecksumAlgorithm", rgw::cksum::to_uc_string(cksum_algo));
+        if (iter->meta.cksum_flags & rgw::cksum::Cksum::FLAG_COMPOSITE) {
+          s->formatter->dump_string("ChecksumType", "COMPOSITE");
+        } else {
+          s->formatter->dump_string("ChecksumType", "FULL_OBJECT");
+        }
       }
       s->formatter->close_section();
     }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4663,6 +4663,11 @@ void RGWInitMultipart_ObjStore_S3::send_response()
   }
   if (cksum_algo != rgw::cksum::Type::none) {
     dump_header(s, "x-amz-checksum-algorithm", to_uc_string(cksum_algo));
+    if (cksum_flags & rgw::cksum::Cksum::FLAG_COMPOSITE) {
+      dump_header(s, "x-amz-checksum-type", "COMPOSITE");
+    } else {
+      dump_header(s, "x-amz-checksum-type", "FULL_OBJECT");
+    }
   }
   end_header(s, this, to_mime_type(s->format));
   if (op_ret == 0) {


### PR DESCRIPTION
tracker: [74071](https://tracker.ceph.com/issues/74071)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
