### PR TITLE
mgr/dashboard: Add uirouter peers list

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -59,6 +59,7 @@ import { SmbClusterListComponent } from './ceph/smb/smb-cluster-list/smb-cluster
 import { SmbJoinAuthListComponent } from './ceph/smb/smb-join-auth-list/smb-join-auth-list.component';
 import { SmbUsersgroupsListComponent } from './ceph/smb/smb-usersgroups-list/smb-usersgroups-list.component';
 import { SmbOverviewComponent } from './ceph/smb/smb-overview/smb-overview.component';
+import { CephfsMirroringListComponent } from './ceph/cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component';
 
 @Injectable()
 export class PerformanceCounterBreadcrumbsResolver extends BreadcrumbsResolver {
@@ -405,6 +406,11 @@ const routes: Routes = [
             path: `fs/${URLVerbs.EDIT}/:id`,
             component: CephfsVolumeFormComponent,
             data: { breadcrumbs: ActionLabels.EDIT }
+          },
+          {
+            path: 'mirroring',
+            component: CephfsMirroringListComponent,
+            data: { breadcrumbs: 'File/Mirroring' }
           },
           {
             path: 'nfs',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component.html
@@ -1,0 +1,19 @@
+<ng-container *ngIf="daemonStatus$ | async as daemonStatus">
+  <cd-table
+    [data]="daemonStatus"
+    [columns]="columns"
+    selectionType="single"
+    [hasDetails]="false"
+    (setExpandedRow)="setExpandedRow($event)"
+    (fetchData)="loadDaemonStatus($event)"
+    (updateSelection)="updateSelection($event)"
+  >
+  </cd-table>
+</ng-container>
+
+<ng-template #remoteClusterName
+             let-row="data.row">
+  <span>{{ row?.remote_cluster_name }}</span
+  ><br />
+  <span>{{ row?.peerId }}</span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CephfsMirroringListComponent } from './cephfs-mirroring-list.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { SharedModule } from '~/app/shared/shared.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { ToastrModule } from 'ngx-toastr';
+
+describe('CephfsMirroringListComponent', () => {
+  let component: CephfsMirroringListComponent;
+  let fixture: ComponentFixture<CephfsMirroringListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        SharedModule,
+        HttpClientTestingModule,
+        ToastrModule.forRoot(),
+        RouterTestingModule
+      ],
+      declarations: [CephfsMirroringListComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CephfsMirroringListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -1,0 +1,99 @@
+import { Component, ViewChild, OnInit, TemplateRef } from '@angular/core';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+import { TableComponent } from '~/app/shared/datatable/table/table.component';
+import { CdTableColumn } from '~/app/shared/models/cd-table-column';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { Daemon, MirroringRow } from '../cephfs-mirroring.model';
+import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
+import { CdTableAction } from '~/app/shared/models/cd-table-action';
+import { URLBuilderService } from '~/app/shared/services/url-builder.service';
+
+export const MIRRORING_PATH = 'cephfs/mirroring';
+@Component({
+  selector: 'cd-cephfs-mirroring-list',
+  templateUrl: './cephfs-mirroring-list.component.html',
+  styleUrls: ['./cephfs-mirroring-list.component.scss'],
+  providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(MIRRORING_PATH) }]
+})
+export class CephfsMirroringListComponent implements OnInit {
+  @ViewChild('table', { static: true }) table: TableComponent;
+  @ViewChild('remoteClusterName', { static: true }) remoteClusterName: TemplateRef<any>;
+
+  columns: CdTableColumn[];
+  selection = new CdTableSelection();
+  subject$ = new BehaviorSubject<MirroringRow[]>([]);
+  daemonStatus$: Observable<MirroringRow[]>;
+  context: CdTableFetchDataContext;
+  tableActions: CdTableAction[];
+
+  constructor(public actionLabels: ActionLabelsI18n, private cephfsService: CephfsService) {}
+
+  ngOnInit() {
+    this.columns = [
+      {
+        name: $localize`Remote cluster name`,
+        prop: 'remote_cluster_name',
+        flexGrow: 2,
+        cellTemplate: this.remoteClusterName
+      },
+      { name: $localize`Remote filesystem`, prop: 'fs_name', flexGrow: 2 },
+      { name: $localize`Remote client`, prop: 'client_name', flexGrow: 2 },
+      { name: $localize`Snapshot directories`, prop: 'directory_count', flexGrow: 1 }
+    ];
+
+    this.daemonStatus$ = this.subject$.pipe(
+      switchMap(() =>
+        this.cephfsService.listDaemonStatus()?.pipe(
+          switchMap((daemons: Daemon[]) => {
+            const result: MirroringRow[] = [];
+
+            daemons.forEach((d) => {
+              d.filesystems.forEach((fs) => {
+                if (!fs.peers || fs.peers.length === 0) {
+                  result.push({
+                    remote_cluster_name: '-',
+                    fs_name: fs.name,
+                    client_name: '-',
+                    directory_count: fs.directory_count,
+                    peerId: '-',
+                    id: `${d.daemon_id}-${fs.filesystem_id}`
+                  });
+                } else {
+                  fs.peers.forEach((peer) => {
+                    result.push({
+                      remote_cluster_name: peer.remote.cluster_name,
+                      fs_name: peer.remote.fs_name,
+                      client_name: peer.remote.client_name,
+                      directory_count: fs.directory_count,
+                      peerId: peer.uuid,
+                      id: `${d.daemon_id}-${fs.filesystem_id}`
+                    });
+                  });
+                }
+              });
+            });
+
+            return of(result);
+          }),
+          catchError(() => {
+            this.context?.error();
+            return of(null);
+          })
+        )
+      )
+    );
+
+    this.loadDaemonStatus();
+  }
+
+  loadDaemonStatus() {
+    this.subject$.next([]);
+  }
+
+  updateSelection(selection: CdTableSelection) {
+    this.selection = selection;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs-mirroring/cephfs-mirroring.model.ts
@@ -1,0 +1,40 @@
+export interface RemoteInfo {
+  client_name: string;
+  cluster_name: string;
+  fs_name: string;
+}
+
+export interface PeerStats {
+  failure_count: number;
+  recovery_count: number;
+}
+
+export interface Peer {
+  uuid: string;
+  remote: RemoteInfo;
+  stats: PeerStats;
+}
+
+export interface Filesystem {
+  filesystem_id: number;
+  name: string;
+  directory_count: number;
+  peers: Peer[];
+  id: string;
+}
+
+export interface Daemon {
+  daemon_id: number;
+  filesystems: Filesystem[];
+}
+
+export interface MirroringRow {
+  remote_cluster_name: string;
+  fs_name: string;
+  client_name: string;
+  directory_count: number;
+  peerId?: string;
+  id?: string;
+}
+
+export type DaemonResponse = Daemon[];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -31,6 +31,7 @@ import { CephfsSubvolumeSnapshotsFormComponent } from './cephfs-subvolume-snapsh
 import { CephfsSnapshotscheduleFormComponent } from './cephfs-snapshotschedule-form/cephfs-snapshotschedule-form.component';
 import { CephfsMountDetailsComponent } from './cephfs-mount-details/cephfs-mount-details.component';
 import { CephfsAuthModalComponent } from './cephfs-auth-modal/cephfs-auth-modal.component';
+import { CephfsMirroringListComponent } from '../cephfs-mirroring/cephfs-mirroring-list/cephfs-mirroring-list.component';
 import {
   ButtonModule,
   CheckboxModule,
@@ -106,7 +107,8 @@ import Trash from '@carbon/icons/es/trash-can/32';
     CephfsSnapshotscheduleFormComponent,
     CephfsSubvolumeSnapshotsFormComponent,
     CephfsMountDetailsComponent,
-    CephfsAuthModalComponent
+    CephfsAuthModalComponent,
+    CephfsMirroringListComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -270,6 +270,12 @@
                             i18n-title
                             *ngIf="permissions.cephfs.read && enabledFeature.cephfs"
                             class="tc_submenuitem tc_submenuitem_file_cephfs"><span i18n>File systems</span></cds-sidenav-item>
+          <cds-sidenav-item route="/cephfs/mirroring"
+                            [useRouter]="true"
+                            title="Mirroring"
+                            i18n-title
+                            *ngIf="permissions.cephfs.read && enabledFeature.cephfs"
+                            class="tc_submenuitem tc_submenuitem_file_cephfs"><span i18n>Mirroring</span></cds-sidenav-item>
           <cds-sidenav-item route="/cephfs/nfs"
                             [useRouter]="true"
                             title="NFS"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 import { cdEncode } from '../decorators/cd-encode';
 import { CephfsDir, CephfsQuotas } from '../models/cephfs-directory-models';
 import { shareReplay } from 'rxjs/operators';
+import { Daemon } from '~/app/ceph/cephfs-mirroring/cephfs-mirroring.model';
 
 @cdEncode
 @Injectable({
@@ -125,5 +126,9 @@ export class CephfsService {
 
   getUsedPools(): Observable<number[]> {
     return this.http.get<number[]>(`${this.baseUiURL}/used-pools`);
+  }
+
+  listDaemonStatus(): Observable<Daemon[]> {
+    return this.http.get<Daemon[]>(`${this.baseURL}/mirror/daemon-status`);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -7,7 +7,6 @@ import { Observable } from 'rxjs';
 import { cdEncode } from '../decorators/cd-encode';
 import { CephfsDir, CephfsQuotas } from '../models/cephfs-directory-models';
 import { shareReplay } from 'rxjs/operators';
-import { Daemon } from '~/app/ceph/cephfs-mirroring/cephfs-mirroring.model';
 
 @cdEncode
 @Injectable({
@@ -128,7 +127,7 @@ export class CephfsService {
     return this.http.get<number[]>(`${this.baseUiURL}/used-pools`);
   }
 
-  listDaemonStatus(): Observable<Daemon[]> {
-    return this.http.get<Daemon[]>(`${this.baseURL}/mirror/daemon-status`);
+  listPeersStatus(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.baseUiURL}/mirror/peers-status`);
   }
 }


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
