### PR TITLE
osd, extblkdev: alternative support for thin provisioned NVMe devices.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "src/lss"]
 	path = src/lss
 	url = https://chromium.googlesource.com/linux-syscall-support
+[submodule "src/nvme"]
+	path = src/nvme
+	url = https://github.com/linux-nvme/libnvme

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -176,9 +176,11 @@ class HealthTest(DashboardTestCase):
                     'id': int
                 })),
                 'stats': JObj({
-                    'total_avail_bytes': int,
                     'total_bytes': int,
+                    'total_avail_bytes': int,
                     'total_used_bytes': int,
+                    'total_raw_bytes': int,
+                    'total_avail_raw_bytes': int,
                     'total_used_raw_bytes': int,
                     'total_used_raw_ratio': float,
                     'num_osds': int,

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -246,7 +246,7 @@ public:
   bool is_discard_supported() const { return support_discard; }
 
   /// hook to provide utilization of thinly-provisioned device
-  virtual int get_ebd_state(ExtBlkDevState &state) const {
+  virtual int get_ebd_statfs(store_statfs_t &statfs) const {
     return -ENOENT;
   }
 

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -467,12 +467,12 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
   return 0;
 }
 
-int KernelDevice::get_ebd_state(ExtBlkDevState &state) const
+int KernelDevice::get_ebd_statfs(store_statfs_t &statfs) const
 {
   // use compression driver plugin to determine physical size and availability
   // VDO specific get_thin_utilization has moved into VDO plugin
   if (ebd_impl) {
-    return ebd_impl->get_state(state);
+    return ebd_impl->get_statfs(statfs);
   }
   return -ENOENT;
 }

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -282,23 +282,36 @@ int KernelDevice::open(const string& p)
       size = st.st_size;
     }
 
-    char partition[PATH_MAX], devname[PATH_MAX];
+    char partition[PATH_MAX], _devname[PATH_MAX];
     if ((r = blkdev_buffered.partition(partition, PATH_MAX)) ||
-	(r = blkdev_buffered.wholedisk(devname, PATH_MAX))) {
+	(r = blkdev_buffered.wholedisk(_devname, PATH_MAX))) {
       derr << "unable to get device name for " << path << ": "
 	<< cpp_strerror(r) << dendl;
       rotational = true;
     } else {
-      dout(20) << __func__ << " devname " << devname << dendl;
+      std::set<std::string> devices;
+      this->devname = _devname;
+      dout(10) << __func__ << " devname: " << _devname << dendl;
+      get_devices(&devices);
       rotational = blkdev_buffered.is_rotational();
       support_discard = blkdev_buffered.support_discard();
       optimal_io_size = blkdev_buffered.get_optimal_io_size();
-      this->devname = devname;
-      // check if any extended block device plugin recognizes this device
-      // detect_vdo has moved into the VDO plugin
-      int rc = extblkdev::detect_device(cct, devname, ebd_impl);
-      if (rc != 0) {
-	dout(20) << __func__ << " no plugin volume maps to " << devname << dendl;
+      dout(10) << __func__
+               << " devices: " << devices
+               << " rotational: " << rotational
+               << " support_discard: " << support_discard
+               << " optimal_io_size: " << optimal_io_size
+               << dendl;
+      if (devices.size() == 1) {
+        // check if any extended block device plugin recognizes this device
+        // detect_vdo has moved into the VDO plugin
+        int rc = extblkdev::detect_device(cct, _devname, *(devices.begin()), ebd_impl);
+        if (rc != 0) {
+	  dout(0) << __func__ << " no plugin volume maps to " << _devname << dendl;
+        }
+      } else {
+        derr << __func__ << " device consists of zero or multiple underlying devices:"
+             << _devname << dendl;
       }
     }
   }

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -147,7 +147,7 @@ public:
   }
   int get_devices(std::set<std::string> *ls) const override;
 
-  int get_ebd_state(ExtBlkDevState &state) const override;
+  int get_ebd_statfs(store_statfs_t& statfs) const override;
 
   int read(uint64_t off, uint64_t len, ceph::buffer::list *pbl,
 	   IOContext *ioc,

--- a/src/extblkdev/CMakeLists.txt
+++ b/src/extblkdev/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(extblkdev_plugin_dir ${CEPH_INSTALL_PKGLIBDIR}/extblkdev)
 
 add_subdirectory(vdo)
+add_subdirectory(thin_nvme)
 
 add_library(extblkdev STATIC ExtBlkDevPlugin.cc)
 
@@ -12,4 +13,4 @@ if(LINUX)
 endif()
 
 add_custom_target(extblkdev_plugins DEPENDS
-    ceph_ebd_vdo)
+    ceph_ebd_vdo ceph_ebd_thin_nvme)

--- a/src/extblkdev/ExtBlkDevInterface.h
+++ b/src/extblkdev/ExtBlkDevInterface.h
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <map>
+#include <set>
 #include <ostream>
 #include <memory>
 #ifdef __linux__
@@ -56,9 +57,11 @@ namespace ceph {
      * Return 0 on success or a negative errno on error
      *
      * @param [in] logdevname name of device to check for support by this plugin
+     * @param [in] device name of a physical device to check this plugin support for
      * @return 0 on success or a negative errno on error.
      */
-    virtual int init(const std::string& logdevname) = 0;
+    virtual int init(const std::string& logdevname,
+                     const std::string& device) = 0;
 
     /**
      * Return the name of the underlying device detected by **init** method
@@ -116,10 +119,12 @@ namespace ceph {
      * Factory method, creating ExtBlkDev instances
      *
      * @param [in] logdevname name of logic device, may be composed of physical devices
+     * @param [in] device name of a physical device
      * @param [out] ext_blk_dev object created on successful device support detection
      * @return 0 on success or a negative errno on error.
      */
     virtual int factory(const std::string& logdevname,
+                        const std::string& device,
                         ExtBlkDevInterfaceRef& ext_blk_dev) = 0;
   };
 

--- a/src/extblkdev/ExtBlkDevInterface.h
+++ b/src/extblkdev/ExtBlkDevInterface.h
@@ -42,24 +42,9 @@ typedef void *cap_t;
 #endif
 
 #include "common/PluginRegistry.h"
+#include "osd/osd_types.h"
 
 namespace ceph {
-  class ExtBlkDevState {
-    uint64_t logical_total=0;
-    uint64_t logical_avail=0;
-    uint64_t physical_total=0;
-    uint64_t physical_avail=0;
-  public:
-    uint64_t get_logical_total(){return logical_total;}
-    uint64_t get_logical_avail(){return logical_avail;}
-    uint64_t get_physical_total(){return physical_total;}
-    uint64_t get_physical_avail(){return physical_avail;}
-    void set_logical_total(uint64_t alogical_total){logical_total=alogical_total;}
-    void set_logical_avail(uint64_t alogical_avail){logical_avail=alogical_avail;}
-    void set_physical_total(uint64_t aphysical_total){physical_total=aphysical_total;}
-    void set_physical_avail(uint64_t aphysical_avail){physical_avail=aphysical_avail;}
-  };
-
 
   class ExtBlkDevInterface {
   public:
@@ -83,14 +68,15 @@ namespace ceph {
     virtual const std::string& get_devname() const = 0;
 
     /**
-     * Provide status of underlying physical storage after compression
+     * Provide total/available stats of underlying physical storage
+     * after compression
      *
      * Return 0 on success or a negative errno on error.
      *
-     * @param [out] state current state of the undelying device
+     * @param [out] statfs updated total/available statfs members
      * @return 0 on success or a negative errno on error.
      */
-    virtual int get_state(ExtBlkDevState& state) = 0;
+    virtual int get_statfs(store_statfs_t& statfs) = 0;
 
     /**
      * Populate property map with meta data of device.

--- a/src/extblkdev/ExtBlkDevPlugin.cc
+++ b/src/extblkdev/ExtBlkDevPlugin.cc
@@ -220,7 +220,8 @@ namespace ceph {
 
     // scan extblkdev plugins for support of this device
     int detect_device(CephContext *cct,
-		      const std::string &logdevname,
+		      const std::string& logdevname,
+		      const std::string& device,
 		      ExtBlkDevInterfaceRef& ebd_impl)
     {
       int rc = -ENOENT;
@@ -229,7 +230,7 @@ namespace ceph {
       std::lock_guard l(registry->lock);
       auto ptype = registry->plugins.find("extblkdev");
       if (ptype == registry->plugins.end()) {
-	return -ENOENT;
+	return rc;
       }
 
       for (auto& it : ptype->second) {
@@ -241,7 +242,7 @@ namespace ceph {
 	  derr << __func__ << " Is not an extblkdev plugin: " << it.first << dendl;
 	  return -ENOENT;
 	}
-	rc = ebdplugin->factory(logdevname, ebd_impl);
+	rc = ebdplugin->factory(logdevname, device, ebd_impl);
 	if (rc == 0) {
 	  plg_name = it.first;
 	  break;

--- a/src/extblkdev/ExtBlkDevPlugin.h
+++ b/src/extblkdev/ExtBlkDevPlugin.h
@@ -30,7 +30,8 @@ namespace ceph {
   namespace extblkdev {
     int preload(CephContext *cct);
     int detect_device(CephContext *cct,
-			  const std::string &logdevname,
+			  const std::string& logdevname,
+			  const std::string& device,
 			  ExtBlkDevInterfaceRef& ebd_impl);
     int release_device(ExtBlkDevInterfaceRef& ebd_impl);
   }

--- a/src/extblkdev/thin_nvme/CMakeLists.txt
+++ b/src/extblkdev/thin_nvme/CMakeLists.txt
@@ -1,0 +1,9 @@
+# thin_nvme plugin
+
+set(thin_nvme_srcs
+  ExtBlkDevPluginThinNVMe.cc
+  ExtBlkDevThinNVMe.cc
+)
+
+add_library(ceph_ebd_thin_nvme SHARED ${thin_nvme_srcs})
+install(TARGETS ceph_ebd_thin_nvme DESTINATION ${extblkdev_plugin_dir})

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
@@ -20,15 +20,24 @@
 // This plugin does not require any capabilities to be set
 int ExtBlkDevPluginThinNVMe::get_required_cap_set(cap_t caps)
 {
+  cap_value_t arr[1];
+  arr[0] = CAP_SYS_ADMIN;
+  if (cap_set_flag(caps, CAP_PERMITTED, 1, arr, CAP_SET) < 0) {
+    return -errno;
+  }
+  if (cap_set_flag(caps, CAP_EFFECTIVE, 1, arr, CAP_SET) < 0) {
+    return -errno;
+  }
   return 0;
 }
 
 
 int ExtBlkDevPluginThinNVMe::factory(const std::string& logdevname,
+                                const std::string& device,
 				ceph::ExtBlkDevInterfaceRef& ext_blk_dev)
 {
   auto dev = new ExtBlkDevThinNVMe(cct);
-  int r = dev->init(logdevname);
+  int r = dev->init(logdevname, device);
   if (r != 0) {
     delete dev;
     return r;

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include <set>
+#include "ceph_ver.h"
+#include "ExtBlkDevPluginThinNVMe.h"
+#include "common/ceph_context.h"
+
+
+// This plugin does not require any capabilities to be set
+int ExtBlkDevPluginThinNVMe::get_required_cap_set(cap_t caps)
+{
+  return 0;
+}
+
+
+int ExtBlkDevPluginThinNVMe::factory(const std::string& logdevname,
+				ceph::ExtBlkDevInterfaceRef& ext_blk_dev)
+{
+  auto dev = new ExtBlkDevThinNVMe(cct);
+  int r = dev->init(logdevname);
+  if (r != 0) {
+    delete dev;
+    return r;
+  }
+  ext_blk_dev.reset(dev);
+  return 0;
+};
+
+const char *__ceph_plugin_version() { return CEPH_GIT_NICE_VER; }
+
+int __ceph_plugin_init(CephContext *cct,
+		       const std::string& type,
+		       const std::string& name)
+{
+  auto plg = new ExtBlkDevPluginThinNVMe(cct);
+  if(plg == 0) return -ENOMEM;
+  int rc = cct->get_plugin_registry()->add(type, name, plg);
+  if(rc != 0){
+    delete plg;
+  }
+  return rc;
+}

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
@@ -20,6 +20,7 @@ public:
   explicit ExtBlkDevPluginThinNVMe(CephContext *cct) : ExtBlkDevPlugin(cct) {}
   int get_required_cap_set(cap_t caps) override;
   int factory(const std::string& logdevname,
+              const std::string& device,
 	      ceph::ExtBlkDevInterfaceRef& ext_blk_dev) override;
 };
 

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph distributed storage system
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef CEPH_EXT_BLK_DEV_PLUGIN_THIN_NVME_H
+#define CEPH_EXT_BLK_DEV_PLUGIN_THIN_NVME_H
+
+#include "ExtBlkDevThinNVMe.h"
+
+class ExtBlkDevPluginThinNVMe : public ceph::ExtBlkDevPlugin {
+public:
+  explicit ExtBlkDevPluginThinNVMe(CephContext *cct) : ExtBlkDevPlugin(cct) {}
+  int get_required_cap_set(cap_t caps) override;
+  int factory(const std::string& logdevname,
+	      ceph::ExtBlkDevInterfaceRef& ext_blk_dev) override;
+};
+
+#endif

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
@@ -1,0 +1,108 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
+#include <errno.h>
+#include <string>
+
+#include <linux/nvme_ioctl.h>
+#include <sys/ioctl.h>
+
+#include "ExtBlkDevThinNVMe.h"
+#include "common/blkdev.h"
+#include "nvme/src/nvme/types.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+#include "common/debug.h"
+
+#define dout_subsys ceph_subsys_bdev
+#define dout_context cct
+#undef dout_prefix
+#define dout_prefix *_dout << "ThinNVMe(" << this << ") "
+
+int ExtBlkDevThinNVMe::init(const std::string& alogdevname)
+{
+  dout(3) << __func__ << " devname:" << alogdevname << dendl;
+  logdevname = alogdevname;
+  int _dev = -1;
+  int _ns = -1;
+  int n = -1;
+  int r = sscanf(alogdevname.c_str(), "nvme%dn%d%n", &_dev, &_ns, &n);
+  if (r == 2 && n == int(alogdevname.length())) {
+    // FIXME: make additional checking for vendor/model or something
+    ceph_assert(_dev >= 0);
+    ceph_assert(_ns >= 0);
+    std::string dev_name("/dev/nvme");
+    dev_name += stringify(_dev);
+    int _fd = open(dev_name.c_str(), O_RDONLY);
+    if (_fd < 0) {
+      r = -errno;
+      derr << __func__ << " failed to open " << dev_name.c_str() << ": " << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = 0;
+    dev = _dev;
+    ns = _ns;
+    fd = _fd;
+    dout(3) << __func__ << " use dev:" << dev << " ns:" << ns << " as thin NVMe device" << dendl;
+  } else {
+    r = -EINVAL;
+  }
+  return r;
+}
+
+int ExtBlkDevThinNVMe::get_statfs(store_statfs_t& buf)
+{
+  if (fd < 0) {
+    return -EBADF;
+  }
+  struct nvme_admin_cmd cmd = {};
+  struct nvme_id_ns ns_data = {};
+
+  cmd.opcode = nvme_admin_identify;
+  cmd.nsid = ns;
+  cmd.addr = (__u64)&ns_data;
+  cmd.data_len = sizeof(ns_data);
+  cmd.cdw10 = 0; // CNS value for Identify Namespace (0x00)
+
+
+  int r = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+  if (r < 0) {
+    r = -errno;
+    derr << __func__ << " ioctl failed: " << r << " " << cpp_strerror(-r) << dendl;
+  } else {
+    uint64_t lba_size = 1ULL << ns_data.lbaf[ns_data.flbas & 0x0F].ds;
+
+    uint64_t nsze = ns_data.nsze * lba_size; // Namespace(logical) size: bytes available to the host
+    uint64_t ncap = ns_data.ncap * lba_size; // Namespace capacity: the actual capacity (in bytes) provided
+    uint64_t nuse = ns_data.nuse * lba_size; // Namespace usage: the current capacity utilization (in bytes)
+                                             // of the namespace
+
+    buf.total = ns_data.nsze * lba_size;
+    buf.available = (ns_data.ncap - ns_data.nuse) * lba_size;
+    buf.raw_use = ns_data.nuse * lba_size;
+    dout(0) << __func__ << " stats (nsze/ncap/nuse):"
+                        << nsze << "/"
+                        << ncap << "/"
+                        << nuse
+                        << dendl;
+  }
+  return r;
+}
+
+int ExtBlkDevThinNVMe::collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
+{
+  (*pm)[prefix + "thin_nvme"] = "1";
+  return 0;
+}

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
@@ -101,10 +101,8 @@ int ExtBlkDevThinNVMe::get_statfs(store_statfs_t& buf)
     uint64_t ncap = ns_data.ncap * lba_size; // Namespace capacity: the actual capacity (in bytes) provided
     uint64_t nuse = ns_data.nuse * lba_size; // Namespace usage: the current capacity utilization (in bytes)
                                              // of the namespace
-
-    buf.total = ns_data.nsze * lba_size;
-    buf.available = (ns_data.ncap - ns_data.nuse) * lba_size;
-    buf.raw_use = ns_data.nuse * lba_size;
+    buf.total = ncap; //ns_data.nsze * lba_size;
+    buf.available = ncap - nuse;
     dout(0) << __func__ << " stats (nsze/ncap/nuse):"
                         << nsze << "/"
                         << ncap << "/"

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
@@ -1,0 +1,41 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_EXT_BLK_DEV_THIN_NVME_H
+#define CEPH_EXT_BLK_DEV_THIN_NVME_H
+
+#include "extblkdev/ExtBlkDevInterface.h"
+#include "include/compat.h"
+
+class ExtBlkDevThinNVMe final : public ceph::ExtBlkDevInterface
+{
+  std::string name;   // name of the underlying vdo device
+  std::string logdevname; // name of the top level logical device
+  int dev = -1;
+  int ns = -1;
+  int fd = -1;
+  CephContext *cct;
+
+public:
+  explicit ExtBlkDevThinNVMe(CephContext *cct) : cct(cct) {}
+  ~ExtBlkDevThinNVMe() {
+    if (fd >= 0)
+      VOID_TEMP_FAILURE_RETRY(::close(fd));
+  }
+  int init(const std::string& logdevname) override;
+  const std::string& get_devname() const override {return name;}
+  int get_statfs(store_statfs_t& statfs) override;
+  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) override;
+};
+
+#endif

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
@@ -32,7 +32,7 @@ public:
     if (fd >= 0)
       VOID_TEMP_FAILURE_RETRY(::close(fd));
   }
-  int init(const std::string& logdevname) override;
+  int init(const std::string& logdevname, const std::string& device) override;
   const std::string& get_devname() const override {return name;}
   int get_statfs(store_statfs_t& statfs) override;
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) override;

--- a/src/extblkdev/vdo/ExtBlkDevPluginVdo.cc
+++ b/src/extblkdev/vdo/ExtBlkDevPluginVdo.cc
@@ -32,10 +32,11 @@ int ExtBlkDevPluginVdo::get_required_cap_set(cap_t caps)
 
 
 int ExtBlkDevPluginVdo::factory(const std::string& logdevname,
+                                const std::string& device,
 				ceph::ExtBlkDevInterfaceRef& ext_blk_dev)
 {
   auto vdo = new ExtBlkDevVdo(cct);
-  int r = vdo->init(logdevname);
+  int r = vdo->init(logdevname, device);
   if (r != 0) {
     delete vdo;
     return r;

--- a/src/extblkdev/vdo/ExtBlkDevPluginVdo.h
+++ b/src/extblkdev/vdo/ExtBlkDevPluginVdo.h
@@ -29,6 +29,7 @@ public:
   explicit ExtBlkDevPluginVdo(CephContext *cct) : ExtBlkDevPlugin(cct) {}
   int get_required_cap_set(cap_t caps) override;
   int factory(const std::string& logdevname,
+              const std::string& device,
 	      ceph::ExtBlkDevInterfaceRef& ext_blk_dev) override;
 };
 

--- a/src/extblkdev/vdo/ExtBlkDevVdo.cc
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.cc
@@ -113,15 +113,14 @@ int ExtBlkDevVdo::init(const std::string& alogdevname)
   return get_vdo_stats_handle();
 }
 
-
-int ExtBlkDevVdo::get_state(ceph::ExtBlkDevState& state)
+int ExtBlkDevVdo::get_statfs(store_statfs_t& statfs)
 {
   int64_t block_size = get_vdo_stat("block_size");
   int64_t physical_blocks = get_vdo_stat("physical_blocks");
   int64_t overhead_blocks_used = get_vdo_stat("overhead_blocks_used");
   int64_t data_blocks_used = get_vdo_stat("data_blocks_used");
   int64_t logical_blocks = get_vdo_stat("logical_blocks");
-  int64_t logical_blocks_used = get_vdo_stat("logical_blocks_used");
+  //int64_t logical_blocks_used = get_vdo_stat("logical_blocks_used");
   if (!block_size
       || !physical_blocks
       || !overhead_blocks_used
@@ -137,23 +136,21 @@ int ExtBlkDevVdo::get_state(ceph::ExtBlkDevState& state)
   }
   int64_t avail_blocks =
     physical_blocks - overhead_blocks_used - data_blocks_used;
-  int64_t logical_avail_blocks =
-    logical_blocks - logical_blocks_used;
-  state.set_logical_total(block_size * logical_blocks);
-  state.set_logical_avail(block_size * logical_avail_blocks);
-  state.set_physical_total(block_size * physical_blocks);
-  state.set_physical_avail(block_size * avail_blocks);
+
+  statfs.total = block_size * physical_blocks;
+  statfs.available = block_size * avail_blocks;
+
   return 0;
 }
 
 int ExtBlkDevVdo::collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
 {
-  ceph::ExtBlkDevState state;
-  int rc = get_state(state);
+  store_statfs_t statfs;
+  int rc = get_statfs(statfs);
   if(rc != 0){
     return rc;
   }
   (*pm)[prefix + "vdo"] = "true";
-  (*pm)[prefix + "vdo_physical_size"] = stringify(state.get_physical_total());
+  (*pm)[prefix + "vdo_physical_size"] = stringify(statfs.total);
   return 0;
 }

--- a/src/extblkdev/vdo/ExtBlkDevVdo.cc
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.cc
@@ -106,7 +106,8 @@ int64_t ExtBlkDevVdo::get_vdo_stat(const char *property)
 }
 
 
-int ExtBlkDevVdo::init(const std::string& alogdevname)
+int ExtBlkDevVdo::init(const std::string& alogdevname,
+                       const std::string& /*device*/)
 {
   logdevname = alogdevname;
   // get directory handle for VDO metadata

--- a/src/extblkdev/vdo/ExtBlkDevVdo.h
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.h
@@ -46,7 +46,7 @@ public:
   int64_t get_vdo_stat(const char *property);
   virtual int init(const std::string& logdevname);
   virtual const std::string& get_devname() const {return name;}
-  virtual int get_state(ceph::ExtBlkDevState& state);
+  virtual int get_statfs(store_statfs_t& statfs);
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm);
 };
 

--- a/src/extblkdev/vdo/ExtBlkDevVdo.h
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.h
@@ -44,7 +44,7 @@ public:
   int _get_vdo_stats_handle(const std::string& devname);
   int get_vdo_stats_handle();
   int64_t get_vdo_stat(const char *property);
-  virtual int init(const std::string& logdevname);
+  virtual int init(const std::string& logdevname, const std::string& device);
   virtual const std::string& get_devname() const {return name;}
   virtual int get_statfs(store_statfs_t& statfs);
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2859,7 +2859,6 @@ private:
   int _open_super_meta();
 
   void _open_statfs();
-  void _get_statfs_overall(struct store_statfs_t *buf);
 
   void _dump_alloc_on_failure();
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->
This is a draft and incomplete implementation alternative to https://github.com/ceph/ceph/pull/63526

It uses physical bytes as a basis for total/available statfs field. Hence df reports are leaning toward being rather physiscal space oriented.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
