### PR TITLE
client: fix edge cases in fscrypt truncate

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -17487,6 +17487,9 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
 
   Inode *in = fh->inode.get();
 
+  if (in->is_fscrypt_enabled())
+    return -EOPNOTSUPP;
+
   if (objecter->osdmap_pool_full(in->layout.pool_id) &&
       !(mode & FALLOC_FL_PUNCH_HOLE)) {
     return -ENOSPC;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3919,24 +3919,28 @@ void Client::put_cap_ref(Inode *in, int cap)
 int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 {
   Inode *in = fh->inode.get();
+  return get_caps(in, fh, need, want, phave, endoff);
+}
 
+int Client::get_caps(Inode *in, Fh *fh, int need, int want, int *phave, loff_t endoff)
+{
   int r = check_pool_perm(in, need);
   if (r < 0)
     return r;
 
   while (1) {
     int file_wanted = in->caps_file_wanted();
-    if ((file_wanted & need) != need) {
+    if (fh && (file_wanted & need) != need) {
       ldout(cct, 10) << "get_caps " << *in << " need " << ccap_string(need)
 		     << " file_wanted " << ccap_string(file_wanted) << ", EBADF "
 		     << dendl;
       return -EBADF;
     }
 
-    if ((fh->mode & CEPH_FILE_MODE_WR) && fh->gen != fd_gen)
+    if (fh && (fh->mode & CEPH_FILE_MODE_WR) && fh->gen != fd_gen)
       return -EBADF;
 
-    if ((in->flags & I_ERROR_FILELOCK) && fh->has_any_filelocks())
+    if (fh && (in->flags & I_ERROR_FILELOCK) && fh->has_any_filelocks())
       return -EIO;
 
     int implemented;
@@ -8645,17 +8649,38 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
                                  &fscrypt_denc);
       read_start = offset;
 
-      get_cap_ref(in, CEPH_CAP_FILE_CACHE);
       std::vector<ObjectCacher::ObjHole> holes;
       auto target_len = std::min(read_len, stx->stx_size - offset);
-      int r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
-                                     read_start, target_len, &bl, 0, &holes, io_finish.get());
+
+      int have;
+      int r = get_caps(in, nullptr, CEPH_CAP_FILE_RD, 0, &have, -1);
+      if (r < 0) {
+        return r;
+      }
+
+      if (cct->_conf->client_oc)
+        r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
+                                       read_start, target_len, &bl, 0, &holes, io_finish.get());
+      else
+        filer->read_trunc(in->ino, &in->layout, in->snapid, read_start, 4096, &bl, 0,
+                          in->truncate_size, in->truncate_seq, io_finish.get());
+
       if (r == 0) {
         client_lock.unlock();
         r = io_finish_cond->wait();
         client_lock.lock();
       }
-      put_cap_ref(in, CEPH_CAP_FILE_CACHE);
+
+      // if r is -ENOENT, no data to return, not a real error
+      if (r == -ENOENT) {
+        r = 0;
+      }
+
+      if (r < 0) {
+        return r;
+      }
+
+      put_cap_ref(in, CEPH_CAP_FILE_RD);
 
       header.ver = 1;
       header.compat = 1;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -990,7 +990,14 @@ void Client::update_inode_file_size(Inode *in, int issued, uint64_t size,
           // in the case of fscrypt truncate, you'll want to invalidate
           // the whole fscrypt block (from start of block to end)
           // otherwise on a read you'll have an invalid fscrypt block
-	  _invalidate_inode_cache(in, fscrypt_block_start(size), FSCRYPT_BLOCK_SIZE);
+          int64_t padded_len = FSCRYPT_BLOCK_SIZE;
+          int64_t start = fscrypt_block_start(size);
+          int64_t end = fscrypt_next_block_start(prior_size);
+
+          if (start != end)
+                padded_len = end - start;
+
+          _invalidate_inode_cache(in, start, padded_len);
 	} else
 #endif
           _invalidate_inode_cache(in, size, prior_size - size);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8628,14 +8628,13 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       bufferlist ebl;
       ceph_fscrypt_last_block_header header;
 
-      int r;
       std::unique_ptr<Context> io_finish = nullptr;
 
       uint64_t read_start;
       uint64_t read_len;
 
       C_SaferCond *io_finish_cond = nullptr;
-      io_finish_cond = new C_SaferCond("Client::_read_async flock");
+      io_finish_cond = new C_SaferCond("Client::_do_setattr flock");
       io_finish.reset(io_finish_cond);
 
       FSCryptFDataDencRef fscrypt_denc;
@@ -8649,9 +8648,8 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       get_cap_ref(in, CEPH_CAP_FILE_CACHE);
       std::vector<ObjectCacher::ObjHole> holes;
       auto target_len = std::min(read_len, stx->stx_size - offset);
-      r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
+      int r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
                                      read_start, target_len, &bl, 0, &holes, io_finish.get());
-
       if (r == 0) {
         client_lock.unlock();
         r = io_finish_cond->wait();
@@ -8676,9 +8674,13 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
           return r;
         }
 
+        bufferlist newbl;
+        bl.splice(0, target_len, &newbl);
+        newbl.append_zero(FSCRYPT_BLOCK_SIZE - target_len);
+
 	// 2. encrypt bl
         if (fscrypt_denc) {
-          r = fscrypt_denc->encrypt_bl(offset, bl.length(), bl, &ebl);
+          r = fscrypt_denc->encrypt_bl(offset, newbl.length(), newbl, &ebl);
 	}
 
         header.data_len = (8 + 8 + 4 + ebl.length());

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8660,9 +8660,9 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
 
       if (cct->_conf->client_oc)
         r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
-                                       read_start, target_len, &bl, 0, &holes, io_finish.get());
+                                       read_start, FSCRYPT_BLOCK_SIZE, &bl, 0, &holes, io_finish.get());
       else
-        filer->read_trunc(in->ino, &in->layout, in->snapid, read_start, 4096, &bl, 0,
+        filer->read_trunc(in->ino, &in->layout, in->snapid, read_start, FSCRYPT_BLOCK_SIZE, &bl, 0,
                           in->truncate_size, in->truncate_seq, io_finish.get());
 
       if (r == 0) {
@@ -8681,6 +8681,16 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       }
 
       put_cap_ref(in, CEPH_CAP_FILE_RD);
+
+      // if we are holding any buffered _dirty_ data for this inode,
+      // preemptively fsync/flush this data at this time and drop caps. This
+      // is needed when the mds writes last block.
+      if (issued & (CEPH_CAP_FILE_BUFFER)) {
+        r = _fsync(in, false);
+        if (r < 0) {
+          return r;
+        }
+      }
 
       header.ver = 1;
       header.compat = 1;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -848,6 +848,7 @@ public:
   void kick_flushing_caps(Inode *in, MetaSession *session);
   void kick_flushing_caps(MetaSession *session);
   void early_kick_flushing_caps(MetaSession *session);
+  int get_caps(Inode *in, Fh *fh, int need, int want, int *have, loff_t endoff);
   int get_caps(Fh *fh, int need, int want, int *have, loff_t endoff);
   int get_caps_used(Inode *in);
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6743,11 +6743,12 @@ void MDCache::_truncate_inode(CInode *in, LogSegmentRef const& ls)
     dout(10) << "_truncate_inode write on inode " << *in << " change_attr: "
              << header.change_attr << " offset: " << header.file_offset << " blen: "
 	     << header.block_size << dendl;
+    auto filer_finisher = new C_SaferCond("flock for last block");
     filer.write(in->ino(), &layout, *snapc, header.file_offset, header.block_size,
-                data, ceph::real_clock::zero(), 0,
-                new C_OnFinisher(new C_IO_MDC_TruncateWriteFinish(this, in, ls,
-                                                                  header.block_size),
-                                 mds->finisher));
+                data, ceph::real_clock::zero(), 0, filer_finisher);
+    int r = filer_finisher->wait();
+    auto wf = new C_IO_MDC_TruncateWriteFinish(this, in, ls, header.block_size);
+    wf->finish(r);
   } else { // located in file hole.
     uint64_t length = pi->truncate_from - pi->truncate_size;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5632,6 +5632,7 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
     pi.inode->time_warp_seq++;   // maybe not a timewarp, but still a serialization point.
   if (mask & CEPH_SETATTR_SIZE) {
     if (truncating_smaller) {
+      mdr->no_early_reply = true;
       pi.inode->truncate(old_size, req->head.args.setattr.size, req->get_data().cbegin());
       le->metablob.add_truncate_start(cur->ino());
     } else {


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
