### PR TITLE
tentacle: rgw/rados: fix init/shutdown order for RGWIndexCompletionManager

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1138,7 +1138,6 @@ void RGWRados::finalize()
     reshard->stop_processor();
   }
   delete reshard;
-  delete index_completion_manager;
 
   if (run_notification_thread) {
     rgw::notify::shutdown();
@@ -1153,6 +1152,7 @@ void RGWRados::finalize()
     restore->stop_processor();
   }
   restore = NULL;
+  delete index_completion_manager;
 }
 
 /** 
@@ -1281,6 +1281,8 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y)
     return ret;
 
   pools_initialized = true;
+
+  index_completion_manager = new RGWIndexCompletionManager(this);
 
   if (use_gc) {
     gc = new RGWGC();
@@ -1429,8 +1431,6 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y)
   if (run_reshard_thread)  {
     reshard->start_processor();
   }
-
-  index_completion_manager = new RGWIndexCompletionManager(this);
 
   if (run_bucket_logging_thread) {
     if (!rgw::bucketlogging::init(dpp, this->driver, *svc.site)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74103

---

backport of https://github.com/ceph/ceph/pull/66487
parent tracker: https://tracker.ceph.com/issues/74067

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh