### PR TITLE
squid: rgw/rados: fix init/shutdown order for RGWIndexCompletionManager

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1097,12 +1097,13 @@ void RGWRados::finalize()
     reshard->stop_processor();
   }
   delete reshard;
-  delete index_completion_manager;
 
   if (run_notification_thread) {
     rgw::notify::shutdown();
     v1_topic_migration.stop();
   }
+
+  delete index_completion_manager;
 }
 
 /** 
@@ -1219,6 +1220,8 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y)
     return ret;
 
   pools_initialized = true;
+
+  index_completion_manager = new RGWIndexCompletionManager(this);
 
   if (use_gc) {
     gc = new RGWGC();
@@ -1356,8 +1359,6 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y)
   if (run_reshard_thread)  {
     reshard->start_processor();
   }
-
-  index_completion_manager = new RGWIndexCompletionManager(this);
 
   if (run_notification_thread) {
     if (!rgw::notify::init(dpp, driver, *svc.site)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74104

---

backport of https://github.com/ceph/ceph/pull/66487
parent tracker: https://tracker.ceph.com/issues/74067

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh