### PR TITLE
os/bluestore: Enable HAVE_PPC64LE flag and revert the barrett constant value

### DIFF
--- a/src/arch/ppc.h
+++ b/src/arch/ppc.h
@@ -9,6 +9,8 @@
 #ifndef CEPH_ARCH_PPC_H
 #define CEPH_ARCH_PPC_H
 
+#include "acconfig.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/common/crc32c_ppc.h
+++ b/src/common/crc32c_ppc.h
@@ -9,6 +9,8 @@
 #ifndef CEPH_COMMON_CRC32C_PPC_H
 #define CEPH_COMMON_CRC32C_PPC_H
 
+#include "arch/ppc.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/common/crc32c_ppc_fast_zero_asm.S
+++ b/src/common/crc32c_ppc_fast_zero_asm.S
@@ -1,6 +1,6 @@
 /*
  * Use the fixed point version of Barrett reduction to compute a mod n
- * over GF(2) for n = 0x104c11db7 using POWER8 instructions. We use k = 32.
+ * over GF(2) for n = 0x11edc6f41 using POWER8 instructions. We use k = 32.
  *
  * http://en.wikipedia.org/wiki/Barrett_reduction
  *
@@ -44,26 +44,26 @@
 
 	.section	.data
 .balign 16
-.constants:
+
+/*
+* Barrett reduction for CRC-32C (Castagnoli polynomial 0x1EDC6F41).
+*
+* Adapted from the hand-written barrett_reduction.S in crc32-vpmsum:
+* https://github.com/antonblanchard/crc32-vpmsum
+* Upstream's barrett_reduction_constants.c hardcodes the IEEE 802.3
+* polynomial, so its barrett_reduction.S is CRC-32, not CRC-32C.
+*/
+.barrett_fz_constants:
 	/* Barrett constant m - (4^32)/n */
-	.octa 0x00000000000000000000000104d101df
+	.octa 0x0000000000000000000000011f91caf6	/* x^64 div p(x) */
 
 	/* Barrett constant n */
-	.octa 0x00000000000000000000000104c11db7
-
-.bit_reflected_constants:
-	/* 33 bit reflected Barrett constant m - (4^32)/n */
-	.octa 0x000000000000000000000001f7011641
-
-	/* 33 bit reflected Barrett constant n */
-	.octa 0x000000000000000000000001db710641
-
-	.text
+	.octa 0x0000000000000000000000011edc6f41
 
 /* unsigned int barrett_reduction(unsigned long val) */
 FUNC_START(barrett_reduction)
-	addis   r4,r2,.constants@toc@ha
-	addi    r4,r4,.constants@toc@l
+	addis	r4,r2,.barrett_fz_constants@toc@ha
+	addi	r4,r4,.barrett_fz_constants@toc@l
 
 	li	r5,16
 	vxor	v1,v1,v1	/* zero v1 */
@@ -97,47 +97,3 @@ FUNC_START(barrett_reduction)
 
 	blr
 FUNC_END(barrett_reduction)
-
-/* unsigned int barrett_reduction_reflected(unsigned long val) */
-FUNC_START(barrett_reduction_reflected)
-	addis   r4,r2,.bit_reflected_constants@toc@ha
-	addi    r4,r4,.bit_reflected_constants@toc@l
-
-	li	r5,16
-	vxor	v1,v1,v1	/* zero v1 */
-
-	/* Get a into v0 */
-	MTVRD(v0, r3)
-	vsldoi	v0,v1,v0,8	/* shift into bottom 64 bits, this is a */
-
-	/* Load constants */
-	lvx	v2,0,r4		/* m */
-	lvx	v3,r5,r4	/* n */
-
-	vspltisw v5,-1		/* all ones */
-	vsldoi	v6,v1,v5,4	/* bitmask with low 32 bits set */
-
-	/*
-	 * Now for the Barrett reduction algorithm. Instead of bit reflecting
-	 * our data (which is expensive to do), we bit reflect our constants
-	 * and our algorithm, which means the intermediate data in our vector
-	 * registers goes from 0-63 instead of 63-0. We can reflect the
-	 * algorithm because we don't carry in mod 2 arithmetic.
-	 */
-	vand	v4,v0,v6	/* bottom 32 bits of a */
-	VPMSUMD(v4,v4,v2)	/* ma */
-	vand	v4,v4,v6	/* bottom 32bits of ma */
-	VPMSUMD(v4,v4,v3)	/* qn */
-	vxor	v0,v0,v4	/* a - qn, subtraction is xor in GF(2) */
-
-	/*
-	 * Since we are bit reflected, the result (ie the low 32 bits) is in the
-	 * high 32 bits. We just need to shift it left 4 bytes
-	 * V0 [ 0 1 X 3 ]
-	 * V0 [ 0 X 2 3 ]
-	 */
-	vsldoi	v0,v0,v1,4	/* shift result into top 64 bits of v0 */
-	MFVRD(r3, v0)
-
-	blr
-FUNC_END(barrett_reduction_reflected)

--- a/src/common/crc32c_ppc_fast_zero_asm.S
+++ b/src/common/crc32c_ppc_fast_zero_asm.S
@@ -1,6 +1,6 @@
 /*
  * Use the fixed point version of Barrett reduction to compute a mod n
- * over GF(2) for n = 0x104c11db7 using POWER8 instructions. We use k = 32.
+ * over GF(2) for n = 0x11edc6f41 using POWER8 instructions. We use k = 32.
  *
  * http://en.wikipedia.org/wiki/Barrett_reduction
  *
@@ -36,7 +36,6 @@
  * This is because the assembler has no builtin support for
  * registers, and we should either define them ourselves or
  * use their indexes explicitly like:
- *       addis   4,2,.bit_reflected_constants@toc@ha
  */
 #ifndef r2
 #define r2 2
@@ -44,26 +43,29 @@
 
 	.section	.data
 .balign 16
-.constants:
+
+/*
+* Barrett reduction for CRC-32C (Castagnoli polynomial 0x1EDC6F41).
+*
+* Adapted from the hand-written barrett_reduction.S in crc32-vpmsum:
+* https://github.com/antonblanchard/crc32-vpmsum
+* Upstream's barrett_reduction_constants.c hardcodes the IEEE 802.3
+* polynomial, so its barrett_reduction.S is CRC-32, not CRC-32C. To
+* regenerate the constants below, set CRC=0x1EDC6F41 / CRC_FULL=0x11EDC6F41
+* in barrett_reduction_constants.c, build and run it, and paste its output.
+*/
+.barrett_fz_constants:
 	/* Barrett constant m - (4^32)/n */
-	.octa 0x00000000000000000000000104d101df
+	.octa 0x0000000000000000000000011f91caf6	/* x^64 div p(x) */
 
 	/* Barrett constant n */
-	.octa 0x00000000000000000000000104c11db7
+	.octa 0x0000000000000000000000011edc6f41
 
-.bit_reflected_constants:
-	/* 33 bit reflected Barrett constant m - (4^32)/n */
-	.octa 0x000000000000000000000001f7011641
-
-	/* 33 bit reflected Barrett constant n */
-	.octa 0x000000000000000000000001db710641
-
-	.text
-
+.text
 /* unsigned int barrett_reduction(unsigned long val) */
 FUNC_START(barrett_reduction)
-	addis   r4,r2,.constants@toc@ha
-	addi    r4,r4,.constants@toc@l
+	addis	r4,r2,.barrett_fz_constants@toc@ha
+	addi	r4,r4,.barrett_fz_constants@toc@l
 
 	li	r5,16
 	vxor	v1,v1,v1	/* zero v1 */
@@ -97,47 +99,3 @@ FUNC_START(barrett_reduction)
 
 	blr
 FUNC_END(barrett_reduction)
-
-/* unsigned int barrett_reduction_reflected(unsigned long val) */
-FUNC_START(barrett_reduction_reflected)
-	addis   r4,r2,.bit_reflected_constants@toc@ha
-	addi    r4,r4,.bit_reflected_constants@toc@l
-
-	li	r5,16
-	vxor	v1,v1,v1	/* zero v1 */
-
-	/* Get a into v0 */
-	MTVRD(v0, r3)
-	vsldoi	v0,v1,v0,8	/* shift into bottom 64 bits, this is a */
-
-	/* Load constants */
-	lvx	v2,0,r4		/* m */
-	lvx	v3,r5,r4	/* n */
-
-	vspltisw v5,-1		/* all ones */
-	vsldoi	v6,v1,v5,4	/* bitmask with low 32 bits set */
-
-	/*
-	 * Now for the Barrett reduction algorithm. Instead of bit reflecting
-	 * our data (which is expensive to do), we bit reflect our constants
-	 * and our algorithm, which means the intermediate data in our vector
-	 * registers goes from 0-63 instead of 63-0. We can reflect the
-	 * algorithm because we don't carry in mod 2 arithmetic.
-	 */
-	vand	v4,v0,v6	/* bottom 32 bits of a */
-	VPMSUMD(v4,v4,v2)	/* ma */
-	vand	v4,v4,v6	/* bottom 32bits of ma */
-	VPMSUMD(v4,v4,v3)	/* qn */
-	vxor	v0,v0,v4	/* a - qn, subtraction is xor in GF(2) */
-
-	/*
-	 * Since we are bit reflected, the result (ie the low 32 bits) is in the
-	 * high 32 bits. We just need to shift it left 4 bytes
-	 * V0 [ 0 1 X 3 ]
-	 * V0 [ 0 X 2 3 ]
-	 */
-	vsldoi	v0,v0,v1,4	/* shift result into top 64 bits of v0 */
-	MFVRD(r3, v0)
-
-	blr
-FUNC_END(barrett_reduction_reflected)

--- a/src/common/ppc-opcode.h
+++ b/src/common/ppc-opcode.h
@@ -1,37 +1,3 @@
-/*
- * Copyright (C) 2015 Anton Blanchard <anton@au.ibm.com>, IBM
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of either:
- *
- *  a) the GNU General Public License as published by the Free Software
- *     Foundation; either version 2 of the License, or (at your option)
- *     any later version, or
- *  b) the Apache License, Version 2.0
- */
-#ifndef __OPCODES_H
-#define __OPCODES_H
-
-#define __PPC_RA(a)		(((a) & 0x1f) << 16)
-#define __PPC_RB(b)		(((b) & 0x1f) << 11)
-#define __PPC_XA(a)		((((a) & 0x1f) << 16) | (((a) & 0x20) >> 3))
-#define __PPC_XB(b)		((((b) & 0x1f) << 11) | (((b) & 0x20) >> 4))
-#define __PPC_XS(s)		((((s) & 0x1f) << 21) | (((s) & 0x20) >> 5))
-#define __PPC_XT(s)		__PPC_XS(s)
-#define VSX_XX3(t, a, b)	(__PPC_XT(t) | __PPC_XA(a) | __PPC_XB(b))
-#define VSX_XX1(s, a, b)	(__PPC_XS(s) | __PPC_RA(a) | __PPC_RB(b))
-
-#define PPC_INST_VPMSUMW	0x10000488
-#define PPC_INST_VPMSUMD	0x100004c8
-#define PPC_INST_MFVSRD		0x7c000066
-#define PPC_INST_MTVSRD		0x7c000166
-
-#define VPMSUMW(t, a, b)	.long PPC_INST_VPMSUMW | VSX_XX3((t), a, b)
-#define VPMSUMD(t, a, b)	.long PPC_INST_VPMSUMD | VSX_XX3((t), a, b)
-#define MFVRD(a, t)		.long PPC_INST_MFVSRD | VSX_XX1((t)+32, a, 0)
-#define MTVRD(t, a)		.long PPC_INST_MTVSRD | VSX_XX1((t)+32, a, 0)
-
-#endif
 /* Copyright (C) 2017 International Business Machines Corp.
  * All rights reserved.
  *

--- a/src/common/ppc-opcode.h
+++ b/src/common/ppc-opcode.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Anton Blanchard <anton@au.ibm.com>, IBM
+/* Copyright (C) 2017 International Business Machines Corp.
+ * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of either:
@@ -8,37 +9,6 @@
  *     Foundation; either version 2 of the License, or (at your option)
  *     any later version, or
  *  b) the Apache License, Version 2.0
- */
-#ifndef __OPCODES_H
-#define __OPCODES_H
-
-#define __PPC_RA(a)		(((a) & 0x1f) << 16)
-#define __PPC_RB(b)		(((b) & 0x1f) << 11)
-#define __PPC_XA(a)		((((a) & 0x1f) << 16) | (((a) & 0x20) >> 3))
-#define __PPC_XB(b)		((((b) & 0x1f) << 11) | (((b) & 0x20) >> 4))
-#define __PPC_XS(s)		((((s) & 0x1f) << 21) | (((s) & 0x20) >> 5))
-#define __PPC_XT(s)		__PPC_XS(s)
-#define VSX_XX3(t, a, b)	(__PPC_XT(t) | __PPC_XA(a) | __PPC_XB(b))
-#define VSX_XX1(s, a, b)	(__PPC_XS(s) | __PPC_RA(a) | __PPC_RB(b))
-
-#define PPC_INST_VPMSUMW	0x10000488
-#define PPC_INST_VPMSUMD	0x100004c8
-#define PPC_INST_MFVSRD		0x7c000066
-#define PPC_INST_MTVSRD		0x7c000166
-
-#define VPMSUMW(t, a, b)	.long PPC_INST_VPMSUMW | VSX_XX3((t), a, b)
-#define VPMSUMD(t, a, b)	.long PPC_INST_VPMSUMD | VSX_XX3((t), a, b)
-#define MFVRD(a, t)		.long PPC_INST_MFVSRD | VSX_XX1((t)+32, a, 0)
-#define MTVRD(t, a)		.long PPC_INST_MTVSRD | VSX_XX1((t)+32, a, 0)
-
-#endif
-/* Copyright (C) 2017 International Business Machines Corp.
- * All rights reserved.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version
- * 2 of the License, or (at your option) any later version.
  */
 #ifndef __OPCODES_H
 #define __OPCODES_H

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -337,6 +337,9 @@
 /* Support POWER8 instructions */
 #cmakedefine HAVE_POWER8
 
+/* Support PPC64LE */
+#cmakedefine HAVE_PPC64LE
+
 /* Define if endian type is big endian */
 #cmakedefine CEPH_BIG_ENDIAN
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -331,6 +331,9 @@
 /* Support POWER8 instructions */
 #cmakedefine HAVE_POWER8
 
+/* Support PPC64LE */
+#cmakedefine HAVE_PPC64LE
+
 /* Define if endian type is big endian */
 #cmakedefine CEPH_BIG_ENDIAN
 

--- a/src/test/common/test_crc32c.cc
+++ b/src/test/common/test_crc32c.cc
@@ -14,6 +14,7 @@
 #include "common/sctp_crc32.h"
 #include "common/crc32c_intel_baseline.h"
 #include "common/crc32c_aarch64.h"
+#include "common/crc32c_ppc.h"
 
 TEST(Crc32c, Small) {
   const char *a = "foo bar baz";
@@ -92,6 +93,17 @@ TEST(Crc32c, Performance) {
     utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "aarch64 = " << rate << " MB/sec" << std::endl;
+    ASSERT_EQ(261108528u, val);
+  }
+#endif
+#if defined(__PPC64__) || defined(__powerpc64__)
+  if (ceph_arch_ppc_crc32) // Skip if CRC32C instructions are not defined.
+  {
+    utime_t start = ceph_clock_now();
+    unsigned val = ceph_crc32c_ppc(0, (unsigned char *)a, len);
+    utime_t end = ceph_clock_now();
+    float rate = (float)len / (float)(1024*1024) / (float)(end - start);
+    std::cout << "ppc64le = " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(261108528u, val);
   }
 #endif

--- a/src/test/common/test_crc32c.cc
+++ b/src/test/common/test_crc32c.cc
@@ -15,6 +15,7 @@
 #include "common/crc32c_intel_baseline.h"
 #include "common/crc32c_aarch64.h"
 #include "common/crc32c_riscv.h"
+#include "common/crc32c_ppc.h"
 
 TEST(Crc32c, Small) {
   const char *a = "foo bar baz";
@@ -104,6 +105,17 @@ TEST(Crc32c, Performance) {
     utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "riscv = " << rate << " MB/sec" << std::endl;
+    ASSERT_EQ(261108528u, val);
+  }
+#endif
+#if defined(__PPC64__) || defined(__powerpc64__)
+  if (ceph_arch_ppc_crc32) // Skip if CRC32C instructions are not defined.
+  {
+    utime_t start = ceph_clock_now();
+    unsigned val = ceph_crc32c_ppc(0, (unsigned char *)a, len);
+    utime_t end = ceph_clock_now();
+    float rate = (float)len / (float)(1024*1024) / (float)(end - start);
+    std::cout << "ppc64le = " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(261108528u, val);
   }
 #endif

--- a/src/test/test_arch.cc
+++ b/src/test/test_arch.cc
@@ -20,9 +20,14 @@
 #include "arch/probe.h"
 #include "arch/intel.h"
 #include "arch/arm.h"
+#include "arch/ppc.h"
 #include "global/global_context.h"
 #include "gtest/gtest.h"
 
+#if (__powerpc64__)
+#include <sys/auxv.h>
+#include <asm/cputable.h>
+#endif
 
 #define FLAGS_SIZE 4096
 
@@ -31,7 +36,7 @@ TEST(Arch, all)
   ceph_arch_probe();
   EXPECT_TRUE(ceph_arch_probed);
   
-#if (__arm__ || __aarch64__ || __x86_64__) && __linux__
+#if (__arm__ || __aarch64__ || __x86_64__ || __powerpc64__) && __linux__
   char flags[FLAGS_SIZE];
   FILE *f = popen("grep '^\\(flags\\|Features\\)[	 ]*:' "
                   "/proc/cpuinfo | head -1", "r");
@@ -78,6 +83,16 @@ TEST(Arch, all)
 
   expected = strstr(flags, " sse2 ") ? 1 : 0;
   EXPECT_EQ(expected, ceph_arch_intel_sse2);
+
+#endif
+#if (__powerpc64__)
+
+  // /proc/cpuinfo is unreliable for determining crypto features on PowerPC.
+  // altivec support does NOT mean POWER8 crypto support is present.
+  // We check the hardware capability directly.
+  unsigned long hwcap2 = getauxval(AT_HWCAP2);
+  expected = (hwcap2 & PPC_FEATURE2_VEC_CRYPTO) ? 1 : 0;
+  EXPECT_EQ(expected, ceph_arch_ppc_crc32);
 
 #endif
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/74111

This PR address the issue enabling power optimized crc32c code. After the fix all the UTs are passing.

```
[ RUN      ] Crc32c.Performance
populating large buffer
calculating crc
best choice = 13997.7 MB/sec
best choice 0xffffffff = 14154.2 MB/sec
sctp = 279.734 MB/sec
intel baseline = 102.071 MB/sec
ppc64le = 14149.8 MB/sec
[       OK ] Crc32c.Performance (14407 ms)
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
