### PR TITLE
qa/cephfs: increase number of files to cloned in test_clone_stats.py

### DIFF
--- a/qa/tasks/cephfs/volumes/test_clone_stats.py
+++ b/qa/tasks/cephfs/volumes/test_clone_stats.py
@@ -332,7 +332,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         c = 'ss1clone1'
 
         self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
-        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        size = self._do_subvolume_io(sv, None, None, 30, 100)
 
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
@@ -369,7 +369,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         c = 'ss1clone1'
 
         self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
-        size = self._do_subvolume_io(sv, None, None, 10, 1024)
+        size = self._do_subvolume_io(sv, None, None, 100, 100)
 
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
@@ -417,7 +417,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
 
         self.run_ceph_cmd(f'fs subvolumegroup create {v} {group}')
         self.run_ceph_cmd(f'fs subvolume create {v} {sv} {group} --mode=777')
-        size = self._do_subvolume_io(sv, group, None, 10, 1024)
+        size = self._do_subvolume_io(sv, group, None, 100, 100)
 
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss} {group}')
         self.wait_till_rbytes_is_right(v, sv, size, group)
@@ -469,7 +469,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         self.config_set('mds', 'mds_snap_rstat', 'true')
 
         self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
-        size = self._do_subvolume_io(sv, None, None, 10, 1024)
+        size = self._do_subvolume_io(sv, None, None, 100, 100)
 
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
@@ -513,7 +513,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         c = self._gen_subvol_clone_name(4)
 
         self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
-        size = self._do_subvolume_io(sv, None, None, 10, 1024)
+        size = self._do_subvolume_io(sv, None, None, 100, 100)
 
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
@@ -563,7 +563,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
 
         self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', 'false')
         self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
-        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        size = self._do_subvolume_io(sv, None, None, 30, 100)
 
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
@@ -614,7 +614,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
 
         self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', 'false')
         self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
-        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        size = self._do_subvolume_io(sv, None, None, 30, 100)
 
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
@@ -673,7 +673,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
         sv_path = sv_path[1:]
 
-        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        size = self._do_subvolume_io(sv, None, None, 30, 100)
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
 
@@ -716,7 +716,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
         sv_path = sv_path[1:]
 
-        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        size = self._do_subvolume_io(sv, None, None, 30, 100)
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
 
@@ -763,7 +763,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
         sv_path = sv_path[1:]
 
-        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        size = self._do_subvolume_io(sv, None, None, 30, 100)
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
 
@@ -814,7 +814,7 @@ class TestOngoingClonesCounter(CloneProgressReporterHelper):
         sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
         sv_path = sv_path[1:]
 
-        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        size = self._do_subvolume_io(sv, None, None, 30, 100)
         self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
         self.wait_till_rbytes_is_right(v, sv, size)
 

--- a/qa/tasks/cephfs/volumes/test_clone_stats.py
+++ b/qa/tasks/cephfs/volumes/test_clone_stats.py
@@ -797,7 +797,7 @@ class TestOngoingClonesCounter(CloneProgressReporterHelper):
     '''
     Class CloneProgressReporter contains the code that lets it figure out the
     number of ongoing clones on its own, without referring the MGR config
-    option mgr/volumes/max_concurrenr_clones. This class contains tests to
+    option mgr/volumes/max_concurrent_clones. This class contains tests to
     ensure that this code, that does the figuring out, is working fine.
     '''
 

--- a/qa/tasks/cephfs/volumes/test_clone_stats.py
+++ b/qa/tasks/cephfs/volumes/test_clone_stats.py
@@ -376,7 +376,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
 
         self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {c}')
 
-        with safe_while(tries=10, sleep=1) as proceed:
+        with safe_while(tries=10, sleep=2) as proceed:
             while proceed():
                 pev = self.get_pevs_from_ceph_status(c)
 
@@ -425,7 +425,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {c} '
                           f'--group-name {group}')
 
-        with safe_while(tries=10, sleep=1) as proceed:
+        with safe_while(tries=10, sleep=2) as proceed:
             while proceed():
                 pev = self.get_pevs_from_ceph_status(c)
 
@@ -521,7 +521,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
         for i in c:
             self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {i}')
 
-        with safe_while(tries=10, sleep=1) as proceed:
+        with safe_while(tries=10, sleep=2) as proceed:
             while proceed():
                 pev = self.get_pevs_from_ceph_status(c)
 
@@ -573,7 +573,7 @@ class TestCloneProgressReporter(CloneProgressReporterHelper):
 
         msg = ('messages for progress bars for snapshot cloning are not how '
                'they were expected')
-        with safe_while(tries=20, sleep=1, action=msg) as proceed:
+        with safe_while(tries=20, sleep=2, action=msg) as proceed:
             while proceed():
                 pevs = self.get_pevs_from_ceph_status(c)
 

--- a/src/pybind/mgr/volumes/fs/stats_util.py
+++ b/src/pybind/mgr/volumes/fs/stats_util.py
@@ -47,6 +47,7 @@ def get_amount_copied(src_path, dst_path, fs_handle):
 
     try:
         size_t = int(fs_handle.getxattr(src_path, rbytes))
+        log.debug(f'rbytes on path src_path ({src_path}) = {size_t}')
     except ObjectNotFound:
         log.info(f'get_amount_copied(): source path "{src_path}" went missing, '
                   'couldn\'t run getxattr on it')
@@ -54,6 +55,7 @@ def get_amount_copied(src_path, dst_path, fs_handle):
 
     try:
         size_c = int(fs_handle.getxattr(dst_path, rbytes))
+        log.debug(f'rbytes on path dst_path ({dst_path}) = {size_c}')
     except ObjectNotFound:
         log.info(f'get_amount_copied(): destination path "{dst_path}" went '
                   'missing, couldn\'t run getxattr on it')
@@ -210,8 +212,8 @@ class CloneProgressReporter:
                     # get clone in order in which they were launched, this
                     # should be same as the ctime on clone entry.
                     clone_index_entries = clone_index.list_entries_by_ctime_order()
-                    log.debug('finished collecting all clone index entries, '
-                              f'found {len(clones)} clone index entries')
+                    log.debug(f'found {len(clone_index_entries)} clone index '
+                               'entries')
 
                 # reset ongoing clone counter before iterating over all clone
                 # entries
@@ -248,8 +250,7 @@ class CloneProgressReporter:
 
                     clones.append(ci)
 
-        log.debug('finished collecting info on all clones, found '
-                  f'{len(clones)} clones out of which '
+        log.debug(f'found {len(clones)} clones, out of which '
                   f'{self.ongoing_clones_count} are ongoing clones')
         return clones
 


### PR DESCRIPTION
There's a race condition between cloning operation and clone progress
reporter thread to open the subvolume, former does so to copy/clone
files and latter to get details of the source and destination subvolume.

A low number of files in the snapshot gives clone progress reporter
thread less or no chance to fetch and process the details needed to
display the progress bar. This causes tests to fails when progress bar
isn't displayed in the output of "ceph status" output.
    
Increasing the number of files will give clone progress reporter more
time to display the progress bar and therefore these unnecessary test
failures wlll reduce/stop.
    
This failure wasn't seen earlier because Python code was being used to
copy files which was comparatively slow (compared to C++ code that was
merged to copy files as a part of fscrypt work) which allowed enough
time to clone progress reporter thread to process stats and display
clone progress bar.
    
Fixes: https://tracker.ceph.com/issues/74082







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>