### PR TITLE
src/cephadm: updated crash dir creation

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -475,9 +475,6 @@ def make_data_dir_base(fsid, data_dir, uid, gid):
     # type: (str, str, int, int) -> str
     data_dir_base = os.path.join(data_dir, fsid)
     makedirs(data_dir_base, uid, gid, DATA_DIR_MODE)
-    makedirs(os.path.join(data_dir_base, 'crash'), uid, gid, DATA_DIR_MODE)
-    makedirs(os.path.join(data_dir_base, 'crash', 'posted'), uid, gid,
-             DATA_DIR_MODE)
     return data_dir_base
 
 

--- a/src/cephadm/cephadmlib/daemons/__init__.py
+++ b/src/cephadm/cephadmlib/daemons/__init__.py
@@ -1,4 +1,4 @@
-from .ceph import Ceph, OSD, CephExporter
+from .ceph import Ceph, OSD, CephExporter, Crash
 from .custom import CustomContainer
 from .ingress import HAproxy, Keepalived
 from .iscsi import CephIscsi
@@ -15,6 +15,7 @@ from .oauth2_proxy import OAuth2Proxy
 __all__ = [
     'Ceph',
     'CephExporter',
+    'Crash',
     'CephIscsi',
     'CephNvmeof',
     'CustomContainer',

--- a/src/cephadm/cephadmlib/daemons/ceph.py
+++ b/src/cephadm/cephadmlib/daemons/ceph.py
@@ -52,7 +52,10 @@ class Ceph(ContainerDaemonForm):
     @classmethod
     def for_daemon_type(cls, daemon_type: str) -> bool:
         # TODO: figure out a way to un-special-case osd
-        return daemon_type in cls._daemons and daemon_type not in ('osd', 'crash')
+        return daemon_type in cls._daemons and daemon_type not in (
+            'osd',
+            'crash',
+        )
 
     def __init__(self, ctx: CephadmContext, ident: DaemonIdentity) -> None:
         self.ctx = ctx
@@ -335,6 +338,7 @@ class OSD(Ceph):
     def osd_fsid(self) -> Optional[str]:
         return self._osd_fsid
 
+
 @register_daemon_form
 class Crash(Ceph):
     @classmethod
@@ -352,10 +356,17 @@ class Crash(Ceph):
     def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'Ceph':
         (uid, gid) = extract_uid_gid(ctx)
         data_dir_base = f'{ctx.data_dir}/{ident.fsid}'
-        makedirs(os.path.join(data_dir_base, 'crash'), uid, gid, DATA_DIR_MODE)
-        makedirs(os.path.join(data_dir_base, 'crash', 'posted'), uid, gid,
-                 DATA_DIR_MODE)
+        makedirs(
+            os.path.join(data_dir_base, 'crash'), uid, gid, DATA_DIR_MODE
+        )
+        makedirs(
+            os.path.join(data_dir_base, 'crash', 'posted'),
+            uid,
+            gid,
+            DATA_DIR_MODE,
+        )
         return cls(ctx, ident)
+
 
 @register_daemon_form
 class CephExporter(ContainerDaemonForm):

--- a/src/cephadm/tests/test_daemon_form.py
+++ b/src/cephadm/tests/test_daemon_form.py
@@ -72,6 +72,9 @@ def test_can_create_all_daemon_forms(monkeypatch):
     }
     _os_path_isdir = mock.MagicMock(return_value=True)
     monkeypatch.setattr('os.path.isdir', _os_path_isdir)
+    monkeypatch.setattr('cephadmlib.daemons.ceph.extract_uid_gid',
+                        lambda ctx: (167, 167))
+    monkeypatch.setattr('os.chown', lambda *args, **kwargs: None)
     dtypes = _cephadm.get_supported_daemons()
     for daemon_type in dtypes:
         if daemon_type == 'agent':


### PR DESCRIPTION
This change is meant to address the issue of daemons like grafana changing the uid and gid of the crash directory, /var/lib/ceph<fsid>/crash, the crash service only works if this directory has the standard ceph-user uid and gid. I've added a condition which will only create a crash directory if the crash daemon is being deployed. This ensures uid and gid are always correct.

Fixes: https://tracker.ceph.com/issues/69590
Signed-off-by: Timothy Q Nguyen <timqn22@gmail.com>