### PR TITLE
mgr/dashboard: add a command to refresh certificates

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -7,9 +7,7 @@ import errno
 import logging
 import os
 import socket
-import ssl
 import sys
-import tempfile
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -26,8 +24,7 @@ if TYPE_CHECKING:
 from ceph.cryptotools.select import choose_crypto_caller
 from mgr_module import CLIReadCommand, CLIWriteCommand, HandleCommandResult, \
     MgrModule, MgrStandbyModule, NotifyType, Option, _get_localized_key
-from mgr_util import ServerConfigException, build_url, \
-    create_self_signed_cert, get_default_addr, verify_tls_files
+from mgr_util import ServerConfigException, build_url, create_self_signed_cert, get_default_addr
 
 from . import mgr
 from .controllers import nvmeof  # noqa # pylint: disable=unused-import
@@ -40,7 +37,7 @@ from .services.service import RgwServiceManager
 from .services.sso import SSO_COMMANDS, handle_sso_command
 from .settings import handle_option_command, options_command_list, options_schema_list
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
-    configure_cors, prepare_url_prefix, str_to_bool
+    configure_cors, configure_ssl_certs, prepare_url_prefix, str_to_bool
 
 try:
     import cherrypy
@@ -155,39 +152,7 @@ class CherryPyConfig(object):
         }
 
         if use_ssl:
-            # SSL initialization
-            cert = self.get_localized_store("crt")  # type: ignore
-            if cert is not None:
-                self.cert_tmp = tempfile.NamedTemporaryFile()
-                self.cert_tmp.write(cert.encode('utf-8'))
-                self.cert_tmp.flush()  # cert_tmp must not be gc'ed
-                cert_fname = self.cert_tmp.name
-            else:
-                cert_fname = self.get_localized_module_option('crt_file')  # type: ignore
-
-            pkey = self.get_localized_store("key")  # type: ignore
-            if pkey is not None:
-                self.pkey_tmp = tempfile.NamedTemporaryFile()
-                self.pkey_tmp.write(pkey.encode('utf-8'))
-                self.pkey_tmp.flush()  # pkey_tmp must not be gc'ed
-                pkey_fname = self.pkey_tmp.name
-            else:
-                pkey_fname = self.get_localized_module_option('key_file')  # type: ignore
-
-            verify_tls_files(cert_fname, pkey_fname)
-
-            # Create custom SSL context to disable TLS 1.0 and 1.1.
-            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-            context.load_cert_chain(cert_fname, pkey_fname)
-            if sys.version_info >= (3, 7):
-                context.minimum_version = ssl.TLSVersion.TLSv1_3
-            else:
-                context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
-
-            config['server.ssl_module'] = 'builtin'
-            config['server.ssl_certificate'] = cert_fname
-            config['server.ssl_private_key'] = pkey_fname
-            config['server.ssl_context'] = context
+            configure_ssl_certs()
 
         self.update_cherrypy_config(config)
 
@@ -501,6 +466,11 @@ class Module(MgrModule, CherryPyConfig):
         self.set_module_option('cross_origin_url', ','.join(cross_origin_urls_list))
         configure_cors()
         return 0, 'Cross-origin URL set', ''
+
+    @CLIWriteCommand("dashboard refresh-ssl-certificates")
+    def refresh_ssl_certificates(self):
+        configure_ssl_certs(restart_engine=True)
+        return 0, 'SSL certificates refreshed', ''
 
     @CLIReadCommand("dashboard get-cross-origin-url")
     def get_cross_origin_url(self):


### PR DESCRIPTION
if you set a new certificate, you need to restart the dashboard module for that certificate to get applied on the cherrypy. instead you just need to reconfigure the ssl adapter for it to work.

reconfiguring adapter is the best way since it won't close the current connection where the engine restart will close the connection which will be an inconvenience.

apply the new certificates

```
ceph dashboard set-ssl-certificate -i <cert_file>
ceph dashboard set-ssl-certificate-key -i <key_file
```
and then run
```
ceph dashboard refresh-ssl-certificates
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
