### PR TITLE
rgw/lua: provide a formatted debug log function

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -135,6 +135,14 @@ Debug Log
 The ``RGWDebugLog()`` function accepts a string and prints it to the debug log with priority 20.
 Each log message is prefixed ``Lua INFO:``. This function has no return value.
 
+The ``RGWDebugLogF()`` function accepts a format string and a list of arguments,
+and prints the formatted string to the debug log with priority 20.
+Instances of "{}" in the format string are sequentially replaced by the arguments.
+Lua types string, boolean, number and nil are supported as arguments.
+Other types (e.g. tables) will fail the function.
+Escape sequences, `arg-id` and `format-spec` are not supported in the format string, and will fail the function if used.
+Each log message is prefixed with ``Lua INFO:``. This function has no return value.
+
 Request Fields
 -----------------
 
@@ -383,6 +391,25 @@ Lua Code Samples
     RGWDebugLog("copy from object:")
     print_object(Request.CopyFrom.Object)
     RGWDebugLog("to object:")
+    print_object(Request.Object)
+  end
+
+- Print information using ``RGWDebugLogF`` on source and destination objects in case of copy:
+
+.. code-block:: lua
+
+  function print_object(object)
+    RGWDebugLogF("  Name: {}", object.Name)
+    RGWDebugLogF("  Instance: {}", object.Instance)
+    RGWDebugLogF("  Id: {}", object.Id)
+    RGWDebugLogF("  Size: {}", object.Size)
+    RGWDebugLogF("  MTime: {}", object.MTime)
+  end
+
+  if Request.CopyFrom and Request.Object and Request.CopyFrom.Object then
+    RGWDebugLogF("copy from object:")
+    print_object(Request.CopyFrom.Object)
+    RGWDebugLogF("to object:")
     print_object(Request.Object)
   end
 

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -121,6 +121,7 @@ std::unique_ptr<lua_state_guard> Background::initialize_lguard_state() {
     open_standard_libs(L);
     set_package_path(L, lua_manager->luarocks_path());
     create_debug_action(L, cct);
+    create_debug_action_f(L, cct);
     create_background_metatable(L);
   } catch (const std::runtime_error& e) {
     ldpp_dout(&dp, 1)

--- a/src/rgw/rgw_lua_data_filter.cc
+++ b/src/rgw/rgw_lua_data_filter.cc
@@ -85,6 +85,7 @@ int RGWObjFilter::execute(bufferlist& bl, off_t offset, const char* op_name) con
     open_standard_libs(L);
 
     create_debug_action(L, s->cct);  
+    create_debug_action_f(L, s->cct);
 
     // create the "Data" table
     static const char* data_metatable_name = "Data";

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -805,6 +805,7 @@ int execute(
     set_package_path(L, s->penv.lua.manager->luarocks_path());
 
     create_debug_action(L, s->cct);  
+    create_debug_action_f(L, s->cct);
   
     create_top_metatable(L, s, const_cast<char*>(op_name));  
 

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -277,6 +277,17 @@ struct EmptyMetaTable {
 //
 void create_debug_action(lua_State* L, CephContext* cct);
 
+// create a formatted debug log action
+// it expects CephContext to be captured
+// it expects the first string parameter to specify the format followed by
+// boolean/nil.strings/numbers which will replace the instances of "{}"
+// in the format string.
+// could be executed from any context that has CephContext
+// e.g.
+//    RGWDebugLogF("Added object {}", Request.Object.Name)
+//
+void create_debug_action_f(lua_State* L, CephContext* cct);
+
 // set the packages search path according to:
 // package.path  = "<install_dir>/share/lua/5.3/?.lua"
 // package.cpath = "<install_dir>/lib/lua/5.3/?.so"


### PR DESCRIPTION
Adds a function called RGWDebugLogF which takes a format string and arguments as inputs and outputs a formatted string.

Fixes: https://tracker.ceph.com/issues/70962



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
