### PR TITLE
Add ceph_test_rados_io_sequence to rados suite in teuthology

### DIFF
--- a/qa/suites/rados/thrash-erasure-code-overwrites/workloads/ec-iosequence.yaml
+++ b/qa/suites/rados/thrash-erasure-code-overwrites/workloads/ec-iosequence.yaml
@@ -1,0 +1,40 @@
+tasks:
+- iosequence:
+    clients: [client.0]
+    ec_pool: true
+    erasure_code_profile:
+      name: jerasure21profile
+      plugin: jerasure
+      k: 2
+      m: 1
+      technique: reed_sol_van
+      crush-failure-domain: osd
+    runs: 3
+    threads: 5
+    blocksize: 2048
+- iosequence:
+    clients: [client.0]
+    ec_pool: true
+    erasure_code_profile:
+      name: jerasure42profile
+      plugin: jerasure
+      k: 4
+      m: 2
+      technique: reed_sol_van
+      crush-failure-domain: osd
+    runs: 3
+    threads: 5
+    blocksize: 3767
+- iosequence:
+    clients: [client.0]
+    ec_pool: true
+    erasure_code_profile:
+      name: jerasure86profile
+      plugin: jerasure
+      k: 8
+      m: 6
+      technique: reed_sol_van
+      crush-failure-domain: osd
+    runs: 3
+    threads: 5
+    blocksize: 4096

--- a/qa/tasks/daemonwatchdog.py
+++ b/qa/tasks/daemonwatchdog.py
@@ -1,6 +1,7 @@
 import logging
 import signal
 import time
+import traceback
 
 from gevent import sleep
 from gevent.greenlet import Greenlet
@@ -15,7 +16,7 @@ class BarkError(Exception):
     """
 
     def __init__(self, bark_reason):
-        self.message = f"The WatchDog barked due to {bark_reason}"
+        self.message = f"Watchdog timeout: {bark_reason}"
         super().__init__(self.message)
 
 class DaemonWatchdog(Greenlet):
@@ -61,6 +62,7 @@ class DaemonWatchdog(Greenlet):
         self.stopping = Event()
         self.thrashers = ctx.ceph[config["cluster"]].thrashers
         self.watched_processes = ctx.ceph[config["cluster"]].watched_processes
+        self.assert_trackers = ctx.ceph[config["cluster"]].assert_trackers
 
     def _run(self):
         try:
@@ -113,7 +115,7 @@ class DaemonWatchdog(Greenlet):
         daemon_timeout = int(self.config.get('daemon_timeout', 300))
         daemon_restart = self.config.get('daemon_restart', False)
         daemon_failure_time = {}
-        bark_reason: str = ""
+        bark_reason = []
         while not self.stopping.is_set():
             bark = False
             now = time.time()
@@ -131,39 +133,92 @@ class DaemonWatchdog(Greenlet):
             daemon_failures.extend(filter(lambda daemon: daemon.finished(), rgws))
             daemon_failures.extend(filter(lambda daemon: daemon.finished(), mgrs))
 
-            for daemon in daemon_failures:
-                name = daemon.role + '.' + daemon.id_
-                dt = daemon_failure_time.setdefault(name, (daemon, now))
-                assert dt[0] is daemon
-                delta = now-dt[1]
-                self.log("daemon {name} is failed for ~{t:.0f}s".format(name=name, t=delta))
-                if delta > daemon_timeout:
-                    bark = True
-                    bark_reason = f"Daemon {name} has failed"
-                if daemon_restart == 'normal' and daemon.proc.exitstatus == 0:
-                    self.log(f"attempting to restart daemon {name}")
-                    daemon.restart()
+            def shorten_failure_list(failures, reason):
+                if len(failures) > 1:
+                    # Remove common prefixes from failure list
+                    last=""
+                    failures2 = []
+                    for f in failures:
+                        p = last.split(".")
+                        n = f.split(".")
+                        if p[0] != n[0] or len(p) == 1 or len(n) == 1:
+                            failures2.append(f)
+                        elif p[1] != n[1] or len(n) == 2:
+                            failures2.append(".".join(n[1:]))
+                        else:
+                            failures2.append(".".join(n[2:]))
+                        last = f
+                    failure_list = ",".join(failures2)
+                    bark_reason.append(f"Multiple daemons {failure_list} have {reason}")
+                elif len(failures) == 1:
+                    bark_reason.append(f"Daemon {failures[0]} has {reason}")
 
-            # If a daemon is no longer failed, remove it from tracking:
-            for name in list(daemon_failure_time.keys()):
-                if name not in [d.role + '.' + d.id_ for d in daemon_failures]:
-                    self.log("daemon {name} has been restored".format(name=name))
-                    del daemon_failure_time[name]
+            try:
+                earliest = None
+                failures = []
+                for daemon in daemon_failures:
+                    name = daemon.role + '.' + daemon.id_
+                    dt = daemon_failure_time.setdefault(name, (daemon, now))
+                    assert dt[0] is daemon
+                    delta = now-dt[1]
+                    self.log("daemon {name} is failed for ~{t:.0f}s".format(name=name, t=delta))
+                    if delta > daemon_timeout:
+                        bark = True
+                        failures.append(f"{name}")
+                        for at in self.assert_trackers:
+                            if at.match_id(daemon.role, daemon.id_):
+                                exception = at.get_exception()
+                                if exception is not None:
+                                    if earliest == None or at.get_failure_time() < earliest.get_failure_time():
+                                        earliest = at
 
-            for thrasher in self.thrashers:
-                if thrasher.exception is not None:
-                    self.log("{name} failed".format(name=thrasher.name))
-                    bark_reason = f"Thrasher {name} threw exception {thrasher.exception}"
-                    bark = True
+                    if daemon_restart == 'normal' and daemon.proc.exitstatus == 0:
+                        self.log(f"attempting to restart daemon {name}")
+                        daemon.restart()
 
-            for proc in self.watched_processes:
-                if proc.exception is not None:
-                    self.log("Remote process %s failed" % proc.id)
-                    bark_reason = f"Remote process {proc.id} threw exception {proc.exception}"
-                    bark = True
+                shorten_failure_list(failures, "timed out")
+
+                # If a daemon is no longer failed, remove it from tracking:
+                for name in list(daemon_failure_time.keys()):
+                    if name not in [d.role + '.' + d.id_ for d in daemon_failures]:
+                        self.log("daemon {name} has been restored".format(name=name))
+                        del daemon_failure_time[name]
+
+                for thrasher in self.thrashers:
+                    if thrasher.exception is not None:
+                        self.log("{name} failed".format(name=thrasher.name))
+                        bark_reason.append(f"Thrasher {name} threw exception {thrasher.exception}")
+                        bark = True
+
+                for proc in self.watched_processes:
+                    if proc.exception is not None:
+                        self.log("Remote process %s failed" % proc.id)
+                        bark_reason.append(f"Remote process {proc.id} threw exception {proc.exception}")
+                        bark = True
+
+                # If a thrasher or watched process failed then check for the earliest daemon failure
+                failures = []
+                if bark and earliest == None:
+                    for at in self.assert_trackers:
+                        exception = at.get_exception()
+                        if exception is not None:
+                            failures.append(f"{at.role}.{at.id_}")
+                            if earliest == None or at.get_failure_time() < earliest.get_failure_time():
+                                earliest = at
+
+                shorten_failure_list(failures, "crashed")
+
+                # Only report details about one daemon failure
+                if earliest != None:
+                    bark_reason.append(f"First crash: Daemon {earliest.role}.{earliest.id_} at {time.ctime(earliest.get_failure_time())}")
+                    bark_reason.append(f"{earliest.get_exception()}")
+
+            except:
+                bark = True
+                bark_reason.append(f"Watchdog bug {traceback.format_exc()}")
 
             if bark:
-                self.bark(bark_reason)
+                self.bark("\n".join(bark_reason))
                 return
 
             sleep(5)

--- a/qa/tasks/iosequence.py
+++ b/qa/tasks/iosequence.py
@@ -1,0 +1,234 @@
+"""
+ceph_test_rados_io_sequence I/O exerciser
+
+Generate sequences of I/O to a single object with different offsets
+and lengths with a focus on testing boundary conditions such as
+chunk size, stripe size, etc. Good for testing Erasure Coding and
+Object Stores.
+"""
+
+import contextlib
+import logging
+import threading
+from typing import Any, Dict
+
+import gevent
+
+from teuthology import misc as teuthology
+from teuthology.orchestra import run
+
+from .watched_process import WatchedProcess
+
+log = logging.getLogger(__name__)
+_lock = threading.Lock()
+_uid = 0
+
+@contextlib.contextmanager
+def task(ctx, config):
+    """
+    Run ceph_test_rados_io_sequence based integration tests.
+
+    The config should be as follows::
+
+        iosequence:
+          clients: [client list]
+          ec_pool: use an ec pool
+          erasure_code_profile: profile to use with the erasure coded pool
+          min_size: set the min_size of created pool
+          runs: <number of times to run> - the pool is remade between runs
+          objectsize: <min>,<max> - see ceph_test_radios_io_sequence help
+          sequence: <min>,<max> - see ceph_test_radios_io_sequence help
+          blocksize: <bytes> - see ceph_test_radios_io_sequence help
+          threads: <numthreads> - see ceph_test_radios_io_sequence help
+          seed: <int> - see ceph_test_radios_io_sequence help
+          seqseed: <int> - see ceph_test_radios_io_sequence help
+    For example::
+
+        tasks:
+        - ceph:
+        - iosequence:
+            clients: [client.0]
+            ec_pool: create an ec pool, defaults to False
+            erasure_code_profile:
+              name: teuthologyprofile
+              k: 2
+              m: 1
+              crush-failure-domain: osd
+            runs: 10
+            blocksize: 2048
+            objectsize: 2,10
+            sequence: 1,8
+            threads: 5
+            seed: 12345678
+        - interactive:
+
+    Optionally, you can provide the pool name to run against:
+
+        tasks:
+        - ceph:
+        - exec:
+            client.0:
+              - ceph osd pool create foo
+        - iosequence:
+            clients: [client.0]
+            pools: [foo]
+            ...
+
+    Alternatively, you can provide a pool prefix:
+
+        tasks:
+        - ceph:
+        - exec:
+            client.0:
+              - ceph osd pool create foo.client.0
+        - iosequence:
+            clients: [client.0]
+            pool_prefix: foo
+            ...
+
+    The tests are run asynchronously, they are not complete when the task
+    returns. For instance:
+
+        - iosequence:
+            clients: [client.0]
+            pools: [ecbase]
+        - print: "**** done rados ec-cache-agent (part 2)"
+
+     will run the print task immediately after the ceph_test_rados_iosequence
+     tasks begins but not after it completes. To make the iosequence task a
+     blocking / sequential task, use:
+
+        - sequential:
+          - iosequence:
+              clients: [client.0]
+              pools: [ecbase]
+        - print: "**** done rados ec-cache-agent (part 2)"
+
+    """
+    log.info('Beginning iosequence...')
+    assert isinstance(config, dict), \
+        "please list clients to run on"
+
+    log.info("config is {config}".format(config=str(config)))
+    overrides = ctx.config.get('overrides', {})
+    log.info("overrides is {overrides}".format(overrides=str(overrides)))
+    teuthology.deep_merge(config, overrides.get('iosequence', {}))
+    log.info("config is {config}".format(config=str(config)))
+
+    testdir = teuthology.get_testdir(ctx)
+    pct_update_delay = None
+    args = [
+        'adjust-ulimits',
+        'ceph-coverage',
+        '{tdir}/archive/coverage'.format(tdir=testdir),
+        'stdin-killer',
+        '--',
+        'ceph_test_rados_io_sequence']
+
+    def thread():
+        """Thread spawned by gevent"""
+        global _lock
+        global _uid
+        clients = ['client.{id}'.format(id=id_) for id_ in teuthology.all_roles_of_type(ctx.cluster, 'client')]
+        log.info('clients are %s' % clients)
+        manager = ctx.managers['ceph']
+        if config.get('ec_pool', False):
+            profile = config.get('erasure_code_profile', {})
+            profile_name = profile.get('name', 'teuthologyprofile')
+            manager.create_erasure_code_profile(profile_name, profile)
+            crush_prof = config.get('erasure_code_crush', {})
+            crush_name = None
+            if crush_prof:
+                crush_name = crush_prof.get('name', 'teuthologycrush')
+                manager.create_erasure_code_crush_rule(crush_name, crush_prof)
+
+        else:
+            profile_name = None
+            crush_name = None
+
+        cluster = config.get("cluster", "ceph")
+
+        for i in range(int(config.get('runs', '1'))):
+            log.info("starting run %s out of %s", str(i), config.get('runs', '1'))
+            tests = {}
+            existing_pools = config.get('pools', [])
+            created_pools = []
+            for role in config.get('clients', clients):
+                assert isinstance(role, str)
+                PREFIX = 'client.'
+                assert role.startswith(PREFIX)
+                id_ = role[len(PREFIX):]
+
+                pool = config.get('pool', None)
+                if not pool and existing_pools:
+                    pool = existing_pools.pop()
+                else:
+                    pool = manager.create_pool_with_unique_name(
+                        erasure_code_profile_name=profile_name,
+                        erasure_code_crush_rule_name=crush_name,
+                        erasure_code_use_overwrites=True,
+                    )
+                    created_pools.append(pool)
+                    min_size = config.get('min_size', None)
+                    if min_size is not None:
+                        manager.raw_cluster_cmd(
+                            'osd', 'pool', 'set', pool, 'min_size', str(min_size))
+
+                (remote,) = ctx.cluster.only(role).remotes.keys()
+                extraargs = []
+                if config.get('objectsize', False):
+                    extraargs.extend(['--objectsize', str(config.get('objectsize'))])
+                if config.get('sequence', False):
+                    extraargs.extend(['--sequence', str(config.get('sequence'))])
+                if config.get('blocksize', False):
+                    extraargs.extend(['--blocksize', str(config.get('blocksize'))])
+                if config.get('threads', False):
+                    extraargs.extend(['--threads', str(config.get('threads'))])
+                if config.get('seed', False):
+                    extraargs.extend(['--seed', str(config.get('seed'))])
+                if config.get('seqseed', False):
+                    extraargs.extend(['--seqseed', str(config.get('seqseed'))])
+                with _lock:
+                    uid = "iosequence.{id}".format(id=_uid)
+                    _uid += 1
+                proc = remote.run(
+                    args=["CEPH_CLIENT_ID={id_}".format(id_=id_)] + args +
+                    extraargs +
+                    ["--pool", pool] +
+                    ["--object", uid] +
+                    ["--verbose"],
+                    logger=log.getChild(uid),
+                    stdin=run.PIPE,
+                    wait=False
+                    )
+                tests[id_] = proc
+
+            watched_process: WatchedProcess = WatchedProcess(ctx, log, "iosequence", cluster, tests)
+            try:
+                run.wait(tests.values())
+            except Exception as e:
+                watched_process.try_set_exception(e)
+
+            # If test has failed then don't try to clean up
+            if watched_process.exception:
+                raise watched_process.exception
+
+            wait_for_all_active_clean_pgs = config.get("wait_for_all_active_clean_pgs", False)
+            # usually set when we do min_size testing.
+            if wait_for_all_active_clean_pgs:
+                # Make sure we finish the test first before deleting the pool.
+                # Mainly used for test_pool_min_size
+                manager.wait_for_clean()
+                manager.wait_for_all_osds_up(timeout=1800)
+
+            for pool in created_pools:
+                manager.wait_snap_trimming_complete(pool)
+                manager.remove_pool(pool)
+
+    running = gevent.spawn(thread)
+
+    try:
+        yield
+    finally:
+        log.info('joining iosequence')
+        running.get()

--- a/qa/tasks/watched_process.py
+++ b/qa/tasks/watched_process.py
@@ -4,12 +4,12 @@ WatchedProcess process base class.
 This can be applied to an object that we want the DaemonWatchdog to monitor
 for failure, and bark when it sees an error
 """
+import logging
 
 from abc import ABCMeta, abstractmethod
-from typing import Optional
+from typing import Optional, Any, Dict
 
 from gevent.greenlet import Greenlet
-
 
 class WatchedProcess(Greenlet, metaclass=ABCMeta):
     """
@@ -18,19 +18,23 @@ class WatchedProcess(Greenlet, metaclass=ABCMeta):
     The abstract base class for a process that the DaemonWatchdog can monitor
     for errors. It is based on the ThrasherGreenlet class in qa/tasks/thrasher.py
     """
-    def __init__(self) -> None:
+    def __init__(self, ctx: Dict[Any, Any], log, process: str, cluster: str, sub_processes: Dict[str, Any]) -> None:
+        self.log = log
         self._exception: Optional[BaseException] = None
+        self._sub_processes = sub_processes
+        self._name: str = f"{process}-{cluster}"
+        ctx.ceph[cluster].watched_processes.append(self)
 
     @property
     def exception(self) -> Optional[BaseException]:
         return self._exception
 
     @property
-    @abstractmethod
     def id(self) -> str:
         """
         Return a string identifier for this process
         """
+        return self._name
 
     def set_exception(self, e: Exception) -> None:
         """
@@ -38,8 +42,21 @@ class WatchedProcess(Greenlet, metaclass=ABCMeta):
         """
         self._exception = e
 
-    @abstractmethod
+    def try_set_exception(self, e: Exception) -> None:
+        """
+        Set the exception for this process unless there is a previous exception
+        """
+        if (self._exception == None):
+            self._exception = e
+
     def stop(self) -> None:
         """
         Stop the remote process running
         """
+        debug: str = f"Stopping {self._name}"
+        if self._exception:
+            debug += f" due to exception {self._exception}"
+        self.log.debug(debug)
+        for test_id, proc in self._sub_processes.items():
+            self.log.info("Stopping instance %s", test_id)
+            proc.stdin.close()


### PR DESCRIPTION
Depends: https://github.com/ceph/ceph/pull/65067

First commit is from 65067, 2nd commit is new for this PR. iosequence.py is based on rados.py

ceph_test_rados_io_sequence is another I/O exerciser, similar to rados bench and ceph_test_rados but designed to be complimentary focused on generating sequences of I/Os to test boundary conditions such as the erasure coding chunk size and stripe width and testing the object size boundary both extending and truncating objects. It is good for testing erasure coding and object stores. It typically only issues I/O to a single object so is poor at testing PGs, splitting, merging, etc.

The tool itself has been part of the release for several months and is hardened. This PR adds a new teuthology task that can run this tool and a new workload to the rados suite to use it

Depends on 65067 because the task registers with the watchdog so that it can stop cleanly if daemons or a thrasher crashes.

Example teuthology run - use the rados/thrash-erasure-code-overwrites suite and filter on iosequence:

`teuthology-suite -m smithi -s rados/thrash-erasure-code-overwrites --suite-branch teuthology_iosequence --suite-repo https://github.com/bill-scales/ceph.git -S d78e0f22b6caee9efe99f2eebc5103a80f2c1e29 --subset 0/3 --seed 7 --filter "iosequence" --limit 1 -p 80
`

The workload tests 3 different erasure code profiles each with a different value of K and a different value of M and runs ceph_test_rados_io_sequence with 3 different blocksizes to get coverage of many different boundary conditions.

Other parameters for ceph_test_rados_io_sequence can be specified in the yaml, including selecting a subset of sequences or object sizes and seeds to rerun exactly the same test. Use of these parameters have been tested but most parameters are unused in the final version of the workload.

Results:

https://pulpito.ceph.com/billscales-2025-12-12_12:20:05-rados:thrash-erasure-code-overwrites-main-distro-default-smithi/

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
