### PR TITLE
crimson/os/seastore/lba_mapping: Simplify LBAMapping::refresh() interface

### DIFF
--- a/src/crimson/os/seastore/btree/btree_types.h
+++ b/src/crimson/os/seastore/btree/btree_types.h
@@ -281,7 +281,6 @@ struct LBACursor : BtreeCursor<laddr_t, lba::lba_map_val_t> {
   }
   extent_ref_count_t get_refcount() const {
     assert(!is_end());
-    assert(!is_indirect());
     return val->refcount;
   }
 

--- a/src/crimson/os/seastore/btree/btree_types.h
+++ b/src/crimson/os/seastore/btree/btree_types.h
@@ -258,6 +258,9 @@ struct LBACursor : BtreeCursor<laddr_t, lba::lba_map_val_t> {
   bool is_indirect() const {
     return !is_end() && val->pladdr.is_laddr();
   }
+  bool is_direct() const {
+    return !is_end() && val->pladdr.is_paddr();
+  }
   laddr_t get_laddr() const {
     return key;
   }

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -2378,6 +2378,15 @@ struct is_fixed_kv_tree<
     cursor_t,
     node_size>> : std::true_type {};
 
+template <typename tree_type_t,
+          std::enable_if_t<is_fixed_kv_tree<tree_type_t>::value, int> = 0>
+Cache::get_root_iertr::future<tree_type_t>
+get_btree(Cache &cache, op_context_t c)
+{
+  auto croot = co_await cache.get_root(c.trans);
+  co_return tree_type_t{croot};
+}
+
 template <
   typename tree_type_t,
   typename F,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1011,30 +1011,6 @@ BtreeLBAManager::get_physical_extent_if_live(
     });
 }
 
-BtreeLBAManager::complete_lba_mapping_ret
-BtreeLBAManager::complete_indirect_lba_mapping(
-  Transaction &t,
-  LBAMapping mapping)
-{
-  assert(mapping.is_viewable());
-  assert(mapping.is_indirect());
-  if (mapping.is_complete_indirect()) {
-    return complete_lba_mapping_iertr::make_ready_future<
-      LBAMapping>(std::move(mapping));
-  }
-  auto c = get_context(t);
-  return with_btree_state<LBABtree, LBAMapping>(
-    cache,
-    c,
-    std::move(mapping),
-    [this, c](auto &btree, auto &mapping) {
-    return resolve_indirect_cursor(c, btree, *mapping.indirect_cursor
-    ).si_then([&mapping](auto cursor) {
-      mapping.direct_cursor = std::move(cursor);
-    });
-  });
-}
-
 void BtreeLBAManager::register_metrics()
 {
   LOG_PREFIX(BtreeLBAManager::register_metrics);

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1073,14 +1073,9 @@ BtreeLBAManager::get_end_mapping(
   LOG_PREFIX(BtreeLBAManager::get_end_mapping);
   DEBUGT("", t);
   auto c = get_context(t);
-  return with_btree<LBABtree>(
-    cache,
-    c,
-    [c](auto &btree) {
-    return btree.end(c).si_then([c](auto iter) {
-      return LBAMapping::create_direct(iter.get_cursor(c));
-    });
-  });
+  auto btree = co_await get_btree<LBABtree>(cache, c);
+  auto iter = co_await btree.end(c);
+  co_return LBAMapping::create_direct(iter.get_cursor(c));
 }
 #endif
 

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -360,7 +360,7 @@ BtreeLBAManager::reserve_region(
     iter.get_leaf_pos(),
     get_reserved_ptr<LBALeafNode, laddr_t>(),
     leaf_node.get_size() - 1 /*the size before the insert*/);
-  co_return LBAMapping::create_direct(iter.get_cursor(c));
+  co_return iter.get_cursor(c);
 }
 
 BtreeLBAManager::alloc_extents_ret

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1075,7 +1075,7 @@ BtreeLBAManager::get_end_mapping(
   auto c = get_context(t);
   auto btree = co_await get_btree<LBABtree>(cache, c);
   auto iter = co_await btree.end(c);
-  co_return LBAMapping::create_direct(iter.get_cursor(c));
+  co_return iter.get_cursor(c);
 }
 #endif
 

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -111,16 +111,9 @@ BtreeLBAManager::mkfs(
 {
   LOG_PREFIX(BtreeLBAManager::mkfs);
   INFOT("start", t);
-  return cache.get_root(t).si_then([this, &t](auto croot) {
-    assert(croot->is_mutation_pending());
-    croot->get_root().lba_root = LBABtree::mkfs(croot, get_context(t));
-    return mkfs_iertr::now();
-  }).handle_error_interruptible(
-    mkfs_iertr::pass_further{},
-    crimson::ct_error::assert_all{
-      "Invalid error in BtreeLBAManager::mkfs"
-    }
-  );
+  auto croot = co_await cache.get_root(t);
+  assert(croot->is_mutation_pending());
+  croot->get_root().lba_root = LBABtree::mkfs(croot, get_context(t));
 }
 
 BtreeLBAManager::get_mappings_ret

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -239,17 +239,16 @@ BtreeLBAManager::resolve_indirect_cursor(
 BtreeLBAManager::alloc_extent_ret
 BtreeLBAManager::reserve_region(
   Transaction &t,
-  LBAMapping pos,
+  LBACursorRef cursor,
   laddr_t addr,
   extent_len_t len)
 {
   LOG_PREFIX(BtreeLBAManager::reserve_region);
-  DEBUGT("{} {}~{}", t, pos, addr, len);
-  assert(pos.is_viewable());
+  DEBUGT("{} {}~{}", t, *cursor, addr, len);
+  assert(cursor->is_viewable());
   auto c = get_context(t);
   auto btree = co_await get_btree<LBABtree>(cache, c);
-  auto &cursor = pos.get_effective_cursor();
-  auto iter = btree.make_partial_iter(c, cursor);
+  auto iter = btree.make_partial_iter(c, *cursor);
   lba_map_val_t val{len, P_ADDR_ZERO, EXTENT_DEFAULT_REF_COUNT, 0};
   auto p = co_await btree.insert(c, iter, addr, val);
   ceph_assert(p.second);

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -1038,106 +1038,76 @@ BtreeLBAManager::remap_mappings(
   assert(mapping.is_viewable());
   assert(mapping.is_indirect() == mapping.is_complete_indirect());
   auto c = get_context(t);
-  return with_btree<LBABtree>(
-    cache,
-    c,
-    [mapping=std::move(mapping), c, this,
-    remaps=std::move(remaps)](auto &btree) mutable {
-    auto &cursor = mapping.get_effective_cursor();
-    return seastar::do_with(
-      std::move(remaps),
-      std::move(mapping),
-      btree.make_partial_iter(c, cursor),
-      std::vector<LBAMapping>(),
-      [c, &btree, this, &cursor](auto &remaps, auto &mapping, auto &iter, auto &ret) {
-      auto val = iter.get_val();
-      assert(val.refcount == EXTENT_DEFAULT_REF_COUNT);
-      assert(mapping.is_indirect() ||
-	(val.pladdr.is_paddr() &&
-	 val.pladdr.get_paddr().is_absolute()));
-      return update_refcount(c.trans, &cursor, -1
-      ).si_then([&mapping, &btree, &iter, c, &ret,
-		&remaps, pladdr=val.pladdr](auto r) {
-	assert(r.refcount == 0);
-	auto &cursor = r.mapping.get_effective_cursor();
-	iter = btree.make_partial_iter(c, cursor);
-	return trans_intr::do_for_each(
-	  remaps,
-	  [&mapping, &btree, &iter, c, &ret, pladdr](auto &remap) {
-	  assert(remap.offset + remap.len <= mapping.get_length());
-	  assert((bool)remap.extent == !mapping.is_indirect());
-	  lba_map_val_t val;
-	  auto old_key = mapping.get_key();
-	  auto new_key = (old_key + remap.offset).checked_to_laddr();
-	  val.len = remap.len;
-	  if (pladdr.is_laddr()) {
-	    auto laddr = pladdr.get_laddr();
-	    val.pladdr = (laddr + remap.offset).checked_to_laddr();
-	  } else {
-	    auto paddr = pladdr.get_paddr();
-	    val.pladdr = paddr + remap.offset;
-	  }
-	  val.refcount = EXTENT_DEFAULT_REF_COUNT;
-	  // Checksum will be updated when the committing the transaction
-	  val.checksum = CRC_NULL;
-	  return btree.insert(c, iter, new_key, std::move(val)
-	  ).si_then([c, &remap, &mapping, &ret, &iter](auto p) {
-	    auto &[it, inserted] = p;
-	    ceph_assert(inserted);
-	    auto &leaf_node = *it.get_leaf_node();
-	    if (mapping.is_indirect()) {
-	      leaf_node.insert_child_ptr(
-		it.get_leaf_pos(),
-		get_reserved_ptr<LBALeafNode, laddr_t>(),
-		leaf_node.get_size() - 1 /*the size before the insert*/);
-	      ret.push_back(
-		LBAMapping::create_indirect(nullptr, it.get_cursor(c)));
-	    } else {
-	      leaf_node.insert_child_ptr(
-		it.get_leaf_pos(),
-		remap.extent,
-		leaf_node.get_size() - 1 /*the size before the insert*/);
-	      ret.push_back(
-		LBAMapping::create_direct(it.get_cursor(c)));
-	    }
-	    return it.next(c).si_then([&iter](auto it) {
-	      iter = std::move(it);
-	    });
-	  });
-	});
-      }).si_then([&mapping, &ret] {
-	if (mapping.is_indirect()) {
-	  auto &cursor = mapping.direct_cursor;
-	  return cursor->refresh(
-	  ).si_then([&ret, &mapping] {
-	    for (auto &m : ret) {
-	      m.direct_cursor = mapping.direct_cursor;
-	    }
-	  });
-	}
-	return base_iertr::now();
-      }).si_then([this, c, &mapping, &remaps] {
-	if (remaps.size() > 1 && mapping.is_indirect()) {
-	  auto &cursor = mapping.direct_cursor;
-	  assert(cursor->is_viewable());
-	  return update_refcount(
-	    c.trans, cursor.get(), 1).discard_result();
-	}
-	return update_refcount_iertr::now();
-      }).si_then([&ret] {
-	return trans_intr::parallel_for_each(
-	  ret,
-	  [](auto &remapped_mapping) {
-	  return remapped_mapping.refresh(
-	  ).si_then([&remapped_mapping](auto mapping) {
-	    remapped_mapping = std::move(mapping);
-	  });
-	});
-      }).si_then([&ret] {
-	return std::move(ret);
+  auto btree = co_await get_btree<LBABtree>(cache, c);
+  auto iter = btree.make_partial_iter(c, mapping.get_effective_cursor());
+  std::vector<LBAMapping> ret;
+  auto val = iter.get_val();
+  assert(val.refcount == EXTENT_DEFAULT_REF_COUNT);
+  assert(mapping.is_indirect() ||
+	 (val.pladdr.is_paddr() &&
+	  val.pladdr.get_paddr().is_absolute()));
+  auto updated_cursor = co_await update_mapping_refcount(
+    c.trans, mapping.get_effective_cursor_ref(), -1);
+  iter = btree.make_partial_iter(c, *updated_cursor);
+  for (auto &remap : remaps) {
+    assert(remap.offset + remap.len <= mapping.get_length());
+    assert((bool)remap.extent == !mapping.is_indirect());
+    lba_map_val_t val;
+    auto old_key = mapping.get_key();
+    auto new_key = (old_key + remap.offset).checked_to_laddr();
+    val.len = remap.len;
+    if (val.pladdr.is_laddr()) {
+      auto laddr = val.pladdr.get_laddr();
+      val.pladdr = (laddr + remap.offset).checked_to_laddr();
+    } else {
+      auto paddr = val.pladdr.get_paddr();
+      val.pladdr = paddr + remap.offset;
+    }
+    val.refcount = EXTENT_DEFAULT_REF_COUNT;
+    // Checksum will be updated when the committing the transaction
+    val.checksum = CRC_NULL;
+    // committing the transaction
+    auto p = co_await btree.insert(c, iter, new_key, std::move(val));
+    auto &[it, inserted] = p;
+    ceph_assert(inserted);
+    auto &leaf_node = *it.get_leaf_node();
+    if (mapping.is_indirect()) {
+      leaf_node.insert_child_ptr(
+	it.get_leaf_pos(),
+	get_reserved_ptr<LBALeafNode, laddr_t>(),
+	leaf_node.get_size() - 1 /*the size before the insert*/);
+      ret.push_back(
+	LBAMapping::create_indirect(nullptr, it.get_cursor(c)));
+    } else {
+      leaf_node.insert_child_ptr(
+	it.get_leaf_pos(),
+	remap.extent,
+	leaf_node.get_size() - 1 /*the size before the insert*/);
+      ret.push_back(
+	LBAMapping::create_direct(it.get_cursor(c)));
+    }
+    it = co_await it.next(c);
+    iter = std::move(it);
+  }
+  if (mapping.is_indirect()) {
+    co_await mapping.direct_cursor->refresh();
+    for (auto &m : ret) {
+      m.direct_cursor = mapping.direct_cursor;
+    }
+  }
+  if (remaps.size() > 1 && mapping.is_indirect()) {
+    assert(mapping.direct_cursor->is_viewable());
+    co_await update_mapping_refcount(c.trans, mapping.direct_cursor, 1);
+  }
+  co_await trans_intr::parallel_for_each(
+    ret,
+    [](auto &remapped_mapping) {
+      return remapped_mapping.refresh(
+      ).si_then([&remapped_mapping](auto mapping) {
+	remapped_mapping = std::move(mapping);
       });
     });
-  });
+  co_return ret;
 }
 
 }

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -325,81 +325,45 @@ BtreeLBAManager::clone_mapping(
   DEBUGT("pos={}, mapping={}, laddr={}, {}~{} updateref={}",
     t, pos, mapping, laddr, offset, len, updateref);
   assert(offset + len <= mapping.get_length());
-  struct state_t {
-    LBAMapping pos;
-    LBAMapping mapping;
-    laddr_t laddr;
-    extent_len_t offset;
-    extent_len_t len;
-  };
   auto c = get_context(t);
-  return seastar::do_with(
-    std::move(mapping),
-    [this, updateref, c](auto &mapping) {
-    if (updateref) {
-      auto fut = update_refcount_iertr::make_ready_future<
-	LBACursorRef>(mapping.direct_cursor);
-      if (!mapping.direct_cursor) {
-	fut = resolve_indirect_cursor(c, *mapping.indirect_cursor);
-      }
-      return fut.si_then([this, c, &mapping](auto cursor) {
-	mapping.direct_cursor = cursor;
-	assert(mapping.direct_cursor->is_viewable());
-	return update_refcount(c.trans, cursor.get(), 1
-	).si_then([&mapping](auto res) {
-	  assert(!res.mapping.is_indirect());
-	  mapping.direct_cursor = std::move(res.mapping.direct_cursor);
-	  return std::move(mapping);
-	});
-      });
-    } else {
-      return update_refcount_iertr::make_ready_future<
-	LBAMapping>(std::move(mapping));
+  if (updateref) {
+    if (!mapping.direct_cursor) {
+      mapping.direct_cursor = co_await resolve_indirect_cursor(
+	c, *mapping.indirect_cursor);
     }
-  }).si_then([c, this, pos=std::move(pos), len,
-	      offset, laddr](auto mapping) mutable {
-    return seastar::do_with(
-      state_t{std::move(pos), std::move(mapping), laddr, offset, len},
-      [this, c](auto &state) {
-      return with_btree<LBABtree>(
-	cache,
-	c,
-	[c, &state](auto &btree) mutable {
-	auto &cursor = state.pos.get_effective_cursor();
-	return cursor.refresh(
-	).si_then([&state, c, &btree]() mutable {
-	  auto &cursor = state.pos.get_effective_cursor();
-	  assert(state.laddr + state.len <= cursor.key);
-          auto inter_key = state.mapping.is_indirect()
-            ? state.mapping.get_intermediate_key()
-            : state.mapping.get_key();
-          inter_key = (inter_key + state.offset).checked_to_laddr();
-	  return btree.insert(
-	    c,
-	    btree.make_partial_iter(c, cursor),
-	    state.laddr,
-            lba_map_val_t{state.len, inter_key, EXTENT_DEFAULT_REF_COUNT, 0});
-	}).si_then([c, &state](auto p) {
-	  auto &[iter, inserted] = p;
-	  auto &leaf_node = *iter.get_leaf_node();
-	  leaf_node.insert_child_ptr(
-	    iter.get_leaf_pos(),
-	    get_reserved_ptr<LBALeafNode, laddr_t>(),
-	    leaf_node.get_size() - 1 /*the size before the insert*/);
-	  auto cursor = iter.get_cursor(c);
-	  return state.mapping.refresh(
-	  ).si_then([cursor=std::move(cursor)](auto mapping) mutable {
-	    return clone_mapping_ret_t{
-	      LBAMapping(mapping.direct_cursor, std::move(cursor)),
-	      mapping};
-	  });
-	});
-      });
-    });
-  }).handle_error_interruptible(
-    clone_mapping_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected error"}
-  );
+    assert(mapping.direct_cursor->is_viewable());
+    auto res = co_await update_refcount(
+      c.trans, mapping.direct_cursor.get(), 1
+    ).handle_error_interruptible(
+      clone_mapping_iertr::pass_further{},
+      crimson::ct_error::assert_all{"unexpected error"}
+    );
+    assert(!res.mapping.is_indirect());
+    mapping.direct_cursor = std::move(res.mapping.direct_cursor);
+  }
+  auto btree = co_await get_btree<LBABtree>(cache, c);
+  auto &cursor = pos.get_effective_cursor();
+  co_await cursor.refresh();
+  assert(laddr + len <= cursor.key);
+  auto inter_key = mapping.is_indirect()
+    ? mapping.get_intermediate_key()
+    : mapping.get_key();
+  inter_key = (inter_key + offset).checked_to_laddr();
+  auto p = co_await btree.insert(
+    c,
+    btree.make_partial_iter(c, cursor),
+    laddr,
+    lba_map_val_t{len, inter_key, EXTENT_DEFAULT_REF_COUNT, 0});
+  auto &[iter, inserted] = p;
+  auto &leaf_node = *iter.get_leaf_node();
+  leaf_node.insert_child_ptr(
+    iter.get_leaf_pos(),
+    get_reserved_ptr<LBALeafNode, laddr_t>(),
+    leaf_node.get_size() - 1 /*the size before the insert*/);
+  mapping = co_await mapping.refresh();
+  co_return clone_mapping_ret_t{
+    LBAMapping(mapping.direct_cursor, iter.get_cursor(c)),
+    mapping};
 }
 
 BtreeLBAManager::get_cursor_ret

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -232,23 +232,6 @@ public:
     };
   }
 
-  ref_ret remove_indirect_mapping_only(
-    Transaction &t,
-    LBAMapping mapping) final {
-    assert(mapping.is_viewable());
-    assert(mapping.is_indirect());
-    return seastar::do_with(
-      std::move(mapping),
-      [&t, this](auto &mapping) {
-      return update_refcount(t, mapping.indirect_cursor.get(), -1
-      ).si_then([](auto res) {
-	return ref_iertr::make_ready_future<
-	  ref_update_result_t>(ref_update_result_t{
-	    std::move(res), std::nullopt});
-      });
-    });
-  }
-
   ref_ret remove_mapping(
     Transaction &t,
     LBAMapping mapping) final {

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -75,19 +75,6 @@ public:
     Transaction &t,
     LogicalChildNode &extent) final;
 
-  get_mappings_ret get_mappings(
-    Transaction &t,
-    laddr_t offset, extent_len_t length) final;
-
-  get_mapping_ret get_mapping(
-    Transaction &t,
-    laddr_t offset,
-    bool search_containing = false) final;
-
-  get_mapping_ret get_mapping(
-    Transaction &t,
-    LogicalChildNode &extent) final;
-
   alloc_extent_ret reserve_region(
     Transaction &t,
     LBAMapping pos,
@@ -506,7 +493,7 @@ private:
     laddr_t offset,
     extent_len_t length);
 
-  using resolve_indirect_cursor_ret = get_mappings_iertr::future<LBACursorRef>;
+  using resolve_indirect_cursor_ret = base_iertr::future<LBACursorRef>;
   resolve_indirect_cursor_ret resolve_indirect_cursor(
     op_context_t c,
     LBABtree& btree,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -398,7 +398,7 @@ private:
   _update_mapping_ret _update_mapping(
     Transaction &t,
     LBACursor &cursor,
-    update_func_t &&f,
+    update_func_t f,
     LogicalChildNode*);
 
   struct insert_position_t {

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -62,6 +62,19 @@ public:
   mkfs_ret mkfs(
     Transaction &t) final;
 
+  get_cursors_ret get_cursors(
+    Transaction &t,
+    laddr_t offset, extent_len_t length) final;
+
+  get_cursor_ret get_cursor(
+    Transaction &t,
+    laddr_t offset,
+    bool search_containing = false) final;
+
+  get_cursor_ret get_cursor(
+    Transaction &t,
+    LogicalChildNode &extent) final;
+
   get_mappings_ret get_mappings(
     Transaction &t,
     laddr_t offset, extent_len_t length) final;
@@ -620,19 +633,17 @@ private:
     });
   }
 
-  using _get_cursor_ret = get_mapping_iertr::future<LBACursorRef>;
-  _get_cursor_ret get_cursor(
+  get_cursor_ret get_cursor(
     op_context_t c,
     LBABtree& btree,
     laddr_t offset);
 
-  _get_cursor_ret get_containing_cursor(
+  get_cursor_ret get_containing_cursor(
     op_context_t c,
     LBABtree &btree,
     laddr_t laddr);
 
-  using _get_cursors_ret = get_mappings_iertr::future<std::list<LBACursorRef>>;
-  _get_cursors_ret get_cursors(
+  get_cursors_ret get_cursors(
     op_context_t c,
     LBABtree& btree,
     laddr_t offset,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -333,10 +333,6 @@ public:
     laddr_t laddr,
     extent_len_t len) final;
 
-  complete_lba_mapping_ret complete_indirect_lba_mapping(
-    Transaction &t,
-    LBAMapping mapping) final;
-
 private:
   Cache &cache;
 

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -198,7 +198,7 @@ public:
 
   remap_ret remap_mappings(
     Transaction &t,
-    LBAMapping mapping,
+    LBACursorRef mapping,
     std::vector<remap_entry_t> remaps) final;
 
   /**

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -104,7 +104,7 @@ public:
     auto cursors = co_await alloc_contiguous_mappings(
       t, hint, alloc_infos, alloc_policy_t::linear_search);
     assert(cursors.size() == 1);
-    co_return LBAMapping::create_direct(std::move(cursors.front()));
+    co_return std::move(cursors.front());
   }
 
   clone_mapping_ret clone_mapping(
@@ -146,7 +146,7 @@ public:
       t, hint, alloc_infos, alloc_policy_t::linear_search
     );
     assert(cursors.size() == 1);
-    co_return LBAMapping::create_direct(std::move(cursors.front()));
+    co_return std::move(cursors.front());
   }
 
   alloc_extents_ret alloc_extents(

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -101,16 +101,10 @@ public:
   {
     std::vector<alloc_mapping_info_t> alloc_infos = {
       alloc_mapping_info_t::create_zero(len)};
-    return seastar::do_with(
-      std::move(alloc_infos),
-      [&t, hint, this](auto &alloc_infos) {
-      return alloc_contiguous_mappings(
-	t, hint, alloc_infos, alloc_policy_t::linear_search
-      ).si_then([](auto cursors) {
-	assert(cursors.size() == 1);
-	return LBAMapping::create_direct(std::move(cursors.front()));
-      });
-    });
+    auto cursors = co_await alloc_contiguous_mappings(
+      t, hint, alloc_infos, alloc_policy_t::linear_search);
+    assert(cursors.size() == 1);
+    co_return LBAMapping::create_direct(std::move(cursors.front()));
   }
 
   clone_mapping_ret clone_mapping(

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -148,16 +148,11 @@ public:
 	refcount,
 	ext.get_last_committed_crc(),
 	ext)};
-    return seastar::do_with(
-      std::move(alloc_infos),
-      [this, &t, hint](auto &alloc_infos) {
-      return alloc_contiguous_mappings(
-	t, hint, alloc_infos, alloc_policy_t::linear_search
-      ).si_then([](auto cursors) {
-	assert(cursors.size() == 1);
-	return LBAMapping::create_direct(std::move(cursors.front()));
-      });
-    });
+    auto cursors = co_await alloc_contiguous_mappings(
+      t, hint, alloc_infos, alloc_policy_t::linear_search
+    );
+    assert(cursors.size() == 1);
+    co_return LBAMapping::create_direct(std::move(cursors.front()));
   }
 
   alloc_extents_ret alloc_extents(

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -614,17 +614,6 @@ private:
     LBABtree::iterator iter,
     std::vector<alloc_mapping_info_t> &alloc_infos);
 
-  ref_ret _incref_extent(
-    Transaction &t,
-    laddr_t addr,
-    int delta) {
-    ceph_assert(delta > 0);
-    return update_refcount(t, addr, delta
-    ).si_then([](auto res) {
-      return ref_update_result_t(std::move(res), std::nullopt);
-    });
-  }
-
   get_cursor_ret get_cursor(
     op_context_t c,
     LBABtree& btree,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -493,21 +493,6 @@ private:
     }
   }
 
-  ref_update_result_t get_ref_update_result(
-    update_mapping_ret_bare_t &result,
-    std::optional<update_mapping_ret_bare_t> direct_result) {
-    mapping_update_result_t primary_r = get_mapping_update_result(result);
-
-    if (direct_result) {
-      // only removing indirect mapping can have direct_result
-      assert(result.is_removed_mapping());
-      assert(result.get_removed_mapping().map_value.pladdr.is_laddr());
-      auto direct_r = get_mapping_update_result(*direct_result);
-      return ref_update_result_t{std::move(primary_r), std::move(direct_r)};
-    }
-    return ref_update_result_t{std::move(primary_r), std::nullopt};
-  }
-
   using update_refcount_iertr = ref_iertr;
   using update_refcount_ret = update_refcount_iertr::future<
     mapping_update_result_t>;

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -122,7 +122,7 @@ public:
 
   alloc_extents_ret alloc_extents(
     Transaction &t,
-    LBAMapping pos,
+    LBACursorRef pos,
     std::vector<LogicalChildNodeRef> ext) final;
 
   alloc_extent_ret alloc_extent(
@@ -187,11 +187,7 @@ public:
       cursors = co_await alloc_contiguous_mappings(
 	t, hint, alloc_infos, alloc_policy_t::linear_search);
     }
-    std::vector<LBAMapping> ret;
-    for (auto &cursor : cursors) {
-      ret.emplace_back(LBAMapping::create_direct(std::move(cursor)));
-    }
-    co_return ret;
+    co_return std::vector<LBACursorRef>(cursors.begin(), cursors.end());
   }
 
   base_iertr::future<LBACursorRef> update_mapping_refcount(

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -215,60 +215,6 @@ public:
     });
   }
 
-  ref_ret remove_mapping(
-    Transaction &t,
-    laddr_t addr) final {
-    auto result = co_await update_refcount(t, addr, -1);
-    ceph_assert(result.refcount == 0);
-    if (result.addr.is_paddr()) {
-      co_return ref_update_result_t{std::move(result), std::nullopt};
-    }
-
-    auto direct_result = co_await update_refcount(t, result.key, -1);
-    result.mapping = co_await result.mapping.refresh();
-    co_return ref_update_result_t{
-      std::move(result),
-      std::move(direct_result)
-    };
-  }
-
-  ref_ret remove_mapping(
-    Transaction &t,
-    LBAMapping mapping) final {
-    assert(mapping.is_viewable());
-    assert(mapping.is_complete());
-    return seastar::do_with(
-      std::move(mapping),
-      [&t, this](auto &mapping) {
-      auto &cursor = mapping.get_effective_cursor();
-      return update_refcount(t, &cursor, -1
-      ).si_then([this, &t, &mapping](auto res) {
-	ceph_assert(res.refcount == 0);
-	if (res.addr.is_paddr()) {
-	  assert(!mapping.is_indirect());
-	  return ref_iertr::make_ready_future<
-	    ref_update_result_t>(ref_update_result_t{
-	      std::move(res), std::nullopt});
-	}
-	assert(mapping.is_indirect());
-	auto &cursor = *mapping.direct_cursor;
-	return cursor.refresh().si_then([this, &t, &cursor] {
-	  return update_refcount(t, &cursor, -1);
-	}).si_then([indirect_result=std::move(res)]
-		   (auto direct_result) mutable {
-	  return indirect_result.mapping.refresh(
-	  ).si_then([direct_result=std::move(direct_result),
-		     indirect_result=std::move(indirect_result)](auto) {
-	    return ref_iertr::make_ready_future<
-	      ref_update_result_t>(ref_update_result_t{
-		std::move(indirect_result),
-		std::move(direct_result)});
-	  });
-	});
-      });
-    });
-  }
-
   base_iertr::future<LBACursorRef> update_mapping_refcount(
     Transaction &t,
     LBACursorRef cursor,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -96,10 +96,10 @@ public:
 
   clone_mapping_ret clone_mapping(
     Transaction &t,
-    LBAMapping pos,
-    LBAMapping mapping,
+    LBACursorRef pos,
+    LBACursorRef mapping,
     laddr_t laddr,
-    extent_len_t offset,
+    laddr_t inter_key,
     extent_len_t len,
     bool updateref) final;
 

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -351,7 +351,7 @@ public:
 
   update_mapping_ret update_mapping(
     Transaction& t,
-    LBAMapping mapping,
+    LBACursorRef cursor,
     extent_len_t prev_len,
     paddr_t prev_addr,
     LogicalChildNode&) final;

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -77,7 +77,7 @@ public:
 
   alloc_extent_ret reserve_region(
     Transaction &t,
-    LBAMapping pos,
+    LBACursorRef pos,
     laddr_t laddr,
     extent_len_t len) final;
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -122,7 +122,7 @@ public:
    */
   virtual alloc_extent_ret reserve_region(
     Transaction &t,
-    LBAMapping pos,
+    LBACursorRef cursor,
     laddr_t hint,
     extent_len_t len) = 0;
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -308,10 +308,24 @@ public:
   using update_mapping_ret = base_iertr::future<extent_ref_count_t>;
   virtual update_mapping_ret update_mapping(
     Transaction& t,
-    LBAMapping mapping,
+    LBACursorRef cursor,
     extent_len_t prev_len,
     paddr_t prev_addr,
     LogicalChildNode& nextent) = 0;
+  update_mapping_ret update_mapping(
+    Transaction& t,
+    LBAMapping mapping,
+    extent_len_t prev_len,
+    paddr_t prev_addr,
+    LogicalChildNode& nextent) {
+    assert(!mapping.is_indirect());
+    return update_mapping(
+      t,
+      mapping.direct_cursor,
+      prev_len,
+      prev_addr,
+      nextent);
+  }
 
   /**
    * update_mappings

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -261,9 +261,24 @@ public:
 };
 using LBAManagerRef = std::unique_ptr<LBAManager>;
 
+inline std::ostream &operator<<(
+  std::ostream &lhs,
+  const LBAManager::remap_entry_t &rhs)
+{
+  return lhs << "remap_entry_t("
+	     << "offset=0x" << std::hex << rhs.offset
+	     << ", len=0x" << rhs.len << std::dec
+	     << ", extent=" << rhs.extent
+	     << ")";
+}
+
 class Cache;
 namespace lba {
 LBAManagerRef create_lba_manager(Cache &cache);
 }
 
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::LBAManager::remap_entry_t> : fmt::ostream_formatter {};
+#endif

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -205,19 +205,6 @@ public:
     Transaction &t,
     LBAMapping mapping) = 0;
 
-  /*
-   * remove_indirect_mapping_only
-   *
-   * Remove the indirect mapping without touch the corresponding
-   * direct one.
-   *
-   * @return returns the information about the removed
-   * indirect mapping.
-   */
-  virtual ref_ret remove_indirect_mapping_only(
-    Transaction &t,
-    LBAMapping mapping) = 0;
-
   /**
    * Update ref count on mapping
    */

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -111,7 +111,7 @@ public:
     extent_ref_count_t refcount) = 0;
 
   using alloc_extents_ret = alloc_extent_iertr::future<
-    std::vector<LBAMapping>>;
+    std::vector<LBACursorRef>>;
   virtual alloc_extents_ret alloc_extents(
     Transaction &t,
     laddr_t hint,
@@ -124,7 +124,7 @@ public:
    */
   virtual alloc_extents_ret alloc_extents(
     Transaction &t,
-    LBAMapping pos,
+    LBACursorRef cursor,
     std::vector<LogicalChildNodeRef> ext) = 0;
 
   struct clone_mapping_ret_t {

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -103,7 +103,7 @@ public:
    * is called on the LBAMapping.
    */
   using alloc_extent_iertr = base_iertr;
-  using alloc_extent_ret = alloc_extent_iertr::future<LBAMapping>;
+  using alloc_extent_ret = alloc_extent_iertr::future<LBACursorRef>;
   virtual alloc_extent_ret alloc_extent(
     Transaction &t,
     laddr_t hint,

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -175,35 +175,8 @@ public:
       return refcount == 0 && addr.is_paddr() && !addr.get_paddr().is_zero();
     }
   };
-  struct ref_update_result_t {
-    mapping_update_result_t result;
-    std::optional<mapping_update_result_t> direct_result;
-  };
   using ref_iertr = base_iertr::extend<
     crimson::ct_error::enoent>;
-  using ref_ret = ref_iertr::future<ref_update_result_t>;
-
-  /**
-   * Removes a mapping and deal with indirection
-   *
-   * @return returns the information about the removed
-   * mappings including the corresponding direct mapping
-   * if the mapping of laddr is indirect.
-   */
-  virtual ref_ret remove_mapping(
-    Transaction &t,
-    laddr_t addr) = 0;
-
-  /*
-   * Removes the mapping and deal with indirection
-   *
-   * @return returns the information about the removed
-   * mappings including the corresponding direct mapping
-   * if the mapping of laddr is indirect.
-   */
-  virtual ref_ret remove_mapping(
-    Transaction &t,
-    LBAMapping mapping) = 0;
 
   /**
    * Update ref count on mapping

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -347,18 +347,6 @@ public:
     laddr_t laddr,
     extent_len_t len) = 0;
 
-  using complete_lba_mapping_iertr = get_mappings_iertr;
-  using complete_lba_mapping_ret =
-    complete_lba_mapping_iertr::future<LBAMapping>;
-  /*
-   * Completes an incomplete indirect mappings
-   *
-   * No effect if the indirect mapping is already complete
-   */
-  virtual complete_lba_mapping_ret complete_indirect_lba_mapping(
-    Transaction &t,
-    LBAMapping mapping) = 0;
-
   virtual ~LBAManager() {}
 };
 using LBAManagerRef = std::unique_ptr<LBAManager>;

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -54,7 +54,7 @@ public:
 
 #ifdef UNIT_TESTS_BUILT
   using get_end_mapping_iertr = base_iertr;
-  using get_end_mapping_ret = get_end_mapping_iertr::future<LBAMapping>;
+  using get_end_mapping_ret = get_end_mapping_iertr::future<LBACursorRef>;
   virtual get_end_mapping_ret get_end_mapping(Transaction &t) = 0;
 #endif
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -219,16 +219,19 @@ public:
     LBAMapping mapping) = 0;
 
   /**
-   * Increments ref count on extent
-   *
-   * @return returns resulting refcount
+   * Update ref count on mapping
    */
-  virtual ref_ret incref_extent(
+  virtual base_iertr::future<LBACursorRef> update_mapping_refcount(
     Transaction &t,
-    laddr_t addr) = 0;
-  virtual ref_ret incref_extent(
+    LBACursorRef cursor,
+    int delta) = 0;
+  ref_iertr::future<> update_mapping_refcount(
     Transaction &t,
-    LBAMapping mapping) = 0;
+    laddr_t addr,
+    int delta) {
+    auto cursor = co_await get_cursor(t, addr);
+    co_await update_mapping_refcount(t, cursor, delta);
+  }
 
   struct remap_entry_t {
     extent_len_t offset;

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -126,18 +126,6 @@ public:
     laddr_t hint,
     extent_len_t len) = 0;
 
-  struct mapping_update_result_t {
-    laddr_t key;
-    extent_ref_count_t refcount = 0;
-    pladdr_t addr;
-    extent_len_t length = 0;
-    LBAMapping mapping; // the mapping pointing to the updated lba entry if
-			// refcount is non-zero; the next lba entry or the
-			// end mapping otherwise.
-    bool need_to_remove_extent() const {
-      return refcount == 0 && addr.is_paddr() && !addr.get_paddr().is_zero();
-    }
-  };
   using ref_iertr = base_iertr::extend<
     crimson::ct_error::enoent>;
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -91,8 +91,8 @@ public:
     std::vector<LogicalChildNodeRef> ext) = 0;
 
   struct clone_mapping_ret_t {
-    LBAMapping cloned_mapping;
-    LBAMapping orig_mapping;
+    LBACursorRef cloned_mapping;
+    LBACursorRef orig_mapping;
   };
   using clone_mapping_iertr = alloc_extent_iertr;
   using clone_mapping_ret = clone_mapping_iertr::future<clone_mapping_ret_t>;
@@ -101,11 +101,11 @@ public:
    */
   virtual clone_mapping_ret clone_mapping(
     Transaction &t,
-    LBAMapping pos,		// the destined position
-    LBAMapping mapping,		// the mapping to be cloned
+    LBACursorRef pos,		// the destined position
+    LBACursorRef mapping,	// the mapping to be cloned
     laddr_t laddr,		// the new lba key of the cloned mapping
-    extent_len_t offset,	// the offset of the part to be cloned,
-				// relative to the start of the mapping.
+    laddr_t inter_key,	        // offset within mapping of the target of the
+                                // clone
     extent_len_t len,		// the length of the part to be cloned
     bool updateref		// whether to update the refcount of the
 				// direct mapping

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -238,20 +238,6 @@ public:
     extent_len_t prev_len,
     paddr_t prev_addr,
     LogicalChildNode& nextent) = 0;
-  update_mapping_ret update_mapping(
-    Transaction& t,
-    LBAMapping mapping,
-    extent_len_t prev_len,
-    paddr_t prev_addr,
-    LogicalChildNode& nextent) {
-    assert(!mapping.is_indirect());
-    return update_mapping(
-      t,
-      mapping.direct_cursor,
-      prev_len,
-      prev_addr,
-      nextent);
-  }
 
   /**
    * update_mappings

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -52,43 +52,6 @@ public:
     Transaction &t,
     LogicalChildNode &extent) = 0;
 
-  /**
-   * Fetches mappings for laddr_t in range [offset, offset + len)
-   *
-   * Future will not resolve until all pins have resolved (set_paddr called)
-   * For indirect lba mappings, get_mappings will always retrieve the original
-   * lba value.
-   */
-  using get_mappings_iertr = base_iertr;
-  using get_mappings_ret = get_mappings_iertr::future<lba_mapping_list_t>;
-  virtual get_mappings_ret get_mappings(
-    Transaction &t,
-    laddr_t offset, extent_len_t length) = 0;
-
-  /**
-   * Fetches the mapping for laddr_t
-   *
-   * Future will not resolve until the pin has resolved (set_paddr called)
-   * For indirect lba mappings, get_mapping will always retrieve the original
-   * lba value.
-   */
-  using get_mapping_iertr = base_iertr::extend<
-    crimson::ct_error::enoent>;
-  using get_mapping_ret = get_mapping_iertr::future<LBAMapping>;
-  virtual get_mapping_ret get_mapping(
-    Transaction &t,
-    laddr_t offset,
-    bool search_containing = false) = 0;
-
-  /*
-   * Fetches the mapping corresponding to the "extent"
-   *
-   */
-  virtual get_mapping_ret get_mapping(
-    Transaction &t,
-    LogicalChildNode &extent) = 0;
-
-
 #ifdef UNIT_TESTS_BUILT
   using get_end_mapping_iertr = base_iertr;
   using get_end_mapping_ret = get_end_mapping_iertr::future<LBAMapping>;

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -156,7 +156,7 @@ public:
     {}
   };
   using remap_iertr = ref_iertr;
-  using remap_ret = remap_iertr::future<std::vector<LBAMapping>>;
+  using remap_ret = remap_iertr::future<std::vector<LBACursorRef>>;
 
   /**
    * remap_mappings
@@ -166,7 +166,7 @@ public:
    */
   virtual remap_ret remap_mappings(
     Transaction &t,
-    LBAMapping orig_mapping,
+    LBACursorRef orig_mapping,
     std::vector<remap_entry_t> remaps
     ) = 0;
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -35,6 +35,23 @@ public:
     Transaction &t
   ) = 0;
 
+  using get_cursors_iertr = base_iertr;
+  using get_cursors_ret = get_cursors_iertr::future<std::list<LBACursorRef>>;
+  virtual get_cursors_ret get_cursors(
+    Transaction &t,
+    laddr_t offset, extent_len_t length) = 0;
+
+  using get_cursor_iertr = base_iertr::extend<
+    crimson::ct_error::enoent>;
+  using get_cursor_ret = get_cursor_iertr::future<LBACursorRef>;
+  virtual get_cursor_ret get_cursor(
+    Transaction &t,
+    laddr_t offset,
+    bool search_containing = false) = 0;
+  virtual get_cursor_ret get_cursor(
+    Transaction &t,
+    LogicalChildNode &extent) = 0;
+
   /**
    * Fetches mappings for laddr_t in range [offset, offset + len)
    *

--- a/src/crimson/os/seastore/lba_mapping.h
+++ b/src/crimson/os/seastore/lba_mapping.h
@@ -207,6 +207,13 @@ private:
     return *direct_cursor;
   }
 
+  LBACursorRef get_effective_cursor_ref() {
+    if (is_indirect()) {
+      return indirect_cursor;
+    }
+    return direct_cursor;
+  }
+
   bool is_null() const {
     return !direct_cursor && !indirect_cursor;
   }

--- a/src/crimson/os/seastore/lba_mapping.h
+++ b/src/crimson/os/seastore/lba_mapping.h
@@ -195,6 +195,7 @@ public:
   base_iertr::future<LBAMapping> next();
 
 private:
+  friend class LBAManager;
   friend lba::BtreeLBAManager;
   friend class TransactionManager;
   friend std::ostream &operator<<(std::ostream&, const LBAMapping&);

--- a/src/crimson/os/seastore/lba_mapping.h
+++ b/src/crimson/os/seastore/lba_mapping.h
@@ -182,15 +182,7 @@ public:
 
   LogicalChildNodeRef peek_logical_extent(Transaction &t) const;
 
-  // [[deprecated]]
-  //TODO: should be changed to return future<> once all calls
-  //	  to refresh are through co_await. We return LBAMapping
-  //	  for now to avoid mandating the callers to make sure
-  //	  the life of the lba mapping survives the refresh.
-  base_iertr::future<LBAMapping> refresh();
-
-  // once the deprecated refresh is removed we can rename this to refresh
-  base_iertr::future<> co_refresh();
+  base_iertr::future<> mapping_refresh();
 
   base_iertr::future<LBAMapping> next();
 

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -82,6 +82,13 @@ struct get_child_ret_t {
     ceph_assert(ret.index() == 1);
     return std::get<1>(ret);
   }
+
+  template <typename T>
+  get_child_ifut<T> get_child_fut_as() {
+    return std::move(get_child_fut()).si_then([](auto e) {
+      return e->template cast<T>();
+    });
+  }
 };
 
 template <typename T, typename key_t>

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -1701,7 +1701,7 @@ ObjectDataHandler::do_clone(
   LBAMapping first_mapping,
   bool updateref)
 {
-  LOG_PREFIX("ObjectDataHandler::do_clone");
+  LOG_PREFIX(ObjectDataHandler::do_clone);
   assert(d_object_data.is_null());
   auto old_base = object_data.get_reserved_data_base();
   auto old_len = object_data.get_reserved_data_len();

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -230,7 +230,8 @@ TransactionManager::ref_ret TransactionManager::remove(
 {
   LOG_PREFIX(TransactionManager::remove);
   DEBUGT("{} ...", t, offset);
-  auto mapping = co_await lba_manager->get_mapping(t, offset);
+  auto cursor = co_await lba_manager->get_cursor(t, offset);
+  auto mapping = co_await resolve_cursor_to_mapping(t, std::move(cursor));
   auto result = co_await _remove(t, std::move(mapping));
   co_return result.result.refcount;
 }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -245,11 +245,13 @@ TransactionManager::_remove_indirect_mapping_only(
   Transaction &t,
   LBAMapping mapping)
 {
-  return lba_manager->remove_indirect_mapping_only(
-    t, std::move(mapping)
-  ).si_then([](auto result) {
-    return std::move(result.result.mapping);
-  });
+  assert(mapping.is_indirect());
+  auto ret_cursor = co_await lba_manager->update_mapping_refcount(
+    t, std::move(mapping.indirect_cursor), -1
+  );
+  co_return co_await resolve_cursor_to_mapping(
+    t,
+    ret_cursor);
 }
 
 TransactionManager::ref_iertr::future<

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -690,14 +690,14 @@ TransactionManager::rewrite_logical_extent(
 	);
       } else {
 	ceph_assert(refcount != 0);
-	auto mapping = co_await lba_manager->alloc_extent(
+	auto cursor = co_await lba_manager->alloc_extent(
 	  t,
 	  (extent->get_laddr() + off).checked_to_laddr(),
 	  *nextent,
 	  refcount
 	);
-	ceph_assert(mapping.get_key() == extent->get_laddr() + off);
-	ceph_assert(mapping.get_val() == nextent->get_paddr());
+	ceph_assert(cursor->get_laddr() == extent->get_laddr() + off);
+	ceph_assert(cursor->get_paddr() == nextent->get_paddr());
       }
       off += nextent->get_length();
       left -= nextent->get_length();

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -628,7 +628,7 @@ TransactionManager::rewrite_logical_extent(
      * extents since we're going to do it again once we either do the ool write
      * or allocate a relative inline addr.  TODO: refactor AsyncCleaner to
      * avoid this complication. */
-    auto mapping = co_await lba_manager->get_mapping(
+    auto cursor = co_await lba_manager->get_cursor(
       t, *extent
     ).handle_error_interruptible(
       rewrite_extent_iertr::pass_further{},
@@ -636,7 +636,7 @@ TransactionManager::rewrite_logical_extent(
     );
     co_await lba_manager->update_mapping(
       t,
-      std::move(mapping),
+      std::move(cursor),
       extent->get_length(),
       extent->get_paddr(),
       *nextent
@@ -672,7 +672,7 @@ TransactionManager::rewrite_logical_extent(
        * avoid this complication. */
       if (first_extent) {
 	assert(off == 0);
-	auto mapping = co_await lba_manager->get_mapping(
+	auto cursor = co_await lba_manager->get_cursor(
 	  t, *extent
 	).handle_error_interruptible(
 	  rewrite_extent_iertr::pass_further{},
@@ -680,7 +680,7 @@ TransactionManager::rewrite_logical_extent(
 	);
 	refcount = co_await lba_manager->update_mapping(
 	  t,
-	  std::move(mapping),
+	  std::move(cursor),
 	  extent->get_length(),
 	  extent->get_paddr(),
 	  *nextent

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -267,8 +267,7 @@ TransactionManager::_remove_indirect_mapping(
   LBAMapping mapping)
 {
   LOG_PREFIX(TransactionManager::_remove_indirect_mapping);
-  mapping = co_await lba_manager->complete_indirect_lba_mapping(t, std::move(mapping)
-  );
+  mapping = co_await complete_mapping(t, std::move(mapping));
   auto ret = get_extent_if_linked(t, *(mapping.direct_cursor));
   if (ret.has_child()) {
     auto extent = co_await ret.template get_child_fut_as<LogicalChildNode>();

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -263,131 +263,65 @@ TransactionManager::_remove_indirect_mapping_only(
 }
 
 TransactionManager::ref_iertr::future<LBAMapping>
-TransactionManager::_remove_indirect_mapping(
-  Transaction &t,
-  LBAMapping mapping)
-{
-  LOG_PREFIX(TransactionManager::_remove_indirect_mapping);
-  mapping = co_await complete_mapping(t, std::move(mapping));
-  auto ret = get_extent_if_linked(t, *(mapping.direct_cursor));
-  if (ret.has_child()) {
-    auto extent = co_await ret.template get_child_fut_as<LogicalChildNode>();
-    auto result = co_await lba_manager->remove_mapping(t, std::move(mapping));
-    ceph_assert(result.direct_result);
-    auto &primary_result = result.result;
-    ceph_assert(primary_result.refcount == 0);
-    auto &direct_result = *result.direct_result;
-    ceph_assert(direct_result.addr.is_paddr());
-    ceph_assert(!direct_result.addr.get_paddr().is_zero());
-    ceph_assert(extent);
-    if (direct_result.refcount == 0) {
-      cache->retire_extent(t, extent);
-    }
-    DEBUGT("removed indirect mapping {}~0x{:x} refcount={} offset={} "
-	   "with direct mapping {}~0x{:x} refcount={} offset={}",
-	   t, primary_result.addr,
-	   primary_result.length,
-	   primary_result.refcount,
-	   primary_result.key,
-	   direct_result.addr,
-	   direct_result.length,
-	   direct_result.refcount,
-	   direct_result.key);
-    co_return result.result.mapping;
-  } else {
-    auto remove_direct = mapping.would_cascade_remove();
-    if (remove_direct) {
-      auto retired_placeholder = cache->retire_absent_extent_addr(
-	t, mapping.get_intermediate_base(),
-	mapping.get_val(),
-	mapping.get_intermediate_length()
-      )->template cast<RetiredExtentPlaceholder>();
-      ret.get_child_pos().link_child(retired_placeholder.get());
-    }
-    auto result = co_await lba_manager->remove_mapping(t, std::move(mapping));
-    ceph_assert(result.direct_result);
-    auto &primary_result = result.result;
-    ceph_assert(primary_result.refcount == 0);
-    auto &direct_result = *result.direct_result;
-    ceph_assert(direct_result.addr.is_paddr());
-    ceph_assert(!direct_result.addr.get_paddr().is_zero());
-    ceph_assert(remove_direct == (direct_result.refcount == 0));
-    DEBUGT("removed indirect mapping {}~0x{:x} refcount={} offset={} "
-	   "with direct mapping {}~0x{:x} refcount={} offset={}",
-	   t, primary_result.addr,
-	   primary_result.length,
-	   primary_result.refcount,
-	   primary_result.key,
-	   direct_result.addr,
-	   direct_result.length,
-	   direct_result.refcount,
-	   direct_result.key);
-    co_return result.result.mapping;
-  }
-}
-
-TransactionManager::ref_iertr::future<LBAMapping>
-TransactionManager::_remove_direct_mapping(
-  Transaction &t,
-  LBAMapping mapping)
-{
-  LOG_PREFIX(TransactionManager::_remove_direct_mapping);
-  auto ret = get_extent_if_linked(t, *(mapping.direct_cursor));
-  if (ret.has_child()) {
-    auto extent = co_await ret.template get_child_fut_as<LogicalChildNode>();
-    auto result = co_await lba_manager->remove_mapping(t, std::move(mapping));
-    auto &primary_result = result.result;
-    ceph_assert(primary_result.refcount == 0);
-    ceph_assert(primary_result.addr.is_paddr());
-    ceph_assert(!primary_result.addr.get_paddr().is_zero());
-    ceph_assert(extent);
-    cache->retire_extent(t, extent);
-    DEBUGT("removed {}~0x{:x} refcount={} -- offset={}",
-	   t, primary_result.addr, primary_result.length,
-	   primary_result.refcount, primary_result.key);
-    co_return result.result.mapping;
-  } else {
-    auto retired_placeholder = cache->retire_absent_extent_addr(
-      t, mapping.get_key(), mapping.get_val(), mapping.get_length()
-    )->template cast<RetiredExtentPlaceholder>();
-    ret.get_child_pos().link_child(retired_placeholder.get());
-    auto result = co_await lba_manager->remove_mapping(t, std::move(mapping));
-    auto &primary_result = result.result;
-    ceph_assert(primary_result.refcount == 0);
-    ceph_assert(primary_result.addr.is_paddr());
-    ceph_assert(!primary_result.addr.get_paddr().is_zero());
-    DEBUGT("removed {}~0x{:x} refcount={} -- offset={}",
-	   t, primary_result.addr, primary_result.length,
-	   primary_result.refcount, primary_result.key);
-    co_return result.result.mapping;
-  }
-}
-
-TransactionManager::ref_iertr::future<LBAMapping>
 TransactionManager::_remove(
   Transaction &t,
   LBAMapping mapping)
 {
   LOG_PREFIX(TransactionManager::_remove);
-  if (mapping.is_indirect()) {
-    return _remove_indirect_mapping(t, std::move(mapping));
-  } else if (mapping.get_val().is_real_location()) {
-    return _remove_direct_mapping(t, std::move(mapping));
-  } else {
-    return lba_manager->remove_mapping(t, std::move(mapping)
-    ).si_then([&t, FNAME](auto result) {
-      auto &primary_result = result.result;
-      ceph_assert(primary_result.refcount == 0);
-      ceph_assert(primary_result.addr.is_paddr());
-      ceph_assert(primary_result.addr.get_paddr().is_zero());
-      DEBUGT("removed {}~0x{:x} refcount={} -- offset={}",
-             t, primary_result.addr,
-             primary_result.length,
-             primary_result.refcount,
-             primary_result.key);
-      return result.result.mapping;
-    });
+  DEBUGT("{}", t, mapping);
+  mapping = co_await complete_mapping(t, mapping);
+
+  if (!mapping.is_zero_reserved() &&
+      mapping.direct_cursor->get_refcount() == 1) {
+    auto maybe_mapped_extent = get_extent_if_linked(t, *(mapping.direct_cursor));
+    if (maybe_mapped_extent.has_child()) {
+      DEBUGT("waiting for child fut for {}", t, mapping);
+      auto extent = co_await maybe_mapped_extent.get_child_fut_as<
+	LogicalChildNode
+	>();
+      ceph_assert(extent);
+      cache->retire_extent(t, std::move(extent));
+    } else {
+      auto retired_placeholder = cache->retire_absent_extent_addr(
+	t, mapping.get_key(), mapping.get_val(), mapping.get_length()
+      )->template cast<RetiredExtentPlaceholder>();
+      maybe_mapped_extent.get_child_pos().link_child(retired_placeholder.get());
+    }
   }
+
+  LBACursorRef indirect_cursor;
+  if (mapping.is_indirect()) {
+    DEBUGT("removing indirect mapping {}~0x{:x} refcount={} -- offset={}",
+	   t,
+	   mapping.indirect_cursor->get_intermediate_key(),
+	   mapping.indirect_cursor->get_length(),
+	   mapping.indirect_cursor->get_refcount(),
+	   mapping.indirect_cursor->get_laddr());
+    ceph_assert(mapping.indirect_cursor->get_refcount() == 1);
+    indirect_cursor = co_await lba_manager->update_mapping_refcount(
+      t, mapping.indirect_cursor, -1);
+    co_await mapping.direct_cursor->refresh();
+  }
+
+  DEBUGT("removing direct mapping {}~0x{:x} refcount={} -- offset={}",
+	 t,
+	 mapping.direct_cursor->get_paddr(),
+	 mapping.direct_cursor->get_length(),
+	 mapping.direct_cursor->get_refcount(),
+	 mapping.direct_cursor->get_laddr());
+
+  ceph_assert(mapping.direct_cursor->get_refcount() >= 1);
+
+  LBACursorRef direct_cursor = co_await lba_manager->update_mapping_refcount(
+    t, mapping.direct_cursor, -1);
+
+  auto ret = co_await resolve_cursor_to_mapping(
+    t,
+    indirect_cursor ? std::move(indirect_cursor) : std::move(direct_cursor)
+  );
+  DEBUGT("returning {}", t, ret);
+  ceph_assert(ret.is_viewable());
+  co_return ret;
 }
 
 using resolve_cursor_to_mapping_iertr = base_iertr;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -202,24 +202,21 @@ TransactionManager::close() {
 
 TransactionManager::ref_ret TransactionManager::remove(
   Transaction &t,
-  LogicalChildNodeRef &ref)
+  LogicalChildNodeRef ref)
 {
   LOG_PREFIX(TransactionManager::remove);
   DEBUGT("{} ...", t, *ref);
-  return lba_manager->get_mapping(t, *ref
-  ).si_then([ref, this, &t](auto mapping) {
-    return lba_manager->remove_mapping(t, std::move(mapping));
-  }).si_then([this, FNAME, &t, ref](auto result) {
-    assert(!result.direct_result);
-    auto &primary_result = result.result;
-    if (primary_result.refcount == 0) {
-      cache->retire_extent(t, ref);
-    }
-    DEBUGT("removed {}~0x{:x} refcount={} -- {}",
-           t, primary_result.addr, primary_result.length,
-           primary_result.refcount, *ref);
-    return primary_result.refcount;
-  });
+  auto mapping = co_await lba_manager->get_mapping(t, *ref);
+  auto result = co_await lba_manager->remove_mapping(t, std::move(mapping));
+  assert(!result.direct_result);
+  auto &primary_result = result.result;
+  if (primary_result.refcount == 0) {
+    cache->retire_extent(t, ref);
+  }
+  DEBUGT("removed {}~0x{:x} refcount={} -- {}",
+	 t, primary_result.addr, primary_result.length,
+	 primary_result.refcount, *ref);
+  co_return primary_result.refcount;
 }
 
 TransactionManager::ref_ret TransactionManager::remove(
@@ -228,12 +225,9 @@ TransactionManager::ref_ret TransactionManager::remove(
 {
   LOG_PREFIX(TransactionManager::remove);
   DEBUGT("{} ...", t, offset);
-  return lba_manager->get_mapping(t, offset
-  ).si_then([&t, this](auto mapping) {
-    return _remove(t, std::move(mapping));
-  }).si_then([](auto result) {
-    return result.result.refcount;
-  });
+  auto mapping = co_await lba_manager->get_mapping(t, offset);
+  auto result = co_await _remove(t, std::move(mapping));
+  co_return result.result.refcount;
 }
 
 TransactionManager::ref_iertr::future<LBAMapping>
@@ -241,11 +235,9 @@ TransactionManager::remove(
   Transaction &t,
   LBAMapping mapping)
 {
-  return mapping.refresh().si_then([&t, this](auto mapping) {
-    return _remove(t, std::move(mapping));
-  }).si_then([](auto res) {
-    return std::move(res.result.mapping);
-  });
+  mapping = co_await mapping.refresh();
+  auto res = co_await _remove(t, std::move(mapping));
+  co_return std::move(res.result.mapping);
 }
 
 TransactionManager::ref_iertr::future<LBAMapping>

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -409,6 +409,37 @@ TransactionManager::_remove(
   }
 }
 
+using resolve_cursor_to_mapping_iertr = base_iertr;
+resolve_cursor_to_mapping_iertr::future<LBAMapping>
+TransactionManager::resolve_cursor_to_mapping(
+  Transaction &t,
+  LBACursorRef cursor)
+{
+  if (cursor->is_end() || !cursor->is_indirect()) {
+    co_return co_await LBAMapping::create_direct(std::move(cursor)).refresh();
+  }
+
+  assert(cursor->val->refcount == EXTENT_DEFAULT_REF_COUNT);
+  assert(cursor->val->checksum == 0);
+
+  auto direct_cursors = co_await lba_manager->get_cursors(
+    t,
+    cursor->get_intermediate_key(),
+    cursor->get_length()
+  );
+
+  ceph_assert(direct_cursors.size() == 1);
+  auto& direct_cursor = direct_cursors.front();
+  auto intermediate_key = cursor->get_intermediate_key();
+  assert(!direct_cursor->is_indirect());
+  assert(direct_cursor->get_laddr() <= intermediate_key);
+  assert(direct_cursor->get_laddr() + direct_cursor->get_length()
+	 >= intermediate_key + cursor->get_length());
+  co_return co_await LBAMapping::create_indirect(
+    std::move(direct_cursor),
+    std::move(cursor)).refresh();
+}
+
 TransactionManager::refs_ret TransactionManager::remove(
   Transaction &t,
   std::vector<laddr_t> offsets)

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -305,10 +305,10 @@ public:
 
     // checking the lba child must be atomic with creating
     // and linking the absent child
-    auto ret = get_extent_if_linked<T>(t, std::move(pin));
+    auto ret = get_extent_if_linked(t, *(pin.direct_cursor));
     TCachedExtentRef<T> extent;
-    if (ret.index() == 1) {
-      extent = co_await std::move(std::get<1>(ret));
+    if (ret.has_child()) {
+      extent = co_await ret.template get_child_fut_as<T>();
       extent = co_await cache->read_extent_maybe_partial(
 	t, std::move(extent), direct_partial_off, partial_len);
       if (!extent->is_seen_by_users()) {
@@ -316,9 +316,8 @@ public:
 	extent->set_seen_by_users();
       }
     } else {
-      auto &r = std::get<0>(ret);
       extent = co_await this->pin_to_extent<T>(
-	t, std::move(r.mapping), std::move(r.child_pos),
+	t, std::move(pin), std::move(ret.get_child_pos()),
 	direct_partial_off, partial_len,
 	std::move(maybe_init));
     }
@@ -1162,35 +1161,19 @@ private:
     LBACursorRef cursor);
 
   using LBALeafNode = lba::LBALeafNode;
-  struct unlinked_child_t {
-    LBAMapping mapping;
-    child_pos_t<LBALeafNode> child_pos;
-  };
-  template <typename T>
-  std::variant<unlinked_child_t, get_child_ifut<T>>
-  get_extent_if_linked(
+  get_child_ret_t<LBALeafNode, LogicalChildNode> get_extent_if_linked(
     Transaction &t,
-    LBAMapping pin)
+    LBACursor &cursor)
   {
-    ceph_assert(pin.is_viewable());
-    // checking the lba child must be atomic with creating
-    // and linking the absent child
-    auto v = pin.get_logical_extent(t);
-    if (v.has_child()) {
-      return v.get_child_fut(
-      ).si_then([pin](auto extent) {
-#ifndef NDEBUG
-        auto lextent = extent->template cast<LogicalChildNode>();
-        auto pin_laddr = pin.get_intermediate_base();
-        assert(lextent->get_laddr() == pin_laddr);
-#endif
-	return extent->template cast<T>();
-      });
-    } else {
-      return unlinked_child_t{
-	std::move(const_cast<LBAMapping&>(pin)),
-	v.get_child_pos()};
-    }
+    ceph_assert(cursor.is_viewable());
+    ceph_assert(cursor.ctx.trans.get_trans_id()
+		== t.get_trans_id());
+    assert(!cursor.is_end());
+    assert(cursor.pos != BTREENODE_POS_NULL);
+    ceph_assert(t.get_trans_id() == cursor.ctx.trans.get_trans_id());
+    auto p = cursor.parent->cast<LBALeafNode>();
+    return p->template get_child<LogicalChildNode>(
+      t, cursor.ctx.cache, cursor.pos, cursor.key);
   }
 
   base_iertr::future<LogicalChildNodeRef> read_pin_by_type(
@@ -1205,7 +1188,7 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      auto extent = co_await std::move(v.get_child_fut());
+      auto extent = co_await v.get_child_fut_as<LogicalChildNode>();
       auto len = extent->get_length();
       auto ext = co_await cache->read_extent_maybe_partial(
 	t, std::move(extent), 0, len);
@@ -1288,23 +1271,20 @@ private:
         assert(!maybe_indirect_extent.is_clone);
         extent = maybe_indirect_extent.extent;
       } else {
-        auto ret = get_extent_if_linked<T>(t, pin);
-        if (std::holds_alternative<get_child_ifut<T>>(ret)) {
+	auto ret = get_extent_if_linked(t, *(pin.direct_cursor));
+        if (ret.has_child()) {
           SUBTRACET(seastore_tm, "getting linked child...", t);
-          extent = co_await std::move(std::get<get_child_ifut<T>>(ret));
+          extent = co_await ret.template get_child_fut_as<T>();
           if (!extent->is_seen_by_users()) {
             // Note, no maybe_init available for data extents
             extent->set_seen_by_users();
           }
-        } else if (std::holds_alternative<unlinked_child_t>(ret)) {
+        } else {
           SUBTRACET(seastore_tm, "retire extent place holder...", t);
-          auto unlinked_child =  std::move(std::get<unlinked_child_t>(ret));
           auto retired_placeholder = cache->retire_absent_extent_addr(
             t, pin.get_key(), original_paddr, original_len
           )->template cast<RetiredExtentPlaceholder>();
-          unlinked_child.child_pos.link_child(retired_placeholder.get());
-        } else {
-          ceph_abort("unexpected varaint in remap_pin");
+	  ret.get_child_pos().link_child(retired_placeholder.get());
         }
       }
 

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1444,22 +1444,20 @@ private:
       direct_partial_off,
       partial_len,
       // extent_init_func
-      seastar::coroutine::lambda(
-        [laddr=pin.get_intermediate_base(),
-        maybe_init=std::move(maybe_init),
-        child_pos=std::move(child_pos),
-        &t, this] (T &extent) mutable {
-          assert(extent.is_logical());
-          assert(!extent.has_laddr());
-          assert(!extent.has_been_invalidated());
-          child_pos.link_child(&extent);
-          child_pos.invalidate_retired_placeholder(t, *cache, extent);
-          extent.set_laddr(laddr);
-          maybe_init(extent);
-          extent.set_seen_by_users();
-      }),
-      pin.get_checksum()
-    );
+      [laddr=pin.get_intermediate_base(),
+      maybe_init=std::move(maybe_init),
+      child_pos=std::move(child_pos),
+      &t, this] (T &extent) mutable {
+        assert(extent.is_logical());
+        assert(!extent.has_laddr());
+        assert(!extent.has_been_invalidated());
+        child_pos.link_child(&extent);
+        child_pos.invalidate_retired_placeholder(t, *cache, extent);
+        extent.set_laddr(laddr);
+        maybe_init(extent);
+        extent.set_seen_by_users();
+      },
+      pin.get_checksum());
 
     SUBDEBUGT(seastore_tm, "got extent -- {} fully_loaded: {}",
               t, *ref, ref->is_fully_loaded());
@@ -1495,7 +1493,6 @@ private:
       direct_key,
       direct_length,
       // extent_init_func
-      seastar::coroutine::lambda(
       [direct_key, child_pos=std::move(child_pos),
       &t, this](CachedExtent &extent) mutable {
         assert(extent.is_logical());
@@ -1507,9 +1504,8 @@ private:
         lextent.set_laddr(direct_key);
         // No change to extent::seen_by_user because this path is only
         // for background cleaning.
-      }
-    ),
-    cursor->get_checksum());
+      },
+      cursor->get_checksum());
     SUBDEBUGT(seastore_tm, "got extent -- {} fully_loaded: {}",
               t, *ref, ref->is_fully_loaded());
     assert(ref->is_fully_loaded());

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1155,6 +1155,12 @@ private:
 
   shard_stats_t& shard_stats;
 
+  using resolve_cursor_to_mapping_iertr = base_iertr;
+  resolve_cursor_to_mapping_iertr::future<LBAMapping>
+  resolve_cursor_to_mapping(
+    Transaction &t,
+    LBACursorRef cursor);
+
   using LBALeafNode = lba::LBALeafNode;
   struct unlinked_child_t {
     LBAMapping mapping;

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -161,9 +161,13 @@ public:
     extent_len_t length) {
     LOG_PREFIX(TransactionManager::get_pins);
     SUBDEBUGT(seastore_tm, "{}~0x{:x} ...", t, offset, length);
-    auto pins = co_await lba_manager->get_mappings(t, offset, length);
-    SUBDEBUGT(seastore_tm, "got {} pins", t, pins.size());
-    co_return pins;
+    auto cursors = co_await lba_manager->get_cursors(t, offset, length);
+    std::list<LBAMapping> ret;
+    for (auto &cursor: cursors) {
+      ret.emplace_back(co_await resolve_cursor_to_mapping(t, cursor));
+    }
+    SUBDEBUGT(seastore_tm, "got {} pins", t, ret.size());
+    co_return ret;
   }
 
   /**

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1366,14 +1366,7 @@ private:
   ref_iertr::future<LBAMapping> _remove(
     Transaction &t,
     LBAMapping mapping);
-  ref_iertr::future<LBAMapping>
-  _remove_indirect_mapping(
-    Transaction &t,
-    LBAMapping mapping);
-  ref_iertr::future<LBAMapping>
-  _remove_direct_mapping(
-    Transaction &t,
-    LBAMapping mapping);
+
   ref_iertr::future<LBAMapping>
   _remove_indirect_mapping_only(
     Transaction &t,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -530,8 +530,8 @@ public:
       hint,
       len
     );
-    SUBDEBUGT(seastore_tm, "reserved {}", t, pin);
-    co_return pin;
+    SUBDEBUGT(seastore_tm, "reserved {}", t, *pin);
+    co_return LBAMapping::create_direct(std::move(pin));
   }
 
   reserve_extent_ret reserve_region(
@@ -548,7 +548,7 @@ public:
       hint,
       len
     );
-    co_return pin;
+    co_return LBAMapping::create_direct(std::move(pin));
   }
 
   /*

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -464,7 +464,7 @@ public:
       auto npos = co_await pos->refresh();
       co_await lba_manager->alloc_extents(
 	t,
-	std::move(npos),
+	npos.get_effective_cursor_ref(),
 	std::vector<LogicalChildNodeRef>(
 	  exts.begin(), exts.end()));
     } else {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -525,14 +525,13 @@ public:
     extent_len_t len) {
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "hint {}~0x{:x} ...", t, hint, len);
-    return lba_manager->reserve_region(
+    auto pin = co_await lba_manager->reserve_region(
       t,
       hint,
       len
-    ).si_then([FNAME, &t](auto pin) {
-      SUBDEBUGT(seastore_tm, "reserved {}", t, pin);
-      return pin;
-    });
+    );
+    SUBDEBUGT(seastore_tm, "reserved {}", t, pin);
+    co_return pin;
   }
 
   reserve_extent_ret reserve_region(
@@ -542,18 +541,14 @@ public:
     extent_len_t len) {
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "hint {}~0x{:x} ...", t, hint, len);
-    return pos.refresh(
-    ).si_then([FNAME, this, &t, hint, len](auto pos) {
-      return lba_manager->reserve_region(
-	t,
-	std::move(pos),
-	hint,
-	len
-      ).si_then([FNAME, &t](auto pin) {
-	SUBDEBUGT(seastore_tm, "reserved {}", t, pin);
-	return pin;
-      });
-    });
+    pos = co_await pos.refresh();
+    auto pin = co_await lba_manager->reserve_region(
+      t,
+      std::move(pos),
+      hint,
+      len
+    );
+    co_return pin;
   }
 
   /*

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -234,18 +234,14 @@ public:
     LOG_PREFIX(TransactionManager::read_extent);
     SUBDEBUGT(seastore_tm, "{}~0x{:x} {} ...",
               t, offset, length, T::TYPE);
-    return get_pin(
-      t, offset
-    ).si_then([this, FNAME, &t, offset, length,
-	      maybe_init=std::move(maybe_init)] (auto pin) mutable
-      -> read_extent_ret<T> {
-      if (length != pin.get_length() || !pin.get_val().is_real_location()) {
-        SUBERRORT(seastore_tm, "{}~0x{:x} {} got wrong pin {}",
-                  t, offset, length, T::TYPE, pin);
-        ceph_abort_msg("Impossible");
-      }
-      return this->read_pin<T>(t, std::move(pin), std::move(maybe_init));
-    });
+    auto pin = co_await get_pin(t, offset);
+    if (length != pin.get_length() || !pin.get_val().is_real_location()) {
+      SUBERRORT(seastore_tm, "{}~0x{:x} {} got wrong pin {}",
+		t, offset, length, T::TYPE, pin);
+      ceph_abort_msg("Impossible");
+    }
+    co_return co_await this->read_pin<T>(
+      t, std::move(pin), std::move(maybe_init));
   }
 
   /**
@@ -261,18 +257,14 @@ public:
     LOG_PREFIX(TransactionManager::read_extent);
     SUBDEBUGT(seastore_tm, "{} {} ...",
               t, offset, T::TYPE);
-    return get_pin(
-      t, offset
-    ).si_then([this, FNAME, &t, offset,
-	      maybe_init=std::move(maybe_init)] (auto pin) mutable
-      -> read_extent_ret<T> {
-      if (!pin.get_val().is_real_location()) {
-        SUBERRORT(seastore_tm, "{} {} got wrong pin {}",
-                  t, offset, T::TYPE, pin);
-        ceph_abort_msg("Impossible");
-      }
-      return this->read_pin<T>(t, std::move(pin), std::move(maybe_init));
-    });
+    auto pin = co_await get_pin(t, offset);
+    if (!pin.get_val().is_real_location()) {
+      SUBERRORT(seastore_tm, "{} {} got wrong pin {}",
+		t, offset, T::TYPE, pin);
+      ceph_abort_msg("Impossible");
+    }
+    co_return co_await this->read_pin<T>(
+      t, std::move(pin), std::move(maybe_init));
   }
 
   template <typename T>

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1363,15 +1363,14 @@ private:
        co_return std::move(mapping_vec);
   }
 
-  using _remove_mapping_result_t = LBAManager::ref_update_result_t;
-  ref_iertr::future<_remove_mapping_result_t> _remove(
+  ref_iertr::future<LBAMapping> _remove(
     Transaction &t,
     LBAMapping mapping);
-  ref_iertr::future<_remove_mapping_result_t>
+  ref_iertr::future<LBAMapping>
   _remove_indirect_mapping(
     Transaction &t,
     LBAMapping mapping);
-  ref_iertr::future<_remove_mapping_result_t>
+  ref_iertr::future<LBAMapping>
   _remove_direct_mapping(
     Transaction &t,
     LBAMapping mapping);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -109,8 +109,9 @@ public:
    *
    * Get the logical pin at offset
    */
-  using get_pin_iertr = LBAManager::get_mapping_iertr;
-  using get_pin_ret = LBAManager::get_mapping_iertr::future<LBAMapping>;
+  using get_pin_iertr = base_iertr::extend<
+    crimson::ct_error::enoent>;
+  using get_pin_ret = get_pin_iertr::future<LBAMapping>;
   get_pin_ret get_pin(
     Transaction &t,
     laddr_t offset) {
@@ -153,7 +154,7 @@ public:
    *
    * Get logical pins overlapping offset~length
    */
-  using get_pins_iertr = LBAManager::get_mappings_iertr;
+  using get_pins_iertr = base_iertr;
   using get_pins_ret = get_pins_iertr::future<lba_mapping_list_t>;
   get_pins_ret get_pins(
     Transaction &t,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -116,11 +116,9 @@ public:
     laddr_t offset) {
     LOG_PREFIX(TransactionManager::get_pin);
     SUBDEBUGT(seastore_tm, "{} ...", t, offset);
-    return lba_manager->get_mapping(t, offset, false
-    ).si_then([FNAME, &t](LBAMapping pin) {
-      SUBDEBUGT(seastore_tm, "got {}", t, pin);
-      return pin;
-    });
+    auto pin = co_await lba_manager->get_mapping(t, offset, false);
+    SUBDEBUGT(seastore_tm, "got {}", t, pin);
+    co_return pin;
   }
 
   /**
@@ -133,21 +131,17 @@ public:
     laddr_t laddr) {
     LOG_PREFIX(TransactionManager::get_containing_pin);
     SUBDEBUGT(seastore_tm, "{} ...", t, laddr);
-    return lba_manager->get_mapping(t, laddr, true
-    ).si_then([FNAME, &t](LBAMapping pin) {
-      SUBDEBUGT(seastore_tm, "got {}", t, pin);
-      return pin;
-    });
+    auto pin = co_await lba_manager->get_mapping(t, laddr, true);
+    SUBDEBUGT(seastore_tm, "got {}", t, pin);
+    co_return pin;
   }
 
   get_pin_ret get_pin(Transaction &t, LogicalChildNode &extent) {
     LOG_PREFIX(TransactionManager::get_pin);
     SUBDEBUGT(seastore_tm, "{} ...", t, extent);
-    return lba_manager->get_mapping(t, extent
-    ).si_then([FNAME, &t](LBAMapping pin) {
-      SUBDEBUGT(seastore_tm, "got {}", t, pin);
-      return pin;
-    });
+    auto pin = co_await lba_manager->get_mapping(t, extent);
+    SUBDEBUGT(seastore_tm, "got {}", t, pin);
+    co_return pin;
   }
 
   /**
@@ -163,12 +157,9 @@ public:
     extent_len_t length) {
     LOG_PREFIX(TransactionManager::get_pins);
     SUBDEBUGT(seastore_tm, "{}~0x{:x} ...", t, offset, length);
-    return lba_manager->get_mappings(
-      t, offset, length
-    ).si_then([FNAME, &t](lba_mapping_list_t pins) {
-      SUBDEBUGT(seastore_tm, "got {} pins", t, pins.size());
-      return pins;
-    });
+    auto pins = co_await lba_manager->get_mappings(t, offset, length);
+    SUBDEBUGT(seastore_tm, "got {} pins", t, pins.size());
+    co_return pins;
   }
 
   /**

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -361,7 +361,7 @@ public:
    */
   ref_ret remove(
     Transaction &t,
-    LogicalChildNodeRef &ref);
+    LogicalChildNodeRef ref);
 
   ref_ret remove(
     Transaction &t,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -538,7 +538,7 @@ public:
     pos = co_await pos.refresh();
     auto pin = co_await lba_manager->reserve_region(
       t,
-      std::move(pos),
+      pos.get_effective_cursor_ref(),
       hint,
       len
     );

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -929,7 +929,10 @@ public:
     LBAMapping mapping,
     std::array<TransactionManager::remap_entry_t, N> remaps)
   {
+    LOG_PREFIX(TransactionManager::remap_mappings);
     if (!mapping.is_indirect() && mapping.is_zero_reserved()) {
+      SUBDEBUGT(seastore_tm, "zero reserved, mapping {}, {} remaps",
+		t, mapping, remaps);
       std::vector<LBAMapping> ret;
       auto orig_laddr = mapping.get_key();
       auto pos = co_await remove(
@@ -954,6 +957,10 @@ public:
       }
       co_return ret;
     } else {
+      SUBDEBUGT(
+	seastore_tm,
+	"not zero reserved, calling remap_pin, mapping {}, {} remaps",
+	t, mapping, remaps);
       co_return co_await remap_pin<T, N>(
 	t, std::move(mapping), std::move(remaps));
     }

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -565,16 +565,16 @@ struct btree_lba_manager_test : btree_test_base {
 	});
       }).unsafe_get();
     for (auto &ret : rets) {
-      logger().debug("alloc'd: {}", ret);
-      EXPECT_EQ(len, ret.get_length());
-      auto [b, e] = get_overlap(t, ret.get_key(), len);
+      logger().debug("alloc'd: {}", *ret);
+      EXPECT_EQ(len, ret->get_length());
+      auto [b, e] = get_overlap(t, ret->get_laddr(), len);
       EXPECT_EQ(b, e);
       t.mappings.emplace(
 	std::make_pair(
-	  ret.get_key(),
+	  ret->get_laddr(),
 	  test_extent_t{
-	    ret.get_val(),
-	    ret.get_length(),
+	    ret->get_paddr(),
+	    ret->get_length(),
 	    1
 	  }
 	));

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -656,24 +656,24 @@ struct btree_lba_manager_test : btree_test_base {
       auto ret_list = with_trans_intr(
 	*t.t,
 	[=, this](auto &t) {
-	  return lba_manager->get_mappings(
+	  return lba_manager->get_cursors(
 	    t, laddr, len);
 	}).unsafe_get();
       EXPECT_EQ(ret_list.size(), 1);
       auto &ret = *ret_list.begin();
-      EXPECT_EQ(i.second.addr, ret.get_val());
-      EXPECT_EQ(laddr, ret.get_key());
-      EXPECT_EQ(len, ret.get_length());
+      EXPECT_EQ(i.second.addr, ret->get_paddr());
+      EXPECT_EQ(laddr, ret->get_laddr());
+      EXPECT_EQ(len, ret->get_length());
 
       auto ret_pin = with_trans_intr(
 	*t.t,
 	[=, this](auto &t) {
-	  return lba_manager->get_mapping(
+	  return lba_manager->get_cursor(
 	    t, laddr);
 	}).unsafe_get();
-      EXPECT_EQ(i.second.addr, ret_pin.get_val());
-      EXPECT_EQ(laddr, ret_pin.get_key());
-      EXPECT_EQ(len, ret_pin.get_length());
+      EXPECT_EQ(i.second.addr, ret_pin->get_paddr());
+      EXPECT_EQ(laddr, ret_pin->get_laddr());
+      EXPECT_EQ(len, ret_pin->get_length());
     }
     with_trans_intr(
       *t.t,

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -726,9 +726,9 @@ struct transaction_manager_test_t :
   }
 
   LBAMapping get_end(test_transaction_t &t) {
-    return with_trans_intr(*(t.t), [&](auto &trans) {
+    return LBAMapping::create_direct(with_trans_intr(*(t.t), [&](auto &trans) {
       return lba_manager->get_end_mapping(trans);
-    }).unsafe_get();
+    }).unsafe_get());
   }
 
   std::optional<LBAMapping> try_get_pin(


### PR DESCRIPTION
```
LBAMapping::refresh returned new LBAMapping instance
instead of reusing `this`.
The main reason was to avoid making sure that the callers keep
the LBAMapping instance alive while being refreshed.

The way the interface worked required creating a new mapping instance
each time a refresh() was needed - this largely complicated
the users logic.

This commit updates the refresh to reuse `this`, for this to be
possible `with_btree_state` overload which previously got the mapping
as rval (of the copied mapping) is now moved to by-value mapping.

* refresh is renamed to refresh_mapping for easier differentiation
  with LBACursor::refresh

* refresh would likely be deprecated soon, this PR would make this
  deprecation smoother once all users are one-liners instead of
  chained continuations.
```

PR is separated into multiple commits for easier `git bisect` while this PR is being tested.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
