### PR TITLE
tentacle: mgr/smb: Allow whitespace in share login names

### DIFF
--- a/src/pybind/mgr/smb/tests/test_resources.py
+++ b/src/pybind/mgr/smb/tests/test_resources.py
@@ -724,7 +724,7 @@ login_control:
   - name: itstaff
     category: group
     access: rw
-  - name: caldor
+  - name: "caldor hart"
     category: user
     access: admin
   - name: delbard
@@ -742,7 +742,7 @@ login_control:
     assert share.login_control[1].name == 'itstaff'
     assert share.login_control[1].category == enums.LoginCategory.GROUP
     assert share.login_control[1].access == enums.LoginAccess.READ_WRITE
-    assert share.login_control[2].name == 'caldor'
+    assert share.login_control[2].name == 'caldor hart'
     assert share.login_control[2].category == enums.LoginCategory.USER
     assert share.login_control[2].access == enums.LoginAccess.ADMIN
     assert share.login_control[3].name == 'delbard'

--- a/src/pybind/mgr/smb/tests/test_validation.py
+++ b/src/pybind/mgr/smb/tests/test_validation.py
@@ -117,9 +117,9 @@ def test_clean_custom_options():
     [
         ("tim", True, ""),
         ("britons\\arthur", True, ""),
-        ("lance a lot", False, "spaces, tabs, or newlines"),
-        ("tabs\ta\tlot", False, "spaces, tabs, or newlines"),
-        ("bed\nivere", False, "spaces, tabs, or newlines"),
+        ("lance a lot", True, ""),
+        ("tabs\ta\tlot", False, "tabs or newlines"),
+        ("bed\nivere", False, "tabs or newlines"),
         ("runawa" + ("y" * 122), True, ""),
         ("runawa" + ("y" * 123), False, "128"),
     ],

--- a/src/pybind/mgr/smb/validation.py
+++ b/src/pybind/mgr/smb/validation.py
@@ -108,10 +108,8 @@ def clean_custom_options(
 
 
 def check_access_name(name: str) -> None:
-    if ' ' in name or '\t' in name or '\n' in name:
-        raise ValueError(
-            'login name may not contain spaces, tabs, or newlines'
-        )
+    if '\t' in name or '\n' in name:
+        raise ValueError('login name may not contain tabs or newlines')
     if len(name) > 128:
         raise ValueError('login name may not exceed 128 characters')
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/66574

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
