### PR TITLE
Wip rename cleanup

### DIFF
--- a/src/test/librgw_file_rename.cc
+++ b/src/test/librgw_file_rename.cc
@@ -44,12 +44,15 @@ namespace {
 
   string bucket1_name = "wyndemere";
   string bucket2_name = "galahad";
+  string bucket3_name = "sharkys";
+  string bucket4_name = "night";
   string obj_name1 = "tommy1";
   string obj_name2 = "ricky1";
   string obj_name3 = "zoot";
 
   struct rgw_file_handle* bucket1_fh = nullptr;
   struct rgw_file_handle* bucket2_fh = nullptr;
+  struct rgw_file_handle* bucket3_fh = nullptr;
   struct rgw_file_handle* object_fh = nullptr;
 
   string subdir1_name = "meep";
@@ -179,28 +182,24 @@ TEST(LibRGW, SUBDIR_RENAME) {
 
       ret = make_object(subdir1_fh, obj_name1);
       ASSERT_EQ(ret, 0);
-  } else {
-    ret = rgw_lookup(fs, bucket1_fh, subdir1_name.c_str(), &subdir1_fh,
-		     nullptr, 0, RGW_LOOKUP_FLAG_NONE);
-    ASSERT_EQ(ret, 0);
+
+      /* now move it */
+      ret = rgw_rename(fs,
+                       subdir1_fh, obj_name1.c_str(),
+                       subdir1_fh, obj_name2.c_str(),
+                       0 /* flags */);
+      ASSERT_EQ(ret, 0);
+      /* now check the result */
+      struct rgw_file_handle* name2_fh;
+      ret = rgw_lookup(fs, subdir1_fh, obj_name2.c_str(), &name2_fh,
+                       nullptr, 0, RGW_LOOKUP_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+      /* release file handle */
+      ret = rgw_fh_rele(fs, name2_fh, 0 /* flags */);
+      ASSERT_EQ(ret, 0);
+
+      /* we'll re-use subdir1_fh */
   }
-
-  /* now move it */
-  ret = rgw_rename(fs,
-		   subdir1_fh, obj_name1.c_str(),
-		   subdir1_fh, obj_name2.c_str(),
-		   0 /* flags */);
-  ASSERT_EQ(ret, 0);
-  /* now check the result */
-  struct rgw_file_handle* name2_fh;
-  ret = rgw_lookup(fs, subdir1_fh, obj_name2.c_str(), &name2_fh,
-		   nullptr, 0, RGW_LOOKUP_FLAG_NONE);
-  ASSERT_EQ(ret, 0);
-  /* release file handle */
-  ret = rgw_fh_rele(fs, name2_fh, 0 /* flags */);
-  ASSERT_EQ(ret, 0);
-
-  /* we'll re-use subdir1_fh */
 }
 
 TEST(LibRGW, CROSS_BUCKET_RENAME) {
@@ -227,26 +226,48 @@ TEST(LibRGW, CROSS_BUCKET_RENAME) {
 
       ret = make_object(subdir1_fh, obj_name1); // wyndemere/meep/tommy1
       ASSERT_EQ(ret, 0);
-  } else {
-    ret = rgw_lookup(fs, bucket2_fh, subdir2_name.c_str(), &subdir2_fh,
-		     nullptr, 0, RGW_LOOKUP_FLAG_NONE);
-    ASSERT_EQ(ret, 0);
-  }
 
-  /* now move it -- subdir2 is directory mork in bucket galahad */
-  ret = rgw_rename(fs,
-		   subdir1_fh, obj_name1.c_str(),
-		   subdir2_fh, obj_name3.c_str(),
-		   0 /* flags */);
-  ASSERT_EQ(ret, 0);
-  /* now check the result */
-  struct rgw_file_handle* name3_fh; // galahad/mork/zoot
-  ret = rgw_lookup(fs, subdir2_fh, obj_name3.c_str(), &name3_fh,
-		   nullptr, 0, RGW_LOOKUP_FLAG_NONE);
-  ASSERT_EQ(ret, 0);
-  /* release file handle */
-  ret = rgw_fh_rele(fs, name3_fh, 0 /* flags */);
-  ASSERT_EQ(ret, 0);
+      /* now move it -- subdir2 is directory mork in bucket galahad */
+      ret = rgw_rename(fs,
+                       subdir1_fh, obj_name1.c_str(),
+                       subdir2_fh, obj_name3.c_str(),
+                       0 /* flags */);
+      ASSERT_EQ(ret, 0);
+      /* now check the result */
+      struct rgw_file_handle* name3_fh; // galahad/mork/zoot
+      ret = rgw_lookup(fs, subdir2_fh, obj_name3.c_str(), &name3_fh,
+                       nullptr, 0, RGW_LOOKUP_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+      /* release file handle */
+      ret = rgw_fh_rele(fs, name3_fh, 0 /* flags */);
+      ASSERT_EQ(ret, 0);
+  }
+}
+
+TEST(LibRGW, RENAME_BUCKET)
+{
+  int ret{0};
+
+  if (do_create) {
+    struct stat st;
+
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
+    ret = rgw_mkdir(fs, fs->root_fh, bucket3_name.c_str(), &st, create_mask,
+                    &bucket3_fh, RGW_MKDIR_FLAG_NONE);
+    ASSERT_TRUE((ret == 0) || (ret == -EEXIST));
+    if (ret == 0) {
+      ret = rgw_fh_rele(fs, bucket1_fh, 0 /* flags */);
+      ASSERT_EQ(ret, 0);
+    }
+
+  /* now move it -- currently, librgw2 can't do this */
+    ret = rgw_rename(fs, fs->root_fh, bucket3_name.c_str(), fs->root_fh,
+                     bucket4_name.c_str(), 0 /* flags */);
+    ASSERT_EQ(ret, -EPERM);
+  } /* create */
 }
 
 TEST(LibRGW, CLEANUP)
@@ -254,14 +275,20 @@ TEST(LibRGW, CLEANUP)
   if (do_delete) {
     int ret{0};
 
-    ret = rgw_unlink(fs, subdir1_fh, obj_name1.c_str(), RGW_UNLINK_FLAG_NONE);
-    ret = rgw_unlink(fs, subdir1_fh, obj_name2.c_str(), RGW_UNLINK_FLAG_NONE);
-    ret = rgw_fh_rele(fs, subdir1_fh, 0 /* flags */);
-    ret = rgw_unlink(fs, bucket1_fh, subdir1_name.c_str(),
-                     RGW_UNLINK_FLAG_NONE);
+    if (subdir1_fh) {
+      ret = rgw_unlink(fs, subdir1_fh, obj_name1.c_str(), RGW_UNLINK_FLAG_NONE);
+      ret = rgw_unlink(fs, subdir1_fh, obj_name2.c_str(), RGW_UNLINK_FLAG_NONE);
+      ret = rgw_fh_rele(fs, subdir1_fh, 0 /* flags */);
+      ret = rgw_unlink(
+          fs, bucket1_fh, subdir1_name.c_str(), RGW_UNLINK_FLAG_NONE);
+    }
 
     ret = rgw_unlink(fs, bucket1_fh, obj_name1.c_str(), RGW_UNLINK_FLAG_NONE);
     ret = rgw_unlink(fs, bucket1_fh, obj_name2.c_str(), RGW_UNLINK_FLAG_NONE);
+    ret = rgw_unlink(fs, fs->root_fh, bucket3_name.c_str(),
+                     RGW_UNLINK_FLAG_NONE);
+    ret = rgw_unlink(fs, fs->root_fh, bucket4_name.c_str(),
+                     RGW_UNLINK_FLAG_NONE);
   }
 }
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
