### PR TITLE
objectstore: Reporting predicted available space

### DIFF
--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -181,6 +181,8 @@ class HealthTest(DashboardTestCase):
                     'total_used_bytes': int,
                     'total_used_raw_bytes': int,
                     'total_used_raw_ratio': float,
+                    'total_estimated_capacity': int,
+                    'total_estimated_avail_bytes': int,
                     'num_osds': int,
                     'num_per_pool_osds': int,
                     'num_per_pool_omap_osds': int

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1383,7 +1383,9 @@ public:
   store_statfs_t get_stat() const final {
     store_statfs_t st;
     st.total = segments.get_total_bytes();
+    st.total_raw = st.total;
     st.available = segments.get_total_bytes() - stats.used_bytes;
+    st.avail_raw = st.available;
     st.allocated = stats.used_bytes;
     st.data_stored = stats.used_bytes;
 
@@ -1747,7 +1749,9 @@ public:
   store_statfs_t get_stat() const final {
     store_statfs_t st;
     st.total = get_total_bytes();
+    st.total_raw = st.total;
     st.available = get_total_bytes() - get_journal_bytes() - stats.used_bytes;
+    st.avail_raw = st.available;
     st.allocated = get_journal_bytes() + stats.used_bytes;
     st.data_stored = get_journal_bytes() + stats.used_bytes;
     return st;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1383,9 +1383,9 @@ public:
   store_statfs_t get_stat() const final {
     store_statfs_t st;
     st.total = segments.get_total_bytes();
-    st.total_raw = st.total;
+    st.est_capacity = st.total;
     st.available = segments.get_total_bytes() - stats.used_bytes;
-    st.avail_raw = st.available;
+    st.est_available = st.available;
     st.allocated = stats.used_bytes;
     st.data_stored = stats.used_bytes;
 
@@ -1749,9 +1749,9 @@ public:
   store_statfs_t get_stat() const final {
     store_statfs_t st;
     st.total = get_total_bytes();
-    st.total_raw = st.total;
+    st.est_capacity = st.total;
     st.available = get_total_bytes() - get_journal_bytes() - stats.used_bytes;
-    st.avail_raw = st.available;
+    st.est_available = st.available;
     st.allocated = get_journal_bytes() + stats.used_bytes;
     st.data_stored = get_journal_bytes() + stats.used_bytes;
     return st;

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -851,10 +851,10 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     f->dump_int("total_bytes", osd_sum.statfs.total);
     f->dump_int("total_avail_bytes", osd_sum.statfs.available);
     f->dump_int("total_used_bytes", osd_sum.statfs.get_used());
-    f->dump_int("total_raw_bytes", osd_sum.statfs.total_raw);
-    f->dump_int("total_avail_raw_bytes", osd_sum.statfs.get_avail_raw());
     f->dump_int("total_used_raw_bytes", osd_sum.statfs.get_used_raw());
     f->dump_float("total_used_raw_ratio", osd_sum.statfs.get_used_raw_ratio());
+    f->dump_int("total_estimated_capacity", osd_sum.statfs.est_capacity);
+    f->dump_int("total_estimated_avail_bytes", osd_sum.statfs.est_available);
     f->dump_unsigned("num_osds", osd_sum.num_osds);
     f->dump_unsigned("num_per_pool_osds", osd_sum.num_per_pool_osds);
     f->dump_unsigned("num_per_pool_omap_osds", osd_sum.num_per_pool_omap_osds);
@@ -865,9 +865,9 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
       f->dump_int("total_bytes", i.second.statfs.total);
       f->dump_int("total_avail_bytes", i.second.statfs.available);
       f->dump_int("total_used_bytes", i.second.statfs.get_used());
-      f->dump_int("total_raw_bytes", i.second.statfs.total_raw);
-      f->dump_int("total_avail_raw_bytes", i.second.statfs.get_avail_raw());
       f->dump_int("total_used_raw_bytes", i.second.statfs.get_used_raw());
+      f->dump_int("total_estimated_capacity", i.second.statfs.est_capacity);
+      f->dump_int("total_estimated_avail_bytes", i.second.statfs.est_available);
       f->dump_float("total_used_raw_ratio",
 		    i.second.statfs.get_used_raw_ratio());
       f->close_section();
@@ -880,9 +880,9 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     tbl.define_column("SIZE", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("AVAIL", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("USED", TextTable::RIGHT, TextTable::RIGHT);
-    tbl.define_column("RAW AVAIL", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("RAW USED", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("%RAW USED", TextTable::RIGHT, TextTable::RIGHT);
+    tbl.define_column("EST AVAIL", TextTable::RIGHT, TextTable::RIGHT);
 
 
     for (auto& i : osd_sum_by_class) {
@@ -890,21 +890,21 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
       tbl << stringify(byte_u_t(i.second.statfs.total))
 	  << stringify(byte_u_t(i.second.statfs.available))
 	  << stringify(byte_u_t(i.second.statfs.get_used()))
-	  << stringify(byte_u_t(i.second.statfs.get_avail_raw()))
 	  << stringify(byte_u_t(i.second.statfs.get_used_raw()))
 	  << percentify(i.second.statfs.get_used_raw_ratio()*100.0)
+	  << stringify(byte_u_t(i.second.statfs.est_available))
 	  << TextTable::endrow;
     }
     tbl << "TOTAL";
     tbl << stringify(byte_u_t(osd_sum.statfs.total))
         << stringify(byte_u_t(osd_sum.statfs.available))
         << stringify(byte_u_t(osd_sum.statfs.get_used()))
-        << stringify(byte_u_t(osd_sum.statfs.get_avail_raw()))
         << stringify(byte_u_t(osd_sum.statfs.get_used_raw()))
-	<< percentify(osd_sum.statfs.get_used_raw_ratio()*100.0)
+        << percentify(osd_sum.statfs.get_used_raw_ratio()*100.0)
+        << stringify(byte_u_t(osd_sum.statfs.est_available))
 	<< TextTable::endrow;
 
-    *ss << "--- STORAGE ---\n";
+    *ss << "--- RAW STORAGE ---\n";
     *ss << tbl;
   }
 }

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -851,6 +851,8 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     f->dump_int("total_bytes", osd_sum.statfs.total);
     f->dump_int("total_avail_bytes", osd_sum.statfs.available);
     f->dump_int("total_used_bytes", osd_sum.statfs.get_used());
+    f->dump_int("total_raw_bytes", osd_sum.statfs.total_raw);
+    f->dump_int("total_avail_raw_bytes", osd_sum.statfs.get_avail_raw());
     f->dump_int("total_used_raw_bytes", osd_sum.statfs.get_used_raw());
     f->dump_float("total_used_raw_ratio", osd_sum.statfs.get_used_raw_ratio());
     f->dump_unsigned("num_osds", osd_sum.num_osds);
@@ -863,6 +865,8 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
       f->dump_int("total_bytes", i.second.statfs.total);
       f->dump_int("total_avail_bytes", i.second.statfs.available);
       f->dump_int("total_used_bytes", i.second.statfs.get_used());
+      f->dump_int("total_raw_bytes", i.second.statfs.total_raw);
+      f->dump_int("total_avail_raw_bytes", i.second.statfs.get_avail_raw());
       f->dump_int("total_used_raw_bytes", i.second.statfs.get_used_raw());
       f->dump_float("total_used_raw_ratio",
 		    i.second.statfs.get_used_raw_ratio());
@@ -876,6 +880,7 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     tbl.define_column("SIZE", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("AVAIL", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("USED", TextTable::RIGHT, TextTable::RIGHT);
+    tbl.define_column("RAW AVAIL", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("RAW USED", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("%RAW USED", TextTable::RIGHT, TextTable::RIGHT);
 
@@ -885,6 +890,7 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
       tbl << stringify(byte_u_t(i.second.statfs.total))
 	  << stringify(byte_u_t(i.second.statfs.available))
 	  << stringify(byte_u_t(i.second.statfs.get_used()))
+	  << stringify(byte_u_t(i.second.statfs.get_avail_raw()))
 	  << stringify(byte_u_t(i.second.statfs.get_used_raw()))
 	  << percentify(i.second.statfs.get_used_raw_ratio()*100.0)
 	  << TextTable::endrow;
@@ -893,11 +899,12 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     tbl << stringify(byte_u_t(osd_sum.statfs.total))
         << stringify(byte_u_t(osd_sum.statfs.available))
         << stringify(byte_u_t(osd_sum.statfs.get_used()))
+        << stringify(byte_u_t(osd_sum.statfs.get_avail_raw()))
         << stringify(byte_u_t(osd_sum.statfs.get_used_raw()))
 	<< percentify(osd_sum.statfs.get_used_raw_ratio()*100.0)
 	<< TextTable::endrow;
 
-    *ss << "--- RAW STORAGE ---\n";
+    *ss << "--- STORAGE ---\n";
     *ss << tbl;
   }
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12257,6 +12257,32 @@ int BlueStore::get_devices(set<string> *ls)
 
 void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
 {
+  auto estimate_capacity = [&](double total, double used, double stored) -> uint64_t {
+    // Use linear proportion: (total) is to (used) as (est_capacity) is to (stored).
+    // used/total:
+    // < 0.1%   est_capacity = total
+    // ...      interpolate
+    // > 1%     est_capacity = (total * stored) / used;
+    double est_capacity;
+    double low_range = 0.001;
+    double high_range = 0.01;
+    if (used < total * low_range) {
+      est_capacity = total;
+    } else {
+      double est_cap = total * stored / used;
+      if (used > total * high_range) {
+        est_capacity = est_cap;
+      } else {
+        double in_range = (used / total - low_range) * (1 / (high_range - low_range));
+        in_range = std::max(std::min(in_range, 1.), 0.); // make sure is <0..1>
+        est_capacity = total * (1. - in_range) + est_cap * in_range;
+      }
+    }
+    // make sure that est_capacity >= stored
+    est_capacity = std::max(est_capacity, stored);
+    return est_capacity;
+  };
+
   auto prefix = per_pool_omap == OMAP_BULK ?
     PREFIX_OMAP :
     per_pool_omap == OMAP_PER_POOL ?
@@ -12284,39 +12310,29 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
   ExtBlkDevState ebd_state;
   int rc = bdev->get_ebd_state(ebd_state);
   if (rc == 0) {
-    buf->total += ebd_state.get_physical_total();
+    uint64_t phy_total = ebd_state.get_physical_total();
+    uint64_t phy_avail = ebd_state.get_physical_avail();
+    buf->total += phy_total;
     // we are limited by both the size of the virtual device and the
     // underlying physical device.
     buf->available = std::min(bfree, ebd_state.get_physical_avail());
-    // fixme! create algorithm to provide better estimates
-    buf->est_capacity = buf->total;
-    buf->est_available = buf->available;
+    uint64_t est_capacity_by_phy = estimate_capacity(
+      phy_total, phy_total - phy_avail, buf->data_stored);
+    uint64_t log_total = ebd_state.get_logical_total();
+    uint64_t log_avail = ebd_state.get_logical_avail();
+    uint64_t est_capacity_by_log = estimate_capacity(
+      log_total, log_total - log_avail, buf->data_stored);
+    dout(20) << __func__ << " by_phy=" << est_capacity_by_phy
+      << " by_log=" << est_capacity_by_log << dendl;
+    buf->est_capacity = std::min(est_capacity_by_log, est_capacity_by_phy);
+    buf->est_available = std::max(buf->est_capacity - buf->data_stored, buf->available);
   } else {
-    buf->total += bdev->get_size();
-    buf->available = bfree;
-    // Use linear proportion: (total) is to (used) as (est_capacity) is to (stored).
-    // used/total:
-    // < 0.1%   est_capacity = total
-    // ...      interpolate
-    // > 1%     est_capacity = (total * stored) / used;
-    double total = buf->total;
-    double used = std::max(total - buf->available, 0.);
-
-    double low_range = 0.1;
-    double high_range = 1;
-    if (used < total * low_range) {
-      buf->est_capacity = buf->total;
-    } else {
-      double est_cap = total * buf->data_stored / used;
-      if (used > total * high_range) {
-        buf->est_capacity = est_cap;
-      } else {
-        double in_range = (used / total - low_range) * (1 / (high_range - low_range));
-        in_range = std::max(std::min(in_range, 1.), 0.); // make sure is <0..1>
-        buf->est_capacity = total * (1. - in_range) + est_cap * in_range;
-      }
-    }
-    buf->est_available = buf->est_capacity - buf->data_stored;
+    uint64_t dev_total = bdev->get_size();
+    buf->total += dev_total;
+    buf->available = std::min(bfree, dev_total); // min to make sure avail <= total
+    buf->est_capacity = estimate_capacity(
+      dev_total, dev_total - buf->available, buf->data_stored);
+    buf->est_available = std::max(buf->est_capacity - buf->data_stored, buf->available);
   }
 
   logger->set(l_bluestore_omap, buf->omap_allocated);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12257,8 +12257,6 @@ int BlueStore::get_devices(set<string> *ls)
 
 void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
 {
-  buf->reset();
-
   auto prefix = per_pool_omap == OMAP_BULK ?
     PREFIX_OMAP :
     per_pool_omap == OMAP_PER_POOL ?
@@ -12287,19 +12285,39 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
   int rc = bdev->get_ebd_state(ebd_state);
   if (rc == 0) {
     buf->total += ebd_state.get_physical_total();
-
     // we are limited by both the size of the virtual device and the
     // underlying physical device.
-    bfree = std::min(bfree, ebd_state.get_physical_avail());
-
-    buf->allocated = ebd_state.get_physical_total() - ebd_state.get_physical_avail();;
+    buf->available = std::min(bfree, ebd_state.get_physical_avail());
+    // fixme! create algorithm to provide better estimates
+    buf->est_capacity = buf->total;
+    buf->est_available = buf->available;
   } else {
     buf->total += bdev->get_size();
+    buf->available = bfree;
+    // Use linear proportion: (total) is to (used) as (est_capacity) is to (stored).
+    // used/total:
+    // < 0.1%   est_capacity = total
+    // ...      interpolate
+    // > 1%     est_capacity = (total * stored) / used;
+    double total = buf->total;
+    double used = std::max(total - buf->available, 0.);
+
+    double low_range = 0.1;
+    double high_range = 1;
+    if (used < total * low_range) {
+      buf->est_capacity = buf->total;
+    } else {
+      double est_cap = total * buf->data_stored / used;
+      if (used > total * high_range) {
+        buf->est_capacity = est_cap;
+      } else {
+        double in_range = (used / total - low_range) * (1 / (high_range - low_range));
+        in_range = std::max(std::min(in_range, 1.), 0.); // make sure is <0..1>
+        buf->est_capacity = total * (1. - in_range) + est_cap * in_range;
+      }
+    }
+    buf->est_available = buf->est_capacity - buf->data_stored;
   }
-  buf->available = bfree;
-  // fixme! create algorithm to provide better estimates
-  buf->est_capacity = buf->total;
-  buf->est_available = buf->available;
 
   logger->set(l_bluestore_omap, buf->omap_allocated);
 }
@@ -12311,7 +12329,7 @@ int BlueStore::statfs(struct store_statfs_t *buf,
     alerts->clear();
     _log_alerts(*alerts);
   }
-  _get_statfs_overall(buf);
+  buf->reset();
   {
     std::lock_guard l(vstatfs_lock);
     buf->allocated = vstatfs.allocated();
@@ -12320,6 +12338,7 @@ int BlueStore::statfs(struct store_statfs_t *buf,
     buf->data_compressed_original = vstatfs.compressed_original();
     buf->data_compressed_allocated = vstatfs.compressed_allocated();
   }
+  _get_statfs_overall(buf);
 
   dout(20) << __func__ << " " << *buf << dendl;
   return 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12273,7 +12273,9 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
     buf->internally_reserved = 0;
     // include dedicated db, too, if that isn't the shared device.
     if (bluefs_layout.shared_bdev != BlueFS::BDEV_DB) {
-      buf->total += bluefs->get_block_device_size(BlueFS::BDEV_DB);
+      uint64_t s = bluefs->get_block_device_size(BlueFS::BDEV_DB);
+      buf->total += s;
+      buf->internally_reserved += s;
     }
     // call any non-omap bluefs space "internal metadata"
     buf->internal_metadata =
@@ -12295,6 +12297,9 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
     buf->total += bdev->get_size();
   }
   buf->available = bfree;
+  // fixme! create algorithm to provide better estimates
+  buf->est_capacity = buf->total;
+  buf->est_available = buf->available;
 
   logger->set(l_bluestore_omap, buf->omap_allocated);
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1108,7 +1108,9 @@ float OSDService::compute_adjusted_ratio(osd_stat_t new_stat, float *pratio,
   if (backfill_adjusted) {
     dout(20) << __func__ << " backfill adjusted " << new_stat << dendl;
   }
-  return ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
+  float ratio = ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
+  dout(5) << __func__ << " ratio:" << ratio << " pratio: " << *pratio << dendl;
+  return ratio;
 }
 
 void OSDService::send_message_osd_cluster(int peer, Message *m, epoch_t from_epoch)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1108,9 +1108,7 @@ float OSDService::compute_adjusted_ratio(osd_stat_t new_stat, float *pratio,
   if (backfill_adjusted) {
     dout(20) << __func__ << " backfill adjusted " << new_stat << dendl;
   }
-  float ratio = ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
-  dout(5) << __func__ << " ratio:" << ratio << " pratio: " << *pratio << dendl;
-  return ratio;
+  return ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
 }
 
 void OSDService::send_message_osd_cluster(int peer, Message *m, epoch_t from_epoch)

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -7069,15 +7069,12 @@ protected:
       dumped_osds.insert(qi.id);
     float reweight = qi.is_bucket() ? -1 : osdmap->get_weightf(qi.id);
     int64_t kb = 0, kb_used = 0, kb_used_data = 0, kb_used_omap = 0,
-      kb_used_meta = 0, kb_avail = 0, kb_used_raw = 0, kb_avail_raw = 0;
+      kb_used_meta = 0, kb_avail = 0;
     double util = 0;
     if (get_bucket_utilization(qi.id, &kb, &kb_used, &kb_used_data,
-			       &kb_used_omap, &kb_used_meta, &kb_avail,
-			       &kb_used_raw, &kb_avail_raw)) {
-      auto kb_raw = kb_used_raw + kb_avail_raw;
-      if (kb_raw)
-        util = 100.0 * (double)kb_used_raw / (double)kb_raw;
-    }
+			       &kb_used_omap, &kb_used_meta, &kb_avail))
+      if (kb_used && kb)
+        util = 100.0 * (double)kb_used / (double)kb;
 
     double var = 1.0;
     if (average_util)
@@ -7087,8 +7084,7 @@ protected:
 
     dump_item(qi, reweight, kb, kb_used,
 	      kb_used_data, kb_used_omap, kb_used_meta,
-	      kb_avail, util, kb_used_raw, kb_avail_raw,
-	      var, num_pgs, f);
+	      kb_avail, util, var, num_pgs, f);
 
     if (!qi.is_bucket() && reweight > 0) {
       if (min_var < 0 || var < min_var)
@@ -7112,8 +7108,6 @@ protected:
 			 int64_t kb_used_meta,
 			 int64_t kb_avail,
 			 double& util,
-			 int64_t kb_used_raw,
-			 int64_t kb_avail_raw,
 			 double& var,
 			 const size_t num_pgs,
 			 F *f) = 0;
@@ -7130,10 +7124,9 @@ protected:
           !should_dump(i))
 	continue;
       int64_t kb_i, kb_used_i, kb_used_data_i, kb_used_omap_i, kb_used_meta_i,
-	kb_avail_i, kb_used_raw_i, kb_avail_raw_i;
+	kb_avail_i;
       if (get_osd_utilization(i, &kb_i, &kb_used_i, &kb_used_data_i,
-			      &kb_used_omap_i, &kb_used_meta_i, &kb_avail_i,
-			      &kb_used_raw_i, &kb_avail_raw_i)) {
+			      &kb_used_omap_i, &kb_used_meta_i, &kb_avail_i)) {
 	kb += kb_i;
 	kb_used += kb_used_i;
       }
@@ -7145,19 +7138,15 @@ protected:
 			   int64_t* kb_used_data,
 			   int64_t* kb_used_omap,
 			   int64_t* kb_used_meta,
-			   int64_t* kb_avail,
-			   int64_t* kb_used_raw,
-			   int64_t* kb_avail_raw) const {
+			   int64_t* kb_avail) const {
     const osd_stat_t *p = pgmap.get_osd_stat(id);
     if (!p) return false;
     *kb = p->statfs.kb();
-    *kb_used = p->statfs.kb_used();
+    *kb_used = p->statfs.kb_used_raw();
     *kb_used_data = p->statfs.kb_used_data();
     *kb_used_omap = p->statfs.kb_used_omap();
     *kb_used_meta = p->statfs.kb_used_internal_metadata();
     *kb_avail = p->statfs.kb_avail();
-    *kb_used_raw = p->statfs.kb_used_raw();
-    *kb_avail_raw = p->statfs.kb_avail_raw();
     
     return true;
   }
@@ -7166,10 +7155,7 @@ protected:
 			      int64_t* kb_used_data,
 			      int64_t* kb_used_omap,
 			      int64_t* kb_used_meta,
-			      int64_t* kb_avail,
-			      int64_t* kb_used_raw,
-			      int64_t* kb_avail_raw
-			      ) const {
+			      int64_t* kb_avail) const {
     if (id >= 0) {
       if (osdmap->is_out(id) || !should_dump(id)) {
         *kb = 0;
@@ -7178,13 +7164,10 @@ protected:
 	*kb_used_omap = 0;
 	*kb_used_meta = 0;
         *kb_avail = 0;
-        *kb_used_raw = 0;
-        *kb_avail_raw = 0;
         return true;
       }
       return get_osd_utilization(id, kb, kb_used, kb_used_data,
-				 kb_used_omap, kb_used_meta, kb_avail,
-				 kb_used_raw, kb_avail_raw);
+				 kb_used_omap, kb_used_meta, kb_avail);
     }
 
     *kb = 0;
@@ -7193,18 +7176,14 @@ protected:
     *kb_used_omap = 0;
     *kb_used_meta = 0;
     *kb_avail = 0;
-    *kb_used_raw = 0;
-    *kb_avail_raw = 0;
 
     for (int k = osdmap->crush->get_bucket_size(id) - 1; k >= 0; k--) {
       int item = osdmap->crush->get_bucket_item(id, k);
       int64_t kb_i = 0, kb_used_i = 0, kb_used_data_i = 0,
-	kb_used_omap_i = 0, kb_used_meta_i = 0, kb_avail_i = 0,
-	kb_used_raw_i = 0, kb_avail_raw_i = 0;
+	kb_used_omap_i = 0, kb_used_meta_i = 0, kb_avail_i = 0;
       if (!get_bucket_utilization(item, &kb_i, &kb_used_i,
 				  &kb_used_data_i, &kb_used_omap_i,
-				  &kb_used_meta_i, &kb_avail_i,
-				  &kb_used_raw_i, &kb_avail_raw_i))
+				  &kb_used_meta_i, &kb_avail_i))
 	return false;
       *kb += kb_i;
       *kb_used += kb_used_i;
@@ -7212,8 +7191,6 @@ protected:
       *kb_used_omap += kb_used_omap_i;
       *kb_used_meta += kb_used_meta_i;
       *kb_avail += kb_avail_i;
-      *kb_used_raw += kb_used_raw_i;
-      *kb_avail_raw += kb_avail_raw_i;
     }
     return true;
   }
@@ -7248,14 +7225,14 @@ public:
     tbl->define_column("WEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("REWEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("SIZE", TextTable::LEFT, TextTable::RIGHT);
-    tbl->define_column("USE", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("RAW USE", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("DATA", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("OMAP", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("META", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("%USE", TextTable::LEFT, TextTable::RIGHT);
-    tbl->define_column("RAW USE", TextTable::LEFT, TextTable::RIGHT);
-    tbl->define_column("RAW AVAIL", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("EST AVAIL", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("EST CAPAC", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("VAR", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("PGS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("STATUS", TextTable::LEFT, TextTable::RIGHT);
@@ -7271,14 +7248,14 @@ public:
 	 << ""
 	 << "" << "TOTAL"
 	 << byte_u_t(sum.statfs.total)
-	 << byte_u_t(sum.statfs.get_used())
+	 << byte_u_t(sum.statfs.get_used_raw())
 	 << byte_u_t(sum.statfs.allocated)
 	 << byte_u_t(sum.statfs.omap_allocated)
 	 << byte_u_t(sum.statfs.internal_metadata)
 	 << byte_u_t(sum.statfs.available)
 	 << lowprecision_t(average_util)
-	 << byte_u_t(sum.statfs.get_used_raw())
-	 << byte_u_t(sum.statfs.get_avail_raw())
+	 << byte_u_t(sum.statfs.est_available)
+	 << byte_u_t(sum.statfs.est_capacity)
 	 << ""
 	 << TextTable::endrow;
   }
@@ -7300,8 +7277,6 @@ protected:
 			 int64_t kb_used_meta,
 			 int64_t kb_avail,
 			 double& util,
-			 int64_t kb_used_raw,
-			 int64_t kb_avail_raw,
 			 double& var,
 			 const size_t num_pgs,
 			 TextTable *tbl) override {
@@ -7319,8 +7294,6 @@ protected:
 	 << byte_u_t(kb_used_meta << 10)
 	 << byte_u_t(kb_avail << 10)
 	 << lowprecision_t(util)
-	 << byte_u_t(kb_used_raw << 10)
-	 << byte_u_t(kb_avail_raw << 10)
 	 << lowprecision_t(var);
 
     if (qi.is_bucket()) {
@@ -7407,8 +7380,6 @@ protected:
 		 int64_t kb_used_meta,
 		 int64_t kb_avail,
 		 double& util,
-		 int64_t kb_used_raw, //FIXME
-		 int64_t kb_avail_raw,
 		 double& var,
 		 const size_t num_pgs,
 		 Formatter *f) override {
@@ -7422,8 +7393,6 @@ protected:
     f->dump_int("kb_used_meta", kb_used_meta);
     f->dump_int("kb_avail", kb_avail);
     f->dump_float("utilization", util);
-    f->dump_int("kb_used_raw", kb_used_raw);
-    f->dump_int("kb_avail_raw", kb_avail_raw);
     f->dump_float("var", var);
     f->dump_unsigned("pgs", num_pgs);
     if (!qi.is_bucket()) {
@@ -7446,14 +7415,12 @@ public:
     auto& s = sum.statfs;
 
     f->dump_int("total_kb", s.kb());
-    f->dump_int("total_kb_used", s.kb_used());
+    f->dump_int("total_kb_used", s.kb_used_raw());
     f->dump_int("total_kb_used_data", s.kb_used_data());
     f->dump_int("total_kb_used_omap", s.kb_used_omap());
     f->dump_int("total_kb_used_meta", s.kb_used_internal_metadata());
     f->dump_int("total_kb_avail", s.kb_avail());
     f->dump_float("average_utilization", average_util);
-    f->dump_int("total_kb_used_raw", s.kb_used_raw());
-    f->dump_int("total_kb_avail_raw", s.kb_avail_raw());
     f->dump_float("min_var", min_var);
     f->dump_float("max_var", max_var);
     f->dump_float("dev", dev());

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -7069,12 +7069,15 @@ protected:
       dumped_osds.insert(qi.id);
     float reweight = qi.is_bucket() ? -1 : osdmap->get_weightf(qi.id);
     int64_t kb = 0, kb_used = 0, kb_used_data = 0, kb_used_omap = 0,
-      kb_used_meta = 0, kb_avail = 0;
+      kb_used_meta = 0, kb_avail = 0, kb_used_raw = 0, kb_avail_raw = 0;
     double util = 0;
     if (get_bucket_utilization(qi.id, &kb, &kb_used, &kb_used_data,
-			       &kb_used_omap, &kb_used_meta, &kb_avail))
-      if (kb_used && kb)
-        util = 100.0 * (double)kb_used / (double)kb;
+			       &kb_used_omap, &kb_used_meta, &kb_avail,
+			       &kb_used_raw, &kb_avail_raw)) {
+      auto kb_raw = kb_used_raw + kb_avail_raw;
+      if (kb_raw)
+        util = 100.0 * (double)kb_used_raw / (double)kb_raw;
+    }
 
     double var = 1.0;
     if (average_util)
@@ -7084,7 +7087,8 @@ protected:
 
     dump_item(qi, reweight, kb, kb_used,
 	      kb_used_data, kb_used_omap, kb_used_meta,
-	      kb_avail, util, var, num_pgs, f);
+	      kb_avail, util, kb_used_raw, kb_avail_raw,
+	      var, num_pgs, f);
 
     if (!qi.is_bucket() && reweight > 0) {
       if (min_var < 0 || var < min_var)
@@ -7108,6 +7112,8 @@ protected:
 			 int64_t kb_used_meta,
 			 int64_t kb_avail,
 			 double& util,
+			 int64_t kb_used_raw,
+			 int64_t kb_avail_raw,
 			 double& var,
 			 const size_t num_pgs,
 			 F *f) = 0;
@@ -7124,9 +7130,10 @@ protected:
           !should_dump(i))
 	continue;
       int64_t kb_i, kb_used_i, kb_used_data_i, kb_used_omap_i, kb_used_meta_i,
-	kb_avail_i;
+	kb_avail_i, kb_used_raw_i, kb_avail_raw_i;
       if (get_osd_utilization(i, &kb_i, &kb_used_i, &kb_used_data_i,
-			      &kb_used_omap_i, &kb_used_meta_i, &kb_avail_i)) {
+			      &kb_used_omap_i, &kb_used_meta_i, &kb_avail_i,
+			      &kb_used_raw_i, &kb_avail_raw_i)) {
 	kb += kb_i;
 	kb_used += kb_used_i;
       }
@@ -7138,15 +7145,19 @@ protected:
 			   int64_t* kb_used_data,
 			   int64_t* kb_used_omap,
 			   int64_t* kb_used_meta,
-			   int64_t* kb_avail) const {
+			   int64_t* kb_avail,
+			   int64_t* kb_used_raw,
+			   int64_t* kb_avail_raw) const {
     const osd_stat_t *p = pgmap.get_osd_stat(id);
     if (!p) return false;
     *kb = p->statfs.kb();
-    *kb_used = p->statfs.kb_used_raw();
+    *kb_used = p->statfs.kb_used();
     *kb_used_data = p->statfs.kb_used_data();
     *kb_used_omap = p->statfs.kb_used_omap();
     *kb_used_meta = p->statfs.kb_used_internal_metadata();
     *kb_avail = p->statfs.kb_avail();
+    *kb_used_raw = p->statfs.kb_used_raw();
+    *kb_avail_raw = p->statfs.kb_avail_raw();
     
     return true;
   }
@@ -7155,7 +7166,10 @@ protected:
 			      int64_t* kb_used_data,
 			      int64_t* kb_used_omap,
 			      int64_t* kb_used_meta,
-			      int64_t* kb_avail) const {
+			      int64_t* kb_avail,
+			      int64_t* kb_used_raw,
+			      int64_t* kb_avail_raw
+			      ) const {
     if (id >= 0) {
       if (osdmap->is_out(id) || !should_dump(id)) {
         *kb = 0;
@@ -7164,10 +7178,13 @@ protected:
 	*kb_used_omap = 0;
 	*kb_used_meta = 0;
         *kb_avail = 0;
+        *kb_used_raw = 0;
+        *kb_avail_raw = 0;
         return true;
       }
       return get_osd_utilization(id, kb, kb_used, kb_used_data,
-				 kb_used_omap, kb_used_meta, kb_avail);
+				 kb_used_omap, kb_used_meta, kb_avail,
+				 kb_used_raw, kb_avail_raw);
     }
 
     *kb = 0;
@@ -7176,14 +7193,18 @@ protected:
     *kb_used_omap = 0;
     *kb_used_meta = 0;
     *kb_avail = 0;
+    *kb_used_raw = 0;
+    *kb_avail_raw = 0;
 
     for (int k = osdmap->crush->get_bucket_size(id) - 1; k >= 0; k--) {
       int item = osdmap->crush->get_bucket_item(id, k);
       int64_t kb_i = 0, kb_used_i = 0, kb_used_data_i = 0,
-	kb_used_omap_i = 0, kb_used_meta_i = 0, kb_avail_i = 0;
+	kb_used_omap_i = 0, kb_used_meta_i = 0, kb_avail_i = 0,
+	kb_used_raw_i = 0, kb_avail_raw_i = 0;
       if (!get_bucket_utilization(item, &kb_i, &kb_used_i,
 				  &kb_used_data_i, &kb_used_omap_i,
-				  &kb_used_meta_i, &kb_avail_i))
+				  &kb_used_meta_i, &kb_avail_i,
+				  &kb_used_raw_i, &kb_avail_raw_i))
 	return false;
       *kb += kb_i;
       *kb_used += kb_used_i;
@@ -7191,6 +7212,8 @@ protected:
       *kb_used_omap += kb_used_omap_i;
       *kb_used_meta += kb_used_meta_i;
       *kb_avail += kb_avail_i;
+      *kb_used_raw += kb_used_raw_i;
+      *kb_avail_raw += kb_avail_raw_i;
     }
     return true;
   }
@@ -7225,12 +7248,14 @@ public:
     tbl->define_column("WEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("REWEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("SIZE", TextTable::LEFT, TextTable::RIGHT);
-    tbl->define_column("RAW USE", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("USE", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("DATA", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("OMAP", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("META", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("%USE", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("RAW USE", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("RAW AVAIL", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("VAR", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("PGS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("STATUS", TextTable::LEFT, TextTable::RIGHT);
@@ -7246,12 +7271,14 @@ public:
 	 << ""
 	 << "" << "TOTAL"
 	 << byte_u_t(sum.statfs.total)
-	 << byte_u_t(sum.statfs.get_used_raw())
+	 << byte_u_t(sum.statfs.get_used())
 	 << byte_u_t(sum.statfs.allocated)
 	 << byte_u_t(sum.statfs.omap_allocated)
 	 << byte_u_t(sum.statfs.internal_metadata)
 	 << byte_u_t(sum.statfs.available)
 	 << lowprecision_t(average_util)
+	 << byte_u_t(sum.statfs.get_used_raw())
+	 << byte_u_t(sum.statfs.get_avail_raw())
 	 << ""
 	 << TextTable::endrow;
   }
@@ -7273,6 +7300,8 @@ protected:
 			 int64_t kb_used_meta,
 			 int64_t kb_avail,
 			 double& util,
+			 int64_t kb_used_raw,
+			 int64_t kb_avail_raw,
 			 double& var,
 			 const size_t num_pgs,
 			 TextTable *tbl) override {
@@ -7290,6 +7319,8 @@ protected:
 	 << byte_u_t(kb_used_meta << 10)
 	 << byte_u_t(kb_avail << 10)
 	 << lowprecision_t(util)
+	 << byte_u_t(kb_used_raw << 10)
+	 << byte_u_t(kb_avail_raw << 10)
 	 << lowprecision_t(var);
 
     if (qi.is_bucket()) {
@@ -7376,6 +7407,8 @@ protected:
 		 int64_t kb_used_meta,
 		 int64_t kb_avail,
 		 double& util,
+		 int64_t kb_used_raw, //FIXME
+		 int64_t kb_avail_raw,
 		 double& var,
 		 const size_t num_pgs,
 		 Formatter *f) override {
@@ -7389,6 +7422,8 @@ protected:
     f->dump_int("kb_used_meta", kb_used_meta);
     f->dump_int("kb_avail", kb_avail);
     f->dump_float("utilization", util);
+    f->dump_int("kb_used_raw", kb_used_raw);
+    f->dump_int("kb_avail_raw", kb_avail_raw);
     f->dump_float("var", var);
     f->dump_unsigned("pgs", num_pgs);
     if (!qi.is_bucket()) {
@@ -7411,12 +7446,14 @@ public:
     auto& s = sum.statfs;
 
     f->dump_int("total_kb", s.kb());
-    f->dump_int("total_kb_used", s.kb_used_raw());
+    f->dump_int("total_kb_used", s.kb_used());
     f->dump_int("total_kb_used_data", s.kb_used_data());
     f->dump_int("total_kb_used_omap", s.kb_used_omap());
     f->dump_int("total_kb_used_meta", s.kb_used_internal_metadata());
     f->dump_int("total_kb_avail", s.kb_avail());
     f->dump_float("average_utilization", average_util);
+    f->dump_int("total_kb_used_raw", s.kb_used_raw());
+    f->dump_int("total_kb_avail_raw", s.kb_avail_raw());
     f->dump_float("min_var", min_var);
     f->dump_float("max_var", max_var);
     f->dump_float("dev", dev());

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -7059,6 +7059,16 @@ protected:
     }
   }
 
+  struct common_stat_t {
+    int64_t kb = 0;
+		int64_t kb_used = 0;
+		int64_t kb_used_data = 0;
+		int64_t kb_used_omap = 0;
+		int64_t kb_used_meta = 0;
+		int64_t kb_avail = 0;
+		int64_t kb_est_avail = 0;
+		int64_t kb_est_capac = 0;
+  };
   void dump_item(const CrushTreeDumper::Item &qi, F *f) override {
     if (!tree && (qi.is_bucket() || dumped_osds.count(qi.id)))
       return;
@@ -7068,13 +7078,11 @@ protected:
     if (!qi.is_bucket())
       dumped_osds.insert(qi.id);
     float reweight = qi.is_bucket() ? -1 : osdmap->get_weightf(qi.id);
-    int64_t kb = 0, kb_used = 0, kb_used_data = 0, kb_used_omap = 0,
-      kb_used_meta = 0, kb_avail = 0;
+    common_stat_t cs;
     double util = 0;
-    if (get_bucket_utilization(qi.id, &kb, &kb_used, &kb_used_data,
-			       &kb_used_omap, &kb_used_meta, &kb_avail))
-      if (kb_used && kb)
-        util = 100.0 * (double)kb_used / (double)kb;
+    if (get_bucket_utilization(qi.id, cs))
+      if (cs.kb_used && cs.kb)
+        util = 100.0 * (double)cs.kb_used / (double)cs.kb;
 
     double var = 1.0;
     if (average_util)
@@ -7082,9 +7090,7 @@ protected:
 
     size_t num_pgs = qi.is_bucket() ? 0 : pgmap.get_num_pg_by_osd(qi.id);
 
-    dump_item(qi, reweight, kb, kb_used,
-	      kb_used_data, kb_used_omap, kb_used_meta,
-	      kb_avail, util, var, num_pgs, f);
+    dump_item(qi, reweight, cs, util, var, num_pgs, f);
 
     if (!qi.is_bucket() && reweight > 0) {
       if (min_var < 0 || var < min_var)
@@ -7098,15 +7104,9 @@ protected:
       sum += reweight;
     }
   }
-
   virtual void dump_item(const CrushTreeDumper::Item &qi,
 			 float &reweight,
-			 int64_t kb,
-			 int64_t kb_used,
-			 int64_t kb_used_data,
-			 int64_t kb_used_omap,
-			 int64_t kb_used_meta,
-			 int64_t kb_avail,
+			 const common_stat_t& cs,
 			 double& util,
 			 double& var,
 			 const size_t num_pgs,
@@ -7123,74 +7123,52 @@ protected:
            osdmap->get_weight(i) == 0 ||
           !should_dump(i))
 	continue;
-      int64_t kb_i, kb_used_i, kb_used_data_i, kb_used_omap_i, kb_used_meta_i,
-	kb_avail_i;
-      if (get_osd_utilization(i, &kb_i, &kb_used_i, &kb_used_data_i,
-			      &kb_used_omap_i, &kb_used_meta_i, &kb_avail_i)) {
-	kb += kb_i;
-	kb_used += kb_used_i;
+      common_stat_t cs;
+      if (get_osd_utilization(i, cs)) {
+	kb += cs.kb;
+	kb_used += cs.kb_used;
       }
     }
     return kb > 0 ? 100.0 * (double)kb_used / (double)kb : 0;
   }
 
-  bool get_osd_utilization(int id, int64_t* kb, int64_t* kb_used,
-			   int64_t* kb_used_data,
-			   int64_t* kb_used_omap,
-			   int64_t* kb_used_meta,
-			   int64_t* kb_avail) const {
+  bool get_osd_utilization(int id, common_stat_t& cs) const {
     const osd_stat_t *p = pgmap.get_osd_stat(id);
     if (!p) return false;
-    *kb = p->statfs.kb();
-    *kb_used = p->statfs.kb_used_raw();
-    *kb_used_data = p->statfs.kb_used_data();
-    *kb_used_omap = p->statfs.kb_used_omap();
-    *kb_used_meta = p->statfs.kb_used_internal_metadata();
-    *kb_avail = p->statfs.kb_avail();
-    
+    cs.kb = p->statfs.kb();
+    cs.kb_used = p->statfs.kb_used_raw();
+    cs.kb_used_data = p->statfs.kb_used_data();
+    cs.kb_used_omap = p->statfs.kb_used_omap();
+    cs.kb_used_meta = p->statfs.kb_used_internal_metadata();
+    cs.kb_avail = p->statfs.kb_avail();
+    cs.kb_est_avail = p->statfs.kb_est_avail();
+    cs.kb_est_capac = p->statfs.kb_est_capac();
     return true;
   }
 
-  bool get_bucket_utilization(int id, int64_t* kb, int64_t* kb_used,
-			      int64_t* kb_used_data,
-			      int64_t* kb_used_omap,
-			      int64_t* kb_used_meta,
-			      int64_t* kb_avail) const {
+  bool get_bucket_utilization(int id, common_stat_t& cs) const {
     if (id >= 0) {
       if (osdmap->is_out(id) || !should_dump(id)) {
-        *kb = 0;
-        *kb_used = 0;
-	*kb_used_data = 0;
-	*kb_used_omap = 0;
-	*kb_used_meta = 0;
-        *kb_avail = 0;
+        cs = common_stat_t();
         return true;
       }
-      return get_osd_utilization(id, kb, kb_used, kb_used_data,
-				 kb_used_omap, kb_used_meta, kb_avail);
+      return get_osd_utilization(id, cs);
     }
 
-    *kb = 0;
-    *kb_used = 0;
-    *kb_used_data = 0;
-    *kb_used_omap = 0;
-    *kb_used_meta = 0;
-    *kb_avail = 0;
-
+    cs = common_stat_t();
     for (int k = osdmap->crush->get_bucket_size(id) - 1; k >= 0; k--) {
       int item = osdmap->crush->get_bucket_item(id, k);
-      int64_t kb_i = 0, kb_used_i = 0, kb_used_data_i = 0,
-	kb_used_omap_i = 0, kb_used_meta_i = 0, kb_avail_i = 0;
-      if (!get_bucket_utilization(item, &kb_i, &kb_used_i,
-				  &kb_used_data_i, &kb_used_omap_i,
-				  &kb_used_meta_i, &kb_avail_i))
+      common_stat_t cs_i;
+      if (!get_bucket_utilization(item, cs_i))
 	return false;
-      *kb += kb_i;
-      *kb_used += kb_used_i;
-      *kb_used_data += kb_used_data_i;
-      *kb_used_omap += kb_used_omap_i;
-      *kb_used_meta += kb_used_meta_i;
-      *kb_avail += kb_avail_i;
+      cs.kb += cs_i.kb;
+      cs.kb_used += cs_i.kb_used;
+      cs.kb_used_data += cs_i.kb_used_data;
+      cs.kb_used_omap += cs_i.kb_used_omap;
+      cs.kb_used_meta += cs_i.kb_used_meta;
+      cs.kb_avail += cs_i.kb_avail;
+      cs.kb_est_avail += cs_i.kb_est_avail;
+      cs.kb_est_capac += cs_i.kb_est_capac;
     }
     return true;
   }
@@ -7270,12 +7248,7 @@ protected:
   using OSDUtilizationDumper<TextTable>::dump_item;
   void dump_item(const CrushTreeDumper::Item &qi,
 			 float &reweight,
-			 int64_t kb,
-			 int64_t kb_used,
-			 int64_t kb_used_data,
-			 int64_t kb_used_omap,
-			 int64_t kb_used_meta,
-			 int64_t kb_avail,
+			 const common_stat_t& cs,
 			 double& util,
 			 double& var,
 			 const size_t num_pgs,
@@ -7287,13 +7260,15 @@ protected:
 	 << c
 	 << weightf_t(qi.weight)
 	 << weightf_t(reweight)
-	 << byte_u_t(kb << 10)
-	 << byte_u_t(kb_used << 10)
-	 << byte_u_t(kb_used_data << 10)
-	 << byte_u_t(kb_used_omap << 10)
-	 << byte_u_t(kb_used_meta << 10)
-	 << byte_u_t(kb_avail << 10)
+	 << byte_u_t(cs.kb << 10)
+	 << byte_u_t(cs.kb_used << 10)
+	 << byte_u_t(cs.kb_used_data << 10)
+	 << byte_u_t(cs.kb_used_omap << 10)
+	 << byte_u_t(cs.kb_used_meta << 10)
+	 << byte_u_t(cs.kb_avail << 10)
 	 << lowprecision_t(util)
+	 << byte_u_t(cs.kb_est_avail << 10)
+	 << byte_u_t(cs.kb_est_capac << 10)
 	 << lowprecision_t(var);
 
     if (qi.is_bucket()) {
@@ -7373,12 +7348,7 @@ protected:
   using OSDUtilizationDumper<Formatter>::dump_item;
   void dump_item(const CrushTreeDumper::Item &qi,
 		 float &reweight,
-		 int64_t kb,
-		 int64_t kb_used,
-		 int64_t kb_used_data,
-		 int64_t kb_used_omap,
-		 int64_t kb_used_meta,
-		 int64_t kb_avail,
+		 const common_stat_t& cs,
 		 double& util,
 		 double& var,
 		 const size_t num_pgs,
@@ -7386,13 +7356,15 @@ protected:
     f->open_object_section("item");
     CrushTreeDumper::dump_item_fields(crush, weight_set_names, qi, f);
     f->dump_float("reweight", reweight);
-    f->dump_int("kb", kb);
-    f->dump_int("kb_used", kb_used);
-    f->dump_int("kb_used_data", kb_used_data);
-    f->dump_int("kb_used_omap", kb_used_omap);
-    f->dump_int("kb_used_meta", kb_used_meta);
-    f->dump_int("kb_avail", kb_avail);
+    f->dump_int("kb", cs.kb);
+    f->dump_int("kb_used", cs.kb_used);
+    f->dump_int("kb_used_data", cs.kb_used_data);
+    f->dump_int("kb_used_omap", cs.kb_used_omap);
+    f->dump_int("kb_used_meta", cs.kb_used_meta);
+    f->dump_int("kb_avail", cs.kb_avail);
     f->dump_float("utilization", util);
+    f->dump_int("kb_est_avail", cs.kb_est_avail);
+    f->dump_int("kb_est_capac", cs.kb_est_capac);
     f->dump_float("var", var);
     f->dump_unsigned("pgs", num_pgs);
     if (!qi.is_bucket()) {
@@ -7421,6 +7393,8 @@ public:
     f->dump_int("total_kb_used_meta", s.kb_used_internal_metadata());
     f->dump_int("total_kb_avail", s.kb_avail());
     f->dump_float("average_utilization", average_util);
+    f->dump_int("kb_est_avail", s.kb_est_avail());
+    f->dump_int("kb_est_capac", s.kb_est_capac());
     f->dump_float("min_var", min_var);
     f->dump_float("max_var", max_var);
     f->dump_float("dev", dev());

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -633,6 +633,8 @@ void osd_stat_t::decode(ceph::buffer::list::const_iterator &bl)
     } else {
       statfs.internally_reserved = 0;
     }
+    statfs.total_raw = kb << 10;
+    statfs.avail_raw = kb_avail << 10;
     statfs.allocated = kb_used_data << 10;
     statfs.omap_allocated = kb_used_omap << 10;
     statfs.internal_metadata = kb_used_meta << 10;
@@ -3373,8 +3375,10 @@ bool store_statfs_t::operator==(const store_statfs_t& other) const
 {
   return total == other.total
     && available == other.available
-    && allocated == other.allocated
     && internally_reserved == other.internally_reserved
+    && total_raw == other.total_raw
+    && avail_raw == other.avail_raw
+    && allocated == other.allocated
     && data_stored == other.data_stored
     && data_compressed == other.data_compressed
     && data_compressed_allocated == other.data_compressed_allocated
@@ -3388,6 +3392,8 @@ void store_statfs_t::dump(Formatter *f) const
   f->dump_int("total", total);
   f->dump_int("available", available);
   f->dump_int("internally_reserved", internally_reserved);
+  f->dump_int("total_raw", total_raw);
+  f->dump_int("avail_raw", avail_raw);
   f->dump_int("allocated", allocated);
   f->dump_int("data_stored", data_stored);
   f->dump_int("data_compressed", data_compressed);
@@ -3397,12 +3403,59 @@ void store_statfs_t::dump(Formatter *f) const
   f->dump_int("internal_metadata", internal_metadata);
 }
 
+void store_statfs_t::encode(ceph::buffer::list &bl) const
+{
+  ENCODE_START(2, 1, bl);
+  encode(total, bl);
+  encode(available, bl);
+  encode(internally_reserved, bl);
+
+  encode(allocated, bl);
+  encode(data_stored, bl);
+  encode(data_compressed, bl);
+  encode(data_compressed_allocated, bl);
+  encode(data_compressed_original, bl);
+  encode(omap_allocated, bl);
+  encode(internal_metadata, bl);
+
+  // since struct_v == 2
+  encode(total_raw, bl);
+  encode(avail_raw, bl);
+  ENCODE_FINISH(bl);
+}
+void store_statfs_t::decode(ceph::buffer::list::const_iterator &bl)
+{
+  DECODE_START(2, bl);
+  decode(total, bl);
+  decode(available, bl);
+  decode(internally_reserved, bl);
+
+  decode(allocated, bl);
+  decode(data_stored, bl);
+  decode(data_compressed, bl);
+  decode(data_compressed_allocated, bl);
+  decode(data_compressed_original, bl);
+  decode(omap_allocated, bl);
+  decode(internal_metadata, bl);
+
+  if (struct_v >= 2) {
+    decode(total_raw, bl);
+    decode(avail_raw, bl);
+  } else {
+    total_raw = total;
+    avail_raw = available;
+  }
+  DECODE_FINISH(bl);
+}
+
 ostream& operator<<(ostream& out, const store_statfs_t &s)
 {
   out << std::hex
       << "store_statfs(0x" << s.available
       << "/0x"  << s.internally_reserved
       << "/0x"  << s.total
+      << ", raw 0x" << s.avail_raw
+      << "/0x"  << s.total_raw
       << ", data 0x" << s.data_stored
       << "/0x"  << s.allocated
       << ", compress 0x" << s.data_compressed
@@ -3423,6 +3476,8 @@ list<store_statfs_t> store_statfs_t::generate_test_instances()
   a.total = 234;
   a.available = 123;
   a.internally_reserved = 33;
+  a.total_raw = 234;
+  a.avail_raw = 123;
   a.allocated = 32;
   a.data_stored = 44;
   a.data_compressed = 21;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -633,8 +633,8 @@ void osd_stat_t::decode(ceph::buffer::list::const_iterator &bl)
     } else {
       statfs.internally_reserved = 0;
     }
-    statfs.total_raw = kb << 10;
-    statfs.avail_raw = kb_avail << 10;
+    statfs.est_capacity = kb << 10;
+    statfs.est_available = kb_avail << 10;
     statfs.allocated = kb_used_data << 10;
     statfs.omap_allocated = kb_used_omap << 10;
     statfs.internal_metadata = kb_used_meta << 10;
@@ -3376,8 +3376,8 @@ bool store_statfs_t::operator==(const store_statfs_t& other) const
   return total == other.total
     && available == other.available
     && internally_reserved == other.internally_reserved
-    && total_raw == other.total_raw
-    && avail_raw == other.avail_raw
+    && est_capacity == other.est_capacity
+    && est_available == other.est_available
     && allocated == other.allocated
     && data_stored == other.data_stored
     && data_compressed == other.data_compressed
@@ -3392,8 +3392,8 @@ void store_statfs_t::dump(Formatter *f) const
   f->dump_int("total", total);
   f->dump_int("available", available);
   f->dump_int("internally_reserved", internally_reserved);
-  f->dump_int("total_raw", total_raw);
-  f->dump_int("avail_raw", avail_raw);
+  f->dump_int("total_estimated", est_capacity);
+  f->dump_int("available_estimated", est_available);
   f->dump_int("allocated", allocated);
   f->dump_int("data_stored", data_stored);
   f->dump_int("data_compressed", data_compressed);
@@ -3419,8 +3419,8 @@ void store_statfs_t::encode(ceph::buffer::list &bl) const
   encode(internal_metadata, bl);
 
   // since struct_v == 2
-  encode(total_raw, bl);
-  encode(avail_raw, bl);
+  encode(est_capacity, bl);
+  encode(est_available, bl);
   ENCODE_FINISH(bl);
 }
 void store_statfs_t::decode(ceph::buffer::list::const_iterator &bl)
@@ -3439,11 +3439,11 @@ void store_statfs_t::decode(ceph::buffer::list::const_iterator &bl)
   decode(internal_metadata, bl);
 
   if (struct_v >= 2) {
-    decode(total_raw, bl);
-    decode(avail_raw, bl);
+    decode(est_capacity, bl);
+    decode(est_available, bl);
   } else {
-    total_raw = total;
-    avail_raw = available;
+    est_capacity = total;
+    est_available = available;
   }
   DECODE_FINISH(bl);
 }
@@ -3454,8 +3454,8 @@ ostream& operator<<(ostream& out, const store_statfs_t &s)
       << "store_statfs(0x" << s.available
       << "/0x"  << s.internally_reserved
       << "/0x"  << s.total
-      << ", raw 0x" << s.avail_raw
-      << "/0x"  << s.total_raw
+      << ", est 0x" << s.est_available
+      << "/0x"  << s.est_capacity
       << ", data 0x" << s.data_stored
       << "/0x"  << s.allocated
       << ", compress 0x" << s.data_compressed
@@ -3476,8 +3476,8 @@ list<store_statfs_t> store_statfs_t::generate_test_instances()
   a.total = 234;
   a.available = 123;
   a.internally_reserved = 33;
-  a.total_raw = 234;
-  a.avail_raw = 123;
+  a.est_capacity = 234;
+  a.est_available = 123;
   a.allocated = 32;
   a.data_stored = 44;
   a.data_compressed = 21;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2558,9 +2558,14 @@ struct store_statfs_t
   uint64_t kb_used_omap() const {
     return omap_allocated >> 10;
   }
-
   uint64_t kb_used_internal_metadata() const {
     return internal_metadata >> 10;
+  }
+  uint64_t kb_est_avail() const {
+    return est_available >> 10;
+  }
+  uint64_t kb_est_capac() const {
+    return est_capacity >> 10;
   }
 
   void add(const store_statfs_t& o) {


### PR DESCRIPTION
The PR addresses problems related to reporting available space in objectstores.

We need:
- a fixed value attached to device that we use for crush weight
   It is done by reinforcing documentation for `store_statfs_t.total`. 
- a dynamic value reflecting store capacity for user data
   Done by adding `store_statfs_t.est_capacity` that predicts capacity based on current usage.

In addition: 
 - Added `store_statfs_t.est_available`, a dynamic value reflecting how much more user data can objectstore still accomodate.

Replaces: https://github.com/ceph/ceph/pull/66342

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
