### PR TITLE
dashboard: Add friendly labels. grouping and ids to services page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -60,10 +60,16 @@
                   [ngValue]="null">
             -- Select a service type --
           </option>
-          @for (serviceType of serviceTypes; track serviceType) {
-          <option [value]="serviceType">
-            {{ serviceType }}
-          </option>
+          @for (group of serviceTypeOptionGroups; track serviceTypeOptionGroups) {
+            <optgroup [label]="group.label">
+          @for (opt of group.options; track opt) {
+            <option
+              [value]="opt.value"
+              [disabled]="isTypeDisabled(opt.value)">
+              {{ opt.label }}
+            </option>
+          }
+            </optgroup>
           }
         </cds-select>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -71,6 +71,46 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   action: string;
   resource: string;
   serviceTypes: string[] = [];
+  // Options with user friendly labels
+  serviceTypeOptions: Array<{ value: string; label: string }> = [];
+  // Grouped options
+  serviceTypeOptionGroups: Array<{ label: string; options: Array<{ value: string; label: string }> }> = [];
+
+  // Map of known service type -> user friendly label. Fallback will be generated
+  readonly SERVICE_TYPE_LABELS: { [key: string]: string } = {
+    rgw: 'Object(RGW)',
+    nfs: 'NFS',
+    iscsi: 'iSCSI',
+    nvmeof: 'NVMe/TCP',
+    'mgmt-gateway': 'Management Gateway',
+    'oauth2-proxy': 'OAuth2 Proxy',
+    smb: 'SMB',
+    ingress: 'Ingress Controller',
+    grafana: 'Grafana',
+    mds: 'Filesystem(MDS)',
+    mon: 'Ceph Monitor',
+    mgr: 'Ceph Manager',
+    'rbd-mirror': 'Block Mirroring',
+    'cephfs-mirror': 'Filesystem Mirroring',
+    loki: 'Grafana Loki',
+    alloy: 'Grafana Alloy',
+    container: 'Container',
+    osd: 'OSD',
+  };
+
+  // Types that should only allow a single instance in the cluster. If one
+  // already exists, the option will be disabled in the UI.
+  readonly SINGLE_INSTANCE_TYPES: string[] = [
+    'mgr',
+    'mon',
+    'mgmt-gateway',
+    'oauth2-proxy',
+    'grafana',
+    'prometheus',
+    'ceph-exporter',
+    'loki',
+    'alloy'
+  ];
   serviceIds: string[] = [];
   selectedLabels: string[] = [];
   selectedHosts: string[] = [];
@@ -137,6 +177,17 @@ export class ServiceFormComponent extends CdForm implements OnInit {
     super();
     this.resource = $localize`service`;
     this.createForm();
+  }
+
+  isTypeDisabled(type: string): boolean {
+    // Only disable creation of single-instance types if one exists.
+    if (this.editing) {
+      return false;
+    }
+    if (this.SINGLE_INSTANCE_TYPES.includes(type)) {
+      return !!this.serviceList && this.serviceList.some((s) => s.service_type === type);
+    }
+    return false;
   }
 
   createForm() {
@@ -645,9 +696,93 @@ export class ServiceFormComponent extends CdForm implements OnInit {
       // osd       - This is deployed a different way.
       // container - This should only be used in the CLI.
       // promtail  - This is deprecated and replaced by alloy.
-      this.hiddenServices.push('osd', 'container', 'promtail');
+      this.hiddenServices.push('osd', 'container', 'promtail', 'mon', 'mgr');
 
-      this.serviceTypes = _.difference(resp, this.hiddenServices).sort();
+      let rawTypes = _.difference(resp, this.hiddenServices).sort();
+      // If we're editing an existing service whose type is hidden from the
+      // creation list (for example 'mgr' or 'mon'), make sure the currently
+      // edited type is present in the options so the select can show it.
+      if (
+        this.editing &&
+        this.serviceType &&
+        !rawTypes.includes(this.serviceType) &&
+        resp.includes(this.serviceType)
+      ) {
+        rawTypes = [this.serviceType, ...rawTypes];
+      }
+      this.serviceTypes = rawTypes;
+      this.serviceTypeOptions = rawTypes.map((type) => ({
+        value: type,
+        label: this.SERVICE_TYPE_LABELS[type] || _.startCase(type)
+      }));
+
+      // Build ordered groups
+      const serviceGroups: Array<{ label: string; types: string[] }> = [
+        { label: 'Block', types: ['rbd-mirror', 'iscsi', 'nvmeof'] },
+        { label: 'Object', types: ['rgw', 'nfs'] },
+        { label: 'File', types: ['mds', 'cephfs-mirror', 'nfs', 'smb'] },
+        { label: 'Logs & Observability', types: ['loki', 'alloy'] },
+        {
+          label: 'Monitoring',
+          types: [
+            'grafana',
+            'prometheus',
+            'alertmanager',
+            'snmp-gateway',
+            'ceph-exporter',
+            'node-exporter',
+          ]
+        },
+        { label: 'Security & SSO', types: ['mgmt-gateway', 'oauth2-proxy'] },
+      ];
+
+      const multiGroupTypes = new Set(['nfs']);
+
+      const rawSet = new Set(rawTypes);
+      const remaining = new Set(rawTypes);
+      const groups: Array<{ label: string; options: Array<{ value: string; label: string }> }> = [];
+      const addedToAnyGroup = new Set<string>();
+
+      for (const serviceGroup of serviceGroups) {
+        const opts: Array<{ value: string; label: string }> = [];
+        for (const type of serviceGroup.types) {
+          if (!rawSet.has(type)) {
+            continue;
+          }
+          if (remaining.has(type) || multiGroupTypes.has(type)) {
+            // If this is NOT a multi-group type, consume it so it won't
+            // appear in other groups. Multi-group types remain in `remaining`.
+            if (!multiGroupTypes.has(type)) {
+              remaining.delete(type);
+            }
+            opts.push({ value: type, label: this.SERVICE_TYPE_LABELS[type] || _.startCase(type) });
+            addedToAnyGroup.add(type);
+          }
+        }
+        if (opts.length > 0) {
+          groups.push({ label: serviceGroup.label, options: opts });
+        }
+      }
+
+      for (const t of multiGroupTypes) {
+        if (addedToAnyGroup.has(t)) {
+          remaining.delete(t);
+        }
+      }
+
+      // Any remaining types go into "Additional Services"
+      const additional: Array<{ value: string; label: string }> = [];
+      for (const type of rawTypes) {
+        if (remaining.has(type)) {
+          additional.push({ value: type, label: this.SERVICE_TYPE_LABELS[type] || _.startCase(type) });
+          remaining.delete(type);
+        }
+      }
+      if (additional.length > 0) {
+        groups.push({ label: 'Additional Services', options: additional });
+      }
+
+      this.serviceTypeOptionGroups = groups;
     });
     this.hostsAndLabels$ = forkJoin({
       hosts: this.hostService.getAllHosts(),
@@ -926,6 +1061,8 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         break;
       case 'mgr':
       case 'mds':
+        this.serviceForm.get('count').setValue(2);
+        break;
       case 'rgw':
       case 'ingress':
       case 'rbd-mirror':
@@ -1063,7 +1200,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   }
 
   requiresServiceId(serviceType: string) {
-    return ['mds', 'rgw', 'nfs', 'iscsi', 'nvmeof', 'smb', 'ingress'].includes(serviceType);
+    return ['mds', 'rgw', 'nfs', 'iscsi', 'nvmeof', 'smb', 'ingress', 'rbd-mirror', 'cephfs-mirror'].includes(serviceType);
   }
 
   setServiceId(serviceId: string): void {
@@ -1098,6 +1235,24 @@ export class ServiceFormComponent extends CdForm implements OnInit {
     } else {
       this.serviceForm.get('count').enable();
     }
+
+    if (!this.editing) {
+      const shouldPrefill =
+        this.requiresServiceId(selectedServiceType) &&
+        !['nvmeof', 'ingress'].includes(selectedServiceType);
+      if (shouldPrefill) {
+        const generated = this.generateRandomServiceId(selectedServiceType);
+        this.serviceForm.get('service_id').setValue(generated);
+      }
+    }
+  }
+
+  private generateRandomServiceId(serviceType: string): string {
+    const safePrefix = /^[a-zA-Z]/.test(serviceType)
+      ? serviceType.replace(/[^a-zA-Z0-9_.-]/g, '')
+      : 'service';
+    const suffix = Math.random().toString(36).substring(2, 8); // 6 chars
+    return `${safePrefix}-${suffix}`;
   }
 
   onPlacementChange(selected: string) {


### PR DESCRIPTION
**Problem**

Today it is hard to understand what each service does and where it belongs, especially for users who are not deeply familiar with Ceph internals.

**In the current UI:**

- Services are listed with technical names that are not user-friendly
- There is no clear grouping to indicate which services belong together
- It is not obvious which services can have multiple instances and which cannot

This creates confusion and increases the learning curve for new and intermediate users.

What this PR improves / resolves

This PR focuses on improving in the services view:

- **Added service labels with user-friendly names:** Makes it easier to understand what each service does without requiring deep Ceph knowledge.
- **Introduced service grouping aligned with the left navigation**: Services are now grouped in a way that mirrors the Dashboard navigation, helping users quickly understand where a service logically belongs.
- **Disabled services where multiple instances are not allowed:** Prevents users from attempting unsupported configurations and aligns the UI with cephadm service constraints.

Before

https://github.com/user-attachments/assets/74d3b23c-1d04-4c3f-b535-ac00a3487371


**After**

https://github.com/user-attachments/assets/2dec20a1-3312-42ef-8d7e-cb44c51b4b22



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
