### PR TITLE
reef: install-deps: Update Pyyaml version

### DIFF
--- a/monitoring/ceph-mixin/requirements-alerts.txt
+++ b/monitoring/ceph-mixin/requirements-alerts.txt
@@ -1,2 +1,2 @@
-pyyaml==6.0
+pyyaml==6.0.1
 bs4

--- a/monitoring/ceph-mixin/requirements-lint.txt
+++ b/monitoring/ceph-mixin/requirements-lint.txt
@@ -2,7 +2,7 @@ attrs==21.2.0
 behave==1.2.6
 py==1.10.0
 pyparsing==2.4.7
-PyYAML==6.0
+PyYAML==6.0.1
 types-PyYAML==6.0.0
 typing-extensions==3.10.0.2
 termcolor==1.1.0

--- a/monitoring/ceph-mixin/tests_dashboards/requirements.txt
+++ b/monitoring/ceph-mixin/tests_dashboards/requirements.txt
@@ -2,7 +2,7 @@ attrs==21.2.0
 behave==1.2.6
 py==1.10.0
 pyparsing==2.4.7
-PyYAML==6.0
+PyYAML==6.0.1
 types-PyYAML==6.0.0
 typing-extensions==3.10.0.2
 termcolor==1.1.0


### PR DESCRIPTION
Move to 6.0.1 to overcome https://github.com/yaml/pyyaml/issues/601

Fixes: https://tracker.ceph.com/issues/63591


(cherry picked from commit 7863d297eaf03a57ce910ab7f7a08e22789ed8d8)
