### PR TITLE
core: adds ability to reverse iterate through omap entries in bluestore & seastore (crimson)

### DIFF
--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -255,8 +255,12 @@ OMapInnerNode::iterate(
           if (child_ret == ObjectStore::omap_iter_ret_t::STOP) {
             return iterate_iertr::make_ready_future<seastar::stop_iteration>(
                    seastar::stop_iteration::yes);
+          } else if (child_ret == ObjectStore::omap_iter_ret_t::NEXT) {
+            ++iter;
+          } else {
+            // assume child_ret == ObjectStore::omap_iter_ret_t::PREV
+            --iter;
           }
-          ++iter;
           return iterate_iertr::make_ready_future<seastar::stop_iteration>(
                  seastar::stop_iteration::no);
         });

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -293,7 +293,9 @@ extern const char *ceph_osd_state_name(int s);
 									    \
 	/* omap */							    \
 	f(OMAPGETKEYS,	__CEPH_OSD_OP(RD, DATA, 17),	"omap-get-keys")    \
+	f(OMAPGETKEYSREV, __CEPH_OSD_OP(RD, DATA, 46),	"omap-get-keys-rev") \
 	f(OMAPGETVALS,	__CEPH_OSD_OP(RD, DATA, 18),	"omap-get-vals")    \
+	f(OMAPGETVALSREV, __CEPH_OSD_OP(RD, DATA, 47),	"omap-get-vals-rev") \
 	f(OMAPGETHEADER, __CEPH_OSD_OP(RD, DATA, 19),	"omap-get-header")  \
 	f(OMAPGETVALSBYKEYS, __CEPH_OSD_OP(RD, DATA, 20), "omap-get-vals-by-keys") \
 	f(OMAPSETVALS,	__CEPH_OSD_OP(WR, DATA, 21),	"omap-set-vals")    \

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -3534,6 +3534,27 @@ CEPH_RADOS_API void rados_read_op_omap_get_vals2(rados_read_op_t read_op,
 						 int *prval);
 
 /**
+ * Start iterating over key/value pairs on an object in reverse order.
+ *
+ * They will be returned sorted in reverse ordr by key.
+ *
+ * @param read_op operation to add this action to
+ * @param start_before list keys starting before start_before
+ * @param filter_prefix list only keys beginning with filter_prefix
+ * @param max_return list no more than max_return key/value pairs
+ * @param iter where to store the iterator
+ * @param pmore flag indicating whether there are more keys to fetch
+ * @param prval where to store the return value from this action
+ */
+CEPH_RADOS_API void rados_read_op_omap_get_vals_rev(rados_read_op_t read_op,
+                                                    const char *start_before,
+                                                    const char *filter_prefix,
+                                                    uint64_t max_return,
+                                                    rados_omap_iter_t *iter,
+                                                    unsigned char *pmore,
+                                                    int *prval);
+
+/**
  * Start iterating over keys on an object.
  *
  * They will be returned sorted by key, and the iterator
@@ -3571,6 +3592,26 @@ CEPH_RADOS_API void rados_read_op_omap_get_keys2(rados_read_op_t read_op,
 						 rados_omap_iter_t *iter,
 						 unsigned char *pmore,
 						 int *prval);
+
+/**
+ * Start iterating over keys on an object in reverse order.
+ *
+ * They will be returned sorted by key, and the iterator
+ * will fill in NULL for all values if specified.
+ *
+ * @param read_op operation to add this action to
+ * @param start_before list keys starting before start_before
+ * @param max_return list no more than max_return keys
+ * @param iter where to store the iterator
+ * @param pmore flag indicating whether there are more keys to fetch
+ * @param prval where to store the return value from this action
+ */
+CEPH_RADOS_API void rados_read_op_omap_get_keys_rev(rados_read_op_t read_op,
+                                                    const char *start_before,
+                                                    uint64_t max_return,
+                                                    rados_omap_iter_t *iter,
+                                                    unsigned char *pmore,
+                                                    int *prval);
 
 /**
  * Start iterating over specific key/value pairs

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -597,6 +597,26 @@ inline namespace v14_2_0 {
       int *prval);
 
     /**
+     * omap_get_vals_rev: keys and values from the object omap in
+     * reverse order
+     *
+     * Get up to max_return keys and values in reverse order beginning
+     * before start_before
+     *
+     * @param start_before [in] list no keys larger than start_before;
+     *        empty string to start at end
+     * @param max_return [in] list no more than max_return key/value pairs
+     * @param out_vals [out] place returned values in out_vals on completion
+     * @param prval [out] place error code in prval upon completion
+     */
+    void omap_get_vals_rev(
+      const std::string &start_before,
+      uint64_t max_return,
+      std::map<std::string, bufferlist> *out_vals,
+      bool *pmore,
+      int *prval);
+
+    /**
      * omap_get_vals: keys and values from the object omap
      *
      * Get up to max_return keys and values beginning after start_after
@@ -634,6 +654,28 @@ inline namespace v14_2_0 {
       bool *pmore,
       int *prval);
 
+    /**
+     * omap_get_vals_rev: keys and values from the object omap in
+     * reverse order
+     *
+     * Get up to max_return keys and values beginning before
+     * start_before in reverse order
+     *
+     * @param start_before [in] list keys starting before start_before;
+     *        empty string to start at end
+     * @param filter_prefix [in] list only keys beginning with filter_prefix
+     * @param max_return [in] list no more than max_return key/value pairs
+     * @param out_vals [out] place returned values in out_vals on completion
+     * @param pmore [out] pointer to bool indicating whether there are more keys
+     * @param prval [out] place error code in prval upon completion
+     */
+    void omap_get_vals_rev(
+      const std::string &start_before,
+      const std::string &filter_prefix,
+      uint64_t max_return,
+      std::map<std::string, bufferlist> *out_vals,
+      bool *pmore,
+      int *prval);
 
     /**
      * omap_get_keys: keys from the object omap
@@ -666,6 +708,25 @@ inline namespace v14_2_0 {
 			std::set<std::string> *out_keys,
 			bool *pmore,
 			int *prval);
+
+    /**
+     * omap_get_keys_rev: keys from the object omap in reverse order
+     *
+     * Get up to max_return keys in reverse order beginning before
+     * start_before
+     *
+     * @param start_after [in] list keys starting before start_before;
+     *        empty string to start at end
+     * @param max_return [in] list no more than max_return keys
+     * @param out_keys [out] place returned values in out_keys on completion
+     * @param pmore [out] pointer to bool indicating whether there are more keys
+     * @param prval [out] place error code in prval upon completion
+     */
+    void omap_get_keys_rev(const std::string &start_before,
+                           uint64_t max_return,
+                           std::set<std::string> *out_keys,
+                           bool *pmore,
+                           int *prval);
 
     /**
      * omap_get_header: get header from object omap

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -4423,6 +4423,32 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_vals2)(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_vals2);
 
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_vals_rev)(
+  rados_read_op_t read_op,
+  const char *start_before,
+  const char *filter_prefix,
+  uint64_t max_return,
+  rados_omap_iter_t *iter,
+  unsigned char *pmore,
+  int *prval)
+{
+  tracepoint(librados, rados_read_op_omap_get_vals_enter, read_op, start_before, filter_prefix, max_return, prval);
+  RadosOmapIter *omap_iter = new RadosOmapIter;
+  const char *start = start_before ? start_before : "";
+  const char *filter = filter_prefix ? filter_prefix : "";
+  ((::ObjectOperation *)read_op)->omap_get_vals_rev(
+    start,
+    filter,
+    max_return,
+    &omap_iter->values,
+    (bool*)pmore,
+    prval);
+  ((::ObjectOperation *)read_op)->set_handler(new C_OmapIter(omap_iter));
+  *iter = omap_iter;
+  tracepoint(librados, rados_read_op_omap_get_vals_exit, *iter);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_vals_rev);
+
 struct C_OmapKeysIter : public Context {
   RadosOmapIter *iter;
   std::set<std::string> keys;
@@ -4476,6 +4502,27 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_keys2)(
   tracepoint(librados, rados_read_op_omap_get_keys_exit, *iter);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_keys2);
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_keys_rev)(
+  rados_read_op_t read_op,
+  const char *start_before,
+  uint64_t max_return,
+  rados_omap_iter_t *iter,
+  unsigned char *pmore,
+  int *prval)
+{
+  tracepoint(librados, rados_read_op_omap_get_keys_enter, read_op, start_before, max_return, prval);
+  RadosOmapIter *omap_iter = new RadosOmapIter;
+  C_OmapKeysIter *ctx = new C_OmapKeysIter(omap_iter);
+  ((::ObjectOperation *)read_op)->omap_get_keys_rev(
+    start_before ? start_before : "",
+    max_return, &ctx->keys,
+    (bool*)pmore, prval);
+  ((::ObjectOperation *)read_op)->set_handler(ctx);
+  *iter = omap_iter;
+  tracepoint(librados, rados_read_op_omap_get_keys_exit, *iter);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_keys_rev);
 
 static void internal_rados_read_op_omap_get_vals_by_keys(rados_read_op_t read_op,
                                                          set<string>& to_get,

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -269,6 +269,20 @@ void librados::ObjectReadOperation::omap_get_vals2(
 		   prval);
 }
 
+void librados::ObjectReadOperation::omap_get_vals_rev(
+  const std::string &start_before,
+  const std::string &filter_prefix,
+  uint64_t max_return,
+  std::map<std::string, bufferlist> *out_vals,
+  bool *pmore,
+  int *prval)
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->omap_get_vals(start_before, filter_prefix, max_return, out_vals, pmore,
+		   prval);
+}
+
 void librados::ObjectReadOperation::omap_get_vals(
   const std::string &start_after,
   uint64_t max_return,
@@ -292,6 +306,18 @@ void librados::ObjectReadOperation::omap_get_vals2(
   o->omap_get_vals(start_after, "", max_return, out_vals, pmore, prval);
 }
 
+void librados::ObjectReadOperation::omap_get_vals_rev(
+  const std::string &start_before,
+  uint64_t max_return,
+  std::map<std::string, bufferlist> *out_vals,
+  bool *pmore,
+  int *prval)
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->omap_get_vals_rev(start_before, "", max_return, out_vals, pmore, prval);
+}
+
 void librados::ObjectReadOperation::omap_get_keys(
   const std::string &start_after,
   uint64_t max_return,
@@ -313,6 +339,18 @@ void librados::ObjectReadOperation::omap_get_keys2(
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
   o->omap_get_keys(start_after, max_return, out_keys, pmore, prval);
+}
+
+void librados::ObjectReadOperation::omap_get_keys_rev(
+  const std::string &start_before,
+  uint64_t max_return,
+  std::set<std::string> *out_keys,
+  bool *pmore,
+  int *prval)
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->omap_get_keys_rev(start_before, max_return, out_keys, pmore, prval);
 }
 
 void librados::ObjectReadOperation::omap_get_header(bufferlist *bl, int *prval)

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -113,6 +113,17 @@ extern int cls_cxx_map_get_vals(cls_method_context_t hctx,
                                 uint64_t max_to_get,
                                 std::map<std::string, ceph::buffer::list> *vals,
                                 bool *more);
+extern int cls_cxx_map_get_keys_rev(cls_method_context_t hctx,
+                                    const std::string &start_at_before,
+                                    uint64_t max_to_get,
+                                    std::set<std::string> *keys,
+                                    bool *more);
+extern int cls_cxx_map_get_vals_rev(cls_method_context_t hctx,
+                                    const std::string& start_at_before,
+                                    const std::string& filter_prefix,
+                                    uint64_t max_to_get,
+                                    std::map<std::string, ceph::buffer::list> *vals,
+                                    bool *more);
 extern int cls_cxx_map_get_val(cls_method_context_t hctx, const std::string &key,
                                bufferlist *outbl);
 extern int cls_cxx_map_get_vals_by_keys(cls_method_context_t hctx,

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -744,13 +744,16 @@ public:
       // start with provided key (seek_position), if it exists
       LOWER_BOUND,
       // skip provided key (seek_position) even if it exists
-      UPPER_BOUND
+      UPPER_BOUND,
+      // skip to the very end and ignore seek_position
+      LAST
     } seek_type = LOWER_BOUND;
     static omap_iter_seek_t min_lower_bound() { return {}; }
   };
   enum class omap_iter_ret_t {
     STOP,
-    NEXT
+    NEXT,
+    PREV
   };
   /**
    * Iterate over object map with user-provided callable

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -213,6 +213,7 @@ enum {
   //****************************************
   l_bluestore_omap_upper_bound_lat,
   l_bluestore_omap_lower_bound_lat,
+  l_bluestore_omap_seek_last_lat,
   l_bluestore_omap_next_lat,
   l_bluestore_omap_get_keys_lat,
   l_bluestore_omap_get_values_lat,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7745,12 +7745,13 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
       // OMAP Read ops
     case CEPH_OSD_OP_OMAPGETKEYS:
+    case CEPH_OSD_OP_OMAPGETKEYSREV:
       ++ctx->num_read;
       {
-	string start_after;
+	string start; // for forward, start is start_after
 	uint64_t max_return;
 	try {
-	  decode(start_after, bp);
+	  decode(start, bp);
 	  decode(max_return, bp);
 	}
 	catch (ceph::buffer::error& e) {
@@ -7761,7 +7762,32 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	if (max_return > cct->_conf->osd_max_omap_entries_per_request) {
 	  max_return = cct->_conf->osd_max_omap_entries_per_request;
 	}
-	tracepoint(osd, do_osd_op_pre_omapgetkeys, soid.oid.name.c_str(), soid.snap.val, start_after.c_str(), max_return);
+
+        // the enum is unnamed, so use decltype to work around
+        decltype(ObjectStore::omap_iter_seek_t::LOWER_BOUND) seek_type;
+
+        ObjectStore::omap_iter_ret_t iterator_return;
+        bool skip_first;
+
+        if (op.op == CEPH_OSD_OP_OMAPGETKEYS) {
+            seek_type = ObjectStore::omap_iter_seek_t::UPPER_BOUND;
+            iterator_return = ObjectStore::omap_iter_ret_t::NEXT;
+            skip_first = false;
+        } else { // op.op == CEPH_OSD_OP_OMAPGETKEYSREV
+          iterator_return = ObjectStore::omap_iter_ret_t::PREV;
+
+          if (start.empty()) {
+            // when start is empty, we must begin at the extreme,
+            // which is last for a reverse iteration
+            seek_type = ObjectStore::omap_iter_seek_t::LAST;
+            skip_first = false;
+          } else {
+            seek_type = ObjectStore::omap_iter_seek_t::LOWER_BOUND;
+            skip_first = true;
+          }
+        };
+
+	tracepoint(osd, do_osd_op_pre_omapgetkeys, soid.oid.name.c_str(), soid.snap.val, start.c_str(), max_return);
 
 	bufferlist bl;
 	uint32_t num = 0;
@@ -7770,18 +7796,24 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
           const auto result = osd->store->omap_iterate(
             ch, ghobject_t(soid),
             ObjectStore::omap_iter_seek_t{
-              .seek_position = start_after,
-              .seek_type = ObjectStore::omap_iter_seek_t::UPPER_BOUND
+              .seek_position = start,
+              .seek_type = seek_type
             },
-            [&bl, &num, max_return,
+            [&bl, &num, max_return, iterator_return, skip_first,
 	     max_bytes=cct->_conf->osd_max_omap_bytes_per_request]
             (std::string_view key, std::string_view value) mutable {
+              if (skip_first) {
+                // this is a reverse iteration, so the first returned
+                // value is needs to be skipped
+                skip_first = false;
+                return iterator_return;
+              }
 	      if (num >= max_return || bl.length() >= max_bytes) {
                 return ObjectStore::omap_iter_ret_t::STOP;
 	      }
 	      encode(key, bl);
 	      ++num;
-              return ObjectStore::omap_iter_ret_t::NEXT;
+              return iterator_return;
             });
           if (result < 0) {
 	    ceph_abort();
@@ -7798,6 +7830,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
       break;
 
     case CEPH_OSD_OP_OMAPGETVALS:
+    case CEPH_OSD_OP_OMAPGETVALSREV:
       ++ctx->num_read;
       {
 	string start_after;
@@ -7816,26 +7849,93 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	if (max_return > cct->_conf->osd_max_omap_entries_per_request) {
 	  max_return = cct->_conf->osd_max_omap_entries_per_request;
 	}
+
+        // the enum is unnamed, so use decltype to work around
+        decltype(ObjectStore::omap_iter_seek_t::LOWER_BOUND) seek_type;
+
+        ObjectStore::omap_iter_ret_t iterator_return;
+        bool skip_first;
+        std::string actual_start;
+
+        if (op.op == CEPH_OSD_OP_OMAPGETVALS) {
+            iterator_return = ObjectStore::omap_iter_ret_t::NEXT;
+            skip_first = false;
+            actual_start = std::max(start_after, filter_prefix);
+            if (actual_start == start_after) {
+              seek_type = ObjectStore::omap_iter_seek_t::UPPER_BOUND;
+            } else { // must have advanced to filter_prefix
+              seek_type = ObjectStore::omap_iter_seek_t::LOWER_BOUND;
+            }
+        } else { // op.op == CEPH_OSD_OP_OMAPGETVALSREV
+          auto calc_after_filter = [&start_after, &filter_prefix, this]() -> std::string {
+            std::string just_after_filter_prefix = filter_prefix;
+            bool overflow = true;
+            for (auto c = just_after_filter_prefix.rbegin();
+                 c != just_after_filter_prefix.rend();
+                 ++c)
+            {
+              if (*c == '\xFF') {
+                // if this char at highest value, we zero it and
+                // "carry" the increment
+                *c = '\0';
+              } else {
+                ++(*c);
+                overflow = false;
+                break;
+              }
+            }
+            if (overflow) {
+              // the implication is that the filter_prefix is a
+              // sequence of '\xFF' characters...
+              return start_after;
+            } else if (start_after.empty()) {
+              return just_after_filter_prefix;
+            } else {
+              return std::min(start_after, just_after_filter_prefix);
+            }
+          }; // calc_after_filter lambda
+
+          actual_start =
+            filter_prefix.empty() ? start_after : calc_after_filter();
+
+          iterator_return = ObjectStore::omap_iter_ret_t::PREV;
+
+          if (actual_start.empty()) {
+            // when start is empty, we must begin at the extreme,
+            // which is last for a reverse iteration
+            seek_type = ObjectStore::omap_iter_seek_t::LAST;
+            skip_first = false;
+          } else {
+            seek_type = ObjectStore::omap_iter_seek_t::LOWER_BOUND;
+            skip_first = true;
+          }
+        };
+
 	tracepoint(osd, do_osd_op_pre_omapgetvals, soid.oid.name.c_str(), soid.snap.val, start_after.c_str(), max_return, filter_prefix.c_str());
 
 	uint32_t num = 0;
 	bool truncated = false;
 	bufferlist bl;
 	if (oi.is_omap()) {
-	  using omap_iter_seek_t = ObjectStore::omap_iter_seek_t;
 	  const auto result = osd->store->omap_iterate(
 	    ch, ghobject_t(soid),
 	    // try to seek as many keys-at-once as possible for the sake of performance.
 	    // note complexity should be logarithmic, so seek(n/2) + seek(n/2) is worse
 	    // than just seek(n).
 	    ObjectStore::omap_iter_seek_t{
-	      .seek_position = std::max(start_after, filter_prefix),
-	      .seek_type = filter_prefix > start_after ? omap_iter_seek_t::LOWER_BOUND
-						       : omap_iter_seek_t::UPPER_BOUND
+	      .seek_position = actual_start,
+              .seek_type = seek_type
 	    },
 	    [&bl, &truncated, &filter_prefix, &num, max_return,
+             iterator_return, skip_first,
 	     max_bytes=cct->_conf->osd_max_omap_bytes_per_request]
 	    (std::string_view key, std::string_view value) mutable {
+              if (skip_first) {
+                // this is a reverse iteration, so the first returned
+                // value is needs to be skipped
+                skip_first = false;
+                return iterator_return;
+              }
 	      if (key.substr(0, filter_prefix.size()) != filter_prefix) {
 	        return ObjectStore::omap_iter_ret_t::STOP;
 	      }
@@ -7846,7 +7946,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	      encode(key, bl);
 	      encode(value, bl);
 	      ++num;
-	      return ObjectStore::omap_iter_ret_t::NEXT;
+	      return iterator_return;
 	    });
 	  if (result < 0) {
 	    goto fail;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2462,7 +2462,9 @@ void Objecter::_send_op_account(Op *op)
 
     // OMAP read operations
     case CEPH_OSD_OP_OMAPGETVALS:
+    case CEPH_OSD_OP_OMAPGETVALSREV:
     case CEPH_OSD_OP_OMAPGETKEYS:
+    case CEPH_OSD_OP_OMAPGETKEYSREV:
     case CEPH_OSD_OP_OMAPGETHEADER:
     case CEPH_OSD_OP_OMAPGETVALSBYKEYS:
     case CEPH_OSD_OP_OMAP_CMP: code = l_osdc_osdop_omap_rd; break;


### PR DESCRIPTION
For ordered bucket indexes it would help to be able to reverse iterate through omap entries. So this adds that ability to bluestore along with additions to librados and testing. There is also an attempt to add this ability to seastore/crimson, but that is speculative and untested, and I welcome feedback and/or direction, such as not even including the seastore support.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
