### PR TITLE
bluestore: add support for multi-stream SSDs(such as FDP SSDs)

### DIFF
--- a/src/blk/aio/aio.h
+++ b/src/blk/aio/aio.h
@@ -34,12 +34,13 @@ struct aio_t {
   boost::container::small_vector<iovec,4> iov;
   uint64_t offset, length;
   long rval;
+  int write_hint;
   ceph::buffer::list bl;  ///< write payload (so that it remains stable for duration)
 
   boost::intrusive::list_member_hook<> queue_item;
-
-  aio_t(void *p, int f) : priv(p), fd(f), offset(0), length(0), rval(-1000) {
-  }
+  
+  aio_t(void *p, int f, int write_hint) : priv(p), fd(f), offset(0), length(0), rval(-1000) , write_hint(write_hint){
+  } 
 
   void pwritev(uint64_t _offset, uint64_t len) {
     offset = _offset;

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -1159,7 +1159,7 @@ int KernelDevice::aio_write(
 	   << dendl;
       // generate a real io so that aio_wait behaves properly, but make it
       // a read instead of write, and toss the result.
-      ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
+      ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint), write_hint));
       ++ioc->num_pending;
       auto& aio = ioc->pending_aios.back();
       aio.bl.push_back(
@@ -1170,7 +1170,7 @@ int KernelDevice::aio_write(
     } else {
       if (bl.length() <= RW_IO_MAX) {
 	// fast path (non-huge write)
-	ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
+	ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint), write_hint));
 	++ioc->num_pending;
 	auto& aio = ioc->pending_aios.back();
 	bl.prepare_iov(&aio.iov);
@@ -1190,7 +1190,7 @@ int KernelDevice::aio_write(
 	    tmp.substr_of(bl, prev_len, bl.length() - prev_len);
 	  }
 	  auto len = tmp.length();
-	  ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
+	  ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint), write_hint));
 	  ++ioc->num_pending;
 	  auto& aio = ioc->pending_aios.back();
 	  tmp.prepare_iov(&aio.iov);
@@ -1469,7 +1469,7 @@ int KernelDevice::aio_read(
   if (aio && dio) {
     ceph_assert(is_valid_io(off, len));
     _aio_log_start(ioc, off, len);
-    ioc->pending_aios.push_back(aio_t(ioc, fd_directs[WRITE_LIFE_NOT_SET]));
+    ioc->pending_aios.push_back(aio_t(ioc, fd_directs[WRITE_LIFE_NOT_SET], WRITE_LIFE_NOT_SET));
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
     aio.bl.push_back(

--- a/src/blk/kernel/io_uring.cc
+++ b/src/blk/kernel/io_uring.cc
@@ -69,6 +69,7 @@ static void init_sqe(struct ioring_data *d, struct io_uring_sqe *sqe,
 
   io_uring_sqe_set_data(sqe, io);
   io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+  sqe->__pad2[0] = io->write_hint;
 }
 
 static int ioring_queue(struct ioring_data *d, void *priv,

--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -79,6 +79,8 @@ public:
    * removed in main after U is released.
    */
   eversion_t pg_committed_to;
+  
+  int32_t write_hint;
 
   hobject_t new_temp_oid;      ///< new temp object that we must now start tracking
   hobject_t discard_temp_oid;  ///< previously used temp object that we can now stop tracking
@@ -100,6 +102,10 @@ public:
 
   int get_cost() const override {
     return data.length();
+  }
+  
+  int get_write_hint() const {
+    return write_hint;
   }
 
   void set_txn_payload(bufferlist bl)
@@ -143,6 +149,8 @@ public:
 
     ceph_assert(header.version >= 3);
     decode(pg_committed_to, p);
+
+	decode(write_hint, p);
     final_decode_needed = false;
   }
 
@@ -167,6 +175,7 @@ public:
     encode(from, payload);
     encode(updated_hit_set_history, payload);
     encode(pg_committed_to, payload);
+	encode(write_hint, payload);
     bufferlist middle(txn_payload);
     set_middle(middle);
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3755,7 +3755,8 @@ private:
     OnodeRef& o,
     uint64_t offset, uint64_t length,
     ceph::buffer::list::iterator& blp,
-    WriteContext *wctx);
+    WriteContext *wctx,
+    int write_hint = WRITE_LIFE_NOT_SET); 
   void _do_write_big_apply_deferred(
     TransContext* txc,
     CollectionRef& c,
@@ -3774,7 +3775,8 @@ private:
     TransContext *txc,
     CollectionRef c,
     OnodeRef& o,
-    WriteContext *wctx);
+    WriteContext *wctx,
+    int write_hint = WRITE_LIFE_NOT_SET); 
   void _wctx_finish(
     TransContext *txc,
     CollectionRef& c,
@@ -3787,7 +3789,8 @@ private:
 	     OnodeRef& o,
 	     uint64_t offset, size_t len,
 	     ceph::buffer::list& bl,
-	     uint32_t fadvise_flags);
+	     uint32_t fadvise_flags,
+	     int write_hint = WRITE_LIFE_NOT_SET); 
   void _pad_zeros(ceph::buffer::list *bl, uint64_t *offset,
 		  uint64_t chunk_size);
 
@@ -3808,14 +3811,16 @@ private:
 		OnodeRef& o,
 		uint64_t offset, uint64_t length,
 		ceph::buffer::list& bl,
-		uint32_t fadvise_flags);
+		uint32_t fadvise_flags,
+		int write_hint = WRITE_LIFE_NOT_SET); 
   void _do_write_data(TransContext *txc,
                       CollectionRef& c,
                       OnodeRef& o,
                       uint64_t offset,
                       uint64_t length,
                       ceph::buffer::list& bl,
-                      WriteContext *wctx);
+                      WriteContext *wctx,
+                      int write_hint = WRITE_LIFE_NOT_SET); 
   int _do_write_v2(
     TransContext *txc,
     CollectionRef &c,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6054,6 +6054,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   const hobject_t& soid = oi.soid;
   const bool skip_data_digest = osd->store->has_builtin_csum() &&
     *osd->osd_skip_data_digest;
+  int write_hint = ctx->op->get_req<MOSDOp>()->get_write_hint();
 
   PGTransaction* t = ctx->op_t.get();
 
@@ -6851,7 +6852,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  }
 	} else {
 	  t->write(
-	    soid, op.extent.offset, op.extent.length, osd_op.indata, op.flags);
+	    soid, op.extent.offset, op.extent.length, osd_op.indata, op.flags, write_hint); 
 	}
 
 	if (op.extent.offset == 0 && op.extent.length >= oi.size
@@ -6899,7 +6900,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  t->truncate(soid, op.extent.length);
 	}
 	if (op.extent.length) {
-	  t->write(soid, 0, op.extent.length, osd_op.indata, op.flags);
+	  t->write(soid, 0, op.extent.length, osd_op.indata, op.flags, write_hint);
 	}
         if (!skip_data_digest) {
 	  obs.oi.set_data_digest(osd_op.indata.crc32c(-1));

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -481,7 +481,8 @@ void generate_transaction(
 	      extent.get_off(),
 	      extent.get_len(),
 	      op.buffer,
-	      op.fadvise_flags);
+	      op.fadvise_flags,
+	      op.write_hint); 
 	  },
 	  [&](const BufferUpdate::Zero &op) {
 	    t->zero(
@@ -1193,6 +1194,7 @@ Message * ReplicatedBackend::generate_subop(
   wr->new_temp_oid = new_temp_oid;
   wr->discard_temp_oid = discard_temp_oid;
   wr->updated_hit_set_history = hset_hist;
+  wr->write_hint = op_t.get_write_hint();
   return wr;
 }
 
@@ -1309,6 +1311,7 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   p = const_cast<bufferlist&>(m->logbl).begin();
   decode(log, p);
   rm->opt.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+  rm->opt.set_write_hint(m->get_write_hint());
 
   bool update_snaps = false;
   if (!rm->opt.empty()) {


### PR DESCRIPTION
This patch introduces a new feature enabling Ceph to use multi-stream devices (e.g., FDP SSDs) for data storage.
The Linux kernel now supports data lifetime hints via the i_write_hint field in inode structure.
We modified the CephFS kernel client to pass these hints from the kernel and transmit them over the network to the Ceph server.
The CephFS kernel client patch will be submitted later, in alignment with Linux kernel requirements.
This patch updates the Ceph server to accept data lifetime hints from the network and use them to guide data placement on multi-stream devices (e.g., FDP SSDs).
As a result:
Data with different lifetime hints are stored in different regions of the multi-stream device.
Data with same lifetime hints are stored in same regions.
This feature reduces SSD garbage collection (GC) pressure, lowers write amplification, and improves device endurence.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
