### PR TITLE
Use CEPH_VENDOR_RELEASE env to apend vendor release version to the version string

### DIFF
--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -48,7 +48,7 @@ static std::string get_ceph_vendor_release()
 {
   const char* env = std::getenv("CEPH_VENDOR_RELEASE");
 
-  if (!env || env[0] = '\0') {
+  if (!env || env[0] == '\0') {
     return "";
   }
 

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -44,6 +44,17 @@ const char *git_version_to_str(void)
   return STRINGIFY(CEPH_GIT_VER);
 }
 
+static std::string get_ceph_vendor_release()
+{
+  const char* env = std::getenv("CEPH_VENDOR_RELEASE");
+
+  if (!env || env[0] = '\0') {
+    return "";
+  }
+
+  return std::string(" release ") + env;
+}
+
 std::string const pretty_version_to_str(void)
 {
   std::ostringstream oss;
@@ -55,6 +66,7 @@ std::string const pretty_version_to_str(void)
 #ifdef WITH_CRIMSON
       << " (crimson)"
 #endif
+      << get_ceph_vendor_release()
       ;
   return oss.str();
 }


### PR DESCRIPTION
This change introduces a mechanism for vendors and downstream users to append their release version information to the output of the ceph version command. The goal is to make downstream or vendor-specific build metadata visible directly in the version string, without altering the upstream version semantics.

This PR introduces a new environment variable `CEPH_VENDOR_RELEASE`  for appending vendor release information. It may be set by the user or build system to specify a vendor or downstream release version. When this variable is present, its value is appended to the `ceph version` output as a `release` suffix.

NOTE: When `CEPH_VENDOR_RELEASE` is unset or empty, the version output is identical to existing upstream behavior.

For eg: If `CEPH_VENDOR_RELEAS`E is set to `8.1.0`, the version output becomes:

```
> ceph version

ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0
```

The same suffix is reflected consistently for `ceph versions`

```
> ceph versions
{
    "mon": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 3
    },
    "mgr": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 1
    },
    "osd": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 3
    },
    "mds": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 3
    },
    "overall": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 10
    }
}
```






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
