### PR TITLE
Use CEPH_VENDOR_RELEASE define to apend vendor release version to the version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,3 +862,5 @@ add_tags(ctags
   EXCLUDES "*.js" "*.css" ".tox" "python-common/build")
 add_custom_target(tags DEPENDS ctags)
 
+add_compile_definitions(CEPH_VENDOR_RELEASE="${CEPH_VENDOR_RELEASE}")
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ if(WITH_CCACHE)
   endif()
 endif(WITH_CCACHE)
 
+add_compile_definitions(CEPH_VENDOR_RELEASE="${CEPH_VENDOR_RELEASE}")
+
 option(WITH_SCCACHE "Build with sccache.")
 if(WITH_SCCACHE)
   find_program(SCCACHE_EXECUTABLE sccache
@@ -862,5 +864,4 @@ add_tags(ctags
   EXCLUDES "*.js" "*.css" ".tox" "python-common/build")
 add_custom_target(tags DEPENDS ctags)
 
-add_compile_definitions(CEPH_VENDOR_RELEASE="${CEPH_VENDOR_RELEASE}")
 

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -16,10 +16,13 @@
 #include "common/version.h"
 
 #include <stdlib.h>
+#include <cstring>
 #include <sstream>
 
 #include "ceph_ver.h"
 #include "common/ceph_strings.h"
+
+#include <iostream>
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
@@ -46,7 +49,8 @@ const char *git_version_to_str(void)
 
 static std::string get_ceph_vendor_release()
 {
-  if (!CEPH_VENDOR_RELEASE.empty()) {
+  std::cout << "#define value is: " << CEPH_VENDOR_RELEASE ;
+  if (CEPH_VENDOR_RELEASE && strlen(CEPH_VENDOR_RELEASE)) {
     return std::string(" release ") + STRINGIFY(CEPH_VENDOR_RELEASE);
   } else {
     return "";
@@ -57,7 +61,6 @@ static std::string get_ceph_vendor_release()
 std::string const pretty_version_to_str(void)
 {
   std::ostringstream oss;
-  std::cout << CEPH_VENDOR_RELEASE << std::endl;
   oss << "ceph version " << CEPH_GIT_NICE_VER
       << " (" << STRINGIFY(CEPH_GIT_VER) << ") "
       << ceph_release_name(CEPH_RELEASE)

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -49,9 +49,9 @@ const char *git_version_to_str(void)
 
 static std::string get_ceph_vendor_release()
 {
-  std::cout << "#define value is: " << CEPH_VENDOR_RELEASE ;
-  if (CEPH_VENDOR_RELEASE && strlen(CEPH_VENDOR_RELEASE)) {
-    return std::string(" release ") + STRINGIFY(CEPH_VENDOR_RELEASE);
+  const char* ceph_vendor_release = STRINGIFY(CEPH_VENDOR_RELEASE);
+  if (ceph_vendor_release && strlen(ceph_vendor_release)) {
+    return std::string(" release ") + ceph_vendor_release;
   } else {
     return "";
   }

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -44,9 +44,20 @@ const char *git_version_to_str(void)
   return STRINGIFY(CEPH_GIT_VER);
 }
 
+static std::string get_ceph_vendor_release()
+{
+  if (!CEPH_VENDOR_RELEASE.empty()) {
+    return std::string(" release ") + STRINGIFY(CEPH_VENDOR_RELEASE);
+  } else {
+    return "";
+  }
+}
+
+
 std::string const pretty_version_to_str(void)
 {
   std::ostringstream oss;
+  std::cout << CEPH_VENDOR_RELEASE << std::endl;
   oss << "ceph version " << CEPH_GIT_NICE_VER
       << " (" << STRINGIFY(CEPH_GIT_VER) << ") "
       << ceph_release_name(CEPH_RELEASE)
@@ -55,6 +66,7 @@ std::string const pretty_version_to_str(void)
 #ifdef WITH_CRIMSON
       << " (crimson)"
 #endif
+      << get_ceph_vendor_release()
       ;
   return oss.str();
 }

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -33,4 +33,11 @@ std::string const pretty_version_to_str(void);
 // Release type ("dev", "rc", or "stable")
 const char *ceph_release_type(void);
 
+/* Optional vendor release suffix. Default is empty, can be overridden at build
+ * time by users to specify their specific version of ceph
+ */
+#ifndef CEPH_VENDOR_RELEASE
+#define CEPH_VENDOR_RELEASE ""
+#endif
+
 #endif


### PR DESCRIPTION
Closes: https://tracker.ceph.com/issues/76134

This change introduces a build-time mechanism that allows vendors or downstream distributions to append their release version information to the output of the `ceph version` command. The goal is to make downstream or vendor-specific build metadata visible directly in the version string, without altering the upstream version semantics.

This PR adds a new optional build-time variable, `CEPH_VENDOR_RELEASE`, which may be specified during the CMake configuration phase.

When set, the value of `CEPH_VENDOR_RELEASE` is appended to the `ceph version` output as a `release` suffix. When unset (the default), the version output remains unchanged from upstream.

This approach treats the vendor release as build metadata, ensuring the version string is fully determined at compile time and does not depend on runtime configuration.

For eg:
If Ceph is built with the following CMake option:

```
./do_cmake.sh -DCEPH_VENDOR_RELEASE=8.1.0
```

The version output becomes

```
> ceph version

ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0
```

The same suffix is reflected consistently for `ceph versions`

```
> ceph versions
{
    "mon": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 3
    },
    "mgr": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 1
    },
    "osd": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 3
    },
    "mds": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 3
    },
    "overall": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) release 8.1.0": 10
    }
}
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
