### PR TITLE
mgr/dashboard: replace service events table with list view

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
@@ -9,7 +9,8 @@
     <nav ngbNav
          #nav="ngbNav"
          class="nav-tabs"
-         cdStatefulTab="service-details">
+         cdStatefulTab="service-details"
+         (navChange)="onTabChange($event)">
       <ng-container ngbNavItem="details">
         <a ngbNavLink
            i18n>Daemons</a>
@@ -21,13 +22,21 @@
         <a ngbNavLink
            i18n>Service Events</a>
         <ng-template ngbNavContent>
-          <cd-table *ngIf="hasOrchestrator"
-                    #serviceTable
-                    [data]="services"
-                    [columns]="serviceColumns"
-                    columnMode="flex"
-                    (fetchData)="getServices($event)">
-          </cd-table>
+          <div *ngIf="hasOrchestrator">
+  <ng-container *ngIf="services?.length; else noServiceEvents">
+    <div *ngFor="let service of services">
+      <ng-container
+        *ngTemplateOutlet="listTpl; context: { data: { value: service.events } }">
+      </ng-container>
+    </div>
+  </ng-container>
+
+  <ng-template #noServiceEvents>
+    <div class="list-group-item">
+      <span>No data available</span>
+    </div>
+  </ng-template>
+</div>
         </ng-template>
       </ng-container>
     </nav>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
@@ -252,6 +252,13 @@ describe('ServiceDaemonListComponent', () => {
     }
   });
 
+  // ✅ ONLY NEW TEST ADDED
+  it('should load services when service events tab is activated', () => {
+    const spy = jest.spyOn(component, 'getServices');
+    component.onTabChange({ nextId: 'service_events' });
+    expect(spy).toHaveBeenCalled();
+  });
+
   it('should sort daemons events', () => {
     component.sortDaemonEvents();
     const daemon = daemons[0];


### PR DESCRIPTION
This replaces the table-based UI in the Service Events tab with a list view.

Previously, the Service Events tab displayed a table with a single column and a
non-functional search bar, which added unnecessary complexity and poor UX.
This change renders service events as a simple list using the existing list
template, improving readability and aligning with Carbon Design guidelines.

Service events are now loaded and displayed only when the "Service Events" tab
is active.

Fixes: https://tracker.ceph.com/issues/70599?tab=properties
