### PR TITLE
mgr/cephadm:Added NFS port parameter validation

### DIFF
--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1525,6 +1525,12 @@ class NFSServiceSpec(ServiceSpec):
                     f"Invalid NFS spec: colocation_ports[{idx}] missing required "
                     f"fields: {missing_str}. Expected format: {{{format_str}}}"
                 )
+    def validate_port_number(self, port: Optional[int]) -> None:
+        if port is None:
+            return
+        if 0 <= port <= 65535:
+            return
+        raise ValueError("Port must be between 0 and 65535")
 
     def validate(self) -> None:
         super(NFSServiceSpec, self).validate()
@@ -1587,6 +1593,18 @@ class NFSServiceSpec(ServiceSpec):
                 raise SpecValidationError(
                     f'Either none or all of {tls_field_names} attributes must be set'
                 )
+        # Port Parameter Validation
+        # Port values must be less than 65535 (valid TCP/UDP port range: 0-65535)
+        try:
+            self.validate_port_number(self.port)
+        except ValueError as e:
+            raise SpecValidationError(f"NFS spec has invalid port value: {self.port}. {e}")
+        try:
+            self.validate_port_number(self.monitoring_port)
+        except ValueError as e:
+            raise SpecValidationError(
+                f"NFS spec has invalid monitoring port value: "
+                f"{self.monitoring_port}. {e}")
 
 
 yaml.add_representer(NFSServiceSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
Added NFS port parameter validation.

Fixes: https://tracker.ceph.com/issues/74293
Signed-off-by: Pooja Dwivedi (mailto:Pooja.dwivedi@ibm.com)


Testing Steps:

**NFS cluster with High Availability (HA) cluster creation command with a custom port:-**

_ceph nfs cluster create <cluster_id> "<placement>" --port <port_number> --ingress --virtual-ip <vip/mask> -i <spec_file>_

The actual port assigned to the service is calculated by adding 10,000 to the <custom_port> provided in the command.

Example: If --port 52500 is passed, the operational port becomes 62500.

If the provided custom port plus the 10,000 offset exceeds the limit (65535), the command will fail with a validation error.

Testing Logs:-
Positive case: NFS creation " testnfs1" with valid custom port value.
```
[ceph: root@ceph-node-0 /]# ceph nfs cluster create testnfs1 "1 ceph-node-0 ceph-node-1" --port 52500 --ingress --virtual-ip 10.8.130.224/22 -i nfs.yaml
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS                     RUNNING  REFRESHED  AGE  PLACEMENT                        
crash                                                    3/3  9m ago     23h  *                                
ingress.nfs.testnfs1       10.8.130.224:52500,59500      0/2  -          7s   ceph-node-0;ceph-node-1;count:1  
mgr                                                      2/2  9m ago     23h  count:2                          
mon                                                      3/5  9m ago     23h  count:5                          
nfs.foo                                                  0/1  9m ago     22h  count:1                          
nfs.testnfs1               ?:62500                       1/1  1s ago     7s   ceph-node-0;ceph-node-1;count:1  
osd.all-available-devices          
```
Negative case: NFS creation "2" with invalid custom port value.
```
[ceph: root@ceph-node-0 /]# ceph nfs cluster create testnfs2 "1 ceph-node-0 ceph-node-1" --port 62500 --ingress --virtual-ip 10.8.130.224/22 -i nfs.yaml
Error EINVAL: Invalid port number: 72500. Port value must be less than or equal to 65535
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS                     RUNNING  REFRESHED  AGE  PLACEMENT                        
crash                                                    3/3  7m ago     23h  *                                
ingress.nfs.testnfs1       10.8.130.224:52500,59500      0/2  -          6m   ceph-node-0;ceph-node-1;count:1  
mgr                                                      2/2  6m ago     23h  count:2                          
mon                                                      3/5  7m ago     23h  count:5                          
nfs.foo                                                  0/1  5m ago     22h  count:1                          
nfs.testnfs1               ?:62500                       1/1  6m ago     6m   ceph-node-0;ceph-node-1;count:1  
osd.all-available-devices        

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>
