### PR TITLE
mds: add tracing infrastructure and basic flows

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -67,4 +67,5 @@
 .. confval:: mds_min_caps_per_client
 .. confval:: mds_symlink_recovery
 .. confval:: mds_extraordinary_events_dump_interval
+.. confval:: mds_trace_sliding_window_sec
 .. confval:: subv_metrics_window_interval

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -1167,7 +1167,7 @@ class TestMDSTrace(CephFSTestCase):
                 # If has parent, verify parent_span_id format
                 if 'parent_span_id' in span and span['parent_span_id']:
                     self.assertEqual(len(span['parent_span_id']), 16,
-                                     f"parent_span_id should be 16 hex chars")
+                                     "parent_span_id should be 16 hex chars")
 
             # All span_ids should be unique within a trace
             self.assertEqual(len(span_ids), len(spans),

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1812,3 +1812,15 @@ options:
   min: 30
   services:
   - mds
+- name: mds_trace_sliding_window_sec
+  type: secs
+  level: advanced
+  desc: MDS trace sliding window duration in seconds
+  long_desc: Duration in seconds to keep completed traces in memory for admin socket dump
+  default: 30
+  min: 5
+  max: 300
+  services:
+  - mds
+  flags:
+  - runtime

--- a/src/mds/CMakeLists.txt
+++ b/src/mds/CMakeLists.txt
@@ -45,6 +45,7 @@ set(mds_srcs
   QuiesceDbManager.cc
   QuiesceAgent.cc
   MDSRankQuiesce.cc
+  MDSTracer.cc
   ${CMAKE_SOURCE_DIR}/src/common/TrackedOp.cc
   ${CMAKE_SOURCE_DIR}/src/common/MemoryModel.cc
   ${CMAKE_SOURCE_DIR}/src/osdc/Journaler.cc

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -309,6 +309,9 @@ void MDSDaemon::set_up_admin_socket()
   r = admin_socket->register_command("dump_ops_in_flight", asok_hook,
 				     "show the ops currently in flight");
   ceph_assert(r == 0);
+  r = admin_socket->register_command("trace dump", asok_hook,
+				     "dump completed traces from sliding window");
+  ceph_assert(r == 0);
   r = admin_socket->register_command("ops "
 				     "name=flags,type=CephChoices,strings=locks,n=N,req=false "
 				     "name=path,type=CephString,req=false "

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -30,6 +30,7 @@
 #include "SessionMap.h"
 #include "PurgeQueue.h"
 #include "MetricsHandler.h"
+#include "MDSTracer.h"
 
 // Full .h import instead of forward declaration for PerfCounter, for the
 // benefit of those including this header and using MDSRank::logger
@@ -427,6 +428,7 @@ class MDSRank {
     SessionMap sessionmap;
 
     PerfCounters *logger = nullptr, *mlogger = nullptr;
+    MDSTracer tracer;
     OpTracker op_tracker;
 
     std::map<ceph_tid_t, std::unique_ptr<MDSMetaRequest>> internal_client_requests;

--- a/src/mds/MDSTracer.cc
+++ b/src/mds/MDSTracer.cc
@@ -1,0 +1,212 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "MDSTracer.h"
+#include "common/ceph_context.h"
+#include "common/config.h"
+#include "common/debug.h"
+#include "common/Formatter.h"
+
+#include <chrono>
+#include <sstream>
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_mds
+#undef dout_prefix
+#define dout_prefix *_dout << "mds.tracer "
+
+// TraceData implementation
+
+void TraceData::dump(ceph::Formatter* f) const
+{
+  f->open_object_section("trace");
+  f->dump_string("trace_id", trace_id);
+  f->dump_string("name", name);
+  f->dump_stream("start_time") << start_time;
+  f->dump_stream("end_time") << end_time;
+  f->dump_float("duration_ms", duration_ms);
+  f->dump_int("result", result);
+  
+  f->open_object_section("attributes");
+  for (const auto& [key, value] : attributes) {
+    f->dump_string(key.c_str(), value);
+  }
+  f->close_section(); // attributes
+  
+  // Child spans with hierarchy (span_id=0 means direct child of root)
+  f->open_array_section("spans");
+  for (const auto& cs : child_spans) {
+    f->open_object_section("span");
+    f->dump_unsigned("span_id", cs.span_id);
+    f->dump_unsigned("parent_span_id", cs.parent_span_id);
+    f->dump_string("name", cs.name);
+    f->dump_stream("start_time") << cs.start_time;
+    f->dump_stream("end_time") << cs.end_time;
+    f->dump_float("duration_ms", cs.duration_ms);
+    if (cs.async) {
+      f->dump_bool("async", true);
+    }
+    f->close_section();
+  }
+  f->close_section(); // spans
+  
+  f->close_section(); // trace
+}
+
+std::string TraceData::to_json() const
+{
+  std::ostringstream ss;
+  ss << "{\"trace_id\":\"" << trace_id << "\""
+     << ",\"name\":\"" << name << "\""
+     << ",\"start_time\":" << start_time.to_real_time()
+     << ",\"end_time\":" << end_time.to_real_time()
+     << ",\"duration_ms\":" << duration_ms
+     << ",\"result\":" << result
+     << ",\"attributes\":{";
+  
+  bool first = true;
+  for (const auto& [key, value] : attributes) {
+    if (!first) ss << ",";
+    ss << "\"" << key << "\":\"" << value << "\"";
+    first = false;
+  }
+  ss << "},\"spans\":[";
+  
+  first = true;
+  for (const auto& cs : child_spans) {
+    if (!first) ss << ",";
+    ss << "{\"span_id\":" << cs.span_id
+       << ",\"parent_span_id\":" << cs.parent_span_id
+       << ",\"name\":\"" << cs.name << "\""
+       << ",\"start_time\":" << cs.start_time.to_real_time()
+       << ",\"end_time\":" << cs.end_time.to_real_time()
+       << ",\"duration_ms\":" << cs.duration_ms;
+    if (cs.async) {
+      ss << ",\"async\":true";
+    }
+    ss << "}";
+    first = false;
+  }
+  ss << "]}";
+  
+  return ss.str();
+}
+
+// MDSTracer implementation
+
+MDSTracer::MDSTracer(CephContext* cct_)
+  : cct(cct_),
+    completed_traces(30)  // Default 30 seconds, will be updated in init()
+{
+}
+
+void MDSTracer::init()
+{
+  ldout(cct, 5) << "initializing MDS tracer" << dendl;
+  tracer.init(cct, "ceph-mds");
+  
+  // Set sliding window duration from config
+  auto window_duration = cct->_conf.get_val<std::chrono::seconds>("mds_trace_sliding_window_sec");
+  completed_traces.set_window_duration(window_duration.count());
+  ldout(cct, 5) << "trace sliding window set to " << window_duration.count() << " seconds" << dendl;
+}
+
+void MDSTracer::shutdown()
+{
+  ldout(cct, 5) << "shutting down MDS tracer" << dendl;
+  // SlidingWindowTracker will be cleaned up by destructor
+}
+
+bool MDSTracer::is_enabled() const
+{
+  return tracer.is_enabled();
+}
+
+jspan_ptr MDSTracer::start_trace(const char* name)
+{
+  return tracer.start_trace(name);
+}
+
+jspan_ptr MDSTracer::add_span(const char* name, const jspan_ptr& parent)
+{
+  return tracer.add_span(name, parent);
+}
+
+jspan_ptr MDSTracer::add_span(const char* name, const jspan_context& parent_ctx)
+{
+  return tracer.add_span(name, parent_ctx);
+}
+
+void MDSTracer::store_trace(const TraceData& trace)
+{
+  // Update window duration from config in case it changed
+  auto window_duration = cct->_conf.get_val<std::chrono::seconds>("mds_trace_sliding_window_sec");
+  completed_traces.set_window_duration(window_duration.count());
+  
+  // Add trace to sliding window
+  completed_traces.add_value(trace);
+  
+  ldout(cct, 10) << "stored trace " << trace.trace_id 
+                 << " name=" << trace.name 
+                 << " duration=" << trace.duration_ms << "ms"
+                 << " window_size=" << completed_traces.size() << dendl;
+}
+
+void MDSTracer::dump_traces(ceph::Formatter* f)
+{
+  // Update window duration from config and prune old traces
+  auto window_duration = cct->_conf.get_val<std::chrono::seconds>("mds_trace_sliding_window_sec");
+  completed_traces.set_window_duration(window_duration.count());
+  
+  f->open_object_section("trace_dump");
+  f->dump_unsigned("count", completed_traces.size());
+  f->dump_unsigned("window_sec", completed_traces.get_window_duration_sec());
+  
+  f->open_array_section("traces");
+  completed_traces.for_each_value([f](const TraceData& trace) {
+    trace.dump(f);
+  });
+  f->close_section(); // traces
+  
+  f->close_section(); // trace_dump
+}
+
+size_t MDSTracer::get_trace_count() const
+{
+  return completed_traces.size();
+}
+
+void MDSTracer::prune_old_traces()
+{
+  completed_traces.update();
+}
+
+std::string MDSTracer::get_trace_id(const jspan_ptr& span)
+{
+#ifdef HAVE_JAEGER
+  if (span && span->IsRecording()) {
+    auto ctx = span->GetContext();
+    char trace_id[32];
+    ctx.trace_id().ToLowerBase16(trace_id);
+    return std::string(trace_id, 32);
+  }
+#endif
+  return "";
+}
+
+void MDSTracer::trace_event(const char* name, double duration_ms, int result)
+{
+  if (!is_enabled()) {
+    return;
+  }
+  
+  TraceData trace;
+  trace.name = name;
+  trace.end_time = ceph_clock_now();
+  trace.start_time = trace.end_time;
+  trace.start_time -= (duration_ms / 1000.0);  // Subtract duration to get start time
+  trace.duration_ms = duration_ms;
+  trace.result = result;
+  
+  store_trace(trace);
+}

--- a/src/mds/MDSTracer.h
+++ b/src/mds/MDSTracer.h
@@ -1,0 +1,329 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_MDS_TRACER_H
+#define CEPH_MDS_TRACER_H
+
+#include "common/tracer.h"
+#include "common/Clock.h"
+#include "include/common_fwd.h"
+#include "include/utime.h"
+#include "mgr/MDSPerfMetricTypes.h"
+
+#include <atomic>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace ceph { class Formatter; }
+
+/**
+ * TraceData - Completed trace information for sliding window storage
+ * 
+ * Uses span_id/parent_span_id to track call hierarchy.
+ * span_id=0 is the root span.
+ */
+struct TraceData {
+  std::string trace_id;
+  std::string name;
+  utime_t start_time;
+  utime_t end_time;
+  double duration_ms = 0;
+  int result = 0;
+  std::map<std::string, std::string> attributes;
+  
+  // Spans with hierarchy (parent_span_id=0 means direct child of root)
+  struct Span {
+    uint32_t span_id;         // Unique ID within this trace
+    uint32_t parent_span_id;  // 0 = direct child of root
+    std::string name;
+    utime_t start_time;
+    utime_t end_time;
+    double duration_ms;
+    bool async = false;       // true for async spans (may outlive parent)
+  };
+  std::vector<Span> child_spans;
+  
+  // Counter for generating span IDs (root span is 0)
+  // Note: Not thread-safe, but each MDRequest has its own TraceData
+  uint32_t next_span_id = 1;
+  
+  // Current span context for hierarchy tracking (0 = root)
+  uint32_t current_span_id = 0;
+  
+  // Pending spans for async operations (started but not yet completed)
+  struct PendingSpan {
+    uint32_t span_id;
+    uint32_t parent_span_id;
+    std::string name;
+    utime_t start_time;
+  };
+  std::map<uint32_t, PendingSpan> pending_spans;
+  
+  // Get next span ID
+  uint32_t alloc_span_id() { return next_span_id++; }
+  
+  // Start an async/pending span - returns span_id to pass to end_pending_span
+  // Note: Async spans may outlive their parent span - this is valid and shows
+  // the causal relationship (who initiated the async work).
+  uint32_t start_pending_span(const char* name) {
+    PendingSpan ps;
+    ps.span_id = alloc_span_id();
+    ps.parent_span_id = current_span_id;  // Actual parent that started this
+    ps.name = name;
+    ps.start_time = ceph_clock_now();
+    pending_spans[ps.span_id] = ps;
+    return ps.span_id;
+  }
+  
+  // End a pending span and add it to child_spans
+  void end_pending_span(uint32_t span_id) {
+    auto it = pending_spans.find(span_id);
+    if (it != pending_spans.end()) {
+      Span s;
+      s.span_id = it->second.span_id;
+      s.parent_span_id = it->second.parent_span_id;
+      s.name = it->second.name;
+      s.start_time = it->second.start_time;
+      s.end_time = ceph_clock_now();
+      s.duration_ms = (s.end_time - s.start_time) * 1000.0;
+      s.async = true;  // Mark as async span
+      child_spans.push_back(s);
+      pending_spans.erase(it);
+    }
+  }
+  
+  void dump(ceph::Formatter* f) const;
+  std::string to_json() const;
+};
+
+/**
+ * MDSTracer - Distributed tracing for MDS operations
+ *
+ * Follows the same ownership pattern as MetricsHandler:
+ * - Owned by MDSRank as a member
+ * - init()/shutdown() lifecycle
+ *
+ * Features:
+ * - Creates OTEL spans for request tracing
+ * - Stores completed traces in sliding window buffer
+ * - Supports admin socket dump via "trace dump" command
+ * - Trace ID correlation with log records
+ */
+class MDSTracer {
+public:
+  // MDS-specific span attribute names
+  static constexpr const char* ATTR_OP_TYPE = "mds.op_type";
+  static constexpr const char* ATTR_OP_NAME = "mds.op_name";
+  static constexpr const char* ATTR_CLIENT_ID = "mds.client_id";
+  static constexpr const char* ATTR_INODE = "mds.inode";
+  static constexpr const char* ATTR_PATH = "mds.path";
+  static constexpr const char* ATTR_PATH2 = "mds.path2";
+  static constexpr const char* ATTR_REQID = "mds.reqid";
+  static constexpr const char* ATTR_MDS_RANK = "mds.rank";
+  static constexpr const char* ATTR_SESSION_ID = "mds.session_id";
+  static constexpr const char* ATTR_RESULT = "mds.result";
+  static constexpr const char* ATTR_INTERNAL_OP = "mds.internal_op";
+
+  MDSTracer(CephContext* cct);
+  ~MDSTracer() = default;
+
+  // Lifecycle (called by MDSRank)
+  void init();
+  void shutdown();
+
+  // Check if tracing is enabled
+  bool is_enabled() const;
+
+  // Span creation
+  jspan_ptr start_trace(const char* name);
+  jspan_ptr add_span(const char* name, const jspan_ptr& parent);
+  jspan_ptr add_span(const char* name, const jspan_context& parent_ctx);
+
+  // Store completed trace in sliding window
+  void store_trace(const TraceData& trace);
+  
+  // Dump all traces in sliding window
+  void dump_traces(ceph::Formatter* f);
+  
+  // Get trace count in window
+  size_t get_trace_count() const;
+  
+  // Prune old traces
+  void prune_old_traces();
+
+  // Get trace ID string from span (for log correlation)
+  static std::string get_trace_id(const jspan_ptr& span);
+
+  // Create and store a simple trace for housekeeping operations
+  // (operations not tied to an MDRequest)
+  void trace_event(const char* name, double duration_ms, int result = 0);
+
+private:
+  CephContext* cct;
+  tracing::Tracer tracer;
+  
+  // Sliding window for completed traces (reuses generic SlidingWindowTracker)
+  SlidingWindowTracker<TraceData> completed_traces;
+};
+
+/**
+ * ScopedSpan - RAII helper for child spans with automatic duration tracking
+ *
+ * Creates a child span on construction, ends it on destruction.
+ * Duration is automatically captured by OTEL and recorded to TraceData.
+ * Supports hierarchical spans via span_id/parent_span_id tracking.
+ *
+ * Usage:
+ *   void some_function(MDRequestRef& mdr) {
+ *     ScopedSpan span(mds->tracer, "function_name", mdr->trace_span, &mdr->trace_data);
+ *     // ... function body ...
+ *     // Nested spans automatically get this span as parent:
+ *     {
+ *       ScopedSpan inner(mds->tracer, "inner_op", mdr->trace_span, &mdr->trace_data);
+ *     }
+ *   }  // span ends automatically, duration recorded to both OTEL and trace_data
+ */
+class ScopedSpan {
+public:
+  ScopedSpan(MDSTracer& tracer, const char* name, const jspan_ptr& parent,
+             TraceData* trace_data = nullptr)
+    : span_name(name), start_time(ceph_clock_now()), trace_data_ptr(trace_data) {
+    if (parent && parent->IsRecording()) {
+      span = tracer.add_span(name, parent);
+    }
+    // Track hierarchy in trace_data
+    if (trace_data_ptr) {
+      my_span_id = trace_data_ptr->alloc_span_id();
+      parent_span_id = trace_data_ptr->current_span_id;
+      trace_data_ptr->current_span_id = my_span_id;
+    }
+  }
+  
+  ~ScopedSpan() {
+    if (span) {
+      span->End();
+    }
+    // Auto-record to trace_data if provided
+    if (trace_data_ptr && !span_name.empty()) {
+      TraceData::Span s;
+      s.span_id = my_span_id;
+      s.parent_span_id = parent_span_id;
+      s.name = span_name;
+      s.start_time = start_time;
+      s.end_time = ceph_clock_now();
+      s.duration_ms = (s.end_time - s.start_time) * 1000.0;
+      trace_data_ptr->child_spans.push_back(s);
+      // Restore parent context
+      trace_data_ptr->current_span_id = parent_span_id;
+    }
+  }
+
+  // Add an event to this span
+  void AddEvent(const char* name) {
+    if (span && span->IsRecording()) {
+      span->AddEvent(name);
+    }
+  }
+
+  // Set an attribute on this span
+  template<typename T>
+  void SetAttribute(const char* key, const T& value) {
+    if (span && span->IsRecording()) {
+      span->SetAttribute(key, value);
+    }
+  }
+
+  // Check if span is valid/recording
+  bool IsRecording() const {
+    return span && span->IsRecording();
+  }
+  
+  // Get this span's ID (for manual hierarchy tracking)
+  uint32_t get_span_id() const { return my_span_id; }
+
+  // Non-copyable
+  ScopedSpan(const ScopedSpan&) = delete;
+  ScopedSpan& operator=(const ScopedSpan&) = delete;
+
+private:
+  jspan_ptr span;
+  std::string span_name;
+  utime_t start_time;
+  TraceData* trace_data_ptr;
+  uint32_t my_span_id = 0;
+  uint32_t parent_span_id = 0;
+};
+
+/**
+ * ScopedTrace - RAII helper for standalone traces (housekeeping operations)
+ *
+ * For operations not tied to an MDRequest. Creates a complete trace
+ * and stores it in the sliding window on destruction.
+ *
+ * Usage:
+ *   void housekeeping_function() {
+ *     ScopedTrace trace(mds->tracer, "mds:housekeeping:trim_cache");
+ *     // ... do work ...
+ *   }  // trace stored automatically with duration
+ */
+class ScopedTrace {
+public:
+  ScopedTrace(MDSTracer& tracer, const char* name)
+    : tracer_ref(tracer), trace_name(name), start_time(ceph_clock_now()) {
+    if (tracer.is_enabled()) {
+      span = tracer.start_trace(name);
+    }
+  }
+  
+  ~ScopedTrace() {
+    if (span) {
+      span->End();
+    }
+    if (tracer_ref.is_enabled()) {
+      utime_t end_time = ceph_clock_now();
+      double duration_ms = (end_time - start_time) * 1000.0;
+      
+      TraceData trace;
+      trace.trace_id = MDSTracer::get_trace_id(span);
+      trace.name = trace_name;
+      trace.start_time = start_time;
+      trace.end_time = end_time;
+      trace.duration_ms = duration_ms;
+      trace.result = result_code;
+      trace.attributes = attributes;
+      // No child spans for standalone traces (they are the root)
+      
+      tracer_ref.store_trace(trace);
+    }
+  }
+
+  void set_result(int r) { result_code = r; }
+  
+  void set_attribute(const std::string& key, const std::string& value) {
+    attributes[key] = value;
+    if (span && span->IsRecording()) {
+      span->SetAttribute(key.c_str(), value);
+    }
+  }
+
+  void add_event(const char* name) {
+    if (span && span->IsRecording()) {
+      span->AddEvent(name);
+    }
+  }
+
+  // Non-copyable
+  ScopedTrace(const ScopedTrace&) = delete;
+  ScopedTrace& operator=(const ScopedTrace&) = delete;
+
+private:
+  MDSTracer& tracer_ref;
+  jspan_ptr span;
+  std::string trace_name;
+  utime_t start_time;
+  int result_code = 0;
+  std::map<std::string, std::string> attributes;
+};
+
+#endif // CEPH_MDS_TRACER_H

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -15,6 +15,7 @@
 
 #include "Migrator.h"
 #include "MDSRank.h"
+#include "MDSTracer.h"
 #include "MDCache.h"
 #include "CInode.h"
 #include "CDir.h"
@@ -1155,6 +1156,7 @@ public:
 
 void Migrator::dispatch_export_dir(const MDRequestRef& mdr, int count)
 {
+  ScopedSpan trace_span(mds->tracer, "export_dir", mdr->trace_span, &mdr->trace_data);
   CDir *dir = mdr->more()->export_dir;
   auto* diri = dir->get_inode();
   dout(7) << *mdr << " " << *dir << dendl;

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -37,6 +37,7 @@
 
 #include "common/StackStringStream.h"
 #include "common/TrackedOp.h"
+#include "MDSTracer.h"
 
 class LogSegment;
 class BatchOp;
@@ -491,6 +492,14 @@ struct MDRequestImpl : public MutationImpl {
 
   // referent straydn
   bool referent_straydn = false;
+
+  // -- tracing support --
+  // Span for tracing this request through the MDS
+  jspan_ptr trace_span;
+  // Collected trace data for sliding window storage
+  TraceData trace_data;
+  // Pending span ID for async journal wait tracking
+  uint32_t journal_span_id = 0;
 
 protected:
   void _dump(ceph::Formatter *f) const override {

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -16,6 +16,7 @@
 #include "StrayManager.h"
 #include "BatchOp.h"
 #include "MDSRank.h"
+#include "MDSTracer.h"
 #include "Mutation.h"
 
 #include "common/debug.h"

--- a/src/mgr/MDSPerfMetricTypes.h
+++ b/src/mgr/MDSPerfMetricTypes.h
@@ -527,6 +527,24 @@ public:
     auto duration = std::chrono::steady_clock::now() - data_points.back().timestamp;
     return std::chrono::duration_cast<std::chrono::seconds>(duration).count();
    }
+
+    // Update the window duration (for dynamic config changes)
+    void set_window_duration(uint64_t window_duration_seconds) {
+      std::unique_lock lock(data_lock);
+      window_duration = std::chrono::seconds(window_duration_seconds);
+      prune_old_data(std::chrono::steady_clock::now());
+    }
+
+    uint64_t get_window_duration_sec() const {
+      std::shared_lock lock(data_lock);
+      return std::chrono::duration_cast<std::chrono::seconds>(window_duration).count();
+    }
+
+    size_t size() const {
+      std::shared_lock lock(data_lock);
+      return data_points.size();
+    }
+
  private:
     void prune_old_data(TimePoint now) {
       TimePoint window_start = now - window_duration;


### PR DESCRIPTION
## MDS Request Tracing Infrastructure

### Summary

This PR implements a hierarchical request tracing infrastructure for the MDS, enabling detailed performance analysis of client request processing. When OpenTelemetry tracing is enabled, the MDS captures timing information for each phase of request handling and makes it available via a new admin socket command.

Fixes: https://tracker.ceph.com/issues/73701

### Features

- **Hierarchical Span Tracing**: Captures nested function call timing with parent-child relationships
- **Async Span Support**: Properly tracks asynchronous operations (like journal commits) that outlive their parent spans
- **Sliding Window Storage**: Maintains recent traces in memory with configurable retention window
- **Clear-on-Dump Semantics**: Traces are atomically extracted and cleared when dumped, preventing memory growth
- **OTEL Span ID Compatibility**: Uses OpenTelemetry span IDs for Jaeger correlation

### Usage

Dump traces via admin socket:

`ceph daemon mds.<name> trace dump`

**NOTE: after each dump, traces are completely pruned, please remember to save the dump output!**

### Configuration

| Option | Default | Description |
|--------|---------|-------------|
| `jaeger_tracing_enable` | `false` | Enable OpenTelemetry tracing (required for trace generation) |
| `mds_trace_sliding_window_sec` | `10` | Trace retention window in seconds (1-30) |

### Example Output
```json
{
    "trace_id": "89a470995cd418dad345a74a78357005",
    "name": "mds:client_request",
    "start_time": "2025-12-10T18:07:08.496362+0000",
    "end_time": "2025-12-10T18:07:09.932454+0000",
    "duration_ms": 1436.09,
    "result": 0,
    "attributes": {
        "mds.client_id": "4158",
        "mds.op_name": "unlink",
        "mds.reqid": "client.4158:37",
        "mds.path": "myfile"
    },
    "spans": [
        {
            "span_id": "a1b2c3d4e5f6",
            "parent_span_id": "",
            "name": "handle_unlink",
            "start_time": "2025-12-10T18:07:08.496713+0000",
            "end_time": "2025-12-10T18:07:08.500989+0000",
            "duration_ms": 4.28
        },
        {
            "span_id": "f6e5d4c3b2a1",
            "parent_span_id": "a1b2c3d4e5f6",
            "name": "path_traverse",
            "duration_ms": 0.58
        },
        {
            "span_id": "112233445566",
            "parent_span_id": "a1b2c3d4e5f6",
            "name": "journal_wait",
            "duration_ms": 1430.5,
            "async": true
        }
    ]
}
```
### Instrumented Operations

**Request Handlers** (`Server.cc`):
- `handle_client_getattr`, `handle_client_lookup_ino`, `handle_client_open`
- `handle_client_openc`, `handle_client_readdir`, `handle_client_file_setlock`
- `handle_client_file_readlock`, `handle_client_setattr`, `handle_client_setlayout`
- `handle_client_setxattr`, `handle_client_removexattr`, `handle_client_fsync`
- `handle_client_mknod`, `handle_client_mkdir`, `handle_client_symlink`
- `handle_client_link`, `handle_client_unlink`, `handle_client_rmdir`
- `handle_client_rename`, `handle_client_lssnap`, `handle_client_mksnap`
- `handle_client_rmsnap`, `handle_client_renamesnap`, `handle_client_readdir_snapdiff`

**Path & Lock Operations** (`MDCache.cc`, `Locker.cc`):
- `path_traverse`, `rdlock_path_xlock_dentry`, `rdlock_two_paths_xlock_destdn`
- `acquire_locks`, `rdlock_snap_layout`, `create_lock_cache`

**Other Operations**:
- `cap_release`, `prepare_stray_dentry`, `issue_lease`, `journal_wait` (async)

### Testing

New test class `TestMDSTrace` in `qa/tasks/cephfs/test_misc.py`:
- `test_trace_dump_command` - Basic command validation
- `test_trace_noop_when_otel_disabled` - Verifies no-op when OTEL disabled
- `test_trace_dump_basic` - Trace structure validation
- `test_trace_dump_clears_window

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
