### PR TITLE
rgw: add content-range to part get

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -790,6 +790,8 @@ public:
         rgw_obj *target_obj;
 	uint64_t *epoch;
         int* part_num = nullptr;
+        std::optional<uint64_t> part_ofs;
+        std::optional<uint64_t> full_obj_size;
         std::optional<int> parts_count;
         RGWObjVersionTracker *objv_tracker = nullptr;
 
@@ -1101,7 +1103,8 @@ public:
   static int get_part_obj_state(const DoutPrefixProvider* dpp, optional_yield y,
 		       RGWRados* store, RGWBucketInfo& bucket_info,
 		       RGWObjectCtx* rctx, RGWObjManifest* manifest,
-		       int part_num, int* parts_count, bool prefetch,
+		       int part_num, int* parts_count,
+		       uint64_t* part_ofs, bool prefetch,
 		       RGWObjState** pstate, RGWObjManifest** pmanifest);
 
   int on_last_entry_in_listing(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2896,8 +2896,9 @@ int RadosObject::list_parts(const DoutPrefixProvider* dpp, CephContext* cct,
     RGWObjManifest* obj_m = manifest;
     RGWObjState* astate;
     bool part_prefetch = false;
+    uint64_t part_ofs = 0;
     ret = RGWRados::get_part_obj_state(dpp, y, store->getRados(), bucket_info, &obj_ctx,
-				       obj_m, cur_part_id, &parts_count,
+				       obj_m, cur_part_id, &parts_count, &part_ofs,
 				       part_prefetch, &astate, &obj_m);
 
     if (ret < 0) {
@@ -3735,6 +3736,8 @@ int RadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider
   source->set_obj_size(obj_size);
   source->set_mtime(*params.lastmod);
   params.parts_count = parent_op.params.parts_count;
+  params.part_ofs = parent_op.params.part_ofs;
+  params.full_obj_size = parent_op.params.full_obj_size;
 
   return ret;
 }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2504,6 +2504,11 @@ void RGWGetObj::execute(optional_yield y)
   if (op_ret < 0)
     goto done_err;
 
+  if (multipart_part_num) {
+    multipart_part_ofs = read_op->params.part_ofs;
+    full_obj_size = read_op->params.full_obj_size;
+  }
+
   /* STAT ops don't need data, and do no i/o */
   if (get_type() == RGW_OP_STAT_OBJ) {
     return;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -457,6 +457,9 @@ protected:
   std::optional<int> multipart_part_num;
   // PartsCount response when partNumber is specified
   std::optional<int> multipart_parts_count;
+  // Content-Range response when partNumber is specified
+  std::optional<uint64_t> multipart_part_ofs;
+  std::optional<uint64_t> full_obj_size;
 
   int init_common();
 public:

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -322,6 +322,12 @@ int RGWGetObj_ObjStore_S3::get_params(optional_yield y)
   // optional part number
   auto optstr = s->info.args.get_optional("partNumber");
   if (optstr) {
+    auto range_str = s->info.env->get("HTTP_RANGE");
+    if (range_str) {
+      s->err.message = "Cannot specify both Range header and partNumber query parameter";
+      return -ERR_INVALID_REQUEST;
+    }
+
     string err;
     multipart_part_num = strict_strtol(optstr->c_str(), 10, &err);
     if (!err.empty()) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -533,6 +533,10 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
     dump_header(s, "x-amz-mp-parts-count", *multipart_parts_count);
   }
 
+  if (multipart_part_num && multipart_part_ofs && full_obj_size) {
+    dump_range(s, *multipart_part_ofs, *multipart_part_ofs + total_len - 1, *full_obj_size);
+  }
+
   if (! op_ret) {
     if (! lo_etag.empty()) {
       /* Handle etag of Swift API's large objects (DLO/SLO). It's entirely

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1146,6 +1146,8 @@ class Object {
 
         /// If non-null, read data/attributes from the given multipart part.
         int* part_num{nullptr};
+        std::optional<uint64_t> part_ofs;
+        std::optional<uint64_t> full_obj_size;
         /// If the object is multipart, the total number of multipart
         /// parts is assigned to this output parameter.
         std::optional<int> parts_count;


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
