### PR TITLE
mgr/dashboard: set-rgw-credentials creates user with --admin instead of --system 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -89,8 +89,8 @@ class Rgw(BaseController):
                 msg = 'Failed to connect to the Object Gateway\'s Admin Ops API.'
                 raise RequestException(msg)
             # Ensure the system flag is set for the API user ID.
-            if not instance.is_system_user():  # pragma: no cover - no complexity there
-                msg = 'The system flag is not set for user "{}".'.format(
+            if not instance.is_admin_user():  # pragma: no cover - no complexity there
+                msg = 'The admin flag is not set for user "{}".'.format(
                     instance.userid)
                 raise RequestException(msg)
             status['available'] = True

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -460,14 +460,15 @@ class RgwClient(RestClient):
         return self._user_exists(self.admin_path, user_id)
 
     @RestClient.api_get('/{admin_path}/metadata/user?key={userid}',
-                        resp_structure='data > system')
-    def _is_system_user(self, admin_path, userid, request=None) -> bool:
+                        resp_structure='data > admin')
+    def _is_admin_user(self, admin_path, userid, request=None) -> bool:
         # pylint: disable=unused-argument
         response = request()
-        return response['data']['system']
+        # for backward compatibility, treat --system users as --admin users
+        return response['data']['admin'] or response['data']['system']
 
-    def is_system_user(self) -> bool:
-        return self._is_system_user(self.admin_path, self.userid)
+    def is_admin_user(self) -> bool:
+        return self._is_admin_user(self.admin_path, self.userid)
 
     @RestClient.api_get(
         '/{admin_path}/user',

--- a/src/pybind/mgr/dashboard/services/service.py
+++ b/src/pybind/mgr/dashboard/services/service.py
@@ -161,7 +161,7 @@ class RgwServiceManager:
                     'user', 'create',
                     '--uid', user,
                     '--display-name', 'Ceph Dashboard',
-                    '--system',
+                    '--admin',
                 ] + cmd_realm_option
                 _, out, err = mgr.send_rgwadmin_command(rgw_create_user_cmd)
                 if out:

--- a/src/pybind/mgr/dashboard/services/service.py
+++ b/src/pybind/mgr/dashboard/services/service.py
@@ -138,8 +138,10 @@ class RgwServiceManager:
         return all_daemons_up
 
     def _parse_secrets(self, user: str, data: dict) -> Tuple[str, str]:
+        assert data.get('admin') in ['true', True] or data.get('system') in ['true', True], \
+            'dashboard user must be created with --admin or --system flag'
         for key in data.get('keys', []):
-            if key.get('user') == user and data.get('system') in ['true', True]:
+            if key.get('user') == user:
                 access_key = key.get('access_key')
                 secret_key = key.get('secret_key')
                 return access_key, secret_key

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -19,7 +19,7 @@ class RgwControllerTestCase(ControllerTestCase):
 
     @patch.object(RgwClient, '_get_user_id', Mock(return_value='fake-user'))
     @patch.object(RgwClient, 'is_service_online', Mock(return_value=True))
-    @patch.object(RgwClient, '_is_system_user', Mock(return_value=True))
+    @patch.object(RgwClient, '_is_admin_user', Mock(return_value=True))
     @patch('dashboard.services.ceph_service.CephService.send_command')
     def test_status_available(self, send_command):
         send_command.return_value = ''
@@ -50,7 +50,7 @@ class RgwControllerTestCase(ControllerTestCase):
 
     @patch.object(RgwClient, '_get_user_id', Mock(return_value='fake-user'))
     @patch.object(RgwClient, 'is_service_online', Mock(return_value=True))
-    @patch.object(RgwClient, '_is_system_user', Mock(return_value=False))
+    @patch.object(RgwClient, '_is_admin_user', Mock(return_value=False))
     @patch('dashboard.services.ceph_service.CephService.send_command')
     def test_status_not_system_user(self, send_command):
         send_command.return_value = ''


### PR DESCRIPTION
the --admin flag gives the user blanket permissions to all apis, including s3 and /admin

the --system flag gives the same permissions as --admin, along with extra protocol extensions that are specifically for rgw multisite. some s3 requests will return extra headers/data when issued by a --system user that may break clients expecting s3. as far as i can tell, there's no reason for the dashboard to use --system over --admin

see https://docs.ceph.com/en/latest/radosgw/admin/#admin-and-system-users

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
