### PR TITLE
python-common/hostspec: normalize hostnames for case-insensitive matc…

### DIFF
--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -4,6 +4,11 @@ import re
 from typing import Optional, List, Any, Dict
 
 
+def normalize_hostname(hostname: str) -> str:
+    """Normalize hostname to lowercase for case-insensitive matching."""
+    return hostname.lower()
+
+
 def assert_valid_host(name: str) -> None:
     p = re.compile('^[a-zA-Z0-9-]+$')
     if len(name) > 250:
@@ -56,16 +61,16 @@ class HostSpec(object):
         self.service_type = 'host'
 
         #: the bare hostname on the host. Not the FQDN.
-        self.hostname = hostname  # type: str
+        self.hostname = normalize_hostname(hostname)
 
         #: DNS name or IP address to reach it
-        self.addr = addr or hostname  # type: str
+        self.addr = addr or normalize_hostname(hostname)
 
         #: label(s), if any
-        self.labels = labels or []  # type: List[str]
+        self.labels = labels or []
 
         #: human readable status
-        self.status = status or ''  # type: str
+        self.status = status or ''
 
         self.location = location
 
@@ -106,6 +111,8 @@ class HostSpec(object):
 
     @staticmethod
     def normalize_json(host_spec: dict) -> dict:
+        if 'hostname' in host_spec:
+            host_spec['hostname'] = normalize_hostname(host_spec['hostname'])
         labels = host_spec.get('labels')
         if labels is not None:
             if isinstance(labels, str):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -33,7 +33,12 @@ from typing import (
 
 import yaml
 
-from ceph.deployment.hostspec import HostSpec, SpecValidationError, normalize_hostname, assert_valid_host
+from ceph.deployment.hostspec import (
+    HostSpec,
+    SpecValidationError,
+    normalize_hostname,
+    assert_valid_host,
+)
 from ceph.deployment.utils import unwrap_ipv6, valid_addr, verify_non_negative_int
 from ceph.deployment.utils import verify_positive_int, verify_non_negative_number
 from ceph.deployment.utils import verify_boolean, verify_enum, verify_int
@@ -365,10 +370,15 @@ class PlacementSpec(object):
         # To backpopulate the .hosts attribute when using labels or count
         # in the orchestrator backend.
         if all(isinstance(h, HostPlacementSpec) for h in hosts):
-            # All items are HostPlacementSpec → normalize directly
+            # All items are HostPlacementSpec, normalize directly.
+            host_specs = cast(List[HostPlacementSpec], hosts)
             self.hosts = [
-                HostPlacementSpec(normalize_hostname(h.hostname), h.network, h.name)  # type: ignore[union-attr]
-                for h in hosts
+                HostPlacementSpec(
+                    normalize_hostname(h.hostname),
+                    h.network,
+                    h.name,
+                )
+                for h in host_specs
             ]
         else:
             # Otherwise, parse from strings

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -112,11 +112,6 @@ class HostPlacementSpec(NamedTuple):
     network: str
     name: str
 
-    @classmethod
-    def normalized(cls, hostname: str, network: str = '', name: str = '') -> 'HostPlacementSpec':
-        """Create a HostPlacementSpec with normalized hostname."""
-        return cls(normalize_hostname(hostname), network, name)
-
     def __str__(self) -> str:
         res = ''
         res += self.hostname
@@ -131,10 +126,9 @@ class HostPlacementSpec(NamedTuple):
     def from_json(cls, data: Union[dict, str]) -> 'HostPlacementSpec':
         if isinstance(data, str):
             return cls.parse(data)
-        # Use normalized() for consistent lowercasing
         if isinstance(data, dict):
-            return cls.normalized(
-                data.get('hostname', ''),
+            return cls(
+                normalize_hostname(data.get('hostname', '')),
                 data.get('network', ''),
                 data.get('name', '')
             )
@@ -370,16 +364,18 @@ class PlacementSpec(object):
     def set_hosts(self, hosts: Union[List[str], List[HostPlacementSpec]]) -> None:
         # To backpopulate the .hosts attribute when using labels or count
         # in the orchestrator backend.
-        if all(isinstance(host, HostPlacementSpec) for host in hosts):
-            # Type narrowing: all items are HostPlacementSpec
-            placement_hosts = cast(List[HostPlacementSpec], hosts)
+        if all(isinstance(h, HostPlacementSpec) for h in hosts):
+            # All items are HostPlacementSpec → normalize directly
             self.hosts = [
-                HostPlacementSpec.normalized(h.hostname, h.network, h.name)
-                for h in placement_hosts
+                HostPlacementSpec(normalize_hostname(h.hostname), h.network, h.name)  # type: ignore[union-attr]
+                for h in hosts
             ]
         else:
-            self.hosts = [HostPlacementSpec.parse(x, require_network=False)  # type: ignore
-                          for x in hosts if x]
+            # Otherwise, parse from strings
+            self.hosts = [
+                HostPlacementSpec.parse(h, require_network=False)  # type: ignore
+                for h in hosts if h
+            ]
 
     # deprecated
     def filter_matching_hosts(self, _get_hosts_func: Callable) -> List[str]:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -33,7 +33,7 @@ from typing import (
 
 import yaml
 
-from ceph.deployment.hostspec import HostSpec, SpecValidationError, assert_valid_host
+from ceph.deployment.hostspec import HostSpec, SpecValidationError, normalize_hostname, assert_valid_host
 from ceph.deployment.utils import unwrap_ipv6, valid_addr, verify_non_negative_int
 from ceph.deployment.utils import verify_positive_int, verify_non_negative_number
 from ceph.deployment.utils import verify_boolean, verify_enum, verify_int
@@ -112,6 +112,11 @@ class HostPlacementSpec(NamedTuple):
     network: str
     name: str
 
+    @classmethod
+    def normalized(cls, hostname: str, network: str = '', name: str = '') -> 'HostPlacementSpec':
+        """Create a HostPlacementSpec with normalized hostname."""
+        return cls(normalize_hostname(hostname), network, name)
+
     def __str__(self) -> str:
         res = ''
         res += self.hostname
@@ -126,6 +131,13 @@ class HostPlacementSpec(NamedTuple):
     def from_json(cls, data: Union[dict, str]) -> 'HostPlacementSpec':
         if isinstance(data, str):
             return cls.parse(data)
+        # Use normalized() for consistent lowercasing
+        if isinstance(data, dict):
+            return cls.normalized(
+                data.get('hostname', ''),
+                data.get('network', ''),
+                data.get('name', '')
+            )
         return cls(**data)
 
     def to_json(self) -> str:
@@ -159,7 +171,8 @@ class HostPlacementSpec(NamedTuple):
 
         match_host = re.search(host_re, host)
         if match_host:
-            host_spec = host_spec._replace(hostname=match_host.group(1))
+            # Lowercase for case-insensitive matching
+            host_spec = host_spec._replace(hostname=normalize_hostname(match_host.group(1)))
 
         name_match = re.search(name_re, host)
         if name_match:
@@ -220,16 +233,18 @@ class HostPattern():
         self.pattern_type: PatternType = pattern_type
         self.compiled_regex = None
         if self.pattern_type == PatternType.regex and self.pattern:
-            self.compiled_regex = re.compile(self.pattern)
+            self.compiled_regex = re.compile(self.pattern, re.IGNORECASE)
 
     def filter_hosts(self, hosts: List[str]) -> List[str]:
         if not self.pattern:
             return []
         if not self.pattern_type or self.pattern_type == PatternType.fnmatch:
-            return fnmatch.filter(hosts, self.pattern)
+            # Case-insensitive fnmatch comparison
+            pattern_lower = self.pattern.lower()
+            return [h for h in hosts if fnmatch.fnmatch(h.lower(), pattern_lower)]
         elif self.pattern_type == PatternType.regex:
             if not self.compiled_regex:
-                self.compiled_regex = re.compile(self.pattern)
+                self.compiled_regex = re.compile(self.pattern, re.IGNORECASE)
             return [h for h in hosts if re.match(self.compiled_regex, h)]
         raise SpecValidationError(f'Got unexpected pattern_type: {self.pattern_type}')
 
@@ -355,8 +370,13 @@ class PlacementSpec(object):
     def set_hosts(self, hosts: Union[List[str], List[HostPlacementSpec]]) -> None:
         # To backpopulate the .hosts attribute when using labels or count
         # in the orchestrator backend.
-        if all([isinstance(host, HostPlacementSpec) for host in hosts]):
-            self.hosts = hosts  # type: ignore
+        if all(isinstance(host, HostPlacementSpec) for host in hosts):
+            # Type narrowing: all items are HostPlacementSpec
+            placement_hosts = cast(List[HostPlacementSpec], hosts)
+            self.hosts = [
+                HostPlacementSpec.normalized(h.hostname, h.network, h.name)
+                for h in placement_hosts
+            ]
         else:
             self.hosts = [HostPlacementSpec.parse(x, require_network=False)  # type: ignore
                           for x in hosts if x]

--- a/src/python-common/ceph/tests/test_hostspec.py
+++ b/src/python-common/ceph/tests/test_hostspec.py
@@ -37,4 +37,12 @@ def test_parse_host_specs(test_input, expected):
 def test_parse_host_specs(bad_input):
     with pytest.raises(SpecValidationError):
         hs = HostSpec.from_json(bad_input)
+
+
+def test_hostname_case_insensitive():
+    # Test hostname is lowercased
+    hs = HostSpec(hostname="Ceph-Node-00")
+    assert hs.hostname == "ceph-node-00"
     
+    hs2 = HostSpec.from_json({"hostname": "MyHost"})
+    assert hs2.hostname == "myhost"


### PR DESCRIPTION
### Summary
Normalize hostnames at ingest to ensure case-insensitive handling in
python-common HostSpec and placement parsing logic.

### Problem
Service placement could fail with "Unknown hosts" when mixed-case
hostnames were used in service specs while the host was registered
in lowercase.

### Solution
- Centralize hostname normalization
- Apply consistently during placement parsing
- Preserve existing failure semantics

### Testing
- Unit tests cover mixed-case hostname scenarios

Fixes: https://tracker.ceph.com/issues/74299
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

Testing Logs
BEFORE FIX — Reproduce the Issue

```
1. Verify registered hostnames
ceph orch host ls

> ceph-node-00
> ceph-node-01
> ceph-node-02

2. Create a service spec with mixed-case hostname
cat > case-test.yaml << 'EOF'
service_type: nfs
service_id: case-test
placement:
  hosts:
    - Ceph-Node-00
EOF

3. Apply the spec (EXPECTED TO FAIL)
ceph orch apply -i case-test.yaml

Cannot place <NFSServiceSpec ...> on Ceph-Node-00: Unknown hosts

This is the reproduced issue.
```
AFTER FIX:
```
[ceph: root@ceph-node-00 /]# ceph orch host ls 
HOST          ADDR             LABELS  STATUS   
ceph-node-00  192.168.100.100  _admin          
ceph-node-01  192.168.100.101                   
ceph-node-02  192.168.100.102                   
3 hosts in cluster 
[ceph: root@ceph-node-00 /]# cat > case-test.yaml << 'EOF' service_type: nfs service_id: case-test placement: hosts: - Ceph-Node-00 EOF 
[ceph: root@ceph-node-00 /]# ceph orch apply -i case-test.yaml 
Scheduled nfs.case-test update... 
``` 


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
