### PR TITLE
squid: os/bluestore: introduce allocator lookup policy

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5517,6 +5517,23 @@ options:
   - hdd
   - ssd
   with_legacy: true
+- name: bluestore_allocator_lookup_policy
+  type: str
+  level: advanced
+  desc: Determines how to perform the next free extent lookup.
+  long_desc: When set to 'hdd_optimized' the allocator searches from the last
+     location found. This may facilitate contiguous disk writes. It may similarly
+     be beneficial for large-IU QLC SSDs to enable firmware coalescing of sub-IU
+     writes.
+     When set to 'ssd-optimized' the allocator will search from the beginning of
+     the device. This may facilitate SSD firmware housekeeping.
+     When set to 'auto' the value will be derived from the detected device type
+    (rotational or non-rotational).
+  default: auto
+  enum_values:
+  - hdd_optimized
+  - ssd_optimized
+  - auto
 - name: bluestore_avl_alloc_ff_max_search_count
   type: uint
   level: dev

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -108,6 +108,7 @@ private:
   int _allocate(
     uint64_t size,
     uint64_t unit,
+    int64_t  hint,
     uint64_t *offset,
     uint64_t *length);
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -4027,7 +4027,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   ceph_assert(id < alloc.size());
   int64_t alloc_len = 0;
   PExtentVector extents;
-  uint64_t hint = 0;
+  int64_t hint = -1;
   int64_t need = len;
   bool shared = is_shared_alloc(id);
   auto shared_unit = shared_alloc ? shared_alloc->alloc_unit : 0;
@@ -4054,7 +4054,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
     need = round_up_to(len, alloc_unit);
     if (!node->extents.empty() && node->extents.back().bdev == id) {
       hint = node->extents.back().end();
-    }   
+    }
     ++alloc_attempts;
     extents.reserve(4);  // 4 should be (more than) enough for most allocations
     auto t0 = mono_clock::now();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2473,6 +2473,8 @@ private:
 
   bool per_pool_stat_collection = true;
 
+  bool use_last_allocator_lookup_position = true;
+
   struct MempoolThread : public Thread {
   public:
     BlueStore *store;
@@ -2730,6 +2732,7 @@ private:
   void _set_finisher_num();
   void _set_per_pool_omap();
   void _update_osd_memory_options();
+  void _update_allocator_lookup_policy();
 
   int _open_bdev(bool create);
   // Verifies if disk space is enough for reserved + min bluefs

--- a/src/os/bluestore/Btree2Allocator.cc
+++ b/src/os/bluestore/Btree2Allocator.cc
@@ -65,7 +65,7 @@ int64_t Btree2Allocator::allocate(
   uint64_t want,
   uint64_t unit,
   uint64_t max_alloc_size,
-  int64_t  hint, // unused, for now!
+  int64_t  hint, // unused and likely unneeded
   PExtentVector* extents)
 {
   ldout(cct, 10) << __func__ << std::hex
@@ -182,7 +182,7 @@ int64_t Btree2Allocator::_allocate(
   uint64_t want,
   uint64_t unit,
   uint64_t max_alloc_size,
-  int64_t  hint, // unused, for now!
+  int64_t  hint, // unused and likely unneeded
   PExtentVector* extents)
 {
   uint64_t allocated = 0;

--- a/src/os/bluestore/BtreeAllocator.cc
+++ b/src/os/bluestore/BtreeAllocator.cc
@@ -226,14 +226,14 @@ int64_t BtreeAllocator::_allocate(
   uint64_t want,
   uint64_t unit,
   uint64_t max_alloc_size,
-  int64_t  hint, // unused, for now!
+  int64_t  hint,
   PExtentVector* extents)
 {
   uint64_t allocated = 0;
   while (allocated < want) {
     uint64_t offset, length;
     int r = _allocate(std::min(max_alloc_size, want - allocated),
-                      unit, &offset, &length);
+                      unit, hint, &offset, &length);
     if (r < 0) {
       // Allocation failed.
       break;
@@ -248,6 +248,7 @@ int64_t BtreeAllocator::_allocate(
 int BtreeAllocator::_allocate(
   uint64_t size,
   uint64_t unit,
+  int64_t  hint,
   uint64_t *offset,
   uint64_t *length)
 {
@@ -294,7 +295,8 @@ int BtreeAllocator::_allocate(
        * not guarantee that other allocations sizes may exist in the same
        * region.
        */
-      uint64_t* cursor = &lbas[cbits(size) - 1];
+      uint64_t dummy_cursor = (uint64_t)hint;
+      uint64_t* cursor = hint == -1 ? &lbas[cbits(size) - 1] : &dummy_cursor;
       start = _pick_block_after(cursor, size, unit);
       dout(20) << __func__ << " first fit=" << start << " size=" << size << dendl;
       if (start != uint64_t(-1ULL)) {
@@ -376,7 +378,7 @@ int64_t BtreeAllocator::allocate(
   uint64_t want,
   uint64_t unit,
   uint64_t max_alloc_size,
-  int64_t  hint, // unused, for now!
+  int64_t  hint,
   PExtentVector* extents)
 {
   ldout(cct, 10) << __func__ << std::hex

--- a/src/os/bluestore/BtreeAllocator.h
+++ b/src/os/bluestore/BtreeAllocator.h
@@ -102,6 +102,7 @@ private:
   int _allocate(
     uint64_t size,
     uint64_t unit,
+    int64_t  hint,
     uint64_t *offset,
     uint64_t *length);
 

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -32,7 +32,7 @@ int64_t HybridBtree2Allocator::allocate(
   uint64_t want,
   uint64_t unit,
   uint64_t max_alloc_size,
-  int64_t  hint,
+  int64_t  hint, // unused and likely unneeded for btree2 allocator
   PExtentVector* extents)
 {
   ldout(get_context(), 10) << __func__ << std::hex

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -67,56 +67,56 @@ int64_t StupidAllocator::allocate_int(
 
   auto p = free[0].begin();
 
-  if (!hint)
+  if (hint < 0)
     hint = last_alloc;
 
   // search up (from hint)
-  if (hint) {
-    for (bin = orig_bin; bin < (int)free.size(); ++bin) {
-      p = free[bin].lower_bound(hint);
-      while (p != free[bin].end()) {
-	if (p.get_len() >= want_size) {
-	  goto found;
-	}
-	++p;
+  for (bin = orig_bin; bin < (int)free.size(); ++bin) {
+    p = free[bin].lower_bound(hint);
+    while (p != free[bin].end()) {
+      if (p.get_len() >= want_size) {
+        goto found;
       }
+      ++p;
     }
   }
 
   // search up (from origin, and skip searched extents by hint)
-  for (bin = orig_bin; bin < (int)free.size(); ++bin) {
-    p = free[bin].begin();
-    auto end = hint ? free[bin].lower_bound(hint) : free[bin].end();
-    while (p != end) {
-      if (p.get_len() >= want_size) {
-	goto found;
+  if (hint) {
+    for (bin = orig_bin; bin < (int)free.size(); ++bin) {
+      p = free[bin].begin();
+      auto end = free[bin].lower_bound(hint);
+      while (p != end) {
+        if (p.get_len() >= want_size) {
+	  goto found;
+        }
+        ++p;
       }
-      ++p;
     }
   }
 
   // search down (hint)
-  if (hint) {
-    for (bin = orig_bin; bin >= 0; --bin) {
-      p = free[bin].lower_bound(hint);
-      while (p != free[bin].end()) {
-	if (p.get_len() >= alloc_unit) {
-	  goto found;
-	}
-	++p;
+  for (bin = orig_bin; bin >= 0; --bin) {
+    p = free[bin].lower_bound(hint);
+    while (p != free[bin].end()) {
+      if (p.get_len() >= alloc_unit) {
+        goto found;
       }
+      ++p;
     }
   }
 
   // search down (from origin, and skip searched extents by hint)
-  for (bin = orig_bin; bin >= 0; --bin) {
-    p = free[bin].begin();
-    auto end = hint ? free[bin].lower_bound(hint) : free[bin].end();
-    while (p != end) {
-      if (p.get_len() >= alloc_unit) {
-	goto found;
+  if (hint) {
+    for (bin = orig_bin; bin >= 0; --bin) {
+      p = free[bin].begin();
+      auto end = free[bin].lower_bound(hint);
+      while (p != end) {
+        if (p.get_len() >= alloc_unit) {
+	  goto found;
+        }
+        ++p;
       }
-      ++p;
     }
   }
 

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -699,7 +699,7 @@ protected:
   void _allocate_l2(uint64_t length,
     uint64_t min_length,
     uint64_t max_length,
-    uint64_t hint,
+    int64_t hint,
     
     uint64_t* allocated,
     interval_vector_t* res)
@@ -724,7 +724,7 @@ protected:
     if (available < min_length) {
       return;
     }
-    if (hint != 0) {
+    if (hint != -1) {
       last_pos = (hint / (d * l2_granularity)) < l2.size() ? p2align(hint / l2_granularity, d) : 0;
     }
     auto l2_pos = last_pos;

--- a/src/test/objectstore/Allocator_bench.cc
+++ b/src/test/objectstore/Allocator_bench.cc
@@ -156,7 +156,7 @@ TEST_P(AllocTest, test_alloc_bench_seq)
   {
     tmp.clear();
     EXPECT_EQ(static_cast<int64_t>(want_size),
-	      alloc->allocate(want_size, alloc_unit, 0, 0, &tmp));
+	      alloc->allocate(want_size, alloc_unit, 0, -1, &tmp));
     if (0 == (i % (1 * 1024 * _1m))) {
       std::cout << "alloc " << i / 1024 / 1024 << " mb of "
         << capacity / 1024 / 1024 << std::endl;
@@ -234,7 +234,7 @@ TEST_P(AllocTest, test_alloc_bench)
     uint32_t want = alloc_unit << u1(rng);
 
     tmp.clear();
-    auto r = alloc->allocate(want, alloc_unit, 0, 0, &tmp);
+    auto r = alloc->allocate(want, alloc_unit, 0, -1, &tmp);
     if (r < want) {
       break;
     }
@@ -388,7 +388,7 @@ void AllocTest::doOverwriteTest(uint64_t capacity, uint64_t prefill,
   {
     uint32_t want = alloc_unit << u1(rng);
     tmp.clear();
-    auto r = alloc->allocate(want, alloc_unit, 0, 0, &tmp);
+    auto r = alloc->allocate(want, alloc_unit, 0, -1, &tmp);
     if (r < want) {
       break;
     }
@@ -828,10 +828,10 @@ TEST_P(AllocTest, mempoolAccounting)
   std::map<uint32_t, PExtentVector> all_allocs;
   for (size_t i = 0; i < 10000; i++) {
     PExtentVector tmp;
-    alloc->allocate(alloc_size, alloc_size, 0, 0, &tmp);
+    alloc->allocate(alloc_size, alloc_size, 0, -1, &tmp);
     all_allocs[rand()] = tmp;
     tmp.clear();
-    alloc->allocate(alloc_size, alloc_size, 0, 0, &tmp);
+    alloc->allocate(alloc_size, alloc_size, 0, -1, &tmp);
     all_allocs[rand()] = tmp;
     tmp.clear();
 

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -81,7 +81,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
     dump_alloc();
     PExtentVector extents;
     EXPECT_EQ(block_size, alloc->allocate(block_size, block_size,
-					  0, (int64_t) 0, &extents));
+					  0, (int64_t) -1, &extents));
   }
 
   /*
@@ -93,7 +93,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
     PExtentVector extents;
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
-			      0, (int64_t) 0, &extents));
+			      0, (int64_t) -1, &extents));
     EXPECT_EQ(1u, extents.size());
     EXPECT_EQ(extents[0].length, 4 * block_size);
   }
@@ -109,7 +109,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
   
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
-			      0, (int64_t) 0, &extents));
+			      0, (int64_t) -1, &extents));
     EXPECT_EQ(2u, extents.size());
     EXPECT_EQ(extents[0].length, 2 * block_size);
     EXPECT_EQ(extents[1].length, 2 * block_size);
@@ -134,7 +134,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
     PExtentVector extents;
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
-			      block_size, (int64_t) 0, &extents));
+			      block_size, (int64_t) -1, &extents));
     for (auto e : extents) {
       EXPECT_EQ(e.length, block_size);
     }
@@ -152,7 +152,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
     PExtentVector extents;
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
-			      2 * block_size, (int64_t) 0, &extents));
+			      2 * block_size, (int64_t) -1, &extents));
     EXPECT_EQ(2u, extents.size());
     for (auto& e : extents) {
       EXPECT_EQ(e.length, block_size * 2);
@@ -169,7 +169,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
     EXPECT_EQ(1024 * block_size,
 	      alloc->allocate(1024 * (uint64_t)block_size,
 			      (uint64_t) block_size * 4,
-			      block_size * 4, (int64_t) 0, &extents));
+			      block_size * 4, (int64_t) -1, &extents));
     for (auto& e : extents) {
       EXPECT_EQ(e.length, block_size * 4);
     }
@@ -185,7 +185,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
     PExtentVector extents;
     EXPECT_EQ(16 * block_size,
 	      alloc->allocate(16 * (uint64_t)block_size, (uint64_t) block_size,
-			      2 * block_size, (int64_t) 0, &extents));
+			      2 * block_size, (int64_t) -1, &extents));
 
     EXPECT_EQ(extents.size(), 8u);
     for (auto& e : extents) {
@@ -217,14 +217,14 @@ TEST_P(AllocTest, test_alloc_failure)
     EXPECT_EQ(512 * block_size,
 	      alloc->allocate(512 * (uint64_t)block_size,
 			      (uint64_t) block_size * 256,
-			      block_size * 256, (int64_t) 0, &extents));
+			      block_size * 256, (int64_t) -1, &extents));
     alloc->init_add_free(0, block_size * 256);
     alloc->init_add_free(block_size * 512, block_size * 256);
     extents.clear();
     EXPECT_EQ(-ENOSPC,
 	      alloc->allocate(512 * (uint64_t)block_size,
 			      (uint64_t) block_size * 512,
-			      block_size * 512, (int64_t) 0, &extents));
+			      block_size * 512, (int64_t) -1, &extents));
   }
 }
 
@@ -239,7 +239,7 @@ TEST_P(AllocTest, test_alloc_big)
     cout << big << std::endl;
     PExtentVector extents;
     EXPECT_EQ(big,
-	      alloc->allocate(big, mas, 0, &extents));
+	      alloc->allocate(big, mas, -1, &extents));
   }
 }
 
@@ -256,7 +256,7 @@ TEST_P(AllocTest, test_alloc_non_aligned_len)
   alloc->init_add_free(3670016, 2097152);
 
   PExtentVector extents;
-  EXPECT_EQ(want_size, alloc->allocate(want_size, alloc_unit, 0, &extents));
+  EXPECT_EQ(want_size, alloc->allocate(want_size, alloc_unit, -1, &extents));
 }
 
 TEST_P(AllocTest, test_alloc_39334)
@@ -286,7 +286,7 @@ TEST_P(AllocTest, test_alloc_fragmentation)
   {
     tmp.clear();
     EXPECT_EQ(static_cast<int64_t>(want_size),
-      alloc->allocate(want_size, alloc_unit, 0, 0, &tmp));
+      alloc->allocate(want_size, alloc_unit, 0, -1, &tmp));
     allocated.insert(allocated.end(), tmp.begin(), tmp.end());
 
     // bitmap fragmentation calculation doesn't provide such constant
@@ -296,7 +296,7 @@ TEST_P(AllocTest, test_alloc_fragmentation)
     }
   }
   tmp.clear();
-  EXPECT_EQ(-ENOSPC, alloc->allocate(want_size, alloc_unit, 0, 0, &tmp));
+  EXPECT_EQ(-ENOSPC, alloc->allocate(want_size, alloc_unit, 0, -1, &tmp));
 
   if (!(GetParam() == string("stupid") || GetParam() == string("bitmap"))) {
     GTEST_SKIP() << "skipping for specific allocators";
@@ -440,7 +440,7 @@ TEST_P(AllocTest, test_dump_fragmentation_score)
 	//allocate
 	want_size = ( rng() % one_alloc_max ) / alloc_unit * alloc_unit + alloc_unit;
 	tmp.clear();
-        int64_t r = alloc->allocate(want_size, alloc_unit, 0, 0, &tmp);
+        int64_t r = alloc->allocate(want_size, alloc_unit, 0, -1, &tmp);
         if (r > 0) {
           for (auto& t: tmp) {
             if (t.length > 0)
@@ -505,7 +505,7 @@ TEST_P(AllocTest, test_alloc_bug_24598)
   alloc->init_add_free(0x4b00000, 0x200000);
 
   EXPECT_EQ(static_cast<int64_t>(want_size),
-	    alloc->allocate(want_size, 0x100000, 0, 0, &tmp));
+	    alloc->allocate(want_size, 0x100000, 0, -1, &tmp));
   EXPECT_EQ(1u, tmp.size());
   EXPECT_EQ(0x4b00000u, tmp[0].offset);
   EXPECT_EQ(0x200000u, tmp[0].length);
@@ -525,11 +525,11 @@ TEST_P(AllocTest, test_alloc_big2)
   PExtentVector extents;
   uint64_t need = block_size * blocks / 4; // 2GB
   EXPECT_EQ(need,
-      alloc->allocate(need, mas, 0, &extents));
+      alloc->allocate(need, mas, -1, &extents));
   need = block_size * blocks / 4; // 2GB
   extents.clear();
   EXPECT_EQ(need,
-      alloc->allocate(need, mas, 0, &extents));
+      alloc->allocate(need, mas, -1, &extents));
   EXPECT_TRUE(extents[0].length > 0);
 }
 
@@ -547,7 +547,7 @@ TEST_P(AllocTest, test_alloc_big3)
   PExtentVector extents;
   uint64_t need = block_size * blocks / 2; // 4GB
   EXPECT_EQ(need,
-      alloc->allocate(need, mas, 0, &extents));
+      alloc->allocate(need, mas, -1, &extents));
   EXPECT_TRUE(extents[0].length > 0);
 }
 
@@ -564,7 +564,7 @@ TEST_P(AllocTest, test_alloc_contiguous)
     uint64_t need = 4 * block_size;
     EXPECT_EQ(need,
       alloc->allocate(need, need,
-        0, (int64_t)0, &extents));
+        0, (int64_t)-1, &extents));
     EXPECT_EQ(1u, extents.size());
     EXPECT_EQ(extents[0].offset, 0);
     EXPECT_EQ(extents[0].length, 4 * block_size);
@@ -572,7 +572,7 @@ TEST_P(AllocTest, test_alloc_contiguous)
     extents.clear();
     EXPECT_EQ(need,
       alloc->allocate(need, need,
-        0, (int64_t)0, &extents));
+        0, (int64_t)-1, &extents));
     EXPECT_EQ(1u, extents.size());
     EXPECT_EQ(extents[0].offset, 4 * block_size);
     EXPECT_EQ(extents[0].length, 4 * block_size);
@@ -602,7 +602,7 @@ TEST_P(AllocTest, test_alloc_47883)
 
   PExtentVector extents;
   auto need = 0x3f980000;
-  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)0, &extents);
+  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)-1, &extents);
   EXPECT_GE(got, 0x630000);
 }
 
@@ -622,7 +622,7 @@ TEST_P(AllocTest, test_alloc_50656_best_fit)
 
   PExtentVector extents;
   auto need = 0x400000;
-  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)0, &extents);
+  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)-1, &extents);
   EXPECT_GT(got, 0);
   EXPECT_EQ(got, 0x400000);
 }
@@ -642,7 +642,7 @@ TEST_P(AllocTest, test_alloc_50656_first_fit)
 
   PExtentVector extents;
   auto need = 0x400000;
-  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)0, &extents);
+  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)-1, &extents);
   EXPECT_GT(got, 0);
   EXPECT_EQ(got, 0x400000);
 }
@@ -668,6 +668,130 @@ TEST_P(AllocTest, test_init_rm_free_unbound)
     alloc->foreach(cb);
   }
 }
+
+TEST_P(AllocTest, test_alloc_spatial_locality)
+{
+  if (GetParam() == string("hybrid_btree2")) {
+    // new generation allocator doesn't support legacy
+    // spatial locality approach. Which is being able to start searching
+    // free extent from the previous lookup success (or externally hinted)
+    // position.
+    // This looks generally useless on a fragmented volume, it might cause
+    // excessive fragmentation and misguide PTL level on SSD drives.
+    // Hence the test case is not applicable.
+    GTEST_SKIP() << "skipping for hybrid_btree2 allocator";
+  }
+
+  int64_t block_size = 0x1000;
+  int64_t capacity = 128 * (1ull << 30); // 128GB
+
+  // do allocations with no hint provided hence enabling internal spatial locality
+  {
+    init_alloc(capacity, block_size);
+
+    alloc->init_add_free(0, capacity);
+
+    PExtentVector extents1;
+    PExtentVector extents2;
+    PExtentVector extents3;
+
+    uint64_t need = 0x1000;
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)-1, &extents1));
+    EXPECT_EQ(1u, extents1.size());
+    EXPECT_EQ(extents1[0].offset, 0);
+    EXPECT_EQ(extents1[0].length, need);
+
+    // mark a large extent allocated
+    // to work around bitmap cursor tracking which uses
+    // l2 granularity (equal to 32GB for 4K unit).
+    uint64_t skip;
+    if (GetParam() == string("bitmap")) {
+      skip = 32 * (1ull << 30) - need;
+      alloc->init_rm_free(need, skip);
+    } else {
+      skip = 0;
+    }
+
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)-1, &extents2));
+    EXPECT_EQ(1u, extents2.size());
+    EXPECT_EQ(extents2[0].offset, need + skip);
+    EXPECT_EQ(extents2[0].length, need);
+
+    {
+      // now release the very first 4K extent
+      interval_set<uint64_t> release_set;
+      release_set.insert(extents1[0].offset, block_size);
+      alloc->release(release_set);
+    }
+    // and now allocate once again, this will get the following LBA,
+    // not zero one
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)-1, &extents3));
+    EXPECT_EQ(1u, extents3.size());
+    EXPECT_EQ(extents3[0].offset, need + need + skip);
+    EXPECT_EQ(extents3[0].length, need);
+    alloc->shutdown();
+  }
+
+  // do allocations with zero hint provided hence disabling internal spatial locality
+  {
+    init_alloc(capacity, block_size);
+
+    alloc->init_add_free(0, capacity);
+
+    PExtentVector extents1;
+    PExtentVector extents2;
+    PExtentVector extents3;
+
+    uint64_t need = 0x1000;
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)0, &extents1));
+    EXPECT_EQ(1u, extents1.size());
+    EXPECT_EQ(extents1[0].offset, 0);
+    EXPECT_EQ(extents1[0].length, need);
+
+    // mark a large extent allocated
+    // to work around bitmap cursor tracking which uses
+    // l2 granularity (equal to 32GB for 4K unit).
+    uint64_t skip;
+    if (GetParam() == string("bitmap")) {
+      skip = 32 * (1ull << 30) - need;
+      alloc->init_rm_free(need, skip);
+    } else {
+      skip = 0;
+    }
+
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)0, &extents2));
+    EXPECT_EQ(1u, extents2.size());
+    EXPECT_EQ(extents2[0].offset, need + skip);
+    EXPECT_EQ(extents2[0].length, need);
+
+    {
+      // now release the very first 4K extent
+      interval_set<uint64_t> release_set;
+      release_set.insert(extents1[0].offset, block_size);
+      alloc->release(release_set);
+    }
+    // and allocate once again, this will get the extent at LBA = 0
+    // which just has been released
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)0, &extents3));
+    EXPECT_EQ(1u, extents3.size());
+    EXPECT_EQ(extents3[0].offset, 0);
+    EXPECT_EQ(extents3[0].length, need);
+    alloc->shutdown();
+  }
+}
+
 
 INSTANTIATE_TEST_SUITE_P(
   Allocator,

--- a/src/test/objectstore/allocator_replay_test.cc
+++ b/src/test/objectstore/allocator_replay_test.cc
@@ -184,7 +184,7 @@ int replay_and_check_for_duplicate(char* fname)
 	return -1;
       }
       tmp.clear();
-      auto allocated = alloc->allocate(want, alloc_unit, 0, 0, &tmp);
+      auto allocated = alloc->allocate(want, alloc_unit, 0, -1, &tmp);
       std::cout << "allocated TOTAL: " << allocated << std::endl;
       for (auto& ee : tmp) {
         std::cerr << "dump extent: " << std::hex
@@ -627,7 +627,7 @@ int main(int argc, char **argv)
           for(size_t i = 0; i < count; i++) {
             extents.clear();
 	    auto t0 = ceph::mono_clock::now();
-            auto r = a->allocate(want, alloc_unit, 0, &extents);
+            auto r = a->allocate(want, alloc_unit, -1, &extents);
             std::cout << "Duration (ns): " << (ceph::mono_clock::now() - t0).count() << std::endl;
             if (r < 0) {
               std::cerr << "Error: allocation failure at step:" << i + 1
@@ -694,7 +694,8 @@ int main(int argc, char **argv)
           for (auto i = 0; i < replay_count; ++i) {
             while (fgets(s, sizeof(s), f_alloc_list) != nullptr) {
               /* parse allocation request */
-              uint64_t want = 0, unit = 0, max = 0, hint = 0;
+              uint64_t want = 0, unit = 0, max = 0;
+              int64_t hint = -1;
 
               if (std::sscanf(s, "%ji %ji %ji %ji", &want, &unit, &max, &hint) < 2)
               {

--- a/src/test/objectstore/hybrid_allocator_test.cc
+++ b/src/test/objectstore/hybrid_allocator_test.cc
@@ -113,7 +113,7 @@ TEST(HybridAllocator, basic)
     PExtentVector extents;
     // allocate 4K, to be served from bitmap
     EXPECT_EQ(block_size, ha.allocate(block_size, block_size,
-      0, (int64_t)0, &extents));
+      0, (int64_t)-1, &extents));
     ASSERT_EQ(1, extents.size());
     ASSERT_EQ(0, extents[0].offset);
 
@@ -253,7 +253,7 @@ TEST(HybridAllocator, basic)
     // allocate 12M using 2M chunks. 10M to be returned
     PExtentVector extents;
     EXPECT_EQ(10 * _1m, ha.allocate(12 * _1m, 2 * _1m,
-      0, (int64_t)0, &extents));
+      0, (int64_t)-1, &extents));
 
     // release everything allocated
     for (auto& e : extents) {

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -967,6 +967,9 @@ $DAEMONOPTS
 
         bluestore fsck on mount = true
         bluestore block create = true
+        bluestore allocator = bitmap
+        bluestore alloc favor spatial locality = false
+        
 $BLUESTORE_OPTS
 
         ; kstore

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -967,8 +967,6 @@ $DAEMONOPTS
 
         bluestore fsck on mount = true
         bluestore block create = true
-        bluestore allocator = bitmap
-        bluestore alloc favor spatial locality = false
         
 $BLUESTORE_OPTS
 


### PR DESCRIPTION
This allows to have different free space lookup approaches for ssd and hdd drives.
The backport PR omits empty commit https://github.com/ceph/ceph/pull/57789/changes/71ce48752f163065568cc21784590530aabbf96c 
from the original PR.

Backports: https://github.com/ceph/ceph/pull/57789
Parent tracker: https://tracker.ceph.com/issues/76975
Fixes: https://tracker.ceph.com/issues/76977

Additionally this reverts unintended allocator type change in vstart.sh which the original PR brought in.
Backports: https://github.com/ceph/ceph/pull/66886
Parent tracker: https://tracker.ceph.com/issues/76974
Fixes: https://tracker.ceph.com/issues/76976

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
