### PR TITLE
mgr/cephadm: fail early if iSCSI service spec is missing

### DIFF
--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -9,6 +9,7 @@ from mgr_module import HandleCommandResult
 from ceph.deployment.service_spec import IscsiServiceSpec, ServiceSpec
 
 from orchestrator import DaemonDescription, DaemonDescriptionStatus
+from pybind.mgr.orchestrator._interface import OrchestratorError
 from .cephadmservice import CephadmDaemonDeploySpec, CephService
 from .service_registry import register_cephadm_service
 from .. import utils
@@ -97,6 +98,11 @@ class IscsiService(CephService):
             gateways = json.loads(out)['gateways']
             cmd_dicts = []
             # TODO: fail, if we don't have a spec
+            if spec is None:
+                raise OrchestratorError(
+                    "iSCSI service requires a service spec, but none was provided"
+                )
+
             spec = cast(IscsiServiceSpec,
                         self.mgr.spec_store.all_specs.get(daemon_descrs[0].service_name(), None))
             if spec.api_secure and spec.ssl_cert and spec.ssl_key:


### PR DESCRIPTION
## Summary

This change improves robustness in cephadm iSCSI service handling by failing
early when the service specification is missing.

Previously, execution could proceed with an undefined spec and fail later with
less clear errors. Introducing an explicit early failure improves error clarity
and makes failures easier to diagnose.

Local sanity checks were performed under WSL Ubuntu to ensure the change behaves
as expected.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)

- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked

- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate

- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests
