### PR TITLE
cmake: disable ASan exception interception in tests

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -29,10 +29,12 @@ function(add_ceph_test test_name test_path)
     # AddressSanitizer: odr-violation: global 'ceph::buffer::list::always_empty_bptr' at
     # /home/jenkins-build/build/workspace/ceph-pull-requests/src/common/buffer.cc:1267:34
     # see https://tracker.ceph.com/issues/65098
+    # intercept_cxx_exceptions=0: Disable exception interception to avoid CHECK failures
+    # when exceptions are thrown during early initialization (e.g., in Python bindings)
     set_property(TEST ${test_name}
       APPEND
       PROPERTY ENVIRONMENT
-      ASAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/qa/asan.supp,detect_odr_violation=0
+      ASAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/qa/asan.supp,detect_odr_violation=0,intercept_cxx_exceptions=0
       LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/qa/lsan.supp,print_suppressions=0)
   endif()
   set_property(TEST ${test_name}

--- a/qa/asan.supp
+++ b/qa/asan.supp
@@ -1,3 +1,10 @@
 # ASan's interceptor is not able to find the real throw function because of
 # https://github.com/google/sanitizers/issues/934
 interceptor_via_fun:__interceptor___cxa_throw
+
+# Note: The above suppression only works for ASan reports about the interceptor.
+# It does NOT prevent CHECK failures when __cxa_throw is called before ASan is
+# fully initialized (e.g., during early library initialization in Python bindings).
+# For those cases, we disable exception interception entirely by setting
+# ASAN_OPTIONS=intercept_cxx_exceptions=0 in cmake/modules/AddCephTest.cmake.
+


### PR DESCRIPTION
Fix ASan CHECK failure when exceptions are thrown during early initialization, particularly in Python bindings that load Ceph shared libraries.

ASan reported the following error:
```
  AddressSanitizer: CHECK failed: asan_interceptors.cpp:335
  "((__interception::real___cxa_throw)) != (0)" (0x0, 0x0)
    #0 CheckUnwind asan_rtl.cpp:69
    #1 CheckFailed sanitizer_termination.cpp:86
    #2 __interceptor___cxa_throw asan_interceptors.cpp:335
    #3 boost::throw_exception<boost::bad_lexical_cast>
    #4 boost::conversion::detail::throw_bad_cast
    #5 boost::lexical_cast<unsigned long, std::string>
    #6 librbd::rbd_features_from_string /ceph/src/librbd/Features.cc:67
    #7 get_rbd_options()::$_2::operator() rbd_options.cc:44
    #8 Option::pre_validate /ceph/src/common/options.cc:94
    #9 md_config_t::md_config_t /ceph/src/common/config.cc:208
    #10 CephContext::CephContext /ceph/src/common/ceph_context.cc:730
    #11 rados_create_cct /ceph/src/librados/librados_c.cc:120
    #12 Python rados module initialization
```
Root cause: When Python loads the Ceph shared library (e.g., rados.so), CephContext initialization validates configuration options. The RBD default features option validator calls `rbd_features_from_string()`, which uses `boost::lexical_cast` to parse the feature string. When the string is not numeric (e.g., "`layering,exclusive-lock`,..."), lexical_cast throws `boost::bad_lexical_cast`.

This exception is properly caught and handled in the code. However, ASan's exception interceptor (__cxa_throw) may not be fully initialized when exceptions are thrown during early library initialization, causing a CHECK failure.

Why `qa/asan.supp` is not sufficient:
The existing suppression in qa/asan.supp for `__interceptor___cxa_throw` only suppresses ASan *reports* about the interceptor. It does NOT prevent CHECK failures in ASan's runtime itself. CHECK failures are assertions that terminate the program immediately, before any suppression mechanism can be applied. The CHECK fails because real___cxa_throw is NULL (not yet initialized), which is a precondition violation in ASan's interceptor code.

Suppressions work by filtering ASan's output after an issue is detected, but they cannot prevent internal CHECK failures in ASan's initialization logic.

Solution: Disable ASan's C++ exception interception by adding intercept_cxx_exceptions=0 to ASAN_OPTIONS. This prevents ASan from intercepting exception throws/catches, avoiding the initialization order issue. Exception handling still works correctly; we just lose ASan's ability to detect exception-related memory issues.

This is a known limitation when using ASan with code that throws exceptions during static/early initialization, particularly in shared libraries loaded by interpreters like Python.

Note: This does not hide real bugs - the exception is properly caught and handled. We're only disabling ASan's interception mechanism to avoid the initialization order problem.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
