### PR TITLE
tentacle: test/ceph-helpers: Pass timeout and add timeout for commands in test_pg_scrub

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1948,7 +1948,7 @@ function test_pg_scrub() {
     wait_for_clean || return 1
     pg_scrub 1.0 || return 1
     kill_daemons $dir KILL osd || return 1
-    ! TIMEOUT=2 pg_scrub 1.0 || return 1
+    ! WAIT_FOR_CLEAN_TIMEOUT=10 TIMEOUT=2 pg_scrub 1.0 || return 1
     teardown $dir || return 1
 }
 
@@ -2255,10 +2255,9 @@ function flush_pg_stats()
     ids=`ceph osd ls`
     seqs=''
     for osd in $ids; do
-	    seq=`ceph tell osd.$osd flush_pg_stats`
-	    if test -z "$seq"
-	    then
-		continue
+        seq=$(timeout $timeout ceph tell osd.$osd flush_pg_stats 2>/dev/null) || true
+	    if test -z "$seq"; then
+		    continue
 	    fi
 	    seqs="$seqs $osd-$seq"
     done


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74375

---

backport of https://github.com/ceph/ceph/pull/66457
parent tracker: https://tracker.ceph.com/issues/74004

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh