### PR TITLE
tentacle: Implement Admin REST APIs for Setting Account Quota

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -373,7 +373,7 @@ Special Error Responses
 None.
 
 Create Account
-===========
+==============
 .. versionadded:: Squid
 
 Create a new account.
@@ -400,7 +400,7 @@ Request Parameters
 :Example: ``RGW00000000000000001``
 :Required: Yes
 
-An account ID must be 20 bytes long.
+An account ID must be 20 characters long, and in the format of the string "RGW" followed by 17 numeric characters.
 
 ``name``
 
@@ -425,35 +425,35 @@ An account ID must be 20 bytes long.
 
 ``max-users``
 
-:Description: Specifies the maximum number of users the account can own.
+:Description: Specifies the maximum number of users the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
 
 ``max-roles``
 
-:Description: Specifies the maximum number of roles the account can own.
+:Description: Specifies the maximum number of roles the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
 
 ``max-groups``
 
-:Description: Specifies the maximum number of groups the account can own.
+:Description: Specifies the maximum number of groups the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
 
 ``max-access-keys``
 
-:Description: Specifies the maximum number of access keys the account can own.
+:Description: Specifies the maximum number of access keys the account can own. The default is 4.
 :Type: Integer
 :Example: 1 [4]
 :Required: No
 
 ``max-buckets``
 
-:Description: Specifies the maximum number of buckets the account can own.
+:Description: Specifies the maximum number of buckets the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
@@ -600,15 +600,15 @@ Special Error Responses
 
 ``AccountAlreadyExists``
 
-:Description: Attempt to create existing account. This can happen if the Account ID or the email is already in use.
+:Description: Attempt to create existing account. This can happen if the account ID or the email is already in use.
 :Code: 409 Conflict
 
 
 Modify Account
-===========
+==============
 .. versionadded:: Squid
 
-Modify a account. Either an "id", "name", or "email" needs to be provided.
+Modify an account. Either ``id``, ``name``, or ``email`` must be provided.
 
 :caps: accounts=write
 
@@ -647,35 +647,35 @@ Request Parameters
 
 ``max-users``
 
-:Description: Specifies the maximum number of users the account can own.
+:Description: Specifies the maximum number of users the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
 
 ``max-roles``
 
-:Description: Specifies the maximum number of roles the account can own.
+:Description: Specifies the maximum number of roles the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
 
 ``max-groups``
 
-:Description: Specifies the maximum number of groups the account can own.
+:Description: Specifies the maximum number of groups the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
 
 ``max-access-keys``
 
-:Description: Specifies the maximum number of access keys the account can own.
+:Description: Specifies the maximum number of access keys the account can own. The default is 4.
 :Type: Integer
 :Example: 1 [4]
 :Required: No
 
 ``max-buckets``
 
-:Description: Specifies the maximum number of buckets the account can own.
+:Description: Specifies the maximum number of buckets the account can own. The default is 1000.
 :Type: Integer
 :Example: 500 [1000]
 :Required: No
@@ -692,7 +692,7 @@ If successful, the response contains the following account information.
 
 ``id``
 
-:Description: The account id.
+:Description: The account ID.
 :Type: String
 :Parent: ``account``
 
@@ -826,7 +826,7 @@ Get Account Info
 ===========
 .. versionadded:: Squid
 
-Get account info. Either an "id" or a "name" needs to be provided.
+Get account info. Either an ``id`` or a ``name`` must be provided.
 
 :caps: accounts=write
 
@@ -869,7 +869,7 @@ If successful, the response contains the following account information.
 
 ``id``
 
-:Description: The account id.
+:Description: The account ID.
 :Type: String
 :Parent: ``account``
 
@@ -1000,10 +1000,10 @@ Special Error Responses
 None.
 
 Remove Account
-===========
+==============
 .. versionadded:: Squid
 
-Remove an existing account. Either an "id", "name", or "email" needs to be provided.
+Remove an existing account. Either ``id``, ``name``, or ``email`` must be provided.
 
 :caps: accounts=write
 
@@ -1189,7 +1189,7 @@ A tenant name may also specified as a part of ``uid``, by following the syntax
 
 ``account-id``
 
-:Description: the Account under which a user should exist.
+:Description: the account under which a user should exist.
 :Type: string
 :Example: RGW00000000000000001
 :Required: No
@@ -2769,7 +2769,7 @@ as mentioned in Set Bucket Quota section above.
 
 
 Set Account Quota
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 To set a quota, the user must have ``accounts`` capability set with ``write``
 permission. ::
@@ -2777,7 +2777,7 @@ permission. ::
 	PUT /admin/account?quota&id=<account_id>&quota-type=account
 
 Set Bucket Quota under an Account
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To set a quota, the user must have ``accounts`` capability set with ``write``
 permission. ::

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -372,6 +372,692 @@ Special Error Responses
 
 None.
 
+Create Account
+===========
+.. versionadded:: Squid
+
+Create a new account.
+
+:caps: accounts=write
+
+Syntax
+~~~~~~
+
+::
+
+	POST /{admin}/account?format=json HTTP/1.1
+	Host: {fqdn}
+
+
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``id``
+
+:Description: The ID of the account to be created.
+:Type: String
+:Example: ``RGW00000000000000001``
+:Required: Yes
+
+An account ID must be 20 bytes long.
+
+``name``
+
+:Description: The name of the account to be created.
+:Type: String
+:Example: ``account_name``
+:Required: Yes
+
+``email``
+
+:Description: The email address associated with the account.
+:Type: String
+:Example: ``foo@bar.com``
+:Required: No
+
+``tenant``
+
+:Description: The Tenant under which the account exists.
+:Type: string
+:Example: tenant1
+:Required: No
+
+``max-users``
+
+:Description: Specifies the maximum number of users the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+``max-roles``
+
+:Description: Specifies the maximum number of roles the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+``max-groups``
+
+:Description: Specifies the maximum number of groups the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+``max-access-keys``
+
+:Description: Specifies the maximum number of access keys the account can own.
+:Type: Integer
+:Example: 1 [4]
+:Required: No
+
+``max-buckets``
+
+:Description: Specifies the maximum number of buckets the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+
+Response Entities
+~~~~~~~~~~~~~~~~~
+
+If successful, the response contains the following account information.
+
+``account``
+
+:Description: A container for the account information.
+:Type: Container
+
+``id``
+
+:Description: The ID of the account created.
+:Type: String
+:Parent: ``account``
+
+``tenant``
+
+:Description: The Tenant under which the account exists.
+:Type: String
+:Parent: ``account``
+
+``name``
+
+:Description: The name of the account created.
+:Type: String
+:Parent: ``account``
+
+``email``
+
+:Description: The email address associated with the account.
+:Type: String
+:Parent: ``account``
+
+``max_users``
+
+:Description: The maximum number of users the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_roles``
+
+:Description: The maximum number of roles the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_groups``
+
+:Description: The maximum number of groups the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_buckets``
+
+:Description: The maximum number of buckets the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_access_keys``
+
+:Description: The maximum number of access keys the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``quota``
+
+:Description: A container for the account quota information.
+:Type: Container
+:Parent: ``account``
+
+``enabled``
+
+:Description: Whether quota is enabled at the account level.
+:Type: Bool
+:Parent: ``quota``
+
+``check_on_raw``
+
+:Description: Whether quota should be checked on raw usage instead of the 4 KiB rounded one.
+:Type: Bool
+:Parent: ``quota``
+
+``max_size``
+
+:Description: The max quota size in bytes.
+:Type: Integer
+:Parent: ``quota``
+
+``max_size_kb``
+
+:Description: The max quota size in kilobytes.
+:Type: Integer
+:Parent: ``quota``
+
+``max_objects``
+
+:Description: The max number of objects that an account can own.
+:Type: Integer
+:Parent: ``quota``
+
+``bucket_quota``
+
+:Description: A container for the account bucket-level quota information.
+:Type: Container
+:Parent: ``account``
+
+``enabled``
+
+:Description: Whether quota is enabled at the bucket level for the account.
+:Type: Bool
+:Parent: ``bucket_quota``
+
+``check_on_raw``
+
+:Description: Whether bucket quota for the account should be checked on raw usage instead of the 4 KiB rounded one.
+:Type: Bool
+:Parent: ``bucket_quota``
+
+``max_size``
+
+:Description: The max quota size in bytes for buckets under the account.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+``max_size_kb``
+
+:Description: The max quota size in kilobytes for buckets under the account.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+``max_objects``
+
+:Description: The max number of objects that a bucket under the account can have.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+Special Error Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``AccountAlreadyExists``
+
+:Description: Attempt to create existing account. This can happen if the Account ID or the email is already in use.
+:Code: 409 Conflict
+
+
+Modify Account
+===========
+.. versionadded:: Squid
+
+Modify a account. Either an "id", "name", or "email" needs to be provided.
+
+:caps: accounts=write
+
+Syntax
+~~~~~~
+
+::
+
+	PUT /{admin}/account?format=json HTTP/1.1
+	Host: {fqdn}
+
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``id``
+
+:Description: The ID of the account to be modified.
+:Type: String
+:Example: ``RGW00000000000000001``
+:Required: No
+
+``name``
+
+:Description: The name of the account to be modified.
+:Type: String
+:Example: ``account_name``
+:Required: No
+
+``email``
+
+:Description: The email address of the account to be modified.
+:Type: String
+:Example: ``foo@bar.com``
+:Required: No
+
+``max-users``
+
+:Description: Specifies the maximum number of users the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+``max-roles``
+
+:Description: Specifies the maximum number of roles the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+``max-groups``
+
+:Description: Specifies the maximum number of groups the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+``max-access-keys``
+
+:Description: Specifies the maximum number of access keys the account can own.
+:Type: Integer
+:Example: 1 [4]
+:Required: No
+
+``max-buckets``
+
+:Description: Specifies the maximum number of buckets the account can own.
+:Type: Integer
+:Example: 500 [1000]
+:Required: No
+
+Response Entities
+~~~~~~~~~~~~~~~~~
+
+If successful, the response contains the following account information.
+
+``account``
+
+:Description: A container for the account information.
+:Type: Container
+
+``id``
+
+:Description: The account id.
+:Type: String
+:Parent: ``account``
+
+``tenant``
+
+:Description: The Tenant under which the account exists.
+:Type: String
+:Parent: ``account``
+
+``name``
+
+:Description: The name of the account created.
+:Type: String
+:Parent: ``account``
+
+``email``
+
+:Description: The email address associated with the account.
+:Type: String
+:Parent: ``account``
+
+``max_users``
+
+:Description: The maximum number of users the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_roles``
+
+:Description: The maximum number of roles the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_groups``
+
+:Description: The maximum number of groups the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_buckets``
+
+:Description: The maximum number of buckets the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_access_keys``
+
+:Description: The maximum number of access keys the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``quota``
+
+:Description: A container for the account quota information.
+:Type: Container
+:Parent: ``account``
+
+``enabled``
+
+:Description: Whether quota is enabled at the account level.
+:Type: Bool
+:Parent: ``quota``
+
+``check_on_raw``
+
+:Description: Whether quota should be checked on raw usage instead of the 4 KiB rounded one.
+:Type: Bool
+:Parent: ``quota``
+
+``max_size``
+
+:Description: The max quota size in bytes.
+:Type: Integer
+:Parent: ``quota``
+
+``max_size_kb``
+
+:Description: The max quota size in kilobytes.
+:Type: Integer
+:Parent: ``quota``
+
+``max_objects``
+
+:Description: The max number of objects that an account can own.
+:Type: Integer
+:Parent: ``quota``
+
+``bucket_quota``
+
+:Description: A container for the account bucket-level quota information.
+:Type: Container
+:Parent: ``account``
+
+``enabled``
+
+:Description: Whether quota is enabled at the bucket level for the account.
+:Type: Bool
+:Parent: ``bucket_quota``
+
+``check_on_raw``
+
+:Description: Whether bucket quota for the account should be checked on raw usage instead of the 4 KiB rounded one.
+:Type: Bool
+:Parent: ``bucket_quota``
+
+``max_size``
+
+:Description: The max quota size in bytes for buckets under the account.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+``max_size_kb``
+
+:Description: The max quota size in kilobytes for buckets under the account.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+``max_objects``
+
+:Description: The max number of objects that a bucket under the account can have.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+
+Special Error Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+None.
+
+Get Account Info
+===========
+.. versionadded:: Squid
+
+Get account info. Either an "id" or a "name" needs to be provided.
+
+:caps: accounts=write
+
+Syntax
+~~~~~~
+
+::
+
+	GET /{admin}/account?format=json HTTP/1.1
+	Host: {fqdn}
+
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``id``
+
+:Description: The ID of the account to get info for.
+:Type: String
+:Example: ``RGW00000000000000001``
+:Required: No
+
+``name``
+
+:Description: The name of the account to get info for.
+:Type: String
+:Example: ``account_name``
+:Required: No
+
+
+Response Entities
+~~~~~~~~~~~~~~~~~
+
+If successful, the response contains the following account information.
+
+``account``
+
+:Description: A container for the account information.
+:Type: Container
+
+``id``
+
+:Description: The account id.
+:Type: String
+:Parent: ``account``
+
+``tenant``
+
+:Description: The Tenant under which the account exists.
+:Type: String
+:Parent: ``account``
+
+``name``
+
+:Description: The name of the account created.
+:Type: String
+:Parent: ``account``
+
+``email``
+
+:Description: The email address associated with the account.
+:Type: String
+:Parent: ``account``
+
+``max_users``
+
+:Description: The maximum number of users the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_roles``
+
+:Description: The maximum number of roles the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_groups``
+
+:Description: The maximum number of groups the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_buckets``
+
+:Description: The maximum number of buckets the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``max_access_keys``
+
+:Description: The maximum number of access keys the account can own.
+:Type: Integer
+:Parent: ``account``
+
+``quota``
+
+:Description: A container for the account quota information.
+:Type: Container
+:Parent: ``account``
+
+``enabled``
+
+:Description: Whether quota is enabled at the account level.
+:Type: Bool
+:Parent: ``quota``
+
+``check_on_raw``
+
+:Description: Whether quota should be checked on raw usage instead of the 4 KiB rounded one.
+:Type: Bool
+:Parent: ``quota``
+
+``max_size``
+
+:Description: The max quota size in bytes.
+:Type: Integer
+:Parent: ``quota``
+
+``max_size_kb``
+
+:Description: The max quota size in kilobytes.
+:Type: Integer
+:Parent: ``quota``
+
+``max_objects``
+
+:Description: The max number of objects that an account can own.
+:Type: Integer
+:Parent: ``quota``
+
+``bucket_quota``
+
+:Description: A container for the account bucket-level quota information.
+:Type: Container
+:Parent: ``account``
+
+``enabled``
+
+:Description: Whether quota is enabled at the bucket level for the account.
+:Type: Bool
+:Parent: ``bucket_quota``
+
+``check_on_raw``
+
+:Description: Whether bucket quota for the account should be checked on raw usage instead of the 4 KiB rounded one.
+:Type: Bool
+:Parent: ``bucket_quota``
+
+``max_size``
+
+:Description: The max quota size in bytes for buckets under the account.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+``max_size_kb``
+
+:Description: The max quota size in kilobytes for buckets under the account.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+``max_objects``
+
+:Description: The max number of objects that a bucket under the account can have.
+:Type: Integer
+:Parent: ``bucket_quota``
+
+
+Special Error Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+None.
+
+Remove Account
+===========
+.. versionadded:: Squid
+
+Remove an existing account. Either an "id", "name", or "email" needs to be provided.
+
+:caps: accounts=write
+
+Syntax
+~~~~~~
+
+::
+
+	DELETE /{admin}/account?format=json HTTP/1.1
+	Host: {fqdn}
+
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``id``
+
+:Description: The ID of the account to be removed.
+:Type: String
+:Example: ``RGW00000000000000001``
+:Required: No
+
+``tenant``
+
+:Description: The Tenant under which the account exists.
+:Type: String
+:Example: ``tenant``
+:Required: No
+
+``name``
+
+:Description: The name of the account to be removed.
+:Type: String
+:Example: ``account_name``
+:Required: No
+
+``email``
+
+:Description: The email address associated with the account to be removed.
+:Type: String
+:Example: ``foo@bar.com``
+:Required: No
+
+
+Response Entities
+~~~~~~~~~~~~~~~~~
+
+None
+
+Special Error Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+None.
+
 Create User
 ===========
 
@@ -497,6 +1183,15 @@ A tenant name may also specified as a part of ``uid``, by following the syntax
 :Description: default storage class for the user, default-placement must be defined when setting this option.
 :Type: string
 :Example: STANDARD-1A
+:Required: No
+
+.. versionadded:: Squid
+
+``account-id``
+
+:Description: the Account under which a user should exist.
+:Type: string
+:Example: RGW00000000000000001
 :Required: No
 
 Response Entities
@@ -1987,12 +2682,16 @@ Special Error Responses
 Quotas
 ======
 
-The Admin Operations API enables you to set quotas on users and on bucket owned
-by users. See `Quota Management`_ for additional details. Quotas include the
-maximum number of objects in a bucket and the maximum storage size in megabytes.
+The Admin Operations API enables you to set quotas on users and on buckets owned
+by users, and on accounts and on buckets owned by accounts. See `Quota Management`_
+for additional details. Quotas include the maximum number of objects in a bucket 
+and the maximum storage size in megabytes.
 
-To view quotas, the user must have a ``users=read`` capability. To set,
+To view quotas for users, the user must have a ``users=read`` capability. To set,
 modify or disable a quota, the user must have ``users=write`` capability.
+
+To view quotas for accounts, the user must have a ``accounts=read`` capability. To set,
+modify or disable a quota, the user must have ``accounts=write`` capability.
 See the `Admin Guide`_ for details.
 
 Valid parameters for quotas include:
@@ -2008,7 +2707,8 @@ Valid parameters for quotas include:
   to specify it in KiB. A negative value disables this setting.
 
 - **Quota Type:** The ``quota-type`` option sets the scope for the quota.
-  The options are ``bucket`` and ``user``.
+  The options are ``bucket`` and ``user`` for user-level quota.
+  The options are ``bucket`` and ``account`` for account-level quota.
 
 - **Enable/Disable Quota:** The ``enabled`` option specifies whether the
   quota should be enabled. The value should be either 'True' or 'False'.
@@ -2067,6 +2767,22 @@ permission. ::
 The content must include a JSON representation of the quota settings
 as mentioned in Set Bucket Quota section above.
 
+
+Set Account Quota
+~~~~~~~~~~~~~~
+
+To set a quota, the user must have ``accounts`` capability set with ``write``
+permission. ::
+
+	PUT /admin/account?quota&id=<account_id>&quota-type=account
+
+Set Bucket Quota under an Account
+~~~~~~~~~~~~~~~~
+
+To set a quota, the user must have ``accounts`` capability set with ``write``
+permission. ::
+
+	PUT /admin/account?quota&id=<account_id>&quota-type=bucket
 
 
 Rate Limit

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -29,13 +29,9 @@ def rgwadmin_rest(connection, cmd, params=None, headers=None, raw=False):
     """
     log.info('radosgw-admin-rest: %s %s' % (cmd, params))
     put_cmds = ['create', 'link', 'add', 'set']
-    post_cmds = ['unlink', 'modify']
+    post_cmds = ['unlink', 'modify', 'post']
     delete_cmds = ['trim', 'rm', 'process']
     get_cmds = ['check', 'info', 'show', 'list', 'get', '']
-
-    bucket_sub_resources = ['object', 'policy', 'index']
-    user_sub_resources = ['subuser', 'key', 'caps', 'quota']
-    zone_sub_resources = ['pool', 'log', 'garbage']
 
     def get_cmd_method_and_handler(cmd):
         """
@@ -53,29 +49,21 @@ def rgwadmin_rest(connection, cmd, params=None, headers=None, raw=False):
 
     def get_resource(cmd):
         """
-        Get the name of the resource from information in cmd.
+        Always return (resource, subresource) as a 2-tuple.
+        Accepts:
+        ['user','info']                  -> ('user','')
+        [('user','key'),'create']        -> ('user','key')
+        ['info','']                      -> ('info','')
         """
-        if cmd[0] == 'bucket' or cmd[0] in bucket_sub_resources:
-            if cmd[0] == 'bucket':
-                return 'bucket', ''
+        r = cmd[0]
+        if isinstance(r, (list, tuple)):
+            if len(r) == 1:
+                return r[0], ''
             else:
-                return 'bucket', cmd[0]
-        elif cmd[0] == 'user' or cmd[0] in user_sub_resources:
-            if cmd[0] == 'user':
-                return 'user', ''
-            else:
-                return 'user', cmd[0]
-        elif cmd[0] == 'usage':
-            return 'usage', ''
-        elif cmd[0] == 'info':
-            return 'info', ''
-        elif cmd[0] == 'ratelimit':
-            return 'ratelimit', ''
-        elif cmd[0] == 'zone' or cmd[0] in zone_sub_resources:
-            if cmd[0] == 'zone':
-                return 'zone', ''
-            else:
-                return 'zone', cmd[0]
+                return r
+        if isinstance(r, str):
+            return r, ''
+        raise TypeError(f'Unsupported resource type for {str(r)}')
 
     def build_admin_request(conn, method, resource = '', headers=None, data='',
             query_args=None, params=None):
@@ -302,7 +290,7 @@ def task(ctx, config):
     admin_display_name = 'Ms. Admin User'
     admin_access_key = 'MH1WC2XQ1S8UISFDZC8W'
     admin_secret_key = 'dQyrTPA0s248YeN5bBv4ukvKU0kh54LWWywkrpoG'
-    admin_caps = 'users=read, write; usage=read, write; buckets=read, write; zone=read, write; info=read;ratelimit=read, write'
+    admin_caps = 'users=read, write; usage=read, write; buckets=read, write; zone=read, write; info=read; ratelimit=read, write; accounts=read, write'
 
     user1 = 'foo'
     user2 = 'fud'
@@ -320,6 +308,7 @@ def task(ctx, config):
     swift_secret2 = 'ri2VJQcKSYATOY6uaDUX7pxgkW+W1YmC6OCxPHwy'
 
     bucket_name = 'myfoo'
+    account_id = 'RGW00000000000000001'
 
     # legend (test cases can be easily grep-ed out)
     # TESTCASE 'testname','object','method','operation','assertion'
@@ -476,7 +465,7 @@ def task(ctx, config):
 
     # TESTCASE 'add-keys','key','create','w/valid info','succeeds'
     (ret, out) = rgwadmin_rest(admin_conn,
-            ['key', 'create'],
+            [('user', 'key'), 'create'],
             {'uid' : user1,
              'access-key' : access_key2,
              'secret-key' : secret_key2
@@ -494,7 +483,7 @@ def task(ctx, config):
 
     # TESTCASE 'rm-key','key','rm','newly added key','succeeds, key is removed'
     (ret, out) = rgwadmin_rest(admin_conn,
-            ['key', 'rm'],
+            [('user', 'key'), 'rm'],
             {'uid' : user1,
              'access-key' : access_key2
             })
@@ -509,7 +498,7 @@ def task(ctx, config):
 
     # TESTCASE 'add-swift-key','key','create','swift key','succeeds'
     (ret, out) = rgwadmin_rest(admin_conn,
-            ['subuser', 'create'],
+            [('user', 'subuser'), 'create'],
             {'subuser' : subuser1,
              'secret-key' : swift_secret1,
              'key-type' : 'swift'
@@ -526,7 +515,7 @@ def task(ctx, config):
 
     # TESTCASE 'add-swift-subuser','key','create','swift sub-user key','succeeds'
     (ret, out) = rgwadmin_rest(admin_conn,
-            ['subuser', 'create'],
+            [('user', 'subuser'), 'create'],
             {'subuser' : subuser2,
              'secret-key' : swift_secret2,
              'key-type' : 'swift'
@@ -543,7 +532,7 @@ def task(ctx, config):
 
     # TESTCASE 'rm-swift-key1','key','rm','subuser','succeeds, one key is removed'
     (ret, out) = rgwadmin_rest(admin_conn,
-            ['key', 'rm'],
+            [('user', 'key'), 'rm'],
             {'subuser' : subuser1,
              'key-type' :'swift'
             })
@@ -555,7 +544,7 @@ def task(ctx, config):
 
     # TESTCASE 'rm-subuser','subuser','rm','subuser','success, subuser is removed'
     (ret, out) = rgwadmin_rest(admin_conn,
-            ['subuser', 'rm'],
+            [('user', 'subuser'), 'rm'],
             {'subuser' : subuser1
             })
 
@@ -566,7 +555,7 @@ def task(ctx, config):
 
     # TESTCASE 'rm-subuser-with-keys','subuser','rm','subuser','succeeds, second subser and key is removed'
     (ret, out) = rgwadmin_rest(admin_conn,
-            ['subuser', 'rm'],
+            [('user', 'subuser'), 'rm'],
             {'subuser' : subuser2,
              'key-type' : 'swift',
              '{purge-keys' :True
@@ -712,7 +701,7 @@ def task(ctx, config):
     key.set_contents_from_string(object_name)
 
     # now delete it
-    (ret, out) = rgwadmin_rest(admin_conn, ['object', 'rm'], {'bucket' : bucket_name, 'object' : object_name})
+    (ret, out) = rgwadmin_rest(admin_conn, [('bucket', 'object'), 'rm'], {'bucket' : bucket_name, 'object' : object_name})
     assert ret == 200
 
     # TESTCASE 'bucket-stats6','bucket','stats','after deleting key','succeeds, lists one no objects'
@@ -837,14 +826,14 @@ def task(ctx, config):
     # should be private already but guarantee it
     key.set_acl('private')
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
+    (ret, out) = rgwadmin_rest(admin_conn, [('bucket', 'policy'), 'show'], {'bucket' : bucket.name, 'object' : key.key})
     assert ret == 200
     assert len(out['acl']['grant_map']) == 1
 
     # add another grantee by making the object public read
     key.set_acl('public-read')
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['policy', 'show'], {'bucket' : bucket.name, 'object' : key.key})
+    (ret, out) = rgwadmin_rest(admin_conn, [('bucket', 'policy'), 'show'], {'bucket' : bucket.name, 'object' : key.key})
     assert ret == 200
     assert len(out['acl']['grant_map']) == 2
 
@@ -865,12 +854,12 @@ def task(ctx, config):
 
     # TESTCASE 'caps-add', 'caps', 'add', 'add user cap', 'succeeds'
     caps = 'usage=read'
-    (ret, out) = rgwadmin_rest(admin_conn, ['caps', 'add'], {'uid' :  user1, 'user-caps' : caps})
+    (ret, out) = rgwadmin_rest(admin_conn, [('user', 'caps'), 'add'], {'uid' :  user1, 'user-caps' : caps})
     assert ret == 200
     assert out[0]['perm'] == 'read'
 
     # TESTCASE 'caps-rm', 'caps', 'rm', 'remove existing cap from user', 'succeeds'
-    (ret, out) = rgwadmin_rest(admin_conn, ['caps', 'rm'], {'uid' :  user1, 'user-caps' : caps})
+    (ret, out) = rgwadmin_rest(admin_conn, [('user', 'caps'), 'rm'], {'uid' :  user1, 'user-caps' : caps})
     assert ret == 200
     assert not out
 
@@ -981,4 +970,150 @@ def task(ctx, config):
 
     # TESTCASE 'ratelimit' 'global' 'modify' 'anonymous' 'enabled' 'succeeds'
     (ret, out) = rgwadmin_rest(admin_conn, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'global': 'true', 'enabled' : 'true'})
+    assert ret == 200
+
+    # TESTCASE 'create account' 'account' 'post' 'creating a new account' 'succeeds'
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'post'], {'id' : account_id, 'name': account_id})
+    assert ret == 200
+
+    # TESTCASE 'account-info' 'account' 'info' 'getting the account info, including its quota, and checking for default values' 'succeeds'
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'info'], {'id' : account_id})
+    assert ret == 200
+    account_quota = out['quota']
+    assert not account_quota["enabled"]
+    assert account_quota["max_size"] == -1
+    assert account_quota["max_objects"] == -1
+    bucket_quota = out['bucket_quota']
+    assert not bucket_quota["enabled"]
+    assert bucket_quota["max_size"] == -1
+    assert bucket_quota["max_objects"] == -1
+    assert out["max_users"] == 1000
+    assert out["max_roles"] == 1000
+    assert out["max_groups"] == 1000
+    assert out["max_buckets"] == 1000
+    assert out["max_access_keys"] == 4
+
+    # TESTCASE 'bucket-level-account-quota-set' 'account-quota-set' 'setting account quota at the bucket level. Other values should remain the same' 'succeeds'
+    (ret, out) = rgwadmin_rest(admin_conn, [('account', 'quota'), 'set'], {'id': account_id, 'quota-type' : 'bucket', 'max-size': 12345, 'max-objects' : 54321, 'enabled': True})
+    assert ret == 200
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'info'], {'id' : account_id})
+    assert ret == 200
+    # verifying bucket-level quota has been changed
+    bucket_quota = out['bucket_quota']
+    assert bucket_quota["enabled"]
+    assert bucket_quota["max_size"] == 12345
+    assert bucket_quota["max_objects"] == 54321
+    # verifying the rest of the values remain the same
+    account_quota = out['quota']
+    assert not account_quota["enabled"]
+    assert account_quota["max_size"] == -1
+    assert account_quota["max_objects"] == -1
+    assert out["max_users"] == 1000
+    assert out["max_roles"] == 1000
+    assert out["max_groups"] == 1000
+    assert out["max_buckets"] == 1000
+    assert out["max_access_keys"] == 4
+    # cleanup the account
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'rm'], {'id' : account_id})
+    assert ret == 200
+
+
+    # TESTCASE 'account-level-quota-set' 'account-quota-set' 'setting account quota at the account level. Other values should remain the same' 'succeeds'
+    # re-create the account
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'post'], {'id' : account_id, 'name': account_id})
+    assert ret == 200
+    (ret, out) = rgwadmin_rest(admin_conn, [('account', 'quota'), 'set'], {'id': account_id, 'quota-type' : 'account', 'max-size': 12345, 'max-objects' : 54321, 'enabled': True})
+    assert ret == 200
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'info'], {'id' : account_id})
+    assert ret == 200
+    # verifying account-level quota has been changed
+    account_quota = out['quota']
+    assert account_quota["enabled"]
+    assert account_quota["max_size"] == 12345
+    assert account_quota["max_objects"] == 54321
+    # verifying the rest of the values remain the same
+    bucket_quota = out['bucket_quota']
+    assert not bucket_quota["enabled"]
+    assert bucket_quota["max_size"] == -1
+    assert bucket_quota["max_objects"] == -1
+    assert out["max_users"] == 1000
+    assert out["max_roles"] == 1000
+    assert out["max_groups"] == 1000
+    assert out["max_buckets"] == 1000
+    assert out["max_access_keys"] == 4
+    # cleanup the account
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'rm'], {'id' : account_id})
+    assert ret == 200
+
+    # TESTCASE 'account-quota-set-invalid-args' 'account-quota-set' 'verify set quota requests with invalid args fail' 'fails'
+    # re-create the account
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'post'], {'id' : account_id, 'name': account_id})
+    assert ret == 200
+
+    # verify invalid quota-type fails
+    (ret, out) = rgwadmin_rest(admin_conn, [('account', 'quota'), 'set'], {'id': account_id, 'quota-type' : 'invalid', 'max-size': 12345, 'max-objects' : 54321, 'enabled': True})
+    assert ret == 400
+
+    # verify empty quota-type fails
+    (ret, out) = rgwadmin_rest(admin_conn, [('account', 'quota'), 'set'], {'id': account_id, 'max-size': 12345, 'max-objects' : 54321, 'enabled': True})
+    assert ret == 400
+
+    # verify request with no account id fails
+    (ret, out) = rgwadmin_rest(admin_conn, [('account', 'quota'), 'set'], {'quota-type' : 'bucket', 'max-size': 12345, 'max-objects' : 54321, 'enabled': True})
+    assert ret == 400
+
+    # cleanup the account
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'rm'], {'id' : account_id})
+    assert ret == 200
+
+    # TESTCASE 'rm account caps' 'user-caps-rm' 'verify access after removing user caps for account read and write' 'fails'
+    (err, out) = rgwadmin(ctx, client, [
+            'caps', 'rm',
+            '--uid', admin_user,
+            '--caps', 'accounts=read, write'
+            ])
+    logging.error(out)
+    logging.error(err)
+    assert not err
+
+    # checking failed access to create account
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'post'], {'id' : account_id, 'name': account_id})
+    assert ret == 403
+
+    # checking failed access to set quota
+    (ret, out) = rgwadmin_rest(admin_conn, [('account', 'quota'), 'set'], {'id': account_id, 'quota-type' : 'account', 'max-size': -1, 'max-objects' : -1, 'enabled': True})
+    assert ret == 403
+
+    # checking failed access to get account info
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'info'], {'id' : account_id})
+    assert ret == 403
+
+    # checking failed access to remove account
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'rm'], {'id' : account_id})
+    assert ret == 403
+
+    # TESTCASE 'add back account caps' 'user-caps-add' 'verify access after adding back user caps for account read and write' 'succeeds'
+    (err, out) = rgwadmin(ctx, client, [
+            'caps', 'add',
+            '--uid', admin_user,
+            '--caps', 'accounts=read, write'
+            ])
+    logging.error(out)
+    logging.error(err)
+    assert not err
+
+    # checking create account access
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'post'], {'id' : account_id, 'name': account_id})
+    assert ret == 200
+
+    # checking set quota access
+    (ret, out) = rgwadmin_rest(admin_conn, [('account', 'quota'), 'set'], {'id': account_id, 'quota-type' : 'account', 'max-size': -1, 'max-objects' : -1, 'enabled': True})
+    assert ret == 200
+
+    # checking get account info access
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'info'], {'id' : account_id})
+    assert ret == 200
+
+    # checking remove account access
+    (ret, out) = rgwadmin_rest(admin_conn, ['account', 'rm'], {'id' : account_id})
     assert ret == 200

--- a/src/rgw/rgw_rest_account.cc
+++ b/src/rgw/rgw_rest_account.cc
@@ -171,7 +171,7 @@ void RGWOp_Account_Modify::execute(optional_yield y)
 class RGWOp_Account_Get : public RGWRESTOp {
 public:
   int check_caps(const RGWUserCaps& caps) override {
-    return caps.check_cap("account", RGW_CAP_READ);
+    return caps.check_cap("accounts", RGW_CAP_READ);
   }
 
   void execute(optional_yield y) override;
@@ -193,7 +193,7 @@ void RGWOp_Account_Get::execute(optional_yield y)
 class RGWOp_Account_Delete : public RGWRESTOp {
 public:
   int check_caps(const RGWUserCaps& caps) override {
-    return caps.check_cap("account", RGW_CAP_WRITE);
+    return caps.check_cap("accounts", RGW_CAP_WRITE);
   }
 
   void execute(optional_yield y) override;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -225,6 +225,33 @@ if(${WITH_RADOSGW})
     ${EXPAT_LIBRARIES}
     ${CMAKE_DL_LIBS} ${UNITTEST_LIBS})
 
+  # ceph_test_cls_rgw_admin_account_quota_set
+  set(test_cls_rgw_admin_account_quota_set_srcs 
+    test_rgw_admin_account_quota_set.cc
+    test_rgw_admin_helper.cc
+  )
+  add_executable(ceph_test_cls_rgw_admin_account_quota_set
+    ${test_cls_rgw_admin_account_quota_set_srcs}
+    )
+  target_link_libraries(ceph_test_cls_rgw_admin_account_quota_set
+    librados
+    ${rgw_libs}
+    global
+    cls_version_client
+    cls_log_client
+    cls_refcount_client
+    cls_rgw_client
+    cls_user_client
+    cls_lock_client
+    ${BLKID_LIBRARIES}
+    ${CURL_LIBRARIES}
+    ${EXPAT_LIBRARIES}
+    ${CMAKE_DL_LIBS} ${UNITTEST_LIBS} ${CRYPTO_LIBS})
+
+  install(TARGETS
+    ceph_test_cls_rgw_admin_account_quota_set
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
   # ceph_test_cls_rgw_meta
   set(test_cls_rgw_meta_srcs test_rgw_admin_meta.cc)
   add_executable(ceph_test_cls_rgw_meta

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -253,7 +253,10 @@ if(${WITH_RADOSGW})
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   # ceph_test_cls_rgw_meta
-  set(test_cls_rgw_meta_srcs test_rgw_admin_meta.cc)
+  set(test_cls_rgw_meta_srcs
+    test_rgw_admin_meta.cc
+    test_rgw_admin_helper.cc
+  )
   add_executable(ceph_test_cls_rgw_meta
     ${test_cls_rgw_meta_srcs}
     )

--- a/src/test/test_rgw_admin_account_quota_set.cc
+++ b/src/test/test_rgw_admin_account_quota_set.cc
@@ -1,0 +1,217 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013 eNovance SAS <licensing@enovance.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/Finisher.h"
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
+#include <gtest/gtest.h>
+#include "test_rgw_admin_helper.h"
+
+
+using namespace std;
+using admin_helper::g_test;
+
+int default_quota_max = -1;
+string account_id = "RGW00000000000000001";
+string account_name = CEPH_UID;
+string uid = CEPH_UID;
+string display_name = "CEPH";
+
+TEST(TestRGWAdmin, account_quota_put_accounts_no_access){
+  JSONParser parser;
+  RGWUserInfo uinfo;
+  RGWAccountInfo ainfo;
+  string request_params = "id=" + account_id + "&max-size=999&max-objects=999&enabled=true";
+
+  ASSERT_EQ(0, admin_helper::account_create(account_id, account_name));
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name, true, account_id, false));
+  ASSERT_EQ(0, admin_helper::user_info(uid, display_name, uinfo));
+
+  // assert default values
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_objects);
+  EXPECT_FALSE(ainfo.quota.enabled);
+
+  // assert a user with no access gets 403 unauthorized
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=account&" + request_params);
+  EXPECT_EQ(403U, g_test->get_resp_code());
+
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::account_rm(account_id));
+}
+
+TEST(TestRGWAdmin, account_quota_put){
+  JSONParser parser;
+  RGWUserInfo uinfo;
+  RGWAccountInfo ainfo;
+
+  string request_params = "id=" + account_id + "&max-size=999&max-objects=999&enabled=true";
+
+  ASSERT_EQ(0, admin_helper::account_create(account_id, account_name));
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name, true, account_id, true));
+  ASSERT_EQ(0, admin_helper::user_info(uid, display_name, uinfo));
+
+  // assert default values
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_objects);
+  EXPECT_FALSE(ainfo.quota.enabled);
+
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=account&" + request_params);
+  EXPECT_EQ(200U, g_test->get_resp_code());
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  // assert quotas are set correctly at the account level
+  EXPECT_EQ(999U, ainfo.quota.max_size);
+  EXPECT_EQ(999U, ainfo.quota.max_objects);
+  EXPECT_TRUE(ainfo.quota.enabled);
+
+  // assert bucket quota remains the default
+  EXPECT_EQ(default_quota_max, ainfo.bucket_quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.bucket_quota.max_objects);
+  EXPECT_FALSE(ainfo.bucket_quota.enabled);
+
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=bucket&" + request_params);
+  EXPECT_EQ(200U, g_test->get_resp_code());
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  // assert quotas are set correctly at the bucket level
+  EXPECT_EQ(999U, ainfo.bucket_quota.max_size);
+  EXPECT_EQ(999U, ainfo.bucket_quota.max_objects);
+  EXPECT_TRUE(ainfo.bucket_quota.enabled);
+
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::account_rm(account_id));
+}
+
+TEST(TestRGWAdmin, account_quota_put_partial){
+  JSONParser parser;
+  RGWUserInfo uinfo;
+  RGWAccountInfo ainfo;
+
+  ASSERT_EQ(0, admin_helper::account_create(account_id, account_name));
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name, true, account_id, true));
+  ASSERT_EQ(0, admin_helper::user_info(uid, display_name, uinfo));
+
+  // assert default values
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_objects);
+  EXPECT_FALSE(ainfo.quota.enabled);
+
+  // assert not having anything changed for account quota (max-objects, etc) maintains the default values
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=account&id=" + account_id);
+  EXPECT_EQ(200U, g_test->get_resp_code());
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_objects);
+  EXPECT_FALSE(ainfo.quota.enabled);
+
+  // assert having one field changed leaves the others unchanged
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=account&id=" + account_id + "&max-size=100");
+  EXPECT_EQ(200U, g_test->get_resp_code());
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  EXPECT_EQ(100U, ainfo.quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_objects);
+  EXPECT_FALSE(ainfo.quota.enabled);
+
+  // assert not having anything changed for bucket quota (max-objects, etc) maintains the default values
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=bucket&id=" + account_id);
+  EXPECT_EQ(200U, g_test->get_resp_code());
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  EXPECT_EQ(default_quota_max, ainfo.bucket_quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.bucket_quota.max_objects);
+  EXPECT_FALSE(ainfo.bucket_quota.enabled);
+
+  // assert having one field changed leaves the others unchanged
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=account&id=" + account_id + "&enabled=true");
+  EXPECT_EQ(200U, g_test->get_resp_code());
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  EXPECT_EQ(default_quota_max, ainfo.bucket_quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.bucket_quota.max_objects);
+  EXPECT_TRUE(ainfo.quota.enabled);
+
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::account_rm(account_id));
+}
+
+TEST(TestRGWAdmin, account_quota_put_invalid_args){
+  JSONParser parser;
+  RGWUserInfo uinfo;
+  RGWAccountInfo ainfo;
+
+  ASSERT_EQ(0, admin_helper::account_create(account_id, account_name));
+  ASSERT_EQ(0, admin_helper::account_info(account_id, ainfo));
+
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name, true, account_id, true));
+  ASSERT_EQ(0, admin_helper::user_info(uid, display_name, uinfo));
+
+  // assert default values
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_size);
+  EXPECT_EQ(default_quota_max, ainfo.quota.max_objects);
+  EXPECT_FALSE(ainfo.quota.enabled);
+
+  // assert trying to set quota with no quota-type returns a 400 error
+  g_test->send_request(string("PUT"), "/admin/account?quota&id=" + account_id);
+  EXPECT_EQ(400U, g_test->get_resp_code());
+
+  // assert trying to set quota with invalid quota type returns a 400 error
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=invalid&id=" + account_id);
+  EXPECT_EQ(400U, g_test->get_resp_code());
+
+  // assert trying to set quota with no account id returns a 400 error
+  g_test->send_request(string("PUT"), "/admin/account?quota&quota-type=account");
+  EXPECT_EQ(400U, g_test->get_resp_code());
+
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::account_rm(account_id));
+}
+
+int main(int argc, char *argv[]){
+  auto args = argv_to_vec(argc, argv);
+
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  g_test = new admin_helper::test_helper();
+  Finisher *finisher = new Finisher(g_ceph_context);
+#ifdef GTEST
+  ::testing::InitGoogleTest(&argc, argv);
+#endif
+  finisher->start();
+
+  if(g_test->extract_input(argc, argv) < 0){
+    admin_helper::print_usage(argv[0]);
+    return -1;
+  }
+#ifdef GTEST
+  int r = RUN_ALL_TESTS();
+  if (r == 0) {
+    cout << "There are no failures in the test case\n";
+  } else {
+    cout << "There are some failures\n";
+  }
+#endif
+  finisher->stop();
+  return 0;
+}

--- a/src/test/test_rgw_admin_helper.cc
+++ b/src/test/test_rgw_admin_helper.cc
@@ -1,0 +1,642 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013 eNovance SAS <licensing@enovance.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <fstream>
+#include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "common/ceph_crypto.h"
+#include "common/ceph_json.h"
+#include "common/code_environment.h"
+#include "common/armor.h"
+#include "include/str_list.h"
+#include "test_rgw_admin_helper.h"
+
+using namespace std;
+
+namespace admin_helper
+{
+    test_helper *g_test;
+
+    void print_usage(char *exec)
+    {
+        cout << "Usage: " << exec << " <Options>\n";
+        cout << "Options:\n"
+                "-g <gw-ip> - The ip address of the gateway\n"
+                "-p <gw-port> - The port number of the gateway\n"
+                "-c <ceph.conf> - Absolute path of ceph config file\n"
+                "-rgw-admin <path/to/radosgw-admin> - radosgw-admin absolute path\n";
+    }
+
+    test_helper::test_helper() : curl_inst(0), resp_data(NULL), resp_code(0)
+    {
+        curl_global_init(CURL_GLOBAL_ALL);
+    }
+
+    test_helper::~test_helper()
+    {
+        curl_global_cleanup();
+    }
+
+    int test_helper::send_request(string method, string res,
+                                  size_t (*read_function)(void *, size_t, size_t, void *),
+                                  void *ud,
+                                  size_t length)
+    {
+        string url;
+        string auth, date;
+        url.append(string("http://") + host);
+        if (port.length() > 0)
+            url.append(string(":") + port);
+        url.append(res);
+        curl_inst = curl_easy_init();
+        if (curl_inst)
+        {
+            curl_easy_setopt(curl_inst, CURLOPT_URL, url.c_str());
+            curl_easy_setopt(curl_inst, CURLOPT_CUSTOMREQUEST, method.c_str());
+            curl_easy_setopt(curl_inst, CURLOPT_VERBOSE, CURL_VERBOSE);
+            curl_easy_setopt(curl_inst, CURLOPT_HEADERFUNCTION, admin_helper::write_header);
+            curl_easy_setopt(curl_inst, CURLOPT_WRITEHEADER, (void *)this);
+            curl_easy_setopt(curl_inst, CURLOPT_WRITEFUNCTION, admin_helper::write_data);
+            curl_easy_setopt(curl_inst, CURLOPT_WRITEDATA, (void *)this);
+            if (read_function)
+            {
+                curl_easy_setopt(curl_inst, CURLOPT_READFUNCTION, read_function);
+                curl_easy_setopt(curl_inst, CURLOPT_READDATA, (void *)ud);
+                curl_easy_setopt(curl_inst, CURLOPT_UPLOAD, 1L);
+                curl_easy_setopt(curl_inst, CURLOPT_INFILESIZE_LARGE, (curl_off_t)length);
+            }
+
+            get_date(date);
+            string http_date;
+            http_date.append(string("Date: ") + date);
+
+            string s3auth;
+            if (admin_helper::get_s3_auth(method, creds, date, res, s3auth) < 0)
+                return -1;
+            auth.append(string("Authorization: AWS ") + s3auth);
+
+            struct curl_slist *slist = NULL;
+            slist = curl_slist_append(slist, auth.c_str());
+            slist = curl_slist_append(slist, http_date.c_str());
+            for (list<string>::iterator it = extra_hdrs.begin();
+                 it != extra_hdrs.end(); ++it)
+            {
+                slist = curl_slist_append(slist, (*it).c_str());
+            }
+            if (read_function)
+                curl_slist_append(slist, "Expect:");
+            curl_easy_setopt(curl_inst, CURLOPT_HTTPHEADER, slist);
+
+            response.erase(response.begin(), response.end());
+            extra_hdrs.erase(extra_hdrs.begin(), extra_hdrs.end());
+            CURLcode res = curl_easy_perform(curl_inst);
+            if (res != CURLE_OK)
+            {
+                cout << "Curl perform failed for " << url << ", res: " << curl_easy_strerror(res) << "\n";
+                return -1;
+            }
+            curl_slist_free_all(slist);
+        }
+        curl_easy_cleanup(curl_inst);
+        return 0;
+    }
+
+    string &test_helper::get_response(string hdr)
+    {
+        return response[hdr];
+    }
+
+    void test_helper::set_extra_header(string hdr)
+    {
+        extra_hdrs.push_back(hdr);
+    }
+
+    void test_helper::set_response(char *r)
+    {
+        string sr(r), h, v;
+        size_t off = sr.find(": ");
+        if (off != string::npos)
+        {
+            h.assign(sr, 0, off);
+            v.assign(sr, off + 2, sr.find("\r\n") - (off + 2));
+        }
+        else
+        {
+            /*Could be the status code*/
+            if (sr.find("HTTP/") != string::npos)
+            {
+                h.assign(HTTP_RESPONSE_STR);
+                off = sr.find(" ");
+                v.assign(sr, off + 1, sr.find("\r\n") - (off + 1));
+                resp_code = atoi((v.substr(0, 3)).c_str());
+            }
+        }
+        response[h] = v;
+    }
+
+    void test_helper::set_response_data(char *data, size_t len)
+    {
+        if (resp_data)
+            delete resp_data;
+        resp_data = new string(data, len);
+    }
+    string &test_helper::get_rgw_admin_path()
+    {
+        return rgw_admin_path;
+    }
+    string &test_helper::get_ceph_conf_path()
+    {
+        return conf_path;
+    }
+    void test_helper::set_creds(string &c)
+    {
+        creds = c;
+    }
+    const string *test_helper::get_response_data() { return resp_data; }
+    unsigned test_helper::get_resp_code() { return resp_code; }
+
+    int test_helper::extract_input(int argc, char *argv[])
+    {
+#define ERR_CHECK_NEXT_PARAM(o)  \
+    if (((int)loop + 1) >= argc) \
+        return -1;               \
+    else                         \
+        o = argv[loop + 1];
+
+        for (unsigned loop = 1; loop < (unsigned)argc; loop += 2)
+        {
+            if (strcmp(argv[loop], "-g") == 0)
+            {
+                ERR_CHECK_NEXT_PARAM(host);
+            }
+            else if (strcmp(argv[loop], "-p") == 0)
+            {
+                ERR_CHECK_NEXT_PARAM(port);
+            }
+            else if (strcmp(argv[loop], "-c") == 0)
+            {
+                ERR_CHECK_NEXT_PARAM(conf_path);
+            }
+            else if (strcmp(argv[loop], "-rgw-admin") == 0)
+            {
+                ERR_CHECK_NEXT_PARAM(rgw_admin_path);
+            }
+            else
+                return -1;
+        }
+        if (host.empty() || rgw_admin_path.empty())
+            return -1;
+        return 0;
+    }
+
+    size_t write_header(void *ptr, size_t size, size_t nmemb, void *ud)
+    {
+        test_helper *h = static_cast<test_helper *>(ud);
+        h->set_response((char *)ptr);
+        return size * nmemb;
+    }
+
+    size_t write_data(void *ptr, size_t size, size_t nmemb, void *ud)
+    {
+        test_helper *h = static_cast<test_helper *>(ud);
+        h->set_response_data((char *)ptr, size * nmemb);
+        return size * nmemb;
+    }
+
+    inline void buf_to_hex(const unsigned char *buf, int len, char *str)
+    {
+        int i;
+        str[0] = '\0';
+        for (i = 0; i < len; i++)
+        {
+            sprintf(&str[i * 2], "%02x", (int)buf[i]);
+        }
+    }
+
+    void calc_hmac_sha1(const char *key, int key_len,
+                        const char *msg, int msg_len, char *dest)
+    /* destination should be CEPH_CRYPTO_HMACSHA1_DIGESTSIZE bytes long */
+    {
+        ceph::crypto::HMACSHA1 hmac((const unsigned char *)key, key_len);
+        hmac.Update((const unsigned char *)msg, msg_len);
+        hmac.Final((unsigned char *)dest);
+
+        char hex_str[(CEPH_CRYPTO_HMACSHA1_DIGESTSIZE * 2) + 1];
+        admin_helper::buf_to_hex((unsigned char *)dest, CEPH_CRYPTO_HMACSHA1_DIGESTSIZE, hex_str);
+    }
+
+    int get_s3_auth(const string &method, string creds, const string &date, string res, string &out)
+    {
+        string aid, secret, auth_hdr;
+        string tmp_res;
+        size_t off = creds.find(":");
+        out = "";
+        if (off != string::npos)
+        {
+            aid.assign(creds, 0, off);
+            secret.assign(creds, off + 1, string::npos);
+
+            /*sprintf(auth_hdr, "%s\n\n\n%s\n%s", req_type, date, res);*/
+            char hmac_sha1[CEPH_CRYPTO_HMACSHA1_DIGESTSIZE];
+            char b64[65]; /* 64 is really enough */
+            size_t off = res.find("?");
+            if (off == string::npos)
+                tmp_res = res;
+            else
+                tmp_res.assign(res, 0, off);
+            auth_hdr.append(method + string("\n\n\n") + date + string("\n") + tmp_res);
+            admin_helper::calc_hmac_sha1(secret.c_str(), secret.length(),
+                                         auth_hdr.c_str(), auth_hdr.length(), hmac_sha1);
+            int ret = ceph_armor(b64, b64 + 64, hmac_sha1,
+                                 hmac_sha1 + CEPH_CRYPTO_HMACSHA1_DIGESTSIZE);
+            if (ret < 0)
+            {
+                cout << "ceph_armor failed\n";
+                return -1;
+            }
+            b64[ret] = 0;
+            out.append(aid + string(":") + b64);
+        }
+        else
+            return -1;
+        return 0;
+    }
+
+    void get_date(string &d)
+    {
+        struct timeval tv;
+        char date[64];
+        struct tm tm;
+        char *days[] = {(char *)"Sun", (char *)"Mon", (char *)"Tue",
+                        (char *)"Wed", (char *)"Thu", (char *)"Fri",
+                        (char *)"Sat"};
+        char *months[] = {(char *)"Jan", (char *)"Feb", (char *)"Mar",
+                          (char *)"Apr", (char *)"May", (char *)"Jun",
+                          (char *)"Jul", (char *)"Aug", (char *)"Sep",
+                          (char *)"Oct", (char *)"Nov", (char *)"Dec"};
+        gettimeofday(&tv, NULL);
+        gmtime_r(&tv.tv_sec, &tm);
+        sprintf(date, "%s, %d %s %d %d:%d:%d GMT",
+                days[tm.tm_wday],
+                tm.tm_mday, months[tm.tm_mon],
+                tm.tm_year + 1900,
+                tm.tm_hour, tm.tm_min, 0 /*tm.tm_sec*/);
+        d = date;
+    }
+
+    int run_rgw_admin(string &cmd, string &resp)
+    {
+        pid_t pid;
+        pid = fork();
+        if (pid == 0)
+        {
+            /* child */
+            list<string> l;
+            get_str_list(cmd, " \t", l);
+            char *argv[l.size()];
+            unsigned loop = 1;
+
+            argv[0] = (char *)"radosgw-admin";
+            for (list<string>::iterator it = l.begin();
+                 it != l.end(); ++it)
+            {
+                argv[loop++] = (char *)(*it).c_str();
+            }
+            argv[loop] = NULL;
+            if (!freopen(RGW_ADMIN_RESP_PATH, "w+", stdout))
+            {
+                cout << "Unable to open stdout file" << std::endl;
+            }
+            execv((g_test->get_rgw_admin_path()).c_str(), argv);
+        }
+        else if (pid > 0)
+        {
+            int status;
+            waitpid(pid, &status, 0);
+            if (WIFEXITED(status))
+            {
+                if (WEXITSTATUS(status) != 0)
+                {
+                    cout << "Child exited with status " << WEXITSTATUS(status) << std::endl;
+                    return -1;
+                }
+            }
+            ifstream in;
+            struct stat st;
+
+            if (stat(RGW_ADMIN_RESP_PATH, &st) < 0)
+            {
+                cout << "Error stating the admin response file, errno " << errno << std::endl;
+                return -1;
+            }
+            else
+            {
+                char *data = (char *)malloc(st.st_size + 1);
+                in.open(RGW_ADMIN_RESP_PATH);
+                in.read(data, st.st_size);
+                in.close();
+                data[st.st_size] = 0;
+                resp = data;
+                free(data);
+                unlink(RGW_ADMIN_RESP_PATH);
+                /* cout << "radosgw-admin " << cmd << ": " << resp << std::endl;*/
+            }
+        }
+        else
+            return -1;
+        return 0;
+    }
+
+    int get_creds(string &json, string &creds)
+    {
+        JSONParser parser;
+        if (!parser.parse(json.c_str(), json.length()))
+        {
+            cout << "Error parsing create user response" << std::endl;
+            return -1;
+        }
+
+        RGWUserInfo info;
+        decode_json_obj(info, &parser);
+        creds = "";
+        for (map<string, RGWAccessKey>::iterator it = info.access_keys.begin();
+             it != info.access_keys.end(); ++it)
+        {
+            RGWAccessKey _k = it->second;
+            /*cout << "accesskeys [ " << it->first << " ] = " <<
+              "{ " << _k.id << ", " << _k.key << ", " << _k.subuser << "}" << std::endl;*/
+            creds.append(it->first + string(":") + _k.key);
+            break;
+        }
+        return 0;
+    }
+
+    int account_create(string &account_id, string &account_name)
+    {
+        stringstream ss;
+        ss << "-c " << g_test->get_ceph_conf_path() << " account create --account-id=" << account_id << " --account-name=" << account_name;
+        string cmd = ss.str();
+        string out;
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error creating account" << std::endl;
+            return -1;
+        }
+        return 0;
+    }
+
+    int user_create(string &uid, string &display_name, bool set_creds, const string &account_id, bool is_admin)
+    {
+        stringstream ss;
+        string creds;
+        ss << "-c " << g_test->get_ceph_conf_path() << " user create --uid=" << uid
+           << " --display-name=" << display_name;
+        if (!account_id.empty()){
+            ss << " --account-id=" << account_id;
+        }
+        if (is_admin)
+        {
+            ss << " --admin";
+        }
+        string out;
+        string cmd = ss.str();
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error creating user" << std::endl;
+            return -1;
+        }
+        get_creds(out, creds);
+        if (set_creds)
+            g_test->set_creds(creds);
+        return 0;
+    }
+
+    int account_info(string &account_id, RGWAccountInfo &a_info)
+    {
+        stringstream ss;
+        ss << "-c " << g_test->get_ceph_conf_path() << " account get --account-id=" << account_id;
+        string cmd = ss.str();
+        string out;
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error reading account information" << std::endl;
+            return -1;
+        }
+        JSONParser parser;
+        if (!parser.parse(out.c_str(), out.length()))
+        {
+            cout << "Error parsing account info response" << std::endl;
+            return -1;
+        }
+        decode_json_obj(a_info, &parser);
+        return 0;
+    }
+
+    int user_info(string &uid, string &display_name, RGWUserInfo &uinfo)
+    {
+        stringstream ss;
+        ss << "-c " << g_test->get_ceph_conf_path() << " user info --uid=" << uid
+           << " --display-name=" << display_name;
+
+        string out;
+        string cmd = ss.str();
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error reading user information" << std::endl;
+            return -1;
+        }
+        JSONParser parser;
+        if (!parser.parse(out.c_str(), out.length()))
+        {
+            cout << "Error parsing create user response" << std::endl;
+            return -1;
+        }
+        decode_json_obj(uinfo, &parser);
+        return 0;
+    }
+
+    int account_rm(string &account_id)
+    {
+        stringstream ss;
+        ss << "-c " << g_test->get_ceph_conf_path() << " account rm --account-id=" << account_id;
+        string cmd = ss.str();
+        string out;
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error removing account" << std::endl;
+            return -1;
+        }
+        return 0;
+    }
+
+    int user_rm(string &uid, string &display_name)
+    {
+        stringstream ss;
+        ss << "-c " << g_test->get_ceph_conf_path() << " user rm --uid=" << uid
+           << " --display-name=" << display_name;
+
+        string out;
+        string cmd = ss.str();
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error removing user" << std::endl;
+            return -1;
+        }
+        return 0;
+    }
+
+    int caps_add(const string caps_name, const string uid, const char *perm)
+    {
+        stringstream ss;
+
+        ss << "-c " << g_test->get_ceph_conf_path() << " caps add --caps=" << caps_name << "=" << perm << " --uid=" << uid;
+        string out;
+        string cmd = ss.str();
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error adding caps to user" << std::endl;
+            return -1;
+        }
+        return 0;
+    }
+
+    int caps_rm(const string caps_name, const string uid, const char *perm)
+    {
+        stringstream ss;
+
+        ss << "-c " << g_test->get_ceph_conf_path() << " caps rm --caps=" << caps_name << "=" << perm << " --uid=" << uid;
+        string out;
+        string cmd = ss.str();
+        if (run_rgw_admin(cmd, out) != 0)
+        {
+            cout << "Error removing caps from user" << std::endl;
+            return -1;
+        }
+        return 0;
+    }
+
+    int compare_access_keys(RGWAccessKey &k1, RGWAccessKey &k2)
+    {
+        if (k1.id.compare(k2.id) != 0)
+            return -1;
+        if (k1.key.compare(k2.key) != 0)
+            return -1;
+        if (k1.subuser.compare(k2.subuser) != 0)
+            return -1;
+
+        return 0;
+    }
+
+    int compare_user_info(RGWUserInfo &i1, RGWUserInfo &i2, const string meta_caps)
+    {
+        int rv;
+
+        if ((rv = i1.user_id.id.compare(i2.user_id.id)) != 0)
+            return rv;
+        if ((rv = i1.display_name.compare(i2.display_name)) != 0)
+            return rv;
+        if ((rv = i1.user_email.compare(i2.user_email)) != 0)
+            return rv;
+        if (i1.access_keys.size() != i2.access_keys.size())
+            return -1;
+        for (map<string, RGWAccessKey>::iterator it = i1.access_keys.begin();
+             it != i1.access_keys.end(); ++it)
+        {
+            RGWAccessKey k1, k2;
+            k1 = it->second;
+            if (i2.access_keys.count(it->first) == 0)
+                return -1;
+            k2 = i2.access_keys[it->first];
+            if (compare_access_keys(k1, k2) != 0)
+                return -1;
+        }
+        if (i1.swift_keys.size() != i2.swift_keys.size())
+            return -1;
+        for (map<string, RGWAccessKey>::iterator it = i1.swift_keys.begin();
+             it != i1.swift_keys.end(); ++it)
+        {
+            RGWAccessKey k1, k2;
+            k1 = it->second;
+            if (i2.swift_keys.count(it->first) == 0)
+                return -1;
+            k2 = i2.swift_keys[it->first];
+            if (compare_access_keys(k1, k2) != 0)
+                return -1;
+        }
+        if (i1.subusers.size() != i2.subusers.size())
+            return -1;
+        for (map<string, RGWSubUser>::iterator it = i1.subusers.begin();
+             it != i1.subusers.end(); ++it)
+        {
+            RGWSubUser k1, k2;
+            k1 = it->second;
+            if (!i2.subusers.count(it->first))
+                return -1;
+            k2 = i2.subusers[it->first];
+            if (k1.name.compare(k2.name) != 0)
+                return -1;
+            if (k1.perm_mask != k2.perm_mask)
+                return -1;
+        }
+        if (i1.suspended != i2.suspended)
+            return -1;
+        if (i1.max_buckets != i2.max_buckets)
+            return -1;
+        uint32_t p1, p2;
+        p1 = p2 = RGW_CAP_ALL;
+        if (i1.caps.check_cap(meta_caps, p1) != 0)
+            return -1;
+        if (i2.caps.check_cap(meta_caps, p2) != 0)
+            return -1;
+        return 0;
+    }
+
+    size_t read_dummy_post(void *ptr, size_t s, size_t n, void *ud)
+    {
+        int dummy = 0;
+        memcpy(ptr, &dummy, sizeof(dummy));
+        return sizeof(dummy);
+    }
+
+    int parse_json_resp(JSONParser &parser)
+    {
+        string *resp;
+        resp = (string *)g_test->get_response_data();
+        if (!resp)
+            return -1;
+        if (!parser.parse(resp->c_str(), resp->length()))
+        {
+            cout << "Error parsing create user response" << std::endl;
+            return -1;
+        }
+        return 0;
+    }
+
+    size_t meta_read_json(void *ptr, size_t s, size_t n, void *ud)
+    {
+        stringstream *ss = (stringstream *)ud;
+        size_t len = ss->str().length();
+        if (s * n < len)
+        {
+            cout << "Cannot copy json data, as len is not enough\n";
+            return 0;
+        }
+        memcpy(ptr, (void *)ss->str().c_str(), len);
+        return len;
+    }
+};

--- a/src/test/test_rgw_admin_helper.h
+++ b/src/test/test_rgw_admin_helper.h
@@ -1,0 +1,89 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013 eNovance SAS <licensing@enovance.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <map>
+#include <list>
+extern "C"{
+#include <curl/curl.h>
+}
+#include <string.h>
+#include "rgw_common.h"
+
+using namespace std;
+
+#define CURL_VERBOSE 0
+#define HTTP_RESPONSE_STR "RespCode"
+#define CEPH_CRYPTO_HMACSHA1_DIGESTSIZE 20
+#define RGW_ADMIN_RESP_PATH "/tmp/.test_rgw_admin_resp"
+#define CEPH_UID "ceph"
+
+namespace admin_helper
+{
+    class test_helper
+    {
+    private:
+        string host;
+        string port;
+        string creds;
+        string rgw_admin_path;
+        string conf_path;
+        CURL *curl_inst;
+        map<string, string> response;
+        list<string> extra_hdrs;
+        string *resp_data;
+        unsigned resp_code;
+
+    public:
+        test_helper();
+        ~test_helper();
+        int send_request(string method, string uri,
+                         size_t (*function)(void *, size_t, size_t, void *) = 0,
+                         void *ud = 0, size_t length = 0);
+        int extract_input(int argc, char *argv[]);
+        string &get_response(string hdr);
+        void set_extra_header(string hdr);
+        void set_response(char *val);
+        void set_response_data(char *data, size_t len);
+        string &get_rgw_admin_path();
+        string &get_ceph_conf_path();
+        void set_creds(string &c);
+        const string *get_response_data();
+        unsigned get_resp_code();
+    };
+
+    size_t write_header(void *ptr, size_t size, size_t nmemb, void *ud);
+    size_t write_data(void *ptr, size_t size, size_t nmemb, void *ud);
+    inline void buf_to_hex(const unsigned char *buf, int len, char *str);
+    void calc_hmac_sha1(const char *key, int key_len,
+                        const char *msg, int msg_len, char *dest);
+    int get_s3_auth(const string &method, string creds, const string &date, string res, string &out);
+    void get_date(string &d);
+    void print_usage(char *exec);
+    int run_rgw_admin(string &cmd, string &resp);
+    int account_create(string &account_id, string &account_name);
+    int user_create(string &uid, string &display_name, bool set_creds = true, const string &account_id = "", bool is_admin = false);
+    int account_info(string &account_id, RGWAccountInfo &a_info);
+    int user_info(string &uid, string &display_name, RGWUserInfo &uinfo);
+    int account_rm(string &account_id);
+    int user_rm(string &uid, string &display_name);
+    int get_creds(string &json, string &creds);
+    int caps_add(const string caps_name, const string uid, const char *perm);
+    int caps_rm(const string caps_name, const string uid, const char *perm);
+    int compare_access_keys(RGWAccessKey &k1, RGWAccessKey &k2);
+    int compare_user_info(RGWUserInfo &i1, RGWUserInfo &i2, const string meta_caps);
+    size_t read_dummy_post(void *ptr, size_t s, size_t n, void *ud);
+    int parse_json_resp(JSONParser &parser);
+    size_t meta_read_json(void *ptr, size_t s, size_t n, void *ud);
+    extern admin_helper::test_helper *g_test;
+};

--- a/src/test/test_rgw_admin_meta.cc
+++ b/src/test/test_rgw_admin_meta.cc
@@ -11,554 +11,33 @@
  * Foundation. See file COPYING.
  *
  */
-#include <iostream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#include <fstream>
-#include <map>
-#include <list>
-extern "C"{
-#include <curl/curl.h>
-}
-#include "common/ceph_crypto.h"
-#include "include/str_list.h"
-#include "common/ceph_json.h"
-#include "common/code_environment.h"
-#include "common/ceph_argparse.h"
-#include "common/armor.h"
 #include "common/Finisher.h"
+#include "common/ceph_argparse.h"
 #include "global/global_init.h"
-#include "rgw_common.h"
-#include "rgw_rados.h"
 #include <gtest/gtest.h>
+#include "test_rgw_admin_helper.h"
+
 
 using namespace std;
+using admin_helper::g_test;
 
-#define CURL_VERBOSE 0
-#define HTTP_RESPONSE_STR "RespCode"
-#define CEPH_CRYPTO_HMACSHA1_DIGESTSIZE 20
-#define RGW_ADMIN_RESP_PATH "/tmp/.test_rgw_admin_resp"
-#define CEPH_UID  "ceph"
-
-static string uid = CEPH_UID;
-static string display_name = "CEPH";
-static string meta_caps = "metadata";
-
-static void print_usage(char *exec){
-  cout << "Usage: " << exec << " <Options>\n";
-  cout << "Options:\n"
-          "-g <gw-ip> - The ip address of the gateway\n"
-          "-p <gw-port> - The port number of the gateway\n"
-          "-c <ceph.conf> - Absolute path of ceph config file\n"
-          "-rgw-admin <path/to/radosgw-admin> - radosgw-admin absolute path\n";
-}
-
-namespace admin_meta {
-class test_helper {
-  private:
-    string host;
-    string port;
-    string creds;
-    string rgw_admin_path;
-    string conf_path;
-    CURL *curl_inst;
-    map<string, string> response;
-    list<string> extra_hdrs;
-    string *resp_data;
-    unsigned resp_code;
-  public:
-    test_helper() : curl_inst(0), resp_data(NULL), resp_code(0) {
-      curl_global_init(CURL_GLOBAL_ALL);
-    }
-    ~test_helper(){
-      curl_global_cleanup();
-    }
-    int send_request(string method, string uri, 
-                     size_t (*function)(void *,size_t,size_t,void *) = 0,
-                     void *ud = 0, size_t length = 0);
-    int extract_input(int argc, char *argv[]);
-    string& get_response(string hdr){
-      return response[hdr];
-    }
-    void set_extra_header(string hdr){
-      extra_hdrs.push_back(hdr);
-    }
-    void set_response(char *val);
-    void set_response_data(char *data, size_t len){
-      if(resp_data) delete resp_data;
-      resp_data = new string(data, len);
-    }
-    string& get_rgw_admin_path() {
-      return rgw_admin_path;
-    }
-    string& get_ceph_conf_path() {
-      return conf_path;
-    }
-    void set_creds(string& c) {
-      creds = c;
-    }
-    const string *get_response_data(){return resp_data;}
-    unsigned get_resp_code(){return resp_code;}
-};
-
-int test_helper::extract_input(int argc, char *argv[]){
-#define ERR_CHECK_NEXT_PARAM(o) \
-  if(((int)loop + 1) >= argc)return -1;		\
-  else o = argv[loop+1];
-
-  for(unsigned loop = 1;loop < (unsigned)argc; loop += 2){
-    if(strcmp(argv[loop], "-g") == 0){
-      ERR_CHECK_NEXT_PARAM(host);
-    }else if(strcmp(argv[loop],"-p") == 0){
-      ERR_CHECK_NEXT_PARAM(port);
-    }else if(strcmp(argv[loop], "-c") == 0){
-      ERR_CHECK_NEXT_PARAM(conf_path);
-    }else if(strcmp(argv[loop], "-rgw-admin") == 0){
-      ERR_CHECK_NEXT_PARAM(rgw_admin_path);
-    }else return -1;
-  }
-  if(host.empty() || rgw_admin_path.empty())
-    return -1;
-  return 0;
-}
-
-void test_helper::set_response(char *r){
-  string sr(r), h, v;
-  size_t off = sr.find(": ");
-  if(off != string::npos){
-    h.assign(sr, 0, off);
-    v.assign(sr, off + 2, sr.find("\r\n") - (off+2));
-  }else{
-    /*Could be the status code*/
-    if(sr.find("HTTP/") != string::npos){
-      h.assign(HTTP_RESPONSE_STR);
-      off = sr.find(" ");
-      v.assign(sr, off + 1, sr.find("\r\n") - (off + 1));
-      resp_code = atoi((v.substr(0, 3)).c_str());
-    }
-  }
-  response[h] = v;
-}
-
-size_t write_header(void *ptr, size_t size, size_t nmemb, void *ud){
-  test_helper *h = static_cast<test_helper *>(ud);
-  h->set_response((char *)ptr);
-  return size*nmemb;
-}
-
-size_t write_data(void *ptr, size_t size, size_t nmemb, void *ud){
-  test_helper *h = static_cast<test_helper *>(ud);
-  h->set_response_data((char *)ptr, size*nmemb);
-  return size*nmemb;
-}
-
-static inline void buf_to_hex(const unsigned char *buf, int len, char *str)
-{
-  int i;
-  str[0] = '\0';
-  for (i = 0; i < len; i++) {
-    sprintf(&str[i*2], "%02x", (int)buf[i]);
-  }
-}
-
-static void calc_hmac_sha1(const char *key, int key_len,
-                    const char *msg, int msg_len, char *dest)
-/* destination should be CEPH_CRYPTO_HMACSHA1_DIGESTSIZE bytes long */
-{
-  ceph::crypto::HMACSHA1 hmac((const unsigned char *)key, key_len);
-  hmac.Update((const unsigned char *)msg, msg_len);
-  hmac.Final((unsigned char *)dest);
-  
-  char hex_str[(CEPH_CRYPTO_HMACSHA1_DIGESTSIZE * 2) + 1];
-  admin_meta::buf_to_hex((unsigned char *)dest, CEPH_CRYPTO_HMACSHA1_DIGESTSIZE, hex_str);
-}
-
-static int get_s3_auth(const string &method, string creds, const string &date, string res, string& out){
-  string aid, secret, auth_hdr;
-  string tmp_res;
-  size_t off = creds.find(":");
-  out = "";
-  if(off != string::npos){
-    aid.assign(creds, 0, off);
-    secret.assign(creds, off + 1, string::npos);
-
-    /*sprintf(auth_hdr, "%s\n\n\n%s\n%s", req_type, date, res);*/
-    char hmac_sha1[CEPH_CRYPTO_HMACSHA1_DIGESTSIZE];
-    char b64[65]; /* 64 is really enough */
-    size_t off = res.find("?");
-    if(off == string::npos)
-      tmp_res = res;
-    else
-      tmp_res.assign(res, 0, off);
-    auth_hdr.append(method + string("\n\n\n") + date + string("\n") + tmp_res);
-    admin_meta::calc_hmac_sha1(secret.c_str(), secret.length(), 
-                               auth_hdr.c_str(), auth_hdr.length(), hmac_sha1);
-    int ret = ceph_armor(b64, b64 + 64, hmac_sha1,
-                         hmac_sha1 + CEPH_CRYPTO_HMACSHA1_DIGESTSIZE);
-    if (ret < 0) {
-      cout << "ceph_armor failed\n";
-      return -1;
-    }
-    b64[ret] = 0;
-    out.append(aid + string(":") + b64);
-  }else return -1;
-  return 0;
-}
-
-void get_date(string& d){
-  struct timeval tv;
-  char date[64];
-  struct tm tm;
-  char *days[] = {(char *)"Sun", (char *)"Mon", (char *)"Tue",
-                  (char *)"Wed", (char *)"Thu", (char *)"Fri", 
-                  (char *)"Sat"};
-  char *months[] = {(char *)"Jan", (char *)"Feb", (char *)"Mar", 
-                    (char *)"Apr", (char *)"May", (char *)"Jun",
-                    (char *)"Jul",(char *) "Aug", (char *)"Sep", 
-                    (char *)"Oct", (char *)"Nov", (char *)"Dec"};
-  gettimeofday(&tv, NULL);
-  gmtime_r(&tv.tv_sec, &tm);
-  sprintf(date, "%s, %d %s %d %d:%d:%d GMT", 
-          days[tm.tm_wday], 
-          tm.tm_mday, months[tm.tm_mon], 
-          tm.tm_year + 1900,
-          tm.tm_hour, tm.tm_min, 0 /*tm.tm_sec*/);
-  d = date;
-}
-
-int test_helper::send_request(string method, string res, 
-                                   size_t (*read_function)( void *,size_t,size_t,void *),
-                                   void *ud,
-                                   size_t length){
-  string url;
-  string auth, date;
-  url.append(string("http://") + host);
-  if(port.length() > 0)url.append(string(":") + port);
-  url.append(res);
-  curl_inst = curl_easy_init();
-  if(curl_inst){
-    curl_easy_setopt(curl_inst, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(curl_inst, CURLOPT_CUSTOMREQUEST, method.c_str());
-    curl_easy_setopt(curl_inst, CURLOPT_VERBOSE, CURL_VERBOSE);
-    curl_easy_setopt(curl_inst, CURLOPT_HEADERFUNCTION, admin_meta::write_header);
-    curl_easy_setopt(curl_inst, CURLOPT_WRITEHEADER, (void *)this);
-    curl_easy_setopt(curl_inst, CURLOPT_WRITEFUNCTION, admin_meta::write_data);
-    curl_easy_setopt(curl_inst, CURLOPT_WRITEDATA, (void *)this);
-    if(read_function){
-      curl_easy_setopt(curl_inst, CURLOPT_READFUNCTION, read_function);
-      curl_easy_setopt(curl_inst, CURLOPT_READDATA, (void *)ud);
-      curl_easy_setopt(curl_inst, CURLOPT_UPLOAD, 1L);
-      curl_easy_setopt(curl_inst, CURLOPT_INFILESIZE_LARGE, (curl_off_t)length);
-    }
-
-    get_date(date);
-    string http_date;
-    http_date.append(string("Date: ") + date);
-
-    string s3auth;
-    if (admin_meta::get_s3_auth(method, creds, date, res, s3auth) < 0)
-      return -1;
-    auth.append(string("Authorization: AWS ") + s3auth);
-
-    struct curl_slist *slist = NULL;
-    slist = curl_slist_append(slist, auth.c_str());
-    slist = curl_slist_append(slist, http_date.c_str());
-    for(list<string>::iterator it = extra_hdrs.begin();
-        it != extra_hdrs.end(); ++it){
-      slist = curl_slist_append(slist, (*it).c_str());
-    }
-    if(read_function)
-      curl_slist_append(slist, "Expect:");
-    curl_easy_setopt(curl_inst, CURLOPT_HTTPHEADER, slist); 
-
-    response.erase(response.begin(), response.end());
-    extra_hdrs.erase(extra_hdrs.begin(), extra_hdrs.end());
-    CURLcode res = curl_easy_perform(curl_inst);
-    if(res != CURLE_OK){
-      cout << "Curl perform failed for " << url << ", res: " << 
-        curl_easy_strerror(res) << "\n";
-      return -1;
-    }
-    curl_slist_free_all(slist);
-  }
-  curl_easy_cleanup(curl_inst);
-  return 0;
-}
-};
-
-admin_meta::test_helper *g_test;
-Finisher *finisher;
-
-int run_rgw_admin(string& cmd, string& resp) {
-  pid_t pid;
-  pid = fork();
-  if (pid == 0) {
-    /* child */
-    list<string> l;
-    get_str_list(cmd, " \t", l);
-    char *argv[l.size()];
-    unsigned loop = 1;
-
-    argv[0] = (char *)"radosgw-admin";
-    for (list<string>::iterator it = l.begin(); 
-         it != l.end(); ++it) {
-      argv[loop++] = (char *)(*it).c_str();
-    }
-    argv[loop] = NULL;
-    if (!freopen(RGW_ADMIN_RESP_PATH, "w+", stdout)) {
-      cout << "Unable to open stdout file" << std::endl;
-    }
-    execv((g_test->get_rgw_admin_path()).c_str(), argv); 
-  } else if (pid > 0) {
-    int status;
-    waitpid(pid, &status, 0);
-    if (WIFEXITED(status)) {
-      if(WEXITSTATUS(status) != 0) {
-        cout << "Child exited with status " << WEXITSTATUS(status) << std::endl;
-        return -1;
-      }
-    }
-    ifstream in;
-    struct stat st;
-
-    if (stat(RGW_ADMIN_RESP_PATH, &st) < 0) {
-      cout << "Error stating the admin response file, errno " << errno << std::endl;
-      return -1;
-    } else {
-      char *data = (char *)malloc(st.st_size + 1);
-      in.open(RGW_ADMIN_RESP_PATH);
-      in.read(data, st.st_size);
-      in.close();
-      data[st.st_size] = 0;
-      resp = data;
-      free(data);
-      unlink(RGW_ADMIN_RESP_PATH);
-      /* cout << "radosgw-admin " << cmd << ": " << resp << std::endl;*/
-    }
-  } else 
-    return -1;
-  return 0;
-}
-
-int get_creds(string& json, string& creds) {
-  JSONParser parser;
-  if(!parser.parse(json.c_str(), json.length())) {
-    cout << "Error parsing create user response" << std::endl;
-    return -1;
-  }
-
-  RGWUserInfo info;
-  decode_json_obj(info, &parser);
-  creds = "";
-  for(map<string, RGWAccessKey>::iterator it = info.access_keys.begin();
-      it != info.access_keys.end(); ++it) {
-    RGWAccessKey _k = it->second;
-    /*cout << "accesskeys [ " << it->first << " ] = " << 
-      "{ " << _k.id << ", " << _k.key << ", " << _k.subuser << "}" << std::endl;*/
-    creds.append(it->first + string(":") + _k.key);
-    break;
-  }
-  return 0;
-}
-
-int user_create(string& uid, string& display_name, bool set_creds = true) {
-  stringstream ss;
-  string creds;
-  ss << "-c " << g_test->get_ceph_conf_path() << " user create --uid=" << uid
-    << " --display-name=" << display_name;
-
-  string out;
-  string cmd = ss.str();
-  if(run_rgw_admin(cmd, out) != 0) {
-    cout << "Error creating user" << std::endl;
-    return -1;
-  }
-  get_creds(out, creds);
-  if(set_creds)
-    g_test->set_creds(creds);
-  return 0;
-}
-
-int user_info(string& uid, string& display_name, RGWUserInfo& uinfo) {
-  stringstream ss;
-  ss << "-c " << g_test->get_ceph_conf_path() << " user info --uid=" << uid
-    << " --display-name=" << display_name;
-
-  string out;
-  string cmd = ss.str();
-  if(run_rgw_admin(cmd, out) != 0) {
-    cout << "Error reading user information" << std::endl;
-    return -1;
-  }
-  JSONParser parser;
-  if(!parser.parse(out.c_str(), out.length())) {
-    cout << "Error parsing create user response" << std::endl;
-    return -1;
-  }
-  decode_json_obj(uinfo, &parser);
-  return 0;
-}
-
-int user_rm(string& uid, string& display_name) {
-  stringstream ss;
-  ss << "-c " << g_test->get_ceph_conf_path() << " user rm --uid=" << uid
-    << " --display-name=" << display_name;
-
-  string out;
-  string cmd = ss.str();
-  if(run_rgw_admin(cmd, out) != 0) {
-    cout << "Error removing user" << std::endl;
-    return -1;
-  }
-  return 0;
-}
-
-int meta_caps_add(const char *perm) {
-  stringstream ss;
-
-  ss << "-c " << g_test->get_ceph_conf_path() << " caps add --caps=" <<
-     meta_caps << "=" << perm << " --uid=" << uid;
-  string out;
-  string cmd = ss.str();
-  if(run_rgw_admin(cmd, out) != 0) {
-    cout << "Error creating user" << std::endl;
-    return -1;
-  }
-  return 0;
-}
-
-int meta_caps_rm(const char *perm) {
-  stringstream ss;
-
-  ss << "-c " << g_test->get_ceph_conf_path() << " caps rm --caps=" <<
-     meta_caps << "=" << perm << " --uid=" << uid;
-  string out;
-  string cmd = ss.str();
-  if(run_rgw_admin(cmd, out) != 0) {
-    cout << "Error creating user" << std::endl;
-    return -1;
-  }
-  return 0;
-}
-
-int compare_access_keys(RGWAccessKey& k1, RGWAccessKey& k2) {
-  if (k1.id.compare(k2.id) != 0)
-    return -1;
-  if (k1.key.compare(k2.key) != 0) 
-    return -1;
-  if (k1.subuser.compare(k2.subuser) != 0) 
-    return -1;
-
-  return 0;
-}
-
-int compare_user_info(RGWUserInfo& i1, RGWUserInfo& i2) {
-  int rv;
-
-  if ((rv = i1.user_id.id.compare(i2.user_id.id)) != 0)
-    return rv;
-  if ((rv = i1.display_name.compare(i2.display_name)) != 0)
-    return rv;
-  if ((rv = i1.user_email.compare(i2.user_email)) != 0)
-    return rv;
-  if (i1.access_keys.size() != i2.access_keys.size())
-    return -1;
-  for (map<string, RGWAccessKey>::iterator it = i1.access_keys.begin();
-       it != i1.access_keys.end(); ++it) {
-    RGWAccessKey k1, k2;
-    k1 = it->second;
-    if (i2.access_keys.count(it->first) == 0)
-      return -1;
-    k2 = i2.access_keys[it->first];
-    if (compare_access_keys(k1, k2) != 0)
-      return -1;
-  }
-  if (i1.swift_keys.size() != i2.swift_keys.size())
-    return -1;
-  for (map<string, RGWAccessKey>::iterator it = i1.swift_keys.begin();
-       it != i1.swift_keys.end(); ++it) {
-    RGWAccessKey k1, k2;
-    k1 = it->second;
-    if (i2.swift_keys.count(it->first) == 0)
-      return -1;
-    k2 = i2.swift_keys[it->first];
-    if (compare_access_keys(k1, k2) != 0)
-      return -1;
-  }
-  if (i1.subusers.size() != i2.subusers.size()) 
-    return -1;
-  for (map<string, RGWSubUser>::iterator it = i1.subusers.begin();
-       it != i1.subusers.end(); ++it) {
-    RGWSubUser k1, k2;
-    k1 = it->second;
-    if (!i2.subusers.count(it->first))
-      return -1;
-    k2 = i2.subusers[it->first];
-    if (k1.name.compare(k2.name) != 0) 
-      return -1;
-    if (k1.perm_mask != k2.perm_mask)
-      return -1;
-  }
-  if (i1.suspended != i2.suspended)
-    return -1;
-  if (i1.max_buckets != i2.max_buckets)
-    return -1;
-  uint32_t p1, p2;
-  p1 = p2 = RGW_CAP_ALL;
-  if (i1.caps.check_cap(meta_caps, p1) != 0)
-    return -1;
-  if (i2.caps.check_cap(meta_caps, p2) != 0)
-    return -1;
-  return 0;
-}
-
-size_t read_dummy_post(void *ptr, size_t s, size_t n, void *ud) {
-  int dummy = 0;
-  memcpy(ptr, &dummy, sizeof(dummy));
-  return sizeof(dummy);
-}
-
-
-int parse_json_resp(JSONParser &parser) {
-  string *resp;
-  resp = (string *)g_test->get_response_data();
-  if(!resp)
-    return -1;
-  if(!parser.parse(resp->c_str(), resp->length())) {
-    cout << "Error parsing create user response" << std::endl;
-    return -1;
-  }
-  return 0;
-}
-
-size_t meta_read_json(void *ptr, size_t s, size_t n, void *ud){
-  stringstream *ss = (stringstream *)ud;
-  size_t len = ss->str().length();
-  if(s*n < len){
-    cout << "Cannot copy json data, as len is not enough\n";
-    return 0;
-  }
-  memcpy(ptr, (void *)ss->str().c_str(), len);
-  return len;
-}
+string uid = CEPH_UID;
+string display_name = "CEPH";
+string meta_caps = "metadata";
 
 TEST(TestRGWAdmin, meta_list){
   JSONParser parser;
   bool found = false;
   const char *perm = "*";
 
-  ASSERT_EQ(0, user_create(uid, display_name));
-  ASSERT_EQ(0, meta_caps_add(perm));
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name));
+  ASSERT_EQ(0, admin_helper::caps_add(meta_caps, uid, perm));
 
   /*Check the sections*/
   g_test->send_request(string("GET"), string("/admin/metadata/"));
   EXPECT_EQ(200U, g_test->get_resp_code());
 
-  ASSERT_TRUE(parse_json_resp(parser) == 0);
+  ASSERT_TRUE(admin_helper::parse_json_resp(parser) == 0);
   EXPECT_TRUE(parser.is_array());
   
   vector<string> l;
@@ -580,11 +59,13 @@ TEST(TestRGWAdmin, meta_list){
   g_test->send_request(string("GET"), string("/admin/metadata/user"));
   EXPECT_EQ(200U, g_test->get_resp_code());
 
-  ASSERT_TRUE(parse_json_resp(parser) == 0);
+  ASSERT_TRUE(admin_helper::parse_json_resp(parser) == 0);
   EXPECT_TRUE(parser.is_array());
   
   l = parser.get_array_elements();
-  EXPECT_EQ(1U, l.size());
+  // depending on the setup, the result may be different.
+  // on an empty cluster, the size will be 1. with vstart, the size will be 9.
+  ASSERT_TRUE(l.size() == 1U || l.size() == 9U);
   for(vector<string>::iterator it = l.begin();
       it != l.end(); ++it) {
     if((*it).compare(string("\"") + uid + string("\"")) == 0) {
@@ -596,16 +77,18 @@ TEST(TestRGWAdmin, meta_list){
 
   /*Check with second user*/
   string uid2 = "ceph1", display_name2 = "CEPH1";
-  ASSERT_EQ(0, user_create(uid2, display_name2, false));
+  ASSERT_EQ(0, admin_helper::user_create(uid2, display_name2, false));
   /*Check the list of keys*/
   g_test->send_request(string("GET"), string("/admin/metadata/user"));
   EXPECT_EQ(200U, g_test->get_resp_code());
 
-  ASSERT_TRUE(parse_json_resp(parser) == 0);
+  ASSERT_TRUE(admin_helper::parse_json_resp(parser) == 0);
   EXPECT_TRUE(parser.is_array());
   
   l = parser.get_array_elements();
-  EXPECT_EQ(2U, l.size());
+  // depending on the setup, the result may be different.
+  // on an empty cluster, the size will be 2. with vstart, the size will be 10.
+  ASSERT_TRUE(l.size() == 2U || l.size() == 10U);
   bool found2 = false;
   for(vector<string>::iterator it = l.begin();
       it != l.end(); ++it) {
@@ -617,10 +100,10 @@ TEST(TestRGWAdmin, meta_list){
     }
   }
   EXPECT_TRUE(found && found2);
-  ASSERT_EQ(0, user_rm(uid2, display_name2));
+  ASSERT_EQ(0, admin_helper::user_rm(uid2, display_name2));
 
   /*Remove the metadata caps*/
-  int rv = meta_caps_rm(perm);
+  int rv = admin_helper::caps_rm(meta_caps, uid, perm);
   EXPECT_EQ(0, rv);
   
   if(rv == 0) {
@@ -630,7 +113,7 @@ TEST(TestRGWAdmin, meta_list){
     g_test->send_request(string("GET"), string("/admin/metadata/user"));
     EXPECT_EQ(403U, g_test->get_resp_code());
   }
-  ASSERT_EQ(0, user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
 }
 
 TEST(TestRGWAdmin, meta_get){
@@ -638,18 +121,22 @@ TEST(TestRGWAdmin, meta_get){
   const char *perm = "*";
   RGWUserInfo info;
 
-  ASSERT_EQ(0, user_create(uid, display_name));
-  ASSERT_EQ(0, meta_caps_add(perm));
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name));
+  ASSERT_EQ(0, admin_helper::caps_add(meta_caps, uid, perm));
 
-  ASSERT_EQ(0, user_info(uid, display_name, info));
+  ASSERT_EQ(0, admin_helper::user_info(uid, display_name, info));
  
+  // user with key = "test" exists in vstart
   g_test->send_request(string("GET"), string("/admin/metadata/user?key=test"));
-  EXPECT_EQ(404U, g_test->get_resp_code());
+  ASSERT_TRUE(g_test->get_resp_code() == 200U || g_test->get_resp_code() == 404U);
+
+  g_test->send_request(string("GET"), string("/admin/metadata/user?key=doesnotexist"));
+  ASSERT_EQ(404U, g_test->get_resp_code());
 
   g_test->send_request(string("GET"), (string("/admin/metadata/user?key=") + uid));
   EXPECT_EQ(200U, g_test->get_resp_code());
 
-  ASSERT_TRUE(parse_json_resp(parser) == 0);
+  ASSERT_TRUE(admin_helper::parse_json_resp(parser) == 0);
   RGWObjVersionTracker objv_tracker;
   string metadata_key;
 
@@ -666,18 +153,18 @@ TEST(TestRGWAdmin, meta_get){
   RGWUserInfo obt_info;
   decode_json_obj(obt_info, jo);
 
-  EXPECT_TRUE(compare_user_info(info, obt_info) == 0);
+  EXPECT_TRUE(admin_helper::compare_user_info(info, obt_info, meta_caps) == 0);
 
   /*Make a modification and check if its reflected*/
-  ASSERT_EQ(0, meta_caps_rm(perm));
+  ASSERT_EQ(0, admin_helper::caps_rm(meta_caps, uid, perm));
   perm = "read";
-  ASSERT_EQ(0, meta_caps_add(perm));
+  ASSERT_EQ(0, admin_helper::caps_add(meta_caps, uid, perm));
   
   JSONParser parser1;
   g_test->send_request(string("GET"), (string("/admin/metadata/user?key=") + uid));
   EXPECT_EQ(200U, g_test->get_resp_code());
 
-  ASSERT_TRUE(parse_json_resp(parser1) == 0);
+  ASSERT_TRUE(admin_helper::parse_json_resp(parser1) == 0);
  
   RGWObjVersionTracker objv_tracker1;
   obj_version *objv1 = &objv_tracker1.read_version;
@@ -700,14 +187,14 @@ TEST(TestRGWAdmin, meta_get){
   EXPECT_TRUE(objv1->ver > objv->ver);
   EXPECT_EQ(objv1->tag, objv->tag);
   
-  int rv = meta_caps_rm(perm);
+  int rv = admin_helper::caps_rm(meta_caps, uid, perm);
   EXPECT_EQ(0, rv);
   
   if(rv == 0) {
     g_test->send_request(string("GET"), (string("/admin/metadata/user?key=") + uid));
     EXPECT_EQ(403U, g_test->get_resp_code());
   }
-  ASSERT_EQ(0, user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
 }
 
 TEST(TestRGWAdmin, meta_put){
@@ -715,13 +202,13 @@ TEST(TestRGWAdmin, meta_put){
   const char *perm = "*";
   RGWUserInfo info;
 
-  ASSERT_EQ(0, user_create(uid, display_name));
-  ASSERT_EQ(0, meta_caps_add(perm));
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name));
+  ASSERT_EQ(0, admin_helper::caps_add(meta_caps, uid, perm));
   
   g_test->send_request(string("GET"), (string("/admin/metadata/user?key=") + uid));
   EXPECT_EQ(200U, g_test->get_resp_code());
 
-  ASSERT_TRUE(parse_json_resp(parser) == 0);
+  ASSERT_TRUE(admin_helper::parse_json_resp(parser) == 0);
   RGWObjVersionTracker objv_tracker;
   string metadata_key;
 
@@ -755,119 +242,24 @@ TEST(TestRGWAdmin, meta_put){
   f->flush(ss);
 
   g_test->send_request(string("PUT"), (string("/admin/metadata/user?key=") + uid), 
-                       meta_read_json,
+                       admin_helper::meta_read_json,
                        (void *)&ss, ss.str().length());
-  EXPECT_EQ(200U, g_test->get_resp_code());
+  EXPECT_EQ(204U, g_test->get_resp_code());
 
-  ASSERT_EQ(0, user_info(uid, display_name, obt_info));
+  ASSERT_EQ(0, admin_helper::user_info(uid, display_name, obt_info));
   uint32_t cp;
   cp = RGW_CAP_WRITE;
   EXPECT_TRUE (obt_info.caps.check_cap(meta_caps, cp) == 0);
   cp = RGW_CAP_READ;
   EXPECT_TRUE (obt_info.caps.check_cap(meta_caps, cp) != 0);
   
-  int rv = meta_caps_rm("write");
+  int rv = admin_helper::caps_rm(meta_caps, uid, "write");
   EXPECT_EQ(0, rv);
   if(rv == 0) {
     g_test->send_request(string("PUT"), (string("/admin/metadata/user?key=") + uid));
     EXPECT_EQ(403U, g_test->get_resp_code());
   }
-  ASSERT_EQ(0, user_rm(uid, display_name));
-}
-
-TEST(TestRGWAdmin, meta_lock_unlock) {
-  const char *perm = "*";
-  string rest_req;
-
-  ASSERT_EQ(0, user_create(uid, display_name));
-  ASSERT_EQ(0, meta_caps_add(perm));
-
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(400U, g_test->get_resp_code()); /*Bad request*/
-  
-  rest_req = "/admin/metadata/user?lock&length=3&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(400U, g_test->get_resp_code()); /*Bad request*/
-
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&unlock";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(400U, g_test->get_resp_code()); /*Bad request*/
-
-  rest_req = "/admin/metadata/user?unlock&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(400U, g_test->get_resp_code()); /*Bad request*/
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&unlock&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph1";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&unlock&lock_id=ceph1";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  utime_t sleep_time(3, 0);
-
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph1";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(500U, g_test->get_resp_code()); 
-
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(409U, g_test->get_resp_code()); 
-  sleep_time.sleep();
-
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph1";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&unlock&lock_id=ceph1";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-
-  ASSERT_EQ(0, meta_caps_rm(perm));
-  perm = "read";
-  ASSERT_EQ(0, meta_caps_add(perm));
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(403U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&unlock&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(403U, g_test->get_resp_code()); 
-  
-  ASSERT_EQ(0, meta_caps_rm(perm));
-  perm = "write";
-  ASSERT_EQ(0, meta_caps_add(perm));
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&unlock&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(200U, g_test->get_resp_code()); 
-  
-  ASSERT_EQ(0, meta_caps_rm(perm));
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&lock&length=3&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(403U, g_test->get_resp_code()); 
-  
-  rest_req = "/admin/metadata/user?key=" CEPH_UID "&unlock&lock_id=ceph";
-  g_test->send_request(string("POST"), rest_req, read_dummy_post, NULL, sizeof(int));
-  EXPECT_EQ(403U, g_test->get_resp_code()); 
-  
-  ASSERT_EQ(0, user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
 }
 
 TEST(TestRGWAdmin, meta_delete){
@@ -875,21 +267,21 @@ TEST(TestRGWAdmin, meta_delete){
   const char *perm = "*";
   RGWUserInfo info;
 
-  ASSERT_EQ(0, user_create(uid, display_name));
-  ASSERT_EQ(0, meta_caps_add(perm));
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name));
+  ASSERT_EQ(0, admin_helper::caps_add(meta_caps, uid, perm));
 
   g_test->send_request(string("DELETE"), (string("/admin/metadata/user?key=") + uid));
   EXPECT_EQ(200U, g_test->get_resp_code());
 
-  ASSERT_TRUE(user_info(uid, display_name, info) != 0);
+  ASSERT_TRUE(admin_helper::user_info(uid, display_name, info) != 0);
 
-  ASSERT_EQ(0, user_create(uid, display_name));
+  ASSERT_EQ(0, admin_helper::user_create(uid, display_name));
   perm = "read";
-  ASSERT_EQ(0, meta_caps_add(perm));
+  ASSERT_EQ(0, admin_helper::caps_add(meta_caps, uid, perm));
   
   g_test->send_request(string("DELETE"), (string("/admin/metadata/user?key=") + uid));
   EXPECT_EQ(403U, g_test->get_resp_code());
-  ASSERT_EQ(0, user_rm(uid, display_name));
+  ASSERT_EQ(0, admin_helper::user_rm(uid, display_name));
 }
 
 int main(int argc, char *argv[]){
@@ -899,20 +291,20 @@ int main(int argc, char *argv[]){
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
-  g_test = new admin_meta::test_helper();
-  finisher = new Finisher(g_ceph_context);
+  g_test = new admin_helper::test_helper();
+  Finisher *finisher = new Finisher(g_ceph_context);
 #ifdef GTEST
   ::testing::InitGoogleTest(&argc, argv);
 #endif
   finisher->start();
 
   if(g_test->extract_input(argc, argv) < 0){
-    print_usage(argv[0]);
+    admin_helper::print_usage(argv[0]);
     return -1;
   }
 #ifdef GTEST
   int r = RUN_ALL_TESTS();
-  if (r >= 0) {
+  if (r == 0) {
     cout << "There are no failures in the test case\n";
   } else {
     cout << "There are some failures\n";


### PR DESCRIPTION
Backport Tracker : https://tracker.ceph.com/issues/74390


backport of https://github.com/ceph/ceph/pull/65480
parent tracker: https://tracker.ceph.com/issues/72527

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
