### PR TITLE
mgr/cephadm: Add a new cephadm's API to get nvmeof TLS bundle

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -84,6 +84,7 @@ from .services.osd import OSDRemovalQueue, OSDService, OSD, NotFoundError
 from .services.monitoring import AlertmanagerService, PrometheusService
 from .services.node_proxy import NodeProxy
 from .services.smb import SMBService
+from .services.nvmeof import NvmeofService
 from .schedule import HostAssignment
 from .inventory import (
     Inventory,
@@ -3487,6 +3488,12 @@ Then run the following:
     @handle_orch_error
     def cert_store_key_ls(self, include_cephadm_generated_keys: bool = False) -> Dict[str, Any]:
         return self.cert_mgr.key_ls(include_cephadm_generated_keys)
+
+    @handle_orch_error
+    def get_nvmeof_tls_bundle(self, service_name: str) -> Dict[str, str]:
+        nvmeof_svc = cast(NvmeofService, service_registry.get_service('nvmeof'))
+        tls_bundle = nvmeof_svc.get_nvmeof_tls_bundle(service_name)
+        return tls_bundle._asdict() if tls_bundle else {}
 
     @handle_orch_error
     def cert_store_get_cert(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3490,9 +3490,9 @@ Then run the following:
         return self.cert_mgr.key_ls(include_cephadm_generated_keys)
 
     @handle_orch_error
-    def get_nvmeof_tls_bundle(self, service_name: str) -> Dict[str, str]:
+    def get_nvmeof_tls_bundle(self, service_name: str, daemon_name: str) -> Dict[str, str]:
         nvmeof_svc = cast(NvmeofService, service_registry.get_service('nvmeof'))
-        tls_bundle = nvmeof_svc.get_nvmeof_tls_bundle(service_name)
+        tls_bundle = nvmeof_svc.get_nvmeof_tls_bundle(service_name, daemon_name)
         return tls_bundle._asdict() if tls_bundle else {}
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -381,7 +381,7 @@ class NvmeofService(CephService):
 
         for dd in dds:
             # dd.hostname is the short host name used for HOST-scoped certmgr objects
-            if dd.name == daemon_name:
+            if dd.name() == daemon_name:
                 return dd.hostname
 
         return None

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -368,7 +368,7 @@ class NvmeofService(CephService):
         ]
         return blocking_daemon_hosts
 
-    def _pick_running_daemon_host_for_service(self, service_name: str) -> Optional[str]:
+    def _get_daemon_hostname(self, service_name: str, daemon_name: str) -> Optional[str]:
         """
         Resolve a deterministic host for a service when HOST-scoped objects are needed.
         Picks the first RUNNING daemon host from the orchestrator cache.
@@ -381,17 +381,12 @@ class NvmeofService(CephService):
 
         for dd in dds:
             # dd.hostname is the short host name used for HOST-scoped certmgr objects
-            if dd.status == DaemonDescriptionStatus.running and dd.hostname:
-                return dd.hostname
-
-        # fallback: any host if nothing is RUNNING
-        for dd in dds:
-            if dd.hostname:
+            if dd.name == daemon_name:
                 return dd.hostname
 
         return None
 
-    def get_nvmeof_tls_bundle(self, service_name: str) -> Optional[NvmeofTLSBundle]:
+    def get_nvmeof_tls_bundle(self, service_name: str, daemon_name: str) -> Optional[NvmeofTLSBundle]:
         """
         Deterministic NVMeoF TLS bundle retrieval based on the NVMeoF spec's certificate_source.
 
@@ -443,7 +438,7 @@ class NvmeofService(CephService):
 
         # -------- CEPHADM_SIGNED --------
         elif cert_source == CertificateSource.CEPHADM_SIGNED.value:
-            hostname = self._pick_running_daemon_host_for_service(service_name)
+            hostname = self._get_daemon_hostname(service_name, daemon_name)
             if not hostname:
                 logger.error(f"certificate_source=cephadm-signed for '{service_name}' but no hostname could be resolved")
                 return None

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -704,6 +704,9 @@ class TestNvmeofTLSBundle:
         if hasattr(cephadm_module.spec_store, 'spec_created'):
             cephadm_module.spec_store.spec_created[spec.service_name()] = datetime_now()
 
+    def _daemon_name(self, spec: NvmeofServiceSpec) -> str:
+        return f'{spec.service_name()}.test-daemon'
+
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_get_nvmeof_tls_bundle_ssl_disabled(self, cephadm_module: CephadmOrchestrator):
         """Test that SSL disabled returns empty bundle"""
@@ -716,7 +719,9 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
-        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(
+            spec.service_name(), self._daemon_name(spec)
+        )
 
         assert bundle is not None
         assert bundle.server_cert == ''
@@ -744,7 +749,9 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
-        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(
+            spec.service_name(), self._daemon_name(spec)
+        )
 
         assert bundle is not None
         assert bundle.server_cert == server_cert
@@ -778,7 +785,9 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
-        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(
+            spec.service_name(), self._daemon_name(spec)
+        )
 
         assert bundle is not None
         assert bundle.server_cert == server_cert
@@ -804,6 +813,7 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
+        daemon_name = self._daemon_name(spec)
 
         # Mock cert_mgr.get_cert and get_key for SERVICE-scoped lookups
         def _get_cert(name, service_name=None, host=None):
@@ -818,7 +828,7 @@ class TestNvmeofTLSBundle:
 
         with patch.object(cephadm_module.cert_mgr, 'get_cert', side_effect=_get_cert), \
              patch.object(cephadm_module.cert_mgr, 'get_key', side_effect=_get_key):
-            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name(), daemon_name)
 
         assert bundle is not None
         assert bundle.server_cert == server_cert
@@ -847,6 +857,7 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
+        daemon_name = self._daemon_name(spec)
 
         def _get_cert(name, service_name=None, host=None):
             if name == nvmeof_service.cert_name:
@@ -866,7 +877,7 @@ class TestNvmeofTLSBundle:
 
         with patch.object(cephadm_module.cert_mgr, 'get_cert', side_effect=_get_cert), \
              patch.object(cephadm_module.cert_mgr, 'get_key', side_effect=_get_key):
-            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name(), daemon_name)
 
         assert bundle is not None
         assert bundle.server_cert == server_cert
@@ -875,11 +886,11 @@ class TestNvmeofTLSBundle:
         assert bundle.client_key == client_key
         assert bundle.ca_cert == ca_cert
 
-    @patch("cephadm.services.nvmeof.NvmeofService._pick_running_daemon_host_for_service")
+    @patch("cephadm.services.nvmeof.NvmeofService._get_daemon_hostname")
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    def test_get_nvmeof_tls_bundle_cephadm_signed_server_only(self, _pick_host, cephadm_module: CephadmOrchestrator):
+    def test_get_nvmeof_tls_bundle_cephadm_signed_server_only(self, _get_daemon_hostname, cephadm_module: CephadmOrchestrator):
         """Test CEPHADM_SIGNED certificate source without mTLS"""
-        _pick_host.return_value = 'test-host'
+        _get_daemon_hostname.return_value = 'test-host'
 
         spec = NvmeofServiceSpec(
             service_id='test.group',
@@ -902,8 +913,13 @@ class TestNvmeofTLSBundle:
             return server_creds
 
         nvmeof_service = NvmeofService(cephadm_module)
-        with patch.object(cephadm_module.cert_mgr, 'get_self_signed_tls_credentials', side_effect=_get_self_signed):
-            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        daemon_name = self._daemon_name(spec)
+        with patch.object(
+            cephadm_module.cert_mgr,
+            'get_self_signed_tls_credentials',
+            side_effect=_get_self_signed,
+        ):
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name(), daemon_name)
 
         assert bundle is not None
         assert bundle.server_cert == ceph_generated_cert
@@ -912,11 +928,11 @@ class TestNvmeofTLSBundle:
         assert bundle.client_cert == ''
         assert bundle.client_key == ''
 
-    @patch("cephadm.services.nvmeof.NvmeofService._pick_running_daemon_host_for_service")
+    @patch("cephadm.services.nvmeof.NvmeofService._get_daemon_hostname")
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    def test_get_nvmeof_tls_bundle_cephadm_signed_with_mtls(self, _pick_host, cephadm_module: CephadmOrchestrator):
+    def test_get_nvmeof_tls_bundle_cephadm_signed_with_mtls(self, _get_daemon_hostname, cephadm_module: CephadmOrchestrator):
         """Test CEPHADM_SIGNED certificate source with mTLS enabled"""
-        _pick_host.return_value = 'test-host'
+        _get_daemon_hostname.return_value = 'test-host'
 
         spec = NvmeofServiceSpec(
             service_id='test.group',
@@ -946,8 +962,13 @@ class TestNvmeofTLSBundle:
             return server_creds
 
         nvmeof_service = NvmeofService(cephadm_module)
-        with patch.object(cephadm_module.cert_mgr, 'get_self_signed_tls_credentials', side_effect=_get_self_signed):
-            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        daemon_name = self._daemon_name(spec)
+        with patch.object(
+            cephadm_module.cert_mgr,
+            'get_self_signed_tls_credentials',
+            side_effect=_get_self_signed,
+        ):
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name(), daemon_name)
 
         assert bundle is not None
         assert bundle.server_cert == ceph_generated_cert
@@ -957,11 +978,11 @@ class TestNvmeofTLSBundle:
         # API returns the CA from server_creds
         assert bundle.ca_cert == cephadm_root_ca
 
-    @patch("cephadm.services.nvmeof.NvmeofService._pick_running_daemon_host_for_service")
+    @patch("cephadm.services.nvmeof.NvmeofService._get_daemon_hostname")
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    def test_get_nvmeof_tls_bundle_cephadm_signed_no_hostname(self, _pick_host, cephadm_module: CephadmOrchestrator):
+    def test_get_nvmeof_tls_bundle_cephadm_signed_no_hostname(self, _get_daemon_hostname, cephadm_module: CephadmOrchestrator):
         """Test CEPHADM_SIGNED returns None when no hostname can be resolved"""
-        _pick_host.return_value = None
+        _get_daemon_hostname.return_value = None
 
         spec = NvmeofServiceSpec(
             service_id='test.group',
@@ -973,14 +994,18 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
-        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(
+            spec.service_name(), self._daemon_name(spec)
+        )
         assert bundle is None
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_get_nvmeof_tls_bundle_service_not_found(self, cephadm_module: CephadmOrchestrator):
         """Test that None is returned when service doesn't exist"""
         nvmeof_service = NvmeofService(cephadm_module)
-        bundle = nvmeof_service.get_nvmeof_tls_bundle('nvmeof.nonexistent')
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(
+            'nvmeof.nonexistent', 'nvmeof.nonexistent.test-daemon'
+        )
         assert bundle is None
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -996,7 +1021,9 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
-        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(
+            spec.service_name(), self._daemon_name(spec)
+        )
         assert bundle is None
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -1013,11 +1040,12 @@ class TestNvmeofTLSBundle:
         self._store_spec(cephadm_module, spec)
 
         nvmeof_service = NvmeofService(cephadm_module)
+        daemon_name = self._daemon_name(spec)
 
         # Mock get_cert and get_key to return None for all lookups
         with patch.object(cephadm_module.cert_mgr, 'get_cert', return_value=None), \
              patch.object(cephadm_module.cert_mgr, 'get_key', return_value=None):
-            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name(), daemon_name)
 
         assert bundle is not None
         assert bundle.server_cert == ''

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -2,13 +2,22 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 from typing import Dict, List
+from ceph.utils import datetime_now
 
-from cephadm.services.nvmeof import NvmeofService
+from cephadm.services.nvmeof import NvmeofService, NVMEOF_CLIENT_CERT_LABEL
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import NvmeofServiceSpec
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm, async_side_effect
 from orchestrator import OrchestratorError
 from cephadm.tlsobject_types import TLSCredentials
+
+cephadm_root_ca = """-----BEGIN CERTIFICATE-----\nMIIE7DCCAtSgAwIBAgIUE8b2zZ64geu2ns3Zfn3/4L+Cf6MwDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MB4XDTI0MDYyNjE0NDA1M1oXDTM0\nMDYyNzE0NDA1M1owFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsZRJsdtTr9GLG1lWFql5SGc46ldFanNJd1Gl\nqXq5vgZVKRDTmNgAb/XFuNEEmbDAXYIRZolZeYKMHfn0pouPRSel0OsC6/02ZUOW\nIuN89Wgo3IYleCFpkVIumD8URP3hwdu85plRxYZTtlruBaTRH38lssyCqxaOdEt7\nAUhvYhcMPJThB17eOSQ73mb8JEC83vB47fosI7IhZuvXvRSuZwUW30rJanWNhyZq\neS2B8qw2RSO0+77H6gA4ftBnitfsE1Y8/F9Z/f92JOZuSMQXUB07msznPbRJia3f\nueO8gOc32vxd1A1/Qzp14uX34yEGY9ko2lW226cZO29IVUtXOX+LueQttwtdlpz8\ne6Npm09pXhXAHxV/OW3M28MdXmobIqT/m9MfkeAErt5guUeC5y8doz6/3VQRjFEn\nRpN0WkblgnNAQ3DONPc+Qd9Fi/wZV2X7bXoYpNdoWDsEOiE/eLmhG1A2GqU/mneP\nzQ6u79nbdwTYpwqHpa+PvusXeLfKauzI8lLUJotdXy9EK8iHUofibB61OljYye6B\nG3b8C4QfGsw8cDb4APZd/6AZYyMx/V3cGZ+GcOV7WvsC8k7yx5Uqasm/kiGQ3EZo\nuNenNEYoGYrjb8D/8QzqNUTwlEh27/ps80tO7l2GGTvWVZL0PRZbmLDvO77amtOf\nOiRXMoUCAwEAAaMwMC4wGwYDVR0RBBQwEocQAAAAAAAAAAAAAAAAAAAAATAPBgNV\nHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAxwzX5AhYEWhTV4VUwUj5+\nqPdl4Q2tIxRokqyE+cDxoSd+6JfGUefUbNyBxDt0HaBq8obDqqrbcytxnn7mpnDu\nhtiauY+I4Amt7hqFOiFA4cCLi2mfok6g2vL53tvhd9IrsfflAU2wy7hL76Ejm5El\nA+nXlkJwps01Whl9pBkUvIbOn3pXX50LT4hb5zN0PSu957rjd2xb4HdfuySm6nW4\n4GxtVWfmGA6zbC4XMEwvkuhZ7kD2qjkAguGDF01uMglkrkCJT3OROlNBuSTSBGqt\ntntp5VytHvb7KTF7GttM3ha8/EU2KYaHM6WImQQTrOfiImAktOk4B3lzUZX3HYIx\n+sByO4P4dCvAoGz1nlWYB2AvCOGbKf0Tgrh4t4jkiF8FHTXGdfvWmjgi1pddCNAy\nn65WOCmVmLZPERAHOk1oBwqyReSvgoCFo8FxbZcNxJdlhM0Z6hzKggm3O3Dl88Xl\n5euqJjh2STkBW8Xuowkg1TOs5XyWvKoDFAUzyzeLOL8YSG+gXV22gPTUaPSVAqdb\nwd0Fx2kjConuC5bgTzQHs8XWA930U3XWZraj21Vaa8UxlBLH4fUro8H5lMSYlZNE\nJHRNW8BkznAClaFSDG3dybLsrzrBFAu/Qb5zVkT1xyq0YkepGB7leXwq6vjWA5Pw\nmZbKSphWfh0qipoqxqhfkw==\n-----END CERTIFICATE-----\n"""
+
+
+ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaLJzmvntjukjMA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzEzMTE0NzA3WhcN\nMzIwNzEwMTE0NzA3WjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyyMe4DMA+MeYK7BHZMHB\nq7zjliEOcNgxomjU8qbf5USF7Mqrf6+/87XWqj4pCyAW8x0WXEr6A56a+cmBVmt+\nqtWDzl020aoId6lL5EgLLn6/kMDCCJLq++Lg9cEofMSvcZh+lY2f+1p+C+00xent\nrLXvXGOilAZWaQfojT2BpRnNWWIFbpFwlcKrlg2G0cFjV5c1m6a0wpsQ9JHOieq0\nSvwCixajwq3CwAYuuiU1wjI4oJO4Io1+g8yB3nH2Mo/25SApCxMXuXh4kHLQr/T4\n4hqisvG4uJYgKMcSIrWj5o25mclByGi1UI/kZkCUES94i7Z/3ihx4Bad0AMs/9tw\nFwIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQAf+pwz7Gd7mDwU2LY0TQXsK6/8KGzh\nHuX+ErOb8h5cOAbvCnHjyJFWf6gCITG98k9nxU9NToG0WYuNm/max1y/54f0dtxZ\npUo6KSNl3w6iYCfGOeUIj8isi06xMmeTgMNzv8DYhDt+P2igN6LenqWTVztogkiV\nxQ5ZJFFLEw4sN0CXnrZX3t5ruakxLXLTLKeE0I91YJvjClSBGkVJq26wOKQNHMhx\npWxeydQ5EgPZY+Aviz5Dnxe8aB7oSSovpXByzxURSabOuCK21awW5WJCGNpmqhWK\nZzACBDEstccj57c4OGV0eayHJRsluVr2e9NHRINZA3qdB37e6gsI1xHo\n-----END CERTIFICATE-----\n"""
+
+
+ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
 
 
 class FakeInventory:
@@ -685,3 +694,334 @@ timeout = 1.0
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+
+class TestNvmeofTLSBundle:
+    def _store_spec(self, cephadm_module: CephadmOrchestrator, spec: NvmeofServiceSpec) -> None:
+        # SpecStore in unit tests stores ServiceSpec objects directly.
+        cephadm_module.spec_store._specs[spec.service_name()] = spec
+        # Some SpecStore helpers expect spec_created to exist.
+        if hasattr(cephadm_module.spec_store, 'spec_created'):
+            cephadm_module.spec_store.spec_created[spec.service_name()] = datetime_now()
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_ssl_disabled(self, cephadm_module: CephadmOrchestrator):
+        """Test that SSL disabled returns empty bundle"""
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=False,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == ''
+        assert bundle.server_key == ''
+        assert bundle.client_cert == ''
+        assert bundle.client_key == ''
+        assert bundle.ca_cert == ''
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_inline_server_only(self, cephadm_module: CephadmOrchestrator):
+        """Test INLINE certificate source with server creds only (no mTLS)"""
+        server_cert = '-----BEGIN CERTIFICATE-----\nSERVER_CERT\n-----END CERTIFICATE-----'
+        server_key = '-----BEGIN PRIVATE KEY-----\nSERVER_KEY\n-----END PRIVATE KEY-----'
+
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='inline',
+            ssl_cert=server_cert,
+            ssl_key=server_key,
+            enable_auth=False,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == server_cert
+        assert bundle.server_key == server_key
+        assert bundle.client_cert == ''
+        assert bundle.client_key == ''
+        assert bundle.ca_cert == ''
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_inline_with_mtls(self, cephadm_module: CephadmOrchestrator):
+        """Test INLINE certificate source with mTLS enabled"""
+        server_cert = '-----BEGIN CERTIFICATE-----\nSERVER_CERT\n-----END CERTIFICATE-----'
+        server_key = '-----BEGIN PRIVATE KEY-----\nSERVER_KEY\n-----END PRIVATE KEY-----'
+        client_cert = '-----BEGIN CERTIFICATE-----\nCLIENT_CERT\n-----END CERTIFICATE-----'
+        client_key = '-----BEGIN PRIVATE KEY-----\nCLIENT_KEY\n-----END PRIVATE KEY-----'
+        ca_cert = '-----BEGIN CERTIFICATE-----\nCA_CERT\n-----END CERTIFICATE-----'
+
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='inline',
+            ssl_cert=server_cert,
+            ssl_key=server_key,
+            enable_auth=True,
+            client_cert=client_cert,
+            client_key=client_key,
+            root_ca_cert=ca_cert,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == server_cert
+        assert bundle.server_key == server_key
+        assert bundle.client_cert == client_cert
+        assert bundle.client_key == client_key
+        assert bundle.ca_cert == ca_cert
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_reference_server_only(self, cephadm_module: CephadmOrchestrator):
+        """Test REFERENCE certificate source with server creds only"""
+        server_cert = '-----BEGIN CERTIFICATE-----\nREF_SERVER_CERT\n-----END CERTIFICATE-----'
+        server_key = '-----BEGIN PRIVATE KEY-----\nREF_SERVER_KEY\n-----END PRIVATE KEY-----'
+
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='reference',
+            enable_auth=False,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+
+        # Mock cert_mgr.get_cert and get_key for SERVICE-scoped lookups
+        def _get_cert(name, service_name=None, host=None):
+            if name == nvmeof_service.cert_name:
+                return server_cert
+            return None
+
+        def _get_key(name, service_name=None, host=None):
+            if name == nvmeof_service.key_name:
+                return server_key
+            return None
+
+        with patch.object(cephadm_module.cert_mgr, 'get_cert', side_effect=_get_cert), \
+             patch.object(cephadm_module.cert_mgr, 'get_key', side_effect=_get_key):
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == server_cert
+        assert bundle.server_key == server_key
+        assert bundle.client_cert == ''
+        assert bundle.client_key == ''
+        assert bundle.ca_cert == ''
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_reference_with_mtls(self, cephadm_module: CephadmOrchestrator):
+        """Test REFERENCE certificate source with mTLS enabled"""
+        server_cert = '-----BEGIN CERTIFICATE-----\nREF_SERVER_CERT\n-----END CERTIFICATE-----'
+        server_key = '-----BEGIN PRIVATE KEY-----\nREF_SERVER_KEY\n-----END PRIVATE KEY-----'
+        client_cert = '-----BEGIN CERTIFICATE-----\nREF_CLIENT_CERT\n-----END CERTIFICATE-----'
+        client_key = '-----BEGIN PRIVATE KEY-----\nREF_CLIENT_KEY\n-----END PRIVATE KEY-----'
+        ca_cert = '-----BEGIN CERTIFICATE-----\nREF_CA_CERT\n-----END CERTIFICATE-----'
+
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='reference',
+            enable_auth=True,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+
+        def _get_cert(name, service_name=None, host=None):
+            if name == nvmeof_service.cert_name:
+                return server_cert
+            if name == nvmeof_service.client_cert_name:
+                return client_cert
+            if name == nvmeof_service.ca_cert_name:
+                return ca_cert
+            return None
+
+        def _get_key(name, service_name=None, host=None):
+            if name == nvmeof_service.key_name:
+                return server_key
+            if name == nvmeof_service.client_key_name:
+                return client_key
+            return None
+
+        with patch.object(cephadm_module.cert_mgr, 'get_cert', side_effect=_get_cert), \
+             patch.object(cephadm_module.cert_mgr, 'get_key', side_effect=_get_key):
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == server_cert
+        assert bundle.server_key == server_key
+        assert bundle.client_cert == client_cert
+        assert bundle.client_key == client_key
+        assert bundle.ca_cert == ca_cert
+
+    @patch("cephadm.services.nvmeof.NvmeofService._pick_running_daemon_host_for_service")
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_cephadm_signed_server_only(self, _pick_host, cephadm_module: CephadmOrchestrator):
+        """Test CEPHADM_SIGNED certificate source without mTLS"""
+        _pick_host.return_value = 'test-host'
+
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='cephadm-signed',
+            enable_auth=False,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        server_creds = TLSCredentials(
+            cert=ceph_generated_cert,
+            key=ceph_generated_key,
+            ca_cert=cephadm_root_ca,
+        )
+
+        def _get_self_signed(service_name, hostname, label=None):
+            assert label is None
+            return server_creds
+
+        nvmeof_service = NvmeofService(cephadm_module)
+        with patch.object(cephadm_module.cert_mgr, 'get_self_signed_tls_credentials', side_effect=_get_self_signed):
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == ceph_generated_cert
+        assert bundle.server_key == ceph_generated_key
+        assert bundle.ca_cert == cephadm_root_ca
+        assert bundle.client_cert == ''
+        assert bundle.client_key == ''
+
+    @patch("cephadm.services.nvmeof.NvmeofService._pick_running_daemon_host_for_service")
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_cephadm_signed_with_mtls(self, _pick_host, cephadm_module: CephadmOrchestrator):
+        """Test CEPHADM_SIGNED certificate source with mTLS enabled"""
+        _pick_host.return_value = 'test-host'
+
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='cephadm-signed',
+            enable_auth=True,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        server_creds = TLSCredentials(
+            cert=ceph_generated_cert,
+            key=ceph_generated_key,
+            ca_cert=cephadm_root_ca,
+        )
+        client_creds = TLSCredentials(
+            cert='-----BEGIN CERTIFICATE-----\nCLIENT_CERT\n-----END CERTIFICATE-----',
+            key='-----BEGIN PRIVATE KEY-----\nCLIENT_KEY\n-----END PRIVATE KEY-----',
+            ca_cert=cephadm_root_ca,
+        )
+
+        def _get_self_signed(service_name, hostname, label=None):
+            if label == NVMEOF_CLIENT_CERT_LABEL:
+                return client_creds
+            assert label is None
+            return server_creds
+
+        nvmeof_service = NvmeofService(cephadm_module)
+        with patch.object(cephadm_module.cert_mgr, 'get_self_signed_tls_credentials', side_effect=_get_self_signed):
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == ceph_generated_cert
+        assert bundle.server_key == ceph_generated_key
+        assert bundle.client_cert == client_creds.cert
+        assert bundle.client_key == client_creds.key
+        # API returns the CA from server_creds
+        assert bundle.ca_cert == cephadm_root_ca
+
+    @patch("cephadm.services.nvmeof.NvmeofService._pick_running_daemon_host_for_service")
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_cephadm_signed_no_hostname(self, _pick_host, cephadm_module: CephadmOrchestrator):
+        """Test CEPHADM_SIGNED returns None when no hostname can be resolved"""
+        _pick_host.return_value = None
+
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='cephadm-signed',
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        assert bundle is None
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_service_not_found(self, cephadm_module: CephadmOrchestrator):
+        """Test that None is returned when service doesn't exist"""
+        nvmeof_service = NvmeofService(cephadm_module)
+        bundle = nvmeof_service.get_nvmeof_tls_bundle('nvmeof.nonexistent')
+        assert bundle is None
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_unknown_cert_source(self, cephadm_module: CephadmOrchestrator):
+        """Test that None is returned for unknown certificate_source"""
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='unknown-source',
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+        bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+        assert bundle is None
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_get_nvmeof_tls_bundle_reference_missing_certs(self, cephadm_module: CephadmOrchestrator):
+        """Test REFERENCE source when certs are not stored in certmgr"""
+        spec = NvmeofServiceSpec(
+            service_id='test.group',
+            pool='testpool',
+            group='group',
+            ssl=True,
+            certificate_source='reference',
+            enable_auth=True,
+        )
+        self._store_spec(cephadm_module, spec)
+
+        nvmeof_service = NvmeofService(cephadm_module)
+
+        # Mock get_cert and get_key to return None for all lookups
+        with patch.object(cephadm_module.cert_mgr, 'get_cert', return_value=None), \
+             patch.object(cephadm_module.cert_mgr, 'get_key', return_value=None):
+            bundle = nvmeof_service.get_nvmeof_tls_bundle(spec.service_name())
+
+        assert bundle is not None
+        assert bundle.server_cert == ''
+        assert bundle.server_key == ''
+        assert bundle.client_cert == ''
+        assert bundle.client_key == ''
+        assert bundle.ca_cert == ''

--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -35,6 +35,17 @@ else:
         pb2 = pb2
 
         def __init__(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+
+            def encode_tls_bundle(bundle: Dict[str, str]) -> Dict[str, bytes]:
+                """Encode TLS bundle string values to bytes for gRPC."""
+                encoded: Dict[str, bytes] = {}
+                for key, value in bundle.items():
+                    if isinstance(value, str):
+                        encoded[key] = value.encode('utf-8')
+                    else:
+                        encoded[key] = value
+                return encoded
+
             logger.info("Initiating nvmeof gateway connection...")
             try:
                 if not gw_group:
@@ -69,21 +80,27 @@ else:
                     logger.debug("Gateway address set to: %s", self.gateway_addr)
             enable_auth = is_mtls_enabled(service_name)
             if enable_auth:
-                client_key = NvmeofGatewaysConfig.get_client_key(service_name)
-                client_cert = NvmeofGatewaysConfig.get_client_cert(service_name)
-                server_cert = NvmeofGatewaysConfig.get_ssl_cert(service_name)
-                logger.info('Securely connecting to: %s', self.gateway_addr)
-                credentials = grpc.ssl_channel_credentials(
-                    root_certificates=server_cert,
-                    private_key=client_key,
-                    certificate_chain=client_cert,
-                )
-                self.channel = grpc.secure_channel(self.gateway_addr, credentials)
+                tls_bundle = NvmeofGatewaysConfig.get_nvmeof_tls_bundle(service_name)
+                if tls_bundle:
+                    logger.info('Securely connecting to: %s', self.gateway_addr)
+                    encoded_tls_bundle = encode_tls_bundle(tls_bundle)
+                    credentials = grpc.ssl_channel_credentials(
+                        root_certificates=encoded_tls_bundle['server_cert'],
+                        private_key=encoded_tls_bundle['client_key'],
+                        certificate_chain=encoded_tls_bundle['client_cert'],
+                    )
+                    self.channel = grpc.secure_channel(self.gateway_addr, credentials)
+                else:
+                    self.channel = None
+                    logger.error("Cannot obtain nvmeof TLS bundle for the service %s (gw: %s)",
+                                 service_name, self.gateway_addr)
             else:
                 logger.info("Insecurely connecting to: %s", self.gateway_addr)
                 self.channel = grpc.insecure_channel(self.gateway_addr)
-            self.stub = pb2_grpc.GatewayStub(self.channel)
             self.service_name = service_name
+            if self.channel is not None:
+                self.stub = pb2_grpc.GatewayStub(self.channel)
+
 
     Model = Dict[str, Any]
     Collection = List[Model]

--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -54,13 +54,12 @@ else:
                     res = NvmeofGatewaysConfig.get_service_info(gw_group)
                 if res is None:
                     raise DashboardException("Gateway group does not exist")
-                service_name, self.gateway_addr = res
+                service_name, self.gateway_addr, self.daemon_name = res
             except TypeError as e:
                 raise DashboardException(
                     f'Unable to retrieve the gateway info: {e}'
                 )
 
-            self.daemon_name = ''
             # While creating listener need to direct request to the gateway
             # address where listener is supposed to be added.
             if server_address:
@@ -75,12 +74,12 @@ else:
                     None
                 )
                 if matched_gateway:
-                    self.daemon_name = matched_gateway.get('daemon_name')
                     self.gateway_addr = matched_gateway.get('service_url')
                     logger.debug("Gateway address set to: %s", self.gateway_addr)
             enable_auth = is_mtls_enabled(service_name)
             if enable_auth:
-                tls_bundle = NvmeofGatewaysConfig.get_nvmeof_tls_bundle(service_name)
+                tls_bundle = NvmeofGatewaysConfig.get_nvmeof_tls_bundle(service_name,
+                                                                        self.daemon_name)
                 if tls_bundle:
                     logger.info('Securely connecting to: %s', self.gateway_addr)
                     encoded_tls_bundle = encode_tls_bundle(tls_bundle)
@@ -100,7 +99,6 @@ else:
             self.service_name = service_name
             if self.channel is not None:
                 self.stub = pb2_grpc.GatewayStub(self.channel)
-
 
     Model = Dict[str, Any]
     Collection = List[Model]

--- a/src/pybind/mgr/dashboard/services/nvmeof_conf.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_conf.py
@@ -120,35 +120,11 @@ class NvmeofGatewaysConfig(object):
             )
 
     @classmethod
-    def get_client_cert(cls, service_name: str):
-        client_cert = cls.from_cert_store('nvmeof_client_cert', service_name)
-        return client_cert.encode() if client_cert else None
-
-    @classmethod
-    def get_client_key(cls, service_name: str):
-        client_key = cls.from_cert_store('nvmeof_client_key', service_name, key=True)
-        return client_key.encode() if client_key else None
-
-    @classmethod
-    def get_root_ca_cert(cls, service_name: str):
-        root_ca_cert = cls.from_cert_store('nvmeof_root_ca_cert', service_name)
-        return root_ca_cert.encode() if root_ca_cert else None
-
-    @classmethod
-    def get_ssl_cert(cls, service_name: str):
-        server_cert = cls.from_cert_store('nvmeof_ssl_cert', service_name)
-        return server_cert.encode() if server_cert else None
-
-    @classmethod
-    def from_cert_store(cls, entity: str, service_name: str, key=False):
+    def get_nvmeof_tls_bundle(cls, service_name: str):
         try:
             orch = OrchClient.instance()
             if orch.available():
-                if key:
-                    return orch.cert_store.get_key(entity, service_name,
-                                                   ignore_missing_exception=True)
-                return orch.cert_store.get_cert(entity, service_name,
-                                                ignore_missing_exception=True)
+                return orch.cert_store.get_nvmeof_tls_bundle(service_name)
             return None
         except OrchestratorError:
             # just return None if any orchestrator error is raised

--- a/src/pybind/mgr/dashboard/services/nvmeof_conf.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_conf.py
@@ -120,11 +120,11 @@ class NvmeofGatewaysConfig(object):
             )
 
     @classmethod
-    def get_nvmeof_tls_bundle(cls, service_name: str):
+    def get_nvmeof_tls_bundle(cls, service_name: str, daemon_name: str):
         try:
             orch = OrchClient.instance()
             if orch.available():
-                return orch.cert_store.get_nvmeof_tls_bundle(service_name)
+                return orch.cert_store.get_nvmeof_tls_bundle(service_name, daemon_name)
             return None
         except OrchestratorError:
             # just return None if any orchestrator error is raised
@@ -144,7 +144,7 @@ def _get_name_url_for_group(gateways, group):
                 config = _get_running_daemon_svc_config(svc_config, running_daemons)
 
                 if config:
-                    return service_name, config['service_url']
+                    return service_name, config['service_url'], config['daemon_name']
         return None
 
     except OrchestratorError:
@@ -182,7 +182,8 @@ def _get_default_service(gateways):
                 component="nvmeof"
             )
         service_name = gateway_keys[0]
-        return service_name, gateways[service_name][0]['service_url']
+        return service_name, gateways[service_name][0]['service_url'], \
+            gateways[service_name][0]['daemon_name']
     return None
 
 

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -208,6 +208,10 @@ class HardwareManager(ResourceManager):
 class CertStoreManager(ResourceManager):
 
     @wait_api_result
+    def get_nvmeof_tls_bundle(self, service_name: str) -> Dict[str, str]:
+        return self.api.get_nvmeof_tls_bundle(service_name)
+
+    @wait_api_result
     def get_cert(self, entity: str, service_name: Optional[str] = None,
                  hostname: Optional[str] = None,
                  ignore_missing_exception: bool = False) -> str:

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -208,8 +208,8 @@ class HardwareManager(ResourceManager):
 class CertStoreManager(ResourceManager):
 
     @wait_api_result
-    def get_nvmeof_tls_bundle(self, service_name: str) -> Dict[str, str]:
-        return self.api.get_nvmeof_tls_bundle(service_name)
+    def get_nvmeof_tls_bundle(self, service_name: str, daemon_name: str) -> Dict[str, str]:
+        return self.api.get_nvmeof_tls_bundle(service_name, daemon_name)
 
     @wait_api_result
     def get_cert(self, entity: str, service_name: Optional[str] = None,

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -539,7 +539,7 @@ class Orchestrator(object):
     def cert_store_key_ls(self, include_cephadm_generated_keys: bool = False) -> OrchResult[Dict[str, Any]]:
         raise NotImplementedError()
 
-    def get_nvmeof_tls_bundle(self, service_name: str) -> OrchResult[Dict[str, str]]:
+    def get_nvmeof_tls_bundle(self, service_name: str, daemon_name: str) -> OrchResult[Dict[str, str]]:
         raise NotImplementedError()
 
     def cert_store_get_cert(

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -539,6 +539,9 @@ class Orchestrator(object):
     def cert_store_key_ls(self, include_cephadm_generated_keys: bool = False) -> OrchResult[Dict[str, Any]]:
         raise NotImplementedError()
 
+    def get_nvmeof_tls_bundle(self, service_name: str) -> OrchResult[Dict[str, str]]:
+        raise NotImplementedError()
+
     def cert_store_get_cert(
         self,
         cert_name: str,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -2014,18 +2014,19 @@ class NvmeofServiceSpec(ServiceSpec):
         data = super().to_json()
         spec = data.setdefault('spec', {})
 
-        if self.ssl:
-            if self.server_cert and self.server_key:
-                spec['server_cert'] = self.server_cert
-                spec['server_key'] = self.server_key
-            else:
-                spec['ssl_cert'] = self.ssl_cert
-                spec['ssl_key'] = self.ssl_key
+        if self.certificate_source == CertificateSource.INLINE.value:
+            if self.ssl:
+                if self.server_cert and self.server_key:
+                    spec['server_cert'] = self.server_cert
+                    spec['server_key'] = self.server_key
+                else:
+                    spec['ssl_cert'] = self.ssl_cert
+                    spec['ssl_key'] = self.ssl_key
 
-        if self.enable_auth:
-            spec['client_cert'] = self.client_cert
-            spec['client_key'] = self.client_key
-            spec['root_ca_cert'] = self.root_ca_cert
+            if self.enable_auth:
+                spec['client_cert'] = self.client_cert
+                spec['client_key'] = self.client_key
+                spec['root_ca_cert'] = self.root_ca_cert
 
         return data
 


### PR DESCRIPTION
## Summary
Fix the Ceph Dashboard ↔ NVMeoF gateway integration when TLS/mTLS is enabled by introducing a dedicated cephadm API that returns a complete NVMeoF TLS bundle resolved by certmgr (based on `certificate_source`), and updating Dashboard to consume that API.

## Problem
Dashboard’s NVMeoF client previously tried to assemble TLS material by reading individual cert-store objects and/or spec fields directly. This breaks (or becomes brittle) when:
- `certificate_source` is `reference` or `cephadm-signed` (certificates are not embedded in the spec),
- `ssl` handling in the spec was unintentionally overridden by `enable_auth`,
- spec JSON serialization could include cert/key fields even when they are not expected for non-`inline` sources.

## What this PR changes
### mgr/cephadm
- Add a small certmgr helper to fetch cert/key material while respecting TLS object scope (SERVICE/HOST/GLOBAL).
- Add `NvmeofService.get_nvmeof_tls_bundle(service_name)` that returns:
  - `server_cert`, `server_key`, `client_cert`, `client_key`, `ca_cert`
  - Resolution strategy:
    1. **INLINE**: read from spec (client fields only when `enable_auth` is true)
    2. **REFERENCE**: read from certmgr store (respecting object scope)
    3. **CEPHADM_SIGNED**: resolve a running daemon host and pull cephadm-signed creds from certmgr  
- Expose a cephadm/module orchestrator API entrypoint: `get_nvmeof_tls_bundle(service_name)` returning the bundle as a dict.

### Dashboard
- Switch NVMeoF gRPC client to request the TLS bundle via orchestrator (`cert_store.get_nvmeof_tls_bundle`) and build gRPC SSL credentials from the returned bundle.
- Remove/simplify the per-object cert-store lookups in `nvmeof_conf` in favor of the bundle API.

### Spec fixes
- Ensure `ssl` is not inadvertently forced to `enable_auth` (preserve explicit `ssl=True` even when auth is disabled).
- Only populate cert/key fields in the spec JSON when `certificate_source=inline` (non-inline sources should not serialize inline material).

## Testing
- Added cephadm unit-tests for TLS bundle resolution covering:
  - `ssl` disabled
  - INLINE (server-only + mTLS)
  - REFERENCE (server-only + mTLS + missing objects)
  - CEPHADM_SIGNED (server-only + mTLS + missing hostname)
  - service not found / unknown certificate source


## Tracker
Fixes: https://tracker.ceph.com/issues/74377


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
