### PR TITLE
rbd-mirror: implement semi-dynamic groups with support for adding images

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -968,12 +968,10 @@ test_mirrored_group_remove_all_images()
   check_daemon_running "${secondary_cluster}"
 }
 
-# create group then enable mirroring before adding images to the group.  Disable mirroring before removing group
-declare -a test_create_group_mirror_then_add_images_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${group0}" "${image_prefix}" 'false' 5)
-# create group then enable mirroring before adding images to the group.  Remove group with mirroring enabled
-declare -a test_create_group_mirror_then_add_images_2=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${group0}" "${image_prefix}" 'true' 5)
+# create group then enable mirroring before adding images to the group.
+declare -a test_create_group_mirror_then_add_images_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${group0}" "${image_prefix}" 5)
 
-test_create_group_mirror_then_add_images_scenarios=2
+test_create_group_mirror_then_add_images_scenarios=1
 
 test_create_group_mirror_then_add_images()
 {
@@ -982,8 +980,10 @@ test_create_group_mirror_then_add_images()
   local pool=$1 ; shift
   local group=$1 ; shift
   local image_prefix=$1 ; shift
-  local disable_before_remove=$1 ; shift
   local image_count=$(($1*"${image_multiplier}")) ; shift
+
+  check_daemon_running "${primary_cluster}" true
+  check_daemon_running "${secondary_cluster}" true
 
   group_create "${primary_cluster}" "${pool}/${group}"
   mirror_group_enable "${primary_cluster}" "${pool}/${group}"
@@ -991,45 +991,24 @@ test_create_group_mirror_then_add_images()
   wait_for_group_present "${secondary_cluster}" "${pool}" "${group}" 0
   wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group}" 0
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' 0
-  if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
-    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group}" 'down+unknown' 0
-  fi
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group}" 'up+stopped' 0
 
   images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
   group_images_add "${primary_cluster}" "${pool}/${group}" "${pool}/${image_prefix}" "${image_count}"
 
-  if [ -n "${RBD_MIRROR_NEW_IMPLICIT_BEHAVIOUR}" ]; then
-    # check secondary cluster sees 0 images
-    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' 0
-    mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}"/"${group}"
-  fi
-
+  get_newest_complete_mirror_group_snapshot_id "${primary_cluster}" "${pool}/${group}" group_snap_id
+  wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}" 1
+  wait_for_group_snap_sync_complete "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}"
   wait_for_group_present "${secondary_cluster}" "${pool}" "${group}" "${image_count}"
-  check_daemon_running "${secondary_cluster}"
-
   wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group}" "${image_count}"
-  check_daemon_running "${secondary_cluster}"
-
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group}" 'up+stopped' "${image_count}"
 
-  check_daemon_running "${secondary_cluster}"
-  if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
-    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group}" 'down+unknown' 0
-  fi
-  check_daemon_running "${secondary_cluster}"
-
-  if [ 'false' != "${disable_before_remove}" ]; then
-    mirror_group_disable "${primary_cluster}" "${pool}/${group}"
-  fi
-
+  # tidy up
+  mirror_group_disable "${primary_cluster}" "${pool}/${group}"
   group_remove "${primary_cluster}" "${pool}/${group}"
-  check_daemon_running "${secondary_cluster}"
-
   wait_for_group_not_present "${primary_cluster}" "${pool}" "${group}"
-  check_daemon_running "${secondary_cluster}"
   wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group}"
-  check_daemon_running "${secondary_cluster}"
-
   images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
 }
 
@@ -3143,7 +3122,8 @@ test_interrupted_sync()
   wait_for_group_snap_sync_complete "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
 
   local new_image_snap_id
-  get_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${image_prefix}1" "${group_snap_id}" new_image_snap_id
+  get_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${image_prefix}1" "${group_snap_id}" new_image_snap_id ||
+    fail "failed to find image snapshot associated with group snap ${group_snap_id}"
   if [ "${scenario}" = 'snap_creating' ]; then
     test "${image_snap_id}" != "${new_image_snap_id}" ||  { fail "failed to recreate image snapshot with a new snap_id after restart"; return 1; }
   elif [ "${scenario}" = 'snap_created' ]; then
@@ -3805,6 +3785,117 @@ test_demote_snap_sync_after_restart()
   check_daemon_running "${secondary_cluster}"
 }
 
+declare -a test_rollback_after_add_image_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 2)
+
+test_rollback_after_add_image_scenarios=1
+
+test_rollback_after_add_image()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+
+  local snap0='snap_0'
+  check_daemon_running "${primary_cluster}" true
+  check_daemon_running "${secondary_cluster}" true
+
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  image_create "${primary_cluster}" "${pool}/${image_prefix}0" 1G
+  image_create "${primary_cluster}" "${pool}/${image_prefix}1" 4G
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped'
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+
+  write_image "${primary_cluster}" "${pool}" "${image_prefix}0" 10 4096
+  write_image "${primary_cluster}" "${pool}" "${image_prefix}1" 10 4096
+
+  create_snapshot "${primary_cluster}" "${pool}" "${image_prefix}0" "${snap0}"
+  create_snapshot "${primary_cluster}" "${pool}" "${image_prefix}1" "${snap0}"
+  mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}"/"${group0}"
+  write_image "${primary_cluster}" "${pool}" "${image_prefix}1" 1024 4194304
+
+  # add image to already enabled group for mirroring
+  new_image=test-image-new
+  image_create "${primary_cluster}" "${pool}/${new_image}" 1G
+  group_image_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${new_image}"
+  wait_for_image_present "${secondary_cluster}" "${pool}" "${new_image}" 'present'
+  get_image_mirroring_global_id "${primary_cluster}" "${pool}/${new_image}" global_id
+  test_image_with_global_id_present "${secondary_cluster}" "${pool}" "${new_image}" "${global_id}"
+  local group_snap_id
+  get_newest_created_group_snapshot_id "${primary_cluster}" "${pool}/${group0}" group_snap_id
+  # make sure snapshot is present on secondary cluster
+  wait_for_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+
+  # stop the daemon to prevent further syncing of snapshots
+  stop_mirrors "${secondary_cluster}" '-9'
+  # make sure the snapshot remains in an incomplete state after the daemon is stopped
+  test_group_snap_sync_incomplete "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+
+  # force promote the group on the secondary - should rollback to the last complete snapshot with only two images in it.
+  local old_primary_cluster
+  mirror_group_promote "${secondary_cluster}" "${pool}/${group0}" '--force'
+
+  old_primary_cluster="${primary_cluster}"
+  primary_cluster="${secondary_cluster}"
+  secondary_cluster="${old_primary_cluster}"
+
+  # verify incomplete group snapshot was removed
+  wait_for_group_snap_not_present "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+
+  # verify incomplete per-image snapshots are removed
+  local image_snap_id0
+  if get_image_snapshot_with_group_snap_info "${primary_cluster}" "${pool}" "${image_prefix}0" "${group_snap_id}" image_snap_id0; then
+    fail "image snapshot ${image_snap_id0} associated with group snap ${group_snap_id} still exists after force promote"
+  fi
+
+  local image_snap_id1
+  if get_image_snapshot_with_group_snap_info "${primary_cluster}" "${pool}" "${image_prefix}1" "${group_snap_id}" image_snap_id1; then
+    fail "image snapshot ${image_snap_id1} associated with group snap ${group_snap_id} still exists after force promote"
+  fi
+
+  # check that we rolled back to snap0 state
+  compare_image_with_snapshot "${primary_cluster}" "${pool}/${image_prefix}0" "${primary_cluster}" "${pool}/${image_prefix}0@${snap0}"
+  compare_image_with_snapshot "${primary_cluster}" "${pool}/${image_prefix}1" "${primary_cluster}" "${pool}/${image_prefix}1@${snap0}"
+  # check that new image is not present
+  test_image_with_global_id_not_present "${primary_cluster}" "${pool}" "${new_image}" "${global_id}"
+  # ensure the new image no longer exists in the pool
+  test_image_not_present "${primary_cluster}" "${pool}" "${new_image}"
+
+  # restart daemon and wait for the right status to reflect
+  start_mirrors "${primary_cluster}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped'
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+stopped'
+
+  # demote and wait for split-brain to follow
+  mirror_group_demote "${secondary_cluster}" "${pool}/${group0}"
+  # Note the group contain 3 images
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+error' $(("${image_count}"+1)) 'split-brain'
+
+  # resync and verify status of mirror group snapshot
+  local group_id_before_resync
+  get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before_resync
+  mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  wait_for_group_id_changed  "${secondary_cluster}" "${pool}/${group0}" "${group_id_before_resync}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+
+  # TEST group membership has 2 images only and the respective groups reflect right mirror status
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' ${image_count}
+
+  # cleanup
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+}
+
 check_for_no_keys()
 {
   local primary_cluster=$1
@@ -3956,7 +4047,8 @@ run_all_tests()
   # This next test also requires dynamic groups - TODO enable
   # run_test_all_scenarios test_mirrored_group_add_and_remove_images
   # This next also requires dynamic groups - TODO enable
-  # run_test_all_scenarios test_create_group_mirror_then_add_images
+  run_test_all_scenarios test_create_group_mirror_then_add_images
+  run_test_all_scenarios test_rollback_after_add_image
   run_test_all_scenarios test_create_group_with_images_then_mirror
   # TODO: add the capabilty to have image from different pool in the mirror group
   run_test_all_scenarios test_images_different_pools

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -1890,7 +1890,7 @@ get_image_snapshot_with_group_snap_info() {
         _id="${img_snap_id}"
         return 0
     fi
-    fail "failed to find image snapshot associated with group snap ${group_snap_id}"; return 1;
+    return 1
 }
 
 stop_mirror_while_group_snapshot_incomplete() {
@@ -2722,7 +2722,7 @@ test_group_snap_present()
     local group_snap_id=$3
     local expected_snap_count=$4
 
-    run_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format" 
+    try_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format" || :
 
     test "${expected_snap_count}" = "$(xmlstarlet sel -t -v "count(//group_snaps/group_snap[id='${group_snap_id}'])" < "$CMD_STDOUT")" || { fail; return 1; }
 }

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -160,6 +160,7 @@ set(librbd_internal_srcs
   mirror/GroupEnableRequest.cc
   mirror/GroupGetInfoRequest.cc
   mirror/GroupPromoteRequest.cc
+  mirror/GroupRemoveImageRequest.cc
   mirror/ImageRemoveRequest.cc
   mirror/ImageStateUpdateRequest.cc
   mirror/PromoteRequest.cc

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -154,11 +154,12 @@ set(librbd_internal_srcs
   mirror/GetInfoRequest.cc
   mirror/GetStatusRequest.cc
   mirror/GetUuidRequest.cc
+  mirror/GroupAddImageRequest.cc
   mirror/GroupDemoteRequest.cc
   mirror/GroupDisableRequest.cc
   mirror/GroupEnableRequest.cc
-  mirror/GroupPromoteRequest.cc
   mirror/GroupGetInfoRequest.cc
+  mirror/GroupPromoteRequest.cc
   mirror/ImageRemoveRequest.cc
   mirror/ImageStateUpdateRequest.cc
   mirror/PromoteRequest.cc

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -601,10 +601,6 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
                << cpp_strerror(r) << dendl;
     return r;
   } else if (r == 0) {
-    if (mirror_group.state != cls::rbd::MIRROR_GROUP_STATE_DISABLED) {
-      lderr(cct) << "cannot add image to mirror enabled group" << dendl;
-      return -EINVAL;
-    }
     if (promotion_state != mirror::PROMOTION_STATE_PRIMARY) {
       lderr(cct) << "group is not primary, cannot add image" << dendl;
       return -EINVAL;
@@ -668,6 +664,13 @@ int Group<I>::image_add(librados::IoCtx& group_ioctx, const char *group_name,
     return r;
   }
   ImageWatcher<>::notify_header_update(image_ioctx, image_header_oid);
+
+  r = Mirror<I>::group_image_add(group_ioctx, group_id, image_ioctx, image_id);
+  if (r < 0) {
+    lderr(cct) << "error adding image to mirror group: "
+               << cpp_strerror(r) << dendl;
+    return r;
+  }
 
   r = cls_client::group_image_set(&group_ioctx, group_header_oid,
 				  attached_st);

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -25,6 +25,7 @@
 #include "librbd/mirror/GetInfoRequest.h"
 #include "librbd/mirror/GetStatusRequest.h"
 #include "librbd/mirror/GetUuidRequest.h"
+#include "librbd/mirror/GroupAddImageRequest.h"
 #include "librbd/mirror/GroupEnableRequest.h"
 #include "librbd/mirror/GroupDisableRequest.h"
 #include "librbd/mirror/GroupPromoteRequest.h"
@@ -2442,6 +2443,65 @@ int Mirror<I>::group_disable(IoCtx& group_ioctx, const char *group_name,
   r = cond.wait();
   if (r < 0) {
     lderr(cct) << "failed to mirror disable group: "
+               << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Mirror<I>::group_image_add(IoCtx &group_ioctx,
+                               const std::string &group_id,
+                               IoCtx &image_ioctx,
+                               const std::string &image_id) {
+  CephContext *cct = reinterpret_cast<CephContext *>(group_ioctx.cct());
+  ldout(cct, 20) << "group io_ctx=" << &group_ioctx
+                 << ", group_id=" << group_id
+                 << ", image io_ctx=" << &image_ioctx
+                 << ", image_id=" << image_id << dendl;
+
+  cls::rbd::MirrorGroup mirror_group;
+  int r = cls_client::mirror_group_get(&group_ioctx, group_id, &mirror_group);
+  if (r == -ENOENT) {
+    ldout(cct, 10) << "group is not enabled for mirroring" << dendl;
+    return 0;
+  } else if (r < 0) {
+    lderr(cct) << "failed to retrieve mirror group metadata: "
+               << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  if (mirror_group.mirror_image_mode != cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT) {
+    lderr(cct) << "invalid group mirroring mode" << dendl;
+    return -EINVAL;
+  }
+
+  if (mirror_group.state != cls::rbd::MIRROR_GROUP_STATE_ENABLED) {
+    lderr(cct) << "mirroring on group is not enabled: "
+               << mirror_group.state << dendl;
+    return -EINVAL;
+  }
+
+  uint64_t internal_flags;
+  r = librbd::util::snap_create_flags_api_to_internal(
+      cct, librbd::util::get_default_snap_create_flags(group_ioctx),
+      &internal_flags);
+  if (r < 0) {
+    lderr(cct) << "error getting flags: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  C_SaferCond cond;
+  auto req = mirror::GroupAddImageRequest<>::create(
+      group_ioctx, group_id, image_id, internal_flags,
+      static_cast<cls::rbd::MirrorImageMode>(RBD_MIRROR_IMAGE_MODE_SNAPSHOT),
+      mirror_group, &cond);
+
+  req->send();
+  r = cond.wait();
+  if (r < 0) {
+    lderr(cct) << "failed to add image to group: "
                << cpp_strerror(r) << dendl;
     return r;
   }

--- a/src/librbd/api/Mirror.h
+++ b/src/librbd/api/Mirror.h
@@ -130,6 +130,8 @@ struct Mirror {
                           mirror_image_mode_t group_image_mode);
   static int group_disable(IoCtx &group_ioctx, const char *group_name,
                            bool force);
+  static int group_image_add(IoCtx &group_ioctx, const std::string &group_id,
+                             IoCtx &image_ioctx, const std::string &image_id);
   static int group_promote(IoCtx &group_ioctx, const char *group_name,
                            bool force);
   static int group_demote(IoCtx &group_ioctx, const char *group_name);

--- a/src/librbd/mirror/GroupAddImageRequest.cc
+++ b/src/librbd/mirror/GroupAddImageRequest.cc
@@ -1,0 +1,457 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "librbd/mirror/GroupAddImageRequest.h"
+#include "common/Cond.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/MirroringWatcher.h"
+#include "librbd/Utils.h"
+#include "librbd/mirror/ImageStateUpdateRequest.h"
+#include "librbd/mirror/ImageRemoveRequest.h"
+#include "librbd/mirror/snapshot/GroupImageCreatePrimaryRequest.h"
+#include "librbd/mirror/snapshot/RemoveGroupSnapshotRequest.h"
+#include "librbd/mirror/snapshot/GroupPrepareImagesRequest.h"
+
+#include <shared_mutex>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::mirror::GroupAddImageRequest: " \
+                           << this << " " << __func__ << ": "
+
+namespace librbd {
+namespace mirror {
+
+using util::create_context_callback;
+using util::create_rados_callback;
+
+template <typename I>
+GroupAddImageRequest<I>::GroupAddImageRequest(librados::IoCtx &io_ctx,
+                                     const std::string &group_id,
+                                     const std::string &image_id,
+                                     uint64_t group_snap_create_flags,
+                                     cls::rbd::MirrorImageMode mode,
+                                     const cls::rbd::MirrorGroup &mirror_group,
+                                     Context *on_finish)
+  : m_group_ioctx(io_ctx), m_group_id(group_id), m_image_id(image_id),
+    m_group_snap_create_flags(group_snap_create_flags), m_mode(mode),
+    m_mirror_group(mirror_group), m_on_finish(on_finish),
+    m_cct(reinterpret_cast<CephContext*>(io_ctx.cct())) {
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::send() {
+  ceph_assert(m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_ENABLED);
+
+  prepare_group_images();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::prepare_group_images() {
+  ldout(m_cct, 10) << dendl;
+
+  ceph_assert(m_image_ctxs.empty());
+
+  auto ctx = create_context_callback<GroupAddImageRequest<I>,
+    &GroupAddImageRequest<I>::handle_prepare_group_images>(this);
+
+  auto req = snapshot::GroupPrepareImagesRequest<I>::create(
+    m_group_ioctx, m_group_id, m_image_ctxs, m_images,
+    &m_mirror_images, &m_mirror_peer_uuids, m_image_id,
+    librbd::mirror::snapshot::GroupPrepareImagesRequest<I>::OP_ADD_IMAGE,
+    false, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_prepare_group_images(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to prepare group images: "
+                 << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    close_images();
+    return;
+  }
+
+  // get the newly added image context and index
+  for (size_t i = 0; i < m_image_ctxs.size(); ++i) {
+    auto ictx = m_image_ctxs[i];
+    if (ictx != nullptr && ictx->id == m_image_id) {
+      m_add_image_ctx = ictx;
+      m_add_image_index = i;
+      break;
+    }
+  }
+  ceph_assert(m_add_image_ctx != nullptr);
+
+  validate_image();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::validate_image() {
+  ldout(m_cct, 10) << dendl;
+
+  std::shared_lock image_locker{m_add_image_ctx->image_lock};
+
+  // cloned images are not supported yet
+  if (m_add_image_ctx->parent) {
+    lderr(m_cct) << "cannot enable mirroring: cloned image not supported"
+                 << dendl;
+    m_ret_val = -EINVAL;
+    close_images();
+    return;
+  }
+
+  // FIXME: For now images must belong to the same pool as the group
+  auto group_pool_id = m_group_ioctx.get_id();
+  if (m_add_image_ctx->md_ctx.get_id() != group_pool_id) {
+    lderr(m_cct) << "cannot enable mirroring: image in a different pool"
+                 << dendl;
+    m_ret_val = -EINVAL;
+    close_images();
+    return;
+  }
+
+  create_primary_group_snapshot();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::create_primary_group_snapshot() {
+  // generate_image_id is also used for group and group snapshot ids.
+  m_group_snap.id = librbd::util::generate_image_id(m_group_ioctx);
+  m_group_snap.name = ".mirror.primary." + m_mirror_group.global_group_id
+                      + "." + m_group_snap.id;
+
+  ldout(m_cct, 10) << "creating group snapshot " << m_group_snap.name << dendl;
+
+  librados::Rados rados(m_group_ioctx);
+  int8_t require_osd_release;
+  int r = rados.get_min_compatible_osd(&require_osd_release);
+  if (r < 0) {
+    lderr(m_cct) << "failed to retrieve min OSD release: "
+                 << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    close_images();
+    return;
+  }
+
+  auto complete = cls::rbd::get_mirror_group_snapshot_complete_initial(
+      require_osd_release);
+  m_group_snap.snapshot_namespace = cls::rbd::GroupSnapshotNamespaceMirror{
+    cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY, m_mirror_peer_uuids, {}, {},
+    complete};
+
+  for (auto image_ctx : m_image_ctxs) {
+    m_group_snap.snaps.emplace_back(image_ctx->md_ctx.get_id(), image_ctx->id,
+                                    CEPH_NOSNAP);
+  }
+
+  librados::ObjectWriteOperation op;
+  cls_client::group_snap_set(&op, m_group_snap);
+
+  auto aio_comp = create_rados_callback<
+    GroupAddImageRequest<I>,
+    &GroupAddImageRequest<I>::handle_create_primary_group_snapshot>(this);
+  r = m_group_ioctx.aio_operate(librbd::util::group_header_name(m_group_id),
+                                aio_comp, &op);
+  ceph_assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_create_primary_group_snapshot(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to create group snapshot: "
+                 << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    close_images();
+    return;
+  }
+
+  create_primary_image_snapshots();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::create_primary_image_snapshots() {
+  ldout(m_cct, 10) << dendl;
+
+  size_t num_images = m_image_ctxs.size();
+  m_global_image_ids.resize(num_images);
+  m_mirror_images.resize(num_images);
+  m_snap_ids.resize(num_images);
+
+  ceph_assert(m_image_ctxs.size() == m_global_image_ids.size());
+
+  uuid_d uuid_gen;
+  for (size_t i = 0; i < num_images; i++) {
+    uuid_gen.generate_random();
+    m_global_image_ids[i] = uuid_gen.to_string();
+    m_mirror_images[i].global_image_id = m_global_image_ids[i];
+  }
+
+  auto ctx = librbd::util::create_context_callback<GroupAddImageRequest<I>,
+    &GroupAddImageRequest<I>::handle_create_primary_image_snapshots>(this);
+
+  auto req = snapshot::GroupImageCreatePrimaryRequest<I>::create(
+    m_cct, m_image_ctxs, m_global_image_ids, m_group_snap_create_flags,
+    snapshot::CREATE_PRIMARY_FLAG_IGNORE_EMPTY_PEERS, m_group_snap.id,
+    &m_snap_ids, true, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_create_primary_image_snapshots(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  for (size_t i = 0; i < m_image_ctxs.size(); i++) {
+    m_group_snap.snaps[i].snap_id = m_snap_ids[i];
+  }
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to create primary mirror image snapshots: "
+                 << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    remove_primary_group_snapshot();
+    return;
+  }
+
+  update_primary_group_snapshot();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::update_primary_group_snapshot() {
+  ldout(m_cct, 10) << dendl;
+
+  m_group_snap.state = cls::rbd::GROUP_SNAPSHOT_STATE_CREATED;
+  cls::rbd::set_mirror_group_snapshot_complete(m_group_snap);
+
+  librados::ObjectWriteOperation op;
+  cls_client::group_snap_set(&op, m_group_snap);
+
+  auto aio_comp = create_rados_callback<GroupAddImageRequest<I>,
+    &GroupAddImageRequest<I>::handle_update_primary_group_snapshot>(this);
+  int r = m_group_ioctx.aio_operate(librbd::util::group_header_name(m_group_id),
+                                    aio_comp, &op);
+  ceph_assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_update_primary_group_snapshot(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to update group snapshot: "
+                 << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    remove_primary_group_snapshot();
+    return;
+  }
+
+  enable_mirror_image();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::enable_mirror_image() {
+  ldout(m_cct, 10) << dendl;
+
+  ceph_assert(m_add_image_ctx != nullptr);
+
+  cls::rbd::MirrorImage mirror_image;
+  mirror_image.type = cls::rbd::MIRROR_IMAGE_TYPE_GROUP;
+  mirror_image.mode = m_mode;
+  mirror_image.global_image_id = m_global_image_ids[m_add_image_index];
+
+  auto ctx = create_context_callback<GroupAddImageRequest<I>,
+      &GroupAddImageRequest<I>::handle_enable_mirror_image>(this);
+
+  auto req = ImageStateUpdateRequest<I>::create(m_add_image_ctx->md_ctx,
+      m_add_image_ctx->id, cls::rbd::MIRROR_IMAGE_STATE_ENABLED,
+      mirror_image, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_enable_mirror_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to enable mirror image: "
+                 << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    disable_mirror_image();
+    return;
+  }
+
+  notify_mirroring_watcher();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::notify_mirroring_watcher() {
+  ldout(m_cct, 10) << dendl;
+
+  ceph_assert(m_add_image_ctx != nullptr);
+
+  auto ctx = util::create_context_callback<GroupAddImageRequest<I>,
+      &GroupAddImageRequest<I>::handle_notify_mirroring_watcher>(this);
+
+  MirroringWatcher<I>::notify_group_updated(m_group_ioctx,
+      cls::rbd::MIRROR_GROUP_STATE_ENABLED, m_group_id,
+      m_mirror_group.global_group_id, m_image_ctxs.size(), ctx);
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_notify_mirroring_watcher(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to notify mirror group update for new image: "
+                 << cpp_strerror(r) << dendl;
+  }
+
+  close_images();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::close_images() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupAddImageRequest<I>,
+      &GroupAddImageRequest<I>::handle_close_images>(this);
+
+  auto gather_ctx = new C_Gather(m_cct, ctx);
+
+  for (auto ictx: m_image_ctxs) {
+    if (ictx != nullptr) {
+      ictx->state->close(gather_ctx->new_sub());
+    }
+  }
+
+  gather_ctx->activate();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_close_images(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && m_ret_val == 0) {
+    lderr(m_cct) << "failed to close images: " << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+  }
+
+  finish(m_ret_val);
+}
+
+
+template <typename I>
+void GroupAddImageRequest<I>::disable_mirror_image() {
+  ldout(m_cct, 10) << dendl;
+
+  ceph_assert(m_add_image_ctx != nullptr && m_add_image_index >= 0);
+
+  cls::rbd::MirrorImage &mirror_image = m_mirror_images[m_add_image_index];
+  if (mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_DISABLING ||
+      mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_DISABLED) {
+    remove_primary_group_snapshot();
+    return;
+  }
+
+  auto ctx = create_context_callback<GroupAddImageRequest<I>,
+      &GroupAddImageRequest<I>::handle_disable_mirror_image>(this);
+
+  auto req = ImageStateUpdateRequest<I>::create(m_add_image_ctx->md_ctx,
+      m_add_image_ctx->id, cls::rbd::MIRROR_IMAGE_STATE_DISABLING,
+      mirror_image, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_disable_mirror_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to disable mirror image: "
+                 << cpp_strerror(r) << dendl;
+    close_images();
+    return;
+  }
+
+  remove_primary_group_snapshot();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::remove_primary_group_snapshot() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupAddImageRequest<I>,
+    &GroupAddImageRequest<I>::handle_remove_primary_group_snapshot>(this);
+
+  auto req = snapshot::RemoveGroupSnapshotRequest<I>::create(m_group_ioctx,
+     m_group_id, &m_group_snap, &m_image_ctxs, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_remove_primary_group_snapshot(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to remove mirror group snapshot: "
+                 << cpp_strerror(r) << dendl;
+    close_images();
+    return;
+  }
+
+  remove_mirror_image();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::remove_mirror_image() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupAddImageRequest<I>,
+    &GroupAddImageRequest<I>::handle_remove_mirror_image>(this);
+
+  auto req = ImageRemoveRequest<I>::create(m_add_image_ctx->md_ctx,
+      m_global_image_ids[m_add_image_index], m_add_image_ctx->id, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::handle_remove_mirror_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to remove mirror images: "
+                 << cpp_strerror(r) << dendl;
+  }
+
+  close_images();
+}
+
+template <typename I>
+void GroupAddImageRequest<I>::finish(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace mirror
+} // namespace librbd
+
+template class librbd::mirror::GroupAddImageRequest<librbd::ImageCtx>;

--- a/src/librbd/mirror/GroupAddImageRequest.h
+++ b/src/librbd/mirror/GroupAddImageRequest.h
@@ -1,0 +1,148 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_LIBRBD_MIRROR_GROUP_ADD_IMAGE_REQUEST_H
+#define CEPH_LIBRBD_MIRROR_GROUP_ADD_IMAGE_REQUEST_H
+
+#include "librbd/ImageCtx.h"
+#include "librbd/mirror/ImageStateUpdateRequest.h"
+#include "librbd/mirror/ImageRemoveRequest.h"
+#include "librbd/mirror/snapshot/GroupPrepareImagesRequest.h"
+#include "librbd/mirror/snapshot/GroupImageCreatePrimaryRequest.h"
+#include "librbd/mirror/snapshot/RemoveGroupSnapshotRequest.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "include/rbd/librbd.hpp"
+#include <string>
+#include <vector>
+
+namespace librbd {
+namespace mirror {
+
+template <typename I = librbd::ImageCtx>
+class GroupAddImageRequest {
+public:
+  static GroupAddImageRequest *create(librados::IoCtx &group_io_ctx,
+                                      const std::string &group_id,
+                                      const std::string &image_id,
+                                      uint64_t group_snap_create_flags,
+                                      cls::rbd::MirrorImageMode mode,
+                                      const cls::rbd::MirrorGroup &mirror_group,
+                                      Context *on_finish) {
+    return new GroupAddImageRequest(group_io_ctx, group_id, image_id,
+          group_snap_create_flags, mode, mirror_group, on_finish);
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v                         (on error)
+   * PREPARE_GROUP_IMAGES  * * * * * * * * *
+   *    |                                  *
+   *    v  (skip if not needed)            *
+   * VALIDATE_IMAGE  * * * * * * * * * * * *
+   *    |                                  *
+   *    v  (incomplete)                    *
+   * CREATE_PRIMARY_GROUP_SNAP * * * * * * *
+   *    |                                  *
+   *    v (skip if not needed)             *
+   * CREATE_PRIMARY_IMAGE_SNAPS            *
+   *    |                                  *
+   *    v (complete)                       *
+   * UPDATE_PRIMARY_GROUP_SNAP * * * * * * *
+   *    |                                  *
+   *    v                                  *
+   * ENABLE_MIRROR_IMAGE (only new image)  *
+   *    |                                  *
+   *    v                                  *
+   * NOTIFY_MIRRORING_WATCHER              *
+   *    |                                  *
+   *    v                                  *
+   * CLOSE_IMAGES  * * * * * * * * * * * * *
+   *    |                                  *
+   *    v                                  *
+   * <finish>                              *
+   *                                       * (on failure)
+   *                                       *
+   * CLEANUP / ERROR PATHS INLINE:         *
+   * ----------------------------          *
+   *                 (skip if not needed)  *
+   * DISABLE_MIRROR_IMAGE  * * * * * * * * *
+   *    |                                  *
+   *    v                                  *
+   * REMOVE_PRIMARY_GROUP_SNAPSHOT * * * * *
+   *    |
+   *    v
+   * REMOVE_MIRROR_IMAGE
+   *    |
+   *    v
+   * CLOSE_IMAGES
+   *
+   * @endverbatim
+   */
+
+  GroupAddImageRequest(librados::IoCtx &group_io_ctx,
+      const std::string &group_id, const std::string &image_id,
+      uint64_t group_snap_create_flags, cls::rbd::MirrorImageMode mode,
+      const cls::rbd::MirrorGroup &mirror_group, Context *on_finish);
+
+  librados::IoCtx &m_group_ioctx;
+  std::string m_group_id;
+  std::string m_image_id;
+  uint64_t m_group_snap_create_flags;
+  cls::rbd::MirrorImageMode m_mode;
+  cls::rbd::MirrorGroup m_mirror_group;
+  Context *m_on_finish;
+
+  CephContext *m_cct;
+  std::vector<I*> m_image_ctxs;
+  std::vector<cls::rbd::GroupImageStatus> m_images;
+  std::vector<cls::rbd::MirrorImage> m_mirror_images;
+   std::set<std::string> m_mirror_peer_uuids;
+  std::vector<uint64_t> m_snap_ids;
+  std::vector<std::string> m_global_image_ids;
+
+  // Newly added image
+  I *m_add_image_ctx = nullptr;
+  int m_add_image_index = -1;
+
+  cls::rbd::GroupSnapshot m_group_snap;
+
+  int m_ret_val = 0;
+
+  void prepare_group_images();
+  void handle_prepare_group_images(int r);
+  void validate_image();
+  void create_primary_group_snapshot();
+  void handle_create_primary_group_snapshot(int r);
+  void create_primary_image_snapshots();
+  void handle_create_primary_image_snapshots(int r);
+  void update_primary_group_snapshot();
+  void handle_update_primary_group_snapshot(int r);
+  void enable_mirror_image();
+  void handle_enable_mirror_image(int r);
+  void notify_mirroring_watcher();
+  void handle_notify_mirroring_watcher(int r);
+
+  // Cleanup
+  void close_images();
+  void handle_close_images(int r);
+  void disable_mirror_image();
+  void handle_disable_mirror_image(int r);
+  void remove_primary_group_snapshot();
+  void handle_remove_primary_group_snapshot(int r);
+  void remove_mirror_image();
+  void handle_remove_mirror_image(int r);
+
+  void finish(int r);
+
+};
+
+} // namespace mirror
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_MIRROR_GROUP_ADD_IMAGE_REQUEST_H

--- a/src/librbd/mirror/GroupDemoteRequest.cc
+++ b/src/librbd/mirror/GroupDemoteRequest.cc
@@ -81,7 +81,7 @@ void GroupDemoteRequest<I>::prepare_group_images() {
 
   auto req = snapshot::GroupPrepareImagesRequest<I>::create(m_group_ioctx,
     m_group_id, m_image_ctxs, m_images, &m_mirror_images, &m_mirror_peer_uuids,
-    snapshot::GroupPrepareImagesRequest<I>::OP_DEMOTE, false, ctx);
+    "", snapshot::GroupPrepareImagesRequest<I>::OP_DEMOTE, false, ctx);
   req->send();
 }
 

--- a/src/librbd/mirror/GroupDisableRequest.cc
+++ b/src/librbd/mirror/GroupDisableRequest.cc
@@ -116,7 +116,7 @@ void GroupDisableRequest<I>::prepare_group_images() {
     &GroupDisableRequest<I>::handle_prepare_group_images>(this);
 
   auto req = snapshot::GroupPrepareImagesRequest<I>::create(m_group_ioctx,
-    m_group_id, m_image_ctxs, m_images, &m_mirror_images, nullptr,
+    m_group_id, m_image_ctxs, m_images, &m_mirror_images, nullptr, "", // no specific image
     snapshot::GroupPrepareImagesRequest<I>::OP_DISABLE, m_force, ctx);
   req->send();
 }

--- a/src/librbd/mirror/GroupEnableRequest.cc
+++ b/src/librbd/mirror/GroupEnableRequest.cc
@@ -220,11 +220,13 @@ template <typename I>
 void GroupEnableRequest<I>::create_primary_group_snapshot() {
   ldout(m_cct, 10) << dendl;
 
+  // generate_image_id is also used for group and group snapshot ids.
   m_group_snap.id = librbd::util::generate_image_id(m_group_ioctx);
 
-  auto snap_name = ".mirror.primary." + m_mirror_group.global_group_id
+  m_group_snap.name = ".mirror.primary." + m_mirror_group.global_group_id
                 + "." + m_group_snap.id;
-  m_group_snap.name = snap_name;
+
+  ldout(m_cct, 10) << "creating group snapshot " << m_group_snap.name << dendl;
 
   librados::Rados rados(m_group_ioctx);
   int8_t require_osd_release;
@@ -233,7 +235,7 @@ void GroupEnableRequest<I>::create_primary_group_snapshot() {
     lderr(m_cct) << "failed to retrieve min OSD release: " << cpp_strerror(r)
                  << dendl;
     m_ret_val = r;
-    disable_mirror_group();
+    close_images();
     return;
   }
 
@@ -270,7 +272,7 @@ void GroupEnableRequest<I>::handle_create_primary_group_snapshot(int r) {
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    disable_mirror_group();
+    close_images();
     return;
   }
 
@@ -323,7 +325,7 @@ void GroupEnableRequest<I>::handle_create_primary_image_snapshots(int r) {
       m_group_snap.snaps[i].snap_id = m_snap_ids[i];
     }
 
-    disable_mirror_group();
+    remove_primary_group_snapshot();
     return;
   }
 
@@ -362,7 +364,7 @@ void GroupEnableRequest<I>::handle_update_primary_group_snapshot(int r) {
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    disable_mirror_group();
+    remove_primary_group_snapshot();
     return;
   }
 
@@ -470,7 +472,6 @@ void GroupEnableRequest<I>::handle_notify_mirroring_watcher(int r) {
   if (r < 0) {
     lderr(m_cct) << "failed to notify mirror group update: " << cpp_strerror(r)
                  << dendl;
-    m_ret_val = r;
   }
 
   close_images();
@@ -618,7 +619,8 @@ void GroupEnableRequest<I>::disable_mirror_images() {
 
   auto gather_ctx = new C_Gather(m_cct, ctx);
   for (size_t i = 0; i < m_images.size(); i++) {
-    if (m_mirror_images[i].state != cls::rbd::MIRROR_IMAGE_STATE_DISABLED) {
+    if (m_mirror_images[i].state != cls::rbd::MIRROR_IMAGE_STATE_DISABLING &&
+        m_mirror_images[i].state != cls::rbd::MIRROR_IMAGE_STATE_DISABLED) {
       auto req = ImageStateUpdateRequest<I>::create(
         m_image_ctxs[i]->md_ctx, m_image_ctxs[i]->id,
         cls::rbd::MIRROR_IMAGE_STATE_DISABLING, m_mirror_images[i],

--- a/src/librbd/mirror/GroupEnableRequest.cc
+++ b/src/librbd/mirror/GroupEnableRequest.cc
@@ -124,7 +124,7 @@ void GroupEnableRequest<I>::prepare_group_images() {
     &GroupEnableRequest<I>::handle_prepare_group_images>(this);
 
   auto req = snapshot::GroupPrepareImagesRequest<I>::create(m_group_ioctx,
-    m_group_id, m_image_ctxs, m_images, nullptr, &m_mirror_peer_uuids,
+    m_group_id, m_image_ctxs, m_images, nullptr, &m_mirror_peer_uuids, "", // no specific image
     snapshot::GroupPrepareImagesRequest<I>::OP_ENABLE, false, ctx);
   req->send();
 }

--- a/src/librbd/mirror/GroupPromoteRequest.cc
+++ b/src/librbd/mirror/GroupPromoteRequest.cc
@@ -11,6 +11,8 @@
 #include "librbd/Utils.h"
 #include "librbd/mirror/snapshot/Utils.h"
 #include "librbd/group/ListSnapshotsRequest.h"
+#include "librbd/image/RemoveRequest.h"
+#include "librbd/mirror/GroupRemoveImageRequest.h"
 #include "librbd/mirror/snapshot/CreateNonPrimaryRequest.h"
 #include "librbd/mirror/snapshot/GroupUnlinkPeerRequest.h"
 #include "librbd/mirror/snapshot/GroupImageCreatePrimaryRequest.h"
@@ -27,6 +29,12 @@
 
 namespace librbd {
 namespace mirror {
+
+namespace {
+
+const uint32_t MAX_RETURN = 1024;
+
+} // anonymous namespace
 
 using util::create_context_callback;
 using util::create_rados_callback;
@@ -184,7 +192,7 @@ void GroupPromoteRequest<I>::prepare_group_images() {
 
   auto req = snapshot::GroupPrepareImagesRequest<I>::create(m_group_ioctx,
     m_group_id, m_image_ctxs, m_images, &m_mirror_images, &m_mirror_peer_uuids,
-    snapshot::GroupPrepareImagesRequest<I>::OP_PROMOTE, m_force, ctx);
+    "", snapshot::GroupPrepareImagesRequest<I>::OP_PROMOTE, m_force, ctx);
   req->send();
 }
 
@@ -193,7 +201,7 @@ void GroupPromoteRequest<I>::handle_prepare_group_images(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
   if (r < 0) {
-    lderr(m_cct) << "failed to prepare group images" << cpp_strerror(r)
+    lderr(m_cct) << "failed to prepare group images: " << cpp_strerror(r)
                  << dendl;
     m_ret_val = r;
     close_images();
@@ -211,13 +219,6 @@ void GroupPromoteRequest<I>::check_rollback_needed() {
   }
   ldout(m_cct, 10) << dendl;
 
-  std::vector<cls::rbd::GroupImageSpec> current_images;
-  for (const auto& image : m_images) {
-    if (image.state == cls::rbd::GROUP_IMAGE_LINK_STATE_ATTACHED) {
-      current_images.push_back(image.spec);
-    }
-  }
-
   if (m_snaps.empty()) {
     lderr(m_cct) << "cannot rollback, no mirror group snapshot"
                  << " available on group: " << m_group_name << dendl;
@@ -225,14 +226,20 @@ void GroupPromoteRequest<I>::check_rollback_needed() {
     close_images();
     return;
   }
+  ldout(m_cct, 10) << dendl;
 
   m_need_rollback = false;
+  m_orphan_required = false;
   auto snap = m_snaps.rbegin();
   for (; snap != m_snaps.rend(); ++snap) {
     auto mirror_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
         &snap->snapshot_namespace);
     if (mirror_ns == nullptr || mirror_ns->is_orphan()) {
       continue;
+    }
+
+    if (!m_orphan_required) {
+      m_orphan_required = !mirror_ns->is_demoted();
     }
 
     if (!is_mirror_group_snapshot_complete(snap->state, mirror_ns->complete)) {
@@ -249,32 +256,20 @@ void GroupPromoteRequest<I>::check_rollback_needed() {
     close_images();
     return;
   }
-
-  if (m_need_rollback) {
-    // Check for group membership match
-    std::vector<cls::rbd::GroupImageSpec> rollback_images;
-    for (auto& it : snap->snaps) {
-      rollback_images.emplace_back(it.image_id, it.pool);
-    }
-
-    if (rollback_images != current_images) {
-      lderr(m_cct) << "group membership does not match snapshot membership"
-                   << " with rollback_snap_id: " << snap->id << dendl;
-      m_ret_val = -EINVAL;
-      close_images();
-      return;
-    }
-    m_rollback_group_snap = *snap;
-  } else {
-    ldout(m_cct, 10) << "no rollback required" << dendl;
-  }
+  m_rollback_group_snap = *snap;
 
   prepare_group_promotion();
 }
 
 template <typename I>
 void GroupPromoteRequest<I>::prepare_group_promotion() {
-  ldout(m_cct, 10) <<  dendl;
+  ldout(m_cct, 10) << dendl;
+  ceph_assert(m_images.size() == m_image_ctxs.size());
+
+  if (m_orphan_required || m_need_rollback) {
+    create_group_orphan_snapshot();
+    return;
+  }
 
   bool can_skip_orphan = true;
   m_rollback_snap_ids.resize(m_images.size());
@@ -293,7 +288,7 @@ void GroupPromoteRequest<I>::prepare_group_promotion() {
       (m_rollback_snap_ids[i] == CEPH_NOSNAP && !requires_orphan);
   }
 
-  if (can_skip_orphan && !m_need_rollback) {
+  if (can_skip_orphan) {
     create_primary_group_snapshot();
   } else {
     create_group_orphan_snapshot();
@@ -534,15 +529,190 @@ void GroupPromoteRequest<I>::handle_acquire_exclusive_locks(int r) {
     }
   }
 
+  // all required locks are owned
+  if (!m_need_rollback) {
+    ldout(m_cct, 10) << "no rollback required" << dendl;
+    create_primary_group_snapshot();
+  } else {
+    // current membership
+    std::vector<cls::rbd::GroupImageSpec> current_membership;
+    for (const auto& image : m_images) {
+      current_membership.push_back(image.spec);
+    }
+
+    // rollback membership
+    auto* rollback_snap = &m_rollback_group_snap;
+    std::vector<cls::rbd::GroupImageSpec> rollback_membership;
+    for (auto& it : rollback_snap->snaps) {
+      rollback_membership.emplace_back(it.image_id, it.pool);
+    }
+
+    if (rollback_membership != current_membership) {
+      ldout(m_cct, 10) << "rollback group snapshot membership with snap id: "
+                       << rollback_snap->id
+                       << ", does not match current group membership"
+                       << dendl;
+      fix_group_membership(current_membership, rollback_membership);
+      return;
+    }
+    rollback();
+  }
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::fix_group_membership(
+    std::vector<cls::rbd::GroupImageSpec>& current_membership,
+    std::vector<cls::rbd::GroupImageSpec>& rollback_membership) {
+  ldout(m_cct, 10) << dendl;
+
+  m_to_add.clear();
+  m_to_remove.clear();
+
+  std::set<std::pair<std::string, int64_t>> current_set;
+  std::set<std::pair<std::string, int64_t>> rollback_set;
+
+  for (auto& img : current_membership) {
+    current_set.insert({img.image_id, img.pool_id});
+  }
+
+  for (auto& img : rollback_membership) {
+    rollback_set.insert({img.image_id, img.pool_id});
+  }
+
+  for (auto& img : rollback_membership) {
+    if (!current_set.count({img.image_id, img.pool_id})) {
+      m_to_add.push_back(img);
+    }
+  }
+
+  for (auto& img : current_membership) {
+    if (!rollback_set.count({img.image_id, img.pool_id})) {
+      m_to_remove.push_back(img);
+    }
+  }
+
+  ldout(m_cct, 10) << "fixing group membership, "
+                   << "to_add=" << m_to_add.size()
+                   << ", to_remove=" << m_to_remove.size() << dendl;
+
+  if (!m_to_add.empty()) {
+    lderr(m_cct) << "rollback requires adding images to group, but dynamic "
+                 << "group removal is not supported today" << dendl;
+    m_ret_val = -EINVAL;
+    release_exclusive_locks();
+    return;
+  }
+
+  if (!m_to_remove.empty() && m_to_remove.size() > 1) {
+    lderr(m_cct) << "rollback requires more than one image to be removed from "
+                 << "the group, this is not supported today" << dendl;
+    m_ret_val = -EINVAL;
+    release_exclusive_locks();
+    return;
+  }
+
+  auto ctx = create_context_callback<
+      GroupPromoteRequest<I>,
+      &GroupPromoteRequest<I>::handle_fix_group_membership>(this);
+
+  auto gather = new C_Gather(m_cct, ctx);
+  // remove images and disable mirroring
+  for (auto& spec : m_to_remove) {
+    auto it = std::find_if(m_image_ctxs.begin(), m_image_ctxs.end(),
+      [&](auto* ictx) {
+        return spec.image_id == ictx->id &&
+               spec.pool_id == ictx->md_ctx.get_id();
+      });
+
+    if (it == m_image_ctxs.end()) {
+      continue;
+    }
+
+    auto* ictx = *it;
+    Context* subctx = gather->new_sub();
+    auto req = mirror::GroupRemoveImageRequest<I>::create(
+        ictx, m_group_id, m_group_ioctx, subctx);
+    req->send();
+  }
+
+  gather->activate();
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::handle_fix_group_membership(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    m_ret_val = r;
+    release_exclusive_locks();
+    return;
+  }
+
+  // Safe erase of removed images
+  for (auto& spec : m_to_remove) {
+    auto it = std::find_if(
+        m_image_ctxs.begin(), m_image_ctxs.end(),
+        [&](I* ictx) { return ictx->id == spec.image_id; });
+
+    if (it != m_image_ctxs.end()) {
+      m_image_ctxs.erase(it);
+    }
+  }
+
+  m_images.clear();
+  list_group_images();
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::list_group_images() {
+  ldout(m_cct, 10) << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::group_image_list_start(&op, m_start_after, MAX_RETURN);
+
+  auto comp = create_rados_callback<
+    GroupPromoteRequest<I>,
+    &GroupPromoteRequest<I>::handle_list_group_images>(this);
+
+  m_out_bl.clear();
+  int r = m_group_ioctx.aio_operate(
+    librbd::util::group_header_name(m_group_id), comp, &op, &m_out_bl);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::handle_list_group_images(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  std::vector<cls::rbd::GroupImageStatus> images;
+  if (r == 0) {
+    auto iter = m_out_bl.cbegin();
+    r = cls_client::group_image_list_finish(&iter, &images);
+  }
+
+  if (r < 0) {
+    lderr(m_cct) << "group_id=" << m_group_id
+                 << " error listing images in group: "
+                 << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    release_exclusive_locks();
+    return;
+  }
+
+  auto image_count = images.size();
+  m_images.insert(m_images.end(), images.begin(), images.end());
+  if (image_count == MAX_RETURN) {
+    m_start_after = images.rbegin()->spec;
+    list_group_images();
+    return;
+ }
+
   rollback();
 }
 
 template <typename I>
 void GroupPromoteRequest<I>::rollback() {
-  if (!m_need_rollback) {
-    create_primary_group_snapshot();
-    return;
-  }
   ldout(m_cct, 10) << dendl;
 
   auto ctx = create_context_callback<
@@ -775,6 +945,92 @@ void GroupPromoteRequest<I>::handle_group_unlink_peer(int r) {
                  << cpp_strerror(r) << dendl;
   }
 
+  if (r == 0 && !m_to_remove.empty()) {
+    // At this point, any non-primary and incomplete primary group snapshots
+    // should already have been pruned. We can now safely remove the images
+    // that are no longer members of the group.
+    remove_non_member_images();
+    return;
+  }
+
+  release_exclusive_locks();
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::remove_non_member_images() {
+  ldout(m_cct, 10) << dendl;
+
+  Context *ctx = create_context_callback<GroupPromoteRequest<I>,
+    &GroupPromoteRequest<I>::handle_remove_non_member_images>(this);
+
+  auto gather = new C_Gather(m_cct, ctx);
+
+  // keep IoCtx objects alive until all RemoveRequests finish
+  m_remove_ioctxs.clear();
+
+  // Consider a scenario where a group snapshot is just created on the primary,
+  // but the GroupReplayer on the secondary has not yet processed it. During
+  // this window, an image may still appear in GROUP_IMAGE_LINK_STATE_INCOMPLETE
+  // state. At this point the image is not fully added to the group yet.
+  // If a force promote is triggered on the secondary in this state, there will
+  // be no incomplete group snapshot available, so rollback will not be
+  // triggered. However, the image in GROUP_IMAGE_LINK_STATE_INCOMPLETE may
+  // still remain in the group and therefore needs to be cleaned up after
+  // promotion.
+  for (const auto& image : m_images) {
+    if (image.state == cls::rbd::GROUP_IMAGE_LINK_STATE_INCOMPLETE) {
+      ldout(m_cct, 10) << "removing incomplete image: "
+                       << image.spec.image_id << dendl;
+      m_to_remove.push_back(image.spec);
+    }
+  }
+
+  for (auto &spec : m_to_remove) {
+    // allocate IoCtx in vector
+    m_remove_ioctxs.emplace_back();
+    librados::IoCtx &image_ioctx = m_remove_ioctxs.back();
+
+    int r = util::create_ioctx(m_group_ioctx, "", spec.pool_id, {}, &image_ioctx);
+    if (r < 0) {
+      lderr(m_cct) << "failed to create ioctx: " << cpp_strerror(r) << dendl;
+      continue;
+    }
+
+    if (spec.image_id.empty()) {
+      continue;
+    }
+
+    std::string image_name;
+    r = cls_client::dir_get_name(&image_ioctx, RBD_DIRECTORY,
+                                 spec.image_id, &image_name);
+    if (r < 0) {
+      lderr(m_cct) << "failed to resolve image name for id "
+                   << spec.image_id << ": " << cpp_strerror(r) << dendl;
+      continue;
+    }
+
+    ldout(m_cct, 10) << "removing image " << image_name
+                    << " (" << spec.image_id << ")" << dendl;
+
+    Context *subctx = gather->new_sub();
+    auto req = librbd::image::RemoveRequest<I>::create(image_ioctx, image_name,
+      spec.image_id, false, false, m_progress_ctx, nullptr, subctx);
+
+    req->send();
+  }
+
+  gather->activate();
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::handle_remove_non_member_images(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed removing non-member images: "
+                 << cpp_strerror(r) << dendl;
+  }
+
   release_exclusive_locks();
 }
 
@@ -816,6 +1072,10 @@ void GroupPromoteRequest<I>::handle_release_exclusive_locks(int r) {
 
 template <typename I>
 void GroupPromoteRequest<I>::close_images() {
+  if (m_image_ctxs.empty()) {
+    finish(m_ret_val);
+    return;
+  }
   ldout(m_cct, 10) << dendl;
 
   auto ctx = create_context_callback<

--- a/src/librbd/mirror/GroupPromoteRequest.h
+++ b/src/librbd/mirror/GroupPromoteRequest.h
@@ -79,10 +79,16 @@ private:
    *    v                                               |
    * DRAIN_IMAGES_WATCHERS                              |
    *    |                                               |
-   *    v                                               |
-   * ACQUIRE_EXCLUSIVE_LOCKS                            |
+   *    v                       (no rollback needed)    |
+   * ACQUIRE_EXCLUSIVE_LOCKS ---------------------------|
    *    |                                               |
    *    v  (skip if not needed)                         |
+   * FIX_GROUP_MEMBERSHIP                               |
+   *    |                                               |
+   *    v  (skip if not needed)                         |
+   * LIST_GROUP_IMAGES                                  |
+   *    |                                               |
+   *    v                                               |
    * ROLLBACK                                           |
    *    |                                               |
    *    v  (incomplete)                                 |
@@ -100,6 +106,9 @@ private:
    *    v                                                v        |
    * GROUP_UNLINK_PEER               ENABLE_NON_PRIMARY_FEATURES  |
    *    |                                                |        |
+   *    v  (skip if not required)                        |        |
+   * REMOVE_NON_MEMBER_IMAGES                            |        |
+   *    |                                                |        |
    *    v  (skip if not needed)                          v        v
    * RELEASE_EXCLUSIVE_LOCKS <-------------REMOVE_PRIMARY_GROUP_SNAPSHOT
    *    |
@@ -116,16 +125,21 @@ private:
   const std::string m_group_id;
   const std::string m_group_name;
   bool m_force;
+  bool m_orphan_required = false;
   Context *m_on_finish;
   CephContext *m_cct;
 
   std::vector<cls::rbd::GroupSnapshot> m_snaps;
+  std::vector<cls::rbd::GroupImageSpec> m_to_add;
+  std::vector<cls::rbd::GroupImageSpec> m_to_remove;
 
   cls::rbd::MirrorGroup m_mirror_group;
   std::set<std::string> m_mirror_peer_uuids;
   std::vector<cls::rbd::GroupImageStatus> m_images;
   std::vector<ImageCtxT *> m_image_ctxs;
+  std::vector<librados::IoCtx> m_remove_ioctxs;
   ceph::bufferlist m_out_bl;
+  cls::rbd::GroupImageSpec m_start_after;
   bool m_excl_locks_acquire = false;
 
   int m_ret_val = 0;
@@ -176,6 +190,14 @@ private:
   void acquire_exclusive_locks();
   void handle_acquire_exclusive_locks(int r);
 
+  void fix_group_membership(
+      std::vector<cls::rbd::GroupImageSpec>& current_membership,
+      std::vector<cls::rbd::GroupImageSpec>& rollback_membership);
+  void handle_fix_group_membership(int r);
+
+  void list_group_images();
+  void handle_list_group_images(int r);
+
   void rollback();
   void handle_rollback(int r);
 
@@ -193,6 +215,9 @@ private:
 
   void group_unlink_peer();
   void handle_group_unlink_peer(int r);
+
+  void remove_non_member_images();
+  void handle_remove_non_member_images(int r);
 
   void release_exclusive_locks();
   void handle_release_exclusive_locks(int r);

--- a/src/librbd/mirror/GroupRemoveImageRequest.cc
+++ b/src/librbd/mirror/GroupRemoveImageRequest.cc
@@ -1,0 +1,263 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/mirror/GroupRemoveImageRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "librbd/Utils.h"
+#include "librbd/mirror/GetInfoRequest.h"
+#include "librbd/mirror/ImageRemoveRequest.h"
+#include "librbd/mirror/ImageStateUpdateRequest.h"
+#include "librbd/mirror/snapshot/PromoteRequest.h"
+#include "librbd/mirror/snapshot/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::mirror::GroupRemoveImageRequest: " \
+                           << this << " " << __func__ << ": "
+
+namespace librbd {
+namespace mirror {
+
+using librbd::util::create_context_callback;
+using librbd::util::create_rados_callback;
+
+template <typename I>
+GroupRemoveImageRequest<I>::GroupRemoveImageRequest(I* image_ctx,
+                                                    const std::string& group_id,
+                                                    librados::IoCtx& group_io_ctx,
+                                                    Context* on_finish)
+  : m_image_ctx(image_ctx), m_group_id(group_id),
+    m_group_io_ctx(group_io_ctx), m_on_finish(on_finish),
+    m_cct(reinterpret_cast<CephContext*>(image_ctx->md_ctx.cct())) {
+  ldout(m_cct, 10) << "removing image " << m_image_ctx->id
+                   << " from group " << m_group_id << dendl;
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::send() {
+  ldout(m_cct, 10) << dendl;
+
+  get_mirror_info();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::get_mirror_info() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupRemoveImageRequest<I>,
+      &GroupRemoveImageRequest<I>::handle_get_mirror_info>(this);
+
+  auto req = GetInfoRequest<I>::create(*m_image_ctx, &m_mirror_image,
+                                       &m_promotion_state, &m_mirror_uuid, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::handle_get_mirror_info(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    ldout(m_cct, 10) << "mirror info not found" << dendl;
+    remove_group_ref_from_image();
+    return;
+  }
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to get mirror info: "
+                 << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  promote_image();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::promote_image() {
+  ldout(m_cct, 10) << dendl;
+
+  bool is_primary = (m_promotion_state == PROMOTION_STATE_PRIMARY ||
+                     m_promotion_state == PROMOTION_STATE_UNKNOWN);
+  ldout(m_cct, 10) << "image primary=" << is_primary << dendl;
+
+  if (is_primary) {
+    set_mirror_image_disabling();
+    return;
+  }
+
+  ldout(m_cct, 10) << "promoting non-primary image " << m_image_ctx->id
+                   << dendl;
+  auto ctx = create_context_callback<GroupRemoveImageRequest<I>,
+    &GroupRemoveImageRequest<I>::handle_promote_image>(this);
+
+  auto req = snapshot::PromoteRequest<I>::create(m_image_ctx,
+    m_mirror_image.global_image_id, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::handle_promote_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "promotion failed: "
+                 << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  set_mirror_image_disabling();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::set_mirror_image_disabling() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupRemoveImageRequest<I>,
+    &GroupRemoveImageRequest<I>::handle_set_mirror_image_disabling>(this);
+
+  auto req = ImageStateUpdateRequest<I>::create(m_image_ctx->md_ctx,
+    m_image_ctx->id, cls::rbd::MIRROR_IMAGE_STATE_DISABLING,
+    m_mirror_image, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::handle_set_mirror_image_disabling(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed setting DISABLING: "
+                 << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  remove_group_ref_from_image();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::remove_group_ref_from_image() {
+  ldout(m_cct, 10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  cls_client::image_group_remove(&op, {m_group_id, m_group_io_ctx.get_id()});
+
+  auto comp = create_rados_callback<GroupRemoveImageRequest<I>,
+    &GroupRemoveImageRequest<I>::handle_remove_group_ref_from_image>(this);
+
+  int r = m_image_ctx->md_ctx.aio_operate(util::header_name(m_image_ctx->id),
+                                          comp, &op);
+  ceph_assert(r == 0);
+
+  comp->release();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::handle_remove_group_ref_from_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed removing group reference from image: "
+                 << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  remove_image_from_group();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::remove_image_from_group() {
+  ldout(m_cct, 10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  cls_client::group_image_remove(
+      &op, {m_image_ctx->id, m_image_ctx->md_ctx.get_id()});
+
+  auto comp = create_rados_callback<GroupRemoveImageRequest<I>,
+    &GroupRemoveImageRequest<I>::handle_remove_image_from_group>(this);
+
+  int r = m_group_io_ctx.aio_operate(
+      util::group_header_name(m_group_id), comp, &op);
+  ceph_assert(r == 0);
+
+  comp->release();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::handle_remove_image_from_group(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed to remove group image entry: "
+                 << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  remove_global_mirror_image_entry();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::remove_global_mirror_image_entry() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupRemoveImageRequest<I>,
+    &GroupRemoveImageRequest<I>::handle_remove_global_mirror_image_entry>(this);
+
+  auto req = ImageRemoveRequest<I>::create(m_image_ctx->md_ctx,
+    m_mirror_image.global_image_id, m_image_ctx->id, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::handle_remove_global_mirror_image_entry(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    finish(r);
+    return;
+  }
+
+  close_image();
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::close_image() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupRemoveImageRequest<I>,
+    &GroupRemoveImageRequest<I>::handle_close>(this);
+
+  m_image_ctx->state->close(ctx);
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::handle_close(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+  finish(r);
+}
+
+template <typename I>
+void GroupRemoveImageRequest<I>::finish(int r) {
+  ldout(m_cct, 10) << r << dendl;
+
+  Context* on_finish = m_on_finish;
+  delete this;
+  on_finish->complete(r);
+}
+
+} // namespace mirror
+} // namespace librbd
+
+template class librbd::mirror::GroupRemoveImageRequest<librbd::ImageCtx>;

--- a/src/librbd/mirror/GroupRemoveImageRequest.h
+++ b/src/librbd/mirror/GroupRemoveImageRequest.h
@@ -1,0 +1,114 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_MIRROR_GROUP_REMOVE_IMAGE_REQUEST_H
+#define CEPH_LIBRBD_MIRROR_GROUP_REMOVE_IMAGE_REQUEST_H
+
+#include "include/Context.h"
+#include "include/rados/librados.hpp"
+#include "cls/rbd/cls_rbd_types.h"
+#include "librbd/mirror/Types.h"
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace mirror {
+
+template <typename ImageCtxT = ImageCtx>
+class GroupRemoveImageRequest {
+public:
+  static GroupRemoveImageRequest* create(ImageCtxT* image_ctx,
+                                         const std::string& group_id,
+                                         librados::IoCtx& group_io_ctx,
+                                         Context* on_finish) {
+    return new GroupRemoveImageRequest(image_ctx, group_id, group_io_ctx,
+                                       on_finish);
+  }
+
+  GroupRemoveImageRequest(ImageCtxT* image_ctx, const std::string& group_id,
+                          librados::IoCtx& group_io_ctx, Context* on_finish);
+
+  void send();
+
+private:
+
+/**
+ * @verbatim
+ *
+ *            <start>
+ *               |
+ *               v
+ *         GET_MIRROR_INFO
+ *               |
+ *      +--------+--------------------------------+
+ *      |                                         |
+ *  is_primary = false                        is_primary = true
+ *      |                                         |
+ *      v                                         |
+ *  PROMOTE_IMAGE                                 |
+ *      |                                         |
+ *      v                                         |
+ *  SET_MIRROR_IMAGE_DISABLING  ------------------+
+ *      |
+ *      v
+ *  REMOVE_GROUP_REF_FROM_IMAGE
+ *      |
+ *      v
+ *  REMOVE_IMAGE_FROM_GROUP
+ *      |
+ *      v
+ *  REMOVE_GLOBAL_MIRROR_IMAGE_ENTRY
+ *      |
+ *      v
+ *  CLOSE_IMAGE
+ *      |
+ *      v
+ *  <finish>
+ *
+ * @endverbatim
+ */
+
+  ImageCtxT* m_image_ctx;
+  std::string m_group_id;
+  librados::IoCtx& m_group_io_ctx;
+  Context* m_on_finish;
+
+  CephContext* m_cct;
+
+  // mirror state
+  cls::rbd::MirrorImage m_mirror_image;
+  PromotionState m_promotion_state = PROMOTION_STATE_UNKNOWN;
+  std::string m_mirror_uuid;
+
+  void get_mirror_info();
+  void handle_get_mirror_info(int r);
+
+  void set_mirror_image_disabling();
+  void handle_set_mirror_image_disabling(int r);
+
+  void promote_image();
+  void handle_promote_image(int r);
+
+  void remove_group_ref_from_image();
+  void handle_remove_group_ref_from_image(int r);
+
+  void remove_image_from_group();
+  void handle_remove_image_from_group(int r);
+
+  void remove_global_mirror_image_entry();
+  void handle_remove_global_mirror_image_entry(int r);
+
+  void close_image();
+  void handle_close(int r);
+
+  void finish(int r);
+};
+
+} // namespace mirror
+} // namespace librbd
+
+extern template class
+librbd::mirror::GroupRemoveImageRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_MIRROR_GROUP_REMOVE_IMAGE_REQUEST_H

--- a/src/librbd/mirror/snapshot/GroupCreatePrimaryRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupCreatePrimaryRequest.cc
@@ -219,7 +219,7 @@ void GroupCreatePrimaryRequest<I>::prepare_group_images() {
 
   auto req = snapshot::GroupPrepareImagesRequest<I>::create(m_group_ioctx,
     m_group_id, m_image_ctxs, m_images, &m_mirror_images, &m_mirror_peer_uuids,
-    snapshot::GroupPrepareImagesRequest<I>::OP_CREATE_PRIMARY, false, ctx);
+    "", snapshot::GroupPrepareImagesRequest<I>::OP_CREATE_PRIMARY, false, ctx);
   req->send();
 }
 

--- a/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
@@ -39,12 +39,12 @@ GroupPrepareImagesRequest<I>::GroupPrepareImagesRequest(
     std::vector<librbd::ImageCtx *>& image_ctxs,
     std::vector<cls::rbd::GroupImageStatus>& images,
     std::vector<cls::rbd::MirrorImage>* mirror_images,
-    std::set<std::string>* mirror_peer_uuids,
+    std::set<std::string>* mirror_peer_uuids, const std::string& image_id_to_add,
     Operation operation, bool force, Context *on_finish)
      : m_group_ioctx(group_ioctx), m_group_id(group_id),
        m_image_ctxs(image_ctxs), m_images(images),
-       m_mirror_images(mirror_images),
-       m_mirror_peer_uuids(mirror_peer_uuids), m_operation(operation),
+       m_mirror_images(mirror_images), m_mirror_peer_uuids(mirror_peer_uuids),
+       m_image_id_to_add(image_id_to_add), m_operation(operation),
        m_force(force), m_on_finish(on_finish) {
   m_cct = reinterpret_cast<CephContext*>(m_group_ioctx.cct());
   ldout(m_cct, 10) << "group_id=" << m_group_id
@@ -163,7 +163,7 @@ void GroupPrepareImagesRequest<I>::handle_list_group_images(int r) {
     finish(0);
     return;
   }
-  if (m_operation == OP_ENABLE) {
+  if (m_operation == OP_ENABLE || m_operation == OP_ADD_IMAGE) {
     check_mirror_images_disabled();
   } else {
     open_group_images();
@@ -181,6 +181,11 @@ void GroupPrepareImagesRequest<I>::check_mirror_images_disabled() {
 
   m_out_bls.resize(m_images.size());
   for (size_t i = 0; i < m_images.size(); i++) {
+    if (m_operation == OP_ADD_IMAGE &&
+        m_images[i].spec.image_id != m_image_id_to_add) {
+      continue;
+    }
+
     librados::ObjectReadOperation op;
     cls_client::mirror_image_get_start(&op, m_images[i].spec.image_id);
 
@@ -201,7 +206,8 @@ void GroupPrepareImagesRequest<I>::check_mirror_images_disabled() {
           r = -EINVAL;
         } else {
           lderr(m_cct) << "failed to get mirror image info for image_id="
-                       << m_images[i].spec.image_id << dendl;
+                       << m_images[i].spec.image_id << ": "
+                       << cpp_strerror(r) << dendl;
         }
 
         new_sub_ctx->complete(r);
@@ -220,7 +226,7 @@ void GroupPrepareImagesRequest<I>::check_mirror_images_disabled() {
 
 template <typename I>
 void GroupPrepareImagesRequest<I>::handle_check_mirror_images_disabled(int r) {
-  ldout(m_cct, 10) << "r=" << r <<  dendl;
+  ldout(m_cct, 10) << "r=" << r << dendl;
 
   m_out_bls.clear();
 
@@ -294,7 +300,7 @@ void GroupPrepareImagesRequest<I>::handle_open_group_images(int r) {
     return;
   }
 
-  if (m_operation == OP_ENABLE) {
+  if (m_operation == OP_ENABLE || m_operation == OP_ADD_IMAGE) {
     finish(0);
   } else if (m_operation == OP_DISABLE) {
     check_images_mirror_mode();

--- a/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.h
+++ b/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.h
@@ -32,7 +32,8 @@ public:
     OP_DISABLE         = 1,
     OP_PROMOTE         = 2,
     OP_DEMOTE          = 3,
-    OP_CREATE_PRIMARY  = 4,
+    OP_ADD_IMAGE       = 4,
+    OP_CREATE_PRIMARY  = 5,
   };
   static GroupPrepareImagesRequest *create(
       librados::IoCtx& group_ioctx, const std::string& group_id,
@@ -40,10 +41,11 @@ public:
       std::vector<cls::rbd::GroupImageStatus>& images,
       std::vector<cls::rbd::MirrorImage>* mirror_images,
       std::set<std::string>* mirror_peer_uuids,
+      const std::string& image_id_to_add,
       Operation operation, bool force, Context *on_finish) {
     return new GroupPrepareImagesRequest(
       group_ioctx, group_id, image_ctxs, images, mirror_images,
-      mirror_peer_uuids, operation, force, on_finish);
+      mirror_peer_uuids, image_id_to_add, operation, force, on_finish);
   }
 
   GroupPrepareImagesRequest(
@@ -52,6 +54,7 @@ public:
     std::vector<cls::rbd::GroupImageStatus>& images,
     std::vector<cls::rbd::MirrorImage>* mirror_images,
     std::set<std::string>* mirror_peer_uuids,
+    const std::string& image_id_to_add,
     Operation operation, bool force, Context *on_finish);
 
   void send();
@@ -68,11 +71,11 @@ private:
    *       v                              |
    *   LIST_GROUP_IMAGES <----------------/
    *       |            \
-   *       |             \-----(enable)----->CHECK_MIRROR_IMAGES_DISABLED
-   *       |          ___________________________/
+   *       |             \-----(enable/add_image, r=0)----->CHECK_MIRROR_IMAGES_DISABLED
+   *       |          ________________________________________/
    *       |         |
    *       v         V
-   *   OPEN_GROUP_IMAGES ------------------(enable, r=0)-------------------->|
+   *   OPEN_GROUP_IMAGES ------------------(enable/add_image, r=0)---------->|
    *       |            \                                                    |
    *       |             \-------(disable)-------\                           |
    *       |                                     |                           |
@@ -101,6 +104,7 @@ private:
   std::vector<cls::rbd::GroupImageStatus>& m_images;
   std::vector<cls::rbd::MirrorImage>* m_mirror_images;
   std::set<std::string>* m_mirror_peer_uuids;
+  const std::string m_image_id_to_add;
   Operation m_operation;
   bool m_force;
   Context *m_on_finish;

--- a/src/tools/rbd_mirror/GroupReplayer.cc
+++ b/src/tools/rbd_mirror/GroupReplayer.cc
@@ -701,7 +701,9 @@ void GroupReplayer<I>::handle_start_image_replayers(int r) {
 
   if (finish_start_if_interrupted()) {
     return;
-  } else if (r < 0) {
+  } else if (r < 0 && r != -ENOENT) {
+    /* scenario for ENOENT could be, as part of the group snapshot rollback
+     * image might be disabled and hence ENOENT */
     finish_start_fail(r, "failed to start image replayers");
     return;
   }
@@ -817,6 +819,15 @@ void GroupReplayer<I>::handle_replayer_notification() {
     if (error_code == -EEXIST) {
       m_destroy_replayers = true;
     } */
+
+    if (error_code == -ENOENT) {
+      // remap -ENOENT from group_replayer to -EINVAL to avoid GR triggering
+      // set_finished() during shutdown(), which would further mislead
+      // InstanceReplayer to remove the group replayer object before the group
+      // is cleaned locally.
+      error_code = -EINVAL;
+    }
+
     on_stop_replay(error_code, error_description);
     return;
   }

--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -308,11 +308,14 @@ void InstanceReplayer<I>::release_group(const std::string &global_group_id,
   }
 
   auto group_replayer = it->second;
-  m_group_replayers.erase(it);
-
+  if (group_replayer->is_finished()) {
+    m_group_replayers.erase(it);
+  }
   on_finish = new LambdaContext(
     [group_replayer, on_finish] (int r) {
-      group_replayer->destroy();
+      if (group_replayer->is_finished()) {
+        group_replayer->destroy();
+      }
       on_finish->complete(0);
     });
   stop_group_replayer(group_replayer, on_finish);

--- a/src/tools/rbd_mirror/group_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/group_replayer/BootstrapRequest.cc
@@ -284,20 +284,29 @@ template <typename I>
 int BootstrapRequest<I>::create_replayers() {
   dout(10) << dendl;
 
-  //TODO: check that the images have not changed
-  if (!m_image_replayers->empty()) {
-    dout(10) << "image replayers already exist."<< dendl;
-    return 0;
-  }
-
   auto state_builder = *m_state_builder;
   int r = 0;
 
   if ((*m_state_builder)->is_local_primary()) {
+    //TODO: check that the images have not changed
+    if (m_image_replayers->size() == (*m_state_builder)->local_images.size()) {
+      dout(10) << "image replayers already exist."<< dendl;
+      return 0;
+    }
   // The ImageReplayers are required to run even when the group is primary in
   // order to update the image status for the mirror pool status to be healthy.
     for (auto &[global_image_id, p] : (*m_state_builder)->local_images) {
       auto &local_pool_id = p.first;
+      bool is_image_replayer_exists = std::any_of(
+        m_image_replayers->begin(), m_image_replayers->end(),
+        [&global_image_id](const auto& entry) {
+          return entry.second->get_global_image_id() == global_image_id;
+        });
+      if (is_image_replayer_exists) {
+        dout(10) << "image replayer for global image id: " << global_image_id
+                 << "already exists" << dendl;
+        continue;
+      }
 
       m_image_replayers->emplace_back(librados::IoCtx(), nullptr);
       auto &local_io_ctx = m_image_replayers->back().first;
@@ -360,7 +369,22 @@ int BootstrapRequest<I>::create_replayers() {
                                 remote_pool_meta, m_remote_status_updater});
     }
   } else if (!state_builder->remote_group_id.empty()) {
+    //TODO: check that the images have not changed
+    if (m_image_replayers->size() == (*m_state_builder)->remote_images.size()) {
+      dout(10) << "image replayers already exist."<< dendl;
+      return 0;
+    }
     for (auto &[remote_pool_id, global_image_id] : (*m_state_builder)->remote_images) {
+      bool is_image_replayer_exists = std::any_of(
+        m_image_replayers->begin(), m_image_replayers->end(),
+        [&global_image_id](const auto& entry) {
+          return entry.second->get_global_image_id() == global_image_id;
+        });
+      if (is_image_replayer_exists) {
+        dout(10) << "image replayer for global image id: " << global_image_id
+                 << "already exists" << dendl;
+        continue;
+      }
 
       m_image_replayers->emplace_back(librados::IoCtx(), nullptr);
       auto &local_io_ctx = m_image_replayers->back().first;


### PR DESCRIPTION

this capability allows images to be added to an already enabled mirror group without
disabling and re-enabling the group. As a result, it avoids the overhead of re-mirroring
the entire group over the network.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
