### PR TITLE
crimson/os/seastore/seastore_types: extent_types_t categories

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -161,7 +161,6 @@ void Cache::register_metrics()
     {extent_types_t::ROOT,                sm::label_instance("ext", "ROOT")},
     {extent_types_t::LADDR_INTERNAL,      sm::label_instance("ext", "LADDR_INTERNAL")},
     {extent_types_t::LADDR_LEAF,          sm::label_instance("ext", "LADDR_LEAF")},
-    {extent_types_t::DINK_LADDR_LEAF,     sm::label_instance("ext", "DINK_LADDR_LEAF")},
     {extent_types_t::ROOT_META,           sm::label_instance("ext", "ROOT_META")},
     {extent_types_t::OMAP_INNER,          sm::label_instance("ext", "OMAP_INNER")},
     {extent_types_t::OMAP_LEAF,           sm::label_instance("ext", "OMAP_LEAF")},

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1571,8 +1571,6 @@ public:
     switch (type) {
     case extent_types_t::LADDR_INTERNAL:
       [[fallthrough]];
-    case extent_types_t::DINK_LADDR_LEAF:
-      [[fallthrough]];
     case extent_types_t::LADDR_LEAF:
       stats.lba_tree_extents_num += delta;
       ceph_assert(stats.lba_tree_extents_num >= 0);

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -996,8 +996,7 @@ BtreeLBAManager::get_physical_extent_if_live(
       if (type == extent_types_t::LADDR_INTERNAL) {
 	return btree.get_internal_if_live(c, addr, laddr, len);
       } else {
-	assert(type == extent_types_t::LADDR_LEAF ||
-	       type == extent_types_t::DINK_LADDR_LEAF);
+	assert(type == extent_types_t::LADDR_LEAF);
 	return btree.get_leaf_if_live(c, addr, laddr, len);
       }
     });

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -242,8 +242,6 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
     return out << "LADDR_INTERNAL";
   case extent_types_t::LADDR_LEAF:
     return out << "LADDR_LEAF";
-  case extent_types_t::DINK_LADDR_LEAF:
-    return out << "LADDR_LEAF";
   case extent_types_t::ONODE_BLOCK_STAGED:
     return out << "ONODE_BLOCK_STAGED";
   case extent_types_t::ROOT_META:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1461,28 +1461,27 @@ std::ostream &operator<<(std::ostream &out, const paddr_list_t &rhs);
  * Cache::get_extent_by_type in cache.cc
  */
 enum class extent_types_t : uint8_t {
-  ROOT = 0,
-  LADDR_INTERNAL = 1,
-  LADDR_LEAF = 2,
-  DINK_LADDR_LEAF = 3, // should only be used for unitttests
-  ROOT_META = 4,
-  OMAP_INNER = 5,
-  OMAP_LEAF = 6,
-  ONODE_BLOCK_STAGED = 7,
-  COLL_BLOCK = 8,
-  OBJECT_DATA_BLOCK = 9,
-  RETIRED_PLACEHOLDER = 10,
+  ROOT,
+  LADDR_INTERNAL,
+  LADDR_LEAF,
+  ROOT_META,
+  OMAP_INNER,
+  OMAP_LEAF,
+  ONODE_BLOCK_STAGED,
+  COLL_BLOCK,
+  OBJECT_DATA_BLOCK,
+  RETIRED_PLACEHOLDER,
   // the following two types are not extent types,
   // they are just used to indicates paddr allocation deltas
-  ALLOC_INFO = 11,
-  JOURNAL_TAIL = 12,
+  ALLOC_INFO,
+  JOURNAL_TAIL,
   // Test Block Types
-  TEST_BLOCK = 13,
-  TEST_BLOCK_PHYSICAL = 14,
-  BACKREF_INTERNAL = 15,
-  BACKREF_LEAF = 16,
+  TEST_BLOCK,
+  TEST_BLOCK_PHYSICAL,
+  BACKREF_INTERNAL,
+  BACKREF_LEAF,
   // None and the number of valid extent_types_t
-  NONE = 17,
+  NONE,
 };
 using extent_types_le_t = uint8_t;
 constexpr auto EXTENT_TYPES_MAX = static_cast<uint8_t>(extent_types_t::NONE);
@@ -1509,7 +1508,6 @@ constexpr std::array logical_metadata_types {
 constexpr std::array lba_node_types {
   extent_types_t::LADDR_INTERNAL,
   extent_types_t::LADDR_LEAF,
-  extent_types_t::DINK_LADDR_LEAF
 };
 
 constexpr std::array backref_node_types {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <iostream>
 #include <vector>
+#include <ranges>
 #include <boost/core/ignore_unused.hpp>
 
 #include <seastar/core/lowres_clock.hh>
@@ -1490,99 +1491,82 @@ constexpr size_t BACKREF_NODE_SIZE = 4096;
 
 std::ostream &operator<<(std::ostream &out, extent_types_t t);
 
-constexpr bool is_data_type(extent_types_t type) {
-  return type == extent_types_t::OBJECT_DATA_BLOCK ||
-         type == extent_types_t::TEST_BLOCK;
+// ---- extent_types_t categories ----
+
+constexpr std::array data_types {
+  extent_types_t::OBJECT_DATA_BLOCK,
+  extent_types_t::TEST_BLOCK
+};
+
+constexpr std::array logical_metadata_types {
+  extent_types_t::ROOT_META,
+  extent_types_t::OMAP_INNER,
+  extent_types_t::OMAP_LEAF,
+  extent_types_t::ONODE_BLOCK_STAGED,
+  extent_types_t::COLL_BLOCK
+};
+
+constexpr std::array lba_node_types {
+  extent_types_t::LADDR_INTERNAL,
+  extent_types_t::LADDR_LEAF,
+  extent_types_t::DINK_LADDR_LEAF
+};
+
+constexpr std::array backref_node_types {
+  extent_types_t::BACKREF_INTERNAL,
+  extent_types_t::BACKREF_LEAF
+};
+
+// ---- extent_types_t predicates ----
+
+constexpr bool is_data_type(extent_types_t t) {
+  return std::ranges::contains(data_types, t);
 }
 
-constexpr bool is_logical_metadata_type(extent_types_t type) {
-  return type >= extent_types_t::ROOT_META &&
-         type <= extent_types_t::COLL_BLOCK;
+constexpr bool is_logical_metadata_type(extent_types_t t) {
+  return std::ranges::contains(logical_metadata_types, t);
 }
 
-constexpr bool is_logical_type(extent_types_t type) {
-  if ((type >= extent_types_t::ROOT_META &&
-       type <= extent_types_t::OBJECT_DATA_BLOCK) ||
-      type == extent_types_t::TEST_BLOCK) {
-    assert(is_logical_metadata_type(type) ||
-           is_data_type(type));
-    return true;
-  } else {
-    assert(!is_logical_metadata_type(type) &&
-           !is_data_type(type));
-    return false;
-  }
+constexpr bool is_logical_type(extent_types_t t) {
+  return is_logical_metadata_type(t) || is_data_type(t);
 }
 
-constexpr bool is_retired_placeholder_type(extent_types_t type) {
-  return type == extent_types_t::RETIRED_PLACEHOLDER;
+constexpr bool is_retired_placeholder_type(extent_types_t t) {
+  return t == extent_types_t::RETIRED_PLACEHOLDER;
 }
 
-constexpr bool is_root_type(extent_types_t type) {
-  return type == extent_types_t::ROOT;
+constexpr bool is_root_type(extent_types_t t) {
+  return t == extent_types_t::ROOT;
 }
 
-constexpr bool is_lba_node(extent_types_t type) {
-  return type == extent_types_t::LADDR_INTERNAL ||
-         type == extent_types_t::LADDR_LEAF ||
-         type == extent_types_t::DINK_LADDR_LEAF;
+constexpr bool is_lba_node(extent_types_t t) {
+  return std::ranges::contains(lba_node_types, t);
 }
 
-constexpr bool is_backref_node(extent_types_t type) {
-  return type == extent_types_t::BACKREF_INTERNAL ||
-         type == extent_types_t::BACKREF_LEAF;
+constexpr bool is_backref_node(extent_types_t t) {
+  return std::ranges::contains(backref_node_types, t);
 }
 
-constexpr bool is_lba_backref_node(extent_types_t type) {
-  return is_lba_node(type) || is_backref_node(type);
+constexpr bool is_lba_backref_node(extent_types_t t) {
+  return is_lba_node(t) || is_backref_node(t);
 }
 
-constexpr bool is_physical_type(extent_types_t type) {
-  if (type <= extent_types_t::DINK_LADDR_LEAF ||
-      (type >= extent_types_t::TEST_BLOCK_PHYSICAL &&
-       type <= extent_types_t::BACKREF_LEAF)) {
-    assert(is_root_type(type) ||
-           is_lba_backref_node(type) ||
-           type == extent_types_t::TEST_BLOCK_PHYSICAL);
-    return true;
-  } else {
-    assert(!is_root_type(type) &&
-           !is_lba_backref_node(type) &&
-           type != extent_types_t::TEST_BLOCK_PHYSICAL);
-    return false;
-  }
+constexpr bool is_physical_type(extent_types_t t) {
+  return is_root_type(t) ||
+         is_lba_backref_node(t) ||
+         t == extent_types_t::TEST_BLOCK_PHYSICAL;
 }
 
-constexpr bool is_backref_mapped_type(extent_types_t type) {
-  if ((type >= extent_types_t::LADDR_INTERNAL &&
-       type <= extent_types_t::OBJECT_DATA_BLOCK) ||
-      type == extent_types_t::TEST_BLOCK ||
-      type == extent_types_t::TEST_BLOCK_PHYSICAL) {
-    assert(is_logical_type(type) ||
-	   is_lba_node(type) ||
-	   type == extent_types_t::TEST_BLOCK_PHYSICAL);
-    return true;
-  } else {
-    assert(!is_logical_type(type) &&
-	   !is_lba_node(type) &&
-	   type != extent_types_t::TEST_BLOCK_PHYSICAL);
-    return false;
-  }
+constexpr bool is_backref_mapped_type(extent_types_t t) {
+  return is_logical_type(t) ||
+         is_lba_node(t) ||
+         t == extent_types_t::TEST_BLOCK_PHYSICAL;
 }
 
-constexpr bool is_real_type(extent_types_t type) {
-  if (type <= extent_types_t::OBJECT_DATA_BLOCK ||
-      (type >= extent_types_t::TEST_BLOCK &&
-       type <= extent_types_t::BACKREF_LEAF)) {
-    assert(is_logical_type(type) ||
-           is_physical_type(type));
-    return true;
-  } else {
-    assert(!is_logical_type(type) &&
-           !is_physical_type(type));
-    return false;
-  }
+constexpr bool is_real_type(extent_types_t t) {
+  return is_logical_type(t) || is_physical_type(t);
 }
+
 
 std::ostream &operator<<(std::ostream &out, extent_types_t t);
 

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -1051,9 +1051,8 @@ struct transaction_manager_test_t :
         extent_types_t::BACKREF_INTERNAL,
         extent_types_t::BACKREF_LEAF
       };
-      // exclude DINK_LADDR_LEAF, RETIRED_PLACEHOLDER,
-      //         ALLOC_INFO, JOURNAL_TAIL
-      assert(all_extent_types.size() == EXTENT_TYPES_MAX - 4);
+      // exclude RETIRED_PLACEHOLDER, ALLOC_INFO, JOURNAL_TAIL
+      assert(all_extent_types.size() == EXTENT_TYPES_MAX - 3);
 
       std::vector<rewrite_gen_t> all_generations;
       for (auto i = INIT_GENERATION; i <= epm->dynamic_max_rewrite_generation; i++) {


### PR DESCRIPTION
note, Spotted while working on https://github.com/ceph/ceph/pull/66798

---

    Switch predicates from tricky to follow range comparisons to explicit
    constexpr arrays and C++23 std::ranges::contains.
    This should largely help with readability and avoid error prone comparisons.
    Moreover, we can now drop the sanity asserts used after the range
    comparisons.

    
    Example:
    ```
      if (type <= extent_types_t::DINK_LADDR_LEAF ||
          (type >= extent_types_t::TEST_BLOCK_PHYSICAL &&
           type <= extent_types_t::BACKREF_LEAF)) {
    ```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
