### PR TITLE
rgw: replace FMT_STRING by fmt::runtime

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -605,7 +605,7 @@ string gen_v4_scope(const ceph::real_time& timestamp,
   auto mon = bt.tm_mon + 1;
   auto day = bt.tm_mday;
 
-  return fmt::format(FMT_STRING("{:d}{:02d}{:02d}/{:s}/{:s}/aws4_request"),
+  return fmt::format("{:d}{:02d}{:02d}/{:s}/{:s}/aws4_request",
                      year, mon, day, region, service);
 }
 


### PR DESCRIPTION
Fix a build failure with Clang 20+ where fmt's compile-time format parsing fails in a consteval context.

The following error is triggered when building rgw_auth_s3.cc:

  src/rgw/rgw_auth_s3.cc:600:22: error: call to consteval function
  'fmt::basic_format_string<...>' is not a constant expression

Use fmt::runtime() to avoid compile-time format string parsing and restore buildability across toolchains.