### PR TITLE
mgr/cephadm: support monitoring_addr and bind_addr for nfs

### DIFF
--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -173,13 +173,16 @@ class NFSService(CephService):
         rgw_user = f'{rados_user}-rgw'
         rgw_keyring = self.create_rgw_keyring(daemon_spec)
         bind_addr = ''
+
         if spec.virtual_ip and not spec.enable_haproxy_protocol:
+            # keepalive_only mode: prioritize virtual_ip
             bind_addr = spec.virtual_ip
             daemon_spec.port_ips = {str(port): spec.virtual_ip}
             # update daemon spec ip for prometheus, as monitoring will happen on this
             # ip, if no monitor ip specified
             daemon_spec.ip = bind_addr
         elif daemon_spec.ip:
+            # daemon_spec.ip is already set by scheduler from ip_addrs if specified
             bind_addr = daemon_spec.ip
             daemon_spec.port_ips = {str(port): daemon_spec.ip}
         if not bind_addr:
@@ -563,9 +566,26 @@ class NFSService(CephService):
 
         # check if monitor needs to be bind on specific ip
         monitoring_addr = spec.monitoring_ip_addrs.get(host) if spec.monitoring_ip_addrs else None
-        if monitoring_addr and monitoring_addr not in self.mgr.cache.get_host_network_ips(host):
-            logger.debug(f"Monitoring IP {monitoring_addr} is not configured on host {host}.")
-            monitoring_addr = None
+
+        if monitoring_addr:
+            try:
+                ip = ipaddress.ip_address(monitoring_addr)
+
+                # Fetch host IPs once and normalize to strings
+                host_ips = set(self.mgr.cache.get_host_network_ips(host))
+
+                # Allow loopback addresses without requiring them on an interface
+                if not ip.is_loopback and str(ip) not in host_ips:
+                    logger.debug(
+                        f"Monitoring IP {monitoring_addr} is not configured on host {host}."
+                    )
+                    monitoring_addr = None
+
+            except ValueError:
+                logger.warning(
+                    f"Invalid monitoring IP address {monitoring_addr} for host {host}."
+                )
+                monitoring_addr = None
         if not monitoring_addr and spec.monitoring_networks:
             monitoring_addr = self.mgr.get_first_matching_network_ip(host, spec, spec.monitoring_networks)
             if not monitoring_addr:

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -11,6 +11,9 @@ NFS_CORE_PARAM {
         Enable_UDP = false;
         NFS_Port = {{ port }};
         allow_set_io_flusher_fail = true;
+{% if haproxy_hosts %}
+        HAProxy_Hosts = {{ haproxy_hosts|join(", ") }};
+{% endif %}
 {% if monitoring_addr %}
         Monitoring_Addr = {{ monitoring_addr }};
 {% endif %}
@@ -19,9 +22,6 @@ NFS_CORE_PARAM {
 {% endif %}
 {% if bind_addr %}
         Bind_addr = {{ bind_addr }};
-{% endif %}
-{% if haproxy_hosts %}
-        HAProxy_Hosts = {{ haproxy_hosts|join(", ") }};
 {% endif %}
 {% if enable_rdma and rdma_port %}
         NFS_RDMA_Port = {{ rdma_port }};
@@ -94,5 +94,4 @@ TLS_CONFIG{
 {% endif %}
 }
 {% endif %}
-
 %url    {{ url }}

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -11,16 +11,18 @@ NFS_CORE_PARAM {
         Enable_UDP = false;
         NFS_Port = {{ port }};
         allow_set_io_flusher_fail = true;
+{% if monitoring_addr %}
+        Monitoring_Addr = {{ monitoring_addr }};
+{% endif %}
+{% if monitoring_port %}
+        Monitoring_Port = {{ monitoring_port }};
+{% endif %}
 {% if bind_addr %}
         Bind_addr = {{ bind_addr }};
 {% endif %}
 {% if haproxy_hosts %}
         HAProxy_Hosts = {{ haproxy_hosts|join(", ") }};
 {% endif %}
-{% if monitoring_addr %}
-	Monitoring_Addr = {{ monitoring_addr }};
-{% endif %}
-        Monitoring_Port = {{ monitoring_port }};
 {% if enable_rdma and rdma_port %}
         NFS_RDMA_Port = {{ rdma_port }};
 {% endif %}
@@ -78,19 +80,19 @@ TLS_CONFIG{
         TLS_Cert_File = /etc/ganesha/tls/tls_cert.pem;
         TLS_Key_File = /etc/ganesha/tls/tls_key.pem;
         TLS_CA_File = /etc/ganesha/tls/tls_ca_cert.pem;
-	{% if tls_ciphers %}
+{% if tls_ciphers %}
         TLS_Ciphers = "{{ tls_ciphers }}";
-	{% endif %}
-	{% if tls_min_version %}
-        TLS_Min_Version = "{{ tls_min_version }}";
-	{% endif %}
-	{% if tls_ktls %}
-        Enable_KTLS = {{ tls_ktls }};
-	{% endif %}
-	{% if tls_debug %}
-        Enable_debug = {{ tls_debug }};
-	{% endif %}
-}
-
 {% endif %}
+{% if tls_min_version %}
+        TLS_Min_Version = "{{ tls_min_version }}";
+{% endif %}
+{% if tls_ktls %}
+        Enable_KTLS = {{ tls_ktls }};
+{% endif %}
+{% if tls_debug %}
+        Enable_debug = {{ tls_debug }};
+{% endif %}
+}
+{% endif %}
+
 %url    {{ url }}

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -100,6 +100,37 @@ class TestNFS:
                 assert "Bind_addr = 1.2.3.7" in ganesha_conf
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_bind_addr_virtual_ip(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('host1', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.7']
+                }
+            })
+
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['host1']),
+                virtual_ip='1.2.3.100',
+                enable_haproxy_protocol=False
+            )
+
+            with with_service(cephadm_module, nfs_spec, status_running=True) as _:
+                dds = wait(cephadm_module, cephadm_module.list_daemons())
+                daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(dds[0])
+
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(daemon_spec)
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+
+                assert "Bind_addr = 1.2.3.100" in ganesha_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_ingress_without_haproxy_stats(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -170,6 +170,9 @@ class NFSCluster:
             tls_debug: bool = False,
             tls_min_version: Optional[str] = None,
             tls_ciphers: Optional[str] = None,
+            ip_addrs: Optional[Dict[str, str]] = None,
+            monitoring_ip_addrs: Optional[Dict[str, str]] = None,
+            monitoring_port: Optional[int] = None,
             enable_rdma: bool = False,
             rdma_port: Optional[int] = None,
     ) -> None:
@@ -216,6 +219,9 @@ class NFSCluster:
                                   tls_debug=tls_debug,
                                   tls_min_version=tls_min_version,
                                   tls_ciphers=tls_ciphers,
+                                  ip_addrs=ip_addrs,
+                                  monitoring_ip_addrs=monitoring_ip_addrs,
+                                  monitoring_port=monitoring_port,
                                   enable_rdma=enable_rdma,
                                   rdma_port=rdma_port)
             completion = self.mgr.apply_nfs(spec)
@@ -246,6 +252,9 @@ class NFSCluster:
                                   tls_debug=tls_debug,
                                   tls_min_version=tls_min_version,
                                   tls_ciphers=tls_ciphers,
+                                  ip_addrs=ip_addrs,
+                                  monitoring_ip_addrs=monitoring_ip_addrs,
+                                  monitoring_port=monitoring_port,
                                   enable_rdma=enable_rdma,
                                   rdma_port=rdma_port)
             completion = self.mgr.apply_nfs(spec)
@@ -281,6 +290,9 @@ class NFSCluster:
             tls_debug: bool = False,
             tls_min_version: Optional[str] = None,
             tls_ciphers: Optional[str] = None,
+            ip_addrs: Optional[Dict[str, str]] = None,
+            monitoring_ip_addrs: Optional[Dict[str, str]] = None,
+            monitoring_port: Optional[int] = None,
             enable_rdma: bool = False,
             rdma_port: Optional[int] = None,
     ) -> None:
@@ -322,6 +334,9 @@ class NFSCluster:
                     tls_debug=tls_debug,
                     tls_min_version=tls_min_version,
                     tls_ciphers=tls_ciphers,
+                    ip_addrs=ip_addrs,
+                    monitoring_ip_addrs=monitoring_ip_addrs,
+                    monitoring_port=monitoring_port,
                     enable_rdma=enable_rdma,
                     rdma_port=rdma_port
                 )
@@ -402,7 +417,6 @@ class NFSCluster:
                     if len(svc.ports) > 1:
                         monitor_port = svc.ports[1]
         except orchestrator.OrchestratorError:
-            # No ingress service found for this cluster
             log.debug(f"No ingress service found for NFS cluster {cluster_id}")
 
         # Build backend list with daemon information
@@ -412,17 +426,13 @@ class NFSCluster:
                 continue
 
             try:
-                # Resolve daemon IP
                 if daemon.ip:
                     ip = daemon.ip
                 elif daemon.hostname in hosts_map:
-                    # Use cached host data
                     ip = resolve_ip(hosts_map[daemon.hostname].addr)
                 else:
-                    # Fallback to hostname resolution
                     ip = resolve_ip(daemon.hostname)
 
-                # Get daemon status
                 status = orchestrator.DaemonDescriptionStatus.to_str(daemon.status)
 
                 backends.append({
@@ -437,14 +447,11 @@ class NFSCluster:
                     f" on {daemon.hostname} in cluster {cluster_id}")
                 continue
 
-        # Sort backends by hostname for consistent output
         backends.sort(key=lambda x: x["hostname"])
 
-        # Determine deployment type based on ingress configuration and actual daemon count
         deployment_type = "standalone"
         placement = None
 
-        # Get NFS service spec for placement information first
         nfs_sc = self.mgr.describe_service(
             service_type='nfs',
             service_name=f'nfs.{cluster_id}'
@@ -456,17 +463,13 @@ class NFSCluster:
                 break
 
         if ingress_mode:
-            # Determine deployment type from placement spec (source of truth)
-            # Note: Using placement.count instead of len(backends) to avoid race conditions
             if placement and placement.count and placement.count > 1:
                 deployment_type = "active-active"
             elif len(backends) > 1:
-                # Fallback to actual daemon count if placement.count not set
                 deployment_type = "active-active"
             else:
                 deployment_type = "active-passive"
 
-        # Build result dictionary
         r: Dict[str, Any] = {
             'deployment_type': deployment_type,
             'virtual_ip': virtual_ip,
@@ -474,7 +477,6 @@ class NFSCluster:
             'placement': placement.to_json() if placement else {},
         }
 
-        # Add ingress configuration to result
         if ingress_mode:
             r['ingress_mode'] = ingress_mode.value
         if ingress_port is not None:

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -162,6 +162,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                 virtual_ip: Optional[str] = None,
                                 ingress_mode: Optional[IngressType] = None,
                                 port: Optional[int] = None,
+                                bind_addrs: Optional[str] = None,
+                                monitoring_addrs: Optional[str] = None,
+                                monitoring_port: Optional[int] = None,
                                 enable_rdma: bool = False,
                                 rdma_port: Optional[int] = None,
                                 enable_nfsv3: bool = False,
@@ -182,11 +185,31 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             tls_debug = config.get('tls_debug')
             tls_ciphers = config.get('tls_ciphers')
 
+        # Parse bind_addrs and monitoring_addrs from CLI format
+        ip_addrs = None
+        if bind_addrs:
+            ip_addrs = {}
+            for pair in bind_addrs.split(','):
+                if ':' in pair:
+                    host, ip = pair.split(':', 1)
+                    ip_addrs[host.strip()] = ip.strip()
+
+        monitoring_ip_addrs = None
+        if monitoring_addrs:
+            monitoring_ip_addrs = {}
+            for pair in monitoring_addrs.split(','):
+                if ':' in pair:
+                    host, ip = pair.split(':', 1)
+                    monitoring_ip_addrs[host.strip()] = ip.strip()
+
         return self.nfs.create_nfs_cluster(cluster_id=cluster_id, placement=placement,
                                            virtual_ip=virtual_ip, ingress=ingress,
                                            ingress_mode=ingress_mode, port=port,
                                            cluster_qos_config=cluster_qos_config,
                                            enable_nfsv3=enable_nfsv3,
+                                           ip_addrs=ip_addrs,
+                                           monitoring_ip_addrs=monitoring_ip_addrs,
+                                           monitoring_port=monitoring_port,
                                            ssl=ssl,
                                            ssl_cert=ssl_cert,
                                            ssl_key=ssl_key,


### PR DESCRIPTION
### **Problem**

When deploying multiple NFS services on the same host, Ganesha monitoring sockets can conflict if they bind to the same address and port.

While Cephadm already allowed configuring a unique monitoring_port per NFS service via the service spec, there was no supported way to configure the monitoring bind address (Monitoring_Addr) or the NFS bind address (Bind_addr) per host using Cephadm-managed configuration.

**As a result:**

- Multiple NFS daemons could not reliably coexist on the same host
- Manual edits to ganesha.conf were required
- These manual changes were lost on ceph orch redeploy or upgrades

fixes: https://tracker.ceph.com/issues/74403
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

### **What This PR Fixes**

This PR enables spec- and CLI-driven configuration of per-host bind and monitoring addresses for NFS services, ensuring the configuration:

- Is rendered correctly in ganesha.conf
- Persists across redeploys and upgrades
- Requires no manual configuration

### **Key Changes**
**1. Per-host bind and monitoring addresses (spec + CLI)**

Cephadm already supports the following fields in NFSServiceSpec:

- ip_addrs (per-host bind address)
- monitoring_ip_addrs (per-host monitoring address)
- monitoring_port

This PR exposes and wires these fields end-to-end so they are correctly rendered into ganesha.conf.

Supported via:

Service spec (YAML):

`service_type: nfs
service_id: mynfs
placement:
  hosts:
    - ceph-node-00
spec:
  port: 2049
  monitoring_port: 9587
  ip_addrs:
    ceph-node-00: 10.0.0.100
  monitoring_ip_addrs:
    ceph-node-00: 127.0.0.60
`

CLI (ceph nfs cluster create):

`ceph nfs cluster create mynfs ceph-node-00 \
  --port 2049 \
  --bind-addrs ceph-node-00:10.0.0.100 \
  --monitoring-addrs ceph-node-00:127.0.0.60 \
  --monitoring-port 9587
`

**2. Correct Ganesha configuration rendering**

The Ganesha template has been updated so that:

- Monitoring_Addr and Monitoring_Port are rendered independently
- Both are placed inside NFS_CORE_PARAM, which is the only supported location for these options in Ganesha
- Unrelated parameters were removed from the monitoring logic

Updated template behavior:

`NFS_CORE_PARAM {
    Bind_addr = 10.0.0.100;
    Monitoring_Addr = 127.0.0.60;
    Monitoring_Port = 9587;
}
`
This allows users to set:

- only monitoring_port
- only monitoring_ip_addrs
- or both — without coupling or side effects


Before (Failure Scenario)

Two NFS services on the same host using the same monitoring port:

`service_type: nfs
service_id: mynfs1
spec:
  port: 2049
  monitoring_port: 9587

service_type: nfs
service_id: mynfs2
spec:
  port: 2050
  monitoring_port: 9587
`

Result:

Ganesha fails to start due to monitoring socket bind conflict

After (Working Configuration)

`service_type: nfs
service_id: mynfs2
placement:
  hosts: [ceph-node-00, ceph-node-01]
spec:
  port: 2050
  monitoring_port: 9587
  monitoring_ip_addrs:
    ceph-node-00: 127.0.0.2
    ceph-node-01: 127.0.0.3
  ip_addrs:
    ceph-node-00: 10.0.0.100
    ceph-node-01: 10.0.0.101
`

or via CLI:
`ceph nfs cluster create mynfs2 \
  --placement="ceph-node-00,ceph-node-01" \
  --port 2050 \
  --monitoring-port 9587 \
  --bind-addrs ceph-node-00:10.0.0.100,ceph-node-01:10.0.0.101 \
  --monitoring-addrs ceph-node-00:127.0.0.2,ceph-node-01:127.0.0.3
`

Persistence Across Redeploy

The configuration persists correctly across:

`ceph orch redeploy nfs.mynfs2
`

**Because:**

Values are stored in the NFS service spec

Cephadm regenerates ganesha.conf from the spec on every deploy

### **Note on Orchestrator CLI (ceph orch apply nfs)**

ceph orch apply nfs intentionally recreates a minimal service spec and does not preserve NFS-specific fields such as:

- ip_addrs
- monitoring_ip_addrs
- monitoring_port

This is expected behavior.

Services using bind or monitoring address customization must be managed using:

- ceph nfs cluster create
- ceph nfs cluster update
- or ceph orch apply -i <spec.yaml>

This PR does not change orchestrator semantics.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.



## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
