### PR TITLE
common: replace assert(false) with ceph_abort()

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -730,7 +730,7 @@ int block_device_get_metrics(const string& devname, int timeout,
 #include <sys/disk.h>
 
 const char *BlkDev::sysfsdir() const {
-  assert(false);  // Should never be called on Apple
+  ceph_abort(); // Should never be called on Apple
   return "";
 }
 
@@ -843,7 +843,7 @@ std::string get_device_path(const std::string& devname,
 #elif defined(__FreeBSD__)
 
 const char *BlkDev::sysfsdir() const {
-  assert(false);  // Should never be called on FreeBSD
+  ceph_abort(); // Should never be called on FreeBSD
   return "";
 }
 
@@ -1061,7 +1061,7 @@ int BlkDev::wholedisk(char *wd, size_t max) const
 #else
 
 const char *BlkDev::sysfsdir() const {
-  assert(false);  // Should never be called on non-Linux
+  ceph_abort(); // Should never be called on non-Linux
   return "";
 }
 

--- a/src/common/mclock_common.cc
+++ b/src/common/mclock_common.cc
@@ -133,7 +133,7 @@ const dmc::ClientInfo *ClientRegistry::get_info(
   const scheduler_id_t &id) const {
   switch (id.class_id) {
   case SchedulerClass::immediate:
-    ceph_assert(0 == "Cannot schedule immediate");
+    ceph_abort_msg("Cannot schedule immediate");
     return (dmc::ClientInfo*)nullptr;
   case SchedulerClass::client:
     return get_external_client(id.client_profile_id);

--- a/src/common/not_before_queue.h
+++ b/src/common/not_before_queue.h
@@ -272,7 +272,7 @@ public:
 	eligible_queue.erase(
 	  eligible_queue_t::s_iterator_to(std::as_const(*iter)));
       } else {
-	assert(0 == "impossible status");
+        ceph_abort_msg("invalid iter status for class removal");
       }
       iter->status = status_t::INVALID;
       removal_registry.erase_and_dispose(
@@ -312,7 +312,7 @@ public:
 	eligible_queue.erase(
 	    eligible_queue_t::s_iterator_to(std::as_const(*iter)));
       } else {
-	assert(0 == "impossible status");
+        ceph_abort_msg("invalid iter status for class removal");
       }
       iter->status = not_before_queue_t::status_t::INVALID;
       removal_registry.erase_and_dispose(

--- a/src/common/win32/blkdev.cc
+++ b/src/common/win32/blkdev.cc
@@ -37,7 +37,7 @@ int BlkDev::get_devid(dev_t *id) const
 }
 
 const char *BlkDev::sysfsdir() const {
-  assert(false);  // Should never be called on Windows
+  ceph_abort(); // Should never be called on Windows
   return "";
 }
 

--- a/src/dmclock/sim/src/sim_client.h
+++ b/src/dmclock/sim/src/sim_client.h
@@ -263,7 +263,7 @@ namespace crimson {
 	    } // for
 	    ops_count += i.args.req_params.count;
 	  } else {
-	    assert(false);
+            ceph_abort();
 	  }
 	} // for loop
 

--- a/src/dmclock/src/dmclock_server.h
+++ b/src/dmclock/src/dmclock_server.h
@@ -46,6 +46,7 @@
 #include "../support/src/run_every.h"
 #include "dmclock_util.h"
 #include "dmclock_recs.h"
+#include "include/ceph_assert.h"
 
 #ifdef PROFILE
 #include "profile.h"
@@ -1439,7 +1440,7 @@ namespace crimson {
 	  // to avoid nesting, break out and let code below handle this case
 	  break;
 	default:
-	  assert(false);
+          ceph_abort();
 	}
 
 	// we'll only get here if we're returning an entry
@@ -1477,7 +1478,7 @@ namespace crimson {
 	  ++this->prop_sched_count;
 	  break;
 	default:
-	  assert(false);
+          ceph_abort();
 	}
 
 #ifdef PROFILE
@@ -1710,7 +1711,7 @@ namespace crimson {
 	  ++this->prop_sched_count;
 	  break;
 	default:
-	  assert(false);
+          ceph_abort();
 	}
       } // submit_request
 
@@ -1750,7 +1751,7 @@ namespace crimson {
 	  submit_request(next_req.heap_id);
 	  break;
 	default:
-	  assert(false);
+          ceph_abort();
 	}
 	return next_req.type;
       }

--- a/src/json_spirit/json_spirit_reader_template.h
+++ b/src/json_spirit/json_spirit_reader_template.h
@@ -586,7 +586,7 @@ namespace json_spirit
 
         if( !info.hit )
         {
-            ceph_assert( false ); // in theory exception should already have been thrown
+            ceph_abort(); // in theory exception should already have been thrown
             throw_error( info.stop, "error" );
         }
 

--- a/src/json_spirit/json_spirit_writer_template.h
+++ b/src/json_spirit/json_spirit_writer_template.h
@@ -194,7 +194,7 @@ namespace json_spirit
                 case real_type:  output( value.get_real() );  break;
                 case int_type:   output_int( value );         break;
                 case null_type:  os_ << "null";               break;
-                default: ceph_assert( false );
+                default: ceph_abort();
             }
         }
 

--- a/src/librbd/cache/pwl/LogEntry.h
+++ b/src/librbd/cache/pwl/LogEntry.h
@@ -41,7 +41,7 @@ public:
     return false;
   }
   virtual void set_flushed(bool flushed) {
-    ceph_assert(false);
+    ceph_abort();
   }
   virtual unsigned int write_bytes() const {
     return 0;
@@ -54,11 +54,11 @@ public:
   }
   virtual void writeback(librbd::cache::ImageWritebackInterface &image_writeback,
                          Context *ctx) {
-    ceph_assert(false);
+    ceph_abort();
   };
   virtual void writeback_bl(librbd::cache::ImageWritebackInterface &image_writeback,
                  Context *ctx, ceph::bufferlist &&bl) {
-    ceph_assert(false);
+    ceph_abort();
   }
   virtual bool is_write_entry() const {
     return false;
@@ -261,7 +261,7 @@ public:
     return this->completed;
   }
   void copy_cache_bl(bufferlist *out_bl) override {
-    ceph_assert(false);
+    ceph_abort();
   }
   void writeback(librbd::cache::ImageWritebackInterface &image_writeback,
                  Context *ctx) override;

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -556,7 +556,7 @@ private:
     lderr(cct) << "unexpected state transition: "
                << "current_state=" << current_state << ", "
                << "next_state=" << next_state << dendl;
-    ceph_assert(false);
+    ceph_abort();
   }
 
   void complete_work(std::shared_ptr<Work> work, int r, Response&& response) {
@@ -945,7 +945,7 @@ void HttpClient<I>::create_http_session(Context* on_finish) {
     m_http_session = std::make_unique<SslHttpSession>(this);
     break;
   default:
-    ceph_assert(false);
+    ceph_abort();
     break;
   }
 

--- a/src/librbd/migration/QCOWFormat.cc
+++ b/src/librbd/migration/QCOWFormat.cc
@@ -408,7 +408,7 @@ private:
       l2_table->decode();
       *request.l2_table = l2_table;
     } else {
-      ceph_assert(false);
+      ceph_abort();
     }
 
     // complete the L2 cache request

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -395,7 +395,7 @@ bool Locker::acquire_locks(const MDRequestRef& mdr,
 	mustpin.insert(object);
       }
     } else {
-      ceph_assert(0 == "locker unknown lock operation");
+      ceph_abort_msg("locker unknown lock operation");
     }
   }
 
@@ -1207,7 +1207,7 @@ void Locker::create_lock_cache(const MDRequestRef& mdr, CInode *diri, file_layou
     } else if (CDentry *dn = dynamic_cast<CDentry*>(p.first)) {
 	dfv.push_back(dn->get_dir());
     } else {
-      ceph_assert(0 == "unknown type of lock parent");
+      ceph_abort_msg("unknown type of lock parent");
     }
   }
   lock_cache->attach_dirfrags(std::move(dfv));

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -102,7 +102,7 @@ int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
     dir->auth_pin(this);
     dir->scrub_initialize(header);
   } else {
-    ceph_assert(0 == "queue dentry to scrub stack");
+    ceph_abort_msg("queue dentry to scrub stack");
   }
 
   dout(20) << "enqueue " << *obj << " to " << (top ? "top" : "bottom") << " of ScrubStack" << dendl;
@@ -320,7 +320,7 @@ void ScrubStack::kick_off_scrubs()
 	it = next;
       }
     } else {
-      ceph_assert(0 == "dentry in scrub stack");
+      ceph_abort_msg("dentry in scrub stack");
     }
   }
 }

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -209,7 +209,7 @@ void SnapServer::_get_reply_buffer(version_t tid, bufferlist *pbl) const
       encode(last_snap, *pbl);
     return;
   }
-  assert (0 == "tid not found");
+  ceph_abort_msg("tid not found");
 }
 
 void SnapServer::_commit(version_t tid, cref_t<MMDSTableRequest> req)

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -790,7 +790,7 @@ void EMetaBlob::remotebit::dump(Formatter *f) const
   case S_IFSOCK:
     type_string = "sock"; break;
   default:
-    assert (0 == "unknown d_type!");
+    ceph_abort_msg("unknown d_type");
   }
   f->dump_string("d_type", type_string);
   f->dump_string("dirty", dirty ? "true" : "false");

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -245,7 +245,7 @@ void ElectionLogic::receive_propose(int from, epoch_t mepoch,
     propose_connectivity_handler(from, mepoch, ct);
     break;
   default:
-    ceph_assert(0 == "how did election strategy become an invalid value?");
+    ceph_abort_msg("election strategy became an invalid value");
   }
 }
 
@@ -532,7 +532,7 @@ bool ElectionLogic::victory_makes_sense(int from)
     makes_sense = (leader_score >= my_score);
     break;
   default:
-    ceph_assert(0 == "how did you get a nonsense election strategy assigned?");
+    ceph_abort_msg("election strategy became an invalid value");
   }
   return makes_sense;
 }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6917,7 +6917,7 @@ void Monitor::go_recovery_stretch_mode()
   dout(20) << "dead_mon_buckets.size(): " << dead_mon_buckets.size() << dendl;
   dout(20) << "dead_mon_buckets: " << dead_mon_buckets << dendl;
   if (dead_mon_buckets.size()) {
-    ceph_assert( 0 == "how did we try and do stretch recovery while we have dead monitor buckets?");
+    ceph_abort_msg("attempted stretch recovery while dead monitor buckets exist");
     // we can't recover if we are missing monitors in a zone!
     return;
   }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -12411,7 +12411,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       else if (prefix.find("noout") != string::npos)
         flags = CEPH_OSD_NOOUT;
       else
-        ceph_assert(0 == "Unreachable!");
+        ceph_abort_msgf("unhandled OSD flag command: %s", prefix.c_str());
     }
     if (flags == 0) {
       ss << "must specify flag(s) {noup,nodwon,noin,noout} to set/unset";
@@ -12598,7 +12598,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       osd = -1;
     }
     else {
-      ceph_assert(0 == "Unreachable!");
+      ceph_abort_msgf("unhandled primary-temp command: %s", prefix.c_str());
     }
 
     if (osdmap.require_min_compat_client != ceph_release_t::unknown &&

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -987,7 +987,7 @@ CtPtr ProtocolV1::handle_message_footer(char *buffer, int r) {
     message->put();
     if (connection->has_feature(CEPH_FEATURE_RECONNECT_SEQ) &&
         cct->_conf->ms_die_on_old_message) {
-      ceph_assert(0 == "old msgs despite reconnect_seq feature");
+      ceph_abort_msg("old msgs despite reconnect_seq feature");
     }
     return nullptr;
   }
@@ -995,7 +995,7 @@ CtPtr ProtocolV1::handle_message_footer(char *buffer, int r) {
     ldout(cct, 0) << __func__ << " missed message?  skipped from seq "
                   << cur_seq << " to " << message->get_seq() << dendl;
     if (cct->_conf->ms_die_on_skipped_message) {
-      ceph_assert(0 == "skipped incoming seq");
+      ceph_abort_msg("skipped incoming seq");
     }
   }
 

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1474,7 +1474,7 @@ CtPtr ProtocolV2::handle_message() {
     message->put();
     if (connection->has_feature(CEPH_FEATURE_RECONNECT_SEQ) &&
         cct->_conf->ms_die_on_old_message) {
-      ceph_assert(0 == "old msgs despite reconnect_seq feature");
+      ceph_abort_msg("old msgs despite reconnect_seq feature");
     }
     return nullptr;
   }
@@ -1482,7 +1482,7 @@ CtPtr ProtocolV2::handle_message() {
     ldout(cct, 0) << __func__ << " missed message?  skipped from seq "
                   << cur_seq << " to " << message->get_seq() << dendl;
     if (cct->_conf->ms_die_on_skipped_message) {
-      ceph_assert(0 == "skipped incoming seq");
+      ceph_abort_msg("skipped incoming seq");
     }
   }
 
@@ -2560,7 +2560,7 @@ CtPtr ProtocolV2::handle_reconnect(ceph::bufferlist &payload)
   ProtocolV2 *exproto = dynamic_cast<ProtocolV2 *>(existing->protocol.get());
   if (!exproto) {
     ldout(cct, 1) << __func__ << " existing=" << existing << dendl;
-    ceph_assert(false);
+    ceph_abort();
   }
 
   if (exproto->state == CLOSED) {
@@ -2664,7 +2664,7 @@ CtPtr ProtocolV2::handle_existing_connection(const AsyncConnectionRef& existing)
   ProtocolV2 *exproto = dynamic_cast<ProtocolV2 *>(existing->protocol.get());
   if (!exproto) {
     ldout(cct, 1) << __func__ << " existing=" << existing << dendl;
-    ceph_assert(false);
+    ceph_abort();
   }
 
   if (exproto->state == CLOSED) {

--- a/src/msg/async/dpdk/DPDK.cc
+++ b/src/msg/async/dpdk/DPDK.cc
@@ -1366,7 +1366,7 @@ std::unique_ptr<DPDKDevice> create_dpdk_net_device(
 {
   // Check that we have at least one DPDK-able port
   if (rte_eth_dev_count_avail() == 0) {
-    ceph_assert(false && "No Ethernet ports - bye\n");
+    ceph_abort_msg("no ethernet ports available");
   } else {
     ldout(cct, 10) << __func__ << " ports number: " << int(rte_eth_dev_count_avail()) << dendl;
   }

--- a/src/msg/async/dpdk/DPDK.h
+++ b/src/msg/async/dpdk/DPDK.h
@@ -819,7 +819,7 @@ class DPDKDevice {
     /* now initialise the port we will use */
     int ret = init_port_start();
     if (ret != 0) {
-      ceph_assert(false && "Cannot initialise port\n");
+      ceph_abort_msg("cannot initialise port");
     }
     std::string name(std::string("port") + std::to_string(port_idx));
     PerfCountersBuilder plb(cct, name, l_dpdk_dev_first, l_dpdk_dev_last);

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -229,7 +229,7 @@ private:
   virtual void _spillover_range(uint64_t start, uint64_t end) {
     // this should be overriden when range count cap is present,
     // i.e. (range_count_cap > 0)
-    ceph_assert(false);
+    ceph_abort();
   }
   // to be overriden by Hybrid wrapper
   virtual uint64_t _get_spilled_over() const {
@@ -242,7 +242,7 @@ private:
                                       PExtentVector* extents) {
     // this should be overriden when range count cap is present,
     // i.e. (range_count_cap > 0)
-    ceph_assert(false);
+    ceph_abort();
     return 0;
   }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -523,7 +523,7 @@ int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
       dev_name = "slow";
       break;
     default:
-      ceph_assert(false);
+      ceph_abort();
   }
   dout(10) << __func__ << " bdev " << id << " path " << path << " "
            << dendl;
@@ -658,7 +658,7 @@ uint64_t BlueFS::_get_minimal_reserved(unsigned id) const
       reserved = 0;
       break;
     default:
-      ceph_assert(false);
+      ceph_abort();
   }
   return reserved;
 }
@@ -1245,7 +1245,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       REMOVE_WAL,
       layout);
   } else {
-    ceph_assert(false);
+    ceph_abort();
   }
   return 0;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7281,7 +7281,7 @@ int BlueStore::_open_fm(KeyValueDB::Transaction t,
           << std::dec << dendl;
   if (!fm->validate(min_alloc_size)) {
     derr << __func__ << " freelist validation failed, unable to proceed." << dendl;
-    ceph_assert(false);
+    ceph_abort();
   }
   // if space size tracked by free list manager is that higher than actual
   // dev size one can hit out-of-space allocation which will result

--- a/src/os/bluestore/Btree2Allocator.cc
+++ b/src/os/bluestore/Btree2Allocator.cc
@@ -399,7 +399,7 @@ found:
     return allocated;
   }
   // should never get here
-  ceph_assert(false);
+  ceph_abort();
   return -EFAULT;
 }
 

--- a/src/os/bluestore/Btree2Allocator.h
+++ b/src/os/bluestore/Btree2Allocator.h
@@ -239,7 +239,7 @@ protected:
   virtual void _spillover_range(uint64_t start, uint64_t end) {
     // this should be overriden when range count cap is present,
     // i.e. (range_count_cap > 0)
-    ceph_assert(false);
+    ceph_abort();
   }
   // to be overriden by Hybrid wrapper
   virtual uint64_t _get_spilled_over() const {
@@ -252,7 +252,7 @@ protected:
     PExtentVector* extents) {
     // this should be overriden when range count cap is present,
     // i.e. (range_count_cap > 0)
-    ceph_assert(false);
+    ceph_abort();
     return 0;
   }
 

--- a/src/os/bluestore/Compression.cc
+++ b/src/os/bluestore/Compression.cc
@@ -543,7 +543,7 @@ void Scan::candidate(const Extent* e)
       derr << "candidate blob not scanned before! " << h_Blob->print(P::NICK + P::SUSE) << dendl;
       // This blob was seen, but removed as completely consumed?
       // Is it even possible?
-      ceph_assert(false);
+      ceph_abort();
     }
   } else {
     // not compressed

--- a/src/os/bluestore/HybridAllocator_impl.h
+++ b/src/os/bluestore/HybridAllocator_impl.h
@@ -100,7 +100,7 @@ void HybridAllocatorBase<T>::init_rm_free(uint64_t offset, uint64_t length)
             << "Uexpected extent: "
             << " 0x" << o << "~" << l
             << std::dec << dendl;
-          ceph_assert(false);
+          ceph_abort();
         }
       }
     });

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -1141,7 +1141,7 @@ std::ostream &operator<<(std::ostream &out, const log_entry_t &rhs) {
   case COMPLETE: out << "COMPLETE";
     break;
   default:
-    ceph_assert(false);
+    ceph_abort();
   }
   return out << "[" << rhs.shard << "]->" << rhs.io << "\n";
 }

--- a/src/osd/HitSet.cc
+++ b/src/osd/HitSet.cc
@@ -43,7 +43,7 @@ HitSet::HitSet(const HitSet::Params& params)
     break;
 
   default:
-    assert (0 == "unknown HitSet type");
+    ceph_abort_msg("unknown HitSet type");
   }
 }
 

--- a/src/osd/MissingLoc.h
+++ b/src/osd/MissingLoc.h
@@ -239,7 +239,7 @@ class MissingLoc {
 	  lgeneric_dout(cct, 0) << this << " " << pgid << " unexpected need for "
 				<< i->first << " have " << j->second
 				<< " tried to add " << i->second << dendl;
-	  ceph_assert(0 == "unexpected need for missing item");
+          ceph_abort_msg("unexpected need for missing item");
 	}
       }
     }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3829,7 +3829,7 @@ ceph_tid_t PrimaryLogPG::refcount_manifest(hobject_t src_soid, hobject_t tgt_soi
     ::encode(get_call, in);
     obj_op.call("cas", "chunk_create_or_get_ref", in);
   } else {
-    ceph_assert(0 == "unrecognized type");
+    ceph_abort_msg("unrecognized type");
   }
 
   Context *c = nullptr;
@@ -10760,7 +10760,7 @@ std::pair<int, hobject_t> PrimaryLogPG::get_fpoid_from_chunk(
       case pg_pool_t::TYPE_FINGERPRINT_SHA512:
 	return ceph::crypto::digest<ceph::crypto::SHA512>(chunk).to_str();
       default:
-	ceph_assert(0 == "unrecognized fingerprint type");
+        ceph_abort_msg("unrecognized fingerprint type");
 	return {};
     }
   }();    

--- a/src/osd/scheduler/OpScheduler.h
+++ b/src/osd/scheduler/OpScheduler.h
@@ -59,7 +59,7 @@ public:
   virtual op_queue_type_t get_type() const = 0;
 
   virtual double get_cost_per_io() const {
-    ceph_assert(0 == "impossible for wpq");
+    ceph_abort_msg("impossible for wpq");
     return 0.0;
   }
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -934,9 +934,9 @@ std::optional<uint64_t> PgScrubber::select_range()
       candidate_end = back;
       objects.pop_back();
       if (objects.empty()) {
-	ceph_assert(0 ==
-		    "Somehow we got more than 2 objects which"
-		    "have the same head but are not clones");
+        ceph_abort_msg(
+            "There are more than 2 objects which have the same head but are "
+            "not clones");
       }
       back = objects.back();
     }

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -413,7 +413,7 @@ class PgScrubber : public ScrubPgIF,
   void stats_of_handled_objects(const object_stat_sum_t& delta_stats,
 				const hobject_t& soid) override
   {
-    ceph_assert(false);
+    ceph_abort();
   }
 
   /**

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -88,7 +88,7 @@ public:
 	return r;
     }
     static void Free(void *p) {
-	ceph_assert(0 == "Free should not be called");
+	ceph_abort_msg("Free should not be called");
     }
 private:
     //! Copy constructor is not permitted.

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -617,7 +617,7 @@ struct seastore_test_t :
       case type_t::NORMAL:
 	return make_oid(index);
       default:
-	assert(0 == "impossible");
+        ceph_abort_msg("unhandled oid type");
 	return ghobject_t();
       }
     }

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -296,7 +296,7 @@ static seastar::future<> test_echo(unsigned rounds,
       PingSessionRef find_session(crimson::net::Connection *c) {
         auto found = sessions.find(c);
         if (found == sessions.end()) {
-          ceph_assert(false);
+          ceph_abort();
         }
         return found->second;
       }

--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -426,7 +426,7 @@ int KvStoreBench::test_teuthology_aio(next_gen_t distr,
       break;
     default:
       // shouldn't happen here
-      assert(false);
+      ceph_abort();
     }
 
   }

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -136,7 +136,7 @@ void check_fp_oid_refcount(librados::IoCtx& ioctx, std::string foid, uint64_t co
   } else if (fp_algo.empty()) {
     ioctx.getxattr(foid, CHUNK_REFCOUNT_ATTR, t);
   } else if (!fp_algo.empty()) {
-    ceph_assert(0 == "unrecognized fingerprint algorithm");
+    ceph_abort_msg("unrecognized fingerprint algorithm");
   }
 
   chunk_refs_t refs;
@@ -182,7 +182,7 @@ void is_intended_refcount_state(librados::IoCtx& src_ioctx,
       auto iter = t.cbegin();
       decode(refs, iter);
     } catch (buffer::error& err) {
-      ceph_assert(0);
+      ceph_abort();
     }
     dst_refcount = refs.count();
   }

--- a/src/test/librbd/migration/test_mock_HttpClient.cc
+++ b/src/test/librbd/migration/test_mock_HttpClient.cc
@@ -120,7 +120,7 @@ public:
       sstream << "https://localhost";
       break;
     default:
-      ceph_assert(false);
+      ceph_abort();
       break;
     }
 

--- a/src/tools/ceph_dedup/ceph_dedup_daemon.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_daemon.cc
@@ -562,7 +562,7 @@ std::string SampleDedupWorkerThread::generate_fingerprint(const bufferlist& chun
       ret = crypto::digest<crypto::SHA512>(chunk_data).to_str();
       break;
     default:
-      ceph_assert(0 == "Invalid fp type");
+      ceph_abort_msg("invalid fp type");
       break;
   }
   return ret;

--- a/src/tools/ceph_dedup/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_tool.cc
@@ -47,7 +47,7 @@ struct EstimateResult {
       sha512_digest_t sha512_val = crypto::digest<crypto::SHA512>(chunk);
       fp = sha512_val.to_str();
     } else {
-      ceph_assert(0 == "no support fingerperint algorithm");
+      ceph_abort_msg("unsupported fingerprint algorithm");
     }
 
     std::lock_guard l(lock);
@@ -951,7 +951,7 @@ int make_dedup_object(const po::variables_map &opts)
       } else if (fp_algo == "sha512") {
         return ceph::crypto::digest<ceph::crypto::SHA512>(bl).to_str();
       } else {
-        assert(0 == "unrecognized fingerprint type");
+        ceph_abort_msg("unrecognized fingerprint type");
         return {};
       }
     }();

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -295,7 +295,7 @@ int do_bench(librbd::Image& image, io_type_t io_type,
     std::cout << "full sequential";
     break;
   default:
-    ceph_assert(false);
+    ceph_abort();
     break;
   }
   std::cout << std::endl;

--- a/src/tools/rbd/action/Perf.cc
+++ b/src/tools/rbd/action/Perf.cc
@@ -235,7 +235,7 @@ void format_stat(StatDescriptor stat_descriptor, double stat,
     }
     break;
   default:
-    ceph_assert(false);
+    ceph_abort();
     break;
   }
 }
@@ -290,7 +290,7 @@ void format(const ImageStats& image_stats, Formatter* f, bool global_search) {
         title = "RD_LAT ";
         break;
       default:
-        ceph_assert(false);
+        ceph_abort();
         break;
       }
       tbl.define_column(title, TextTable::RIGHT, TextTable::RIGHT);
@@ -439,7 +439,7 @@ private:
         title = "READ LAT";
         break;
       default:
-        ceph_assert(false);
+        ceph_abort();
         break;
       }
       m_columns[pair.first] = (title);

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
@@ -695,7 +695,7 @@ void Replayer<I>::scan_remote_mirror_snapshots(
         }
       } else {
         // should not have been able to reach this
-        ceph_assert(false);
+        ceph_abort();
       }
     } else if (!mirror_ns->is_primary()) {
       dout(15) << "skipping non-primary remote snapshot" << dendl;

--- a/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.cc
@@ -71,7 +71,7 @@ image_sync::SyncPointHandler* StateBuilder<I>::create_sync_point_handler() {
   dout(10) << dendl;
 
   // TODO
-  ceph_assert(false);
+  ceph_abort();
   return nullptr;
 }
 


### PR DESCRIPTION
Throughout the code base instances of `assert(false)`, `ceph_assert(0 == ...`, etc have been used when `ceph_abort` or `ceph_abort_msg(...)` should hav ebeen used. This was done throughout the codebase excluding `src/crimson`.

Fixes: https://tracker.ceph.com/issues/71405
Signed-off-by: Zack Chaffee zachaffee@gmail.com





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
