### PR TITLE
tentacle: mgr/cephadm: add rbd_with_crc32c parameter to nvmeof service spec

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -110,6 +110,7 @@ transports = {{ spec.transports }}
 transport_tcp_options = {{ transport_tcp_options }}
 {% endif %}
 enable_dsa_acceleration = {{ spec.enable_dsa_acceleration }}
+rbd_with_crc32c = {{ spec.rbd_with_crc32c }}
 {% if spec.tgt_cmd_extra_args %}
 tgt_cmd_extra_args = {{ spec.tgt_cmd_extra_args }}
 {% endif %}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -434,6 +434,7 @@ conn_retries = 10
 transports = tcp
 transport_tcp_options = {{"in_capsule_data_size": 8192, "max_io_qpairs_per_ctrlr": 7}}
 enable_dsa_acceleration = False
+rbd_with_crc32c = False
 tgt_cmd_extra_args = {tgt_cmd_extra_args}
 qos_timeslice_in_usecs = 0
 notifications_interval = 60

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1442,6 +1442,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  transport_tcp_options: Optional[Dict[str, int]] =
                  {"in_capsule_data_size": 8192, "max_io_qpairs_per_ctrlr": 7},
                  enable_dsa_acceleration: bool = False,
+                 rbd_with_crc32c: bool = False,
                  tgt_cmd_extra_args: Optional[str] = None,
                  iobuf_options: Optional[Dict[str, int]] = None,
                  qos_timeslice_in_usecs: Optional[int] = 0,
@@ -1618,6 +1619,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.transport_tcp_options: Optional[Dict[str, int]] = transport_tcp_options
         #: ``enable_dsa_acceleration`` enable  dsa acceleration
         self.enable_dsa_acceleration = enable_dsa_acceleration
+        #: ``rbd_with_crc32c`` enable RBD CRC32C checksum reuse optimization
+        self.rbd_with_crc32c = rbd_with_crc32c
         #: ``tgt_cmd_extra_args`` extra arguments for the nvmf_tgt process
         self.tgt_cmd_extra_args = tgt_cmd_extra_args
         #: List of extra arguments for SPDK iobuf in the form opt=value
@@ -1781,6 +1784,8 @@ class NvmeofServiceSpec(ServiceSpec):
         verify_boolean(self.log_files_rotation_enabled, "Log files rotation enabled")
         verify_boolean(self.verbose_log_messages, "Verbose log messages")
         verify_boolean(self.enable_monitor_client, "Enable monitor client")
+        verify_boolean(self.enable_dsa_acceleration, "Enable DSA acceleration")
+        verify_boolean(self.rbd_with_crc32c, "Enable RBD CRC32C checksum reuse")
         verify_positive_int(self.spdk_mem_size, "SPDK memory size")
         verify_positive_int(self.spdk_huge_pages, "SPDK huge pages count")
         if self.spdk_mem_size and self.spdk_huge_pages:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74408

---

backport of https://github.com/ceph/ceph/pull/66425
parent tracker: https://tracker.ceph.com/issues/74406

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh