### PR TITLE
tools/rados: Remove plain text snippets from rados bench JSON output

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -333,13 +333,14 @@ int ObjBencher::aio_bench(
     }
 
     data.start_time = mono_clock::now();
-    out(cout) << "Cleaning up (deleting benchmark objects)" << std::endl;
+    out(cerr) << "Cleaning up (deleting benchmark objects)" << std::endl;
 
     r = clean_up(num_objects, prev_pid, concurrentios);
     if (r != 0) goto out;
 
     timePassed = mono_clock::now() - data.start_time;
-    out(cout) << "Clean up completed and total clean up time :" << timePassed.count() << std::endl;
+    out(cerr) << "Clean up completed and total clean up time :"
+              << timePassed.count() << std::endl;
 
     // lastrun file
     r = sync_remove(run_name_meta);
@@ -1244,7 +1245,8 @@ int ObjBencher::clean_up(int num_objects, int prevPid, int concurrentios) {
 
   completions_done();
 
-  out(cout) << "Removed " << data.finished << " object" << (data.finished != 1 ? "s" : "") << std::endl;
+  out(cerr) << "Removed " << data.finished << " object"
+            << (data.finished != 1 ? "s" : "") << std::endl;
 
   return 0;
 
@@ -1431,7 +1433,8 @@ int ObjBencher::clean_up_slow(const std::string& prefix, int concurrentios) {
 
   completions_done();
 
-  out(cout) << "Removed " << data.finished << " object" << (data.finished != 1 ? "s" : "") << std::endl;
+  out(cerr) << "Removed " << data.finished << " object"
+            << (data.finished != 1 ? "s" : "") << std::endl;
 
   return 0;
 

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3434,7 +3434,6 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       object_size = op_size;
     else if (object_size < op_size)
       op_size = object_size;
-    cout << "hints = " << (int)hints << std::endl;
     ret = bencher.aio_bench(operation, seconds,
 			    concurrent_ios, op_size, object_size,
 			    max_objects, cleanup, hints, run_name, reuse_bench, no_verify);


### PR DESCRIPTION
`rados bench` emits performance stats as its output. It is very helpful for this output to be in a machine-readable format and the CLI provides the `--format=json` flag to achieve this.

There are some logs that do not respect the formatter flag though, as they provide status updates as the tool is running and do not form part of the output dataset. This prevents the contents of stdout from being valid JSON which destroys the machine-readability of the output.

To resolve this we gate those status messages behind a check for the formatter. If any specific formatter is provided we do not emit the status logs. This leaves the plaintext output largely untouched while helping the machine-readable output to be well-formed.

Below is a "diff" of the output (sort of hand constructed from an actual diff because obviously all the numbers etc also changed, also ignore the trailing "added" whitespace, apparently github won't format a diff as such if there are only lines removed):

<details>
<summary>Plain-text output</summary>

```diff
  $ rados -p tp bench 5 write
  2026-01-15T16:08:38.887+0000 7f6c8bf0a100 -1 WARNING: all dangerous and experimental features are enabled.
  2026-01-15T16:08:38.891+0000 7f6c8bf0a100 -1 WARNING: all dangerous and experimental features are enabled.
  2026-01-15T16:08:38.892+0000 7f6c8bf0a100 -1 WARNING: all dangerous and experimental features are enabled.
- hints = 1
  Object prefix: benchmark_data_foo
    sec Cur ops   started  finished  avg MB/s  cur MB/s last lat(s)  avg lat(s)
      0       0         0         0         0         0           -           0
      1      16        73        57   227.958       228    0.251027    0.251335
      2      16       135       119   237.963       248    0.182117    0.249729
      3      16       207       191   254.628       288    0.163453    0.244034
      4      16       268       252   251.963       244    0.198276    0.246531
      5      16       334       318   254.362       264    0.200861    0.244526
  Total time run:         5.13436
  Total writes made:      334
  Write size:             4194304
  Object size:            4194304
  Bandwidth (MB/sec):     260.208
  Stddev Bandwidth:       22.7332
  Max bandwidth (MB/sec): 288
  Min bandwidth (MB/sec): 228
  Average IOPS:           65
  Stddev IOPS:            5.68331
  Max IOPS:               72
  Min IOPS:               57
  Average Latency(s):     0.243039
  Stddev Latency(s):      0.0447988
  Max latency(s):         0.444701
  Min latency(s):         0.0928305
  Cleaning up (deleting benchmark objects)
  Removed 334 objects
  Clean up completed and total clean up time :0.436406
+
```
</details>

<details>
<summary>JSON output</summary>

```diff
$ rados -p tp --format=json bench 5 write
  2026-01-15T16:08:51.563+0000 7f714069e100 -1 WARNING: all dangerous and experimental features are enabled.
  2026-01-15T16:08:51.568+0000 7f714069e100 -1 WARNING: all dangerous and experimental features are enabled.
  2026-01-15T16:08:51.568+0000 7f714069e100 -1 WARNING: all dangerous and experimental features are enabled.
- hints = 1
- {"concurrent_ios":"16","object_size":"4194304","op_size":"4194304","seconds_to_run":"5","max_objects":"0","object_prefix":"benchmark_data_foo","datas":[<snip so it formats properly> {"sec":"5","cur_ops":"16","started":"327","finished":"311","avg_bw":"248.769687","cur_bw":"228.000000","last_lat":"0.272882","avg_lat":"0.247997"}Cleaning up (deleting benchmark objects)
- Removed 327 objects
- Clean up completed and total clean up time :0.48125
- ],"total_time_run":"5.138616","total_writes_made":"327","write_size":"4194304","object_size":"4194304","bandwidth":"254.543228","stddev_bandwidth":"19.879638","max_bandwidth":"280.000000","min_bandwidth":"228.000000","average_iops":"63","stddev_iops":"-1371919792","max_iops":"70","min_iops":"57","average_latency":"0.248902","stddev_latency":"0.045634","max_latency":"0.389138","min_latency":"0.126813"}
+{"concurrent_ios":"16","object_size":"4194304","op_size":"4194304","seconds_to_run":"5","max_objects":"0","object_prefix":"benchmark_data_foo","datas":[{"sec":"0","cur_ops":"0","started":"0","finished":"0","avg_bw":"0.000000","cur_bw":"0.000000","last_lat":"0.000000","avg_lat":"0.000000"},     <snip, because if the line is too long github won't highlight it properly>    ],"total_time_run":"5.112553","total_writes_made":"307","write_size":"4194304","object_size":"4194304","bandwidth":"240.193125","stddev_bandwidth":"11.798305","max_bandwidth":"252.000000","min_bandwidth":"220.000000","average_iops":"60","stddev_iops":"35310160","max_iops":"63","min_iops":"55","average_latency":"0.265146","stddev_latency":"0.056829","max_latency":"0.393825","min_latency":"0.102045"}

```
</details>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
