### PR TITLE
[RFC] add audit logging APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,11 @@ if(WITH_LIBCEPHSQLITE)
   find_package(SQLite3 REQUIRED)
 endif()
 
+option(WITH_AUDITLOGGING "audit logging" ON)
+if (WITH_AUDITLOGGING AND NOT WITH_LIBCEPHSQLITE)
+  message(FATAL_ERROR "Cannot have WITH_AUDITLOGGING without WITH_LIBCEPHSQLITE")
+endif()
+
 # key-value store
 option(WITH_KVS "Key value store is here" OFF)
 

--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -386,6 +386,8 @@ values to their defaults or to a level suitable for normal operations.
 +--------------------------+-----------+--------------+
 | ``trace``                |     1     |      5       |
 +--------------------------+-----------+--------------+
+| ``audit_logging``        |     0     |      5       |
++--------------------------+-----------+--------------+
 
 
 Logging and Debugging Settings

--- a/qa/suites/rados/basic/tasks/auditdb.yaml
+++ b/qa/suites/rados/basic/tasks/auditdb.yaml
@@ -1,0 +1,20 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        debug ms: 1
+        debug client: 20
+        debug cephsqlite: 20
+        debug audit_logging: 20
+    log-ignorelist:
+    - POOL_APP_NOT_ENABLED
+    - do not have an application enabled
+    - application not enabled
+    - or freeform for custom applications
+tasks:
+- exec:
+   client.0:
+   - ceph auth get-or-create client.auditdb mon 'allow r, allow command "osd pool create", allow command "osd pool application enable"' osd 'allow rwx pool=.test_audit_db' >> /etc/ceph/ceph.keyring
+- exec:
+   client.0:
+   - ceph_test_audit_db --id auditdb --no-log-to-stderr

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -993,6 +993,12 @@ if(WITH_LIBCEPHSQLITE)
   install(TARGETS cephsqlite DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(WITH_LIBCEPHSQLITE)
 
+if (WITH_LIBCEPHSQLITE)
+  add_library(audit_db STATIC common/AuditDB.cc)
+  target_link_libraries(audit_db PRIVATE cephsqlite ceph-common librados SQLite3::SQLite3)
+  target_compile_definitions(audit_db PUBLIC WITH_LIBCEPHSQLITE)
+endif()
+
 if(WITH_FUSE)
   set(ceph_fuse_srcs
     ceph_fuse.cc

--- a/src/common/AuditDB.cc
+++ b/src/common/AuditDB.cc
@@ -1,0 +1,1059 @@
+#include <expected>
+#include <mutex>
+#include <optional>
+#include <regex>
+#include <string>
+#include <vector>
+
+#include "common/debug.h"
+
+#include "common/ceph_context.h"
+#include "common/ceph_mutex.h"
+#include "include/rados/librados.hpp"
+
+#include "AuditDB.h"
+
+#define dout_subsys ceph_subsys_audit_logging
+#define adout(cct, lvl) ldout((cct), (lvl)) << "audit_logging: " << __func__ << ": "
+#define aderr(cct) lderr((cct)) << "audit_logging: " << __func__ << ": "
+
+namespace {
+enum class PreparePhase : std::uint8_t {
+  Insert,
+  InsertAutoSeq,
+  Update
+};
+
+std::once_flag sqlite_vfs_init_flag;
+
+const char*
+flag_to_op(int flags)
+{
+  if (flags & SQLITE_OPEN_READONLY)
+    return "read";
+  if ((flags & SQLITE_OPEN_READWRITE) && (flags & SQLITE_OPEN_CREATE))
+    return "create";
+  if (flags & SQLITE_OPEN_READWRITE)
+    return "readwrite";
+  return "unknown";
+}
+
+// allowed columns for ORDER BY to prevent SQL injection
+bool
+is_valid_order_column(const std::string& col)
+{
+  return col == "seq" || col == "init_time" || col == "comp_time" ||
+         col == "status" || col == "retval";
+}
+
+// `table_name` is concatenated as-is into every DDL/DML statement
+// (create_table, prepare_sqlite3_stmt, query, count, trim,
+// get_last_committed_seq). The only way to keep those statements safe
+// is a strict check at the API boundary:
+//   - 1..63 characters
+//   - starts with a letter or underscore
+//   - remaining characters in [A-Za-z0-9_]
+//   - "schema_version" is reserved by this library's schema table
+bool
+is_valid_table_name(const std::string& name)
+{
+  if (name == "schema_version")
+    return false;
+  static const std::regex re(R"(^[A-Za-z_][A-Za-z0-9_]{0,62}$)");
+  return std::regex_match(name, re);
+}
+
+std::expected<void, AuditDBError>
+open_connection(
+    CephContext* cct,
+    const char* db_file,
+    sqlite3*& db_handle,
+    int flags)
+{
+  int rc = sqlite3_open_v2(db_file, &db_handle, flags, "ceph");
+  if (rc != SQLITE_OK) {
+    const char* err = nullptr;
+    if (db_handle) {
+      err = sqlite3_errmsg(db_handle);
+      sqlite3_close(db_handle);
+    } else {
+      err = "no db handle";
+    }
+    db_handle = nullptr;
+    aderr(cct) << "failed to create '" << db_file << "': rc=" << rc
+               << " err=" << err << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_open_failed, rc});
+  }
+
+  // enable extended codes for more granular control over checks
+  sqlite3_extended_result_codes(db_handle, 1);
+  return {};
+}
+
+std::expected<void, AuditDBError>
+apply_pragmas(
+    CephContext* cct,
+    sqlite3*& db_handle,
+    const std::vector<const char*>& pragmas)
+{
+  char* err_msg = nullptr;
+  for (const auto* pragma : pragmas) {
+    int rc = sqlite3_exec(db_handle, pragma, nullptr, nullptr, &err_msg);
+    if (rc != SQLITE_OK) {
+      aderr(cct) << "error while setting '" << pragma
+                 << "': " << (err_msg ? err_msg : "unknown sqlite error")
+                 << dendl;
+      sqlite3_free(err_msg);
+      err_msg = nullptr;
+      return std::unexpected(AuditDBError{AuditDBErr::sqlite_exec_failed, rc});
+    }
+  }
+  return {};
+}
+
+std::expected<void, AuditDBError>
+create_table(CephContext* cct, sqlite3*& db_handle, const std::string& table)
+{
+  char* err_msg = nullptr;
+  std::string table_sql;
+  if (table == "schema_version") {
+    table_sql =
+        "CREATE TABLE IF NOT EXISTS schema_version ("
+        "version INTEGER PRIMARY KEY"
+        ");"
+        "INSERT OR IGNORE INTO schema_version VALUES (1);";
+  } else {
+    table_sql =
+        "CREATE TABLE IF NOT EXISTS " + table +
+        " ("
+        // first-phase commit
+        "seq INTEGER PRIMARY KEY, "
+        "cmd TEXT NOT NULL CHECK (length(trim(cmd)) > 0), "
+        "cmd_args TEXT, "
+        "init_time INTEGER NOT NULL CHECK (init_time > 0), "
+        // second-phase commit therefore nullable until completion
+        "comp_time INTEGER CHECK (comp_time IS NULL OR comp_time >= "
+        "init_time), "
+        "status TEXT CHECK (status IS NULL OR length(trim(status)) > 0), "
+        "retval INTEGER, "
+        "CHECK ((comp_time IS NULL AND status IS NULL AND retval IS NULL) OR "
+        "(comp_time IS NOT NULL AND status IS NOT NULL AND retval IS NOT NULL))"
+        ");";
+  }
+  int rc =
+      sqlite3_exec(db_handle, table_sql.c_str(), nullptr, nullptr, &err_msg);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "cannot create " << table
+               << " table: " << (err_msg ? err_msg : "unknown sqlite error")
+               << dendl;
+    sqlite3_free(err_msg);
+    err_msg = nullptr;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_exec_failed, rc});
+  }
+
+  if (table != "schema_version") {
+    const std::string indexes =
+        "CREATE INDEX IF NOT EXISTS idx_audit_init_time ON " + table +
+        "(init_time);" + "CREATE INDEX IF NOT EXISTS idx_audit_comp_time ON " +
+        table + "(comp_time);" +
+        "CREATE INDEX IF NOT EXISTS idx_audit_status ON " + table +
+        "(status);" + "CREATE INDEX IF NOT EXISTS idx_audit_retval ON " +
+        table + "(retval);";
+    err_msg = nullptr;
+    rc = sqlite3_exec(db_handle, indexes.c_str(), nullptr, nullptr, &err_msg);
+    if (rc != SQLITE_OK) {
+      aderr(cct) << "error while setting indexes: "
+                 << (err_msg ? err_msg : "unknown sqlite error") << dendl;
+      sqlite3_free(err_msg);
+      err_msg = nullptr;
+      return std::unexpected(AuditDBError{AuditDBErr::sqlite_exec_failed, rc});
+    }
+  }
+  return {};
+}
+
+std::expected<std::string, AuditDBError>
+verify_pragma(CephContext* cct, sqlite3*& db_handle, const std::string& sql)
+{
+  sqlite3_stmt* stmt = nullptr;
+  std::string result;
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "pragma prepare failed: " << sqlite3_errmsg(db_handle)
+               << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+  rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW) {
+    if (const auto* t =
+            reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0))) {
+      result = t;
+    }
+  }
+  sqlite3_finalize(stmt);
+  if (rc != SQLITE_ROW) {
+    aderr(cct) << "pragma step failed: rc=" << rc << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+  return result;
+}
+
+std::expected<void, AuditDBError>
+prepare_sqlite3_stmt(
+    CephContext* cct,
+    sqlite3*& db_handle,
+    sqlite3_stmt*& stmt,
+    const std::string& table,
+    PreparePhase phase)
+{
+  std::string sql;
+  if (phase == PreparePhase::Insert) {
+    sql = "INSERT INTO " + table +
+          " (seq, cmd, cmd_args, init_time) "
+          "VALUES (?, ?, ?, ?);";
+  } else if (phase == PreparePhase::InsertAutoSeq) {
+    sql = "INSERT INTO " + table + " (cmd, cmd_args, init_time)"
+    " VALUES (?, ?, ?)";
+  } else {
+    sql = "UPDATE " + table +
+          " SET "
+          "comp_time = ?, status = ?, retval = ? "
+          "WHERE seq = ? AND comp_time IS NULL;";
+  }
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    std::string what;
+    if (phase == PreparePhase::Insert || phase == PreparePhase::InsertAutoSeq) {
+      what = "insert_stmt";
+    } else {
+      what = "update_stmt";
+    }
+    aderr(cct) << what << " prepare failed: " << sqlite3_errmsg(db_handle) << dendl;
+    if (stmt) {
+      sqlite3_finalize(stmt);
+      stmt = nullptr;
+    }
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+
+  return {};
+}
+
+// builds WHERE clause and returns bind values for query/count
+std::string
+build_where(
+    const AuditQuery& q,
+    std::vector<std::pair<int, int64_t>>& int_binds,
+    std::vector<std::pair<int, std::string>>& text_binds)
+{
+  std::string where;
+  int bind_idx = 1;
+
+  auto add_condition = [&](const std::string& clause) {
+    where += where.empty() ? " WHERE " : " AND ";
+    where += clause;
+  };
+
+  if (q.after_seq) {
+    add_condition("seq > ?");
+    int_binds.push_back({bind_idx++, *q.after_seq});
+  }
+  if (q.before_seq) {
+    add_condition("seq < ?");
+    int_binds.push_back({bind_idx++, *q.before_seq});
+  }
+  if (q.since) {
+    add_condition("init_time >= ?");
+    int_binds.push_back({bind_idx++, static_cast<int64_t>(*q.since)});
+  }
+  if (q.until) {
+    add_condition("init_time <= ?");
+    int_binds.push_back({bind_idx++, static_cast<int64_t>(*q.until)});
+  }
+  if (q.status) {
+    add_condition("status = ?");
+    text_binds.push_back({bind_idx++, *q.status});
+  }
+
+  return where;
+}
+
+// bind numerical and textual values with the sqlite3_stmt, primarily used in
+// the query/count after calling build_where()
+int
+bind_params(
+    sqlite3_stmt* stmt,
+    const std::vector<std::pair<int, int64_t>>& int_binds,
+    const std::vector<std::pair<int, std::string>>& text_binds)
+{
+  for (auto& [idx, val] : int_binds) {
+    int rc = sqlite3_bind_int64(stmt, idx, val);
+    if (rc != SQLITE_OK)
+      return rc;
+  }
+  for (auto& [idx, val] : text_binds) {
+    int rc = sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
+    if (rc != SQLITE_OK)
+      return rc;
+  }
+  return SQLITE_OK;
+}
+
+void vacuum(CephContext* cct, sqlite3*& db_handle)
+{
+  char* err_msg = nullptr;
+  int rc = sqlite3_exec(db_handle, "VACUUM;", nullptr, nullptr, &err_msg);
+  
+  if (rc != SQLITE_OK) {
+    adout(cct, 10) << "warning: " << (err_msg ? err_msg :
+      sqlite3_errmsg(db_handle)) << dendl;
+    sqlite3_free(err_msg);
+  } else {
+    adout(cct, 20) << "completed successfully" << dendl;
+  }
+
+}
+
+}
+
+namespace audit_db_detail {
+
+struct InitFailureGuard {
+  AuditDB& db;
+  bool committed{false};
+
+  explicit InitFailureGuard(AuditDB& d) :
+    db(d)
+  {}
+
+  void
+  commit()
+  {
+    committed = true;
+  }
+
+  ~InitFailureGuard()
+  {
+    if (!committed) {
+      db.release_sqlite_handles();
+    }
+  }
+
+  // copying is forbidden, allow only one guard per init()
+  InitFailureGuard(const InitFailureGuard&) = delete;
+  InitFailureGuard& operator=(const InitFailureGuard&) = delete;
+};
+
+}
+
+AuditDB::AuditDB(
+    CephContext* cct_,
+    const char* db_file_or_uri,
+    bool is_uri_,
+    std::string table_name,
+    bool is_standalone_) :
+  cct(cct_),
+  db_file(db_file_or_uri),
+  is_uri(is_uri_),
+  table_name(std::move(table_name)),
+  is_standalone(is_standalone_)
+{}
+
+void
+AuditDB::release_sqlite_handles()
+{
+  if (insert_stmt) {
+    sqlite3_finalize(insert_stmt);
+    insert_stmt = nullptr;
+  }
+  if (update_stmt) {
+    sqlite3_finalize(update_stmt);
+    update_stmt = nullptr;
+  }
+  if (db_handle) {
+    sqlite3_close(db_handle);
+    db_handle = nullptr;
+  }
+}
+
+std::expected<void, AuditDBError>
+AuditDB::init()
+{
+  // init() is documented as "call once before any other method"; all
+  // other methods gate on `initialised` which we only flip at the end
+  // of a successful init, so there is no contending caller to lock
+  // against here.
+  audit_db_detail::InitFailureGuard init_guard(*this);
+
+  // reject bad table names before we touch sqlite; `table_name` is
+  // interpolated directly into every statement this class issues.
+  if (!is_valid_table_name(table_name)) {
+    aderr(cct) << "invalid table name: '" << table_name << "'" << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::invalid_table_name, 0});
+  }
+
+  // ensure ceph vfs is initialized
+  std::call_once(sqlite_vfs_init_flag, init_cephsqlite_vfs, cct);
+
+  // SQLITE_OPEN_READWRITE is mandatory while creating a db
+  int flags = 0;
+  if (is_uri) {
+    flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI;
+  } else {
+    flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+  }
+
+  // create db
+  if (auto e = open_connection(cct, db_file.c_str(), db_handle, flags); !e) {
+    return e;
+  }
+
+  // set a timeout for SQLITE_BUSY
+  sqlite3_busy_timeout(db_handle, 5000); // 5s
+
+  // add pragmas to the db
+  const std::vector<const char*> pragmas = {
+      "PRAGMA page_size = 65536", "PRAGMA cache_size = 4096",
+      "PRAGMA locking_mode = NORMAL", "PRAGMA journal_mode = PERSIST",
+      // would make some queries quicker to execute like ORDER_BY...
+      "PRAGMA temp_store = memory",
+      // link up tables from say mon table and mgr table?
+      "PRAGMA foreign_keys = 1"};
+  if (auto e = apply_pragmas(cct, db_handle, pragmas); !e) {
+    return e;
+  }
+
+  // most pragmas fail loudly via sqlite3_exec() but journal_mode is a
+  // documented exception.
+  if (auto mode = verify_pragma(
+    cct, db_handle, "PRAGMA journal_mode;"); !mode) {
+    return std::unexpected(mode.error());
+  } else if (*mode != "persist") {
+    aderr(cct) << "expected journal_mode=persist, got '" << *mode << "'"
+               << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_exec_failed, 0});
+  }
+
+  // schema versioning for future migrations
+  if (auto e = create_table(cct, db_handle, "schema_version"); !e) {
+    return e;
+  }
+
+  // default table
+  if (auto e = create_table(cct, db_handle, table_name); !e) {
+    return e;
+  }
+
+  // prepare phase-one statement
+  if (auto e = prepare_sqlite3_stmt(cct, db_handle, insert_stmt, table_name,
+    is_standalone ? PreparePhase::InsertAutoSeq : PreparePhase::Insert);
+      !e) {
+    return e;
+  }
+
+  // prepare phase-two statement
+  if (auto e = prepare_sqlite3_stmt(
+          cct, db_handle, update_stmt, table_name, PreparePhase::Update);
+      !e) {
+    return e;
+  }
+
+  initialised = true;
+  init_guard.commit();
+  return {};
+}
+
+AuditDB::~AuditDB() { release_sqlite_handles(); }
+
+bool
+AuditDB::is_initialised() const
+{
+  return initialised;
+}
+
+void
+AuditDB::init_cephsqlite_vfs(CephContext* cct)
+{ // static
+  sqlite3_auto_extension((void (*)())sqlite3_cephsqlite_init);
+  sqlite3* db = nullptr;
+  if (int rc = sqlite3_open_v2(":memory:", &db, SQLITE_OPEN_READWRITE, nullptr);
+      rc == SQLITE_OK) {
+    sqlite3_close(db);
+  } else {
+    std::string err = "could not open sqlite3: " + std::to_string(rc);
+    aderr(cct) << err << dendl;
+    ceph_abort_msg(err);
+  }
+}
+
+std::expected<void, AuditDBError>
+AuditDB::ensure_audit_pool(
+    CephContext* cct,
+    librados::Rados& rados,
+    bool create_pool)
+{
+  std::list<std::string> pools;
+  int rc = rados.pool_list(pools);
+  if (rc < 0) {
+    aderr(cct) << "pool_list failed " << cpp_strerror(rc) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::rados_pool_list_failed, rc});
+  }
+
+  for (auto& pool : pools) {
+    if (pool == AUDIT_POOL_NAME) {
+      return {};
+    }
+  }
+
+  if (create_pool) {
+    ceph::bufferlist inbl, outbl;
+    std::string outs;
+
+    std::string cmd = R"({"prefix":"osd pool create",)"
+                      R"("pool":")" +
+                      std::string(AUDIT_POOL_NAME) +
+                      R"(",)"
+                      R"("pg_num":1,)"
+                      R"("pg_num_min":1,)"
+                      R"("pg_num_max":32,)"
+                      R"("yes_i_really_mean_it":true})";
+    rc = rados.mon_command(std::move(cmd), std::move(inbl), &outbl, &outs);
+    if (rc < 0) {
+      aderr(cct) << "failed to create " << AUDIT_POOL_NAME << " pool: " << outs
+                 << " (" << cpp_strerror(rc) << ")" << dendl;
+      return std::unexpected(
+          AuditDBError{AuditDBErr::audit_pool_create_failed, rc});
+    }
+
+    outbl.clear();
+
+    cmd = R"({"prefix":"osd pool application enable",)"
+          R"("pool":")" +
+          std::string(AUDIT_POOL_NAME) +
+          R"(",)"
+          R"("app":")" +
+          std::string(AUDIT_APP_NAME) +
+          R"(",)"
+          R"("yes_i_really_mean_it":true})";
+    rc = rados.mon_command(std::move(cmd), std::move(inbl), &outbl, &outs);
+    if (rc < 0) {
+      aderr(cct) << "failed to create application on " << AUDIT_POOL_NAME
+                 << " pool: " << outs << " (" << cpp_strerror(rc) << ")"
+                 << dendl;
+      return std::unexpected(
+          AuditDBError{AuditDBErr::audit_pool_app_enable_failed, rc});
+    }
+    return {};
+  }
+
+  return std::unexpected(
+      AuditDBError{AuditDBErr::audit_pool_not_found, -ENOENT});
+}
+
+std::expected<void, AuditDBError>
+AuditDB::delete_db_file(
+    CephContext* cct,
+    librados::Rados& rados,
+    const char* db_path)
+{ // static
+  sqlite3_vfs* vfs = sqlite3_vfs_find("ceph");
+  if (!vfs) {
+    aderr(cct) << "could not find ceph vfs" << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::ceph_vfs_not_found, 0});
+  }
+
+  if (!vfs->xDelete) {
+    aderr(cct) << "ceph vfs has not implemented xDelete, deleting the db file ("
+               << db_path << ") is not possible" << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::vfs_xdelete_unsupported, 0});
+  }
+
+  if (auto pool_res = ensure_audit_pool(cct, rados, false); !pool_res) {
+    aderr(cct) << ".audit pool not found" << dendl;
+    return std::unexpected(pool_res.error());
+  }
+
+  const int rc = vfs->xDelete(vfs, db_path, 1);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "cannot delete " << db_path << " (" << rc << ")" << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::vfs_xdelete_failed, rc});
+  }
+
+  adout(cct, 20) << "successfully deleted " << db_path << dendl;
+  return {};
+}
+
+std::expected<int64_t, AuditDBError> 
+AuditDB::do_first_phase_commit(std::optional<int64_t> seq,
+  const std::string& cmd, const std::string& cmd_args, time_t init_time)
+{
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+  if (seq.has_value() && *seq <= 0) {
+    return std::unexpected(AuditDBError{AuditDBErr::invalid_seq, -EINVAL});
+  }
+
+  sqlite3_reset(insert_stmt);
+  sqlite3_clear_bindings(insert_stmt);
+
+  int idx = 1;
+  int rc = 0;
+  int64_t result_seq = 1;
+  if (seq.has_value()) {
+    rc = sqlite3_bind_int64(insert_stmt, idx++, *seq);
+    if (rc != SQLITE_OK) goto bind_fail;
+  }
+  rc = sqlite3_bind_text(insert_stmt, idx++, cmd.c_str(), -1, SQLITE_TRANSIENT);
+  if (rc != SQLITE_OK) goto bind_fail;
+  rc = sqlite3_bind_text(insert_stmt, idx++, cmd_args.c_str(), -1, SQLITE_TRANSIENT);
+  if (rc != SQLITE_OK) goto bind_fail;
+  rc = sqlite3_bind_int64(insert_stmt, idx++, init_time);
+  if (rc != SQLITE_OK) goto bind_fail;
+
+  rc = sqlite3_step(insert_stmt);
+  if (rc != SQLITE_DONE) {
+    aderr(cct) << "first_phase_commit insert failed: rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  if (sqlite3_changes(db_handle) != 1) {
+    if (seq.has_value()) {
+      aderr(cct) << "audit log seq: " << *seq << " wasn't added" << dendl;
+    } else {
+      aderr(cct) << "audit log could not be added" << dendl;
+    }
+    return std::unexpected(AuditDBError{AuditDBErr::row_count_mismatch, 0});
+  }
+
+  result_seq = seq.value_or(sqlite3_last_insert_rowid(db_handle));
+  adout(cct, 20) << " seq=" << result_seq << dendl;
+  return result_seq;
+
+bind_fail:
+  aderr(cct) << "first_phase_commit bind failed: rc=" << rc
+             << " err=" << sqlite3_errmsg(db_handle) << dendl;
+  return std::unexpected(AuditDBError{AuditDBErr::sqlite_bind_failed, rc});
+}
+
+/**
+ * usage:
+ * if (auto r = db.first_phase_commit(seq, cmd, cmd_args, t); !r) {
+ * const auto& e = r.error();
+ * // e.code, e.detail
+ * return;
+ * }
+ */
+std::expected<void, AuditDBError>
+AuditDB::first_phase_commit(int64_t seq, const std::string& cmd,
+                            const std::string& cmd_args, time_t init_time)
+{
+  std::lock_guard<ceph::mutex> l(lock);
+
+  if (is_standalone) {
+    return std::unexpected(
+      AuditDBError{AuditDBErr::seq_not_allowed_standalone, -EINVAL});
+  }
+  if (auto r = do_first_phase_commit(seq, cmd, cmd_args, init_time); !r) {
+    return std::unexpected(r.error());
+  }
+  return {};
+}
+
+std::expected<int64_t, AuditDBError>
+AuditDB::first_phase_commit(const std::string& cmd,
+                            const std::string& cmd_args, time_t init_time)
+{
+  std::lock_guard<ceph::mutex> l(lock);
+
+  if (!is_standalone) {
+    return std::unexpected(AuditDBError{AuditDBErr::seq_required, -EINVAL});
+  }
+  return do_first_phase_commit(std::nullopt, cmd, cmd_args, init_time);
+}
+
+std::expected<void, AuditDBError>
+AuditDB::second_phase_commit(
+    int64_t seq,
+    time_t comp_time,
+    const std::string& status,
+    int32_t retval)
+{
+  std::lock_guard<ceph::mutex> l(lock);
+
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+
+  if (seq <= 0) {
+    return std::unexpected(AuditDBError{AuditDBErr::invalid_seq, 0});
+  }
+
+  sqlite3_reset(update_stmt);
+  sqlite3_clear_bindings(update_stmt);
+
+  int rc = sqlite3_bind_int64(update_stmt, 1, comp_time);
+  if (rc != SQLITE_OK)
+    goto bind_fail;
+  rc = sqlite3_bind_text(update_stmt, 2, status.c_str(), -1, SQLITE_TRANSIENT);
+  if (rc != SQLITE_OK)
+    goto bind_fail;
+  rc = sqlite3_bind_int(update_stmt, 3, retval);
+  if (rc != SQLITE_OK)
+    goto bind_fail;
+  rc = sqlite3_bind_int64(update_stmt, 4, seq);
+  if (rc != SQLITE_OK)
+    goto bind_fail;
+
+  rc = sqlite3_step(update_stmt);
+  if (rc != SQLITE_DONE) {
+    aderr(cct) << "second_phase_commit update failed: rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  if (sqlite3_changes(db_handle) != 1) {
+    aderr(cct) << "audit log seq: " << seq << " didn't update" << dendl;
+    // this could also mean the PK didn't exist hence the update never happened
+    return std::unexpected(AuditDBError{AuditDBErr::row_count_mismatch, 0});
+  }
+
+  adout(cct, 20) << "seq=" << seq << dendl;
+  return {};
+
+bind_fail:
+  aderr(cct) << "second_phase_commit bind failed: rc=" << rc
+             << " err=" << sqlite3_errmsg(db_handle) << dendl;
+  return std::unexpected(AuditDBError{AuditDBErr::sqlite_bind_failed, rc});
+}
+
+std::expected<std::vector<AuditEntry>, AuditDBError>
+AuditDB::query(const AuditQuery& q)
+{
+  std::lock_guard<ceph::mutex> l(lock);
+
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+
+  std::vector<AuditEntry> results;
+
+  std::string order_col = is_valid_order_column(q.order_by) ? q.order_by
+                                                            : "init_time";
+  std::string direction = q.ascending ? "ASC" : "DESC";
+
+  std::vector<std::pair<int, int64_t>> int_binds;
+  std::vector<std::pair<int, std::string>> text_binds;
+  std::string where = build_where(q, int_binds, text_binds);
+
+  std::string sql =
+      "SELECT seq, cmd, cmd_args, init_time, comp_time, status, retval FROM " +
+      table_name + where + " ORDER BY " + order_col + " " + direction +
+      " LIMIT ?;";
+
+  // limit bind index is after all WHERE binds
+  int limit_idx = static_cast<int>(int_binds.size() + text_binds.size()) + 1;
+
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "query prepare failed: " << sqlite3_errmsg(db_handle)
+               << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+
+  rc = bind_params(stmt, int_binds, text_binds);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "query bind failed: " << sqlite3_errmsg(db_handle) << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_bind_failed, rc});
+  }
+
+  rc = sqlite3_bind_int64(stmt, limit_idx, q.limit);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "query limit bind failed: " << sqlite3_errmsg(db_handle)
+               << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_bind_failed, rc});
+  }
+
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+    AuditEntry entry;
+    
+    entry.seq = sqlite3_column_int64(stmt, 0);
+    
+    if (sqlite3_column_type(stmt, 1) != SQLITE_NULL) {
+      const char* cmd =
+          reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+      entry.cmd = cmd ? cmd : "";
+    }
+    
+    if (sqlite3_column_type(stmt, 2) != SQLITE_NULL) {
+      const char* cmd_args =
+          reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2));
+      entry.cmd_args = cmd_args ? cmd_args : "";
+    }
+    
+    entry.init_time = static_cast<time_t>(sqlite3_column_int64(stmt, 3));
+
+    if (sqlite3_column_type(stmt, 4) != SQLITE_NULL) {
+      entry.comp_time = static_cast<time_t>(sqlite3_column_int64(stmt, 4));
+    }
+    
+    if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+      entry.status = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5));
+    }
+    
+    if (sqlite3_column_type(stmt, 6) != SQLITE_NULL) {
+      entry.retval = sqlite3_column_int(stmt, 6);
+    }
+
+    results.push_back(std::move(entry));
+  }
+
+  if (rc != SQLITE_DONE) {
+    aderr(cct) << "query step failed: rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  sqlite3_finalize(stmt);
+  return results;
+}
+
+std::expected<int64_t, AuditDBError>
+AuditDB::count(const AuditQuery& q)
+{
+  std::lock_guard<ceph::mutex> l(lock);
+
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+
+  std::vector<std::pair<int, int64_t>> int_binds;
+  std::vector<std::pair<int, std::string>> text_binds;
+  std::string where = build_where(q, int_binds, text_binds);
+
+  std::string sql = "SELECT COUNT(*) FROM " + table_name + where + ";";
+
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "count prepare failed: " << sqlite3_errmsg(db_handle)
+               << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+
+  rc = bind_params(stmt, int_binds, text_binds);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "count bind failed: " << sqlite3_errmsg(db_handle) << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_bind_failed, rc});
+  }
+
+  rc = sqlite3_step(stmt);
+  if (rc != SQLITE_ROW) {
+    aderr(cct) << "count step failed (expected ROW): rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  const int64_t result = sqlite3_column_int64(stmt, 0);
+
+  rc = sqlite3_step(stmt);
+  if (rc != SQLITE_DONE) {
+    aderr(cct) << "count step failed (expected DONE): rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  sqlite3_finalize(stmt);
+  return result;
+}
+
+std::expected<int64_t, AuditDBError>
+AuditDB::get_last_committed_seq()
+{
+  std::lock_guard<ceph::mutex> l(lock);
+
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+
+  const std::string sql = "SELECT MAX(seq) FROM " + table_name;
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "get_last_committed_seq prepare failed: "
+               << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+
+  rc = sqlite3_step(stmt);
+  if (rc != SQLITE_ROW) {
+    aderr(cct) << "get_last_committed_seq step failed: rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  // on an empty table, "SELECT MAX(seq)" can still yield one SQLITE_ROW but
+  // column 0 is SQL NULL
+  if (sqlite3_column_type(stmt, 0) == SQLITE_NULL) {
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::empty_table, SQLITE_OK});
+  }
+
+  const int64_t max_seq = sqlite3_column_int64(stmt, 0);
+  sqlite3_finalize(stmt);
+  return max_seq;
+}
+
+std::expected<int, AuditDBError>
+AuditDB::trim(time_t older_than, int64_t max_delete)
+{
+  std::lock_guard<ceph::mutex> l(lock);
+
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+
+  std::string sql;
+  // max_delete > 0: apply LIMIT; anything <= 0 deletes all matching rows
+  if (max_delete > 0) {
+    sql = "DELETE FROM " + table_name + " WHERE seq IN (SELECT seq FROM " +
+          table_name + " WHERE init_time < ? ORDER BY seq ASC LIMIT ?);";
+  } else {
+    sql = "DELETE FROM " + table_name + " WHERE init_time < ?;";
+  }
+
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "prepare failed: " << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+
+  rc = sqlite3_bind_int64(stmt, 1, static_cast<int64_t>(older_than));
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "bind failed: " << sqlite3_errmsg(db_handle) << dendl;
+    sqlite3_finalize(stmt);
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_bind_failed, rc});
+  }
+
+  if (max_delete > 0) {
+    rc = sqlite3_bind_int64(stmt, 2, max_delete);
+    if (rc != SQLITE_OK) {
+      aderr(cct) << "limit bind failed: " << sqlite3_errmsg(db_handle)
+                 << dendl;
+      sqlite3_finalize(stmt);
+      return std::unexpected(AuditDBError{AuditDBErr::sqlite_bind_failed, rc});
+    }
+  }
+
+  rc = sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+  if (rc != SQLITE_DONE) {
+    aderr(cct) << "failed: rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  int deleted = sqlite3_changes(db_handle);
+
+  return deleted;
+}
+
+std::expected<int, AuditDBError>
+AuditDB::clear_logs()
+{
+  std::lock_guard l(lock);
+
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+
+  std::string sql = "DELETE FROM " + table_name + ";";
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "prepare failed: " << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+
+  rc = sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+
+  if (rc != SQLITE_DONE) {
+    aderr(cct) << "failed: rc=" << rc
+               << " err=" << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  int deleted = sqlite3_changes(db_handle);
+  
+  if (deleted > 0) {
+    vacuum(cct, db_handle);
+  }
+  
+  return deleted;
+}
+
+std::expected<int64_t, AuditDBError>
+AuditDB::get_db_size()
+{
+  std::lock_guard l(lock);
+
+  if (!initialised) {
+    return std::unexpected(AuditDBError{AuditDBErr::not_initialised, 0});
+  }
+
+  std::string sql = "SELECT (page_count - freelist_count) * page_size"
+                    " FROM pragma_page_count(), pragma_freelist_count(),"
+                    " pragma_page_size();";
+  sqlite3_stmt* stmt = nullptr;
+  int rc = sqlite3_prepare_v2(db_handle, sql.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    aderr(cct) << "prepare failed: " << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_prepare_failed, rc});
+  }
+
+  rc = sqlite3_step(stmt);
+  int64_t db_size = (rc == SQLITE_ROW) ? sqlite3_column_int64(stmt, 0) : 0;
+  sqlite3_finalize(stmt);
+
+  if (rc != SQLITE_ROW) {
+    aderr(cct) << "step failed: rc=" << rc << " err="
+               << sqlite3_errmsg(db_handle) << dendl;
+    return std::unexpected(AuditDBError{AuditDBErr::sqlite_step_failed, rc});
+  }
+
+  return db_size;
+}
+
+std::optional<sqlite3_ptr>
+AuditDB::open_db(const char* db_file_or_uri, int flags)
+{
+  std::lock_guard l(lock);
+
+  sqlite3* db = nullptr;
+  int rc = sqlite3_open_v2(db_file_or_uri, &db, flags, "ceph");
+  if (rc != SQLITE_OK) {
+    const char* err = nullptr;
+    if (db) {
+      err = sqlite3_errmsg(db);
+      sqlite3_close(db);
+    } else {
+      err = "no db handle";
+    }
+    aderr(cct) << "failed to open '" << db_file_or_uri << "' in "
+               << flag_to_op(flags) << " mode: rc=" << rc << " err=" << err
+               << dendl;
+    return std::nullopt;
+  }
+  return sqlite3_ptr(db, &sqlite3_close);
+}

--- a/src/common/AuditDB.h
+++ b/src/common/AuditDB.h
@@ -1,0 +1,418 @@
+#if defined(__linux__)
+#pragma once
+#endif
+
+#if !defined(WITH_LIBCEPHSQLITE)
+#error "Audit logging APIs require libcephsqlite (build with -DWITH_LIBCEPHSQLITE=ON)"
+#endif
+
+#ifndef AUDIT_DB_H
+#define AUDIT_DB_H
+
+#include <expected>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "include/common_fwd.h"
+#include "include/libcephsqlite.h"
+#include "common/ceph_mutex.h"
+#include "common/errno.h"
+#include "include/rados/librados_fwd.hpp"
+
+inline constexpr auto AUDIT_POOL_NAME = ".audit";
+inline constexpr auto AUDIT_APP_NAME = "audit";
+
+using sqlite3_ptr = std::unique_ptr<sqlite3, decltype(&sqlite3_close)>;
+
+struct AuditEntry {
+  int64_t seq{0};
+  std::string cmd;
+  std::string cmd_args;
+  time_t init_time{0};
+  std::optional<time_t> comp_time;
+  std::optional<std::string> status;
+  std::optional<int32_t> retval;
+};
+
+struct AuditQuery {
+  // seq-based filtering
+  std::optional<int64_t> before_seq;
+  std::optional<int64_t> after_seq;
+
+  // time-based filtering (seconds since epoch)
+  std::optional<time_t> since;
+  std::optional<time_t> until;
+
+  // status filtering
+  std::optional<std::string> status;
+
+  // sorting
+  std::string order_by = "init_time";
+  bool ascending{false};
+
+  // pagination
+  int64_t limit{100};
+};
+
+/**
+ * High-level failure reason for AuditDB operations that use std::expected.
+ */
+enum class AuditDBErr {
+  not_initialised,
+  invalid_seq,
+  /** `sqlite3_open_v2` failed (`init` / open path) */
+  sqlite_open_failed,
+  /** `sqlite3_exec` failed (pragmas, DDL in `init`) */
+  sqlite_exec_failed,
+  sqlite_prepare_failed,
+  sqlite_bind_failed,
+  sqlite_step_failed,
+  /** SELECT MAX(seq) had no rows / NULL (get_last_committed_seq only) */
+  empty_table,
+  /** INSERT/UPDATE step returned DONE but `sqlite3_changes` != 1 */
+  row_count_mismatch,
+  /** `sqlite3_vfs_find("ceph")` returned null (VFS not registered) */
+  ceph_vfs_not_found,
+  /** Ceph VFS has no `xDelete` implementation */
+  vfs_xdelete_unsupported,
+  /** `.audit` pool missing and `ensure_audit_pool(..., false)` failed */
+  audit_pool_not_found,
+  /** Ceph VFS `xDelete` returned non-`SQLITE_OK` */
+  vfs_xdelete_failed,
+  /** `rados.pool_list` failed */
+  rados_pool_list_failed,
+  /** `osd pool create` mon command failed */
+  audit_pool_create_failed,
+  /** `osd pool application enable` mon command failed */
+  audit_pool_app_enable_failed,
+  /** `table_name` fails validation in @ref AuditDB::init (empty, too long,
+     *  characters outside `[A-Za-z0-9_]`, does not start with a letter or
+     *  underscore, or equals the reserved name `schema_version`). */
+  invalid_table_name,
+  seq_not_allowed_standalone,
+  seq_required
+};
+
+/**
+ * Error value for std::expected. @p code classifies the failure; @p detail
+ * is an optional raw code whose meaning depends on @p code (e.g. a SQLite
+ * `SQLITE_*` result, a negative librados/mon return, `-errno`, or 0 if
+ * unused).
+ */
+struct AuditDBError {
+  AuditDBErr code = AuditDBErr::not_initialised;
+  int detail = 0;
+};
+
+namespace audit_db_detail {
+struct InitFailureGuard;
+}
+
+class AuditDB {
+  friend struct audit_db_detail::InitFailureGuard;
+
+public:
+  /**
+     * Constructor stores paths and table name only; does not open SQLite.
+     *
+     * @param cct Ceph context used for logging (must be non-null and must
+     * outlive this object for the lifetime of operations that log).
+     * @param db_file_or_uri Database filename where filename
+     * = file:///<*poolid|poolname>:/<dbname>.db?vfs=ceph
+     * @param is_uri true if @p db_file_or_uri is a URI
+     * @param table_name there is 1:1 db mapping for every entity making use
+     * of audit db, so there exists only one table per db. Validation runs in
+     * @ref init; on failure @ref init returns `invalid_table_name`.
+     * @param is_standalone this is mostly for setting up the insert_stmt, if it is
+     * daemon, the first_phase_commit() will be provided a seq, for standalone
+     * tools - sqlite would assign the next available integer
+     */
+  explicit AuditDB(
+      CephContext* cct,
+      const char* db_file_or_uri,
+      bool is_uri,
+      std::string table_name,
+      bool is_standalone = false);
+
+  /**
+     * @brief Copying is disabled: each instance owns SQLite connection and
+     * prepared-statement state; a copy would duplicate or double-release
+     * those resources.
+     *
+     * @sa init, ~AuditDB, is_initialised
+     */
+  AuditDB(const AuditDB&) = delete;
+  /** @copydoc AuditDB(const AuditDB&) */
+  AuditDB& operator=(const AuditDB&) = delete;
+
+  /**
+     * @brief open the database, configure pragmas, create schema and
+     * prepare statements. Must be called after construction and before
+     * any commit/query operations.
+     *
+     * On failure the database handle is closed, prepared statements are
+     * finalized, and the object remains uninitialised; other operations
+     * return `not_initialised` without effect.
+     */
+  std::expected<void, AuditDBError> init();
+
+  ~AuditDB();
+
+  /**
+     * @brief true after a successful @ref init; false before @ref init or
+     * after a failed @ref init.
+     */
+  bool is_initialised() const;
+
+  /**
+     * @brief register ceph sqlite3 vfs before creating a db, this is a
+     * no-op if it already is registered globally
+     */
+  static void init_cephsqlite_vfs(CephContext* cct);
+
+  /**
+     * @brief ensure the `.audit` RADOS pool exists; optionally create and
+     * appify it via mon commands.
+     *
+     * @param rados an initialised and connected librados handle
+     * @param create_pool if true, create the pool and enable the `audit`
+     * application when missing; if false, only check existence (failure if
+     * the pool is absent).
+     *
+     * @note intended for standalone tools when the cluster does not create
+     * the pool; the mgr normally ensures the pool exists.
+     */
+  static std::expected<void, AuditDBError> ensure_audit_pool(
+      CephContext* cct,
+      librados::Rados& rados,
+      bool create_pool = true);
+
+  /**
+     * @brief delete an audit DB file in the `.audit` pool via the Ceph SQLite
+     * VFS.
+     *
+     * @param cct Ceph context for logging
+     * @param rados connected librados handle
+     * @param db_path Path in Ceph VFS format: `pool_name:namespace/filename.db`
+     *                or `pool_name:/filename.db` (empty namespace).
+     *                Example: `.audit:/my_audit.db`
+     *
+     * @note This function calls the VFS xDelete directly, so it expects a raw
+     *       path, NOT a SQLite URI. Do not pass `file:///` prefix or `?vfs=ceph`
+     *       suffix.
+     *
+     * @return void on success, AuditDBError on failure
+     */
+  static std::expected<void, AuditDBError> delete_db_file(
+      CephContext* cct,
+      librados::Rados& rados,
+      const char* db_path);
+
+      /**
+    * @brief Phase-one commit (daemon mode): record cmd/args/init_time keyed by
+    * a caller-supplied @p seq.
+    *
+    * Use this overload on instances constructed with `is_standalone == false`.
+    * The daemon provides @p seq from its
+    * own counter (e.g. `LogEntry::seq` for the log-audit subscription, or a
+    * local monotonic id for mgr-side commands).
+    *
+    * @param seq monotonic command id; must be > 0 and unique within the
+    * table. Uniqueness is enforced by the PRIMARY KEY constraint, not by
+    * this method.
+    * @param cmd command executed; must be non-empty after trimming.
+    * @param cmd_args command arguments (may be empty).
+    * @param init_time cmd initiation timestamp in seconds since epoch; must
+    * be > 0.
+    *
+    * @return void on success; on failure @ref AuditDBError with one of:
+    * - `not_initialised` — @ref init not called or failed.
+    * - `seq_not_allowed_standalone` — called on a standalone instance.
+    * - `invalid_seq` — @p seq <= 0.
+    * - `sqlite_step_failed` — INSERT failed; `detail` carries the SQLite
+    *   extended result code, e.g. `SQLITE_CONSTRAINT_PRIMARYKEY` for a
+    *   duplicate seq, `SQLITE_CONSTRAINT_CHECK` for an empty cmd or
+    *   non-positive init_time, or `SQLITE_BUSY` under contention.
+    * - `sqlite_bind_failed` — parameter binding failed; `detail` carries
+    *   the SQLite result code.
+    * - `row_count_mismatch` — INSERT returned DONE but no row was added
+    *   (should not occur in practice).
+    */
+   std::expected<void, AuditDBError> first_phase_commit(
+      int64_t seq,
+      const std::string& cmd,
+      const std::string& cmd_args,
+      time_t init_time);
+
+   /**
+    * @brief Phase-one commit (standalone mode): record cmd/args/init_time
+    * with a SQLite-allocated seq, returned to the caller.
+    *
+    * Use this overload on instances constructed with `is_standalone == true`.
+    * Standalone tools (e.g. CephFS DR utilities) cannot rely on a coordinated
+    * seq source and must let SQLite assign one via the `seq INTEGER PRIMARY
+    * KEY` rowid alias. Concurrent invocations of the same tool against the
+    * same DB file are serialized by SQLite's file lock; each invocation
+    * receives a unique seq.
+    *
+    * @param cmd command executed; must be non-empty after trimming.
+    * @param cmd_args command arguments (may be empty).
+    * @param init_time cmd initiation timestamp in seconds since epoch; must
+    * be > 0.
+    *
+    * @return the seq assigned by SQLite on success (use this value when
+    * later calling @ref second_phase_commit). On failure @ref AuditDBError
+    * with one of:
+    * - `not_initialised` — @ref init not called or failed.
+    * - `seq_required` — called on a daemon instance (use the int64_t
+    *   overload instead).
+    * - `sqlite_step_failed` — INSERT failed; `detail` carries the SQLite
+    *   extended result code (e.g. `SQLITE_CONSTRAINT_CHECK`,
+    *   `SQLITE_BUSY`).
+    * - `sqlite_bind_failed` — parameter binding failed; `detail` carries
+    *   the SQLite result code.
+    * - `row_count_mismatch` — INSERT returned DONE but no row was added.
+    */
+   std::expected<int64_t, AuditDBError> first_phase_commit(
+      const std::string& cmd,
+      const std::string& cmd_args,
+      time_t init_time);
+
+  /**
+     * @brief commit - command completion time, the status and its returned
+     * value as part of phase two
+     *
+     * @param seq log number to be updated with completion info
+     * @param comp_time cmd completion timestamp in seconds since epoch
+     * @param status status reported by the daemon
+     * @param retval command return value
+     *
+     * @note this will run an UPDATE SQL statement
+     * @note See @ref first_phase_commit regarding `SQLITE_BUSY` / retries.
+     */
+  std::expected<void, AuditDBError> second_phase_commit(
+      int64_t seq,
+      time_t comp_time,
+      const std::string& status,
+      int32_t retval);
+
+  /**
+     * @brief query audit log entries matching the given filters
+     *
+     * @param q query parameters (filters, sorting, limit)
+     * @return matching entries on success; on failure `AuditDBError` with
+     * `code` and optional `detail` (see `AuditDBError`).
+     */
+  std::expected<std::vector<AuditEntry>, AuditDBError> query(
+      const AuditQuery& q);
+
+  /**
+     * @brief count audit log entries matching the given filters
+     *
+     * @param q query parameters (filters only, sorting/limit ignored)
+     * @return count on success; on failure `AuditDBError`.
+     */
+  std::expected<int64_t, AuditDBError> count(const AuditQuery& q);
+
+  /**
+     * @brief largest `seq` currently stored in the audit table (from the
+     * database).
+     *
+     * @return the max sequence on success; on failure or empty table
+     * (MAX NULL), `AuditDBError` with `empty_table` and `detail` 0, or other
+     * codes on SQLite errors.
+     */
+  std::expected<int64_t, AuditDBError> get_last_committed_seq();
+
+  /**
+     * @brief delete audit entries older than the given timestamp and
+     * reclaim disk space via incremental vacuum
+     *
+     * @param older_than entries with init_time before this are deleted
+     * @param max_delete max rows to delete per call; anything <= 0 means no
+     * limit on how many rows may be removed. Use > 0 to cap deletions.
+     * @return rows deleted on success (including 0); on failure
+     * `AuditDBError`.
+     */
+  std::expected<int, AuditDBError> trim(
+      time_t older_than,
+      int64_t max_delete = -1);
+
+   /**
+     * @brief delete all audit log entries from the table and reclaim disk space
+     *
+     * @return rows deleted on success (including 0); on failure `AuditDBError`
+     * with appropriate code.
+     *
+     * @warning This operation is irreversible. All audit history will be lost.
+     * Use @ref trim for selective deletion based on age.
+     *
+     * @note Vacuum failure does not cause clear_logs() to fail; it only logs
+     * a warning. The entries are still deleted even if vacuum fails.
+     */
+  std::expected<int, AuditDBError> clear_logs();
+
+    /**
+     * @brief return the total size in bytes of all objects
+     * (tables and indexes) in the audit database.
+     *
+     * @return size in bytes on success; on failure `AuditDBError`.
+     */
+    std::expected<int64_t, AuditDBError> get_db_size();
+
+private:
+  CephContext* cct;
+  std::string db_file;
+  bool is_uri{false};
+  std::string table_name;
+  bool is_standalone{false};
+
+  ceph::mutex lock = ceph::make_mutex("AuditDB::lock");
+  std::atomic<bool> initialised{false};
+  sqlite3* db_handle = nullptr;
+  sqlite3_stmt* insert_stmt = nullptr;
+  sqlite3_stmt* update_stmt = nullptr;
+
+  /**
+     * Finalize prepared statements and close the DB handle. Safe when
+     * pointers are already null.
+     *
+     * @sa AuditDB::~AuditDB
+     */
+  void release_sqlite_handles();
+
+   /**
+     * @brief this is a helper for first_phase_commit
+     *
+     * @param seq (optional) log number from mgr/mon/other daemon
+     * @param cmd command executed
+     * @param cmd_args command arguments
+     * @param init_time cmd initiation timestamp in seconds since epoch
+     *
+     * @note this will run an INSERT SQL statement
+     * @note caller must hold the lock
+     */
+  std::expected<int64_t, AuditDBError> do_first_phase_commit(
+      std::optional<int64_t> seq,
+      const std::string& cmd,
+      const std::string& cmd_args,
+      time_t init_time);
+
+  /**
+     * @brief open a db connection.
+     *
+     * @param db_file_or_uri Database filename where filename
+     * = file:///<*poolid|poolname>:/<dbname>.db?vfs=ceph
+     * @param flags SQLITE_OPEN_READONLY or SQLITE_OPEN_READWRITE mode
+     *
+     * @note nothing should directly call this function, this might get useful
+     * to retry connecting to the db after some failure or connect to some
+     * other db with read-only flags. the exact use case for this is yet to be
+     * decided
+     */
+  std::optional<sqlite3_ptr> open_db(const char* db_file_or_uri, int flags);
+};
+
+#endif

--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -113,6 +113,7 @@ SUBSYS(ceph_exporter, 1, 5)
 SUBSYS(memstore, 1, 5)
 SUBSYS(trace, 1, 5)
 SUBSYS(ceph_dedup, 0, 5)
+SUBSYS(audit_logging,0, 5)
 // *********************************************************************
 // Developers should update /doc/rados/troubleshooting/log-and-debug.rst
 // when adding or removing a subsystem accordingly.

--- a/src/mgr/CMakeLists.txt
+++ b/src/mgr/CMakeLists.txt
@@ -39,7 +39,7 @@ if(WITH_MGR)
   add_executable(ceph-mgr ${mgr_srcs})
   target_compile_definitions(ceph-mgr PRIVATE PY_SSIZE_T_CLEAN)
   if(WITH_LIBCEPHSQLITE)
-    target_link_libraries(ceph-mgr cephsqlite SQLite3::SQLite3)
+    target_link_libraries(ceph-mgr cephsqlite audit_db SQLite3::SQLite3)
   endif()
   target_include_directories(ceph-mgr PRIVATE
     $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -429,6 +429,10 @@ void DaemonServer::tick()
 
   schedule_tick_locked(
     g_conf().get_val<std::chrono::seconds>("mgr_tick_period").count());
+
+  if (!(audit_pool_exists && audit_pool_appified)) {
+    _ensure_audit_pool();
+  }
 }
 
 // Currently modules do not set health checks in response to events delivered to
@@ -3821,4 +3825,92 @@ will start to track new ops received afterwards.";
 
 out:
   return false;
+}
+
+// caller must hold lock
+bool DaemonServer::_enough_osds_exist() const {
+  uint64_t count = 0;
+  cluster_state.with_osdmap([&](const OSDMap& osdmap) {
+    for (int i = 0; i < osdmap.get_max_osd(); i++) {
+      if (osdmap.is_up(i) && osdmap.is_in(i)) {
+        count++;
+      }
+    }
+  });
+
+  return count >= g_conf().get_val<uint64_t>("osd_pool_default_size");
+}
+
+// unlock the ceph mutex before calling 
+std::pair<int, std::string> DaemonServer::_create_audit_pool() {
+  Command osd_pool_create;
+  std::string cmd = R"({"prefix":"osd pool create",)"
+  R"("pool":".audit",)"
+  R"("pg_num":1,)"
+  R"("pg_num_min":1,)"
+  R"("pg_num_max":32,)"
+  R"("yes_i_really_mean_it":true})";
+
+  osd_pool_create.run(monc, cmd);
+  osd_pool_create.wait();
+
+  return {osd_pool_create.r, osd_pool_create.outs};
+}
+
+// unlock the ceph mutex before calling
+std::pair<int, std::string> DaemonServer::_appify_audit_pool() {
+  Command appify_pool;
+  std::string cmd = R"({"prefix":"osd pool application enable",)"
+  R"("pool":".audit",)"
+  R"("app":"audit",)"
+  R"("yes_i_really_mean_it":true})";
+
+  appify_pool.run(monc, cmd);
+  appify_pool.wait();
+
+  return {appify_pool.r, appify_pool.outs};
+}
+
+void DaemonServer::ensure_audit_pool() {
+  lock.lock();
+  _ensure_audit_pool();
+  lock.unlock();
+}
+
+void DaemonServer::_ensure_audit_pool() {
+  if (!_enough_osds_exist()) {
+    dout(10) << "not enough OSDs to start .audit pool" << dendl;
+    return;
+  }
+
+  bool need_create = !audit_pool_exists;
+  bool need_appify = audit_pool_exists && !audit_pool_appified;
+
+  bool created{false}, appified{false};
+  // release lock while blocking on mon; lock.lock() below before touching
+  // audit_pool_exists / audit_pool_appified (caller still holds lock on return)
+  lock.unlock();
+  if (need_create) {
+    auto [r, outs] = _create_audit_pool();
+    if (r != 0) {
+      clog->warn() << "failed to create .audit pool: " << outs << "; audit logging disabled until pool is available";
+    } else {
+      clog->info() << outs;
+      created = true;
+    }
+  }
+
+  if ((need_create && created) || need_appify) {
+    auto [r, outs] = _appify_audit_pool();
+    if (r != 0) {
+      clog->warn() << "failed to appify .audit pool: " << outs;
+    } else {
+      clog->info() << outs;
+      appified = true;
+    }
+  }
+
+  lock.lock();
+  if (created) audit_pool_exists = true;
+  if (appified) audit_pool_appified = true;
 }

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -33,6 +33,7 @@
 #include "MetricCollector.h"
 #include "OSDPerfMetricCollector.h"
 #include "MDSPerfMetricCollector.h"
+#include "MgrContext.h"
 
 #include <boost/scoped_ptr.hpp>
 
@@ -246,6 +247,12 @@ private:
   Context *tick_event;
   void tick();
   void schedule_tick_locked(double delay_sec);
+  bool audit_pool_exists{false};
+  bool audit_pool_appified{false};
+  bool _enough_osds_exist() const;
+  std::pair<int, std::string> _create_audit_pool();
+  std::pair<int, std::string> _appify_audit_pool();
+  void _ensure_audit_pool();
 
   class OSDPerfMetricCollectorListener : public MetricListener {
   public:
@@ -370,6 +377,8 @@ public:
                     const cmdmap_t& cmdmap,
                     Formatter *f,
                     std::ostream& ss);
+
+  void ensure_audit_pool();
 };
 
 #endif

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -391,6 +391,8 @@ void Mgr::init()
   }
 #endif
 
+  server.ensure_audit_pool();
+
   dout(4) << "Complete." << dendl;
   initializing = false;
   initialized = true;

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -509,3 +509,20 @@ add_ceph_unittest(unittest_async_cond)
 add_executable(unittest_async_redirect_error test_async_redirect_error.cc)
 target_link_libraries(unittest_async_redirect_error GTest::GTest)
 add_ceph_unittest(unittest_async_redirect_error)
+
+if(WITH_LIBCEPHSQLITE)
+  # Link AuditDB.cc here (not the `audit_db` target): that target is created in
+  # src/CMakeLists.txt after add_subdirectory(test), so it is not visible when
+  # this file is configured.
+  add_executable(ceph_test_audit_db
+    test_audit_db.cc
+    ${CMAKE_SOURCE_DIR}/src/common/AuditDB.cc)
+  target_link_libraries(ceph_test_audit_db
+    cephsqlite
+    librados
+    ceph-common
+    global
+    SQLite3::SQLite3
+    ${UNITTEST_LIBS})
+  install(TARGETS ceph_test_audit_db DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()

--- a/src/test/common/test_audit_db.cc
+++ b/src/test/common/test_audit_db.cc
@@ -1,0 +1,1250 @@
+#include <fmt/format.h>
+#include <sqlite3.h>
+
+#include <chrono>
+#include <expected>
+#include <random>
+#include <thread>
+
+#include "common/debug.h"
+#include "include/rados/librados.hpp"
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
+#include "gtest/gtest.h"
+#include "include/libcephsqlite.h"
+#include "include/uuid.h"
+
+#include "common/AuditDB.h"
+
+#define dout_subsys ceph_subsys_client
+#undef dout_prefix
+#define dout_prefix *_dout << "test_audit_db: "
+
+static boost::intrusive_ptr<CephContext> cct;
+
+using milliseconds = std::chrono::milliseconds;
+using high_resolution_clock = std::chrono::high_resolution_clock;
+
+namespace {
+time_t
+get_time()
+{
+  return high_resolution_clock::to_time_t(high_resolution_clock::now());
+}
+
+} // namespace
+
+class AuditDBTest : public ::testing::Test {
+public:
+  inline static const std::string pool = ".test_audit_db";
+
+  static void
+  SetUpTestSuite()
+  {
+    librados::Rados cluster;
+    ASSERT_LE(0, cluster.init_with_context(cct.get()));
+    ASSERT_LE(0, cluster.connect());
+    if (int rc = cluster.pool_create(pool.c_str()); rc < 0 && rc != -EEXIST) {
+      ASSERT_EQ(0, rc);
+    }
+    cluster.shutdown();
+    sleep(5);
+  }
+
+  void
+  SetUp() override
+  {
+    u.generate_random();
+    uri = fmt::format(
+        "file:///{}:/test_audit_{}.db?vfs=ceph", pool, u.to_string());
+    ASSERT_LE(0, cluster.init_with_context(cct.get()));
+    ASSERT_LE(0, cluster.connect());
+    ASSERT_LE(0, cluster.wait_for_latest_osdmap());
+
+    db = std::make_unique<AuditDB>(cct.get(), uri.c_str(), true, "audit_log");
+    ASSERT_TRUE(db->init().has_value());
+    ASSERT_TRUE(db->is_initialised());
+  }
+
+  void
+  TearDown() override
+  {
+    db.reset();
+    cluster.shutdown();
+  }
+
+protected:
+  std::string uri;
+  uuid_d u;
+  std::unique_ptr<AuditDB> db;
+  librados::Rados cluster;
+};
+
+TEST_F(AuditDBTest, TwoPhaseCommitRoundTrip)
+{
+  int64_t seq = 1;
+  std::string cmd = "osd pool create foo";
+  std::string cmd_args = "8 8";
+  time_t start_time = get_time();
+
+  ASSERT_TRUE(db->first_phase_commit(seq, cmd, cmd_args, start_time).has_value());
+
+  time_t comp_time = get_time();
+  ASSERT_TRUE(db->second_phase_commit(seq, comp_time, "success", 0).has_value());
+
+  AuditQuery q;
+  auto rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  ASSERT_EQ(rows->size(), 1);
+  EXPECT_EQ((*rows)[0].seq, seq);
+  EXPECT_EQ((*rows)[0].cmd, cmd);
+  EXPECT_EQ((*rows)[0].init_time, start_time);
+  EXPECT_EQ((*rows)[0].comp_time.value(), comp_time);
+  EXPECT_EQ((*rows)[0].status.value(), "success");
+  EXPECT_EQ((*rows)[0].retval.value(), 0);
+
+  db->clear_logs();
+  rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  ASSERT_EQ(rows->size(), 0);
+}
+
+TEST_F(AuditDBTest, RejectsDuplicateSeq)
+{
+  ASSERT_TRUE(db->first_phase_commit(5, "a", "b", get_time()).has_value());
+  auto r = db->first_phase_commit(5, "b", "c", get_time());
+  ASSERT_FALSE(r.has_value());
+  ASSERT_EQ(r.error().code, AuditDBErr::sqlite_step_failed);
+  ASSERT_EQ(r.error().detail, SQLITE_CONSTRAINT_PRIMARYKEY);
+}
+
+TEST_F(AuditDBTest, AllowsNonMonotonicSeq)
+{
+  ASSERT_TRUE(db->first_phase_commit(10, "ceph osd ls", "8 8", get_time()).has_value());
+  ASSERT_TRUE(db->first_phase_commit(3, "ceph lspools", "{}", get_time()).has_value());
+}
+
+TEST_F(AuditDBTest, ReadUnfinishedCommandAuditLog)
+{
+  int64_t seq = 1;
+  std::string cmd = "osd pool ls";
+  std::string cmd_args = "detail";
+  time_t init_time = get_time();
+
+  ASSERT_TRUE(db->first_phase_commit(seq, cmd, cmd_args, init_time).has_value());
+
+  AuditQuery q;
+  auto rows = db->query(q);
+  EXPECT_TRUE(rows.has_value());
+  ASSERT_EQ(rows->size(), 1);
+  EXPECT_EQ((*rows)[0].seq, 1);
+  EXPECT_EQ((*rows)[0].cmd, cmd);
+  EXPECT_EQ((*rows)[0].cmd_args, cmd_args);
+  EXPECT_EQ((*rows)[0].init_time, init_time);
+  EXPECT_FALSE((*rows)[0].comp_time.has_value());
+  EXPECT_FALSE((*rows)[0].status.has_value());
+  EXPECT_FALSE((*rows)[0].retval.has_value());
+}
+
+TEST_F(AuditDBTest, InvalidTableNameTest)
+{
+  struct InvalidTableNameCase {
+    std::string name;
+    std::string reason;
+  };
+  
+  std::vector<InvalidTableNameCase> invalid_names = {
+    // Reserved name
+    {"schema_version", "reserved name"},
+    
+    // Too long (>63 chars)
+    {"a" + std::string(63, 'x'), "too long (64 chars)"},
+    
+    // Empty
+    {"", "empty string"},
+    
+    // Starts with number
+    {"123_table", "starts with number"},
+    
+    // Contains special characters
+    {"table-name", "contains hyphen"},
+    {"table.name", "contains dot"},
+    {"table name", "contains space"},
+    {"table;DROP", "contains semicolon (SQL injection attempt)"},
+    {"table'OR'1'='1", "contains quotes (SQL injection attempt)"},
+    
+    // Contains SQL keywords as injection
+    {"audit; DROP TABLE audit--", "SQL injection with DROP"},
+    {"audit/*comment*/", "SQL injection with comment"},
+  };
+  
+  for (const auto& test_case : invalid_names) {
+    std::cout << "Testing invalid table name: '" << test_case.name 
+              << "' (" << test_case.reason << ")\n";
+    
+    auto invalid_db = std::make_unique<AuditDB>(
+        cct.get(), uri.c_str(), true, test_case.name);
+    
+    auto init_result = invalid_db->init();
+    
+    EXPECT_FALSE(init_result.has_value()) 
+        << "Table name '" << test_case.name << "' should be rejected";
+    
+    if (!init_result.has_value()) {
+      EXPECT_EQ(init_result.error().code, AuditDBErr::invalid_table_name)
+          << "Expected invalid_table_name error for '" << test_case.name << "'";
+    }
+  }
+  
+  // Test valid edge cases
+  std::vector<std::string> valid_names = {
+    "a",                          // 1 char (minimum)
+    "_table",                     // starts with underscore
+    "Table123",                   // mixed case with numbers
+    std::string(63, 'a'),        // 63 chars (maximum)
+    "audit_log_2024",            // typical valid name
+  };
+  
+  for (const auto& valid_name : valid_names) {
+    std::cout << "Testing valid table name: '" << valid_name << "'\n";
+    
+    // Create unique URI for each test
+    uuid_d u;
+    u.generate_random();
+    std::string test_uri = fmt::format(
+        "file:///{}:/test_valid_{}.db?vfs=ceph", pool, u.to_string());
+    
+    auto valid_db = std::make_unique<AuditDB>(
+        cct.get(), test_uri.c_str(), true, valid_name);
+    
+    auto init_result = valid_db->init();
+    
+    EXPECT_TRUE(init_result.has_value()) 
+        << "Table name '" << valid_name << "' should be accepted";
+    
+    if (init_result.has_value()) {
+      EXPECT_TRUE(valid_db->is_initialised());
+    }
+  }
+}
+
+TEST_F(AuditDBTest, NegativeSequenceNumberTest)
+{
+  int64_t negative_seq = -1;
+  std::string cmd = "test_command";
+  std::string cmd_args = cmd + " dummy_args";
+  time_t init_time = get_time();
+  
+  auto result = db->first_phase_commit(negative_seq, cmd, cmd_args, init_time);
+  
+  EXPECT_FALSE(result.has_value());
+  if (!result.has_value()) {
+    EXPECT_EQ(result.error().code, AuditDBErr::invalid_seq)
+        << "Negative sequence should fail";
+  }
+  
+  // Verify database is still empty
+  AuditQuery q;
+  auto rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), 0) << "No entries should be added with invalid sequences";
+  
+  // Verify we can still add valid sequences
+  ASSERT_TRUE(db->first_phase_commit(1, cmd, cmd_args, init_time).has_value());
+  ASSERT_TRUE(db->second_phase_commit(1, get_time(), "ok", 0).has_value());
+  
+  rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), 1);
+  EXPECT_EQ((*rows)[0].seq, 1);
+}
+
+TEST_F(AuditDBTest, ReadEmptyDatabaseTest)
+{
+  // Verify database is initialized but empty
+  ASSERT_TRUE(db->is_initialised());
+  
+  // Test query on empty database
+  AuditQuery q;
+  auto rows = db->query(q);
+  ASSERT_TRUE(rows.has_value()) << "Query should succeed on empty database";
+  EXPECT_EQ(rows->size(), 0) << "Empty database should return no rows";
+  
+  // Test count on empty database
+  auto count_result = db->count(q);
+  ASSERT_TRUE(count_result.has_value()) << "Count should succeed on empty database";
+  EXPECT_EQ(*count_result, 0) << "Empty database should have count of 0";
+  
+  // Test get_last_committed_seq on empty database
+  auto seq_result = db->get_last_committed_seq();
+  EXPECT_FALSE(seq_result.has_value()) << "Empty database should not have a last seq";
+  if (!seq_result.has_value()) {
+    EXPECT_EQ(seq_result.error().code, AuditDBErr::empty_table)
+        << "Should return empty_table error";
+  }
+  
+  // Test trim on empty database
+  time_t now = get_time();
+  auto trim_result = db->trim(now);
+  ASSERT_TRUE(trim_result.has_value()) << "Trim should succeed on empty database";
+  EXPECT_EQ(*trim_result, 0) << "Trim should delete 0 rows from empty database";
+  
+  // Test query with various filters on empty database
+  AuditQuery filtered_q;
+  filtered_q.after_seq = 100;
+  filtered_q.before_seq = 200;
+  filtered_q.since = now - 3600;
+  filtered_q.until = now;
+  filtered_q.status = "success";
+  
+  rows = db->query(filtered_q);
+  ASSERT_TRUE(rows.has_value()) << "Filtered query should succeed on empty database";
+  EXPECT_EQ(rows->size(), 0) << "Filtered query on empty database should return no rows";
+  
+  count_result = db->count(filtered_q);
+  ASSERT_TRUE(count_result.has_value()) << "Filtered count should succeed on empty database";
+  EXPECT_EQ(*count_result, 0) << "Filtered count on empty database should be 0";
+}
+
+TEST_F(AuditDBTest, TrimAndQueryDeletedRangeTest)
+{
+  constexpr int64_t TOTAL_ENTRIES = 100;
+  constexpr int64_t ENTRIES_TO_DELETE = 20;
+  
+  // Write 100 entries with timestamps spread over time
+  time_t base_time = get_time() - 1000; // Start 1000 seconds ago
+  
+  for (int64_t seq = 1; seq <= TOTAL_ENTRIES; ++seq) {
+    std::string cmd = fmt::format("command_{}", seq);
+    std::string cmd_args = cmd + " dummy_args";
+    time_t init_time = base_time + (seq * 10); // 10 seconds apart
+    
+    ASSERT_TRUE(db->first_phase_commit(seq, cmd, cmd_args, init_time).has_value());
+    ASSERT_TRUE(db->second_phase_commit(seq, init_time + 1, "success", 0).has_value());
+  }
+  
+  // Verify all 100 entries exist
+  AuditQuery q;
+  q.limit = TOTAL_ENTRIES + 10;
+  auto rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), TOTAL_ENTRIES);
+  
+  // Calculate trim time to delete oldest 20 entries
+  // Entry 20 has init_time = base_time + (20 * 10)
+  // Entry 21 has init_time = base_time + (21 * 10)
+  time_t trim_time = base_time + (ENTRIES_TO_DELETE * 10) + 5; // Between entry 20 and 21
+  
+  // Trim oldest 20 entries
+  auto trim_result = db->trim(trim_time);
+  ASSERT_TRUE(trim_result.has_value());
+  EXPECT_EQ(*trim_result, ENTRIES_TO_DELETE) 
+      << "Should have deleted exactly " << ENTRIES_TO_DELETE << " entries";
+  
+  // Verify total count is now 80
+  auto count_result = db->count(q);
+  ASSERT_TRUE(count_result.has_value());
+  EXPECT_EQ(*count_result, TOTAL_ENTRIES - ENTRIES_TO_DELETE);
+  
+  // Try to query the deleted range (seq 1-20)
+  AuditQuery deleted_range_q;
+  deleted_range_q.after_seq = 0;
+  deleted_range_q.before_seq = ENTRIES_TO_DELETE + 1;
+  deleted_range_q.limit = 50;
+  
+  rows = db->query(deleted_range_q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), 0) 
+      << "Deleted entries (seq 1-20) should not be returned";
+  
+  // Verify remaining entries start from seq 21
+  AuditQuery remaining_q;
+  remaining_q.limit = 10;
+  remaining_q.ascending = true;
+  remaining_q.order_by = "seq";
+  
+  rows = db->query(remaining_q);
+  ASSERT_TRUE(rows.has_value());
+  ASSERT_GT(rows->size(), 0);
+  EXPECT_EQ((*rows)[0].seq, ENTRIES_TO_DELETE + 1) 
+      << "First remaining entry should be seq " << (ENTRIES_TO_DELETE + 1);
+  
+  // Verify we can query specific remaining entries
+  for (int64_t seq = ENTRIES_TO_DELETE + 1; seq <= TOTAL_ENTRIES; ++seq) {
+    AuditQuery specific_q;
+    specific_q.after_seq = seq - 1;
+    specific_q.before_seq = seq + 1;
+    
+    rows = db->query(specific_q);
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows->size(), 1) << "Should find entry with seq " << seq;
+    EXPECT_EQ((*rows)[0].seq, seq);
+    EXPECT_EQ((*rows)[0].cmd, fmt::format("command_{}", seq));
+  }
+  
+  // Verify deleted entries are truly gone by checking specific sequences
+  for (int64_t seq = 1; seq <= ENTRIES_TO_DELETE; ++seq) {
+    AuditQuery deleted_q;
+    deleted_q.after_seq = seq - 1;
+    deleted_q.before_seq = seq + 1;
+    
+    rows = db->query(deleted_q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_EQ(rows->size(), 0) 
+        << "Deleted entry with seq " << seq << " should not be found";
+  }
+  
+  // Test get_last_committed_seq still returns the highest seq (100)
+  auto last_seq = db->get_last_committed_seq();
+  ASSERT_TRUE(last_seq.has_value());
+  EXPECT_EQ(*last_seq, TOTAL_ENTRIES) 
+      << "Last committed seq should still be " << TOTAL_ENTRIES;
+}
+
+TEST_F(AuditDBTest, DeleteAndRecreateDatabaseTest)
+{
+  // Add some entries
+  for (int64_t seq = 1; seq <= 10; ++seq) {
+    std::string cmd = fmt::format("ceph osd pool create {}", seq);
+    std::string cmd_args = "8 8";
+    ASSERT_TRUE(db->first_phase_commit(seq, cmd, cmd_args, get_time()).has_value());
+    ASSERT_TRUE(db->second_phase_commit(seq, get_time(), "ok", 0).has_value());
+  }
+  
+  // Verify entries exist
+  AuditQuery q;
+  auto rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), 10);
+  
+  // Close the database
+  db.reset();
+  
+  // Delete the database file using VFS
+  std::string db_path = fmt::format("{}:/test_audit_{}.db", pool, u);
+  auto delete_result = AuditDB::delete_db_file(cct.get(), cluster, db_path.c_str());
+  ASSERT_TRUE(delete_result.has_value());
+  
+  // Recreate database instance
+  db = std::make_unique<AuditDB>(cct.get(), uri.c_str(), true, "audit_log");
+  ASSERT_TRUE(db->init().has_value());
+  
+  // Try to query - should return empty or handle gracefully
+  rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), 0);
+  
+  // Verify we can still write
+  ASSERT_TRUE(db->first_phase_commit(1, "ceph osd pool create foo", "8 8", get_time()).has_value());
+  
+  rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), 1);
+}
+
+TEST_F(AuditDBTest, PerformanceHeavyWriteAndTrim)
+{
+  constexpr int64_t NUM_ENTRIES = 5000;
+  
+  // Measure write performance
+  auto write_start = high_resolution_clock::now();
+  
+  for (int64_t seq = 1; seq <= NUM_ENTRIES; ++seq) {
+    std::string cmd = fmt::format("test_command_{}", seq);
+    std::string cmd_args = cmd + " dummy_args";
+    time_t init_time = get_time();
+    
+    ASSERT_TRUE(db->first_phase_commit(seq, cmd, cmd_args, init_time).has_value());
+
+    time_t comp_time = get_time();
+    ASSERT_TRUE(db->second_phase_commit(seq, comp_time, "success", 0).has_value());
+  }
+  
+  auto write_end = high_resolution_clock::now();
+  auto write_duration = std::chrono::duration_cast<milliseconds>(
+      write_end - write_start);
+  
+  std::cout << "Write Performance:\n"
+            << "  Entries: " << NUM_ENTRIES << "\n"
+            << "  Duration: " << write_duration.count() << " ms\n"
+            << "  Rate: " << (NUM_ENTRIES * 1000.0 / write_duration.count()) 
+            << " entries/sec\n";
+  
+  // Verify count
+  AuditQuery q;
+  q.limit = NUM_ENTRIES + 1;
+  auto count_result = db->count(q);
+  ASSERT_TRUE(count_result.has_value());
+  EXPECT_EQ(*count_result, NUM_ENTRIES);
+  
+  // Measure trim performance
+  auto clear_start = high_resolution_clock::now();
+  
+  auto clear_result = db->clear_logs();
+  
+  auto clear_end = high_resolution_clock::now();
+  auto trim_duration = std::chrono::duration_cast<milliseconds>(
+      clear_end - clear_start);
+  
+  ASSERT_TRUE(clear_result.has_value());
+  EXPECT_EQ(*clear_result, NUM_ENTRIES);
+  
+  std::cout << "Trim Performance:\n"
+            << "  Deleted: " << *clear_result << " entries\n"
+            << "  Duration: " << trim_duration.count() << " ms\n"
+            << "  Rate: " << (*clear_result * 1000.0 / trim_duration.count()) 
+            << " entries/sec\n";
+  
+  // Verify empty
+  count_result = db->count(q);
+  ASSERT_TRUE(count_result.has_value());
+  EXPECT_EQ(*count_result, 0);
+}
+
+TEST_F(AuditDBTest, MultipleConcurrentReadersTest)
+{
+  for (int64_t seq = 1; seq <= 1000; ++seq) {
+    ASSERT_TRUE(db->first_phase_commit(seq, "cmd", "cmd_args", get_time()).has_value());
+    ASSERT_TRUE(db->second_phase_commit(seq, get_time(), "ok", 0).has_value());
+  }
+  
+  constexpr int NUM_READERS = 5;
+  std::vector<std::thread> readers;
+  std::atomic<int> successful_reads{0};
+  
+  for (int i = 0; i < NUM_READERS; ++i) {
+    readers.emplace_back([&, i]() {
+      auto reader_db = std::make_unique<AuditDB>(
+          cct.get(), uri.c_str(), true, "audit_log");
+      EXPECT_TRUE(reader_db->init().has_value());
+      
+      AuditQuery q;
+      q.limit = 100;
+      q.after_seq = i * 100;
+      
+      auto rows = reader_db->query(q);
+      if (rows.has_value()) {
+        successful_reads++;
+      }
+    });
+  }
+  
+  for (auto& t : readers) {
+    t.join();
+  }
+  
+  EXPECT_EQ(successful_reads, NUM_READERS);
+}
+
+TEST_F(AuditDBTest, SQLiteBusyRetryTest)
+{
+  // This test simulates high contention scenarios
+  constexpr int NUM_WRITERS = 3;
+  constexpr int WRITES_PER_THREAD = 100;
+  
+  std::vector<std::thread> writers;
+  std::atomic<int> successful_writes{0};
+  std::atomic<int> busy_errors{0};
+  
+  for (int thread_id = 0; thread_id < NUM_WRITERS; ++thread_id) {
+    writers.emplace_back([&, thread_id]() {
+      auto writer_db = std::make_unique<AuditDB>(
+          cct.get(), uri.c_str(), true, "audit_log");
+      EXPECT_TRUE(writer_db->init().has_value());
+      
+      for (int i = 0; i < WRITES_PER_THREAD; ++i) {
+        int64_t seq = thread_id * WRITES_PER_THREAD + i + 1;
+        std::string cmd = fmt::format("thread_{}_cmd_{}", thread_id, i);
+        std::string cmd_args = cmd + " dummy_args";
+        
+        // Retry logic for SQLITE_BUSY
+        int retries = 0;
+        const int MAX_RETRIES = 10;
+        bool success = false;
+        
+        while (retries < MAX_RETRIES && !success) {
+          auto result = writer_db->first_phase_commit(seq, cmd, cmd_args, get_time());
+          
+          if (result.has_value()) {
+            auto comp_result = writer_db->second_phase_commit(
+                seq, get_time(), "ok", 0);
+            if (comp_result.has_value()) {
+              successful_writes++;
+              success = true;
+            } else if (comp_result.error().detail == SQLITE_BUSY) {
+              busy_errors++;
+              std::this_thread::sleep_for(milliseconds(50));
+              retries++;
+            }
+          } else if (result.error().detail == SQLITE_BUSY) {
+            busy_errors++;
+            std::this_thread::sleep_for(milliseconds(50));
+            retries++;
+          } else {
+            // Other error, don't retry
+            break;
+          }
+        }
+      }});
+    }
+  
+  for (auto& t : writers) {
+    t.join();
+  }
+  
+  std::cout << "SQLITE_BUSY Test Results:\n"
+            << "  Successful writes: " << successful_writes << "\n"
+            << "  BUSY errors encountered: " << busy_errors << "\n";
+  
+  EXPECT_EQ(successful_writes, NUM_WRITERS * WRITES_PER_THREAD);
+}
+
+TEST_F(AuditDBTest, SecondPhaseFailsWhenSeqMissing) {
+  ASSERT_TRUE(db->first_phase_commit(1, "cmd", "cmd_args", get_time()).has_value());
+  auto r = db->second_phase_commit(2, get_time(), "ok", 0);
+  EXPECT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().code, AuditDBErr::row_count_mismatch);
+}
+ 
+TEST_F(AuditDBTest, SecondPhaseFailsWhenAlreadyCommitted) {  
+  ASSERT_TRUE(db->first_phase_commit(5, "cmd", "cmd_args", get_time()).has_value());
+  ASSERT_TRUE(db->second_phase_commit(5, get_time(), "ok", 0).has_value());
+  auto r = db->second_phase_commit(5, get_time(), "ok", 0);
+  EXPECT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().code, AuditDBErr::row_count_mismatch);
+}
+
+TEST_F(AuditDBTest, TrimWithMaxDeleteTest) {
+  // Add 100 entries
+  for (int64_t seq = 1; seq <= 100; ++seq) {
+    ASSERT_TRUE(db->first_phase_commit(seq, "cmd", "cmd_args", get_time()).has_value());
+    ASSERT_TRUE(db->second_phase_commit(seq, get_time(), "ok", 0).has_value());
+  }
+  
+  // Trim with max_delete = 10
+  auto result = db->trim(get_time() + 1, 10);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 10);
+  
+  // Verify 90 remain
+  AuditQuery q;
+  auto count = db->count(q);
+  ASSERT_TRUE(count.has_value());
+  EXPECT_EQ(*count, 90);
+  
+  // Test max_delete = 0
+  result = db->trim(get_time() + 1, 0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 90);
+
+  // Should report 0
+  count = db->count(q);
+  ASSERT_TRUE(count.has_value());
+  EXPECT_EQ(*count, 0);
+}
+
+TEST_F(AuditDBTest, DatabasePersistenceTest) {
+  // Write entries
+  for (int64_t seq = 1; seq <= 10; ++seq) {
+    ASSERT_TRUE(db->first_phase_commit(seq, "cmd", "cmd_args", get_time()).has_value());
+    ASSERT_TRUE(db->second_phase_commit(seq, get_time(), "ok", 0).has_value());
+  }
+  
+  // Close database
+  db.reset();
+  
+  // Reopen same database
+  db = std::make_unique<AuditDB>(cct.get(), uri.c_str(), true, "audit_log");
+  ASSERT_TRUE(db->init().has_value());
+  
+  // Verify data persisted
+  AuditQuery q;
+  auto rows = db->query(q);
+  ASSERT_TRUE(rows.has_value());
+  EXPECT_EQ(rows->size(), 10);
+  
+  // Verify last committed seq
+  auto seq = db->get_last_committed_seq();
+  EXPECT_TRUE(seq.has_value());
+  EXPECT_EQ(*seq, 10);
+  
+  // Verify we can continue with seq 11
+  ASSERT_TRUE(db->first_phase_commit(11, "cmd", "cmd_args", get_time()).has_value());
+}
+
+TEST_F(AuditDBTest, CountWithFiltersTest) {
+  // Add entries with different statuses
+  for (int64_t seq = 1; seq <= 50; ++seq) {
+    ASSERT_TRUE(db->first_phase_commit(seq, "cmd", "cmd_args", get_time()).has_value());
+    std::string status = (seq % 2 == 0) ? "success" : "failure";
+    ASSERT_TRUE(db->second_phase_commit(seq, get_time(), status, 0).has_value());
+  }
+  
+  // Count with status filter
+  AuditQuery q;
+  q.status = "success";
+  auto count = db->count(q);
+  ASSERT_TRUE(count.has_value());
+  EXPECT_EQ(*count, 25);
+  
+  // Count with seq range
+  q.status.reset();
+  q.after_seq = 10;
+  q.before_seq = 21;
+  count = db->count(q);
+  ASSERT_TRUE(count.has_value());
+  EXPECT_EQ(*count, 10);
+}
+
+TEST_F(AuditDBTest, QueryFilteringTest)
+{
+  // Setup: Create entries with varied attributes for comprehensive filtering tests
+  constexpr int64_t TOTAL_ENTRIES = 50;
+  time_t base_time = get_time() - 1000; // Start 1000 seconds ago
+  
+  // Create entries with different statuses and times
+  for (int64_t seq = 1; seq <= TOTAL_ENTRIES; ++seq) {
+    std::string cmd = fmt::format("command_{}", seq);
+    std::string cmd_args = cmd + " dummy_args";
+    time_t init_time = base_time + (seq * 10); // 10 seconds apart
+    
+    ASSERT_TRUE(db->first_phase_commit(seq, cmd, cmd_args, init_time).has_value());
+    
+    // Vary completion times and statuses
+    time_t comp_time = init_time + (seq % 5) + 1; // 1-5 seconds after init
+    std::string status;
+    int32_t retval;
+    
+    if (seq % 3 == 0) {
+      status = "success";
+      retval = 0;
+    } else if (seq % 3 == 1) {
+      status = "failure";
+      retval = -EINVAL;
+    } else {
+      status = "timeout";
+      retval = -ETIMEDOUT;
+    }
+    
+    ASSERT_TRUE(db->second_phase_commit(seq, comp_time, status, retval).has_value());
+  }
+  
+  // Test 1: Time-based filtering (since)
+  {
+    time_t since_time = base_time + 250; // After seq 25
+    AuditQuery q;
+    q.since = since_time;
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_GT(rows->size(), 0);
+    
+    // Verify all returned entries are after since_time
+    for (const auto& entry : *rows) {
+      EXPECT_GE(entry.init_time, since_time)
+          << "Entry seq=" << entry.seq << " has init_time before since filter";
+    }
+  }
+  
+  // Test 2: Time-based filtering (until)
+  {
+    time_t until_time = base_time + 250; // Before seq 26
+    AuditQuery q;
+    q.until = until_time;
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_GT(rows->size(), 0);
+    
+    // Verify all returned entries are before until_time
+    for (const auto& entry : *rows) {
+      EXPECT_LE(entry.init_time, until_time)
+          << "Entry seq=" << entry.seq << " has init_time after until filter";
+    }
+  }
+  
+  // Test 3: Time-based filtering (since AND until - range)
+  {
+    time_t since_time = base_time + 100; // After seq 10
+    time_t until_time = base_time + 300; // Before seq 31
+    AuditQuery q;
+    q.since = since_time;
+    q.until = until_time;
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_GT(rows->size(), 0);
+    
+    // Verify all entries are within the time range
+    for (const auto& entry : *rows) {
+      EXPECT_GE(entry.init_time, since_time);
+      EXPECT_LE(entry.init_time, until_time);
+    }
+    
+    // Verify count matches
+    auto count = db->count(q);
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(*count, rows->size());
+  }
+  
+  // Test 4: Status filtering (success)
+  {
+    AuditQuery q;
+    q.status = "success";
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_GT(rows->size(), 0);
+    
+    // Verify all entries have success status
+    for (const auto& entry : *rows) {
+      ASSERT_TRUE(entry.status.has_value());
+      EXPECT_EQ(*entry.status, "success")
+          << "Entry seq=" << entry.seq << " has wrong status";
+    }
+    
+    // Count should match (every 3rd entry is success)
+    auto count = db->count(q);
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(*count, TOTAL_ENTRIES / 3);
+  }
+  
+  // Test 5: Status filtering (failure)
+  {
+    AuditQuery q;
+    q.status = "failure";
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    
+    for (const auto& entry : *rows) {
+      ASSERT_TRUE(entry.status.has_value());
+      EXPECT_EQ(*entry.status, "failure");
+      ASSERT_TRUE(entry.retval.has_value());
+      EXPECT_EQ(*entry.retval, -EINVAL);
+    }
+  }
+  
+  // Test 6: Sequence filtering (after_seq)
+  {
+    AuditQuery q;
+    q.after_seq = 25;
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    
+    for (const auto& entry : *rows) {
+      EXPECT_GT(entry.seq, 25);
+    }
+  }
+  
+  // Test 7: Sequence filtering (before_seq)
+  {
+    AuditQuery q;
+    q.before_seq = 26;
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    
+    for (const auto& entry : *rows) {
+      EXPECT_LT(entry.seq, 26);
+    }
+  }
+  
+  // Test 8: Sequence range (after_seq AND before_seq)
+  {
+    AuditQuery q;
+    q.after_seq = 10;
+    q.before_seq = 21;
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_EQ(rows->size(), 10); // seq 11-20
+    
+    for (const auto& entry : *rows) {
+      EXPECT_GT(entry.seq, 10);
+      EXPECT_LT(entry.seq, 21);
+    }
+  }
+  
+  // Test 9: Order by seq, ascending
+  {
+    AuditQuery q;
+    q.order_by = "seq";
+    q.ascending = true;
+    q.limit = 10;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows->size(), 10);
+    
+    // Verify ascending order
+    for (size_t i = 1; i < rows->size(); ++i) {
+      EXPECT_LT((*rows)[i-1].seq, (*rows)[i].seq)
+          << "Entries not in ascending seq order";
+    }
+    
+    // First entry should be seq=1
+    EXPECT_EQ((*rows)[0].seq, 1);
+  }
+  
+  // Test 10: Order by seq, descending (default)
+  {
+    AuditQuery q;
+    q.order_by = "seq";
+    q.ascending = false;
+    q.limit = 10;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows->size(), 10);
+    
+    // Verify descending order
+    for (size_t i = 1; i < rows->size(); ++i) {
+      EXPECT_GT((*rows)[i-1].seq, (*rows)[i].seq)
+          << "Entries not in descending seq order";
+    }
+    
+    // First entry should be seq=50
+    EXPECT_EQ((*rows)[0].seq, TOTAL_ENTRIES);
+  }
+  
+  // Test 11: Order by init_time, ascending
+  {
+    AuditQuery q;
+    q.order_by = "init_time";
+    q.ascending = true;
+    q.limit = 10;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows->size(), 10);
+    
+    // Verify ascending order by init_time
+    for (size_t i = 1; i < rows->size(); ++i) {
+      EXPECT_LE((*rows)[i-1].init_time, (*rows)[i].init_time)
+          << "Entries not in ascending init_time order";
+    }
+  }
+  
+  // Test 12: Order by init_time, descending
+  {
+    AuditQuery q;
+    q.order_by = "init_time";
+    q.ascending = false;
+    q.limit = 10;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows->size(), 10);
+    
+    // Verify descending order by init_time
+    for (size_t i = 1; i < rows->size(); ++i) {
+      EXPECT_GE((*rows)[i-1].init_time, (*rows)[i].init_time)
+          << "Entries not in descending init_time order";
+    }
+  }
+  
+  // Test 13: Order by comp_time, ascending
+  {
+    AuditQuery q;
+    q.order_by = "comp_time";
+    q.ascending = true;
+    q.limit = 10;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows->size(), 10);
+    
+    // Verify ascending order by comp_time
+    for (size_t i = 1; i < rows->size(); ++i) {
+      ASSERT_TRUE((*rows)[i-1].comp_time.has_value());
+      ASSERT_TRUE((*rows)[i].comp_time.has_value());
+      EXPECT_LE(*(*rows)[i-1].comp_time, *(*rows)[i].comp_time)
+          << "Entries not in ascending comp_time order";
+    }
+  }
+  
+  // Test 14: Limit and pagination
+  {
+    AuditQuery q;
+    q.order_by = "seq";
+    q.ascending = true;
+    q.limit = 10;
+    
+    // First page
+    auto page1 = db->query(q);
+    ASSERT_TRUE(page1.has_value());
+    ASSERT_EQ(page1->size(), 10);
+    EXPECT_EQ((*page1)[0].seq, 1);
+    EXPECT_EQ((*page1)[9].seq, 10);
+    
+    // Second page
+    q.after_seq = 10;
+    auto page2 = db->query(q);
+    ASSERT_TRUE(page2.has_value());
+    ASSERT_EQ(page2->size(), 10);
+    EXPECT_EQ((*page2)[0].seq, 11);
+    EXPECT_EQ((*page2)[9].seq, 20);
+    
+    // Third page
+    q.after_seq = 20;
+    auto page3 = db->query(q);
+    ASSERT_TRUE(page3.has_value());
+    ASSERT_EQ(page3->size(), 10);
+    EXPECT_EQ((*page3)[0].seq, 21);
+    EXPECT_EQ((*page3)[9].seq, 30);
+  }
+  
+  // Test 15: Combined filters (time + status + seq range)
+  {
+    time_t since_time = base_time + 100;
+    time_t until_time = base_time + 400;
+    
+    AuditQuery q;
+    q.since = since_time;
+    q.until = until_time;
+    q.status = "success";
+    q.after_seq = 5;
+    q.before_seq = 45;
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    
+    // Verify all filters are applied
+    for (const auto& entry : *rows) {
+      EXPECT_GE(entry.init_time, since_time);
+      EXPECT_LE(entry.init_time, until_time);
+      ASSERT_TRUE(entry.status.has_value());
+      EXPECT_EQ(*entry.status, "success");
+      EXPECT_GT(entry.seq, 5);
+      EXPECT_LT(entry.seq, 45);
+    }
+    
+    // Verify count matches
+    auto count = db->count(q);
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(*count, rows->size());
+  }
+  
+  // Test 16: Empty result set with filters
+  {
+    AuditQuery q;
+    q.status = "nonexistent_status";
+    q.limit = 100;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_EQ(rows->size(), 0);
+    
+    auto count = db->count(q);
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(*count, 0);
+  }
+  
+  // Test 17: Limit of 0 (should return empty)
+  {
+    AuditQuery q;
+    q.limit = 0;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_EQ(rows->size(), 0);
+  }
+  
+  // Test 18: Very large limit (should return all matching entries)
+  {
+    AuditQuery q;
+    q.limit = 10000;
+    
+    auto rows = db->query(q);
+    ASSERT_TRUE(rows.has_value());
+    EXPECT_EQ(rows->size(), TOTAL_ENTRIES);
+  }
+}
+
+TEST_F(AuditDBTest, GetDbSizeTest)
+{
+  auto size = db->get_db_size();
+  ASSERT_TRUE(size.has_value());
+  auto empty_size = *size;
+  std::cout << "empty size : " << empty_size << std::endl;
+  EXPECT_GT(empty_size, 0) << "Schema alone should occupy 448 KiB";
+
+  for (int64_t seq = 1; seq <= 1500; ++seq) {
+    ASSERT_TRUE(db->first_phase_commit(
+      seq, "osd pool create foo", "8 8", get_time()).has_value());
+    ASSERT_TRUE(db->second_phase_commit(
+      seq, get_time(), "success", 0).has_value());
+  }
+
+  size = db->get_db_size();
+  ASSERT_TRUE(size.has_value());
+  EXPECT_GT(*size, empty_size) << "Size should grow to 576 KiB";
+  std::cout << "total size is: " << *size << " bytes" << std::endl;
+
+  // Clear and verify size shrinks
+  auto cleared = db->clear_logs();
+  ASSERT_TRUE(cleared.has_value());
+  EXPECT_EQ(*cleared, 1500);
+
+  size = db->get_db_size();
+  ASSERT_TRUE(size.has_value());
+  EXPECT_EQ(*size, empty_size)
+      << "Size after clear + vacuum should be equal to empty schema size";
+}
+
+TEST_F(AuditDBTest, StandaloneFirstPhaseAllocatesSeq)
+{
+  // build a standalone-mode AuditDB
+  auto sa_db = std::make_unique<AuditDB>(
+      cct.get(), uri.c_str(), true, "audit_log", /*is_standalone=*/true);
+  ASSERT_TRUE(sa_db->init().has_value());
+
+  auto r1 = sa_db->first_phase_commit("cmd", "args", get_time());
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(*r1, 1);               
+
+  auto r2 = sa_db->first_phase_commit("cmd2", "args2", get_time());
+  ASSERT_TRUE(r2.has_value());
+  EXPECT_EQ(*r2, 2);
+}
+
+TEST_F(AuditDBTest, StandaloneRejectsCallerSeq)
+{
+  auto sa_db = std::make_unique<AuditDB>(
+      cct.get(), uri.c_str(), true, "audit_log", true);
+  ASSERT_TRUE(sa_db->init().has_value());
+
+  auto r = sa_db->first_phase_commit(42, "cmd", "args", get_time());
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().code, AuditDBErr::seq_not_allowed_standalone);
+}
+
+TEST_F(AuditDBTest, DaemonRejectsMissingSeq)
+{
+  // existing fixture is daemon-mode (is_standalone defaults to false)
+  auto r = db->first_phase_commit("cmd", "args", get_time());
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().code, AuditDBErr::seq_required);
+}
+
+TEST_F(AuditDBTest, RejectsEmptyCmd)
+{
+  auto r = db->first_phase_commit(1, "", "args", get_time());
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().code, AuditDBErr::sqlite_step_failed);
+  EXPECT_EQ(r.error().detail, SQLITE_CONSTRAINT_CHECK);
+}
+
+TEST_F(AuditDBTest, RejectsWhitespaceOnlyCmd)
+{
+  auto r = db->first_phase_commit(1, "   ", "args", get_time());
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().detail, SQLITE_CONSTRAINT_CHECK);
+}
+
+TEST_F(AuditDBTest, RejectsZeroOrNegativeInitTime)
+{
+  auto r = db->first_phase_commit(1, "cmd", "args", 0);
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().detail, SQLITE_CONSTRAINT_CHECK);
+}
+
+TEST_F(AuditDBTest, RejectsCompTimeBeforeInitTime)
+{
+  time_t init = get_time();
+  ASSERT_TRUE(db->first_phase_commit(1, "cmd", "args", init).has_value());
+  auto r = db->second_phase_commit(1, init - 1, "ok", 0);
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().detail, SQLITE_CONSTRAINT_CHECK);
+}
+
+TEST_F(AuditDBTest, RejectsEmptyStatus)
+{
+  ASSERT_TRUE(db->first_phase_commit(1, "cmd", "args", get_time()).has_value());
+  auto r = db->second_phase_commit(1, get_time(), "", 0);
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().detail, SQLITE_CONSTRAINT_CHECK);
+}
+
+TEST_F(AuditDBTest, MethodsFailBeforeInit)
+{
+  auto fresh = std::make_unique<AuditDB>(cct.get(), "file:///nonexistent.db?vfs=ceph", true, "t");
+  // do NOT call init()
+  EXPECT_FALSE(fresh->is_initialised());
+
+  auto r = fresh->first_phase_commit(1, "c", "a", get_time());
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().code, AuditDBErr::not_initialised);
+
+  r = fresh->second_phase_commit(1, get_time(), "ok", 0);
+  ASSERT_FALSE(r);
+  EXPECT_EQ(r.error().code, AuditDBErr::not_initialised);
+}
+
+TEST_F(AuditDBTest, ClearLogsAllowsSeqReuse)
+{
+  ASSERT_TRUE(db->first_phase_commit(1, "c", "a", get_time()).has_value());
+  ASSERT_TRUE(db->second_phase_commit(1, get_time(), "ok", 0).has_value());
+  ASSERT_TRUE(db->clear_logs().has_value());
+  // seq=1 must be reusable now
+  ASSERT_TRUE(db->first_phase_commit(1, "c2", "a2", get_time()).has_value());
+}
+
+TEST_F(AuditDBTest, RejectsSeqZero)
+{
+  auto r = db->first_phase_commit(0, "c", "a", get_time());
+  ASSERT_FALSE(r.has_value());
+  EXPECT_EQ(r.error().code, AuditDBErr::invalid_seq);
+}
+
+int
+main(int argc, char** argv)
+{
+  auto args = argv_to_vec(argc, argv);
+
+  std::string conf_file_list;
+  std::string cluster;
+  CephInitParameters iparams = ceph_argparse_early_args(
+      args, CEPH_ENTITY_TYPE_CLIENT, &cluster, &conf_file_list);
+  cct = boost::intrusive_ptr<CephContext>(
+      common_preinit(iparams, CODE_ENVIRONMENT_UTILITY, 0), false);
+  cct->_conf.parse_config_files(
+      conf_file_list.empty() ? nullptr : conf_file_list.c_str(), &std::cerr, 0);
+  cct->_conf.parse_env(cct->get_module_type()); // environment variables override
+  cct->_conf.parse_argv(args);
+  cct->_conf.apply_changes(nullptr);
+  common_init_finish(cct.get());
+
+  if (int rc = sqlite3_config(SQLITE_CONFIG_URI, 1); rc) {
+    lderr(cct) << "sqlite3 config failed: " << rc << dendl;
+    exit(EXIT_FAILURE);
+  }
+
+  sqlite3_auto_extension((void (*)())sqlite3_cephsqlite_init);
+  sqlite3* db = nullptr;
+  if (int rc = sqlite3_open_v2(":memory:", &db, SQLITE_OPEN_READWRITE, nullptr);
+      rc == SQLITE_OK) {
+    sqlite3_close(db);
+  } else {
+    lderr(cct) << "could not open sqlite3: " << rc << dendl;
+    exit(EXIT_FAILURE);
+  }
+  if (int rc = cephsqlite_setcct(cct.get(), nullptr); rc < 0) {
+    lderr(cct) << "could not set cct: " << rc << dendl;
+    exit(EXIT_FAILURE);
+  }
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/tools/cephfs/CMakeLists.txt
+++ b/src/tools/cephfs/CMakeLists.txt
@@ -9,22 +9,34 @@ set(cephfs_journal_tool_srcs
   Resetter.cc
   RoleSelector.cc
   MDSUtility.cc)
+if(WITH_AUDITLOGGING)
+  list(APPEND cephfs_journal_tool_srcs ToolsAuditLogger.cc)
+endif()
 add_executable(cephfs-journal-tool ${cephfs_journal_tool_srcs})
 target_link_libraries(cephfs-journal-tool
   legacy-option-headers
   ceph-common librados mds osdc global Boost::boost
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} Boost::filesystem)
+if(WITH_AUDITLOGGING)
+  target_link_libraries(cephfs-journal-tool audit_db cephsqlite SQLite3::SQLite3)
+endif()
 
 set(cephfs-meta-injection_srcs
   cephfs-meta-injection.cc
   MetaTool.cc
   RoleSelector.cc
   MDSUtility.cc)
+if(WITH_AUDITLOGGING)
+  list(APPEND cephfs-meta-injection_srcs ToolsAuditLogger.cc)
+endif()
 add_executable(cephfs-meta-injection ${cephfs-meta-injection_srcs})
 target_link_libraries(cephfs-meta-injection
   legacy-option-headers
   ceph-common librados mds osdc global
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+if(WITH_AUDITLOGGING)
+  target_link_libraries(cephfs-meta-injection audit_db cephsqlite SQLite3::SQLite3)
+endif()
 
 set(cephfs_table_tool_srcs
   cephfs-table-tool.cc
@@ -32,9 +44,15 @@ set(cephfs_table_tool_srcs
   ProgressTracker.cc
   RoleSelector.cc
   MDSUtility.cc)
+if(WITH_AUDITLOGGING)
+  list(APPEND cephfs_table_tool_srcs ToolsAuditLogger.cc)
+endif()
 add_executable(cephfs-table-tool ${cephfs_table_tool_srcs})
 target_link_libraries(cephfs-table-tool ceph-common librados mds osdc global Boost::boost
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} Boost::filesystem)
+if(WITH_AUDITLOGGING)
+  target_link_libraries(cephfs-table-tool audit_db cephsqlite SQLite3::SQLite3)
+endif()
 
 set(cephfs_data_scan_srcs
   cephfs-data-scan.cc
@@ -43,10 +61,16 @@ set(cephfs_data_scan_srcs
   RoleSelector.cc
   PgFiles.cc
   MDSUtility.cc)
+if(WITH_AUDITLOGGING)
+  list(APPEND cephfs_data_scan_srcs ToolsAuditLogger.cc)
+endif()
 add_executable(cephfs-data-scan ${cephfs_data_scan_srcs})
 target_link_libraries(cephfs-data-scan ceph-common librados cephfs mds osdc global Boost::boost
   cls_cephfs_client
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} Boost::filesystem)
+if(WITH_AUDITLOGGING)
+  target_link_libraries(cephfs-data-scan audit_db cephsqlite SQLite3::SQLite3)
+endif()
 
 install(TARGETS
   cephfs-journal-tool

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -83,22 +83,22 @@ bool DataScan::parse_kwarg(
       return false;
     }
     dout(4) << "Using local file output to '" << val << "'" << dendl;
-    driver = new LocalFileDriver(val, data_io);
+    driver = new LocalFileDriver(val, data_io, err);
     return true;
   } else if (arg == std::string("--worker_n")) {
-    std::string err;
-    worker_n = strict_strtoll(val.c_str(), 10, &err);
-    if (!err.empty()) {
-      std::cerr << "Invalid worker number '" << val << "'" << std::endl;
+    std::string err_msg;
+    worker_n = strict_strtoll(val.c_str(), 10, &err_msg);
+    if (!err_msg.empty()) {
+      err << "Invalid worker number '" << val << "'" << std::endl;
       *r = -EINVAL;
       return false;
     }
     return true;
   } else if (arg == std::string("--worker_m")) {
-    std::string err;
-    worker_m = strict_strtoll(val.c_str(), 10, &err);
-    if (!err.empty()) {
-      std::cerr << "Invalid worker count '" << val << "'" << std::endl;
+    std::string err_msg;
+    worker_m = strict_strtoll(val.c_str(), 10, &err_msg);
+    if (!err_msg.empty()) {
+      err << "Invalid worker count '" << val << "'" << std::endl;
       *r = -EINVAL;
       return false;
     }
@@ -111,7 +111,7 @@ bool DataScan::parse_kwarg(
     Filesystem const* fs;
     *r = fsmap->parse_filesystem(val, &fs);
     if (*r != 0) {
-      std::cerr << "Invalid filesystem '" << val << "'" << std::endl;
+      err << "Invalid filesystem '" << val << "'" << std::endl;
       return false;
     }
     fscid = fs->get_fscid();
@@ -120,10 +120,10 @@ bool DataScan::parse_kwarg(
     metadata_pool_name = val;
     return true;
   } else if (arg == std::string("--progress_update_interval")) {
-    std::string err;
-    progress_update_interval = std::chrono::seconds(strict_strtoll(val.c_str(), 10, &err));
-    if (!err.empty()) {
-      std::cerr << "Invalid progress update interval '" << val << "'" << std::endl;
+    std::string err_msg;
+    progress_update_interval = std::chrono::seconds(strict_strtoll(val.c_str(), 10, &err_msg));
+    if (!err_msg.empty()) {
+      err << "Invalid progress update interval '" << val << "'" << std::endl;
       *r = -EINVAL;
       return false;
     }
@@ -157,18 +157,11 @@ int DataScan::main(const std::vector<const char*> &args)
   // Parse args
   // ==========
   if (args.size() < 1) {
-    cerr << "missing position argument" << std::endl;
+    err << "missing position argument" << std::endl;
     return -EINVAL;
   }
 
-  // Common RADOS init: open metadata pool
-  // =====================================
-  int r = rados.init_with_context(g_ceph_context);
-  if (r < 0) {
-    derr << "RADOS unavailable" << dendl;
-    return r;
-  }
-
+  int r = 0;
 
   std::string const &command = args[0];
   std::string data_pool_name;
@@ -218,7 +211,7 @@ int DataScan::main(const std::vector<const char*> &args)
         pg_t pg;
         bool parsed = pg.parse(*i);
         if (!parsed) {
-          std::cerr << "Invalid PG '" << *i << "'" << std::endl;
+          err << "Invalid PG '" << *i << "'" << std::endl;
           return -EINVAL;
         } else {
           pg_files_pgs.insert(pg);
@@ -229,7 +222,7 @@ int DataScan::main(const std::vector<const char*> &args)
     }
 
     // Fall through: unhandled
-    std::cerr << "Unknown argument '" << *i << "'" << std::endl;
+    err << "Unknown argument '" << *i << "'" << std::endl;
     return -EINVAL;
   }
 
@@ -239,7 +232,7 @@ int DataScan::main(const std::vector<const char*> &args)
     if (fsmap->filesystem_count() == 1) {
       fscid = fsmap->get_filesystem().get_fscid();
     } else {
-      std::cerr << "Specify a filesystem with --filesystem" << std::endl;
+      err << "Specify a filesystem with --filesystem" << std::endl;
       return -EINVAL;
     }
   }
@@ -247,18 +240,10 @@ int DataScan::main(const std::vector<const char*> &args)
 
   // Default to output to metadata pool
   if (driver == NULL) {
-    driver = new MetadataDriver();
+    driver = new MetadataDriver(err);
     driver->set_force_corrupt(force_corrupt);
     driver->set_force_init(force_init);
     dout(4) << "Using metadata pool output" << dendl;
-  }
-
-  dout(4) << "connecting to RADOS..." << dendl;
-  r = rados.connect();
-  if (r < 0) {
-    std::cerr << "couldn't connect to cluster: " << cpp_strerror(r)
-              << std::endl;
-    return r;
   }
 
   r = driver->init(rados, metadata_pool_name, fsmap, fscid);
@@ -283,7 +268,7 @@ int DataScan::main(const std::vector<const char*> &args)
     std::string pool_name;
     r = rados.pool_reverse_lookup(data_pool_id, &pool_name);
     if (r < 0) {
-      std::cerr << "Failed to resolve data pool: " << cpp_strerror(r)
+      err << "Failed to resolve data pool: " << cpp_strerror(r)
 		<< std::endl;
       return r;
     }
@@ -292,16 +277,16 @@ int DataScan::main(const std::vector<const char*> &args)
       autodetect_data_pools = true;
       data_pool_name = pool_name;
     } else if (data_pool_name != pool_name) {
-      std::cerr << "Warning: pool '" << data_pool_name << "' is not the "
+      err << "Warning: pool '" << data_pool_name << "' is not the "
         "main CephFS data pool!" << std::endl;
       if (!force_pool) {
-        std::cerr << "Use --force-pool to continue" << std::endl;
+        err << "Use --force-pool to continue" << std::endl;
         return -EINVAL;
       }
 
       data_pool_id = rados.pool_lookup(data_pool_name.c_str());
       if (data_pool_id < 0) {
-	std::cerr << "Data pool '" << data_pool_name << "' not found!"
+	err << "Data pool '" << data_pool_name << "' not found!"
 		  << std::endl;
 	return -ENOENT;
       }
@@ -330,7 +315,7 @@ int DataScan::main(const std::vector<const char*> &args)
 	std::string pool_name;
 	r = rados.pool_reverse_lookup(pool_id, &pool_name);
 	if (r < 0) {
-	  std::cerr << "Failed to resolve data pool: " << cpp_strerror(r)
+	  err << "Failed to resolve data pool: " << cpp_strerror(r)
 		    << std::endl;
 	  return r;
 	}
@@ -341,7 +326,7 @@ int DataScan::main(const std::vector<const char*> &args)
     for (auto &data_pool_name: extra_data_pool_names) {
       int64_t pool_id = rados.pool_lookup(data_pool_name.c_str());
       if (data_pool_id < 0) {
-	std::cerr << "Data pool '" << data_pool_name << "' not found!" << std::endl;
+	err << "Data pool '" << data_pool_name << "' not found!" << std::endl;
 	return -ENOENT;
       } else {
 	dout(4) << "data pool '" << data_pool_name << "' has ID " << pool_id
@@ -349,10 +334,10 @@ int DataScan::main(const std::vector<const char*> &args)
       }
 
       if (!fs.get_mds_map().is_data_pool(pool_id)) {
-	std::cerr << "Warning: pool '" << data_pool_name << "' is not a "
+	err << "Warning: pool '" << data_pool_name << "' is not a "
 	  "CephFS data pool!" << std::endl;
 	if (!force_pool) {
-	  std::cerr << "Use --force-pool to continue" << std::endl;
+	  err << "Use --force-pool to continue" << std::endl;
 	  return -EINVAL;
 	}
       }
@@ -374,7 +359,7 @@ int DataScan::main(const std::vector<const char*> &args)
     dout(4) << "resolving metadata pool " << metadata_pool_id << dendl;
     int r = rados.pool_reverse_lookup(metadata_pool_id, &metadata_pool_name);
     if (r < 0) {
-      std::cerr << "Pool " << metadata_pool_id
+      err << "Pool " << metadata_pool_id
         << " identified in MDS map not found in RADOS!" << std::endl;
       return r;
     }
@@ -401,9 +386,34 @@ int DataScan::main(const std::vector<const char*> &args)
   } else if (command == "init") {
     return driver->init_roots(fs.get_mds_map().get_first_data_pool());
   } else {
-    std::cerr << "Unknown command '" << command << "'" << std::endl;
+    err << "Unknown command '" << command << "'" << std::endl;
     return -EINVAL;
   }
+}
+
+int DataScan::connect_rados()
+{
+  int r = rados.init_with_context(g_ceph_context);
+  if (r < 0) {
+    derr << "RADOS unavailable" << dendl;
+    return r;
+  }
+
+  dout(4) << "connecting to RADOS..." << dendl;
+  r = rados.connect();
+  if (r < 0) {
+    err << "couldn't connect to cluster: " << cpp_strerror(r)
+              << std::endl;
+    return r;
+  }
+  rados_connected = true;
+  return 0;
+}
+
+librados::Rados& DataScan::get_rados_handle()
+{
+  ceph_assert(rados_connected);
+  return rados;
 }
 
 int MetadataDriver::inject_unlinked_inode(
@@ -418,7 +428,7 @@ int MetadataDriver::inject_unlinked_inode(
     return r;
   }
   if (already_exists && !force_init) {
-    std::cerr << "Inode 0x" << std::hex << inono << std::dec << " already"
+    err << "Inode 0x" << std::hex << inono << std::dec << " already"
                " exists, skipping create.  Use --force-init to overwrite"
                " the existing object." << std::endl;
     return 0;
@@ -561,16 +571,16 @@ int parse_oid(const std::string &oid, uint64_t *inode_no, uint64_t *obj_id)
     return -EINVAL;
   }
 
-  std::string err;
+  std::string err_msg;
   std::string inode_str = oid.substr(0, oid.find("."));
-  *inode_no = strict_strtoll(inode_str.c_str(), 16, &err);
-  if (!err.empty()) {
+  *inode_no = strict_strtoll(inode_str.c_str(), 16, &err_msg);
+  if (!err_msg.empty()) {
     return -EINVAL;
   }
 
   std::string pos_string = oid.substr(oid.find(".") + 1);
-  *obj_id = strict_strtoll(pos_string.c_str(), 16, &err);
-  if (!err.empty()) {
+  *obj_id = strict_strtoll(pos_string.c_str(), 16, &err_msg);
+  if (!err_msg.empty()) {
     return -EINVAL;
   }
 
@@ -743,7 +753,7 @@ int DataScan::forall_objects(
                        << dendl;
               continue;
             }
-          } catch (const buffer::error &err) {
+          } catch (const buffer::error&) {
           }
           dout(20) << "read non-matching tag '" << read_tag << "'" << dendl;
         } else {
@@ -854,7 +864,7 @@ int DataScan::scan_inodes()
   }
 
   if (!roots_present) {
-    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
+    err << "Some or all system inodes are absent.  Run 'init' from "
       "one node before running 'scan_inodes'" << std::endl;
     return -EIO;
   }
@@ -1491,7 +1501,7 @@ int DataScan::scan_links()
                  << dir_ino << std::dec << "/" << dname << dendl;
             return -EINVAL;
           }
-        } catch (const buffer::error& err) {
+        } catch (const buffer::error&) {
           derr << "Error decoding dentry 0x" << std::hex << dir_ino << std::dec
                << "/" << dname << dendl;
           return -EINVAL;
@@ -1758,7 +1768,7 @@ int DataScan::scan_frags()
   }
 
   if (!roots_present) {
-    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
+    err << "Some or all system inodes are absent.  Run 'init' from "
       "one node before running 'scan_inodes'" << std::endl;
     return -EIO;
   }
@@ -1927,7 +1937,7 @@ int MetadataTool::read_fnode(
   auto old_fnode_iter = fnode_bl.cbegin();
   try {
     (*fnode).decode(old_fnode_iter);
-  } catch (const buffer::error &err) {
+  } catch (const buffer::error&) {
     return -EINVAL;
   }
 
@@ -1986,7 +1996,7 @@ int MetadataTool::read_dentry(inodeno_t parent_ino, frag_t frag,
     }
     if (dnfirst)
       *dnfirst = first;
-  } catch (const buffer::error &err) {
+  } catch (const buffer::error&) {
     dout(20) << "encoding error in dentry 0x" << std::hex << parent_ino
              << std::dec << "/" << dname << dendl;
     return -EINVAL;
@@ -2013,9 +2023,9 @@ int MetadataDriver::load_table(MDSTable *table)
     decode(table_ver, p);
     table->decode_state(p);
     table->force_replay_version(table_ver);
-  } catch (const buffer::error &err) {
+  } catch (const buffer::error& e) {
     derr << "unable to decode mds table '" << table_oid.name << "': "
-      << err.what() << dendl;
+      << e.what() << dendl;
     return -EIO;
   }
   return 0;

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -25,6 +25,9 @@ class MDSTable;
 
 class RecoveryDriver {
   protected:
+    // used to stream errors to std::cerr and audit db
+    std::ostream& err;
+
     // If true, overwrite structures that generate decoding errors.
     bool force_corrupt;
 
@@ -96,8 +99,8 @@ class RecoveryDriver {
       return std::string(s);
     }
 
-    RecoveryDriver()
-      : force_corrupt(false),
+    RecoveryDriver(std::ostream& err_)
+      : err(err_), force_corrupt(false),
 	force_init(false)
     {}
 
@@ -117,8 +120,8 @@ class LocalFileDriver : public RecoveryDriver
       inodeno_t ino);
   public:
 
-    LocalFileDriver(const std::string &path_, librados::IoCtx &data_io_)
-      : RecoveryDriver(), path(path_), data_io(data_io_)
+    LocalFileDriver(const std::string &path_, librados::IoCtx &data_io_, std::ostream& err_)
+      : RecoveryDriver(err_), path(path_), data_io(data_io_)
     {}
 
     // Implement RecoveryDriver interface
@@ -216,6 +219,7 @@ class MetadataDriver : public RecoveryDriver, public MetadataTool
         frag_t *result_ft);
 
   public:
+    MetadataDriver(std::ostream& err_): RecoveryDriver(err_) {}
 
     // Implement RecoveryDriver interface
     int init(
@@ -344,6 +348,9 @@ protected:
 public:
   static void usage();
   int main(const std::vector<const char*>& args);
+  int connect_rados();
+  bool rados_connected{false};
+  librados::Rados& get_rados_handle();
 
   DataScan() :
     driver(NULL),

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -125,21 +125,6 @@ int JournalTool::main(std::vector<const char*> &argv)
   }
   mode = std::string(*arg);
   arg = argv.erase(arg);
-
-  // RADOS init
-  // ==========
-  r = rados.init_with_context(g_ceph_context);
-  if (r < 0) {
-    derr << "RADOS unavailable, cannot scan filesystem journal" << dendl;
-    return r;
-  }
-
-  dout(4) << "JournalTool: connecting to RADOS..." << dendl;
-  r = rados.connect();
-  if (r < 0) {
-    derr << "couldn't connect to cluster: " << cpp_strerror(r) << dendl;
-    return r;
-  }
  
   auto& fs = fsmap->get_filesystem(role_selector.get_ns());
   stringstream (rank_str.substr(rank_str.find(':') + 1)) >> rank;
@@ -198,6 +183,30 @@ int JournalTool::main(std::vector<const char*> &argv)
   }
 
   return r;
+}
+
+int JournalTool::connect_rados()
+{
+  int r = rados.init_with_context(g_ceph_context);
+  if (r < 0) {
+    derr << "RADOS unavailable, cannot scan filesystem journal" << dendl;
+    return r;
+  }
+
+  dout(4) << "JournalTool: connecting to RADOS..." << dendl;
+  r = rados.connect();
+  if (r < 0) {
+    derr << "couldn't connect to cluster: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  rados_connected = true;
+  return 0;
+}
+
+librados::Rados& JournalTool::get_rados_handle()
+{
+  ceph_assert(rados_connected);
+  return rados;
 }
 
 int JournalTool::validate_type(const std::string &type)

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -96,6 +96,8 @@ class JournalTool : public MDSUtility
     // executed on all ranks.
     bool can_execute_for_all_ranks(const std::string &mode,
                                    const std::string &command);
+
+    bool rados_connected{false};
   public:
     static void usage();
 
@@ -106,5 +108,8 @@ class JournalTool : public MDSUtility
           std::make_unique<ProgressTracker>("Journal processing");
     }
     int main(std::vector<const char*> &argv);
+
+    int connect_rados();
+    librados::Rados& get_rados_handle();
 };
 

--- a/src/tools/cephfs/MDSUtility.h
+++ b/src/tools/cephfs/MDSUtility.h
@@ -25,6 +25,26 @@
 #include "common/Finisher.h"
 #include "common/Timer.h"
 
+struct tee_streambuf : public std::streambuf {
+  std::streambuf* sb1;
+  std::streambuf* sb2;
+protected:
+  int overflow(int c) override {
+    if (c == EOF) return !EOF;
+    int r1 = sb1->sputc(c);
+    int r2 = sb2->sputc(c);
+    return (r1 == EOF || r2 == EOF) ? EOF : c;
+  }
+  int sync() override {
+    int r1 = sb1->pubsync();
+    int r2 = sb2->pubsync();
+    return (r1 || r2) ? -1 : 0;
+  }
+public:
+  tee_streambuf(std::streambuf* sb1_, std::streambuf* sb2_)
+  : sb1(sb1_), sb2(sb2_) {}
+};
+
 /// MDS Utility
 /**
  * This class is the parent for MDS utilities, i.e. classes that
@@ -45,6 +65,10 @@ protected:
   Context *waiting_for_mds_map;
 
   bool inited;
+
+  std::ostringstream audit_buf;
+  tee_streambuf tee_sb{std::cerr.rdbuf(), audit_buf.rdbuf()};
+  std::ostream err{&tee_sb};
 public:
   MDSUtility();
   ~MDSUtility() override;
@@ -56,6 +80,9 @@ public:
   bool ms_handle_refused(Connection *con) override { return false; }
   int init();
   void shutdown();
+  std::string get_audit_status() const {
+    return audit_buf.str();
+  }
 };
 
 #endif /* MDS_UTILITY_H_ */

--- a/src/tools/cephfs/MetaTool.cc
+++ b/src/tools/cephfs/MetaTool.cc
@@ -105,21 +105,6 @@ int MetaTool::main(string& mode,
     }
   }
 
-  // RADOS init
-  r = rados.init_with_context(g_ceph_context);
-  if (r < 0) {
-    cerr << "RADOS unavailable" << std::endl;
-    return r;
-  }
-
-  if (_debug)
-    cout << "MetaTool: connecting to RADOS..." << std::endl;
-  r = rados.connect();
-  if (r < 0) {
-    cerr << "couldn't connect to cluster: " << cpp_strerror(r) << std::endl;
-    return r;
-  }
-
   if (!manual_mode) {
     r = role_selector.parse(*fsmap, rank_str);
     if (r != 0) {
@@ -189,6 +174,31 @@ int MetaTool::main(string& mode,
     cout << "op[" << mode << "] ret : " << r << std::endl;
   }
   return r;
+}
+
+int MetaTool::connect_rados()
+{
+  int r = rados.init_with_context(g_ceph_context);
+  if (r < 0) {
+    cerr << "RADOS unavailable" << std::endl;
+    return r;
+  }
+
+  if (_debug)
+    cout << "MetaTool: connecting to RADOS..." << std::endl;
+  r = rados.connect();
+  if (r < 0) {
+    cerr << "couldn't connect to cluster: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  rados_connected = true;
+  return 0;
+}
+
+librados::Rados& MetaTool::get_rados_handle()
+{
+  ceph_assert(rados_connected);
+  return rados;
 }
 
 int MetaTool::process(string& mode, string& ino, string out, string in, bool confirm)

--- a/src/tools/cephfs/MetaTool.h
+++ b/src/tools/cephfs/MetaTool.h
@@ -250,6 +250,8 @@ private:
   int amend_meta(meta_op &op);
   int show_fn(meta_op &op);
   int amend_fn(meta_op &op);
+
+  bool rados_connected{false};
   public:
   int _file_meta(meta_op &op, librados::IoCtx& io);
   int _show_meta(inode_meta_t& i, const std::string& fn);
@@ -269,5 +271,8 @@ private:
            std::string& in,
            bool confirm = false
            );
+
+  int connect_rados();
+  librados::Rados& get_rados_handle();
 };
 #endif // METATOOL_H__

--- a/src/tools/cephfs/TableTool.cc
+++ b/src/tools/cephfs/TableTool.cc
@@ -325,21 +325,6 @@ int TableTool::main(std::vector<const char*> &argv)
 
   dout(10) << __func__ << dendl;
 
-  // RADOS init
-  // ==========
-  r = rados.init_with_context(g_ceph_context);
-  if (r < 0) {
-    derr << "RADOS unavailable, cannot scan filesystem journal" << dendl;
-    return r;
-  }
-
-  dout(4) << "connecting to RADOS..." << dendl;
-  r = rados.connect();
-  if (r < 0) {
-    derr << "couldn't connect to cluster: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-
   // Require at least 3 args <rank> <mode> <arg> [args...]
   if (argv.size() < 3) {
     cerr << "missing required 3 arguments" << std::endl;
@@ -435,5 +420,29 @@ int TableTool::main(std::vector<const char*> &argv)
   jf.flush(std::cout);
   std::cout << std::endl;
   return r;
+}
+
+int TableTool::connect_rados()
+{
+  int r = rados.init_with_context(g_ceph_context);
+  if (r < 0) {
+    derr << "RADOS unavailable, cannot scan filesystem journal" << dendl;
+    return r;
+  }
+
+  dout(4) << "connecting to RADOS..." << dendl;
+  r = rados.connect();
+  if (r < 0) {
+    derr << "couldn't connect to cluster: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  rados_connected = true;
+  return 0;
+}
+
+librados::Rados& TableTool::get_rados_handle()
+{
+  ceph_assert(rados_connected);
+  return rados;
 }
 

--- a/src/tools/cephfs/TableTool.h
+++ b/src/tools/cephfs/TableTool.h
@@ -36,9 +36,14 @@ class TableTool : public MDSUtility
 
     int apply_role_fn(std::function<int(mds_role_t, Formatter *)> fptr, Formatter *f);
 
+    bool rados_connected{false};
+
   public:
     static void usage();
     int main(std::vector<const char*> &argv);
+
+    int connect_rados();
+    librados::Rados& get_rados_handle();
 
     TableTool()
     {

--- a/src/tools/cephfs/ToolsAuditLogger.cc
+++ b/src/tools/cephfs/ToolsAuditLogger.cc
@@ -1,0 +1,126 @@
+#include "ToolsAuditLogger.h"
+
+#include <ctime>
+
+#include <fmt/format.h>
+
+#include "common/ceph_context.h"
+#include "common/debug.h"
+#include "include/ceph_assert.h"
+#include "include/compat.h"
+#include "include/rados/librados.hpp"
+
+#define dout_subsys ceph_subsys_client
+#undef dout_prefix
+#define dout_prefix *_dout << "tools_audit_logger: " << __func__ << ": "
+
+std::expected<std::unique_ptr<ToolsAuditLogger>, AuditDBError>
+ToolsAuditLogger::create(
+    CephContext* cct,
+    librados::Rados& rados,
+    std::string db_uri,
+    std::string table_name)
+{
+  ceph_assert(cct);
+  if (auto p = AuditDB::ensure_audit_pool(cct, rados); !p) {
+    return std::unexpected(p.error());
+  }
+
+  auto db = std::make_unique<AuditDB>(cct, db_uri.c_str(), true, table_name, true);
+  if (auto init_res = db->init(); !init_res) {
+    return std::unexpected(init_res.error());
+  }
+
+  return std::unique_ptr<ToolsAuditLogger>(new ToolsAuditLogger(
+      cct, std::move(db_uri), std::move(table_name), std::move(db)));
+}
+
+std::expected<std::unique_ptr<ToolsAuditLogger>, AuditDBError>
+ToolsAuditLogger::create_for_tool(
+      CephContext* cct,
+      librados::Rados& rados,
+      std::string table_name)
+{
+  std::string db_uri = fmt::format("file:///.audit:/{}_audit.db?vfs=ceph", table_name);
+  return create(cct, rados, std::move(db_uri), std::move(table_name));
+}
+
+std::string ToolsAuditLogger::get_audit_cmd_args(const std::vector<const char*>& args)
+{
+  std::string result;
+
+  for (size_t i = 0; i < args.size(); ++i) {
+    result += args[i];
+
+    if (i < args.size() - 1) {
+      result += " ";
+    }
+  }
+  return result;
+}
+
+ToolsAuditLogger::ToolsAuditLogger(
+    CephContext* cct_,
+    std::string db_uri_,
+    std::string table_name_,
+    std::unique_ptr<AuditDB> db_)
+    : cct(cct_),
+      db_uri(std::move(db_uri_)),
+      table_name(std::move(table_name_)),
+      db(std::move(db_))
+{
+}
+
+ToolsAuditLogger::~ToolsAuditLogger()
+{
+  if (is_ready() && begin_recorded) {
+    // comp_time must satisfy comp_time >= init_time (schema CHECK)
+    log_end(std::time(nullptr), "aborted", -ECANCELED);
+  }
+}
+
+bool ToolsAuditLogger::is_ready() const
+{
+  return db && db->is_initialised();
+}
+
+void ToolsAuditLogger::log_begin(
+    const std::string& cmd,
+    const std::string& cmd_args,
+    time_t init_time)
+{
+  if (!is_ready()) {
+    return;
+  }
+  if (begin_recorded) {
+    lderr(cct) << "called while previous being (seq=" << seq_in_flight << ") still in flight; dropping" << dendl;
+    return;
+  }
+  auto r = db->first_phase_commit(cmd, cmd_args, init_time);
+  if (r.has_value()) {
+    seq_in_flight = *r;
+    begin_recorded = true;
+  } else {
+    lderr(cct) << "failed: code " << static_cast<int>(r.error().code)
+               << " detail=" << r.error().detail << dendl;
+  }
+}
+
+void ToolsAuditLogger::log_end(
+    time_t comp_time,
+    const std::string& status,
+    int32_t retval)
+{
+  if (!is_ready() || !begin_recorded) {
+    return;
+  }
+  auto r = db->second_phase_commit(seq_in_flight, comp_time, status, retval);
+  if (r.has_value()) {
+    begin_recorded = false;
+    seq_in_flight = 0;
+  } else {
+    lderr(cct) << __func__ << "failed: seq=" << seq_in_flight
+               << " code=" << static_cast<int>(r.error().code)
+               << " detail=" << r.error().detail << dendl;
+  }
+}

--- a/src/tools/cephfs/ToolsAuditLogger.h
+++ b/src/tools/cephfs/ToolsAuditLogger.h
@@ -1,0 +1,108 @@
+#if defined(__linux__)
+#pragma once
+#endif
+
+#ifndef TOOLS_AUDIT_LOGGER_H
+#define TOOLS_AUDIT_LOGGER_H
+
+#include <ctime>
+#include <cstdint>
+#include <expected>
+#include <memory>
+#include <string>
+
+#include "common/AuditDB.h"
+
+/**
+ * Helper for cephfs standalone tools: ensure `.audit` pool, open an audit DB in
+ * standalone mode (SQLite-assigned seq), and pair begin/end commits.
+ *
+ * If @ref log_begin succeeded and @ref log_end was not called, the destructor
+ * records a second-phase row with status `"aborted"` (process exit without
+ * completion).
+ *
+ * The caller must keep @p rados connected for the lifetime of this object.
+ * 
+ * @note best-effort logging; tools should be prepared to skip audit on failure.
+ */
+class ToolsAuditLogger {
+public:
+
+  /*
+   * Typical usage in a cephfs DR tool's main():
+   *
+   *   librados::Rados rados;
+   *   rados.init_with_context(g_ceph_context);
+   *   rados.connect();
+   *
+   *   auto logger_r = ToolsAuditLogger::create_for_tool(g_ceph_context, rados,
+   *       "cephfs_data_scan");
+   *   if (!logger_r) {
+   *       // log warning; proceed without audit
+   *   }
+   *   auto& logger = *logger_r;  // unique_ptr<ToolsAuditLogger>
+   *
+   *   logger->log_begin(argv[0], joined_args, std::time(nullptr));
+   *   int rc = run_tool();
+   *   logger->log_end(std::time(nullptr), rc == 0 ? "completed" : "failed", rc);
+   */
+
+  /**
+   * Ensure the .audit pool exists and create+open the audit DB in standalone
+   * mode (SQLite-allocated seq). The cephsqlite VFS is initialised lazily
+   * on the first call (process-wide).
+   */
+  static std::expected<std::unique_ptr<ToolsAuditLogger>, AuditDBError> create(
+      CephContext* cct,
+      librados::Rados& rados,
+      std::string db_uri,
+      std::string table_name);
+
+  static std::expected<std::unique_ptr<ToolsAuditLogger>, AuditDBError> create_for_tool(
+      CephContext* cct,
+      librados::Rados& rados,
+      std::string table_name);
+
+  /**
+   * A basic helper that takes a vector of C style strings and returns a string
+   * which can be inserted directly as the cmd_args arg in log_end()
+   * 
+   * @note constructs string with args separated by spaces, this is enough since
+   * the pythonic auditman module can scrap the data using its advaced set of
+   * tools to represent data in a structured form
+   */
+  static std::string get_audit_cmd_args(const std::vector<const char*>& args);
+
+  ~ToolsAuditLogger();
+
+  ToolsAuditLogger(const ToolsAuditLogger&) = delete;
+  ToolsAuditLogger& operator=(const ToolsAuditLogger&) = delete;
+
+  /** Standalone first phase; stores seq for @ref log_end. Ignored if a begin is
+   * already in flight without a matching @ref log_end. */
+  void log_begin(
+      const std::string& cmd,
+      const std::string& cmd_args,
+      time_t init_time);
+
+  /** Second phase for the seq returned from the last @ref log_begin. */
+  void log_end(time_t comp_time, const std::string& status, int32_t retval);
+
+  bool is_ready() const;
+
+private:
+  ToolsAuditLogger(
+      CephContext* cct,
+      std::string db_uri,
+      std::string table_name,
+      std::unique_ptr<AuditDB> db);
+
+  CephContext* const cct;
+  std::string db_uri;
+  std::string table_name;
+  std::unique_ptr<AuditDB> db;
+  int64_t seq_in_flight{0};
+  bool begin_recorded{false};
+};
+
+#endif

--- a/src/tools/cephfs/cephfs-data-scan.cc
+++ b/src/tools/cephfs/cephfs-data-scan.cc
@@ -7,6 +7,8 @@
 
 #include "DataScan.h"
 
+#include "ToolsAuditLogger.h"
+
 using namespace std;
 
 int main(int argc, const char **argv)
@@ -34,8 +36,26 @@ int main(int argc, const char **argv)
       return rc;
   }
 
+  rc = data_scan.connect_rados();
+  if (rc != 0) {
+    return rc;
+  }
+
+  std::unique_ptr<ToolsAuditLogger> logger = nullptr;
+  if (auto logger_r = ToolsAuditLogger::create_for_tool(cct.get(), data_scan.get_rados_handle(), "cephfs_data_scan"); logger_r.has_value()) {
+    logger = std::move(logger_r.value());
+    logger->log_begin(argv[0], ToolsAuditLogger::get_audit_cmd_args(args), ceph_clock_now().sec());
+  } else {
+    std::cerr << "could not create audit db for cephfs-data-scan, moving on..." << std::endl;
+  }
+
   // Finally, execute the user's commands
   rc = data_scan.main(args);
+
+  if (logger) {
+    logger->log_end(ceph_clock_now().sec(), rc < 0 ? data_scan.get_audit_status().empty() ? "unknown_error" : data_scan.get_audit_status() : "completed", rc);
+  }
+
   if (rc != 0) {
     std::cerr << "Error (" << cpp_strerror(rc) << ")" << std::endl;
   }

--- a/src/tools/cephfs/cephfs-journal-tool.cc
+++ b/src/tools/cephfs/cephfs-journal-tool.cc
@@ -21,6 +21,8 @@
 
 #include "JournalTool.h"
 
+#include "ToolsAuditLogger.h"
+
 
 int main(int argc, const char **argv)
 {
@@ -47,8 +49,24 @@ int main(int argc, const char **argv)
       return rc;
   }
 
+  rc = jt.connect_rados();
+  if (rc != 0) {
+    return rc;
+  }
+
+  std::unique_ptr<ToolsAuditLogger> logger = nullptr;
+  if (auto logger_r = ToolsAuditLogger::create_for_tool(cct.get(), jt.get_rados_handle(), "cephfs_journal_tool"); logger_r.has_value()) {
+    logger = std::move(logger_r.value());
+    logger->log_begin(argv[0], ToolsAuditLogger::get_audit_cmd_args(args), ceph_clock_now().sec());
+  }
+
   // Finally, execute the user's commands
   rc = jt.main(args);
+
+  if (logger) {
+    logger->log_end(ceph_clock_now().sec(), rc < 0 ? jt.get_audit_status().empty() ? "unknown_error" : jt.get_audit_status() : "completed", rc);
+  }
+
   if (rc != 0) {
     std::cerr << "Error (" << cpp_strerror(rc) << ")" << std::endl;
   }

--- a/src/tools/cephfs/cephfs-meta-injection.cc
+++ b/src/tools/cephfs/cephfs-meta-injection.cc
@@ -13,6 +13,8 @@
 #include <vector>
 
 #include <boost/program_options.hpp>
+
+#include "ToolsAuditLogger.h"
 namespace po = boost::program_options;
 using std::string;
 using namespace std;
@@ -88,7 +90,26 @@ int main(int argc, const char **argv)
     std::cerr << "error in initialization: " << cpp_strerror(rc) << std::endl;
     return rc;
   }
+
+  rc = mt.connect_rados();
+  if (rc != 0) {
+    return rc;
+  }
+
+  std::unique_ptr<ToolsAuditLogger> logger = nullptr;
+  if (auto logger_r = ToolsAuditLogger::create_for_tool(cct.get(), mt.get_rados_handle(), "cephfs_meta_injection"); logger_r.has_value()) {
+    logger = std::move(logger_r.value());
+    logger->log_begin(argv[0], ToolsAuditLogger::get_audit_cmd_args(args), ceph_clock_now().sec());
+  } else {
+    std::cerr << "could not create audit db for cephfs-data-scan, moving on..." << std::endl;
+  }
+
   rc = mt.main(mode, rank_str, minfo, ino, out, in, vm.count("yes-i-really-really-mean-it"));
+
+  if (logger) {
+    logger->log_end(ceph_clock_now().sec(), rc < 0 ? mt.get_audit_status().empty() ? "unknown_error" : mt.get_audit_status() : "completed", rc);
+  }
+
   if (rc != 0) {
     std::cerr << "error (" << cpp_strerror(rc) << ")" << std::endl;
     return -1;

--- a/src/tools/cephfs/cephfs-table-tool.cc
+++ b/src/tools/cephfs/cephfs-table-tool.cc
@@ -7,6 +7,8 @@
 
 #include "TableTool.h"
 
+#include "ToolsAuditLogger.h"
+
 using namespace std;
 
 int main(int argc, const char **argv)
@@ -34,8 +36,24 @@ int main(int argc, const char **argv)
       return rc;
   }
 
+  rc = tt.connect_rados();
+  if (rc != 0) {
+    return rc;
+  }
+
+  std::unique_ptr<ToolsAuditLogger> logger = nullptr;
+  if (auto logger_r = ToolsAuditLogger::create_for_tool(cct.get(), tt.get_rados_handle(), "cephfs_table_tool"); logger_r.has_value()) {
+    logger = std::move(logger_r.value());
+    logger->log_begin(argv[0], ToolsAuditLogger::get_audit_cmd_args(args), ceph_clock_now().sec());
+  }
+
   // Finally, execute the user's commands
   rc = tt.main(args);
+
+  if (logger) {
+    logger->log_end(ceph_clock_now().sec(), rc < 0 ? tt.get_audit_status().empty() ? "unknown_error" : tt.get_audit_status() : "completed", rc);
+  }
+
   if (rc != 0) {
     std::cerr << "Error (" << cpp_strerror(rc) << ")" << std::endl;
   }


### PR DESCRIPTION
This PR introduces APIs to enable writing audit logs into DBs backed by sqlite3 (via `libcephsqlite` which enables a ceph VFS allowing us to decentralise the DBs using RADOS) and marks the first step towards implementing audit logging of cluster-wide commands and standalone tools, starting with CephFS: https://tracker.ceph.com/issues/62856.

A talk on this topic was presented by me and @vshankar at [FOSDEM 2026](https://fosdem.org/2026/schedule/event/VEKE3H-cephfs-tell-me-what-happened-yes-i-really-mean-it/)  which can be referred for more information about the objective, design and architecture of the entire feature.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
