### PR TITLE
librbd/crypto: Authenticated Encryption in librbd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,9 @@ endif()
 if(WITH_RBD AND LINUX)
   find_package(libcryptsetup 2.0.5 REQUIRED)
   set(HAVE_LIBCRYPTSETUP ${LIBCRYPTSETUP_FOUND})
+  if(LIBCRYPTSETUP_VERSION VERSION_GREATER_EQUAL "2.8.0")
+    set(HAVE_CRYPT_FORMAT_INLINE TRUE)
+  endif()
 endif()
 
 # libnbd

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -396,6 +396,9 @@
 /* Define if libcryptsetup can be used (linux only) */
 #cmakedefine HAVE_LIBCRYPTSETUP
 
+/* Define if libcryptsetup >= 2.8.0 with inline integrity support */
+#cmakedefine HAVE_CRYPT_FORMAT_INLINE
+
 /* Define if libnbd can be used */
 #cmakedefine HAVE_LIBNBD
 

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -424,7 +424,7 @@ typedef enum {
 typedef enum {
     RBD_ENCRYPTION_ALGORITHM_AES128 = 0,
     RBD_ENCRYPTION_ALGORITHM_AES256 = 1,
-    RBD_ENCRYPTION_ALGORITHM_AES256_SIV = 2,
+    RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256 = 2,
 } rbd_encryption_algorithm_t;
 
 typedef void *rbd_encryption_options_t;

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -423,7 +423,8 @@ typedef enum {
 
 typedef enum {
     RBD_ENCRYPTION_ALGORITHM_AES128 = 0,
-    RBD_ENCRYPTION_ALGORITHM_AES256 = 1
+    RBD_ENCRYPTION_ALGORITHM_AES256 = 1,
+    RBD_ENCRYPTION_ALGORITHM_AES256_SIV = 2,
 } rbd_encryption_algorithm_t;
 
 typedef void *rbd_encryption_options_t;

--- a/src/librbd/crypto/BlockCrypto.cc
+++ b/src/librbd/crypto/BlockCrypto.cc
@@ -113,10 +113,14 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
         const unsigned char* src_ptr = (leftover_size == 0) ? in_buf_ptr : leftover_block;
         if (mode == CIPHER_MODE_DEC)  {
           crypto_output_length = m_data_cryptor->decrypt(
-              ctx, src_ptr, out_buf_ptr, block_in_size, block_out_size);
+              ctx, src_ptr, out_buf_ptr,
+              block_in_size, block_out_size,
+              iv, m_iv_size);
         } else {
           crypto_output_length = m_data_cryptor->update_context(
-            ctx, src_ptr, out_buf_ptr, block_in_size, block_out_size);
+            ctx, src_ptr, out_buf_ptr,
+            block_in_size, block_out_size,
+            iv, m_iv_size);
         }
         if (std::cmp_not_equal(crypto_output_length, block_out_size)) {
           lderr(m_cct) << "output size not expected\n expected: "

--- a/src/librbd/crypto/BlockCrypto.cc
+++ b/src/librbd/crypto/BlockCrypto.cc
@@ -14,9 +14,9 @@ namespace crypto {
 
 template <typename T>
 BlockCrypto<T>::BlockCrypto(CephContext* cct, DataCryptor<T>* data_cryptor,
-                            uint64_t block_size, uint64_t data_offset)
+                            uint64_t block_size, uint64_t data_offset, uint32_t meta_size)
      : m_cct(cct), m_data_cryptor(data_cryptor), m_block_size(block_size),
-       m_data_offset(data_offset), m_iv_size(data_cryptor->get_iv_size()) {
+       m_data_offset(data_offset), m_meta_size(meta_size), m_iv_size(data_cryptor->get_iv_size()) {
   ceph_assert(std::has_single_bit(block_size));
   ceph_assert((block_size % data_cryptor->get_block_size()) == 0);
   ceph_assert((block_size % 512) == 0);
@@ -33,14 +33,28 @@ BlockCrypto<T>::~BlockCrypto() {
 template <typename T>
 int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
                            CipherMode mode) {
+  size_t block_in_size, block_out_size;
+  if (mode == CipherMode::CIPHER_MODE_ENC) {
+    block_in_size = m_block_size; // Reading Plaintext (e.g., 4096)
+    block_out_size =
+        m_block_size + m_meta_size; // Writing Ciphertext + Tag (e.g., 4112)
+  } else {
+    block_in_size = m_block_size + m_meta_size; // Reading Ciphertext + Tag
+    block_out_size = m_block_size;              // Writing Plaintext
+  }
+  // TODO: Encrypt data with physical or logical offset? 
+    // Currently Data is encrypted with logical offset
+    // The main reason for this is because we divide by 512 to 
+    // determine the sector IV. With logical offsets (4096 alignment)
+    // we will have no remainder.
   if (image_offset % m_block_size != 0) {
     lderr(m_cct) << "image offset: " << image_offset
                  << " not aligned to block size: " << m_block_size << dendl;
     return -EINVAL;
   }
-  if (data->length() % m_block_size != 0) {
+  if (data->length() % block_in_size != 0) {
     lderr(m_cct) << "data length: " << data->length()
-                 << " not aligned to block size: " << m_block_size << dendl;
+                 << " not aligned to block size: " << block_in_size << dendl;
     return -EINVAL;
   }
 
@@ -60,9 +74,12 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
       m_data_cryptor->return_context(ctx, mode); });
 
   auto sector_number = image_offset / 512;
-  auto appender = data->get_contiguous_appender(src.length());
+  size_t num_blocks = src.length() / block_in_size;
+  size_t total_output_size = num_blocks * block_out_size;
+  auto appender = data->get_contiguous_appender(total_output_size);
   unsigned char* out_buf_ptr = nullptr;
-  unsigned char* leftover_block = (unsigned char*)alloca(m_block_size);
+  // TODO: Can this buffer overflow? 
+  unsigned char* leftover_block = (unsigned char*)alloca(block_in_size);
   uint32_t leftover_size = 0;
   for (auto buf = src.buffers().begin(); buf != src.buffers().end(); ++buf) {
     auto in_buf_ptr = reinterpret_cast<const unsigned char*>(buf->c_str());
@@ -78,13 +95,13 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
         }
 
         out_buf_ptr = reinterpret_cast<unsigned char*>(
-                appender.get_pos_add(m_block_size));
+                appender.get_pos_add(block_out_size));
         sector_number += m_block_size / 512;
       }
 
-      if (leftover_size > 0 || remaining_buf_bytes < m_block_size) {
+      if (leftover_size > 0 || remaining_buf_bytes < block_in_size) {
         auto copy_size = std::min(
-                (uint32_t)m_block_size - leftover_size, remaining_buf_bytes);
+                (uint32_t)block_in_size - leftover_size, remaining_buf_bytes);
         memcpy(leftover_block + leftover_size, in_buf_ptr, copy_size);
         in_buf_ptr += copy_size;
         leftover_size += copy_size;
@@ -92,18 +109,28 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
       }
 
       int crypto_output_length = 0;
-      if (leftover_size == 0) {
-        crypto_output_length = m_data_cryptor->update_context(
-              ctx, in_buf_ptr, out_buf_ptr, m_block_size);
-
-        in_buf_ptr += m_block_size;
-        remaining_buf_bytes -= m_block_size;
-      } else if (leftover_size == m_block_size) {
-        crypto_output_length = m_data_cryptor->update_context(
-              ctx, leftover_block, out_buf_ptr, m_block_size);
-        leftover_size = 0;
+      if (leftover_size == 0 || leftover_size == block_in_size) {
+        const unsigned char* src_ptr = (leftover_size == 0) ? in_buf_ptr : leftover_block;
+        if (mode == CIPHER_MODE_DEC)  {
+          crypto_output_length = m_data_cryptor->decrypt(
+              ctx, src_ptr, out_buf_ptr, block_in_size, block_out_size);
+        } else {
+          crypto_output_length = m_data_cryptor->update_context(
+            ctx, src_ptr, out_buf_ptr, block_in_size, block_out_size);
+        }
+        if (std::cmp_not_equal(crypto_output_length, block_out_size)) {
+          lderr(m_cct) << "output size not expected\n expected: "
+                       << block_out_size << " got: " << crypto_output_length
+                       << dendl;
+          return crypto_output_length;
+        }
+        if (leftover_size == 0) {
+          in_buf_ptr += block_in_size;
+          remaining_buf_bytes -= block_in_size;
+        } else {
+          leftover_size = 0;
+        }
       }
-
       if (crypto_output_length < 0) {
         lderr(m_cct) << "crypt update failed" << dendl;
         return crypto_output_length;

--- a/src/librbd/crypto/BlockCrypto.cc
+++ b/src/librbd/crypto/BlockCrypto.cc
@@ -2,11 +2,17 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "librbd/crypto/BlockCrypto.h"
+#include "include/buffer_fwd.h"
 #include "include/byteorder.h"
 #include "include/ceph_assert.h"
+#include "include/rados/buffer_fwd.h"
 #include "include/scope_guard.h"
+#include "librbd/crypto/DataCryptor.h"
+#include "librbd/crypto/Types.h"
 
 #include <bit>
+#include <cstddef>
+#include <optional>
 #include <stdlib.h>
 
 namespace librbd {
@@ -33,117 +39,97 @@ BlockCrypto<T>::~BlockCrypto() {
 template <typename T>
 int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
                            CipherMode mode) {
-  size_t block_in_size, block_out_size;
-  if (mode == CipherMode::CIPHER_MODE_ENC) {
-    block_in_size = m_block_size; // Reading Plaintext (e.g., 4096)
-    block_out_size =
-        m_block_size + m_meta_size; // Writing Ciphertext + Tag (e.g., 4112)
-  } else {
-    block_in_size = m_block_size + m_meta_size; // Reading Ciphertext + Tag
-    block_out_size = m_block_size;              // Writing Plaintext
-  }
-  // TODO: Encrypt data with physical or logical offset? 
-    // Currently Data is encrypted with logical offset
-    // The main reason for this is because we divide by 512 to 
-    // determine the sector IV. With logical offsets (4096 alignment)
-    // we will have no remainder.
+  size_t input_size = (mode == CipherMode::CIPHER_MODE_ENC) 
+                              ? m_block_size 
+                              : m_block_size + m_meta_size;
   if (image_offset % m_block_size != 0) {
     lderr(m_cct) << "image offset: " << image_offset
                  << " not aligned to block size: " << m_block_size << dendl;
     return -EINVAL;
   }
-  if (data->length() % block_in_size != 0) {
+  if (data->length() % input_size != 0) {
     lderr(m_cct) << "data length: " << data->length()
-                 << " not aligned to block size: " << block_in_size << dendl;
+                 << " not aligned to block size: " << m_block_size << dendl;
     return -EINVAL;
   }
-
-  unsigned char* iv = (unsigned char*)alloca(m_iv_size);
-  memset(iv, 0, m_iv_size);
+  bufferlist meta;
+  // make block to flush contiguous_appender(
+  {
+  bufferlist::iterator meta_iter;
+  std::optional<bufferlist::contiguous_appender> meta_appender;
+  auto sector_number = image_offset / 512;
+  size_t num_blocks = data->length() / (input_size);
+  if (m_meta_size != 0 && mode == CipherMode::CIPHER_MODE_DEC) {
+    data->splice(data->length()- (num_blocks * m_meta_size), num_blocks * m_meta_size, &meta);
+    meta_iter = meta.begin();
+  } else if (m_meta_size != 0 && mode == CipherMode::CIPHER_MODE_ENC) {
+    meta_appender.emplace(meta.get_contiguous_appender(num_blocks * m_meta_size));
+  }
 
   bufferlist src = *data;
   data->clear();
-
+  auto data_appender = data->get_contiguous_appender(num_blocks * m_block_size);
+  auto src_iter = src.begin();
   auto ctx = m_data_cryptor->get_context(mode);
   if (ctx == nullptr) {
     lderr(m_cct) << "unable to get crypt context" << dendl;
     return -EIO;
   }
-
   auto sg = make_scope_guard([&] {
       m_data_cryptor->return_context(ctx, mode); });
-
-  auto sector_number = image_offset / 512;
-  size_t num_blocks = src.length() / block_in_size;
-  size_t total_output_size = num_blocks * block_out_size;
-  auto appender = data->get_contiguous_appender(total_output_size);
-  unsigned char* out_buf_ptr = nullptr;
-  // TODO: Can this buffer overflow? 
-  unsigned char* leftover_block = (unsigned char*)alloca(block_in_size);
-  uint32_t leftover_size = 0;
-  for (auto buf = src.buffers().begin(); buf != src.buffers().end(); ++buf) {
-    auto in_buf_ptr = reinterpret_cast<const unsigned char*>(buf->c_str());
-    auto remaining_buf_bytes = buf->length();
-    while (remaining_buf_bytes > 0) {
-      if (leftover_size == 0) {
-        auto block_offset_le = ceph_le64(sector_number);
-        memcpy(iv, &block_offset_le, sizeof(block_offset_le));
-        auto r = m_data_cryptor->init_context(ctx, iv, m_iv_size);
-        if (r != 0) {
-          lderr(m_cct) << "unable to init cipher's IV" << dendl;
-          return r;
-        }
-
-        out_buf_ptr = reinterpret_cast<unsigned char*>(
-                appender.get_pos_add(block_out_size));
-        sector_number += m_block_size / 512;
-      }
-
-      if (leftover_size > 0 || remaining_buf_bytes < block_in_size) {
-        auto copy_size = std::min(
-                (uint32_t)block_in_size - leftover_size, remaining_buf_bytes);
-        memcpy(leftover_block + leftover_size, in_buf_ptr, copy_size);
-        in_buf_ptr += copy_size;
-        leftover_size += copy_size;
-        remaining_buf_bytes -= copy_size;
-      }
-
-      int crypto_output_length = 0;
-      if (leftover_size == 0 || leftover_size == block_in_size) {
-        const unsigned char* src_ptr = (leftover_size == 0) ? in_buf_ptr : leftover_block;
-        if (mode == CIPHER_MODE_DEC)  {
-          crypto_output_length = m_data_cryptor->decrypt(
-              ctx, src_ptr, out_buf_ptr,
-              block_in_size, block_out_size,
-              iv, m_iv_size);
-        } else {
-          crypto_output_length = m_data_cryptor->update_context(
-            ctx, src_ptr, out_buf_ptr,
-            block_in_size, block_out_size,
-            iv, m_iv_size);
-        }
-        if (std::cmp_not_equal(crypto_output_length, block_out_size)) {
-          lderr(m_cct) << "output size not expected\n expected: "
-                       << block_out_size << " got: " << crypto_output_length
-                       << dendl;
-          return crypto_output_length;
-        }
-        if (leftover_size == 0) {
-          in_buf_ptr += block_in_size;
-          remaining_buf_bytes -= block_in_size;
-        } else {
-          leftover_size = 0;
-        }
-      }
-      if (crypto_output_length < 0) {
-        lderr(m_cct) << "crypt update failed" << dendl;
-        return crypto_output_length;
-      }
-
-      out_buf_ptr += crypto_output_length;
+  unsigned char* meta = (unsigned char*)alloca(m_meta_size);
+  std::vector<unsigned char> iv(m_iv_size);
+  std::vector<unsigned char> data_buf(m_block_size);
+  for (size_t i = 0; i < num_blocks; ++i) {
+    auto block_offset_le = ceph_le64(sector_number);
+    memcpy(iv.data(), &block_offset_le, sizeof(block_offset_le));
+    auto r = m_data_cryptor->init_context(ctx, iv.data(), m_iv_size);
+    if (r != 0) {
+      lderr(m_cct) << "unable to init cipher's IV" << dendl;
+      return r;
     }
+    // no need to interate over the items of a bufferlist manually. 
+    src_iter.copy(m_block_size, reinterpret_cast<char*>(data_buf.data()));
+    unsigned char* out_buf_ptr = reinterpret_cast<unsigned char*>(
+        data_appender.get_pos_add(m_block_size));
+    if (m_meta_size != 0) {
+      if (mode == CIPHER_MODE_ENC) {
+        meta = reinterpret_cast<unsigned char*>(
+            meta_appender->get_pos_add(m_meta_size));
+      } else {
+        meta_iter.copy(m_meta_size, reinterpret_cast<char*>(meta));
+      }
+    }
+    CryptArgs params;
+    params.in = data_buf.data();
+    params.out = out_buf_ptr;
+    params.len = m_block_size;
+    if (m_meta_size != 0) {
+      params.iv = iv.data();
+      params.iv_len = m_iv_size;
+      params.meta = meta;
+      params.meta_len = m_meta_size;
+    }
+    int crypto_output_length = (mode == CIPHER_MODE_DEC) ? 
+                          m_data_cryptor->decrypt(ctx, params) : 
+                          m_data_cryptor->update_context(ctx, params);
+    if (crypto_output_length < 0) {
+      lderr(m_cct) << "crypt update failed" << dendl;
+      return crypto_output_length;
+    }
+    if (std::cmp_not_equal(crypto_output_length, m_block_size)) {
+      lderr(m_cct) << "output size not expected\n expected: "
+                    << m_block_size << " got: " << crypto_output_length
+                    << dendl;
+      return -EINVAL;
+    }
+    sector_number += m_block_size / 512;
   }
-
+  // end block to flush contiguous_appender(
+  }
+  if (mode == CIPHER_MODE_ENC) {
+    data->claim_append(meta);
+  }
   return 0;
 }
 

--- a/src/librbd/crypto/BlockCrypto.h
+++ b/src/librbd/crypto/BlockCrypto.h
@@ -11,14 +11,6 @@
 namespace librbd {
 namespace crypto {
 
-inline bool is_aead(const char* algo) {
-  auto cipher = EVP_CIPHER_fetch(NULL, algo, NULL);
-  if (cipher == nullptr) {
-    return false;
-  }
-  return (EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0;
-}
-
 template <typename T>
 class BlockCrypto : public CryptoInterface {
 

--- a/src/librbd/crypto/CryptoContextPool.h
+++ b/src/librbd/crypto/CryptoContextPool.h
@@ -39,13 +39,15 @@ public:
     }
     inline int update_context(T* ctx, const unsigned char* in,
                               unsigned char* out,
-                              uint32_t in_len, uint32_t out_len) const override {
-      return m_data_cryptor->update_context(ctx, in, out, in_len, out_len);
+                              uint32_t in_len, uint32_t out_len, 
+                              const unsigned char* index, uint32_t index_len) const override {
+      return m_data_cryptor->update_context(ctx, in, out, in_len, out_len, index, index_len);
     }
     inline int decrypt(T* ctx, const unsigned char* in,
                               unsigned char* out,
-                              uint32_t in_len, uint32_t out_len) const override {
-      return m_data_cryptor->decrypt(ctx, in, out, in_len, out_len);
+                              uint32_t in_len, uint32_t out_len, 
+                              const unsigned char* index, uint32_t index_len) const override {
+      return m_data_cryptor->decrypt(ctx, in, out, in_len, out_len, index, index_len);
     }
 
     using ContextQueue = boost::lockfree::queue<T*>;

--- a/src/librbd/crypto/CryptoContextPool.h
+++ b/src/librbd/crypto/CryptoContextPool.h
@@ -39,8 +39,13 @@ public:
     }
     inline int update_context(T* ctx, const unsigned char* in,
                               unsigned char* out,
-                              uint32_t len) const override {
-      return m_data_cryptor->update_context(ctx, in, out, len);
+                              uint32_t in_len, uint32_t out_len) const override {
+      return m_data_cryptor->update_context(ctx, in, out, in_len, out_len);
+    }
+    inline int decrypt(T* ctx, const unsigned char* in,
+                              unsigned char* out,
+                              uint32_t in_len, uint32_t out_len) const override {
+      return m_data_cryptor->decrypt(ctx, in, out, in_len, out_len);
     }
 
     using ContextQueue = boost::lockfree::queue<T*>;

--- a/src/librbd/crypto/CryptoContextPool.h
+++ b/src/librbd/crypto/CryptoContextPool.h
@@ -37,17 +37,11 @@ public:
                             uint32_t iv_length) const override {
       return m_data_cryptor->init_context(ctx, iv, iv_length);
     }
-    inline int update_context(T* ctx, const unsigned char* in,
-                              unsigned char* out,
-                              uint32_t in_len, uint32_t out_len, 
-                              const unsigned char* index, uint32_t index_len) const override {
-      return m_data_cryptor->update_context(ctx, in, out, in_len, out_len, index, index_len);
+    inline int update_context(T* ctx, const CryptArgs& params) const override {
+      return m_data_cryptor->update_context(ctx, params);
     }
-    inline int decrypt(T* ctx, const unsigned char* in,
-                              unsigned char* out,
-                              uint32_t in_len, uint32_t out_len, 
-                              const unsigned char* index, uint32_t index_len) const override {
-      return m_data_cryptor->decrypt(ctx, in, out, in_len, out_len, index, index_len);
+    inline int decrypt(T* ctx, const CryptArgs& params) const override {
+      return m_data_cryptor->decrypt(ctx, params);
     }
 
     using ContextQueue = boost::lockfree::queue<T*>;

--- a/src/librbd/crypto/CryptoInterface.h
+++ b/src/librbd/crypto/CryptoInterface.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_CRYPTO_CRYPTO_INTERFACE_H
 
 #include "include/buffer.h"
+#include "include/ceph_assert.h"
 #include "include/intarith.h"
 #include "librbd/io/Types.h"
 
@@ -19,6 +20,7 @@ public:
   virtual int encrypt(ceph::bufferlist* data, uint64_t image_offset) = 0;
   virtual int decrypt(ceph::bufferlist* data, uint64_t image_offset) = 0;
   virtual uint64_t get_block_size() const = 0;
+  virtual uint32_t get_meta_size() const = 0;
   virtual uint64_t get_data_offset() const = 0;
   virtual const unsigned char* get_key() const = 0;
   virtual int get_key_length() const = 0;
@@ -33,6 +35,59 @@ public:
                           p2nphase(off + len, block_size));
   }
 
+  inline std::pair<uint64_t, uint64_t> map_logical_physical(uint64_t log_offset, uint64_t log_length) {
+    const uint64_t meta_size = get_meta_size();
+    if (meta_size == 0) {
+      return {log_offset, log_length};
+    }
+    uint64_t phys_sector_size = get_block_size() + meta_size;
+    uint64_t log_sector_size = get_block_size();
+    uint64_t start_sector_idx = log_offset / log_sector_size;
+    uint64_t last_byte_idx = log_offset + log_length;
+    uint64_t end_sector_idx = (last_byte_idx + log_sector_size - 1) /
+                              log_sector_size;
+    uint64_t phys_offset = start_sector_idx * phys_sector_size;
+    uint64_t num_sectors_to_read = end_sector_idx - start_sector_idx;
+    uint64_t phys_length = num_sectors_to_read * phys_sector_size;
+    return {phys_offset, phys_length};
+  }
+
+  inline std::pair<uint64_t, uint64_t> map_physical_logical(uint64_t phy_offset, 
+                                        uint64_t phy_length) {
+    const uint64_t meta_size = get_meta_size();
+    if (meta_size == 0) {
+      return {phy_offset, phy_length};
+    }
+    uint64_t phys_sector_size = get_block_size() + meta_size;
+    uint64_t log_sector_size = get_block_size();
+    uint64_t start_sector_idx = phy_offset / phys_sector_size;
+    uint64_t last_byte_idx = phy_offset + phy_length;
+    uint64_t end_sector_idx = (last_byte_idx + phys_sector_size - 1) / phys_sector_size;
+    uint64_t log_offset = start_sector_idx * log_sector_size;
+    uint64_t num_sectors_to_read = end_sector_idx - start_sector_idx;
+    uint64_t log_length = num_sectors_to_read * log_sector_size;
+    return {log_offset, log_length};
+  }
+
+  inline std::pair<uint64_t, uint64_t> get_pre_and_post_align_physical(
+      uint64_t off, uint64_t len) {
+    if (len == 0) {
+      return std::make_pair(0, 0);
+    }
+    uint64_t block_size = get_block_size() + get_meta_size();
+    uint64_t end = off + len;
+    uint64_t pre = off % block_size;
+    uint64_t end_rem = end % block_size;
+    uint64_t post = (end_rem == 0) ? 0 : (block_size - end_rem);
+    return std::make_pair(pre, post);
+  }
+
+  inline std::pair<uint64_t, uint64_t> align_physical(uint64_t off, uint64_t len) {
+    auto aligns = get_pre_and_post_align_physical(off, len);
+    return std::make_pair(off - aligns.first,
+                          len + aligns.first + aligns.second);
+  }
+
   inline std::pair<uint64_t, uint64_t> align(uint64_t off, uint64_t len) {
     auto aligns = get_pre_and_post_align(off, len);
     return std::make_pair(off - aligns.first,
@@ -43,10 +98,32 @@ public:
     auto aligns = get_pre_and_post_align(off, len);
     return aligns.first == 0 && aligns.second == 0;
   }
+  
+  inline void align_extents_physical(const io::ReadExtents& extents,
+                            io::ReadExtents* aligned_extents) {
+    for (const auto& extent: extents) {
+      auto physical_aligned = map_logical_physical(extent.offset, extent.length);
+      aligned_extents->emplace_back(physical_aligned.first, physical_aligned.second);
+    }
+  }
 
   inline bool is_aligned(const io::ReadExtents& extents) {
     for (const auto& extent: extents) {
       if (!is_aligned(extent.offset, extent.length)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  inline bool is_physical_aligned(uint64_t offset, uint64_t length) {
+    uint64_t physical_size = get_block_size() + get_meta_size();
+    return (length % physical_size == 0) && (offset % physical_size == 0);
+  }
+
+  inline bool is_physical_aligned(const io::ReadExtents& extents) {
+    for (const auto& extent: extents) {
+      if (!is_physical_aligned(extent.offset, extent.length)) {
         return false;
       }
     }
@@ -66,6 +143,8 @@ public:
     if (extent.length == 0 || extent.bl.length() == 0) {
       return 0;
     }
+    const uint32_t meta_size = get_meta_size();
+    const bool has_meta = (meta_size != 0);
 
     if (extent.extent_map.empty()) {
       extent.extent_map.emplace_back(extent.offset, extent.bl.length());
@@ -81,22 +160,38 @@ public:
 
     // this will add a final loop iteration for decrypting the last extent
     extent.extent_map.emplace_back(
-            extent.offset + extent.length + get_block_size(), 0);
+            extent.offset + extent.length + get_block_size() + meta_size, 0);
 
     for (auto [off, len]: extent.extent_map) {
-      auto [aligned_off, aligned_len] = align(off, len);
+      uint64_t aligned_off, aligned_len;
+      if (has_meta) {
+        std::tie(aligned_off, aligned_len) = align_physical(off, len);
+      } else {
+        std::tie(aligned_off, aligned_len)= align(off, len);
+      }
       if (aligned_off > curr_block_end_offset) {
-        curr_block_bl.append_zero(curr_block_end_offset - curr_offset);
+        if (curr_block_end_offset > curr_offset ) {
+          curr_block_bl.append_zero(curr_block_end_offset - curr_offset);
+        }
         auto curr_block_length = curr_block_bl.length();
         if (curr_block_length > 0) {
-          auto r = decrypt(
-                  &curr_block_bl,
-                  image_offset + curr_block_start_offset - extent.offset);
+          auto block_offset =
+              image_offset +
+              map_physical_logical(curr_block_start_offset - extent.offset, 0)
+                  .first;
+          auto r = decrypt(&curr_block_bl, block_offset);
           if (r != 0) {
             return r;
           }
-
+          if (has_meta) {
+            std::tie(curr_block_start_offset, curr_block_length) =
+                map_physical_logical(
+                    curr_block_start_offset, curr_block_bl.length());
+          }
+          ceph_assert(curr_block_bl.length() == curr_block_length);
           curr_block_bl.splice(0, curr_block_length, &result_bl);
+          // if unalinged read then in remove_alignment_data()
+          // this will be the aligned_extents.extent_map
           result_extent_map.emplace_back(
                   curr_block_start_offset, curr_block_length);
         }

--- a/src/librbd/crypto/CryptoInterface.h
+++ b/src/librbd/crypto/CryptoInterface.h
@@ -26,66 +26,13 @@ public:
   virtual int get_key_length() const = 0;
 
   inline std::pair<uint64_t, uint64_t> get_pre_and_post_align(
-          uint64_t off, uint64_t len) {
+          uint64_t off, uint64_t len, bool meta_align=false) {
     if (len == 0) {
       return std::make_pair(0, 0);
     }
-    auto block_size = get_block_size();
+    auto block_size = !meta_align ? get_block_size() : get_meta_size();
     return std::make_pair(p2phase(off, block_size),
                           p2nphase(off + len, block_size));
-  }
-
-  inline std::pair<uint64_t, uint64_t> map_logical_physical(uint64_t log_offset, uint64_t log_length) {
-    const uint64_t meta_size = get_meta_size();
-    if (meta_size == 0) {
-      return {log_offset, log_length};
-    }
-    uint64_t phys_sector_size = get_block_size() + meta_size;
-    uint64_t log_sector_size = get_block_size();
-    uint64_t start_sector_idx = log_offset / log_sector_size;
-    uint64_t last_byte_idx = log_offset + log_length;
-    uint64_t end_sector_idx = (last_byte_idx + log_sector_size - 1) /
-                              log_sector_size;
-    uint64_t phys_offset = start_sector_idx * phys_sector_size;
-    uint64_t num_sectors_to_read = end_sector_idx - start_sector_idx;
-    uint64_t phys_length = num_sectors_to_read * phys_sector_size;
-    return {phys_offset, phys_length};
-  }
-
-  inline std::pair<uint64_t, uint64_t> map_physical_logical(uint64_t phy_offset, 
-                                        uint64_t phy_length) {
-    const uint64_t meta_size = get_meta_size();
-    if (meta_size == 0) {
-      return {phy_offset, phy_length};
-    }
-    uint64_t phys_sector_size = get_block_size() + meta_size;
-    uint64_t log_sector_size = get_block_size();
-    uint64_t start_sector_idx = phy_offset / phys_sector_size;
-    uint64_t last_byte_idx = phy_offset + phy_length;
-    uint64_t end_sector_idx = (last_byte_idx + phys_sector_size - 1) / phys_sector_size;
-    uint64_t log_offset = start_sector_idx * log_sector_size;
-    uint64_t num_sectors_to_read = end_sector_idx - start_sector_idx;
-    uint64_t log_length = num_sectors_to_read * log_sector_size;
-    return {log_offset, log_length};
-  }
-
-  inline std::pair<uint64_t, uint64_t> get_pre_and_post_align_physical(
-      uint64_t off, uint64_t len) {
-    if (len == 0) {
-      return std::make_pair(0, 0);
-    }
-    uint64_t block_size = get_block_size() + get_meta_size();
-    uint64_t end = off + len;
-    uint64_t pre = off % block_size;
-    uint64_t end_rem = end % block_size;
-    uint64_t post = (end_rem == 0) ? 0 : (block_size - end_rem);
-    return std::make_pair(pre, post);
-  }
-
-  inline std::pair<uint64_t, uint64_t> align_physical(uint64_t off, uint64_t len) {
-    auto aligns = get_pre_and_post_align_physical(off, len);
-    return std::make_pair(off - aligns.first,
-                          len + aligns.first + aligns.second);
   }
 
   inline std::pair<uint64_t, uint64_t> align(uint64_t off, uint64_t len) {
@@ -98,12 +45,27 @@ public:
     auto aligns = get_pre_and_post_align(off, len);
     return aligns.first == 0 && aligns.second == 0;
   }
-  
-  inline void align_extents_physical(const io::ReadExtents& extents,
-                            io::ReadExtents* aligned_extents) {
-    for (const auto& extent: extents) {
-      auto physical_aligned = map_logical_physical(extent.offset, extent.length);
-      aligned_extents->emplace_back(physical_aligned.first, physical_aligned.second);
+
+  inline bool is_meta_aligned(uint64_t off, uint64_t len) {
+    auto meta_align = get_pre_and_post_align(off, len, true);
+    return meta_align.first == 0 && meta_align.second == 0;
+  }
+
+  inline void get_physical_extends(const io::ReadExtents& extents,
+                            io::ReadExtents* aligned_extents, const uint64_t& image_size) {
+    const io::ReadExtents* source_extents = &extents;
+    io::ReadExtents temp_aligned_extents;
+    if (!is_aligned(extents)) { 
+      align_extents(extents, &temp_aligned_extents);
+      source_extents = &temp_aligned_extents;
+    }
+    for (const auto& extent: *source_extents) {
+      aligned_extents->emplace_back(extent.offset, extent.length);
+      size_t block_length = get_block_size();
+      size_t meta_size = get_meta_size();
+      size_t block_num = extent.offset / block_length;
+      size_t blocks_cnt = extent.length / block_length;
+      aligned_extents->emplace_back(image_size + meta_size * block_num, meta_size * blocks_cnt);
     }
   }
 
@@ -116,14 +78,13 @@ public:
     return true;
   }
 
-  inline bool is_physical_aligned(uint64_t offset, uint64_t length) {
-    uint64_t physical_size = get_block_size() + get_meta_size();
-    return (length % physical_size == 0) && (offset % physical_size == 0);
-  }
-
   inline bool is_physical_aligned(const io::ReadExtents& extents) {
-    for (const auto& extent: extents) {
-      if (!is_physical_aligned(extent.offset, extent.length)) {
+    if (extents.size() % 2 != 0) {
+      return false;
+    }
+    for (size_t i = 0; i < extents.size(); i += 2) {
+      if (!is_aligned(extents[i].offset, extents[i].length) ||
+          !is_meta_aligned(extents[i+1].offset, extents[i+1].length)) {
         return false;
       }
     }
@@ -139,12 +100,13 @@ public:
   }
 
   inline int decrypt_aligned_extent(io::ReadExtent& extent,
-                                    uint64_t image_offset) {
+                                    uint64_t image_offset, io::ReadExtent* meta = nullptr) {
     if (extent.length == 0 || extent.bl.length() == 0) {
       return 0;
     }
     const uint32_t meta_size = get_meta_size();
     const bool has_meta = (meta_size != 0);
+    unsigned int meta_block_off = 0;
 
     if (extent.extent_map.empty()) {
       extent.extent_map.emplace_back(extent.offset, extent.bl.length());
@@ -160,38 +122,34 @@ public:
 
     // this will add a final loop iteration for decrypting the last extent
     extent.extent_map.emplace_back(
-            extent.offset + extent.length + get_block_size() + meta_size, 0);
+            extent.offset + extent.length + get_block_size(), 0);
 
     for (auto [off, len]: extent.extent_map) {
-      uint64_t aligned_off, aligned_len;
-      if (has_meta) {
-        std::tie(aligned_off, aligned_len) = align_physical(off, len);
-      } else {
-        std::tie(aligned_off, aligned_len)= align(off, len);
-      }
+      auto [aligned_off, aligned_len] = align(off, len);
       if (aligned_off > curr_block_end_offset) {
-        if (curr_block_end_offset > curr_offset ) {
-          curr_block_bl.append_zero(curr_block_end_offset - curr_offset);
-        }
+        curr_block_bl.append_zero(curr_block_end_offset - curr_offset);
         auto curr_block_length = curr_block_bl.length();
         if (curr_block_length > 0) {
-          auto block_offset =
-              image_offset +
-              map_physical_logical(curr_block_start_offset - extent.offset, 0)
-                  .first;
-          auto r = decrypt(&curr_block_bl, block_offset);
+          if (has_meta) {
+            size_t block_length = get_block_size();
+            size_t meta_size = get_meta_size();
+            size_t block_num = curr_block_bl.length() / block_length;
+            // TODO: Do I need to do something with meta->extent_map or buffer_extents?
+            ceph_assert(meta_block_off + block_num * meta_size <= meta->bl.length());
+            bufferlist meta_block;
+            // TODO: Splice instead of copy
+            meta_block.substr_of(meta->bl, meta_block_off, block_num * meta_size);
+            curr_block_bl.claim_append(std::move(meta_block));
+            meta_block_off += block_num * meta_size;
+          }
+          auto r = decrypt(
+                  &curr_block_bl,
+                  image_offset + curr_block_start_offset - extent.offset);
           if (r != 0) {
             return r;
           }
-          if (has_meta) {
-            std::tie(curr_block_start_offset, curr_block_length) =
-                map_physical_logical(
-                    curr_block_start_offset, curr_block_bl.length());
-          }
-          ceph_assert(curr_block_bl.length() == curr_block_length);
+
           curr_block_bl.splice(0, curr_block_length, &result_bl);
-          // if unalinged read then in remove_alignment_data()
-          // this will be the aligned_extents.extent_map
           result_extent_map.emplace_back(
                   curr_block_start_offset, curr_block_length);
         }

--- a/src/librbd/crypto/CryptoInterface.h
+++ b/src/librbd/crypto/CryptoInterface.h
@@ -109,10 +109,9 @@ public:
     unsigned int meta_block_off = 0;
 
     if (extent.extent_map.empty()) {
-      ceph_assert(extent.bl.length() == extent.length);
-      extent.extent_map.emplace_back(extent.offset, extent.length);
+      ceph_assert(extent.bl.length() <= extent.length);
+      extent.extent_map.emplace_back(extent.offset, extent.bl.length());
     } // else the sparse read case
-    // we assume that the sum of all parts in the extent_map are equal to bl.length()
 
     ceph::bufferlist result_bl;
     io::Extents result_extent_map;

--- a/src/librbd/crypto/CryptoInterface.h
+++ b/src/librbd/crypto/CryptoInterface.h
@@ -109,8 +109,10 @@ public:
     unsigned int meta_block_off = 0;
 
     if (extent.extent_map.empty()) {
-      extent.extent_map.emplace_back(extent.offset, extent.bl.length());
-    }
+      ceph_assert(extent.bl.length() == extent.length);
+      extent.extent_map.emplace_back(extent.offset, extent.length);
+    } // else the sparse read case
+    // we assume that the sum of all parts in the extent_map are equal to bl.length()
 
     ceph::bufferlist result_bl;
     io::Extents result_extent_map;

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -708,7 +708,10 @@ int CryptoObjectDispatch<I>::prepare_copyup(
 
         encrypted_bl.append(aligned_bl);
       }
-
+      if (m_crypto->get_meta_size() != 0) {
+        std::tie(aligned_off, aligned_len) = m_crypto->map_logical_physical(aligned_off, aligned_len);
+      } 
+      ceph_assert(encrypted_bl.length() == aligned_len);
       encrypted_sparse_bufferlist.insert(
         aligned_off, aligned_len, {io::SPARSE_EXTENT_STATE_DATA, aligned_len,
                                    std::move(encrypted_bl)});

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -88,16 +88,26 @@ struct C_AlignedObjectReadRequest : public Context {
       ldout(cct, 20) << "aligned read r=" << r << dendl;
       if (r >= 0) {
         r = 0;
-        for (auto& extent: *extents) {
-          auto off = crypto->map_physical_logical(extent.offset, 0).first;
+        const bool has_meta = (crypto->get_meta_size() > 0);
+        const size_t stride = has_meta ? 2 : 1;
+        for (size_t i = 0; i < extents->size(); i += stride) {
+          if (has_meta && (i + 1 >= extents->size())) {
+             lderr(cct) << "Missing metadata extent for index " << i << dendl;
+             r = -EINVAL; 
+             break;
+          }
+          auto& data_extent = (*extents)[i];
+          auto* meta_extent = has_meta ? &(*extents)[i+1] : nullptr;
           auto crypto_ret = crypto->decrypt_aligned_extent(
-              extent, get_file_offset(image_ctx, object_no, off));
+              data_extent, 
+              get_file_offset(image_ctx, object_no, data_extent.offset),
+              meta_extent);
           if (crypto_ret != 0) {
             ceph_assert(crypto_ret < 0);
             r = crypto_ret;
             break;
           }
-          r += extent.length;
+          r += data_extent.length;
         }
       }
 
@@ -128,7 +138,7 @@ struct C_UnalignedObjectReadRequest : public Context {
             Context* on_dispatched) : cct(image_ctx->cct), extents(extents),
                                       on_finish(on_dispatched) {
     if (crypto->get_meta_size() != 0) {
-      crypto->align_extents_physical(*extents, &aligned_extents);
+      crypto->get_physical_extends(*extents, &aligned_extents, image_ctx->get_object_size());
     } else {
       crypto->align_extents(*extents, &aligned_extents);
     }
@@ -149,9 +159,13 @@ struct C_UnalignedObjectReadRequest : public Context {
     }
 
     void remove_alignment_data() {
+      // When AEAD is active, get_physical_extends creates 2N aligned extents
+      // (data+meta pairs) for N original extents. Use stride 2 to skip meta.
+      const bool has_meta = (aligned_extents.size() > extents->size());
+      const size_t stride = has_meta ? 2 : 1;
       for (uint64_t i = 0; i < extents->size(); ++i) {
         auto& extent = (*extents)[i];
-        auto& aligned_extent = aligned_extents[i];
+        auto& aligned_extent = aligned_extents[i * stride];
         if (aligned_extent.extent_map.empty()) {
           uint64_t cut_offset = extent.offset - aligned_extent.offset;
           int64_t padding_count =
@@ -512,34 +526,13 @@ bool CryptoObjectDispatch<I>::write(
                  << object_off << "~" << data.length() << dendl;
   ceph_assert(m_crypto != nullptr);
 
-  const bool has_meta = (m_crypto->get_meta_size() != 0);
-
-  if (has_meta &&
-      (m_crypto->is_aligned(object_off, data.length()))) {
-    auto align = m_crypto->map_logical_physical(object_off, data.length());
-
+  if (m_crypto->is_aligned(object_off, data.length())) {
     auto r = m_crypto->encrypt(
         &data, get_file_offset(m_image_ctx, object_no, object_off));
-    ceph_assert(data.length() == align.second);
-    ceph_assert(r == 0);
-
-    // re-call this layer to change the offset and length of the write operation
-    *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
-    auto write_req = io::ObjectDispatchSpec::create_write(
-        m_image_ctx,
-        io::util::get_previous_layer(io::OBJECT_DISPATCH_LAYER_CRYPTO),
-        object_no, align.first, std::move(data), io_context, op_flags,
-        write_flags, assert_version, journal_tid == nullptr ? 0 : *journal_tid,
-        parent_trace, on_dispatched);
-    write_req->send();
-
-  } else if (has_meta &&
-             m_crypto->is_physical_aligned(object_off, data.length())) {
-    *dispatch_result = io::DISPATCH_RESULT_CONTINUE;
-    on_dispatched->complete(0);
-  } else if (m_crypto->is_aligned(object_off, data.length())) {
-    auto r = m_crypto->encrypt(
-        &data, get_file_offset(m_image_ctx, object_no, object_off));
+    // TODO: Maybe use issue a new write to use write_flags instead
+    *object_dispatch_flags |= (m_crypto->get_meta_size() > 0)
+                                  ? io::OBJECT_DISPATCH_FLAG_IS_AEAD_ENCRYPTED
+                                  : 0;
     *dispatch_result = r == 0 ? io::DISPATCH_RESULT_CONTINUE
                               : io::DISPATCH_RESULT_COMPLETE;
     on_dispatched->complete(r);
@@ -686,6 +679,9 @@ int CryptoObjectDispatch<I>::prepare_copyup(
 
     // encrypt
     io::SparseBufferlist encrypted_sparse_bufferlist;
+    const uint64_t meta_size = m_crypto->get_meta_size();
+    const uint64_t block_size = m_crypto->get_block_size();
+    const uint64_t object_size = m_image_ctx->get_object_size();
     for (auto& extent : extent_map) {
       auto [aligned_off, aligned_len] = m_crypto->align(
               extent.get_off(), extent.get_len());
@@ -708,13 +704,33 @@ int CryptoObjectDispatch<I>::prepare_copyup(
 
         encrypted_bl.append(aligned_bl);
       }
-      if (m_crypto->get_meta_size() != 0) {
-        std::tie(aligned_off, aligned_len) = m_crypto->map_logical_physical(aligned_off, aligned_len);
-      } 
-      ceph_assert(encrypted_bl.length() == aligned_len);
-      encrypted_sparse_bufferlist.insert(
-        aligned_off, aligned_len, {io::SPARSE_EXTENT_STATE_DATA, aligned_len,
-                                   std::move(encrypted_bl)});
+
+      if (meta_size != 0) {
+        // Split layout: data at logical offsets, meta beyond object_size
+        uint64_t num_blocks = aligned_len / block_size;
+        uint64_t data_len = num_blocks * block_size;
+        uint64_t meta_len = num_blocks * meta_size;
+        ceph_assert(encrypted_bl.length() == data_len + meta_len);
+
+        ceph::bufferlist data_bl;
+        data_bl.substr_of(encrypted_bl, 0, data_len);
+        encrypted_sparse_bufferlist.insert(
+          aligned_off, data_len,
+          {io::SPARSE_EXTENT_STATE_DATA, data_len, std::move(data_bl)});
+
+        uint64_t start_block = aligned_off / block_size;
+        uint64_t meta_off = object_size + start_block * meta_size;
+        ceph::bufferlist meta_bl;
+        meta_bl.substr_of(encrypted_bl, data_len, meta_len);
+        encrypted_sparse_bufferlist.insert(
+          meta_off, meta_len,
+          {io::SPARSE_EXTENT_STATE_DATA, meta_len, std::move(meta_bl)});
+      } else {
+        ceph_assert(encrypted_bl.length() == aligned_len);
+        encrypted_sparse_bufferlist.insert(aligned_off, aligned_len,
+          {io::SPARSE_EXTENT_STATE_DATA, aligned_len,
+           std::move(encrypted_bl)});
+      }
     }
 
     // replace original plaintext sparse bufferlist with encrypted one

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -112,6 +112,15 @@ struct C_AlignedObjectReadRequest : public Context {
       }
 
       if (r == -ENOENT && !disable_read_from_parent) {
+        // For AEAD, strip metadata extents before reading from parent.
+        // read_parent is based on logical extents
+        if (crypto->get_meta_size() > 0) {
+          io::ReadExtents data_only;
+          for (size_t i = 0; i < extents->size(); i += 2) {
+            data_only.push_back(std::move((*extents)[i]));
+          }
+          *extents = std::move(data_only);
+        }
         io::util::read_parent<I>(
                 image_ctx, object_no, extents,
                 io_context->get_read_snap(),
@@ -139,10 +148,11 @@ struct C_UnalignedObjectReadRequest : public Context {
                                       on_finish(on_dispatched) {
     if (crypto->get_meta_size() != 0) {
       crypto->get_physical_extends(*extents, &aligned_extents, image_ctx->get_object_size());
+      read_flags |= io::READ_FLAG_ENCRYPTED_AEAD_READ;
     } else {
       crypto->align_extents(*extents, &aligned_extents);
     }
-    
+
     ldout(cct, 20) << data_object_name(image_ctx, object_no) << " aligned extends "
                  << aligned_extents << dendl;
 
@@ -489,9 +499,14 @@ bool CryptoObjectDispatch<I>::read(
   ceph_assert(m_crypto != nullptr);
 
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
-  bool is_request_aligned = (m_crypto->get_meta_size() != 0) 
-                          ? m_crypto->is_physical_aligned(*extents) 
-                          : m_crypto->is_aligned(*extents);
+  bool is_request_aligned;
+  if (m_crypto->get_meta_size() != 0) {
+    // If the READ_FLAG_ENCRYPTED_AEAD_READ we know it already contains
+    // physically aligned extents. 
+    is_request_aligned = (read_flags & io::READ_FLAG_ENCRYPTED_AEAD_READ) != 0;
+  } else {
+    is_request_aligned = m_crypto->is_aligned(*extents);
+  }
   if (is_request_aligned) {
     auto req = new C_AlignedObjectReadRequest<I>(
             m_image_ctx, m_crypto, object_no, extents, io_context,
@@ -530,6 +545,7 @@ bool CryptoObjectDispatch<I>::write(
     auto r = m_crypto->encrypt(
         &data, get_file_offset(m_image_ctx, object_no, object_off));
     // TODO: Maybe use issue a new write to use write_flags instead
+    ceph_assert(object_dispatch_flags != nullptr);
     *object_dispatch_flags |= (m_crypto->get_meta_size() > 0)
                                   ? io::OBJECT_DISPATCH_FLAG_IS_AEAD_ENCRYPTED
                                   : 0;
@@ -662,7 +678,8 @@ int CryptoObjectDispatch<I>::prepare_copyup(
   }
 
   ceph::bufferlist current_bl;
-  current_bl.append_zero(m_image_ctx->get_object_size());
+  const uint64_t object_size = m_image_ctx->get_object_size();
+  current_bl.append_zero(object_size);
 
   for (auto& [key, extent_map]: *snapshot_sparse_bufferlist) {
     // update current_bl with data from extent_map
@@ -681,7 +698,6 @@ int CryptoObjectDispatch<I>::prepare_copyup(
     io::SparseBufferlist encrypted_sparse_bufferlist;
     const uint64_t meta_size = m_crypto->get_meta_size();
     const uint64_t block_size = m_crypto->get_block_size();
-    const uint64_t object_size = m_image_ctx->get_object_size();
     for (auto& extent : extent_map) {
       auto [aligned_off, aligned_len] = m_crypto->align(
               extent.get_off(), extent.get_len());

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -698,50 +698,69 @@ int CryptoObjectDispatch<I>::prepare_copyup(
     io::SparseBufferlist encrypted_sparse_bufferlist;
     const uint64_t meta_size = m_crypto->get_meta_size();
     const uint64_t block_size = m_crypto->get_block_size();
-    for (auto& extent : extent_map) {
-      auto [aligned_off, aligned_len] = m_crypto->align(
-              extent.get_off(), extent.get_len());
 
+    if (meta_size != 0) {
+      // AEAD: encrypt the full object to generate integrity tags for all
+      // blocks, ensuring complete data+meta coverage for copyup.
       auto [image_extents, _] = io::util::object_to_area_extents(
-          m_image_ctx, object_no, {{aligned_off, aligned_len}});
+          m_image_ctx, object_no, {{0, object_size}});
 
       ceph::bufferlist encrypted_bl;
       uint64_t position = 0;
-      for (auto [image_offset, image_length]: image_extents) {
+      for (auto [image_offset, image_length] : image_extents) {
         ceph::bufferlist aligned_bl;
-        aligned_bl.substr_of(current_bl, aligned_off + position, image_length);
-        aligned_bl.rebuild(); // to deep copy aligned_bl from current_bl
+        aligned_bl.substr_of(current_bl, position, image_length);
+        aligned_bl.rebuild();
         position += image_length;
 
         auto r = m_crypto->encrypt(&aligned_bl, image_offset);
         if (r != 0) {
           return r;
         }
-
         encrypted_bl.append(aligned_bl);
       }
 
-      if (meta_size != 0) {
-        // Split layout: data at logical offsets, meta beyond object_size
-        uint64_t num_blocks = aligned_len / block_size;
-        uint64_t data_len = num_blocks * block_size;
-        uint64_t meta_len = num_blocks * meta_size;
-        ceph_assert(encrypted_bl.length() == data_len + meta_len);
+      uint64_t num_blocks = object_size / block_size;
+      uint64_t data_len = num_blocks * block_size;
+      uint64_t meta_len = num_blocks * meta_size;
+      ceph_assert(encrypted_bl.length() == data_len + meta_len);
 
-        ceph::bufferlist data_bl;
-        data_bl.substr_of(encrypted_bl, 0, data_len);
-        encrypted_sparse_bufferlist.insert(
-          aligned_off, data_len,
-          {io::SPARSE_EXTENT_STATE_DATA, data_len, std::move(data_bl)});
+      ceph::bufferlist data_bl;
+      data_bl.substr_of(encrypted_bl, 0, data_len);
+      encrypted_sparse_bufferlist.insert(
+        0, data_len,
+        {io::SPARSE_EXTENT_STATE_DATA, data_len, std::move(data_bl)});
 
-        uint64_t start_block = aligned_off / block_size;
-        uint64_t meta_off = object_size + start_block * meta_size;
-        ceph::bufferlist meta_bl;
-        meta_bl.substr_of(encrypted_bl, data_len, meta_len);
-        encrypted_sparse_bufferlist.insert(
-          meta_off, meta_len,
-          {io::SPARSE_EXTENT_STATE_DATA, meta_len, std::move(meta_bl)});
-      } else {
+      ceph::bufferlist meta_bl;
+      meta_bl.substr_of(encrypted_bl, data_len, meta_len);
+      encrypted_sparse_bufferlist.insert(
+        object_size, meta_len,
+        {io::SPARSE_EXTENT_STATE_DATA, meta_len, std::move(meta_bl)});
+    } else {
+      // non-AEAD: encrypt only the extents with data
+      for (auto& extent : extent_map) {
+        auto [aligned_off, aligned_len] = m_crypto->align(
+                extent.get_off(), extent.get_len());
+
+        auto [image_extents, _] = io::util::object_to_area_extents(
+            m_image_ctx, object_no, {{aligned_off, aligned_len}});
+
+        ceph::bufferlist encrypted_bl;
+        uint64_t position = 0;
+        for (auto [image_offset, image_length]: image_extents) {
+          ceph::bufferlist aligned_bl;
+          aligned_bl.substr_of(current_bl, aligned_off + position, image_length);
+          aligned_bl.rebuild();
+          position += image_length;
+
+          auto r = m_crypto->encrypt(&aligned_bl, image_offset);
+          if (r != 0) {
+            return r;
+          }
+
+          encrypted_bl.append(aligned_bl);
+        }
+
         ceph_assert(encrypted_bl.length() == aligned_len);
         encrypted_sparse_bufferlist.insert(aligned_off, aligned_len,
           {io::SPARSE_EXTENT_STATE_DATA, aligned_len,

--- a/src/librbd/crypto/DataCryptor.h
+++ b/src/librbd/crypto/DataCryptor.h
@@ -28,10 +28,12 @@ public:
   virtual int init_context(T* ctx, const unsigned char* iv,
                            uint32_t iv_length) const = 0;
   virtual int update_context(T* ctx, const unsigned char* in,
-                             unsigned char* out, uint32_t in_len, uint32_t out_len) const = 0;
+                             unsigned char* out, uint32_t in_len, uint32_t out_len, 
+                             const unsigned char* index, uint32_t index_len) const = 0;
   // TODO: Maybe Update function names
   virtual int decrypt(T* ctx,  const unsigned char* in,
-                             unsigned char* out, uint32_t in_len, uint32_t out_len) const = 0;
+                             unsigned char* out, uint32_t in_len, uint32_t out_len, 
+                             const unsigned char* index, uint32_t index_len) const = 0;
 };
 
 } // namespace crypto

--- a/src/librbd/crypto/DataCryptor.h
+++ b/src/librbd/crypto/DataCryptor.h
@@ -28,7 +28,10 @@ public:
   virtual int init_context(T* ctx, const unsigned char* iv,
                            uint32_t iv_length) const = 0;
   virtual int update_context(T* ctx, const unsigned char* in,
-                             unsigned char* out, uint32_t len) const = 0;
+                             unsigned char* out, uint32_t in_len, uint32_t out_len) const = 0;
+  // TODO: Maybe Update function names
+  virtual int decrypt(T* ctx,  const unsigned char* in,
+                             unsigned char* out, uint32_t in_len, uint32_t out_len) const = 0;
 };
 
 } // namespace crypto

--- a/src/librbd/crypto/DataCryptor.h
+++ b/src/librbd/crypto/DataCryptor.h
@@ -10,6 +10,17 @@
 namespace librbd {
 namespace crypto {
 
+struct CryptArgs {
+  const unsigned char* in;
+  unsigned char* out;
+  uint32_t len;   // Common length (if in_len == out_len)
+  const unsigned char* iv = nullptr;
+  uint32_t iv_len = 0;
+
+  unsigned char* meta = nullptr; 
+  uint32_t meta_len = 0;
+};
+
 template <typename T>
 class DataCryptor {
 
@@ -27,13 +38,9 @@ public:
 
   virtual int init_context(T* ctx, const unsigned char* iv,
                            uint32_t iv_length) const = 0;
-  virtual int update_context(T* ctx, const unsigned char* in,
-                             unsigned char* out, uint32_t in_len, uint32_t out_len, 
-                             const unsigned char* index, uint32_t index_len) const = 0;
-  // TODO: Maybe Update function names
-  virtual int decrypt(T* ctx,  const unsigned char* in,
-                             unsigned char* out, uint32_t in_len, uint32_t out_len, 
-                             const unsigned char* index, uint32_t index_len) const = 0;
+
+  virtual int update_context(T* ctx, const CryptArgs& params) const = 0;
+  virtual int decrypt(T* ctx,  const CryptArgs& params) const = 0;
 };
 
 } // namespace crypto

--- a/src/librbd/crypto/Utils.cc
+++ b/src/librbd/crypto/Utils.cc
@@ -41,18 +41,27 @@ int build_crypto(
         const unsigned char* key, uint32_t key_length,
         uint64_t block_size, uint64_t data_offset, uint32_t meta_size,
         std::unique_ptr<CryptoInterface>* result_crypto) {
-  openssl::DataCryptor* data_cryptor; 
-  if (crypto::is_aead(cipher_suite)) {
-    data_cryptor = new openssl::AEADDataCryptor(cct);
-  } else { 
+  openssl::DataCryptor* data_cryptor;
+  if (meta_size > 0) {
+    // Authenticated encryption: authenc(hmac(sha256),xts(aes))
+    auto authenc = new openssl::AuthEncDataCryptor(cct);
+    int r = authenc->init(cipher_suite, key, key_length);
+    if (r != 0) {
+      lderr(cct) << "error initializing authenc data cryptor: "
+                 << cpp_strerror(r) << dendl;
+      delete authenc;
+      return r;
+    }
+    data_cryptor = authenc;
+  } else {
     data_cryptor = new openssl::DataCryptor(cct);
-  }
-  int r = data_cryptor->init(cipher_suite, key, key_length);
-  if (r != 0) {
-    lderr(cct) << "error initializing data cryptor: " << cpp_strerror(r)
-               << dendl;
-    delete data_cryptor;
-    return r;
+    int r = data_cryptor->init(cipher_suite, key, key_length);
+    if (r != 0) {
+      lderr(cct) << "error initializing data cryptor: " << cpp_strerror(r)
+                 << dendl;
+      delete data_cryptor;
+      return r;
+    }
   }
 
   result_crypto->reset(BlockCrypto<EVP_CIPHER_CTX>::create(

--- a/src/librbd/crypto/Utils.cc
+++ b/src/librbd/crypto/Utils.cc
@@ -37,23 +37,10 @@ void set_crypto(I *image_ctx,
 }
 
 int build_crypto(
-        CephContext* cct, const unsigned char* key, uint32_t key_length,
+        CephContext* cct, const char* cipher_suite,
+        const unsigned char* key, uint32_t key_length,
         uint64_t block_size, uint64_t data_offset, uint32_t meta_size,
         std::unique_ptr<CryptoInterface>* result_crypto) {
-  const char* cipher_suite;
-  switch (key_length) {
-    case 32:
-      cipher_suite = "aes-128-xts";
-      break;
-    case 64:
-    // TODO: Change setup
-      cipher_suite = "AES-256-SIV";
-      //cipher_suite = "aes-256-xts";
-      break;
-    default:
-      lderr(cct) << "unsupported key length: " << key_length << dendl;
-      return -ENOTSUP;
-  }
   openssl::DataCryptor* data_cryptor; 
   if (crypto::is_aead(cipher_suite)) {
     data_cryptor = new openssl::AEADDataCryptor(cct);

--- a/src/librbd/crypto/Utils.h
+++ b/src/librbd/crypto/Utils.h
@@ -23,7 +23,7 @@ void set_crypto(ImageCtxT *image_ctx,
 
 int build_crypto(
         CephContext* cct, const unsigned char* key, uint32_t key_length,
-        uint64_t block_size, uint64_t data_offset,
+        uint64_t block_size, uint64_t data_offset, uint32_t meta_size,
         std::unique_ptr<CryptoInterface>* result_crypto);
 
 } // namespace util

--- a/src/librbd/crypto/Utils.h
+++ b/src/librbd/crypto/Utils.h
@@ -22,7 +22,8 @@ void set_crypto(ImageCtxT *image_ctx,
                 decltype(ImageCtxT::encryption_format) encryption_format);
 
 int build_crypto(
-        CephContext* cct, const unsigned char* key, uint32_t key_length,
+        CephContext* cct, const char* cipher_suite,
+        const unsigned char* key, uint32_t key_length,
         uint64_t block_size, uint64_t data_offset, uint32_t meta_size,
         std::unique_ptr<CryptoInterface>* result_crypto);
 

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -44,6 +44,9 @@ template <typename I>
 void FormatRequest<I>::send() {
   const char* type;
   size_t sector_size;
+  // TODO: Figure out how to handle storing
+  //    metadata size on disk
+  size_t meta_size;
   switch (m_format) {
     case RBD_ENCRYPTION_FORMAT_LUKS1:
       type = CRYPT_LUKS1;
@@ -52,6 +55,7 @@ void FormatRequest<I>::send() {
     case RBD_ENCRYPTION_FORMAT_LUKS2:
       type = CRYPT_LUKS2;
       sector_size = 4096;
+      meta_size = 32;
       break;
     default:
       lderr(m_image_ctx->cct) << "unsupported format type: " << m_format
@@ -124,7 +128,7 @@ void FormatRequest<I>::send() {
 
   r = util::build_crypto(m_image_ctx->cct, key, key_size,
                          m_header.get_sector_size(),
-                         m_header.get_data_offset(), m_result_crypto);
+                         m_header.get_data_offset(), meta_size, m_result_crypto);
   ceph_memzero_s(key, key_size, key_size);
   if (r != 0) {
     finish(r);

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <openssl/rand.h>
+#include "acconfig.h"
 #include "common/dout.h"
 #include "common/errno.h"
 #include "include/compat.h"
@@ -81,13 +82,15 @@ void FormatRequest<I>::send() {
       openssl_cipher = "aes-256-xts";
       key_size = 64;
       break;
-    case RBD_ENCRYPTION_ALGORITHM_AES256_SIV:
+#ifdef HAVE_CRYPT_FORMAT_INLINE
+    case RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256:
       cipher = "cipher_null";
       cipher_mode = "ecb";
-      openssl_cipher = "AES-256-SIV";
-      key_size = 64;
-      meta_size = 32;
+      openssl_cipher = "aes-256-xts";
+      key_size = 96;
+      meta_size = 48;
       break;
+#endif
     default:
       lderr(m_image_ctx->cct) << "unsupported cipher algorithm: " << m_alg
                               << dendl;
@@ -139,9 +142,10 @@ void FormatRequest<I>::send() {
     return;
   }
 
+#ifdef HAVE_CRYPT_FORMAT_INLINE
   if (m_format == RBD_ENCRYPTION_FORMAT_LUKS2 &&
-      m_alg == RBD_ENCRYPTION_ALGORITHM_AES256_SIV) {
-    AEADToken token{meta_size, openssl_cipher};
+      m_alg == RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256) {
+    AEADToken token{meta_size, "authenc(hmac(sha256),xts(aes))"};
     ceph::JSONFormatter jf(false);
     jf.open_object_section("");
     token.encode_json(&jf);
@@ -154,6 +158,7 @@ void FormatRequest<I>::send() {
       return;
     }
   }
+#endif
 
   r = util::build_crypto(m_image_ctx->cct, openssl_cipher, key, key_size,
                          m_header.get_sector_size(),

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -14,6 +14,7 @@
 #include "librbd/crypto/luks/Magic.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
+#include "common/JSONFormatter.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -46,7 +47,6 @@ void FormatRequest<I>::send() {
   size_t sector_size;
   // TODO: Figure out how to handle storing
   //    metadata size on disk
-  size_t meta_size;
   switch (m_format) {
     case RBD_ENCRYPTION_FORMAT_LUKS1:
       type = CRYPT_LUKS1;
@@ -55,7 +55,6 @@ void FormatRequest<I>::send() {
     case RBD_ENCRYPTION_FORMAT_LUKS2:
       type = CRYPT_LUKS2;
       sector_size = 4096;
-      meta_size = 32;
       break;
     default:
       lderr(m_image_ctx->cct) << "unsupported format type: " << m_format
@@ -65,15 +64,29 @@ void FormatRequest<I>::send() {
   }
 
   const char* cipher;
+  const char* cipher_mode;
+  const char* openssl_cipher;
+  uint32_t meta_size = 0;
   size_t key_size;
   switch (m_alg) {
     case RBD_ENCRYPTION_ALGORITHM_AES128:
       cipher = "aes";
+      cipher_mode = "xts-plain64";
+      openssl_cipher = "aes-128-xts";
       key_size = 32;
       break;
     case RBD_ENCRYPTION_ALGORITHM_AES256:
       cipher = "aes";
+      cipher_mode = "xts-plain64";
+      openssl_cipher = "aes-256-xts";
       key_size = 64;
+      break;
+    case RBD_ENCRYPTION_ALGORITHM_AES256_SIV:
+      cipher = "cipher_null";
+      cipher_mode = "ecb";
+      openssl_cipher = "AES-256-SIV";
+      key_size = 64;
+      meta_size = 32;
       break;
     default:
       lderr(m_image_ctx->cct) << "unsupported cipher algorithm: " << m_alg
@@ -101,7 +114,7 @@ void FormatRequest<I>::send() {
   // format (create LUKS header)
   auto stripe_period = m_image_ctx->get_stripe_period();
   r = m_header.format(type, cipher, reinterpret_cast<char*>(key), key_size,
-                      "xts-plain64", sector_size, stripe_period,
+                      cipher_mode, sector_size, stripe_period,
                       m_insecure_fast_mode);
   if (r != 0) {
     finish(r);
@@ -126,7 +139,23 @@ void FormatRequest<I>::send() {
     return;
   }
 
-  r = util::build_crypto(m_image_ctx->cct, key, key_size,
+  if (m_format == RBD_ENCRYPTION_FORMAT_LUKS2 &&
+      m_alg == RBD_ENCRYPTION_ALGORITHM_AES256_SIV) {
+    AEADToken token{meta_size, openssl_cipher};
+    ceph::JSONFormatter jf(false);
+    jf.open_object_section("");
+    token.encode_json(&jf);
+    jf.close_section();
+    std::stringstream ss;
+    jf.flush(ss);
+    r = m_header.token_update(token::TYPE_AEAD, ss.str().c_str());
+    if (r != 0) {
+      finish(r);
+      return;
+    }
+  }
+
+  r = util::build_crypto(m_image_ctx->cct, openssl_cipher, key, key_size,
                          m_header.get_sector_size(),
                          m_header.get_data_offset(), meta_size, m_result_crypto);
   ceph_memzero_s(key, key_size, key_size);

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -15,7 +15,6 @@
 #include "librbd/crypto/luks/Magic.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
-#include "common/JSONFormatter.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -145,14 +144,10 @@ void FormatRequest<I>::send() {
 #ifdef HAVE_CRYPT_FORMAT_INLINE
   if (m_format == RBD_ENCRYPTION_FORMAT_LUKS2 &&
       m_alg == RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256) {
-    AEADToken token{meta_size, "authenc(hmac(sha256),xts(aes))"};
-    ceph::JSONFormatter jf(false);
-    jf.open_object_section("");
-    token.encode_json(&jf);
-    jf.close_section();
-    std::stringstream ss;
-    jf.flush(ss);
-    r = m_header.token_update(token::TYPE_AEAD, ss.str().c_str());
+    // rewrite the LUKS2 JSON to match crypt_format_inline() output:
+    // proper segment cipher/mode, integrity section, inline-hw-tags
+    r = m_header.rewrite_segment_for_inline("aes", "xts-random",
+                                            "hmac(sha256)");
     if (r != 0) {
       finish(r);
       return;

--- a/src/librbd/crypto/luks/Header.cc
+++ b/src/librbd/crypto/luks/Header.cc
@@ -192,6 +192,46 @@ int Header::add_keyslot(const char* passphrase, size_t passphrase_size) {
   return 0;
 }
 
+int Header::token_update(const char* identifier, const char* json_data) {
+  ceph_assert(m_cd != nullptr);
+  int target_slot = find_token_slot(identifier);
+  auto r = crypt_token_json_set(m_cd, target_slot, json_data);
+  if (r < 0) {
+    lderr(m_cct) << "crypt_token_json_set failed: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+int Header::token_get(const char* identifier, const char** json_data) {
+  ceph_assert(m_cd != nullptr);
+  int slot = find_token_slot(identifier);
+  auto r = crypt_token_json_get(m_cd, slot, json_data);
+  if (r < 0) {
+    ldout(m_cct, 20) << "crypt_token_json_get failed for token " << identifier << ": "
+                     << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+int Header::find_token_slot(const char* identifier) const {
+  // Careful this code assume we use the LUKS2 header
+  for (int i = 0; i < crypt_token_max(CRYPT_LUKS2); i++) {
+    const char* token_type = nullptr;
+    int info = crypt_token_status(m_cd, i, &token_type);
+    if (info != CRYPT_TOKEN_INVALID && info != CRYPT_TOKEN_INACTIVE) {
+      if (token_type != nullptr && strcmp(token_type, identifier) == 0) {
+        return i;
+      }
+    }
+  }
+
+  return CRYPT_ANY_TOKEN;
+}
+
 int Header::load(const char* type) {
   ceph_assert(m_cd != nullptr);
 

--- a/src/librbd/crypto/luks/Header.cc
+++ b/src/librbd/crypto/luks/Header.cc
@@ -3,12 +3,15 @@
 
 #include "Header.h"
 
+#include <endian.h>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <openssl/evp.h>
 #include "common/dout.h"
 #include "common/errno.h"
+#include "json_spirit/json_spirit.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -192,44 +195,205 @@ int Header::add_keyslot(const char* passphrase, size_t passphrase_size) {
   return 0;
 }
 
-int Header::token_update(const char* identifier, const char* json_data) {
-  ceph_assert(m_cd != nullptr);
-  int target_slot = find_token_slot(identifier);
-  auto r = crypt_token_json_set(m_cd, target_slot, json_data);
-  if (r < 0) {
-    lderr(m_cct) << "crypt_token_json_set failed: " << cpp_strerror(r) << dendl;
+// Post-process a LUKS2 header (already formatted via crypt_format() with a
+// placeholder cipher) to produce output equivalent to crypt_format_inline().
+// We cannot call crypt_format_inline() directly because it requires NOP DIF
+// hardware, which is unavailable on a memfd.
+//
+// Assumes:
+//   - Called after crypt_format() and add_keyslot() on this Header's memfd
+//   - The header is LUKS2 (not LUKS1) — LUKS1 has no JSON area
+//   - There is exactly one segment ("0") — crypt_format() always creates one
+//   - The checksum algorithm is SHA-256 — the LUKS2 default
+//   - The added fields (integrity section + requirements) fit within the
+//     existing JSON area allocated by crypt_format() — the area is typically
+//     ~12KB and we only modify the JSON string in-place without resizing it
+//
+// The memfd contains two LUKS2 headers (primary at offset 0, secondary at
+// offset hdr_size). Each header is: a 4096-byte binary header followed by a
+// JSON metadata area. For each copy we:
+//   1. Parse the JSON and rewrite the segment with the real cipher/mode
+//   2. Add the integrity section and "inline-hw-tags" requirement
+//   3. Recalculate the SHA-256 checksum over (binary header + JSON area)
+int Header::rewrite_segment_for_inline(const char* cipher,
+                                       const char* cipher_mode,
+                                       const char* integrity) {
+  ceph_assert(m_fd != -1);
+
+  // read the entire memfd
+  struct stat st;
+  if (fstat(m_fd, &st) < 0) {
+    auto r = -errno;
+    lderr(m_cct) << "failed to stat memfd: " << cpp_strerror(r) << dendl;
     return r;
   }
 
-  return 0;
-}
+  if (st.st_size <= 0) {
+    lderr(m_cct) << "memfd is empty" << dendl;
+    return -EINVAL;
+  }
 
-int Header::token_get(const char* identifier, const char** json_data) {
-  ceph_assert(m_cd != nullptr);
-  int slot = find_token_slot(identifier);
-  auto r = crypt_token_json_get(m_cd, slot, json_data);
-  if (r < 0) {
-    ldout(m_cct, 20) << "crypt_token_json_get failed for token " << identifier << ": "
-                     << cpp_strerror(r) << dendl;
+  std::vector<char> buf(st.st_size);
+  if (lseek(m_fd, 0, SEEK_SET) < 0) {
+    auto r = -errno;
+    lderr(m_cct) << "failed to seek memfd: " << cpp_strerror(r) << dendl;
     return r;
   }
 
-  return 0;
-}
+  ssize_t bytes_read = ::read(m_fd, buf.data(), buf.size());
+  if (bytes_read < 0 || static_cast<size_t>(bytes_read) != buf.size()) {
+    lderr(m_cct) << "failed to read memfd" << dendl;
+    return -EIO;
+  }
 
-int Header::find_token_slot(const char* identifier) const {
-  // Careful this code assume we use the LUKS2 header
-  for (int i = 0; i < crypt_token_max(CRYPT_LUKS2); i++) {
-    const char* token_type = nullptr;
-    int info = crypt_token_status(m_cd, i, &token_type);
-    if (info != CRYPT_TOKEN_INVALID && info != CRYPT_TOKEN_INACTIVE) {
-      if (token_type != nullptr && strcmp(token_type, identifier) == 0) {
-        return i;
-      }
+  // LUKS2 binary header constants — from struct luks2_hdr_disk in
+  // cryptsetup lib/luks2/luks2.h (LUKS2_HDR_BIN_LEN, LUKS2_CHECKSUM_L)
+  static constexpr size_t LUKS2_HDR_BIN_LEN = 4096;      // sizeof(luks2_hdr_disk) 
+  // LUKS_HDR_BIN is a fixed binary header that precedes the JSON metadata area in a LUKS2 header.
+  static constexpr size_t LUKS2_HDR_SIZE_OFFSET = 8;      // offset of hdr_size field
+  static constexpr size_t LUKS2_CHECKSUM_OFFSET = 0x01c0; // offset of csum field
+  static constexpr size_t LUKS2_CHECKSUM_LEN = 64;        // LUKS2_CHECKSUM_L
+
+  // LUKS2 spec: device must be large enough to hold at least the binary header
+  if (buf.size() < LUKS2_HDR_BIN_LEN + 1) {
+    lderr(m_cct) << "memfd too small for LUKS2 header" << dendl;
+    return -EINVAL;
+  }
+
+  // LUKS2 spec: hdr_size is a big-endian uint64 at offset 8 in the
+  // 4096-byte fixed binary header (struct luks2_hdr_disk). It gives the
+  // total size of one header copy: the binary header + the JSON metadata
+  // area that follows it. See hdr_from_disk() in luks2_disk_metadata.c.
+  uint64_t hdr_size;
+  memcpy(&hdr_size, buf.data() + LUKS2_HDR_SIZE_OFFSET, sizeof(hdr_size));
+  hdr_size = be64toh(hdr_size);
+
+  // Note: cryptsetup validates the LUKS2 spec limits on hdr_size in
+  // hdr_disk_sanity_check_pre() (>= 16KB, <= 4MB). Since crypt_format()
+  // already enforced those limits when creating this header, we only need
+  // to verify our buffer is self-consistent: hdr_size must cover at least
+  // the binary header, and the memfd must be large enough to hold both
+  // back-to-back copies (primary at offset 0, secondary at offset hdr_size)
+  // that we're about to modify.
+  if (hdr_size < LUKS2_HDR_BIN_LEN || hdr_size * 2 > buf.size()) {
+    lderr(m_cct) << "invalid LUKS2 header size: " << hdr_size << dendl;
+    return -EINVAL;
+  }
+
+  std::string encryption = std::string(cipher) + "-" + cipher_mode;
+
+  // LUKS2 spec: both header copies must be kept in sync. Process primary
+  // (offset 0) and secondary (offset hdr_size) identically.
+  // See hdr_write_disk() in luks2_disk_metadata.c.
+  for (int h = 0; h < 2; h++) {
+    size_t hdr_offset = h * hdr_size;
+    // LUKS2 spec: JSON area starts immediately after the 4096-byte binary
+    // header and extends to hdr_size. See hdr_read_disk() in
+    // luks2_disk_metadata.c.
+    char* json_area = buf.data() + hdr_offset + LUKS2_HDR_BIN_LEN;
+    size_t json_area_size = hdr_size - LUKS2_HDR_BIN_LEN;
+
+    // parse JSON
+    json_spirit::mValue root;
+    std::string json_str(json_area, strnlen(json_area, json_area_size));
+    if (!json_spirit::read(json_str, root)) {
+      lderr(m_cct) << "failed to parse LUKS2 JSON in header " << h << dendl;
+      return -EINVAL;
     }
+
+    auto& root_obj = root.get_obj();
+
+    // modify segments.0.encryption and add integrity
+    auto seg_it = root_obj.find("segments");
+    if (seg_it == root_obj.end()) {
+      lderr(m_cct) << "missing segments in LUKS2 JSON" << dendl;
+      return -EINVAL;
+    }
+    auto& segments = seg_it->second.get_obj();
+    auto seg0_it = segments.find("0");
+    if (seg0_it == segments.end()) {
+      lderr(m_cct) << "missing segment 0 in LUKS2 JSON" << dendl;
+      return -EINVAL;
+    }
+    auto& seg0 = seg0_it->second.get_obj();
+    seg0["encryption"] = json_spirit::mValue(encryption);
+
+    json_spirit::mObject integrity_obj;
+    integrity_obj["type"] = json_spirit::mValue(std::string(integrity));
+    integrity_obj["journal_encryption"] = json_spirit::mValue(std::string("none"));
+    integrity_obj["journal_integrity"] = json_spirit::mValue(std::string("none"));
+    seg0["integrity"] = json_spirit::mValue(integrity_obj);
+
+    // add config.requirements.mandatory = ["inline-hw-tags"]
+    auto config_it = root_obj.find("config");
+    if (config_it == root_obj.end()) {
+      lderr(m_cct) << "missing config in LUKS2 JSON" << dendl;
+      return -EINVAL;
+    }
+    auto& config = config_it->second.get_obj();
+
+    json_spirit::mObject requirements;
+    json_spirit::mArray mandatory;
+    mandatory.push_back(json_spirit::mValue(std::string("inline-hw-tags")));
+    requirements["mandatory"] = json_spirit::mValue(mandatory);
+    config["requirements"] = json_spirit::mValue(requirements);
+
+    // serialize JSON
+    std::string new_json = json_spirit::write(root);
+
+    // LUKS2 spec: JSON must fit within the JSON area (hdr_size - 4096 bytes).
+    // See LUKS2_disk_hdr_write() in luks2_disk_metadata.c.
+    if (new_json.size() >= json_area_size) {
+      lderr(m_cct) << "rewritten JSON exceeds area size" << dendl;
+      return -ENOSPC;
+    }
+
+    // LUKS2 spec: JSON area is null-terminated and zero-padded.
+    // See validate_json_area() in luks2_disk_metadata.c.
+    memset(json_area, 0, json_area_size);
+    memcpy(json_area, new_json.data(), new_json.size());
+
+    // LUKS2 spec: checksum is computed over the binary header (with the
+    // csum field zeroed) concatenated with the full JSON area (including
+    // padding). See hdr_checksum_calculate() in luks2_disk_metadata.c.
+    char* binary_hdr = buf.data() + hdr_offset;
+    memset(binary_hdr + LUKS2_CHECKSUM_OFFSET, 0, LUKS2_CHECKSUM_LEN);
+
+    unsigned char checksum[EVP_MAX_MD_SIZE];
+    unsigned int md_len = 0;
+    EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+    if (!mdctx) {
+      lderr(m_cct) << "failed to create EVP_MD_CTX" << dendl;
+      return -ENOMEM;
+    }
+    EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL);
+    EVP_DigestUpdate(mdctx, binary_hdr, LUKS2_HDR_BIN_LEN);
+    EVP_DigestUpdate(mdctx, json_area, json_area_size);
+    EVP_DigestFinal_ex(mdctx, checksum, &md_len);
+    EVP_MD_CTX_free(mdctx);
+
+    memcpy(binary_hdr + LUKS2_CHECKSUM_OFFSET, checksum, md_len);
   }
 
-  return CRYPT_ANY_TOKEN;
+  // write back to memfd
+  if (lseek(m_fd, 0, SEEK_SET) < 0) {
+    auto r = -errno;
+    lderr(m_cct) << "failed to seek memfd for write: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+  ssize_t bytes_written = ::write(m_fd, buf.data(), buf.size());
+  if (bytes_written < 0 || static_cast<size_t>(bytes_written) != buf.size()) {
+    lderr(m_cct) << "failed to write memfd" << dendl;
+    return -EIO;
+  }
+
+  // reset file position so subsequent Header::read() works correctly
+  lseek(m_fd, 0, SEEK_SET);
+
+  ldout(m_cct, 20) << "rewrote segment for inline integrity: "
+                   << encryption << " + " << integrity << dendl;
+  return 0;
 }
 
 int Header::load(const char* type) {
@@ -294,6 +458,11 @@ const char* Header::get_cipher_mode() {
 const char* Header::get_format_name() {
   ceph_assert(m_cd != nullptr);
   return crypt_get_type(m_cd);
+}
+
+int Header::get_integrity_info(struct crypt_params_integrity* ip) {
+  ceph_assert(m_cd != nullptr);
+  return crypt_get_integrity_info(m_cd, ip);
 }
 
 } // namespace luks

--- a/src/librbd/crypto/luks/Header.h
+++ b/src/librbd/crypto/luks/Header.h
@@ -6,36 +6,11 @@
 
 #include <libcryptsetup.h>
 #include "common/ceph_context.h"
-#include "common/ceph_json.h"
 #include "include/buffer.h"
 
 namespace librbd {
 namespace crypto {
 namespace luks {
-
-namespace token {
-  static const char* const TYPE_AEAD = "ceph-aead";
-  static const char* const KEY_META_SIZE = "meta_size";
-  static const char* const KEY_ALG = "alg";
-}
-
-struct AEADToken {
-  uint32_t meta_size = 0;
-  std::string alg;
-
-  void encode_json(ceph::Formatter *f) const {
-    f->dump_string("type", token::TYPE_AEAD);
-    f->open_array_section("keyslots");
-    f->close_section();
-    f->dump_unsigned(token::KEY_META_SIZE, meta_size);
-    f->dump_string(token::KEY_ALG, alg);
-  }
-
-  void decode_json(JSONObj *obj) {
-    JSONDecoder::decode_json(token::KEY_META_SIZE, meta_size, obj);
-    JSONDecoder::decode_json(token::KEY_ALG, alg, obj);
-  }
-};
 
 class Header {
 public:
@@ -50,8 +25,8 @@ public:
                size_t key_size, const char* cipher_mode, uint32_t sector_size,
                uint32_t data_alignment, bool insecure_fast_mode);
     int add_keyslot(const char* passphrase, size_t passphrase_size);
-    int token_update(const char* identifier, const char* json_data);
-    int token_get(const char* identifier, const char** json_data);
+    int rewrite_segment_for_inline(const char* cipher, const char* cipher_mode,
+                                   const char* integrity);
     int load(const char* type);
     int read_volume_key(const char* passphrase, size_t passphrase_size,
                         char* volume_key, size_t* volume_key_size);
@@ -61,12 +36,12 @@ public:
     const char* get_cipher();
     const char* get_cipher_mode();
     const char* get_format_name();
+    int get_integrity_info(struct crypt_params_integrity* ip);
 
 private:
     void libcryptsetup_log(int level, const char* msg);
     static void libcryptsetup_log_wrapper(int level, const char* msg,
                                           void* header);
-    int find_token_slot(const char* identifier) const; 
 
     CephContext* m_cct;
     int m_fd;

--- a/src/librbd/crypto/luks/Header.h
+++ b/src/librbd/crypto/luks/Header.h
@@ -6,11 +6,36 @@
 
 #include <libcryptsetup.h>
 #include "common/ceph_context.h"
+#include "common/ceph_json.h"
 #include "include/buffer.h"
 
 namespace librbd {
 namespace crypto {
 namespace luks {
+
+namespace token {
+  static const char* const TYPE_AEAD = "ceph-aead";
+  static const char* const KEY_META_SIZE = "meta_size";
+  static const char* const KEY_ALG = "alg";
+}
+
+struct AEADToken {
+  uint32_t meta_size = 0;
+  std::string alg;
+
+  void encode_json(ceph::Formatter *f) const {
+    f->dump_string("type", token::TYPE_AEAD);
+    f->open_array_section("keyslots");
+    f->close_section();
+    f->dump_unsigned(token::KEY_META_SIZE, meta_size);
+    f->dump_string(token::KEY_ALG, alg);
+  }
+
+  void decode_json(JSONObj *obj) {
+    JSONDecoder::decode_json(token::KEY_META_SIZE, meta_size, obj);
+    JSONDecoder::decode_json(token::KEY_ALG, alg, obj);
+  }
+};
 
 class Header {
 public:
@@ -25,6 +50,8 @@ public:
                size_t key_size, const char* cipher_mode, uint32_t sector_size,
                uint32_t data_alignment, bool insecure_fast_mode);
     int add_keyslot(const char* passphrase, size_t passphrase_size);
+    int token_update(const char* identifier, const char* json_data);
+    int token_get(const char* identifier, const char** json_data);
     int load(const char* type);
     int read_volume_key(const char* passphrase, size_t passphrase_size,
                         char* volume_key, size_t* volume_key_size);
@@ -39,6 +66,7 @@ private:
     void libcryptsetup_log(int level, const char* msg);
     static void libcryptsetup_log_wrapper(int level, const char* msg,
                                           void* header);
+    int find_token_slot(const char* identifier) const; 
 
     CephContext* m_cct;
     int m_fd;

--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -248,11 +248,12 @@ void LoadRequest<I>::read_volume_key() {
     finish(r);
     return;
   }
-
+  // TODO: maybe derive metadata sector from openssl 
+  size_t meta_size = 32;
   r = util::build_crypto(
           m_image_ctx->cct, reinterpret_cast<unsigned char*>(volume_key),
-          volume_key_size, m_header.get_sector_size(),
-          m_header.get_data_offset(), m_result_crypto);
+          volume_key_size, m_header.get_sector_size(), 
+          m_header.get_data_offset(), meta_size, m_result_crypto);
   ceph_memzero_s(volume_key, 64, 64);
   finish(r);
 }

--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -4,6 +4,7 @@
 #include "LoadRequest.h"
 #include <string>
 
+#include "acconfig.h"
 #include "common/dout.h"
 #include "common/errno.h"
 #include "librbd/Utils.h"
@@ -223,7 +224,7 @@ void LoadRequest<I>::handle_read_keyslots(int r) {
 
 template <typename I>
 void LoadRequest<I>::read_volume_key() {
-  char volume_key[64];
+  char volume_key[96];
   size_t volume_key_size = sizeof(volume_key);
 
   auto r = m_header.read_volume_key(
@@ -245,6 +246,7 @@ void LoadRequest<I>::read_volume_key() {
 
   size_t meta_size = 0;
   std::string openssl_cipher;
+#ifdef HAVE_CRYPT_FORMAT_INLINE
   if (m_format == RBD_ENCRYPTION_FORMAT_LUKS2 ||
       (m_format == RBD_ENCRYPTION_FORMAT_LUKS &&
        strcmp(m_header.get_format_name(), CRYPT_LUKS2) == 0)) {
@@ -256,13 +258,18 @@ void LoadRequest<I>::read_volume_key() {
         AEADToken aead_token;
         aead_token.decode_json(&parser);
         meta_size = aead_token.meta_size;
-        openssl_cipher = aead_token.alg;
+        if (aead_token.alg == "authenc(hmac(sha256),xts(aes))") {
+          openssl_cipher = "aes-256-xts";
+        } else {
+          openssl_cipher = aead_token.alg;
+        }
         ldout(m_image_ctx->cct, 20)
             << "detected AEAD configuration: meta_size=" << meta_size
-            << " alg=" << openssl_cipher << dendl;
+            << " alg=" << aead_token.alg << dendl;
       }
     }
   }
+#endif
 
   if (openssl_cipher.empty()) {
     if (strcmp(m_header.get_cipher(), "aes") == 0 &&
@@ -272,6 +279,12 @@ void LoadRequest<I>::read_volume_key() {
       } else if (volume_key_size == 64) {
         openssl_cipher = "aes-256-xts";
       }
+    } else if (strcmp(m_header.get_cipher(), "cipher_null") == 0 &&
+               strcmp(m_header.get_cipher_mode(), "ecb") == 0) {
+      lderr(m_image_ctx->cct) << "AEAD encrypted image requires "
+                              << "libcryptsetup >= 2.8.0" << dendl;
+      finish(-ENOTSUP);
+      return;
     } else {
       lderr(m_image_ctx->cct) << "unsupported cipher configuration" << dendl;
       finish(-ENOTSUP);
@@ -284,7 +297,7 @@ void LoadRequest<I>::read_volume_key() {
           reinterpret_cast<unsigned char*>(volume_key),
           volume_key_size, m_header.get_sector_size(), 
           m_header.get_data_offset(), meta_size, m_result_crypto);
-  ceph_memzero_s(volume_key, 64, 64);
+  ceph_memzero_s(volume_key, sizeof(volume_key), sizeof(volume_key));
   finish(r);
 }
 

--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "LoadRequest.h"
+#include <string>
 
 #include "common/dout.h"
 #include "common/errno.h"
@@ -12,6 +13,7 @@
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
 #include "librbd/io/ReadResult.h"
+#include "common/ceph_json.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -178,17 +180,9 @@ void LoadRequest<I>::handle_read_header(int r) {
   ceph_assert(*m_detected_format_name == "LUKS");
   *m_detected_format_name = m_header.get_format_name();
 
-  auto cipher = m_header.get_cipher();
-  if (strcmp(cipher, "aes") != 0) {
-    lderr(m_image_ctx->cct) << "unsupported cipher: " << cipher << dendl;
-    finish(-ENOTSUP);
-    return;
-  }
-
-  auto cipher_mode = m_header.get_cipher_mode();
-  if (strcmp(cipher_mode, "xts-plain64") != 0) {
-    lderr(m_image_ctx->cct) << "unsupported cipher mode: " << cipher_mode
-                            << dendl;
+  std::string cipher = std::string(m_header.get_cipher()) + "-" + std::string(m_header.get_cipher_mode());
+  if ((cipher != "aes-xts-plain64") && (cipher != "cipher_null-ecb")) {
+    lderr(m_image_ctx->cct) << "unsupported cipher or cipher mode: " << cipher << dendl;
     finish(-ENOTSUP);
     return;
   }
@@ -248,10 +242,46 @@ void LoadRequest<I>::read_volume_key() {
     finish(r);
     return;
   }
-  // TODO: maybe derive metadata sector from openssl 
-  size_t meta_size = 32;
+
+  size_t meta_size = 0;
+  std::string openssl_cipher;
+  if (m_format == RBD_ENCRYPTION_FORMAT_LUKS2 ||
+      (m_format == RBD_ENCRYPTION_FORMAT_LUKS &&
+       strcmp(m_header.get_format_name(), CRYPT_LUKS2) == 0)) {
+    const char* json_data = nullptr;
+    r = m_header.token_get(token::TYPE_AEAD, &json_data);
+    if (r == 0 && json_data != nullptr) {
+      JSONParser parser;
+      if (parser.parse(json_data, strlen(json_data))) {
+        AEADToken aead_token;
+        aead_token.decode_json(&parser);
+        meta_size = aead_token.meta_size;
+        openssl_cipher = aead_token.alg;
+        ldout(m_image_ctx->cct, 20)
+            << "detected AEAD configuration: meta_size=" << meta_size
+            << " alg=" << openssl_cipher << dendl;
+      }
+    }
+  }
+
+  if (openssl_cipher.empty()) {
+    if (strcmp(m_header.get_cipher(), "aes") == 0 &&
+        strcmp(m_header.get_cipher_mode(), "xts-plain64") == 0) {
+      if (volume_key_size == 32) {
+        openssl_cipher = "aes-128-xts";
+      } else if (volume_key_size == 64) {
+        openssl_cipher = "aes-256-xts";
+      }
+    } else {
+      lderr(m_image_ctx->cct) << "unsupported cipher configuration" << dendl;
+      finish(-ENOTSUP);
+      return;
+    }
+  }
+
   r = util::build_crypto(
-          m_image_ctx->cct, reinterpret_cast<unsigned char*>(volume_key),
+          m_image_ctx->cct, openssl_cipher.c_str(), 
+          reinterpret_cast<unsigned char*>(volume_key),
           volume_key_size, m_header.get_sector_size(), 
           m_header.get_data_offset(), meta_size, m_result_crypto);
   ceph_memzero_s(volume_key, 64, 64);

--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -14,7 +14,6 @@
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
 #include "librbd/io/ReadResult.h"
-#include "common/ceph_json.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -182,7 +181,11 @@ void LoadRequest<I>::handle_read_header(int r) {
   *m_detected_format_name = m_header.get_format_name();
 
   std::string cipher = std::string(m_header.get_cipher()) + "-" + std::string(m_header.get_cipher_mode());
-  if ((cipher != "aes-xts-plain64") && (cipher != "cipher_null-ecb")) {
+  if (cipher != "aes-xts-plain64"
+#ifdef HAVE_CRYPT_FORMAT_INLINE
+      && cipher != "aes-xts-random"
+#endif
+     ) {
     lderr(m_image_ctx->cct) << "unsupported cipher or cipher mode: " << cipher << dendl;
     finish(-ENOTSUP);
     return;
@@ -246,28 +249,35 @@ void LoadRequest<I>::read_volume_key() {
 
   size_t meta_size = 0;
   std::string openssl_cipher;
+
 #ifdef HAVE_CRYPT_FORMAT_INLINE
-  if (m_format == RBD_ENCRYPTION_FORMAT_LUKS2 ||
-      (m_format == RBD_ENCRYPTION_FORMAT_LUKS &&
-       strcmp(m_header.get_format_name(), CRYPT_LUKS2) == 0)) {
-    const char* json_data = nullptr;
-    r = m_header.token_get(token::TYPE_AEAD, &json_data);
-    if (r == 0 && json_data != nullptr) {
-      JSONParser parser;
-      if (parser.parse(json_data, strlen(json_data))) {
-        AEADToken aead_token;
-        aead_token.decode_json(&parser);
-        meta_size = aead_token.meta_size;
-        if (aead_token.alg == "authenc(hmac(sha256),xts(aes))") {
-          openssl_cipher = "aes-256-xts";
-        } else {
-          openssl_cipher = aead_token.alg;
-        }
-        ldout(m_image_ctx->cct, 20)
-            << "detected AEAD configuration: meta_size=" << meta_size
-            << " alg=" << aead_token.alg << dendl;
-      }
+  if (strcmp(m_header.get_cipher(), "aes") == 0 &&
+      strcmp(m_header.get_cipher_mode(), "xts-random") == 0) {
+    // AEAD: native LUKS2 inline integrity format
+    // TODO: derive meta_size from the LUKS2 segment integrity type
+    // when additional AEAD configs (hmac(sha512), GCM) are supported
+    meta_size = 48;  // 16 IV + 32 HMAC tag for hmac(sha256)
+    openssl_cipher = "aes-256-xts";
+
+    // Verify that cryptsetup's parsed integrity metadata agrees with
+    // our expected tag size. This is the same code path that would
+    // feed parameters to dm-crypt during device activation.
+    struct crypt_params_integrity ip;
+    memset(&ip, 0, sizeof(ip));
+    if (m_header.get_integrity_info(&ip) != 0 ||
+        ip.integrity == nullptr ||
+        ip.tag_size != meta_size) {
+      lderr(m_image_ctx->cct) << "integrity metadata mismatch: expected "
+          << "tag_size=" << meta_size << ", got tag_size=" << ip.tag_size
+          << dendl;
+      finish(-EINVAL);
+      return;
     }
+
+    ldout(m_image_ctx->cct, 20)
+        << "detected AEAD configuration: cipher=aes-xts-random"
+        << " integrity=" << ip.integrity
+        << " meta_size=" << meta_size << dendl;
   }
 #endif
 
@@ -279,12 +289,6 @@ void LoadRequest<I>::read_volume_key() {
       } else if (volume_key_size == 64) {
         openssl_cipher = "aes-256-xts";
       }
-    } else if (strcmp(m_header.get_cipher(), "cipher_null") == 0 &&
-               strcmp(m_header.get_cipher_mode(), "ecb") == 0) {
-      lderr(m_image_ctx->cct) << "AEAD encrypted image requires "
-                              << "libcryptsetup >= 2.8.0" << dendl;
-      finish(-ENOTSUP);
-      return;
     } else {
       lderr(m_image_ctx->cct) << "unsupported cipher configuration" << dendl;
       finish(-ENOTSUP);

--- a/src/librbd/crypto/openssl/DataCryptor.cc
+++ b/src/librbd/crypto/openssl/DataCryptor.cc
@@ -171,7 +171,8 @@ int AEADDataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
                  << iv_length << dendl;
     return -EINVAL;
   }
-  if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, nullptr, nullptr, -1)) {
+  // In AES-256-SIV mode we need to resupply key. 
+  if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, m_key, nullptr, -1)) {
     lderr(m_cct) << "EVP_CipherInit_ex reset failed" << dendl;
     log_errors();
     return -EIO;

--- a/src/librbd/crypto/openssl/DataCryptor.cc
+++ b/src/librbd/crypto/openssl/DataCryptor.cc
@@ -3,9 +3,12 @@
 
 #include "librbd/crypto/openssl/DataCryptor.h"
 #include <openssl/err.h>
+#include <openssl/rand.h>
 #include <string.h>
-#include "include/ceph_assert.h"
-#include "include/compat.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::crypto::openssl::AEADDataCryptor: " << this << " "<< __func__ << ": "
 
 namespace librbd {
 namespace crypto {
@@ -28,15 +31,15 @@ int DataCryptor::init(const char* cipher_name, const unsigned char* key,
     return -EINVAL;
   }
 
-  m_cipher = EVP_get_cipherbyname(cipher_name);
-  if (m_cipher == nullptr) {
+  m_cipher.reset(EVP_CIPHER_fetch(NULL, cipher_name, NULL));
+  if (m_cipher.get() == nullptr) {
     lderr(m_cct) << "EVP_get_cipherbyname failed. Cipher name: " << cipher_name
                  << dendl;
     log_errors();
     return -EINVAL;
   }
 
-  auto expected_key_length = EVP_CIPHER_key_length(m_cipher);
+  auto expected_key_length = EVP_CIPHER_key_length(m_cipher.get());
   if (expected_key_length != key_length) {
     lderr(m_cct) << "cipher " << cipher_name << " expects key of "
                  << expected_key_length << " bytes. got: " << key_length
@@ -47,7 +50,7 @@ int DataCryptor::init(const char* cipher_name, const unsigned char* key,
   m_key_size = key_length;
   m_key = new unsigned char[key_length];
   memcpy(m_key, key, key_length);
-  m_iv_size = static_cast<uint32_t>(EVP_CIPHER_iv_length(m_cipher));
+  m_iv_size = static_cast<uint32_t>(EVP_CIPHER_iv_length(m_cipher.get()));
   return 0;
 }
 
@@ -60,7 +63,7 @@ DataCryptor::~DataCryptor() {
 }
 
 uint32_t DataCryptor::get_block_size() const {
-  return EVP_CIPHER_block_size(m_cipher);
+  return EVP_CIPHER_block_size(m_cipher.get());
 }
 
 uint32_t DataCryptor::get_iv_size() const {
@@ -72,7 +75,7 @@ const unsigned char* DataCryptor::get_key() const {
 }
 
 int DataCryptor::get_key_length() const {
-  return EVP_CIPHER_key_length(m_cipher);
+  return EVP_CIPHER_key_length(m_cipher.get());
 }
 
 EVP_CIPHER_CTX* DataCryptor::get_context(CipherMode mode) {
@@ -96,7 +99,7 @@ EVP_CIPHER_CTX* DataCryptor::get_context(CipherMode mode) {
     return nullptr;
   }
 
-  if (1 != EVP_CipherInit_ex(ctx, m_cipher, nullptr, m_key, nullptr, enc)) {
+  if (1 != EVP_CipherInit_ex(ctx, m_cipher.get(), nullptr, m_key, nullptr, enc)) {
     lderr(m_cct) << "EVP_CipherInit_ex failed" << dendl;
     log_errors();
     return nullptr;
@@ -127,14 +130,20 @@ int DataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
 }
 
 int DataCryptor::update_context(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-                                unsigned char* out, uint32_t len) const {
-  int out_length;
-  if (1 != EVP_CipherUpdate(ctx, out, &out_length, in, len)) {
-    lderr(m_cct) << "EVP_CipherUpdate failed. len=" << len << dendl;
+                                unsigned char* out, uint32_t in_len, uint32_t out_len) const {
+  if (in_len != out_len) {
+    lderr(m_cct) << "EVP_CipherUpdate failed. in_len= " << in_len
+                 << " and out_len=" << out_len << " not equal" << dendl;
     log_errors();
     return -EIO;
   }
-  return out_length;
+  int result_len;
+  if (1 != EVP_CipherUpdate(ctx, out, &result_len, in, in_len)) {
+    lderr(m_cct) << "EVP_CipherUpdate failed. in_len=" << in_len << dendl;
+    log_errors();
+    return -EIO;
+  }
+  return result_len;
 }
 
 void DataCryptor::log_errors() const {
@@ -146,6 +155,152 @@ void DataCryptor::log_errors() const {
     lderr(m_cct) << "OpenSSL error: " << ERR_error_string(error, nullptr)
                  << dendl;
   }
+}
+
+int DataCryptor::decrypt(EVP_CIPHER_CTX *ctx, const unsigned char *in,
+                         unsigned char *out, uint32_t in_len, uint32_t out_len) const {
+  return update_context(ctx, in, out, in_len, out_len);
+}
+
+int AEADDataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv, 
+                                  uint32_t iv_length) const {
+  // IV can be any length since we use it as AAD but this check is nice to have 
+  // to catch some nasty bugs. 
+  if (iv_length != m_iv_size) {
+    lderr(m_cct) << "cipher expects IV of " << m_iv_size << " bytes. got: "
+                 << iv_length << dendl;
+    return -EINVAL;
+  }
+  if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, nullptr, nullptr, -1)) {
+    lderr(m_cct) << "EVP_CipherInit_ex reset failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+  int len = 0;
+  if (1 != EVP_CipherUpdate(ctx, nullptr, &len, iv, iv_length)) {
+    lderr(m_cct) << "Sector IV AAD update failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+  return 0;
+}
+
+  int AEADDataCryptor::update_context(
+    EVP_CIPHER_CTX* ctx,
+    const unsigned char* in,
+    unsigned char* out,
+    uint32_t in_len, uint32_t out_len) const {
+    int result_len = 0;
+    int ciphertext_len = 0;
+    if (out_len != (in_len + AES_256_SIV_OVERHEAD)) {
+      lderr(m_cct) << "Encryption buffer size mismatch. "
+                   << "Input Length: " << in_len
+                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD
+                   << ", Expected Output Length: " << (in_len + AES_256_SIV_OVERHEAD)
+                   << ", Actual Output Length: " << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    // Data layout is: [ Data (len) | Tag (AES_256_SIV_TAG_SIZE) | Nonce (AES_256_SIV_NONCE_SIZE) ]
+    unsigned char* random_nonce = out + in_len + AES_256_SIV_TAG_SIZE;
+    // TODO: Maybe replace with Ceph random
+    if (1 != RAND_bytes(random_nonce, AES_256_SIV_NONCE_SIZE)) {
+        lderr(m_cct) << "RAND_bytes failed" << dendl;
+        log_errors();
+        return -EIO;
+    }
+    if (1 != EVP_EncryptUpdate(ctx, NULL, &result_len, random_nonce, AES_256_SIV_NONCE_SIZE)) {
+      lderr(m_cct) << "Failed to encrypt update context with nonce, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    if (1 != EVP_EncryptUpdate(ctx, out, &result_len, in, in_len)) {
+      lderr(m_cct) << "Failed encryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    ciphertext_len += result_len;
+    if (1 != EVP_EncryptFinal_ex(ctx, out + result_len, &result_len)) {
+      lderr(m_cct) << "Failed to finalize encryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    ciphertext_len += result_len;
+    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, AES_256_SIV_TAG_SIZE,
+                                out + in_len)) {
+      lderr(m_cct) << "Failed to retrieve authentication tag, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    // add tag length
+    ciphertext_len += AES_256_SIV_TAG_SIZE;
+    // Add nonce length
+    ciphertext_len += AES_256_SIV_NONCE_SIZE;
+    if (std::cmp_not_equal(ciphertext_len, out_len)) {
+      lderr(m_cct) << "Encryption failed out_len= " << out_len
+                   << " ciphertext_len=" << ciphertext_len
+                   << " not correct, expected length=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    return ciphertext_len;
+  }
+
+  int AEADDataCryptor::decrypt(EVP_CIPHER_CTX* ctx, const unsigned char* in, 
+                          unsigned char* out, uint32_t in_len, uint32_t out_len) const {                      
+    if (in_len != (out_len + AES_256_SIV_OVERHEAD)) {
+      lderr(m_cct) << "Encryption buffer size mismatch. "
+                   << "Input Length: " << in_len
+                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD
+                   << ", Expected Output Length: " << (in_len - AES_256_SIV_OVERHEAD)
+                   << ", Actual Output Length: " << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    int result_len = 0;
+    int plaintext_len = 0;
+    // Data layout is: [ Data (len) | Tag (AES_256_SIV_TAG_SIZE) | Nonce (AES_256_SIV_NONCE_SIZE) ]
+    if (in_len < AES_256_SIV_OVERHEAD) {
+        lderr(m_cct) << "Input Buffer too short for metadata, in_len=" << in_len << " out_len=" << out_len << dendl;
+        return -EINVAL;
+    }
+    uint32_t data_len = in_len - AES_256_SIV_OVERHEAD;
+    const unsigned char* tag = in + data_len;
+    const unsigned char* nonce = tag + AES_256_SIV_TAG_SIZE;
+    if (!EVP_CIPHER_CTX_ctrl(
+            ctx, EVP_CTRL_AEAD_SET_TAG, AES_256_SIV_TAG_SIZE,
+            const_cast<void*>(static_cast<const void*>(tag)))) {
+      lderr(m_cct) << "failed to set auth-tag, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+
+    if (1 != EVP_DecryptUpdate(ctx, NULL, &result_len, nonce, AES_256_SIV_NONCE_SIZE)) {
+      lderr(m_cct) << "Failed to decrypt update context with nonce, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+
+    if (1 != EVP_DecryptUpdate(ctx, out, &result_len, in, in_len - (AES_256_SIV_NONCE_SIZE+AES_256_SIV_TAG_SIZE))) {
+      lderr(m_cct) << "Failed decryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    plaintext_len += result_len;
+    if (1 != EVP_DecryptFinal_ex(ctx, out + result_len, &result_len)) {
+      lderr(m_cct) << "Failed to finalize decryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+      log_errors();
+      return -EIO;  
+    }
+    plaintext_len += result_len;
+    if (std::cmp_not_equal(plaintext_len, out_len)) {
+      lderr(m_cct) << "Decryption failed, out_len= " << out_len
+                   << " plaintext_len=" << plaintext_len
+                   << " not correct, expected length=" << out_len << dendl;
+      log_errors();
+      return -EIO;
+    }
+    return plaintext_len;
 }
 
 } // namespace openssl

--- a/src/librbd/crypto/openssl/DataCryptor.cc
+++ b/src/librbd/crypto/openssl/DataCryptor.cc
@@ -51,6 +51,11 @@ int DataCryptor::init(const char* cipher_name, const unsigned char* key,
   m_key = new unsigned char[key_length];
   memcpy(m_key, key, key_length);
   m_iv_size = static_cast<uint32_t>(EVP_CIPHER_iv_length(m_cipher.get()));
+  if (m_iv_size == 0) {
+    // When AEAD cipher is used IV equals 0. However I still want to use IV 
+    // as AAD.
+    m_iv_size = sizeof(ceph_le64);
+  }
   return 0;
 }
 
@@ -129,18 +134,10 @@ int DataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
   return 0;
 }
 
-int DataCryptor::update_context(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-                                unsigned char* out, uint32_t in_len, uint32_t out_len, 
-                                const unsigned char* index, uint32_t index_len) const {
-  if (in_len != out_len) {
-    lderr(m_cct) << "EVP_CipherUpdate failed. in_len= " << in_len
-                 << " and out_len=" << out_len << " not equal" << dendl;
-    log_errors();
-    return -EIO;
-  }
+int DataCryptor::update_context(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const {
   int result_len;
-  if (1 != EVP_CipherUpdate(ctx, out, &result_len, in, in_len)) {
-    lderr(m_cct) << "EVP_CipherUpdate failed. in_len=" << in_len << dendl;
+  if (1 != EVP_CipherUpdate(ctx, params.out, &result_len, params.in, params.len)) {
+    lderr(m_cct) << "EVP_CipherUpdate failed. in_len=" << params.len << dendl;
     log_errors();
     return -EIO;
   }
@@ -158,10 +155,8 @@ void DataCryptor::log_errors() const {
   }
 }
 
-int DataCryptor::decrypt(EVP_CIPHER_CTX *ctx, const unsigned char *in,
-                         unsigned char *out, uint32_t in_len, uint32_t out_len, 
-                         const unsigned char* index, uint32_t index_len) const {
-  return update_context(ctx, in, out, in_len, out_len);
+int DataCryptor::decrypt(EVP_CIPHER_CTX *ctx, const CryptArgs& params) const {
+  return update_context(ctx, params);
 }
 
 int AEADDataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv, 
@@ -178,22 +173,18 @@ int AEADDataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
   return 0;
 }
 
-  int AEADDataCryptor::update_context(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-                              unsigned char* out,uint32_t in_len, uint32_t out_len, 
-                              const unsigned char* index,uint32_t index_len) const {
+  int AEADDataCryptor::update_context(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const {
     int result_len = 0;
     int ciphertext_len = 0;
-    if (out_len != (in_len + AES_256_SIV_OVERHEAD)) {
+    if (params.meta_len != AES_256_SIV_OVERHEAD) {
       lderr(m_cct) << "Encryption buffer size mismatch. "
-                   << "Input Length: " << in_len
-                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD
-                   << ", Expected Output Length: " << (in_len + AES_256_SIV_OVERHEAD)
-                   << ", Actual Output Length: " << out_len << dendl;
+                   << "Input meata Length: " << params.meta_len
+                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD << dendl;
       log_errors();
       return -EIO;
     }
     // Data layout is: [ Data (len) | Tag (AES_256_SIV_TAG_SIZE) | Nonce (AES_256_SIV_NONCE_SIZE) ]
-    unsigned char* random_nonce = out + in_len + AES_256_SIV_TAG_SIZE;
+    unsigned char* random_nonce = params.meta + AES_256_SIV_TAG_SIZE;
     // TODO: Maybe replace with Ceph random
     if (1 != RAND_bytes(random_nonce, AES_256_SIV_NONCE_SIZE)) {
         lderr(m_cct) << "RAND_bytes failed" << dendl;
@@ -206,65 +197,50 @@ int AEADDataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
       log_errors();
       return -EIO;
     }
-    if (1 != EVP_EncryptUpdate(ctx, nullptr, &result_len, index, index_len)) {
+    if (1 != EVP_EncryptUpdate(ctx, nullptr, &result_len, params.iv, params.iv_len)) {
       lderr(m_cct) << "Sector IV AAD update failed" << dendl;
       log_errors();
       return -EIO;
     }
-    if (1 != EVP_EncryptUpdate(ctx, out, &result_len, in, in_len)) {
-      lderr(m_cct) << "Failed encryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+    if (1 != EVP_EncryptUpdate(ctx, params.out, &result_len, params.in, params.len)) {
+      lderr(m_cct) << "Failed encryption, len=" << params.len << dendl;
       log_errors();
       return -EIO;
     }
     ciphertext_len += result_len;
-    if (1 != EVP_EncryptFinal_ex(ctx, out + result_len, &result_len)) {
-      lderr(m_cct) << "Failed to finalize encryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+    if (1 != EVP_EncryptFinal_ex(ctx, params.out + result_len, &result_len)) {
+      lderr(m_cct) << "Failed to finalize encryption, len=" << params.len << dendl;
       log_errors();
       return -EIO;
     }
     ciphertext_len += result_len;
     if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, AES_256_SIV_TAG_SIZE,
-                                out + in_len)) {
-      lderr(m_cct) << "Failed to retrieve authentication tag, in_len=" << in_len << " out_len=" << out_len << dendl;
+                                params.meta)) {
+      lderr(m_cct) << "Failed to retrieve authentication tag, len=" << params.len << dendl;
       log_errors();
       return -EIO;
     }
-    // add tag length
-    ciphertext_len += AES_256_SIV_TAG_SIZE;
-    // Add nonce length
-    ciphertext_len += AES_256_SIV_NONCE_SIZE;
-    if (std::cmp_not_equal(ciphertext_len, out_len)) {
-      lderr(m_cct) << "Encryption failed out_len= " << out_len
-                   << " ciphertext_len=" << ciphertext_len
-                   << " not correct, expected length=" << out_len << dendl;
+    if (std::cmp_not_equal(ciphertext_len, params.len)) {
+      lderr(m_cct) << "Decryption failed" << dendl;
       log_errors();
       return -EIO;
     }
     return ciphertext_len;
   }
 
-  int AEADDataCryptor::decrypt(EVP_CIPHER_CTX* ctx, const unsigned char* in, 
-                          unsigned char* out, uint32_t in_len, uint32_t out_len, 
-                          const unsigned char* index, uint32_t index_len) const {                      
-    if (in_len != (out_len + AES_256_SIV_OVERHEAD)) {
+  int AEADDataCryptor::decrypt(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const {                      
+    if (params.meta_len != ( AES_256_SIV_OVERHEAD)) {
       lderr(m_cct) << "Encryption buffer size mismatch. "
-                   << "Input Length: " << in_len
-                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD
-                   << ", Expected Output Length: " << (in_len - AES_256_SIV_OVERHEAD)
-                   << ", Actual Output Length: " << out_len << dendl;
+                   << "Input Length: " << params.meta_len
+                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD << dendl;
       log_errors();
       return -EIO;
     }
     int result_len = 0;
     int plaintext_len = 0;
     // Data layout is: [ Data (len) | Tag (AES_256_SIV_TAG_SIZE) | Nonce (AES_256_SIV_NONCE_SIZE) ]
-    if (in_len < AES_256_SIV_OVERHEAD) {
-        lderr(m_cct) << "Input Buffer too short for metadata, in_len=" << in_len << " out_len=" << out_len << dendl;
-        return -EINVAL;
-    }
-    uint32_t data_len = in_len - AES_256_SIV_OVERHEAD;
-    const unsigned char* tag = in + data_len;
-    const unsigned char* nonce = tag + AES_256_SIV_TAG_SIZE;
+    const unsigned char* tag = params.meta; //in + data_len;
+    const unsigned char* nonce = params.meta + AES_256_SIV_TAG_SIZE;
     if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, m_key, nonce, -1)) {
       lderr(m_cct) << "EVP_CipherInit_ex reset failed" << dendl;
       log_errors();
@@ -273,33 +249,31 @@ int AEADDataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
     if (!EVP_CIPHER_CTX_ctrl(
             ctx, EVP_CTRL_AEAD_SET_TAG, AES_256_SIV_TAG_SIZE,
             const_cast<void*>(static_cast<const void*>(tag)))) {
-      lderr(m_cct) << "failed to set auth-tag, in_len=" << in_len << " out_len=" << out_len << dendl;
+      lderr(m_cct) << "failed to set auth-tag" << dendl;
       log_errors();
       return -EIO;
     }
 
-    if (1 != EVP_DecryptUpdate(ctx, NULL, &result_len, index, index_len)) {
-      lderr(m_cct) << "Failed to decrypt update context with nonce, in_len=" << in_len << " out_len=" << out_len << dendl;
+    if (1 != EVP_DecryptUpdate(ctx, NULL, &result_len, params.iv, params.iv_len)) {
+      lderr(m_cct) << "Failed to decrypt update context with nonce"<< dendl;
       log_errors();
       return -EIO;
     }
-    if (1 != EVP_DecryptUpdate(ctx, out, &result_len, in, in_len - (AES_256_SIV_NONCE_SIZE+AES_256_SIV_TAG_SIZE))) {
-      lderr(m_cct) << "Failed decryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+    if (1 != EVP_DecryptUpdate(ctx, params.out, &result_len, params.in, params.len)) {
+      lderr(m_cct) << "Failed decryption" << dendl;
       log_errors();
       // TODO: Correct error code? 
       return -EBADMSG;
     }
     plaintext_len += result_len;
-    if (1 != EVP_DecryptFinal_ex(ctx, out + result_len, &result_len)) {
-      lderr(m_cct) << "Failed to finalize decryption, in_len=" << in_len << " out_len=" << out_len << dendl;
+    if (1 != EVP_DecryptFinal_ex(ctx, params.out + result_len, &result_len)) {
+      lderr(m_cct) << "Failed to finalize decryption" << dendl;
       log_errors();
       return -EIO;  
     }
     plaintext_len += result_len;
-    if (std::cmp_not_equal(plaintext_len, out_len)) {
-      lderr(m_cct) << "Decryption failed, out_len= " << out_len
-                   << " plaintext_len=" << plaintext_len
-                   << " not correct, expected length=" << out_len << dendl;
+    if (std::cmp_not_equal(plaintext_len, params.len)) {
+      lderr(m_cct) << "Decryption failed" << dendl;
       log_errors();
       return -EIO;
     }

--- a/src/librbd/crypto/openssl/DataCryptor.cc
+++ b/src/librbd/crypto/openssl/DataCryptor.cc
@@ -4,11 +4,12 @@
 #include "librbd/crypto/openssl/DataCryptor.h"
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include <openssl/crypto.h>
 #include <string.h>
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
-#define dout_prefix *_dout << "librbd::crypto::openssl::AEADDataCryptor: " << this << " "<< __func__ << ": "
+#define dout_prefix *_dout << "librbd::crypto::openssl::DataCryptor: " << this << " "<< __func__ << ": "
 
 namespace librbd {
 namespace crypto {
@@ -51,11 +52,6 @@ int DataCryptor::init(const char* cipher_name, const unsigned char* key,
   m_key = new unsigned char[key_length];
   memcpy(m_key, key, key_length);
   m_iv_size = static_cast<uint32_t>(EVP_CIPHER_iv_length(m_cipher.get()));
-  if (m_iv_size == 0) {
-    // When AEAD cipher is used IV equals 0. However I still want to use IV 
-    // as AAD.
-    m_iv_size = sizeof(ceph_le64);
-  }
   return 0;
 }
 
@@ -159,125 +155,232 @@ int DataCryptor::decrypt(EVP_CIPHER_CTX *ctx, const CryptArgs& params) const {
   return update_context(ctx, params);
 }
 
-int AEADDataCryptor::init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv, 
-                                  uint32_t iv_length) const {
-  // IV can be any length since we use it as AAD but this check is nice to have 
-  // to catch some nasty bugs. 
-  if (iv_length != m_iv_size) {
-    lderr(m_cct) << "cipher expects IV of " << m_iv_size << " bytes. got: "
-                 << iv_length << dendl;
+// AuthEncDataCryptor: authenc(hmac(sha256),xts(aes)) implementation
+
+int AuthEncDataCryptor::init(const char* cipher_name, const unsigned char* key,
+                              uint16_t key_length) {
+  if (key_length != TOTAL_KEY_SIZE) {
+    lderr(m_cct) << "authenc expects " << TOTAL_KEY_SIZE
+                 << "-byte key, got: " << key_length << dendl;
     return -EINVAL;
   }
-  // TODO: Maybe Rework AEAD context initialization to match 
-  //  original init_context() semantics
+
+  // Store full volume key for get_key()
+  m_volume_key.reset(new unsigned char[TOTAL_KEY_SIZE]);
+  memcpy(m_volume_key.get(), key, TOTAL_KEY_SIZE);
+
+  // Init XTS cipher with the first 64 bytes
+  int r = DataCryptor::init(cipher_name, key, XTS_KEY_SIZE);
+  if (r != 0) {
+    return r;
+  }
+
+  // Store HMAC key (last 32 bytes)
+  m_hmac_key.reset(new unsigned char[HMAC_KEY_SIZE]);
+  memcpy(m_hmac_key.get(), key + XTS_KEY_SIZE, HMAC_KEY_SIZE);
+
+  // Cache EVP_MAC and pre-initialized HMAC template context
+  m_mac.reset(EVP_MAC_fetch(NULL, "HMAC", NULL));
+  if (m_mac == nullptr) {
+    lderr(m_cct) << "EVP_MAC_fetch(HMAC) failed" << dendl;
+    log_errors();
+    return -EINVAL;
+  }
+
+  m_mac_template.reset(EVP_MAC_CTX_new(m_mac.get()));
+  if (m_mac_template == nullptr) {
+    lderr(m_cct) << "EVP_MAC_CTX_new failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+
+  OSSL_PARAM mac_params[2];
+  mac_params[0] = OSSL_PARAM_construct_utf8_string(
+      OSSL_MAC_PARAM_DIGEST, const_cast<char*>("SHA256"), 0);
+  mac_params[1] = OSSL_PARAM_construct_end();
+
+  if (1 != EVP_MAC_init(m_mac_template.get(), m_hmac_key.get(),
+                         HMAC_KEY_SIZE, mac_params)) {
+    lderr(m_cct) << "EVP_MAC_init (template) failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+
+  // Override m_iv_size to match sector IV size (8 bytes LE sector number)
+  m_iv_size = sizeof(ceph_le64);
+
   return 0;
 }
 
-  int AEADDataCryptor::update_context(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const {
-    int result_len = 0;
-    int ciphertext_len = 0;
-    if (params.meta_len != AES_256_SIV_OVERHEAD) {
-      lderr(m_cct) << "Encryption buffer size mismatch. "
-                   << "Input meata Length: " << params.meta_len
-                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD << dendl;
-      log_errors();
-      return -EIO;
-    }
-    // Data layout is: [ Data (len) | Tag (AES_256_SIV_TAG_SIZE) | Nonce (AES_256_SIV_NONCE_SIZE) ]
-    unsigned char* random_nonce = params.meta + AES_256_SIV_TAG_SIZE;
-    // TODO: Maybe replace with Ceph random
-    if (1 != RAND_bytes(random_nonce, AES_256_SIV_NONCE_SIZE)) {
-        lderr(m_cct) << "RAND_bytes failed" << dendl;
-        log_errors();
-        return -EIO;
-    }
-    // TODO: Maybe do full EVP_EncryptInit_ex re-init to match semantics 
-    if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, m_key, random_nonce, -1)) {
-      lderr(m_cct) << "EVP_CipherInit_ex reset failed" << dendl;
-      log_errors();
-      return -EIO;
-    }
-    if (1 != EVP_EncryptUpdate(ctx, nullptr, &result_len, params.iv, params.iv_len)) {
-      lderr(m_cct) << "Sector IV AAD update failed" << dendl;
-      log_errors();
-      return -EIO;
-    }
-    if (1 != EVP_EncryptUpdate(ctx, params.out, &result_len, params.in, params.len)) {
-      lderr(m_cct) << "Failed encryption, len=" << params.len << dendl;
-      log_errors();
-      return -EIO;
-    }
-    ciphertext_len += result_len;
-    if (1 != EVP_EncryptFinal_ex(ctx, params.out + result_len, &result_len)) {
-      lderr(m_cct) << "Failed to finalize encryption, len=" << params.len << dendl;
-      log_errors();
-      return -EIO;
-    }
-    ciphertext_len += result_len;
-    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, AES_256_SIV_TAG_SIZE,
-                                params.meta)) {
-      lderr(m_cct) << "Failed to retrieve authentication tag, len=" << params.len << dendl;
-      log_errors();
-      return -EIO;
-    }
-    if (std::cmp_not_equal(ciphertext_len, params.len)) {
-      lderr(m_cct) << "Decryption failed" << dendl;
-      log_errors();
-      return -EIO;
-    }
-    return ciphertext_len;
+EVP_CIPHER_CTX* AuthEncDataCryptor::get_context(CipherMode mode) {
+  auto ctx = DataCryptor::get_context(mode);
+  if (ctx != nullptr) {
+    EVP_CIPHER_CTX_set_padding(ctx, 0);
+  }
+  return ctx;
+}
+
+const unsigned char* AuthEncDataCryptor::get_key() const {
+  ceph_assert(CRYPTO_memcmp(m_volume_key.get(), m_key, m_key_size) == 0);
+  ceph_assert(CRYPTO_memcmp(m_volume_key.get() + XTS_KEY_SIZE,
+                             m_hmac_key.get(), HMAC_KEY_SIZE) == 0);
+  return m_volume_key.get();
+}
+
+int AuthEncDataCryptor::get_key_length() const {
+  return TOTAL_KEY_SIZE;
+}
+
+int AuthEncDataCryptor::compute_hmac(
+    const unsigned char* sector_iv, uint32_t sector_iv_len,
+    const unsigned char* iv, const unsigned char* data,
+    uint32_t data_len, unsigned char* tag_out) const {
+  // HMAC(key, sector_number_LE || IV || ciphertext)
+  // Matches dm-crypt authenc AAD layout
+  // Dup from pre-initialized template (key + SHA256 already set)
+  auto mac_ctx = EVP_MAC_CTX_dup(m_mac_template.get());
+  if (mac_ctx == nullptr) {
+    lderr(m_cct) << "EVP_MAC_CTX_dup failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+  // AAD: sector_number_LE (8 bytes)
+  if (1 != EVP_MAC_update(mac_ctx, sector_iv, sector_iv_len)) {
+    lderr(m_cct) << "EVP_MAC_update (sector IV) failed" << dendl;
+    log_errors();
+    EVP_MAC_CTX_free(mac_ctx);
+    return -EIO;
+  }
+  // AAD: random IV (16 bytes)
+  if (1 != EVP_MAC_update(mac_ctx, iv, RANDOM_IV_SIZE)) {
+    lderr(m_cct) << "EVP_MAC_update (IV) failed" << dendl;
+    log_errors();
+    EVP_MAC_CTX_free(mac_ctx);
+    return -EIO;
+  }
+  // Data: ciphertext
+  if (1 != EVP_MAC_update(mac_ctx, data, data_len)) {
+    lderr(m_cct) << "EVP_MAC_update (data) failed" << dendl;
+    log_errors();
+    EVP_MAC_CTX_free(mac_ctx);
+    return -EIO;
   }
 
-  int AEADDataCryptor::decrypt(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const {                      
-    if (params.meta_len != ( AES_256_SIV_OVERHEAD)) {
-      lderr(m_cct) << "Encryption buffer size mismatch. "
-                   << "Input Length: " << params.meta_len
-                   << ", Overhead Length: " << AES_256_SIV_OVERHEAD << dendl;
-      log_errors();
-      return -EIO;
-    }
-    int result_len = 0;
-    int plaintext_len = 0;
-    // Data layout is: [ Data (len) | Tag (AES_256_SIV_TAG_SIZE) | Nonce (AES_256_SIV_NONCE_SIZE) ]
-    const unsigned char* tag = params.meta; //in + data_len;
-    const unsigned char* nonce = params.meta + AES_256_SIV_TAG_SIZE;
-    if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, m_key, nonce, -1)) {
-      lderr(m_cct) << "EVP_CipherInit_ex reset failed" << dendl;
-      log_errors();
-      return -EIO;
-    }
-    if (!EVP_CIPHER_CTX_ctrl(
-            ctx, EVP_CTRL_AEAD_SET_TAG, AES_256_SIV_TAG_SIZE,
-            const_cast<void*>(static_cast<const void*>(tag)))) {
-      lderr(m_cct) << "failed to set auth-tag" << dendl;
-      log_errors();
-      return -EIO;
-    }
+  size_t tag_len = HMAC_SHA256_TAG_SIZE;
+  if (1 != EVP_MAC_final(mac_ctx, tag_out, &tag_len, HMAC_SHA256_TAG_SIZE)) {
+    lderr(m_cct) << "EVP_MAC_final failed" << dendl;
+    log_errors();
+    EVP_MAC_CTX_free(mac_ctx);
+    return -EIO;
+  }
 
-    if (1 != EVP_DecryptUpdate(ctx, NULL, &result_len, params.iv, params.iv_len)) {
-      lderr(m_cct) << "Failed to decrypt update context with nonce"<< dendl;
-      log_errors();
-      return -EIO;
-    }
-    if (1 != EVP_DecryptUpdate(ctx, params.out, &result_len, params.in, params.len)) {
-      lderr(m_cct) << "Failed decryption" << dendl;
-      log_errors();
-      // TODO: Correct error code? 
-      return -EBADMSG;
-    }
-    plaintext_len += result_len;
-    if (1 != EVP_DecryptFinal_ex(ctx, params.out + result_len, &result_len)) {
-      lderr(m_cct) << "Failed to finalize decryption" << dendl;
-      log_errors();
-      return -EIO;  
-    }
-    plaintext_len += result_len;
-    if (std::cmp_not_equal(plaintext_len, params.len)) {
-      lderr(m_cct) << "Decryption failed" << dendl;
-      log_errors();
-      return -EIO;
-    }
-    return plaintext_len;
+  EVP_MAC_CTX_free(mac_ctx);
+  return 0;
+}
+
+int AuthEncDataCryptor::init_context(EVP_CIPHER_CTX* ctx,
+                                      const unsigned char* iv,
+                                      uint32_t iv_length) const {
+  // No-op: random IV is set per-block in update_context/decrypt
+  return 0;
+}
+
+int AuthEncDataCryptor::update_context(EVP_CIPHER_CTX* ctx,
+                                        const CryptArgs& params) const {
+  if (params.meta_len != AUTHENC_OVERHEAD) {
+    lderr(m_cct) << "metadata buffer size mismatch. "
+                 << "got: " << params.meta_len
+                 << ", expected: " << AUTHENC_OVERHEAD << dendl;
+    return -EIO;
+  }
+
+  // Metadata layout: [HMAC tag (32) | random IV (16)]
+  unsigned char* random_iv = params.meta + HMAC_SHA256_TAG_SIZE;
+
+  // 1. Generate random 16-byte IV
+  if (1 != RAND_bytes(random_iv, RANDOM_IV_SIZE)) {
+    lderr(m_cct) << "RAND_bytes failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+
+  // 2. AES-256-XTS encrypt with random IV as tweak
+  if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, nullptr, random_iv, 1)) {
+    lderr(m_cct) << "EVP_CipherInit_ex (set IV) failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+  int ciphertext_len = 0;
+  if (1 != EVP_EncryptUpdate(ctx, params.out, &ciphertext_len,
+                              params.in, params.len)) {
+    lderr(m_cct) << "EVP_EncryptUpdate failed, len=" << params.len << dendl;
+    log_errors();
+    return -EIO;
+  }
+
+  if (std::cmp_not_equal(ciphertext_len, params.len)) {
+    lderr(m_cct) << "ciphertext length mismatch: " << ciphertext_len
+                 << " vs " << params.len << dendl;
+    return -EIO;
+  }
+
+  // 3. HMAC-SHA256 over (sector_LE || IV || ciphertext)
+  int r = compute_hmac(params.iv, params.iv_len, random_iv,
+                       params.out, ciphertext_len, params.meta);
+  if (r != 0) {
+    return r;
+  }
+
+  return ciphertext_len;
+}
+
+int AuthEncDataCryptor::decrypt(EVP_CIPHER_CTX* ctx,
+                                 const CryptArgs& params) const {
+  if (params.meta_len != AUTHENC_OVERHEAD) {
+    lderr(m_cct) << "metadata buffer size mismatch. "
+                 << "got: " << params.meta_len
+                 << ", expected: " << AUTHENC_OVERHEAD << dendl;
+    return -EIO;
+  }
+
+  // Metadata layout: [HMAC tag (32) | random IV (16)]
+  const unsigned char* stored_tag = params.meta;
+  const unsigned char* iv = params.meta + HMAC_SHA256_TAG_SIZE;
+
+  // 1. Verify HMAC over (sector_LE || IV || ciphertext)
+  unsigned char computed_tag[HMAC_SHA256_TAG_SIZE];
+  int r = compute_hmac(params.iv, params.iv_len, iv,
+                       params.in, params.len, computed_tag);
+  if (r != 0) {
+    return r;
+  }
+
+  if (CRYPTO_memcmp(stored_tag, computed_tag, HMAC_SHA256_TAG_SIZE) != 0) {
+    lderr(m_cct) << "HMAC verification failed" << dendl;
+    return -EBADMSG;
+  }
+
+  // 2. AES-256-XTS decrypt with stored IV
+  if (1 != EVP_CipherInit_ex(ctx, nullptr, nullptr, nullptr, iv, 0)) {
+    lderr(m_cct) << "EVP_CipherInit_ex (set IV) failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+  int plaintext_len = 0;
+  if (1 != EVP_DecryptUpdate(ctx, params.out, &plaintext_len,
+                              params.in, params.len)) {
+    lderr(m_cct) << "EVP_DecryptUpdate failed" << dendl;
+    log_errors();
+    return -EIO;
+  }
+
+  if (std::cmp_not_equal(plaintext_len, params.len)) {
+    lderr(m_cct) << "plaintext length mismatch: " << plaintext_len
+                 << " vs " << params.len << dendl;
+    return -EIO;
+  }
+
+  return plaintext_len;
 }
 
 } // namespace openssl

--- a/src/librbd/crypto/openssl/DataCryptor.h
+++ b/src/librbd/crypto/openssl/DataCryptor.h
@@ -35,10 +35,16 @@ public:
     int init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
                      uint32_t iv_length) const override;
     int update_context(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-                       unsigned char* out, uint32_t in_len, uint32_t out_len) const override;
+                       unsigned char* out, uint32_t in_len, 
+                       uint32_t out_len, 
+                       const unsigned char* index = 0,
+                       uint32_t index_len = 0) const override;
 
     int decrypt(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-                             unsigned char* out, uint32_t in_len, uint32_t out_len) const override;
+                             unsigned char* out, uint32_t in_len, 
+                             uint32_t out_len, 
+                             const unsigned char* index = nullptr,
+                             uint32_t index_len = 0) const override;
 protected:
     CephContext* m_cct;
     unsigned char* m_key = nullptr;
@@ -57,10 +63,12 @@ public:
                     uint32_t iv_length) const override;
 
   int update_context(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-        unsigned char* out, uint32_t in_len, uint32_t out_len) const override;
+        unsigned char* out, uint32_t in_len, uint32_t out_len, 
+        const unsigned char* index = nullptr, uint32_t index_len = 0) const override;
 
   int decrypt(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-        unsigned char* out, uint32_t in_len, uint32_t out_len) const override;
+        unsigned char* out, uint32_t in_len, uint32_t out_len, 
+        const unsigned char* index = nullptr, uint32_t index_len = 0) const override;
 
 private:
     static constexpr size_t AES_256_SIV_TAG_SIZE = 16;

--- a/src/librbd/crypto/openssl/DataCryptor.h
+++ b/src/librbd/crypto/openssl/DataCryptor.h
@@ -6,16 +6,32 @@
 
 #include "librbd/crypto/DataCryptor.h"
 #include "include/Context.h"
+#include "include/compat.h"
 #include <openssl/evp.h>
+#include <openssl/core_names.h>
 
 namespace librbd {
 namespace crypto {
 namespace openssl {
 
-struct CipherDeleter {
-    void operator()(EVP_CIPHER* c) { EVP_CIPHER_free(c); }
+template <typename T, void(*FreeFn)(T*)>
+struct OSSLDeleter {
+    void operator()(T* p) const { FreeFn(p); }
 };
-using CipherPtr = std::unique_ptr<EVP_CIPHER, CipherDeleter>;
+
+using CipherPtr  = std::unique_ptr<EVP_CIPHER, OSSLDeleter<EVP_CIPHER, EVP_CIPHER_free>>;
+using MACPtr     = std::unique_ptr<EVP_MAC, OSSLDeleter<EVP_MAC, EVP_MAC_free>>;
+using MACCtxPtr  = std::unique_ptr<EVP_MAC_CTX, OSSLDeleter<EVP_MAC_CTX, EVP_MAC_CTX_free>>;
+
+template <size_t N>
+struct SecureKeyDeleter {
+    void operator()(unsigned char* p) {
+        ceph_memzero_s(p, N, N);
+        delete[] p;
+    }
+};
+template <size_t N>
+using SecureKeyPtr = std::unique_ptr<unsigned char[], SecureKeyDeleter<N>>;
 
 class DataCryptor : public crypto::DataCryptor<EVP_CIPHER_CTX> {
 
@@ -47,21 +63,53 @@ protected:
     void log_errors() const;
 };
 
-class AEADDataCryptor : public DataCryptor {
+// Implements authenc(hmac(sha256),xts(aes)) — AES-256-XTS encryption with
+// HMAC-SHA256 authentication, matching the Linux kernel crypto API template.
+//
+// Key members:
+//   m_key (inherited, 64 bytes): AES-256-XTS key, used by get_context()
+//   m_hmac_key (32 bytes): HMAC-SHA256 key, used by compute_hmac()
+//   m_volume_key (96 bytes): contiguous copy of full volume key [XTS || HMAC],
+//                            returned by get_key() with consistency assertion
+//
+// Per-sector metadata layout (48 bytes, stored in CryptArgs::meta):
+//   [0..31]  HMAC-SHA256 tag
+//   [32..47] random IV (AES-XTS tweak)
+//
+// HMAC Input: sector_number_LE(8) || IV(16) || ciphertext
+class AuthEncDataCryptor : public DataCryptor {
 public:
-    AEADDataCryptor(CephContext* cct) : DataCryptor(cct) {};
+    AuthEncDataCryptor(CephContext* cct) : DataCryptor(cct) {};
 
-  int init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv, 
-                    uint32_t iv_length) const override;
+    int init(const char* cipher_name, const unsigned char* key,
+             uint16_t key_length);
 
-    virtual int update_context(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const override;
+    EVP_CIPHER_CTX* get_context(CipherMode mode) override;
+    int init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
+                     uint32_t iv_length) const override;
+    int update_context(EVP_CIPHER_CTX* ctx,
+                       const CryptArgs& params) const override;
+    int decrypt(EVP_CIPHER_CTX* ctx,
+                const CryptArgs& params) const override;
+    const unsigned char* get_key() const override;
+    int get_key_length() const override;
 
-    virtual int decrypt(EVP_CIPHER_CTX* ctx,  const CryptArgs& params) const override;
+    static constexpr size_t HMAC_SHA256_TAG_SIZE = 32;
+    static constexpr size_t RANDOM_IV_SIZE = 16;
+    static constexpr size_t AUTHENC_OVERHEAD = HMAC_SHA256_TAG_SIZE + RANDOM_IV_SIZE;
+    static constexpr size_t HMAC_KEY_SIZE = 32;
+    static constexpr size_t XTS_KEY_SIZE = 64;
+    static constexpr size_t TOTAL_KEY_SIZE = XTS_KEY_SIZE + HMAC_KEY_SIZE;
 
 private:
-    static constexpr size_t AES_256_SIV_TAG_SIZE = 16;
-    static constexpr size_t AES_256_SIV_NONCE_SIZE = 16;
-    static constexpr size_t AES_256_SIV_OVERHEAD = AES_256_SIV_TAG_SIZE + AES_256_SIV_NONCE_SIZE;
+    int compute_hmac(const unsigned char* sector_iv, uint32_t sector_iv_len,
+                     const unsigned char* iv, const unsigned char* data,
+                     uint32_t data_len, unsigned char* tag_out) const;
+
+    SecureKeyPtr<TOTAL_KEY_SIZE> m_volume_key;
+    SecureKeyPtr<HMAC_KEY_SIZE> m_hmac_key;
+    MACPtr m_mac;
+    MACCtxPtr m_mac_template;
 };
 
 } // namespace openssl

--- a/src/librbd/crypto/openssl/DataCryptor.h
+++ b/src/librbd/crypto/openssl/DataCryptor.h
@@ -34,17 +34,9 @@ public:
     void return_context(EVP_CIPHER_CTX* ctx, CipherMode mode) override;
     int init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv,
                      uint32_t iv_length) const override;
-    int update_context(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-                       unsigned char* out, uint32_t in_len, 
-                       uint32_t out_len, 
-                       const unsigned char* index = 0,
-                       uint32_t index_len = 0) const override;
+    virtual int update_context(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const override;
+    virtual int decrypt(EVP_CIPHER_CTX* ctx,  const CryptArgs& params) const override;
 
-    int decrypt(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-                             unsigned char* out, uint32_t in_len, 
-                             uint32_t out_len, 
-                             const unsigned char* index = nullptr,
-                             uint32_t index_len = 0) const override;
 protected:
     CephContext* m_cct;
     unsigned char* m_key = nullptr;
@@ -62,13 +54,9 @@ public:
   int init_context(EVP_CIPHER_CTX* ctx, const unsigned char* iv, 
                     uint32_t iv_length) const override;
 
-  int update_context(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-        unsigned char* out, uint32_t in_len, uint32_t out_len, 
-        const unsigned char* index = nullptr, uint32_t index_len = 0) const override;
+    virtual int update_context(EVP_CIPHER_CTX* ctx, const CryptArgs& params) const override;
 
-  int decrypt(EVP_CIPHER_CTX* ctx, const unsigned char* in,
-        unsigned char* out, uint32_t in_len, uint32_t out_len, 
-        const unsigned char* index = nullptr, uint32_t index_len = 0) const override;
+    virtual int decrypt(EVP_CIPHER_CTX* ctx,  const CryptArgs& params) const override;
 
 private:
     static constexpr size_t AES_256_SIV_TAG_SIZE = 16;

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -22,6 +22,8 @@
 #include "librbd/io/ObjectRequest.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Utils.h"
+#include "librbd/crypto/CryptoInterface.h"
+#include "librbd/crypto/EncryptionFormat.h"
 
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/construct.hpp>
@@ -402,6 +404,16 @@ void CopyupRequest<I>::copyup() {
   m_image_ctx->image_lock.lock_shared();
   auto snapc = m_image_ctx->snapc;
   auto io_context = m_image_ctx->get_data_io_context();
+// AEAD integrity tags live beyond object_size; thick copyup clips to
+// [0, object_size) and would discard them. Force sparse copyup for
+// AEAD images since cls_cxx_write handles offsets beyond object_size.
+  bool force_sparse_copyup = false;
+  if (m_image_ctx->encryption_format) {
+    auto crypto = m_image_ctx->encryption_format->get_crypto();
+    if (crypto && crypto->get_meta_size() != 0) {
+      force_sparse_copyup = true;
+    }
+  }
   m_image_ctx->image_lock.unlock_shared();
 
   m_lock.lock();
@@ -434,7 +446,7 @@ void CopyupRequest<I>::copyup() {
     op = &write_op;
   }
 
-  if (m_image_ctx->enable_sparse_copyup) {
+  if (m_image_ctx->enable_sparse_copyup || force_sparse_copyup) {
     cls_client::sparse_copyup(op, m_copyup_extent_map, m_copyup_data);
   } else {
     // convert the sparse read back into a standard (thick) read

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -81,6 +81,9 @@ bool ObjectDispatch<I>::write(
                  << object_off << "~" << data.length() << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
+  if (*object_dispatch_flags & io::OBJECT_DISPATCH_FLAG_IS_AEAD_ENCRYPTED) {
+    write_flags |= io::OBJECT_WRITE_FLAG_ENCRYPTED_AEAD_WRITE; 
+  }
   auto req = new ObjectWriteRequest<I>(m_image_ctx, object_no, object_off,
                                        std::move(data), io_context, op_flags,
                                        write_flags, assert_version,

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -662,10 +662,36 @@ void ObjectWriteRequest<I>::add_write_hint(neorados::WriteOp* wr) {
 
 template <typename I>
 void ObjectWriteRequest<I>::add_write_ops(neorados::WriteOp* wr) {
-  if (this->m_full_object) {
-    wr->write_full(bufferlist{m_write_data});
+  I *image_ctx = this->m_ictx;
+  bufferlist data_bl;
+  bufferlist meta_data;
+  size_t block_num = 0;
+  size_t meta_size = 0;
+  if (m_write_flags & OBJECT_WRITE_FLAG_ENCRYPTED_AEAD_WRITE) {
+    auto crypto = image_ctx->encryption_format->get_crypto();
+    ceph_assert(crypto != nullptr);
+    size_t block_length = crypto->get_block_size();
+    meta_size = crypto->get_meta_size();
+    block_num = this->m_object_off / block_length;
+    size_t blocks_cnt = m_write_data.length() / (meta_size + block_length);
+    size_t data_length = blocks_cnt * block_length;
+    // TODO: not splice because in case of a retry we still use the original m_write_data?
+    meta_data.substr_of(m_write_data, data_length, blocks_cnt * meta_size);
+    data_bl.substr_of(m_write_data, 0, data_length);
+    ceph_assert((meta_data.length() % meta_size) == 0);
   } else {
-    wr->write(this->m_object_off, bufferlist{m_write_data});
+    data_bl = m_write_data;
+  }
+  // write data first, then meta — write_full truncates the object,
+  // so meta must come after to avoid being wiped
+  if (this->m_full_object) {
+    wr->write_full(std::move(data_bl));
+  } else {
+    wr->write(this->m_object_off, std::move(data_bl));
+  }
+  if (m_write_flags & OBJECT_WRITE_FLAG_ENCRYPTED_AEAD_WRITE) {
+    wr->write(image_ctx->get_object_size() + block_num * meta_size,
+              std::move(meta_data));
   }
   util::apply_op_flags(m_op_flags, 0U, wr);
 }
@@ -680,10 +706,39 @@ void ObjectDiscardRequest<I>::add_write_ops(neorados::WriteOp* wr) {
     wr->create(false);
     // fall through
   case DISCARD_ACTION_TRUNCATE:
+    // For AEAD with a non-zero truncate point, a plain truncate would remove
+    // meta for surviving blocks stored beyond object_size. Convert to zero ops
+    // that only affect the discarded data range and its corresponding meta.
+    if (this->m_object_off > 0 && this->m_ictx->encryption_format) {
+      auto crypto = this->m_ictx->encryption_format->get_crypto();
+      uint32_t meta_size = crypto->get_meta_size();
+      if (meta_size > 0) {
+        uint64_t block_size = crypto->get_block_size();
+        uint64_t object_size = this->m_ictx->get_object_size();
+        wr->zero(this->m_object_off, object_size - this->m_object_off);
+        uint64_t start_block = this->m_object_off / block_size;
+        uint64_t total_blocks = object_size / block_size;
+        wr->zero(object_size + start_block * meta_size,
+                 (total_blocks - start_block) * meta_size);
+        break;
+      }
+    }
     wr->truncate(this->m_object_off);
     break;
   case DISCARD_ACTION_ZERO:
     wr->zero(this->m_object_off, this->m_object_len);
+    // For AEAD, also zero the corresponding meta region beyond object_size
+    if (this->m_ictx->encryption_format) {
+      auto crypto = this->m_ictx->encryption_format->get_crypto();
+      uint32_t meta_size = crypto->get_meta_size();
+      if (meta_size > 0) {
+        uint64_t block_size = crypto->get_block_size();
+        uint64_t start_block = this->m_object_off / block_size;
+        uint64_t num_blocks = this->m_object_len / block_size;
+        wr->zero(this->m_ictx->get_object_size() + start_block * meta_size,
+                 num_blocks * meta_size);
+      }
+    }
     break;
   default:
     ceph_abort();

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -668,6 +668,7 @@ void ObjectWriteRequest<I>::add_write_ops(neorados::WriteOp* wr) {
   size_t block_num = 0;
   size_t meta_size = 0;
   if (m_write_flags & OBJECT_WRITE_FLAG_ENCRYPTED_AEAD_WRITE) {
+    std::shared_lock image_locker{image_ctx->image_lock};
     auto crypto = image_ctx->encryption_format->get_crypto();
     ceph_assert(crypto != nullptr);
     size_t block_length = crypto->get_block_size();
@@ -709,18 +710,21 @@ void ObjectDiscardRequest<I>::add_write_ops(neorados::WriteOp* wr) {
     // For AEAD with a non-zero truncate point, a plain truncate would remove
     // meta for surviving blocks stored beyond object_size. Convert to zero ops
     // that only affect the discarded data range and its corresponding meta.
-    if (this->m_object_off > 0 && this->m_ictx->encryption_format) {
-      auto crypto = this->m_ictx->encryption_format->get_crypto();
-      uint32_t meta_size = crypto->get_meta_size();
-      if (meta_size > 0) {
-        uint64_t block_size = crypto->get_block_size();
-        uint64_t object_size = this->m_ictx->get_object_size();
-        wr->zero(this->m_object_off, object_size - this->m_object_off);
-        uint64_t start_block = this->m_object_off / block_size;
-        uint64_t total_blocks = object_size / block_size;
-        wr->zero(object_size + start_block * meta_size,
-                 (total_blocks - start_block) * meta_size);
-        break;
+    if (this->m_object_off > 0) {
+      std::shared_lock image_locker{this->m_ictx->image_lock};
+      if (this->m_ictx->encryption_format) {
+        auto crypto = this->m_ictx->encryption_format->get_crypto();
+        uint32_t meta_size = crypto->get_meta_size();
+        if (meta_size > 0) {
+          uint64_t block_size = crypto->get_block_size();
+          uint64_t object_size = this->m_ictx->get_object_size();
+          wr->zero(this->m_object_off, object_size - this->m_object_off);
+          uint64_t start_block = this->m_object_off / block_size;
+          uint64_t total_blocks = object_size / block_size;
+          wr->zero(object_size + start_block * meta_size,
+                   (total_blocks - start_block) * meta_size);
+          break;
+        }
       }
     }
     wr->truncate(this->m_object_off);
@@ -728,15 +732,18 @@ void ObjectDiscardRequest<I>::add_write_ops(neorados::WriteOp* wr) {
   case DISCARD_ACTION_ZERO:
     wr->zero(this->m_object_off, this->m_object_len);
     // For AEAD, also zero the corresponding meta region beyond object_size
-    if (this->m_ictx->encryption_format) {
-      auto crypto = this->m_ictx->encryption_format->get_crypto();
-      uint32_t meta_size = crypto->get_meta_size();
-      if (meta_size > 0) {
-        uint64_t block_size = crypto->get_block_size();
-        uint64_t start_block = this->m_object_off / block_size;
-        uint64_t num_blocks = this->m_object_len / block_size;
-        wr->zero(this->m_ictx->get_object_size() + start_block * meta_size,
-                 num_blocks * meta_size);
+    {
+      std::shared_lock image_locker{this->m_ictx->image_lock};
+      if (this->m_ictx->encryption_format) {
+        auto crypto = this->m_ictx->encryption_format->get_crypto();
+        uint32_t meta_size = crypto->get_meta_size();
+        if (meta_size > 0) {
+          uint64_t block_size = crypto->get_block_size();
+          uint64_t start_block = this->m_object_off / block_size;
+          uint64_t num_blocks = this->m_object_len / block_size;
+          wr->zero(this->m_ictx->get_object_size() + start_block * meta_size,
+                   num_blocks * meta_size);
+        }
       }
     }
     break;

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -12,6 +12,8 @@
 #include "librbd/ObjectMap.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
+#include "librbd/crypto/CryptoInterface.h"
+#include "librbd/crypto/EncryptionFormat.h"
 #include <map>
 
 class Context;
@@ -266,7 +268,10 @@ public:
       int write_flags, std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, Context *completion)
     : AbstractObjectWriteRequest<ImageCtxT>(ictx, object_no, object_off,
-                                            data.length(), io_context, "write",
+                                            logical_data_length(
+                                                ictx, data.length(),
+                                                write_flags),
+                                            io_context, "write",
                                             parent_trace, completion),
       m_write_data(std::move(data)), m_op_flags(op_flags),
       m_write_flags(write_flags), m_assert_version(assert_version) {
@@ -285,6 +290,19 @@ protected:
   void add_write_hint(neorados::WriteOp *wr) override;
 
 private:
+  static uint64_t logical_data_length(ImageCtxT* ictx, uint64_t raw_len,
+                                      int write_flags) {
+    if (write_flags & OBJECT_WRITE_FLAG_ENCRYPTED_AEAD_WRITE) {
+      auto crypto = ictx->encryption_format->get_crypto();
+      size_t meta_size = crypto->get_meta_size();
+      if (meta_size > 0) {
+        size_t block_size = crypto->get_block_size();
+        return (raw_len / (meta_size + block_size)) * block_size;
+      }
+    }
+    return raw_len;
+  }
+
   ceph::bufferlist m_write_data;
   int m_op_flags;
   int m_write_flags;

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -126,13 +126,16 @@ enum ObjectDispatchLayer {
   OBJECT_DISPATCH_LAYER_LAST
 };
 
+// read_op flags
 enum {
   READ_FLAG_DISABLE_READ_FROM_PARENT            = 1UL << 0,
   READ_FLAG_DISABLE_CLIPPING                    = 1UL << 1,
 };
 
+// write_op flags
 enum {
-  OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE            = 1UL << 0
+  OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE            = 1UL << 0,
+  OBJECT_WRITE_FLAG_ENCRYPTED_AEAD_WRITE        = 1UL << 1,
 };
 
 enum {
@@ -142,7 +145,8 @@ enum {
 
 enum {
   OBJECT_DISPATCH_FLAG_FLUSH                    = 1UL << 0,
-  OBJECT_DISPATCH_FLAG_WILL_RETRY_ON_ERROR      = 1UL << 1
+  OBJECT_DISPATCH_FLAG_WILL_RETRY_ON_ERROR      = 1UL << 1,
+  OBJECT_DISPATCH_FLAG_IS_AEAD_ENCRYPTED        = 1UL << 2,
 };
 
 enum {

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -130,6 +130,7 @@ enum ObjectDispatchLayer {
 enum {
   READ_FLAG_DISABLE_READ_FROM_PARENT            = 1UL << 0,
   READ_FLAG_DISABLE_CLIPPING                    = 1UL << 1,
+  READ_FLAG_ENCRYPTED_AEAD_READ               = 1UL << 2,
 };
 
 // write_op flags

--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3
+# cython: legacy_implicit_noexcept=True
 # cython: embedsignature=True
 
 from libc.stdint cimport *

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -148,6 +148,7 @@ endif()
 
 if(LINUX AND HAVE_LIBCRYPTSETUP)
   list(APPEND unittest_librbd_srcs
+          crypto/luks/test_mock_Header.cc
           crypto/luks/test_mock_FlattenRequest.cc
           crypto/luks/test_mock_FormatRequest.cc
           crypto/luks/test_mock_LoadRequest.cc)

--- a/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
@@ -92,7 +92,9 @@ struct TestMockCryptoLuksFormatRequest : public TestMockFixture {
   }
 
   void verify_header(const char* expected_format, size_t expected_key_length,
-                     uint64_t expected_sector_size, bool magic_switched) {
+                     uint64_t expected_sector_size, bool magic_switched,
+                     const char* expected_cipher = nullptr,
+                     const char* expected_cipher_mode = nullptr) {
     Header header(mock_image_ctx->cct);
 
     ASSERT_EQ(0, header.init());
@@ -109,6 +111,13 @@ struct TestMockCryptoLuksFormatRequest : public TestMockFixture {
 
     ASSERT_EQ(expected_sector_size, header.get_sector_size());
     ASSERT_EQ(0, header.get_data_offset() % OBJECT_SIZE);
+
+    if (expected_cipher) {
+      ASSERT_STREQ(expected_cipher, header.get_cipher());
+    }
+    if (expected_cipher_mode) {
+      ASSERT_STREQ(expected_cipher_mode, header.get_cipher_mode());
+    }
 
     char volume_key[96];
     size_t volume_key_size = sizeof(volume_key);
@@ -239,7 +248,8 @@ TEST_F(TestMockCryptoLuksFormatRequest, AES256_HMAC_SHA256) {
   ASSERT_EQ(ETIMEDOUT, finished_cond.wait_for(0));
   complete_aio(0);
   ASSERT_EQ(0, finished_cond.wait());
-  ASSERT_NO_FATAL_FAILURE(verify_header(CRYPT_LUKS2, 96, 4096, false));
+  ASSERT_NO_FATAL_FAILURE(verify_header(CRYPT_LUKS2, 96, 4096, false,
+                                        "aes", "xts-random"));
 }
 #endif
 

--- a/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include "acconfig.h"
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librbd/test_support.h"
 #include "test/librbd/mock/MockImageCtx.h"
@@ -109,7 +110,7 @@ struct TestMockCryptoLuksFormatRequest : public TestMockFixture {
     ASSERT_EQ(expected_sector_size, header.get_sector_size());
     ASSERT_EQ(0, header.get_data_offset() % OBJECT_SIZE);
 
-    char volume_key[64];
+    char volume_key[96];
     size_t volume_key_size = sizeof(volume_key);
     ASSERT_EQ(0, header.read_volume_key(
             passphrase_cstr, strlen(passphrase_cstr),
@@ -224,6 +225,23 @@ TEST_F(TestMockCryptoLuksFormatRequest, WriteFail) {
   complete_aio(-123);
   ASSERT_EQ(-123, finished_cond.wait());
 }
+
+#ifdef HAVE_CRYPT_FORMAT_INLINE
+TEST_F(TestMockCryptoLuksFormatRequest, AES256_HMAC_SHA256) {
+  auto mock_format_request = MockFormatRequest::create(
+          mock_image_ctx, RBD_ENCRYPTION_FORMAT_LUKS2,
+          RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256, std::move(passphrase),
+          &crypto, on_finish, true);
+  expect_get_stripe_period();
+  expect_get_image_size(IMAGE_SIZE);
+  expect_image_write();
+  mock_format_request->send();
+  ASSERT_EQ(ETIMEDOUT, finished_cond.wait_for(0));
+  complete_aio(0);
+  ASSERT_EQ(0, finished_cond.wait());
+  ASSERT_NO_FATAL_FAILURE(verify_header(CRYPT_LUKS2, 96, 4096, false));
+}
+#endif
 
 } // namespace luks
 } // namespace crypto

--- a/src/test/librbd/crypto/luks/test_mock_Header.cc
+++ b/src/test/librbd/crypto/luks/test_mock_Header.cc
@@ -1,0 +1,546 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "acconfig.h"
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "librbd/crypto/luks/Header.h"
+#include <endian.h>
+#include "json_spirit/json_spirit.h"
+
+namespace librbd {
+namespace crypto {
+namespace luks {
+
+struct TestMockCryptoLuksHeader : public TestMockFixture {
+  const size_t OBJECT_SIZE = 4 * 1024 * 1024;
+  const char* passphrase_cstr = "password";
+
+  MockImageCtx* mock_image_ctx;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::ImageCtx *ictx;
+    ASSERT_EQ(0, open_image(m_image_name, &ictx));
+    mock_image_ctx = new MockImageCtx(*ictx);
+  }
+
+  void TearDown() override {
+    delete mock_image_ctx;
+    TestMockFixture::TearDown();
+  }
+};
+
+TEST_F(TestMockCryptoLuksHeader, FormatLoadRoundTrip) {
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "aes", nullptr, 64,
+                                    "xts-plain64", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+
+  uint64_t orig_data_offset = format_header.get_data_offset();
+  int orig_sector_size = format_header.get_sector_size();
+
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(header_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS2));
+
+  ASSERT_EQ(orig_data_offset, load_header.get_data_offset());
+  ASSERT_EQ(orig_sector_size, load_header.get_sector_size());
+  ASSERT_STREQ("aes", load_header.get_cipher());
+  ASSERT_STREQ("xts-plain64", load_header.get_cipher_mode());
+
+  char volume_key[96];
+  size_t volume_key_size = sizeof(volume_key);
+  ASSERT_EQ(0, load_header.read_volume_key(
+      passphrase_cstr, strlen(passphrase_cstr),
+      volume_key, &volume_key_size));
+  ASSERT_EQ(64u, volume_key_size);
+}
+
+TEST_F(TestMockCryptoLuksHeader, FormatLoadRoundTripAES128) {
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "aes", nullptr, 32,
+                                    "xts-plain64", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(header_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS2));
+
+  ASSERT_STREQ("aes", load_header.get_cipher());
+  ASSERT_STREQ("xts-plain64", load_header.get_cipher_mode());
+
+  char volume_key[96];
+  size_t volume_key_size = sizeof(volume_key);
+  ASSERT_EQ(0, load_header.read_volume_key(
+      passphrase_cstr, strlen(passphrase_cstr),
+      volume_key, &volume_key_size));
+  ASSERT_EQ(32u, volume_key_size);
+}
+
+TEST_F(TestMockCryptoLuksHeader, FormatLoadRoundTripLUKS1) {
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS1, "aes", nullptr, 64,
+                                    "xts-plain64", 512, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+
+  uint64_t orig_data_offset = format_header.get_data_offset();
+
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(header_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS1));
+
+  ASSERT_EQ(orig_data_offset, load_header.get_data_offset());
+  ASSERT_EQ(512, load_header.get_sector_size());
+  ASSERT_STREQ("aes", load_header.get_cipher());
+  ASSERT_STREQ("xts-plain64", load_header.get_cipher_mode());
+
+  char volume_key[96];
+  size_t volume_key_size = sizeof(volume_key);
+  ASSERT_EQ(0, load_header.read_volume_key(
+      passphrase_cstr, strlen(passphrase_cstr),
+      volume_key, &volume_key_size));
+  ASSERT_EQ(64u, volume_key_size);
+}
+
+TEST_F(TestMockCryptoLuksHeader, LoadFromSecondaryWhenPrimaryCorrupted) {
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "aes", nullptr, 64,
+                                    "xts-plain64", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+
+  uint64_t orig_data_offset = format_header.get_data_offset();
+
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  // corrupt the primary header's magic bytes (first 6 bytes);
+  // libcryptsetup should fall back to the secondary header copy
+  ceph::bufferlist corrupt_bl;
+  corrupt_bl.append(header_bl);
+  char* data = corrupt_bl.c_str();
+  memset(data, 0, 6);
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(corrupt_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS2));
+
+  ASSERT_EQ(orig_data_offset, load_header.get_data_offset());
+  ASSERT_STREQ("aes", load_header.get_cipher());
+  ASSERT_STREQ("xts-plain64", load_header.get_cipher_mode());
+
+  char volume_key[96];
+  size_t volume_key_size = sizeof(volume_key);
+  ASSERT_EQ(0, load_header.read_volume_key(
+      passphrase_cstr, strlen(passphrase_cstr),
+      volume_key, &volume_key_size));
+  ASSERT_EQ(64u, volume_key_size);
+}
+
+TEST_F(TestMockCryptoLuksHeader, LoadFailsWhenBothHeadersCorrupted) {
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "aes", nullptr, 64,
+                                    "xts-plain64", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  // read hdr_size to locate the secondary header
+  ceph::bufferlist corrupt_bl;
+  corrupt_bl.append(header_bl);
+  char* data = corrupt_bl.c_str();
+  uint64_t hdr_size;
+  memcpy(&hdr_size, data + 8, sizeof(hdr_size));
+  hdr_size = be64toh(hdr_size);
+
+  // corrupt both primary and secondary magic bytes
+  memset(data, 0, 6);
+  memset(data + hdr_size, 0, 6);
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(corrupt_bl));
+  // with both headers corrupted, load must fail
+  ASSERT_NE(0, load_header.load(CRYPT_LUKS2));
+}
+
+#ifdef HAVE_CRYPT_FORMAT_INLINE
+
+// Reference JSON segments from crypt_format_inline() output.
+// Generated using patched cryptsetup 2.9.0-git with CRYPTSETUP_FAKE_DIF_TAG_SIZE=256.
+// Only the structural fields (segments, config.requirements) are compared;
+// volatile fields (keyslots, digests, tokens, UUIDs, salts) are ignored.
+
+// Config 1: AES-256-XTS + hmac(sha256), 96-byte key, 1 keyslot, 4MB alignment
+static const char* REF_JSON_AES256_XTS_HMAC_SHA256_1KS = R"json({"keyslots":{"0":{"type":"luks2","key_size":96,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"32768","size":"385024","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"yZsRNy5mstVt6t44BjOXBVxYWh5x6ya8b4mh17/GoiE="}}},"tokens":{},"segments":{"0":{"type":"crypt","offset":"16777216","size":"dynamic","iv_tweak":"0","encryption":"aes-xts-random","sector_size":4096,"integrity":{"type":"hmac(sha256)","journal_encryption":"none","journal_integrity":"none"}}},"digests":{"0":{"type":"pbkdf2","keyslots":["0"],"segments":["0"],"hash":"sha256","iterations":1000,"salt":"NeBcMFlA5gjEIE/+zolZ4PQvQ8+pwmKQOnvOwMprEQs=","digest":"ECHXn4n7e354pK948UQcWaWuTWXR1IqBeKyEG241Dac="}},"config":{"json_size":"12288","keyslots_size":"16744448","requirements":{"mandatory":["inline-hw-tags"]}}})json";
+
+// Config 2: AES-128-XTS + hmac(sha256), 64-byte key, 1 keyslot
+static const char* REF_JSON_AES128_XTS_HMAC_SHA256_1KS = R"json({"keyslots":{"0":{"type":"luks2","key_size":64,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"32768","size":"258048","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"709jMWoz7M2ZLKIdZgkuhEoY2x2Qjp7aeqU4dncm0m4="}}},"tokens":{},"segments":{"0":{"type":"crypt","offset":"16777216","size":"dynamic","iv_tweak":"0","encryption":"aes-xts-random","sector_size":4096,"integrity":{"type":"hmac(sha256)","journal_encryption":"none","journal_integrity":"none"}}},"digests":{"0":{"type":"pbkdf2","keyslots":["0"],"segments":["0"],"hash":"sha256","iterations":1000,"salt":"nPp6TeJdiu/ebx9XcOv5fJiZat2yHarLaV+D1kYZFN8=","digest":"L+auHjZfJ15JoLN2rEOfNZNlk0JKLtRGX0G/d7yKdho="}},"config":{"json_size":"12288","keyslots_size":"16744448","requirements":{"mandatory":["inline-hw-tags"]}}})json";
+
+// Config 3: AES-256-XTS + hmac(sha512), 128-byte key, 1 keyslot
+static const char* REF_JSON_AES256_XTS_HMAC_SHA512_1KS = R"json({"keyslots":{"0":{"type":"luks2","key_size":128,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"32768","size":"512000","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"p49tiQdNW5d5ibYb8XhKGWNSyRS1n6J4RDF8/apKlaA="}}},"tokens":{},"segments":{"0":{"type":"crypt","offset":"16777216","size":"dynamic","iv_tweak":"0","encryption":"aes-xts-random","sector_size":4096,"integrity":{"type":"hmac(sha512)","journal_encryption":"none","journal_integrity":"none"}}},"digests":{"0":{"type":"pbkdf2","keyslots":["0"],"segments":["0"],"hash":"sha256","iterations":1000,"salt":"0LfrPlhROaQkAPOyieJyN2PI/nRqf9KIwlQpXFzvfN8=","digest":"OlN5SMLQDTh307BYZX8rummcOIQhHbJmzCq0DFkDu3s="}},"config":{"json_size":"12288","keyslots_size":"16744448","requirements":{"mandatory":["inline-hw-tags"]}}})json";
+
+// Config 4: AES-256-XTS + hmac(sha256), 96-byte key, 3 keyslots
+static const char* REF_JSON_AES256_XTS_HMAC_SHA256_3KS = R"json({"keyslots":{"0":{"type":"luks2","key_size":96,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"32768","size":"385024","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"B73ZfuzuP7rRNtrtlMJwawdx8QbL+/soe0cOqlMCdGA="}},"1":{"type":"luks2","key_size":96,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"417792","size":"385024","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"rkVWIPhIhQC6duJFWcGtw/4Lefy1pc2a3tgXKDcENRY="}},"2":{"type":"luks2","key_size":96,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"802816","size":"385024","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"Mp0iRmiD7Vyr3P+QOIp8omdUMqysiRxlB7X5kfczlSo="}}},"tokens":{},"segments":{"0":{"type":"crypt","offset":"16777216","size":"dynamic","iv_tweak":"0","encryption":"aes-xts-random","sector_size":4096,"integrity":{"type":"hmac(sha256)","journal_encryption":"none","journal_integrity":"none"}}},"digests":{"0":{"type":"pbkdf2","keyslots":["0","1","2"],"segments":["0"],"hash":"sha256","iterations":1000,"salt":"/+w+78ArdB6tZ6APuGEEFwHyJPOemOqV7TQJFzXhYWw=","digest":"a1JHN31lCa8xqMtP+lUFvz+n5c46EN44c1YSsxvO2os="}},"config":{"json_size":"12288","keyslots_size":"16744448","requirements":{"mandatory":["inline-hw-tags"]}}})json";
+
+// Config 5: AES-256-XTS + hmac(sha256), custom label="test-vol", 8MB alignment
+static const char* REF_JSON_AES256_XTS_HMAC_SHA256_LABEL = R"json({"keyslots":{"0":{"type":"luks2","key_size":96,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"32768","size":"385024","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"z59SqtsvXHj70Ag1FkKlnIoqwv4OXAAG5nvinn6d3Gw="}}},"tokens":{},"segments":{"0":{"type":"crypt","offset":"16777216","size":"dynamic","iv_tweak":"0","encryption":"aes-xts-random","sector_size":4096,"integrity":{"type":"hmac(sha256)","journal_encryption":"none","journal_integrity":"none"}}},"digests":{"0":{"type":"pbkdf2","keyslots":["0"],"segments":["0"],"hash":"sha256","iterations":1000,"salt":"dF8jso7DaRS0X/5ravOsxMJmFc6lSL+E5/h4ErSzOMg=","digest":"asmRWmrQYds0VgUTT6m38FNzuzs9eP/9/K5r8XtofEQ="}},"config":{"json_size":"12288","keyslots_size":"16744448","requirements":{"mandatory":["inline-hw-tags"]}}})json";
+
+// Config 6: AES-256-GCM + aead, 32-byte key, 1 keyslot
+static const char* REF_JSON_AES256_GCM_AEAD_1KS = R"json({"keyslots":{"0":{"type":"luks2","key_size":32,"af":{"type":"luks1","stripes":4000,"hash":"sha256"},"area":{"type":"raw","offset":"32768","size":"131072","encryption":"aes-xts-plain64","key_size":64},"kdf":{"type":"pbkdf2","hash":"sha256","iterations":1000,"salt":"0s0JdPYxbEvsOyomG8oTAG9jxcY46sxrcG6ggIyFzlo="}}},"tokens":{},"segments":{"0":{"type":"crypt","offset":"16777216","size":"dynamic","iv_tweak":"0","encryption":"aes-gcm-random","sector_size":4096,"integrity":{"type":"aead","journal_encryption":"none","journal_integrity":"none"}}},"digests":{"0":{"type":"pbkdf2","keyslots":["0"],"segments":["0"],"hash":"sha256","iterations":1000,"salt":"pt/T5fD1LqOdSJATwf2e6nWeN/GRhOMHF7zJraoDWxg=","digest":"AvQ6vMUPl2lRMGcBPlKGmQCeZimSloppTbP0YnpBNO4="}},"config":{"json_size":"12288","keyslots_size":"16744448","requirements":{"mandatory":["inline-hw-tags"]}}})json";
+
+// Extract the LUKS2 JSON from a header bufferlist (primary header only).
+static std::string extract_luks2_json(ceph::bufferlist& bl) {
+  ceph_assert(bl.length() > 4096);
+  const char* data = bl.c_str();
+  uint64_t hdr_size;
+  memcpy(&hdr_size, data + 8, sizeof(hdr_size));
+  hdr_size = be64toh(hdr_size);
+  ceph_assert(hdr_size >= 4096 && hdr_size <= bl.length());
+  const char* json_area = data + 4096;
+  size_t json_len = strnlen(json_area, hdr_size - 4096);
+  return std::string(json_area, json_len);
+}
+
+// Compare structural fields of two LUKS2 inline integrity JSONs.
+// Checks segments, integrity, requirements — ignores keyslot/digest contents.
+static void compare_inline_json_structure(
+    const std::string& our_json,
+    const std::string& ref_json,
+    const char* expected_encryption,
+    const char* expected_integrity,
+    int expected_keyslot_count) {
+  json_spirit::mValue our_root, ref_root;
+  ASSERT_TRUE(json_spirit::read(our_json, our_root));
+  ASSERT_TRUE(json_spirit::read(ref_json, ref_root));
+
+  auto& our_obj = our_root.get_obj();
+  auto& ref_obj = ref_root.get_obj();
+
+  // Compare segments.0 structure
+  auto& our_seg0 = our_obj.at("segments").get_obj().at("0").get_obj();
+  auto& ref_seg0 = ref_obj.at("segments").get_obj().at("0").get_obj();
+
+  ASSERT_EQ(ref_seg0.at("type").get_str(), our_seg0.at("type").get_str());
+  ASSERT_EQ(std::string(expected_encryption), our_seg0.at("encryption").get_str());
+  ASSERT_EQ(ref_seg0.at("encryption").get_str(), our_seg0.at("encryption").get_str());
+  ASSERT_EQ(ref_seg0.at("sector_size").get_int(), our_seg0.at("sector_size").get_int());
+  ASSERT_EQ(std::string("dynamic"), our_seg0.at("size").get_str());
+
+  // Compare iv_tweak if present in reference
+  if (ref_seg0.count("iv_tweak")) {
+    ASSERT_TRUE(our_seg0.count("iv_tweak") > 0);
+    ASSERT_EQ(ref_seg0.at("iv_tweak").get_str(), our_seg0.at("iv_tweak").get_str());
+  }
+
+  // Compare integrity section
+  auto& our_integrity = our_seg0.at("integrity").get_obj();
+  auto& ref_integrity = ref_seg0.at("integrity").get_obj();
+
+  ASSERT_EQ(std::string(expected_integrity), our_integrity.at("type").get_str());
+  ASSERT_EQ(ref_integrity.at("type").get_str(), our_integrity.at("type").get_str());
+  ASSERT_EQ(ref_integrity.at("journal_encryption").get_str(),
+            our_integrity.at("journal_encryption").get_str());
+  ASSERT_EQ(ref_integrity.at("journal_integrity").get_str(),
+            our_integrity.at("journal_integrity").get_str());
+
+  // Compare config.requirements.mandatory
+  auto& our_config = our_obj.at("config").get_obj();
+  auto& ref_config = ref_obj.at("config").get_obj();
+  auto& our_mandatory = our_config.at("requirements").get_obj().at("mandatory").get_array();
+  auto& ref_mandatory = ref_config.at("requirements").get_obj().at("mandatory").get_array();
+  ASSERT_EQ(ref_mandatory.size(), our_mandatory.size());
+  for (size_t i = 0; i < ref_mandatory.size(); i++) {
+    ASSERT_EQ(ref_mandatory[i].get_str(), our_mandatory[i].get_str());
+  }
+
+  // Compare keyslot count
+  auto& our_keyslots = our_obj.at("keyslots").get_obj();
+  ASSERT_EQ(expected_keyslot_count, (int)our_keyslots.size());
+
+  // Both should have digests
+  ASSERT_TRUE(our_obj.count("digests") > 0);
+  ASSERT_TRUE(ref_obj.count("digests") > 0);
+}
+
+TEST_F(TestMockCryptoLuksHeader, InlineIntegrityRoundTrip) {
+  // format with cipher_null/ecb then rewrite for inline integrity
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                                    "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, format_header.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  uint64_t orig_data_offset = format_header.get_data_offset();
+
+  // read the header and load in a fresh instance
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(header_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS2));
+
+  // verify segment shows the rewritten cipher/mode
+  ASSERT_STREQ("aes", load_header.get_cipher());
+  ASSERT_STREQ("xts-random", load_header.get_cipher_mode());
+  ASSERT_EQ(orig_data_offset, load_header.get_data_offset());
+  ASSERT_EQ(4096, load_header.get_sector_size());
+
+  // verify volume key extraction works with 96-byte key
+  char volume_key[96];
+  size_t volume_key_size = sizeof(volume_key);
+  ASSERT_EQ(0, load_header.read_volume_key(
+      passphrase_cstr, strlen(passphrase_cstr),
+      volume_key, &volume_key_size));
+  ASSERT_EQ(96u, volume_key_size);
+}
+
+TEST_F(TestMockCryptoLuksHeader, InlineIntegrityLoadAfterReopen) {
+  // simulate the full format → persist → load cycle
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                                    "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, format_header.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  // read header as if persisting to image
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+  uint64_t data_offset = format_header.get_data_offset();
+
+  // simulate a fresh load (as LoadRequest would)
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(header_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS2));
+
+  ASSERT_EQ(data_offset, load_header.get_data_offset());
+  ASSERT_EQ(4096, load_header.get_sector_size());
+  ASSERT_STREQ("aes", load_header.get_cipher());
+  ASSERT_STREQ("xts-random", load_header.get_cipher_mode());
+
+  // extract volume key
+  char volume_key[96];
+  size_t volume_key_size = sizeof(volume_key);
+  ASSERT_EQ(0, load_header.read_volume_key(
+      passphrase_cstr, strlen(passphrase_cstr),
+      volume_key, &volume_key_size));
+  ASSERT_EQ(96u, volume_key_size);
+}
+
+// Comparison tests: verify rewrite_segment_for_inline() output matches
+// crypt_format_inline() reference output structurally.
+
+TEST_F(TestMockCryptoLuksHeader, CompareInlineAES256_HMAC_SHA256) {
+  Header h(mock_image_ctx->cct);
+  ASSERT_EQ(0, h.init());
+  ASSERT_EQ(0, h.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                         "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, h.add_keyslot(passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, h.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  ceph::bufferlist bl;
+  ASSERT_LT(0, h.read(&bl));
+  std::string our_json = extract_luks2_json(bl);
+
+  compare_inline_json_structure(our_json, REF_JSON_AES256_XTS_HMAC_SHA256_1KS,
+      "aes-xts-random", "hmac(sha256)", 1);
+}
+
+TEST_F(TestMockCryptoLuksHeader, CompareInlineAES128_HMAC_SHA256) {
+  Header h(mock_image_ctx->cct);
+  ASSERT_EQ(0, h.init());
+  ASSERT_EQ(0, h.format(CRYPT_LUKS2, "cipher_null", nullptr, 64,
+                         "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, h.add_keyslot(passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, h.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  ceph::bufferlist bl;
+  ASSERT_LT(0, h.read(&bl));
+  std::string our_json = extract_luks2_json(bl);
+
+  compare_inline_json_structure(our_json, REF_JSON_AES128_XTS_HMAC_SHA256_1KS,
+      "aes-xts-random", "hmac(sha256)", 1);
+}
+
+TEST_F(TestMockCryptoLuksHeader, CompareInlineAES256_HMAC_SHA512) {
+  Header h(mock_image_ctx->cct);
+  ASSERT_EQ(0, h.init());
+  ASSERT_EQ(0, h.format(CRYPT_LUKS2, "cipher_null", nullptr, 128,
+                         "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, h.add_keyslot(passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, h.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha512)"));
+
+  ceph::bufferlist bl;
+  ASSERT_LT(0, h.read(&bl));
+  std::string our_json = extract_luks2_json(bl);
+
+  compare_inline_json_structure(our_json, REF_JSON_AES256_XTS_HMAC_SHA512_1KS,
+      "aes-xts-random", "hmac(sha512)", 1);
+}
+
+TEST_F(TestMockCryptoLuksHeader, CompareInlineMultipleKeyslots) {
+  Header h(mock_image_ctx->cct);
+  ASSERT_EQ(0, h.init());
+  ASSERT_EQ(0, h.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                         "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, h.add_keyslot("password", 8));
+  ASSERT_EQ(0, h.add_keyslot("pass2", 5));
+  ASSERT_EQ(0, h.add_keyslot("pass3", 5));
+  ASSERT_EQ(0, h.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  ceph::bufferlist bl;
+  ASSERT_LT(0, h.read(&bl));
+  std::string our_json = extract_luks2_json(bl);
+
+  compare_inline_json_structure(our_json, REF_JSON_AES256_XTS_HMAC_SHA256_3KS,
+      "aes-xts-random", "hmac(sha256)", 3);
+}
+
+TEST_F(TestMockCryptoLuksHeader, CompareInlineCustomLabel) {
+  Header h(mock_image_ctx->cct);
+  ASSERT_EQ(0, h.init());
+  ASSERT_EQ(0, h.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                         "ecb", 4096, 8 * 1024 * 1024, true));
+  ASSERT_EQ(0, h.add_keyslot(passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, h.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  ceph::bufferlist bl;
+  ASSERT_LT(0, h.read(&bl));
+  std::string our_json = extract_luks2_json(bl);
+
+  compare_inline_json_structure(our_json, REF_JSON_AES256_XTS_HMAC_SHA256_LABEL,
+      "aes-xts-random", "hmac(sha256)", 1);
+}
+
+TEST_F(TestMockCryptoLuksHeader, CompareInlineAES256_GCM) {
+  Header h(mock_image_ctx->cct);
+  ASSERT_EQ(0, h.init());
+  ASSERT_EQ(0, h.format(CRYPT_LUKS2, "cipher_null", nullptr, 32,
+                         "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, h.add_keyslot(passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, h.rewrite_segment_for_inline(
+      "aes", "gcm-random", "aead"));
+
+  ceph::bufferlist bl;
+  ASSERT_LT(0, h.read(&bl));
+  std::string our_json = extract_luks2_json(bl);
+
+  compare_inline_json_structure(our_json, REF_JSON_AES256_GCM_AEAD_1KS,
+      "aes-gcm-random", "aead", 1);
+}
+
+TEST_F(TestMockCryptoLuksHeader, InlineIntegrityVerifyCryptsetupParsing) {
+  // Verify that cryptsetup's own parsing logic correctly interprets our
+  // rewritten header — the same code path that feeds parameters to dm-crypt.
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                                    "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, format_header.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(header_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS2));
+
+  struct crypt_params_integrity ip;
+  memset(&ip, 0, sizeof(ip));
+  ASSERT_EQ(0, load_header.get_integrity_info(&ip));
+
+  ASSERT_STREQ("hmac(sha256)", ip.integrity);
+  ASSERT_EQ(48u, ip.tag_size);       // 16 IV + 32 HMAC
+  ASSERT_EQ(4096u, ip.sector_size);
+}
+
+TEST_F(TestMockCryptoLuksHeader, LoadInlineFromSecondaryWhenPrimaryCorrupted) {
+  // format with inline integrity rewrite, then corrupt primary header
+  Header format_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, format_header.init());
+  ASSERT_EQ(0, format_header.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                                    "ecb", 4096, OBJECT_SIZE, true));
+  ASSERT_EQ(0, format_header.add_keyslot(
+      passphrase_cstr, strlen(passphrase_cstr)));
+  ASSERT_EQ(0, format_header.rewrite_segment_for_inline(
+      "aes", "xts-random", "hmac(sha256)"));
+
+  uint64_t orig_data_offset = format_header.get_data_offset();
+
+  ceph::bufferlist header_bl;
+  ASSERT_LT(0, format_header.read(&header_bl));
+
+  // corrupt the primary header's magic bytes
+  ceph::bufferlist corrupt_bl;
+  corrupt_bl.append(header_bl);
+  char* data = corrupt_bl.c_str();
+  memset(data, 0, 6);
+
+  Header load_header(mock_image_ctx->cct);
+  ASSERT_EQ(0, load_header.init());
+  ASSERT_EQ(0, load_header.write(corrupt_bl));
+  ASSERT_EQ(0, load_header.load(CRYPT_LUKS2));
+
+  // verify the inline integrity fields survived via secondary header
+  ASSERT_EQ(orig_data_offset, load_header.get_data_offset());
+  ASSERT_EQ(4096, load_header.get_sector_size());
+  ASSERT_STREQ("aes", load_header.get_cipher());
+  ASSERT_STREQ("xts-random", load_header.get_cipher_mode());
+
+  char volume_key[96];
+  size_t volume_key_size = sizeof(volume_key);
+  ASSERT_EQ(0, load_header.read_volume_key(
+      passphrase_cstr, strlen(passphrase_cstr),
+      volume_key, &volume_key_size));
+  ASSERT_EQ(96u, volume_key_size);
+}
+
+#endif // HAVE_CRYPT_FORMAT_INLINE
+
+} // namespace luks
+} // namespace crypto
+} // namespace librbd

--- a/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
@@ -5,7 +5,6 @@
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librbd/test_support.h"
 #include "test/librbd/mock/MockImageCtx.h"
-#include "common/JSONFormatter.h"
 
 namespace librbd {
 namespace util {
@@ -332,22 +331,15 @@ TEST_F(TestMockCryptoLuksLoadRequest, WrongPassphrase) {
 
 #ifdef HAVE_CRYPT_FORMAT_INLINE
 TEST_F(TestMockCryptoLuksLoadRequest, AES256_HMAC_SHA256) {
-  // generate AEAD header (same as FormatRequest does)
+  // generate AEAD header with inline integrity rewrite
   {
     Header header(mock_image_ctx->cct);
     ASSERT_EQ(0, header.init());
     ASSERT_EQ(0, header.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
                                "ecb", 4096, OBJECT_SIZE, true));
     ASSERT_EQ(0, header.add_keyslot(passphrase_cstr, strlen(passphrase_cstr)));
-
-    AEADToken token{48, "authenc(hmac(sha256),xts(aes))"};
-    ceph::JSONFormatter jf(false);
-    jf.open_object_section("");
-    token.encode_json(&jf);
-    jf.close_section();
-    std::stringstream ss;
-    jf.flush(ss);
-    ASSERT_EQ(0, header.token_update(token::TYPE_AEAD, ss.str().c_str()));
+    ASSERT_EQ(0, header.rewrite_segment_for_inline(
+        "aes", "xts-random", "hmac(sha256)"));
     ASSERT_LT(0, header.read(&header_bl));
     data_offset = header.get_data_offset();
   }

--- a/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
@@ -1,9 +1,11 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include "acconfig.h"
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librbd/test_support.h"
 #include "test/librbd/mock/MockImageCtx.h"
+#include "common/JSONFormatter.h"
 
 namespace librbd {
 namespace util {
@@ -327,6 +329,47 @@ TEST_F(TestMockCryptoLuksLoadRequest, WrongPassphrase) {
   ASSERT_EQ(crypto.get(), nullptr);
   ASSERT_EQ("LUKS2", detected_format_name);
 }
+
+#ifdef HAVE_CRYPT_FORMAT_INLINE
+TEST_F(TestMockCryptoLuksLoadRequest, AES256_HMAC_SHA256) {
+  // generate AEAD header (same as FormatRequest does)
+  {
+    Header header(mock_image_ctx->cct);
+    ASSERT_EQ(0, header.init());
+    ASSERT_EQ(0, header.format(CRYPT_LUKS2, "cipher_null", nullptr, 96,
+                               "ecb", 4096, OBJECT_SIZE, true));
+    ASSERT_EQ(0, header.add_keyslot(passphrase_cstr, strlen(passphrase_cstr)));
+
+    AEADToken token{48, "authenc(hmac(sha256),xts(aes))"};
+    ceph::JSONFormatter jf(false);
+    jf.open_object_section("");
+    token.encode_json(&jf);
+    jf.close_section();
+    std::stringstream ss;
+    jf.flush(ss);
+    ASSERT_EQ(0, header.token_update(token::TYPE_AEAD, ss.str().c_str()));
+    ASSERT_LT(0, header.read(&header_bl));
+    data_offset = header.get_data_offset();
+  }
+
+  expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
+  expect_get_image_size(OBJECT_SIZE << 5);
+  expect_get_stripe_period(OBJECT_SIZE);
+  mock_load_request->send();
+
+  // cipher_null/96 header (~288KB) exceeds DEFAULT_INITIAL_READ_SIZE (256KB),
+  // so crypt_volume_key_get fails on first attempt (incomplete keyslot data),
+  // triggering a retry read up to data_offset
+  expect_image_read(DEFAULT_INITIAL_READ_SIZE,
+                    data_offset - DEFAULT_INITIAL_READ_SIZE);
+  image_read_request->complete(DEFAULT_INITIAL_READ_SIZE);
+
+  image_read_request->complete(data_offset - DEFAULT_INITIAL_READ_SIZE);
+  ASSERT_EQ(0, finished_cond.wait());
+  ASSERT_NE(crypto.get(), nullptr);
+  ASSERT_EQ("LUKS2", detected_format_name);
+}
+#endif
 
 } // namespace luks
 } // namespace crypto

--- a/src/test/librbd/crypto/openssl/test_DataCryptor.cc
+++ b/src/test/librbd/crypto/openssl/test_DataCryptor.cc
@@ -67,13 +67,13 @@ TEST_F(TestCryptoOpensslDataCryptor, EncryptDecrypt) {
 
   unsigned char out[sizeof(TEST_DATA)];
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
   cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
   ctx = cryptor->get_context(CipherMode::CIPHER_MODE_DEC);
   ASSERT_NE(ctx, nullptr);
   ASSERT_EQ(0, cryptor->init_context(ctx, TEST_IV, sizeof(TEST_IV)));
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, out, out, sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, out, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
   ASSERT_EQ(0, memcmp(out, TEST_DATA, sizeof(TEST_DATA)));
   cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
 }
@@ -85,11 +85,11 @@ TEST_F(TestCryptoOpensslDataCryptor, ReuseContext) {
   ASSERT_EQ(0, cryptor->init_context(ctx, TEST_IV, sizeof(TEST_IV)));
   unsigned char out[sizeof(TEST_DATA)];
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
 
   ASSERT_EQ(0, cryptor->init_context(ctx, TEST_IV_2, sizeof(TEST_IV_2)));
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
 
   auto ctx2 = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_NE(ctx2, nullptr);
@@ -97,7 +97,7 @@ TEST_F(TestCryptoOpensslDataCryptor, ReuseContext) {
   ASSERT_EQ(0, cryptor->init_context(ctx2, TEST_IV_2, sizeof(TEST_IV_2)));
   unsigned char out2[sizeof(TEST_DATA)];
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx2, TEST_DATA, out2, sizeof(TEST_DATA)));
+            cryptor->update_context(ctx2, TEST_DATA, out2, sizeof(TEST_DATA), sizeof(TEST_DATA)));
 
   ASSERT_EQ(0, memcmp(out, out2, sizeof(TEST_DATA)));
 

--- a/src/test/librbd/crypto/openssl/test_DataCryptor.cc
+++ b/src/test/librbd/crypto/openssl/test_DataCryptor.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include <librbd/crypto/DataCryptor.h>
 #include "test/librbd/test_fixture.h"
 #include "librbd/crypto/openssl/DataCryptor.h"
 
@@ -67,13 +68,13 @@ TEST_F(TestCryptoOpensslDataCryptor, EncryptDecrypt) {
 
   unsigned char out[sizeof(TEST_DATA)];
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, CryptArgs{TEST_DATA, out, sizeof(TEST_DATA)}));
   cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
   ctx = cryptor->get_context(CipherMode::CIPHER_MODE_DEC);
   ASSERT_NE(ctx, nullptr);
   ASSERT_EQ(0, cryptor->init_context(ctx, TEST_IV, sizeof(TEST_IV)));
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, out, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, CryptArgs{out, out, sizeof(TEST_DATA)}));
   ASSERT_EQ(0, memcmp(out, TEST_DATA, sizeof(TEST_DATA)));
   cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
 }
@@ -85,11 +86,11 @@ TEST_F(TestCryptoOpensslDataCryptor, ReuseContext) {
   ASSERT_EQ(0, cryptor->init_context(ctx, TEST_IV, sizeof(TEST_IV)));
   unsigned char out[sizeof(TEST_DATA)];
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, CryptArgs{TEST_DATA, out, sizeof(TEST_DATA)}));
 
   ASSERT_EQ(0, cryptor->init_context(ctx, TEST_IV_2, sizeof(TEST_IV_2)));
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx, TEST_DATA, out, sizeof(TEST_DATA), sizeof(TEST_DATA)));
+            cryptor->update_context(ctx, CryptArgs{TEST_DATA, out, sizeof(TEST_DATA)}));
 
   auto ctx2 = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_NE(ctx2, nullptr);
@@ -97,7 +98,7 @@ TEST_F(TestCryptoOpensslDataCryptor, ReuseContext) {
   ASSERT_EQ(0, cryptor->init_context(ctx2, TEST_IV_2, sizeof(TEST_IV_2)));
   unsigned char out2[sizeof(TEST_DATA)];
   ASSERT_EQ(sizeof(TEST_DATA),
-            cryptor->update_context(ctx2, TEST_DATA, out2, sizeof(TEST_DATA), sizeof(TEST_DATA)));
+            cryptor->update_context(ctx2, CryptArgs{TEST_DATA, out2, sizeof(TEST_DATA)}));
 
   ASSERT_EQ(0, memcmp(out, out2, sizeof(TEST_DATA)));
 

--- a/src/test/librbd/crypto/openssl/test_DataCryptor.cc
+++ b/src/test/librbd/crypto/openssl/test_DataCryptor.cc
@@ -5,6 +5,14 @@
 #include "test/librbd/test_fixture.h"
 #include "librbd/crypto/openssl/DataCryptor.h"
 
+#include <sys/socket.h>
+#include <linux/if_alg.h>
+#include <linux/rtnetlink.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
 namespace librbd {
 namespace crypto {
 namespace openssl {
@@ -112,6 +120,443 @@ TEST_F(TestCryptoOpensslDataCryptor, InvalidIVLength) {
 
   ASSERT_EQ(-EINVAL, cryptor->init_context(ctx, TEST_IV, 1));
   cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
+}
+
+// AuthEncDataCryptor tests: authenc(hmac(sha256),xts(aes))
+
+const unsigned char TEST_AUTHENC_KEY[96] = {5};
+const unsigned char TEST_SECTOR_IV[8] = {6};
+
+struct TestCryptoOpensslAuthEncDataCryptor : public TestFixture {
+    AuthEncDataCryptor *cryptor;
+
+    void SetUp() override {
+      TestFixture::SetUp();
+      cryptor = new AuthEncDataCryptor(
+          reinterpret_cast<CephContext*>(m_ioctx.cct()));
+      ASSERT_EQ(0,
+                cryptor->init(TEST_CIPHER_NAME, TEST_AUTHENC_KEY,
+                              sizeof(TEST_AUTHENC_KEY)));
+    }
+
+    void TearDown() override {
+      delete cryptor;
+      TestFixture::TearDown();
+    }
+};
+
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, InvalidKeySize) {
+  AuthEncDataCryptor bad(reinterpret_cast<CephContext*>(m_ioctx.cct()));
+  EXPECT_EQ(-EINVAL, bad.init(TEST_CIPHER_NAME, TEST_KEY, sizeof(TEST_KEY)));
+}
+
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, GetKeyLength) {
+  ASSERT_EQ(96, cryptor->get_key_length());
+}
+
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, EncryptDecrypt) {
+  auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char out[sizeof(TEST_DATA)];
+  unsigned char meta[48];  // HMAC tag (32) + IV (16)
+  CryptArgs enc_args{TEST_DATA, out, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->update_context(ctx, enc_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
+
+  // Verify ciphertext differs from plaintext
+  ASSERT_NE(0, memcmp(out, TEST_DATA, sizeof(TEST_DATA)));
+
+  // Decrypt
+  ctx = cryptor->get_context(CipherMode::CIPHER_MODE_DEC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char dec_out[sizeof(TEST_DATA)];
+  CryptArgs dec_args{out, dec_out, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->decrypt(ctx, dec_args));
+  ASSERT_EQ(0, memcmp(dec_out, TEST_DATA, sizeof(TEST_DATA)));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
+}
+
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, TamperedTag) {
+  auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char out[sizeof(TEST_DATA)];
+  unsigned char meta[48];
+  CryptArgs enc_args{TEST_DATA, out, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->update_context(ctx, enc_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
+
+  // Tamper with HMAC tag
+  meta[0] ^= 0xFF;
+
+  ctx = cryptor->get_context(CipherMode::CIPHER_MODE_DEC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char dec_out[sizeof(TEST_DATA)];
+  CryptArgs dec_args{out, dec_out, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ(-EBADMSG, cryptor->decrypt(ctx, dec_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
+}
+
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, TamperedCiphertext) {
+  auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char out[sizeof(TEST_DATA)];
+  unsigned char meta[48];
+  CryptArgs enc_args{TEST_DATA, out, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->update_context(ctx, enc_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
+
+  // Tamper with ciphertext
+  out[0] ^= 0xFF;
+
+  ctx = cryptor->get_context(CipherMode::CIPHER_MODE_DEC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char dec_out[sizeof(TEST_DATA)];
+  CryptArgs dec_args{out, dec_out, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ(-EBADMSG, cryptor->decrypt(ctx, dec_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
+}
+
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, WrongSectorIV) {
+  auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char out[sizeof(TEST_DATA)];
+  unsigned char meta[48];
+  CryptArgs enc_args{TEST_DATA, out, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->update_context(ctx, enc_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
+
+  // Decrypt with different sector IV (sector reassignment attack)
+  unsigned char wrong_sector_iv[8] = {99};
+  ctx = cryptor->get_context(CipherMode::CIPHER_MODE_DEC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char dec_out[sizeof(TEST_DATA)];
+  CryptArgs dec_args{out, dec_out, sizeof(TEST_DATA),
+                     wrong_sector_iv, sizeof(wrong_sector_iv), meta, 48};
+  ASSERT_EQ(-EBADMSG, cryptor->decrypt(ctx, dec_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
+}
+
+// AF_ALG kernel cross-validation helpers
+
+static const size_t AF_ALG_AUTHSIZE = 32;  // HMAC-SHA256 tag
+static const size_t AF_ALG_XTS_KEY_SIZE = 64;
+static const size_t AF_ALG_HMAC_KEY_SIZE = 32;
+
+// Build RTA-formatted key for kernel authenc:
+// [rtattr hdr | enckeylen be32 | HMAC_KEY | XTS_KEY]
+// librbd key layout: [XTS_KEY(64) | HMAC_KEY(32)]
+// kernel expects:    [HMAC_KEY(32) | XTS_KEY(64)] after RTA header
+static std::vector<unsigned char> build_rta_key(
+    const unsigned char* librbd_key, size_t librbd_key_len) {
+  // RTA_SPACE(sizeof(crypto_authenc_key_param)) = RTA header + 4 bytes param
+  size_t rta_hdr_size = RTA_SPACE(sizeof(uint32_t));
+  size_t total = rta_hdr_size + AF_ALG_HMAC_KEY_SIZE + AF_ALG_XTS_KEY_SIZE;
+  std::vector<unsigned char> buf(total, 0);
+
+  auto* rta = reinterpret_cast<struct rtattr*>(buf.data());
+  rta->rta_type = 1;  // CRYPTO_AUTHENC_KEYA_PARAM
+  rta->rta_len = RTA_LENGTH(sizeof(uint32_t));
+
+  // enckeylen in big-endian
+  auto* param = reinterpret_cast<uint32_t*>(RTA_DATA(rta));
+  *param = htonl(AF_ALG_XTS_KEY_SIZE);
+
+  // After RTA header: HMAC key first, then XTS key
+  unsigned char* key_data = buf.data() + rta_hdr_size;
+  memcpy(key_data, librbd_key + AF_ALG_XTS_KEY_SIZE, AF_ALG_HMAC_KEY_SIZE);
+  memcpy(key_data + AF_ALG_HMAC_KEY_SIZE, librbd_key, AF_ALG_XTS_KEY_SIZE);
+
+  return buf;
+}
+
+// Returns -1 if AF_ALG not available, 0 on success.
+// On encrypt: out = ciphertext, tag_out = 32-byte HMAC tag
+// On decrypt: out = plaintext (tag verified by kernel)
+static int af_alg_authenc_crypt(
+    const unsigned char* librbd_key, size_t key_len,
+    const unsigned char* iv, size_t iv_len,          // 16-byte random IV (XTS tweak)
+    const unsigned char* sector_iv, size_t sector_iv_len,  // 8-byte sector LE
+    const unsigned char* in, size_t in_len,          // plaintext or ciphertext
+    unsigned char* out, size_t out_len,
+    unsigned char* tag, size_t tag_len,              // 32-byte tag (in for decrypt, out for encrypt)
+    bool encrypt) {
+  // Open AF_ALG AEAD socket
+  int tfmfd = socket(AF_ALG, SOCK_SEQPACKET, 0);
+  if (tfmfd < 0) {
+    return -1;
+  }
+
+  struct sockaddr_alg sa = {};
+  sa.salg_family = AF_ALG;
+  strcpy(reinterpret_cast<char*>(sa.salg_type), "aead");
+  strcpy(reinterpret_cast<char*>(sa.salg_name),
+         "authenc(hmac(sha256),xts(aes))");
+
+  if (bind(tfmfd, reinterpret_cast<struct sockaddr*>(&sa), sizeof(sa)) < 0) {
+    close(tfmfd);
+    return -1;
+  }
+
+  // Set key (RTA format)
+  auto rta_key = build_rta_key(librbd_key, key_len);
+  if (setsockopt(tfmfd, SOL_ALG, ALG_SET_KEY,
+                 rta_key.data(), rta_key.size()) < 0) {
+    close(tfmfd);
+    return -1;
+  }
+
+  // Set auth tag size
+  if (setsockopt(tfmfd, SOL_ALG, ALG_SET_AEAD_AUTHSIZE,
+                 NULL, AF_ALG_AUTHSIZE) < 0) {
+    close(tfmfd);
+    return -1;
+  }
+
+  int opfd = accept(tfmfd, NULL, NULL);
+  if (opfd < 0) {
+    close(tfmfd);
+    return -1;
+  }
+
+  // Build sendmsg with cmsg headers: operation, IV, assoclen
+  // Data layout for encrypt: [AAD(24) | plaintext]
+  // Data layout for decrypt: [AAD(24) | ciphertext | tag(32)]
+  size_t aad_len = sector_iv_len + iv_len;  // 8 + 16 = 24
+  size_t send_data_len;
+  if (encrypt) {
+    send_data_len = aad_len + in_len;
+  } else {
+    send_data_len = aad_len + in_len + tag_len;
+  }
+
+  std::vector<unsigned char> send_buf(send_data_len);
+  // AAD: sector_LE || random_IV
+  memcpy(send_buf.data(), sector_iv, sector_iv_len);
+  memcpy(send_buf.data() + sector_iv_len, iv, iv_len);
+  // Data
+  memcpy(send_buf.data() + aad_len, in, in_len);
+  if (!encrypt) {
+    // Append tag for decryption
+    memcpy(send_buf.data() + aad_len + in_len, tag, tag_len);
+  }
+
+  struct iovec iov = {};
+  iov.iov_base = send_buf.data();
+  iov.iov_len = send_data_len;
+
+  // cmsg buffer for: ALG_SET_OP + ALG_SET_IV + ALG_SET_AEAD_ASSOCLEN
+  size_t cmsg_iv_len = sizeof(struct af_alg_iv) + iv_len;
+  size_t cbuf_len = CMSG_SPACE(sizeof(uint32_t)) +   // ALG_SET_OP
+                    CMSG_SPACE(cmsg_iv_len) +         // ALG_SET_IV
+                    CMSG_SPACE(sizeof(uint32_t));      // ALG_SET_AEAD_ASSOCLEN
+  std::vector<char> cbuf(cbuf_len, 0);
+
+  struct msghdr msg = {};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = cbuf.data();
+  msg.msg_controllen = cbuf_len;
+
+  // cmsg 1: ALG_SET_OP
+  struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+  cmsg->cmsg_level = SOL_ALG;
+  cmsg->cmsg_type = ALG_SET_OP;
+  cmsg->cmsg_len = CMSG_LEN(sizeof(uint32_t));
+  *reinterpret_cast<uint32_t*>(CMSG_DATA(cmsg)) =
+      encrypt ? ALG_OP_ENCRYPT : ALG_OP_DECRYPT;
+
+  // cmsg 2: ALG_SET_IV
+  cmsg = CMSG_NXTHDR(&msg, cmsg);
+  cmsg->cmsg_level = SOL_ALG;
+  cmsg->cmsg_type = ALG_SET_IV;
+  cmsg->cmsg_len = CMSG_LEN(cmsg_iv_len);
+  auto* aiv = reinterpret_cast<struct af_alg_iv*>(CMSG_DATA(cmsg));
+  aiv->ivlen = iv_len;
+  memcpy(aiv->iv, iv, iv_len);
+
+  // cmsg 3: ALG_SET_AEAD_ASSOCLEN
+  cmsg = CMSG_NXTHDR(&msg, cmsg);
+  cmsg->cmsg_level = SOL_ALG;
+  cmsg->cmsg_type = ALG_SET_AEAD_ASSOCLEN;
+  cmsg->cmsg_len = CMSG_LEN(sizeof(uint32_t));
+  *reinterpret_cast<uint32_t*>(CMSG_DATA(cmsg)) = aad_len;
+
+  ssize_t sent = sendmsg(opfd, &msg, 0);
+  if (sent < 0 || static_cast<size_t>(sent) != send_data_len) {
+    close(opfd);
+    close(tfmfd);
+    return -1;
+  }
+
+  // Receive result
+  // Encrypt output: [AAD(24) | ciphertext | tag(32)]
+  // Decrypt output: [AAD(24) | plaintext]
+  size_t recv_data_len;
+  if (encrypt) {
+    recv_data_len = aad_len + in_len + AF_ALG_AUTHSIZE;
+  } else {
+    recv_data_len = aad_len + in_len;
+  }
+  std::vector<unsigned char> recv_buf(recv_data_len);
+
+  ssize_t received = read(opfd, recv_buf.data(), recv_data_len);
+  close(opfd);
+  close(tfmfd);
+
+  if (received < 0) {
+    return received;
+  }
+  if (static_cast<size_t>(received) != recv_data_len) {
+    return -1;
+  }
+
+  // Extract output (skip AAD prefix)
+  if (encrypt) {
+    memcpy(out, recv_buf.data() + aad_len, in_len);
+    memcpy(tag, recv_buf.data() + aad_len + in_len, AF_ALG_AUTHSIZE);
+  } else {
+    memcpy(out, recv_buf.data() + aad_len, in_len);
+  }
+
+  return 0;
+}
+
+// Test: encrypt with librbd, encrypt with kernel, compare ciphertext + tag
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, KernelCrossValidateEncrypt) {
+  // 1. Encrypt with librbd
+  auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char librbd_ct[sizeof(TEST_DATA)];
+  unsigned char meta[48];  // [HMAC tag(32) | random_IV(16)]
+  CryptArgs enc_args{TEST_DATA, librbd_ct, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->update_context(ctx, enc_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
+
+  // Extract librbd's random IV and HMAC tag from metadata
+  const unsigned char* librbd_tag = meta;        // first 32 bytes
+  const unsigned char* random_iv = meta + 32;    // last 16 bytes
+
+  // 2. Encrypt with kernel AF_ALG using the same random IV
+  unsigned char kernel_ct[sizeof(TEST_DATA)];
+  unsigned char kernel_tag[32];
+  int rc = af_alg_authenc_crypt(
+      TEST_AUTHENC_KEY, sizeof(TEST_AUTHENC_KEY),
+      random_iv, 16,
+      TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV),
+      TEST_DATA, sizeof(TEST_DATA),
+      kernel_ct, sizeof(kernel_ct),
+      kernel_tag, sizeof(kernel_tag),
+      true /* encrypt */);
+  if (rc == -1 && (errno == EAFNOSUPPORT || errno == ENOENT)) {
+    GTEST_SKIP() << "AF_ALG not available (kernel module not loaded?)";
+  }
+  ASSERT_EQ(0, rc) << "AF_ALG encrypt failed, errno=" << errno;
+
+  // 3. Compare ciphertext byte-for-byte
+  ASSERT_EQ(0, memcmp(librbd_ct, kernel_ct, sizeof(TEST_DATA)))
+      << "Ciphertext mismatch between librbd and kernel";
+
+  // 4. Compare HMAC tags byte-for-byte
+  ASSERT_EQ(0, memcmp(librbd_tag, kernel_tag, 32))
+      << "HMAC tag mismatch between librbd and kernel";
+}
+
+// Test: encrypt with one side, decrypt with the other
+TEST_F(TestCryptoOpensslAuthEncDataCryptor, KernelCrossDecrypt) {
+  // --- Part A: Encrypt with librbd, decrypt with kernel ---
+  auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char librbd_ct[sizeof(TEST_DATA)];
+  unsigned char meta[48];
+  CryptArgs enc_args{TEST_DATA, librbd_ct, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->update_context(ctx, enc_args));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
+
+  const unsigned char* librbd_tag = meta;
+  const unsigned char* random_iv = meta + 32;
+
+  // Decrypt librbd's ciphertext with kernel
+  unsigned char kernel_pt[sizeof(TEST_DATA)];
+  unsigned char tag_copy[32];
+  memcpy(tag_copy, librbd_tag, 32);
+  int rc = af_alg_authenc_crypt(
+      TEST_AUTHENC_KEY, sizeof(TEST_AUTHENC_KEY),
+      random_iv, 16,
+      TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV),
+      librbd_ct, sizeof(TEST_DATA),
+      kernel_pt, sizeof(kernel_pt),
+      tag_copy, sizeof(tag_copy),
+      false /* decrypt */);
+  if (rc == -1 && (errno == EAFNOSUPPORT || errno == ENOENT)) {
+    GTEST_SKIP() << "AF_ALG not available (kernel module not loaded?)";
+  }
+  ASSERT_EQ(0, rc) << "Kernel failed to decrypt librbd ciphertext, errno=" << errno;
+
+  ASSERT_EQ(0, memcmp(kernel_pt, TEST_DATA, sizeof(TEST_DATA)))
+      << "Kernel decryption of librbd ciphertext produced wrong plaintext";
+
+  // --- Part B: Encrypt with kernel, decrypt with librbd ---
+  unsigned char fixed_iv[16];
+  memset(fixed_iv, 0xAB, sizeof(fixed_iv));
+
+  unsigned char kernel_ct[sizeof(TEST_DATA)];
+  unsigned char kernel_tag[32];
+  rc = af_alg_authenc_crypt(
+      TEST_AUTHENC_KEY, sizeof(TEST_AUTHENC_KEY),
+      fixed_iv, 16,
+      TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV),
+      TEST_DATA, sizeof(TEST_DATA),
+      kernel_ct, sizeof(kernel_ct),
+      kernel_tag, sizeof(kernel_tag),
+      true /* encrypt */);
+  ASSERT_EQ(0, rc) << "AF_ALG encrypt failed, errno=" << errno;
+
+  // Build meta buffer for librbd: [tag(32) | iv(16)]
+  unsigned char kernel_meta[48];
+  memcpy(kernel_meta, kernel_tag, 32);
+  memcpy(kernel_meta + 32, fixed_iv, 16);
+
+  ctx = cryptor->get_context(CipherMode::CIPHER_MODE_DEC);
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(0, cryptor->init_context(ctx, nullptr, 0));
+
+  unsigned char librbd_pt[sizeof(TEST_DATA)];
+  CryptArgs dec_args{kernel_ct, librbd_pt, sizeof(TEST_DATA),
+                     TEST_SECTOR_IV, sizeof(TEST_SECTOR_IV), kernel_meta, 48};
+  ASSERT_EQ((int)sizeof(TEST_DATA), cryptor->decrypt(ctx, dec_args))
+      << "librbd failed to decrypt kernel ciphertext";
+  ASSERT_EQ(0, memcmp(librbd_pt, TEST_DATA, sizeof(TEST_DATA)))
+      << "librbd decryption of kernel ciphertext produced wrong plaintext";
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
 }
 
 } // namespace openssl

--- a/src/test/librbd/crypto/test_mock_BlockCrypto.cc
+++ b/src/test/librbd/crypto/test_mock_BlockCrypto.cc
@@ -76,7 +76,7 @@ struct TestMockCryptoBlockCrypto : public TestFixture {
       _set_last_expectation(
               EXPECT_CALL(*cryptor, update_context(_,
                                                   CompareArrayToString(in_str),
-                                                  _, in_str.length()))
+                                                  _, in_str.length(), _))
               .After(*expectation_set).WillOnce(Return(out_ret)));
     }
 
@@ -147,7 +147,7 @@ TEST_F(TestMockCryptoBlockCrypto, UpdateContextError) {
   data.append(std::string(4096, '1'));
   expect_get_context(CipherMode::CIPHER_MODE_ENC);
   EXPECT_CALL(*cryptor, init_context(_, _, _));
-  EXPECT_CALL(*cryptor, update_context(_, _, _, _)).WillOnce(Return(-123));
+  EXPECT_CALL(*cryptor, update_context(_, _, _, _, _)).WillOnce(Return(-123));
   expect_return_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_EQ(-123, bc->encrypt(&data, 0));
 }

--- a/src/test/librbd/crypto/test_mock_BlockCrypto.cc
+++ b/src/test/librbd/crypto/test_mock_BlockCrypto.cc
@@ -76,7 +76,7 @@ struct TestMockCryptoBlockCrypto : public TestFixture {
       _set_last_expectation(
               EXPECT_CALL(*cryptor, update_context(_,
                                                   CompareArrayToString(in_str),
-                                                  _, in_str.length(), _))
+                                                  _, in_str.length(), _, _,_))
               .After(*expectation_set).WillOnce(Return(out_ret)));
     }
 
@@ -147,7 +147,7 @@ TEST_F(TestMockCryptoBlockCrypto, UpdateContextError) {
   data.append(std::string(4096, '1'));
   expect_get_context(CipherMode::CIPHER_MODE_ENC);
   EXPECT_CALL(*cryptor, init_context(_, _, _));
-  EXPECT_CALL(*cryptor, update_context(_, _, _, _, _)).WillOnce(Return(-123));
+  EXPECT_CALL(*cryptor, update_context(_, _, _, _, _, _, _)).WillOnce(Return(-123));
   expect_return_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_EQ(-123, bc->encrypt(&data, 0));
 }

--- a/src/test/librbd/crypto/test_mock_BlockCrypto.cc
+++ b/src/test/librbd/crypto/test_mock_BlockCrypto.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include <librbd/crypto/DataCryptor.h>
+#include "gmock/gmock.h"
 #include "test/librbd/test_fixture.h"
 #include "librbd/crypto/BlockCrypto.h"
 #include "test/librbd/mock/crypto/MockDataCryptor.h"
@@ -75,8 +77,10 @@ struct TestMockCryptoBlockCrypto : public TestFixture {
     void expect_update_context(const std::string& in_str, int out_ret) {
       _set_last_expectation(
               EXPECT_CALL(*cryptor, update_context(_,
-                                                  CompareArrayToString(in_str),
-                                                  _, in_str.length(), _, _,_))
+                AllOf(
+                  testing::Field(&CryptArgs::len, in_str.length()),
+                  testing::Field(&CryptArgs::in, CompareArrayToString(in_str))
+                )))
               .After(*expectation_set).WillOnce(Return(out_ret)));
     }
 
@@ -147,7 +151,7 @@ TEST_F(TestMockCryptoBlockCrypto, UpdateContextError) {
   data.append(std::string(4096, '1'));
   expect_get_context(CipherMode::CIPHER_MODE_ENC);
   EXPECT_CALL(*cryptor, init_context(_, _, _));
-  EXPECT_CALL(*cryptor, update_context(_, _, _, _, _, _, _)).WillOnce(Return(-123));
+  EXPECT_CALL(*cryptor, update_context(_, _)).WillOnce(Return(-123));
   expect_return_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_EQ(-123, bc->encrypt(&data, 0));
 }

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include "gmock/gmock.h"
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librbd/test_support.h"
 #include "test/librbd/mock/MockImageCtx.h"
@@ -8,9 +9,14 @@
 #include "test/librbd/mock/crypto/MockCryptoInterface.h"
 #include "librbd/crypto/CryptoObjectDispatch.h"
 #include "librbd/io/ObjectDispatchSpec.h"
+#include "test/librbd/mock/crypto/MockEncryptionFormat.h"
 #include "librbd/io/Utils.h"
 
 #include "librbd/io/Utils.cc"
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <librbd/io/Types.h>
+#include <string>
 template bool librbd::io::util::trigger_copyup(
         MockImageCtx *image_ctx, uint64_t object_no, IOContext io_context,
         Context* on_finish);
@@ -107,7 +113,27 @@ using ::testing::Pair;
 using ::testing::Return;
 using ::testing::WithArg;
 
-struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
+struct CryptoTestParams {
+    std::string name;
+    size_t meta_size;
+    size_t data_block_size;
+    size_t rados_object_size;
+};
+
+MATCHER_P(ReadExtentsEq, expected, "matches ReadExtents contents") {
+    if (arg == nullptr) return false;
+    if (arg->size() != expected->size()) return false;
+    
+    for (size_t i = 0; i < expected->size(); ++i) {
+        if ((*arg)[i].offset != (*expected)[i].offset || 
+            (*arg)[i].length != (*expected)[i].length) {
+            return false;
+        }
+    }
+    return true;
+}
+
+struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture, ::testing::WithParamInterface<CryptoTestParams> {
   typedef CryptoObjectDispatch<librbd::MockImageCtx> MockCryptoObjectDispatch;
   typedef io::AbstractObjectWriteRequest<librbd::MockImageCtx>
           MockAbstractObjectWriteRequest;
@@ -132,10 +158,29 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
 
   void SetUp() override {
     TestMockFixture::SetUp();
-
+    const auto& param = GetParam();
+    crypto.meta_size = param.meta_size;
     librbd::ImageCtx *ictx;
     ASSERT_EQ(0, open_image(m_image_name, &ictx));
     mock_image_ctx = new MockImageCtx(*ictx);
+    if (param.meta_size > 0) {
+      ON_CALL(crypto, encrypt(_, _))
+          .WillByDefault(Invoke([&param](ceph::bufferlist* data, uint64_t) {
+            size_t num_blocks = data->length() / param.data_block_size;
+            data->append_zero(num_blocks * param.meta_size);
+            return 0;
+          }));
+      ON_CALL(crypto, decrypt(_, _))
+          .WillByDefault(Invoke([&param](ceph::bufferlist* data, uint64_t) {
+            ceph::bufferlist tmp;
+            size_t blocks_cnt = data->length() /
+                                (param.meta_size + param.data_block_size);
+            size_t data_length = blocks_cnt * param.data_block_size;
+            data->splice(data_length, blocks_cnt * param.meta_size, &tmp);
+            return 0;
+          }));
+    }
+
     mock_crypto_object_dispatch = new MockCryptoObjectDispatch(
             mock_image_ctx, &crypto);
     data.append(std::string(4096, '1'));
@@ -153,36 +198,70 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
     TestMockFixture::TearDown();
   }
 
-  void expect_object_read(io::ReadExtents* extents, uint64_t version = 0) {
+  void expect_object_read(io::ReadExtents* data_extents = nullptr,
+                          uint64_t version = 0) {
+    const auto& params = GetParam();
     EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, send(_))
-            .WillOnce(Invoke([this, extents,
-                              version](io::ObjectDispatchSpec* spec) {
-                auto* read = std::get_if<io::ObjectDispatchSpec::ReadRequest>(
-                        &spec->request);
-                ASSERT_TRUE(read != nullptr);
+        .WillRepeatedly(Invoke([this, data_extents, version,
+                                params](io::ObjectDispatchSpec *spec) {
+          auto *read = std::get_if<io::ObjectDispatchSpec::ReadRequest>(
+              &spec->request);
+          ASSERT_TRUE(read != nullptr);
 
-                ASSERT_EQ(extents->size(), read->extents->size());
-                for (uint64_t i = 0; i < extents->size(); ++i) {
-                  ASSERT_EQ((*extents)[i].offset, (*read->extents)[i].offset);
-                  ASSERT_EQ((*extents)[i].length, (*read->extents)[i].length);
-                  (*read->extents)[i].bl = (*extents)[i].bl;
-                  (*read->extents)[i].extent_map = (*extents)[i].extent_map;
+          if (spec->dispatch_layer ==
+              io::OBJECT_DISPATCH_LAYER_CRYPTO) {
+            // Aligned read at crypto layer — provide data
+            if (data_extents != nullptr) {
+              if (params.meta_size > 0) {
+                // AEAD: physical extents are data+meta pairs
+                ASSERT_EQ(data_extents->size() * 2,
+                          read->extents->size());
+                for (uint64_t i = 0; i < data_extents->size(); ++i) {
+                  (*read->extents)[i * 2].bl =
+                      (*data_extents)[i].bl;
+                  (*read->extents)[i * 2].extent_map =
+                      (*data_extents)[i].extent_map;
+                  auto meta_len =
+                      (*read->extents)[i * 2 + 1].length;
+                  (*read->extents)[i * 2 + 1].bl.append_zero(
+                      meta_len);
                 }
-
-                if (read->version != nullptr) {
-                  *(read->version) = version;
+              } else {
+                // XTS: physical extents match data extents 1:1
+                ASSERT_EQ(data_extents->size(),
+                          read->extents->size());
+                for (uint64_t i = 0; i < data_extents->size();
+                     ++i) {
+                  (*read->extents)[i].bl = (*data_extents)[i].bl;
+                  (*read->extents)[i].extent_map =
+                      (*data_extents)[i].extent_map;
                 }
+              }
+            }
 
-                spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
-                dispatcher_ctx = &spec->dispatcher_ctx;
-            }));
+            if (read->version != nullptr) {
+              *(read->version) = version;
+            }
+
+            spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
+            dispatcher_ctx = &spec->dispatcher_ctx;
+          } else {
+            // Unaligned re-dispatch through crypto layer
+            mock_crypto_object_dispatch->read(
+                read->object_no, read->extents,
+                mock_image_ctx->get_data_io_context(), 0,
+                read->read_flags, {}, read->version,
+                &object_dispatch_flags, &spec->dispatch_result,
+                &on_finish, spec->dispatcher_ctx.on_finish);
+          }
+        }));
   }
 
   void expect_read_parent(MockUtils &mock_utils, uint64_t object_no,
                           io::ReadExtents* extents, librados::snap_t snap_id,
                           int r) {
     EXPECT_CALL(mock_utils,
-                read_parent(_, object_no, extents, snap_id, _, _))
+                read_parent(_, object_no, ReadExtentsEq(extents), snap_id, _, _))
             .WillOnce(WithArg<5>(CompleteContext(
                     r, static_cast<asio::ContextWQ*>(nullptr))));
   }
@@ -220,9 +299,10 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
             }));
   }
 
-  void expect_get_object_size() {
-    EXPECT_CALL(*mock_image_ctx, get_object_size()).WillOnce(Return(
-            mock_image_ctx->layout.object_size));
+  void expect_get_object_size(int count = 1) {
+    const auto& params = GetParam();
+    EXPECT_CALL(*mock_image_ctx, get_object_size()).Times(count).WillRepeatedly(Return(
+            params.rados_object_size));
   }
 
   void expect_get_parent_overlap(uint64_t overlap) {
@@ -251,16 +331,16 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
             }));
   }
 
-  void expect_encrypt(int count = 1) {
-    EXPECT_CALL(crypto, encrypt(_, _)).Times(count);
-  }
-
   void expect_decrypt(int count = 1) {
-    EXPECT_CALL(crypto, decrypt(_, _)).Times(count);
-  }
+      EXPECT_CALL(crypto, decrypt(_, _)).Times(count);
+    }
+
+  void expect_encrypt(int count = 1) {
+      EXPECT_CALL(crypto, encrypt(_, _)).Times(count);
+    }
 };
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, Flush) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, Flush) {
   ASSERT_FALSE(mock_crypto_object_dispatch->flush(
           io::FLUSH_SOURCE_USER, {}, nullptr, nullptr, &on_finish, nullptr));
   ASSERT_EQ(on_finish, &finished_cond); // not modified
@@ -268,7 +348,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, Flush) {
   ASSERT_EQ(0, finished_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, Discard) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, Discard) {
   expect_object_write_same();
   ASSERT_TRUE(mock_crypto_object_dispatch->discard(
           11, 0, 4096, mock_image_ctx->get_data_io_context(), 0, {},
@@ -281,8 +361,11 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, Discard) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedReadFail) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, AlignedReadFail) {
   io::ReadExtents extents = {{0, 4096}};
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size();
+  }
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
       11, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
@@ -296,15 +379,19 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedReadFail) {
   ASSERT_EQ(-EIO, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedRead) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, AlignedRead) {
+  io::ReadExtents user_extents = {{0, 16384}, {32768, 4096}};
   io::ReadExtents extents = {{0, 16384}, {32768, 4096}};
   extents[0].bl.append(std::string(1024, '1') + std::string(1024, '2') +
                        std::string(1024, '3') + std::string(1024, '4'));
   extents[0].extent_map = {{1024, 1024}, {3072, 2048}, {16384 - 1024, 1024}};
   extents[1].bl.append(std::string(4096, '0'));
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size();
+  }
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
-          11, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
+          11, &user_extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
           nullptr, &object_dispatch_flags, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -320,13 +407,16 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedRead) {
           std::string(1024, '\0') + std::string(1024, '2') +
           std::string(1024, '3') + std::string(3072, '\0') +
           std::string(3072, '\0') + std::string(1024, '4'));
-  ASSERT_TRUE(extents[0].bl.to_str() == expected_bl_data);
-  ASSERT_THAT(extents[0].extent_map,
+  ASSERT_TRUE(user_extents[0].bl.to_str() == expected_bl_data);
+  ASSERT_THAT(user_extents[0].extent_map,
               ElementsAre(Pair(0, 8192), Pair(16384 - 4096, 4096)));
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, ReadFromParent) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, ReadFromParent) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size();
+  }
   expect_object_read(&extents);
   expect_read_parent(mock_utils, 11, &extents, CEPH_NOSNAP, 8192);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
@@ -342,8 +432,11 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, ReadFromParent) {
   ASSERT_EQ(8192, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, ReadFromParentDisabled) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, ReadFromParentDisabled) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size();
+  }
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
           11, &extents, mock_image_ctx->get_data_io_context(), 0,
@@ -359,12 +452,12 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, ReadFromParentDisabled) {
   ASSERT_EQ(-ENOENT, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedRead) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedRead) {
   io::ReadExtents extents = {{0, 1}, {8191, 1}, {8193, 1},
                              {16384 + 1, 4096 * 5 - 2}};
   io::ReadExtents aligned_extents = {{0, 4096}, {4096, 4096}, {8192, 4096},
                                      {16384, 4096 * 5}};
-  aligned_extents[0].bl.append(std::string("1") + std::string(4096, '0'));
+  aligned_extents[0].bl.append(std::string("1") + std::string(4095, '0')); // 4KB read not 4097!
   aligned_extents[1].bl.append(std::string(4095, '0') + std::string("2"));
   aligned_extents[2].bl.append(std::string("03") + std::string(4094, '0'));
   aligned_extents[3].bl.append(std::string("0") + std::string(4095, '4') +
@@ -372,7 +465,10 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedRead) {
                                std::string(4095, '6') + std::string("0"));
   aligned_extents[3].extent_map = {{16384, 4096}, {16384 + 2 * 4096, 4096},
                                    {16384 + 4 * 4096, 4096}};
-
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size();
+  }
+  expect_decrypt(6);
   expect_object_read(&aligned_extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
           11, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
@@ -396,11 +492,12 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedRead) {
                           Pair(16384 + 4 * 4096, 4095)));
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedWrite) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, AlignedWrite) {
   expect_encrypt();
+  int object_dispatch_flags = 0;
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
         11, 0, std::move(data), mock_image_ctx->get_data_io_context(), 0, 0,
-        std::nullopt, {}, nullptr, nullptr, &dispatch_result, &on_finish,
+        std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish,
         on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_CONTINUE);
   ASSERT_EQ(on_finish, &finished_cond); // not modified
@@ -408,14 +505,18 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedWrite) {
   ASSERT_EQ(0, finished_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWrite) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWrite) {
   ceph::bufferlist write_data;
   uint64_t version = 1234;
   write_data.append(std::string(8192, '1'));
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   extents[0].bl.append(std::string(4096, '2'));
   extents[1].bl.append(std::string(4096, '3'));
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size();
+  }
   expect_object_read(&extents, version);
+  expect_decrypt(2);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::nullopt, {}, nullptr, nullptr, &dispatch_result,
@@ -432,10 +533,13 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWrite) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithNoObject) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithNoObject) {
   ceph::bufferlist write_data;
   write_data.append(std::string(8192, '1'));
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size();
+  }
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
@@ -456,10 +560,16 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithNoObject) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailCreate) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailCreate) {
   ceph::bufferlist write_data;
   write_data.append(std::string(8192, '1'));
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(3);
+  } else {
+    expect_get_object_size();
+  }
+  expect_decrypt(2);
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
@@ -468,7 +578,6 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailCreate) {
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
-  expect_get_object_size();
   expect_get_parent_overlap(0);
   auto expected_data = (std::string(1, '\0') + std::string(8192, '1') +
                         std::string(4095, '\0'));
@@ -493,15 +602,20 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailCreate) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteCopyup) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWriteCopyup) {
   MockObjectMap mock_object_map;
   mock_image_ctx->object_map = &mock_object_map;
   MockExclusiveLock mock_exclusive_lock;
   mock_image_ctx->exclusive_lock = &mock_exclusive_lock;
-
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(3);
+  } else {
+    expect_get_object_size();
+  }
   ceph::bufferlist write_data;
   write_data.append(std::string(8192, '1'));
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
+  expect_decrypt(2);
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
@@ -510,7 +624,6 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteCopyup) {
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
-  expect_get_object_size();
   expect_get_parent_overlap(100 << 20);
   expect_prune_parent_extents(mock_image_ctx->layout.object_size);
   EXPECT_CALL(mock_exclusive_lock, is_lock_owner()).WillRepeatedly(
@@ -537,7 +650,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteCopyup) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteEmptyCopyup) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWriteEmptyCopyup) {
   MockObjectMap mock_object_map;
   mock_image_ctx->object_map = &mock_object_map;
   MockExclusiveLock mock_exclusive_lock;
@@ -546,6 +659,11 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteEmptyCopyup) {
   ceph::bufferlist write_data;
   write_data.append(std::string(8192, '1'));
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(3);
+  } else {
+    expect_get_object_size();
+  }
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
@@ -554,7 +672,6 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteEmptyCopyup) {
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
-  expect_get_object_size();
   expect_get_parent_overlap(100 << 20);
   expect_prune_parent_extents(mock_image_ctx->layout.object_size);
   EXPECT_CALL(mock_exclusive_lock, is_lock_owner()).WillRepeatedly(
@@ -580,13 +697,17 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteEmptyCopyup) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailVersionCheck) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailVersionCheck) {
   ceph::bufferlist write_data;
   uint64_t version = 1234;
   write_data.append(std::string(8192, '1'));
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   extents[0].bl.append(std::string(4096, '2'));
   extents[1].bl.append(std::string(4096, '3'));
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(2);
+  }
+  expect_decrypt(4);
   expect_object_read(&extents, version);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
@@ -602,6 +723,8 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailVersionCheck) {
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
 
   version = 1235;
+  extents[0].bl.clear();
+  extents[1].bl.clear();
   expect_object_read(&extents, version);
   extents[0].bl.append(std::string(4096, '2'));
   extents[1].bl.append(std::string(4096, '3'));
@@ -615,7 +738,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailVersionCheck) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithAssertVersion) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithAssertVersion) {
   ceph::bufferlist write_data;
   uint64_t version = 1234;
   uint64_t assert_version = 1233;
@@ -623,6 +746,10 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithAssertVersion) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   extents[0].bl.append(std::string(4096, '2'));
   extents[1].bl.append(std::string(4096, '3'));
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(1);
+  }
+  expect_decrypt(2);
   expect_object_read(&extents, version);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
@@ -635,12 +762,16 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithAssertVersion) {
   ASSERT_EQ(-ERANGE, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithExclusiveCreate) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithExclusiveCreate) {
   ceph::bufferlist write_data;
   write_data.append(std::string(8192, '1'));
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   extents[0].bl.append(std::string(4096, '2'));
   extents[1].bl.append(std::string(4096, '3'));
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(1);
+  }
+  expect_decrypt(2);
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
           11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
@@ -653,7 +784,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithExclusiveCreate) {
   ASSERT_EQ(-EEXIST, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWrite) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, CompareAndWrite) {
   ceph::bufferlist write_data;
   uint64_t version = 1234;
   write_data.append(std::string(8192, '1'));
@@ -663,6 +794,10 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWrite) {
   extents[0].bl.append(std::string(4096, '2'));
   extents[1].bl.append(std::string(4096, '3'));
   extents[2].bl.append(std::string(8192, '2'));
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(1);
+  }
+  expect_decrypt(3);
   expect_object_read(&extents, version);
 
   ASSERT_TRUE(mock_crypto_object_dispatch->compare_and_write(
@@ -681,7 +816,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWrite) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWriteFail) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, CompareAndWriteFail) {
   ceph::bufferlist write_data;
   uint64_t version = 1234;
   write_data.append(std::string(8192, '1'));
@@ -691,6 +826,10 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWriteFail) {
   extents[0].bl.append(std::string(4096, '2'));
   extents[1].bl.append(std::string(4096, '3'));
   extents[2].bl.append(std::string(8192, '2'));
+  if (GetParam().meta_size > 0) {
+    expect_get_object_size(1);
+  }
+  expect_decrypt(3);
   expect_object_read(&extents, version);
 
   uint64_t mismatch_offset;
@@ -706,7 +845,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWriteFail) {
   ASSERT_EQ(mismatch_offset, 4094);
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, WriteSame) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, WriteSame) {
   io::LightweightBufferExtents buffer_extents;
   ceph::bufferlist write_data;
   write_data.append(std::string("12"));
@@ -722,7 +861,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, WriteSame) {
   ASSERT_EQ(0, dispatched_cond.wait());
 }
 
-TEST_F(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
+TEST_P(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   char* data = (char*)"0123456789";
   io::SnapshotSparseBufferlist snapshot_sparse_bufferlist;
   auto& snap1 = snapshot_sparse_bufferlist[0];
@@ -752,6 +891,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   auto& snap1_result = snapshot_sparse_bufferlist[0];
   auto& snap2_result = snapshot_sparse_bufferlist[1];
 
+  // snap1: 3 source extents aligned to 3 contiguous blocks {0, 12288}
   auto it = snap1_result.begin();
   ASSERT_NE(it, snap1_result.end());
   ASSERT_EQ(0, it.get_off());
@@ -761,8 +901,17 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
     std::string("1") + std::string(4095, '\0') +
     std::string(4095, '\0') + std::string("2") +
     std::string(1, '\0') + std::string("345") + std::string(4092, '\0'));
+
+  if (GetParam().meta_size > 0) {
+    // AEAD: meta for 3 blocks at object_size
+    uint64_t obj_size = mock_image_ctx->layout.object_size;
+    ASSERT_NE(++it, snap1_result.end());
+    ASSERT_EQ(obj_size, it.get_off());
+    ASSERT_EQ(3 * GetParam().meta_size, it.get_len());
+  }
   ASSERT_EQ(++it, snap1_result.end());
 
+  // snap2: 3 blocks contiguous {0, 12288} + 1 block at {16384, 4096}
   it = snap2_result.begin();
   ASSERT_NE(it, snap2_result.end());
   ASSERT_EQ(0, it.get_off());
@@ -777,8 +926,34 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   ASSERT_EQ(4096, it.get_len());
   ASSERT_TRUE(it.get_val().bl.to_str() ==
     std::string("9") + std::string(4095, '\0'));
+
+  if (GetParam().meta_size > 0) {
+    // AEAD: meta for first group (3 blocks) at object_size
+    uint64_t obj_size = mock_image_ctx->layout.object_size;
+    ASSERT_NE(++it, snap2_result.end());
+    ASSERT_EQ(obj_size, it.get_off());
+    ASSERT_EQ(3 * GetParam().meta_size, it.get_len());
+
+    // AEAD: meta for second group (1 block at block_num=4) at
+    // object_size + 4 * meta_size
+    ASSERT_NE(++it, snap2_result.end());
+    ASSERT_EQ(obj_size + 4 * GetParam().meta_size, it.get_off());
+    ASSERT_EQ(GetParam().meta_size, it.get_len());
+  }
   ASSERT_EQ(++it, snap2_result.end());
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    EncryptionModes,
+    TestMockCryptoCryptoObjectDispatch,
+    ::testing::Values(
+        CryptoTestParams{"aes_xts", 0, 4096, 4194304},   // Default mode (0 tag)
+        CryptoTestParams{"aes_aead", 32, 4096, 4194304}  // AEAD mode (16 byte tag)
+    ),
+    [](const ::testing::TestParamInfo<CryptoTestParams>& info) {
+        return info.param.name;
+    }
+);
 
 } // namespace crypto
 } // namespace librbd

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -881,7 +881,16 @@ TEST_P(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
                           ceph::bufferlist::static_from_mem(data + 9, 1)});
 
   expect_get_object_size();
-  expect_encrypt(6);
+
+  // AEAD encrypts the full object in one call per snapshot to generate
+  // integrity tags for all blocks. 
+  // Non-AEAD encrypts each aligned extent independently.
+  if (GetParam().meta_size > 0) {
+    expect_encrypt(2);  // 1 full-object encrypt * 2 snapshots
+  } else {
+    expect_encrypt(6);  // 3 extents * 2 snapshots
+  }
+
   InSequence seq;
   ASSERT_EQ(0, mock_crypto_object_dispatch->prepare_copyup(
       11, &snapshot_sparse_bufferlist));
@@ -891,7 +900,57 @@ TEST_P(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   auto& snap1_result = snapshot_sparse_bufferlist[0];
   auto& snap2_result = snapshot_sparse_bufferlist[1];
 
-  // snap1: 3 source extents aligned to 3 contiguous blocks {0, 12288}
+  if (GetParam().meta_size > 0) {
+    // AEAD encrypts the full object so every block has an integrity tag.
+    // Ao ther object data will be at range [0, object_size) and tags at range [object_size,
+    // object_size + total_meta), which SparseBufferlist merges into one
+    // contiguous extent for sparse_copyup.
+    uint64_t obj_size = mock_image_ctx->layout.object_size;
+    uint64_t num_blocks = obj_size / GetParam().data_block_size;
+    uint64_t total_meta = num_blocks * GetParam().meta_size;
+    uint64_t total_len = obj_size + total_meta;
+
+    // snap1: full object data + meta (merged), sparse data overlaid
+    auto it = snap1_result.begin();
+    ASSERT_NE(it, snap1_result.end());
+    ASSERT_EQ(0, it.get_off());
+    ASSERT_EQ(total_len, it.get_len());
+
+    // verify data portion: extents overlaid on zero-filled object buffer
+    std::string snap1_data = it.get_val().bl.to_str().substr(0, obj_size);
+    std::string expected(obj_size, '\0');
+    expected[0] = '1';
+    expected[8191] = '2';
+    expected[8193] = '3'; 
+    expected[8194] = '4'; 
+    expected[8195] = '5';
+    ASSERT_TRUE(snap1_data == expected);
+
+    ASSERT_EQ(++it, snap1_result.end());
+
+    // snap2: accumulated state (snap1 current_bl + snap2 overlays)
+    // snap2 zeroes [0,2), writes "678" at [8191,8194), writes "9" at 16384
+    it = snap2_result.begin();
+    ASSERT_NE(it, snap2_result.end());
+    ASSERT_EQ(0, it.get_off());
+    ASSERT_EQ(total_len, it.get_len());
+
+    std::string snap2_data = it.get_val().bl.to_str().substr(0, obj_size);
+    std::string expected2(obj_size, '\0');
+    // offset 0-1 zeroed by snap2 (was "1\0")
+    // offset 8191-8193 overwritten by snap2 "678"
+    // offset 8194-8195 remain "45" from snap1
+    expected2[8191] = '6'; 
+    expected2[8192] = '7';
+    expected2[8193] = '8'; 
+    expected2[8194] = '4'; 
+    expected2[8195] = '5';
+    expected2[16384] = '9';
+    ASSERT_TRUE(snap2_data == expected2);
+
+    ASSERT_EQ(++it, snap2_result.end());
+    return;
+  }
   auto it = snap1_result.begin();
   ASSERT_NE(it, snap1_result.end());
   ASSERT_EQ(0, it.get_off());
@@ -901,14 +960,6 @@ TEST_P(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
     std::string("1") + std::string(4095, '\0') +
     std::string(4095, '\0') + std::string("2") +
     std::string(1, '\0') + std::string("345") + std::string(4092, '\0'));
-
-  if (GetParam().meta_size > 0) {
-    // AEAD: meta for 3 blocks at object_size
-    uint64_t obj_size = mock_image_ctx->layout.object_size;
-    ASSERT_NE(++it, snap1_result.end());
-    ASSERT_EQ(obj_size, it.get_off());
-    ASSERT_EQ(3 * GetParam().meta_size, it.get_len());
-  }
   ASSERT_EQ(++it, snap1_result.end());
 
   // snap2: 3 blocks contiguous {0, 12288} + 1 block at {16384, 4096}
@@ -926,20 +977,6 @@ TEST_P(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   ASSERT_EQ(4096, it.get_len());
   ASSERT_TRUE(it.get_val().bl.to_str() ==
     std::string("9") + std::string(4095, '\0'));
-
-  if (GetParam().meta_size > 0) {
-    // AEAD: meta for first group (3 blocks) at object_size
-    uint64_t obj_size = mock_image_ctx->layout.object_size;
-    ASSERT_NE(++it, snap2_result.end());
-    ASSERT_EQ(obj_size, it.get_off());
-    ASSERT_EQ(3 * GetParam().meta_size, it.get_len());
-
-    // AEAD: meta for second group (1 block at block_num=4) at
-    // object_size + 4 * meta_size
-    ASSERT_NE(++it, snap2_result.end());
-    ASSERT_EQ(obj_size + 4 * GetParam().meta_size, it.get_off());
-    ASSERT_EQ(GetParam().meta_size, it.get_len());
-  }
   ASSERT_EQ(++it, snap2_result.end());
 }
 

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -7,6 +7,7 @@
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/librbd/mock/MockJournal.h"
 #include "test/librbd/mock/MockObjectMap.h"
+#include "test/librbd/mock/crypto/MockEncryptionFormat.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librados_test_stub/MockTestMemRadosClient.h"
 #include "include/rbd/librbd.hpp"

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -8,6 +8,7 @@
 #include "test/librbd/mock/cache/MockImageCache.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "test/librbd/mock/crypto/MockEncryptionFormat.h"
 #include "include/rbd/librbd.hpp"
 #include "librbd/io/CopyupRequest.h"
 #include "librbd/io/ImageRequest.h"

--- a/src/test/librbd/mock/crypto/MockCryptoInterface.h
+++ b/src/test/librbd/mock/crypto/MockCryptoInterface.h
@@ -15,6 +15,8 @@ struct MockCryptoInterface : CryptoInterface {
 
   static const uint64_t BLOCK_SIZE = 4096;
   static const uint64_t DATA_OFFSET = 4 * 1024 * 1024;
+  uint32_t meta_size;
+  MockCryptoInterface(uint32_t meta_size = 0) : meta_size(meta_size) {}
 
   MOCK_METHOD2(encrypt, int(ceph::bufferlist*, uint64_t));
   MOCK_METHOD2(decrypt, int(ceph::bufferlist*, uint64_t));
@@ -27,6 +29,10 @@ struct MockCryptoInterface : CryptoInterface {
 
   uint64_t get_data_offset() const override {
     return DATA_OFFSET;
+  }
+
+  uint32_t get_meta_size() const override{
+    return meta_size;
   }
 };
 

--- a/src/test/librbd/mock/crypto/MockCryptoInterface.h
+++ b/src/test/librbd/mock/crypto/MockCryptoInterface.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_TEST_LIBRBD_MOCK_CRYPTO_MOCK_CRYPTO_INTERFACE_H
 #define CEPH_TEST_LIBRBD_MOCK_CRYPTO_MOCK_CRYPTO_INTERFACE_H
 
+#include <include/buffer_fwd.h>
 #include "include/buffer.h"
 #include "gmock/gmock.h"
 #include "librbd/crypto/CryptoInterface.h"
@@ -20,6 +21,7 @@ struct MockCryptoInterface : CryptoInterface {
 
   MOCK_METHOD2(encrypt, int(ceph::bufferlist*, uint64_t));
   MOCK_METHOD2(decrypt, int(ceph::bufferlist*, uint64_t));
+
   MOCK_CONST_METHOD0(get_key, const unsigned char*());
   MOCK_CONST_METHOD0(get_key_length, int());
 
@@ -31,7 +33,7 @@ struct MockCryptoInterface : CryptoInterface {
     return DATA_OFFSET;
   }
 
-  uint32_t get_meta_size() const override{
+  uint32_t get_meta_size() const override {
     return meta_size;
   }
 };

--- a/src/test/librbd/mock/crypto/MockDataCryptor.h
+++ b/src/test/librbd/mock/crypto/MockDataCryptor.h
@@ -30,12 +30,12 @@ public:
   MOCK_METHOD2(return_context, void(MockCryptoContext*, CipherMode));
   MOCK_CONST_METHOD3(init_context, int(MockCryptoContext*,
                                        const unsigned char*, uint32_t));
-  MOCK_CONST_METHOD5(update_context, int(MockCryptoContext*,
+  MOCK_CONST_METHOD7(update_context, int(MockCryptoContext*,
                                          const unsigned char*, unsigned char*,
-                                         uint32_t, uint32_t));
-  MOCK_CONST_METHOD5(decrypt, int(MockCryptoContext*,
+                                         uint32_t, uint32_t, const unsigned char*, uint32_t));
+  MOCK_CONST_METHOD7(decrypt, int(MockCryptoContext*,
                                          const unsigned char*, unsigned char*,
-                                         uint32_t, uint32_t));
+                                         uint32_t, uint32_t, const unsigned char*, uint32_t));
   MOCK_CONST_METHOD0(get_key, const unsigned char*());
   MOCK_CONST_METHOD0(get_key_length, int());
 };

--- a/src/test/librbd/mock/crypto/MockDataCryptor.h
+++ b/src/test/librbd/mock/crypto/MockDataCryptor.h
@@ -30,9 +30,12 @@ public:
   MOCK_METHOD2(return_context, void(MockCryptoContext*, CipherMode));
   MOCK_CONST_METHOD3(init_context, int(MockCryptoContext*,
                                        const unsigned char*, uint32_t));
-  MOCK_CONST_METHOD4(update_context, int(MockCryptoContext*,
+  MOCK_CONST_METHOD5(update_context, int(MockCryptoContext*,
                                          const unsigned char*, unsigned char*,
-                                         uint32_t));
+                                         uint32_t, uint32_t));
+  MOCK_CONST_METHOD5(decrypt, int(MockCryptoContext*,
+                                         const unsigned char*, unsigned char*,
+                                         uint32_t, uint32_t));
   MOCK_CONST_METHOD0(get_key, const unsigned char*());
   MOCK_CONST_METHOD0(get_key_length, int());
 };

--- a/src/test/librbd/mock/crypto/MockDataCryptor.h
+++ b/src/test/librbd/mock/crypto/MockDataCryptor.h
@@ -30,12 +30,8 @@ public:
   MOCK_METHOD2(return_context, void(MockCryptoContext*, CipherMode));
   MOCK_CONST_METHOD3(init_context, int(MockCryptoContext*,
                                        const unsigned char*, uint32_t));
-  MOCK_CONST_METHOD7(update_context, int(MockCryptoContext*,
-                                         const unsigned char*, unsigned char*,
-                                         uint32_t, uint32_t, const unsigned char*, uint32_t));
-  MOCK_CONST_METHOD7(decrypt, int(MockCryptoContext*,
-                                         const unsigned char*, unsigned char*,
-                                         uint32_t, uint32_t, const unsigned char*, uint32_t));
+  MOCK_CONST_METHOD2(update_context, int(MockCryptoContext*, const CryptArgs&));
+  MOCK_CONST_METHOD2(decrypt, int(MockCryptoContext*, const CryptArgs&));
   MOCK_CONST_METHOD0(get_key, const unsigned char*());
   MOCK_CONST_METHOD0(get_key_length, int());
 };

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2465,6 +2465,297 @@ TEST_F(TestLibRBD, TestEncryptionLUKS2)
   rados_ioctx_destroy(ioctx);
 }
 
+#ifdef HAVE_CRYPT_FORMAT_INLINE
+TEST_F(TestLibRBD, TestEncryptionLUKS2_AEAD)
+{
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));
+
+  rados_ioctx_t ioctx;
+  rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
+
+  int order = 0;
+  std::string name = get_temp_image_name();
+  uint64_t size = 32 << 20;
+
+  ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
+
+  rbd_image_t image;
+  rbd_encryption_luks2_format_options_t luks2_opts = {
+          .alg = RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256,
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  rbd_encryption_luks_format_options_t luks_opts = {
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_EQ(0, rbd_encryption_format(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+  ASSERT_EQ(-EEXIST, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+
+  ASSERT_PASSED(write_test_data, image, "test", 0, 4, 0);
+  ASSERT_EQ(0, rbd_close(image));
+
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_EQ(0, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+  ASSERT_PASSED(read_test_data, image, "test", 0, 4, 0);
+  ASSERT_EQ(0, rbd_close(image));
+
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_EQ(0, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
+  ASSERT_PASSED(read_test_data, image, "test", 0, 4, 0);
+
+  ASSERT_EQ(0, rbd_close(image));
+  rados_ioctx_destroy(ioctx);
+}
+
+TEST_F(TestLibRBD, TestCloneEncryptionAEAD)
+{
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  rados_ioctx_t ioctx;
+  rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
+
+  // create base image, write 'a's
+  int order = 0;
+  std::string name = get_temp_image_name();
+  uint64_t size = 256 << 20;
+  ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
+
+  rbd_image_t image;
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_PASSED(write_test_data, image, "aaaa", 0, 4, 0);
+  ASSERT_EQ(0, rbd_flush(image));
+
+  // clone, encrypt with LUKS2 (xts-plain64), write 'b's
+  ASSERT_EQ(0, rbd_snap_create(image, "snap"));
+  ASSERT_EQ(0, rbd_snap_protect(image, "snap"));
+
+  rbd_image_options_t image_opts;
+  rbd_image_options_create(&image_opts);
+  BOOST_SCOPE_EXIT_ALL( (&image_opts) ) {
+    rbd_image_options_destroy(image_opts);
+  };
+  std::string child1_name = get_temp_image_name();
+  ASSERT_EQ(0, rbd_clone3(ioctx, name.c_str(), "snap", ioctx,
+                          child1_name.c_str(), image_opts));
+
+  rbd_image_t child1;
+  ASSERT_EQ(0, rbd_open(ioctx, child1_name.c_str(), &child1, NULL));
+
+  rbd_encryption_luks2_format_options_t child1_opts = {
+          .alg = RBD_ENCRYPTION_ALGORITHM_AES256,
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  ASSERT_EQ(0, rbd_encryption_format(
+          child1, RBD_ENCRYPTION_FORMAT_LUKS2, &child1_opts,
+          sizeof(child1_opts)));
+  ASSERT_EQ(0, rbd_encryption_load(
+          child1, RBD_ENCRYPTION_FORMAT_LUKS2, &child1_opts,
+          sizeof(child1_opts)));
+  ASSERT_PASSED(write_test_data, child1, "bbbb", 64 << 20, 4, 0);
+  ASSERT_EQ(0, rbd_flush(child1));
+
+  // clone, encrypt with LUKS2 AEAD, write 'c's
+  ASSERT_EQ(0, rbd_snap_create(child1, "snap"));
+  ASSERT_EQ(0, rbd_snap_protect(child1, "snap"));
+
+  std::string child2_name = get_temp_image_name();
+  ASSERT_EQ(0, rbd_clone3(ioctx, child1_name.c_str(), "snap", ioctx,
+                          child2_name.c_str(), image_opts));
+
+  rbd_image_t child2;
+  ASSERT_EQ(0, rbd_open(ioctx, child2_name.c_str(), &child2, NULL));
+
+  rbd_encryption_luks2_format_options_t child2_opts = {
+          .alg = RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256,
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  ASSERT_EQ(0, rbd_encryption_format(
+          child2, RBD_ENCRYPTION_FORMAT_LUKS2, &child2_opts,
+          sizeof(child2_opts)));
+
+  // multi-spec load: child2 (AEAD) + child1 (xts-plain64)
+  rbd_encryption_spec_t specs[] = {
+          { .format = RBD_ENCRYPTION_FORMAT_LUKS2,
+            .opts = &child2_opts,
+            .opts_size = sizeof(child2_opts)},
+          { .format = RBD_ENCRYPTION_FORMAT_LUKS2,
+            .opts = &child1_opts,
+            .opts_size = sizeof(child1_opts)}
+  };
+  ASSERT_EQ(0, rbd_encryption_load2(child2, specs, 2));
+
+  ASSERT_PASSED(write_test_data, child2, "cccc", 128 << 20, 4, 0);
+  ASSERT_EQ(0, rbd_flush(child2));
+
+  // verify all data through the clone chain
+  ASSERT_PASSED(read_test_data, child2, "aaaa", 0, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "bbbb", 64 << 20, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "cccc", 128 << 20, 4, 0);
+
+  // flatten child2
+  ASSERT_EQ(0, rbd_flatten(child2));
+
+  // reopen and load with single LUKS spec
+  ASSERT_EQ(0, rbd_close(child2));
+  ASSERT_EQ(0, rbd_open(ioctx, child2_name.c_str(), &child2, NULL));
+  rbd_encryption_luks_format_options_t luks_opts = {
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  ASSERT_EQ(0, rbd_encryption_load(
+          child2, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
+
+  // verify flattened image
+  ASSERT_PASSED(read_test_data, child2, "aaaa", 0, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "bbbb", 64 << 20, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "cccc", 128 << 20, 4, 0);
+
+  // cleanup
+  ASSERT_EQ(0, rbd_close(child2));
+  ASSERT_EQ(0, rbd_remove(ioctx, child2_name.c_str()));
+  ASSERT_EQ(0, rbd_snap_unprotect(child1, "snap"));
+  ASSERT_EQ(0, rbd_snap_remove(child1, "snap"));
+  ASSERT_EQ(0, rbd_close(child1));
+  ASSERT_EQ(0, rbd_remove(ioctx, child1_name.c_str()));
+  ASSERT_EQ(0, rbd_snap_unprotect(image, "snap"));
+  ASSERT_EQ(0, rbd_snap_remove(image, "snap"));
+  ASSERT_EQ(0, rbd_close(image));
+  ASSERT_EQ(0, rbd_remove(ioctx, name.c_str()));
+  rados_ioctx_destroy(ioctx);
+}
+
+TEST_F(TestLibRBD, TestCloneEncryptionAEAD_Reverse)
+{
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  rados_ioctx_t ioctx;
+  rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
+
+  // create base image, write 'a's
+  int order = 0;
+  std::string name = get_temp_image_name();
+  uint64_t size = 256 << 20;
+  ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
+
+  rbd_image_t image;
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_PASSED(write_test_data, image, "aaaa", 0, 4, 0);
+  ASSERT_EQ(0, rbd_flush(image));
+
+  // clone, encrypt with LUKS2 AEAD, write 'b's
+  ASSERT_EQ(0, rbd_snap_create(image, "snap"));
+  ASSERT_EQ(0, rbd_snap_protect(image, "snap"));
+
+  rbd_image_options_t image_opts;
+  rbd_image_options_create(&image_opts);
+  BOOST_SCOPE_EXIT_ALL( (&image_opts) ) {
+    rbd_image_options_destroy(image_opts);
+  };
+  std::string child1_name = get_temp_image_name();
+  ASSERT_EQ(0, rbd_clone3(ioctx, name.c_str(), "snap", ioctx,
+                          child1_name.c_str(), image_opts));
+
+  rbd_image_t child1;
+  ASSERT_EQ(0, rbd_open(ioctx, child1_name.c_str(), &child1, NULL));
+
+  rbd_encryption_luks2_format_options_t child1_opts = {
+          .alg = RBD_ENCRYPTION_ALGORITHM_AES256_HMAC_SHA256,
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  ASSERT_EQ(0, rbd_encryption_format(
+          child1, RBD_ENCRYPTION_FORMAT_LUKS2, &child1_opts,
+          sizeof(child1_opts)));
+  ASSERT_EQ(0, rbd_encryption_load(
+          child1, RBD_ENCRYPTION_FORMAT_LUKS2, &child1_opts,
+          sizeof(child1_opts)));
+  ASSERT_PASSED(write_test_data, child1, "bbbb", 64 << 20, 4, 0);
+  ASSERT_EQ(0, rbd_flush(child1));
+
+  // clone, encrypt with LUKS2 xts-plain64, write 'c's
+  ASSERT_EQ(0, rbd_snap_create(child1, "snap"));
+  ASSERT_EQ(0, rbd_snap_protect(child1, "snap"));
+
+  std::string child2_name = get_temp_image_name();
+  ASSERT_EQ(0, rbd_clone3(ioctx, child1_name.c_str(), "snap", ioctx,
+                          child2_name.c_str(), image_opts));
+
+  rbd_image_t child2;
+  ASSERT_EQ(0, rbd_open(ioctx, child2_name.c_str(), &child2, NULL));
+
+  rbd_encryption_luks2_format_options_t child2_opts = {
+          .alg = RBD_ENCRYPTION_ALGORITHM_AES256,
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  ASSERT_EQ(0, rbd_encryption_format(
+          child2, RBD_ENCRYPTION_FORMAT_LUKS2, &child2_opts,
+          sizeof(child2_opts)));
+
+  // multi-spec load: child2 (xts-plain64) + child1 (AEAD)
+  rbd_encryption_spec_t specs[] = {
+          { .format = RBD_ENCRYPTION_FORMAT_LUKS2,
+            .opts = &child2_opts,
+            .opts_size = sizeof(child2_opts)},
+          { .format = RBD_ENCRYPTION_FORMAT_LUKS2,
+            .opts = &child1_opts,
+            .opts_size = sizeof(child1_opts)}
+  };
+  ASSERT_EQ(0, rbd_encryption_load2(child2, specs, 2));
+
+  ASSERT_PASSED(write_test_data, child2, "cccc", 128 << 20, 4, 0);
+  ASSERT_EQ(0, rbd_flush(child2));
+
+  // verify all data through the clone chain
+  ASSERT_PASSED(read_test_data, child2, "aaaa", 0, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "bbbb", 64 << 20, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "cccc", 128 << 20, 4, 0);
+
+  // flatten child2
+  ASSERT_EQ(0, rbd_flatten(child2));
+
+  // reopen and load with single LUKS spec
+  ASSERT_EQ(0, rbd_close(child2));
+  ASSERT_EQ(0, rbd_open(ioctx, child2_name.c_str(), &child2, NULL));
+  rbd_encryption_luks_format_options_t luks_opts = {
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  ASSERT_EQ(0, rbd_encryption_load(
+          child2, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
+
+  // verify flattened image
+  ASSERT_PASSED(read_test_data, child2, "aaaa", 0, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "bbbb", 64 << 20, 4, 0);
+  ASSERT_PASSED(read_test_data, child2, "cccc", 128 << 20, 4, 0);
+
+  // cleanup
+  ASSERT_EQ(0, rbd_close(child2));
+  ASSERT_EQ(0, rbd_remove(ioctx, child2_name.c_str()));
+  ASSERT_EQ(0, rbd_snap_unprotect(child1, "snap"));
+  ASSERT_EQ(0, rbd_snap_remove(child1, "snap"));
+  ASSERT_EQ(0, rbd_close(child1));
+  ASSERT_EQ(0, rbd_remove(ioctx, child1_name.c_str()));
+  ASSERT_EQ(0, rbd_snap_unprotect(image, "snap"));
+  ASSERT_EQ(0, rbd_snap_remove(image, "snap"));
+  ASSERT_EQ(0, rbd_close(image));
+  ASSERT_EQ(0, rbd_remove(ioctx, name.c_str()));
+  rados_ioctx_destroy(ioctx);
+}
+#endif // HAVE_CRYPT_FORMAT_INLINE
+
 #ifdef HAVE_LIBCRYPTSETUP
 
 TEST_F(TestLibRBD, TestCloneEncryption)


### PR DESCRIPTION
### Description
This PR introduces Authenticated Encryption with Associated Data (AEAD) support to librbd.

While existing librbd encryption (XTS) ensures confidentiality, it does not guarantee data integrity. This implementation adds per-object integrity verification to detect data tampering, satisfying stricter security compliance standards (e.g., German BSI guidelines).

### Status: WIP
- Code compiles and can issue Read/Write I/O.
- Basic encryption/decryption logic is functional.
- Pending: Full librbd crypto test suite compliance and integration of LUKS header metadata.
### Motivation
- Integrity vs. Confidentiality: Traditional block encryption (XTS) protects data visibility but cannot detect if ciphertext has been modified on disk. AEAD ensures that any tampering results in a decryption failure.
- Compliance: High-security environments increasingly require authenticated encryption for block storage.
### Architectural Design & Prior Art
One of the main problems of using AEAD ciphers is to atomically write data and its metadata (authentication tags & nonces). To solve this problem we evaluated two common approaches found in other open-source systems:
- Linux dmcrypt+dm-integrity (Interleaved/Journaled):
    - Uses a metadata sector or interleaved layout.
    - Requires a double-write journal to ensure the data sector and metadata sector are updated atomically.
    - Drawback: Write amplification, complexity and incompatible with RBD resizing/thin-provisioning.
- [FreeBSD GELI](https://github.com/freebsd/freebsd-src/blob/821774dfbdaa12ef072ff7eaea8f9966a7e63935/sys/geom/eli/g_eli_integrity.c#L71) (Intra-Sector Fragmentation):
    - Embeds the authentication tag inside standard physical sectors by sacrificing capacity (e.g., using 32 bytes of a 512-byte sector for metadata, leaving 480 bytes for data).
    - Requires reading/writing multiple physical sectors to reconstruct a single standard logical block.
    - Drawback: Storage overhead (~11%) and CPU overhead to encrypt each smaller blocks.

Decision: We adopted a data expansion strategy (neither GELI nor dmcrypt+dm-integrity format). Each IO request to an object will be 4128 bytes (4096 data + 32 metadata) large. With this we achieve full write/read atomicity through RADOS without a journal while minimizing the storage and encryption overhead. However IO will not be 4KB aligned. 

### Implementation Details
1. Cryptographic Primitive: AES-256-SIV
- Cipher: AES-256-SIV (RFC 5297).
- Reasoning:
   - Nonce Misuse Resistance: SIV is robust against nonce reuse, which is critical for block storage where unique nonce generation is difficult.
    - Compatibility: Supported in OpenSSL 3.0.
        - Note: AES-GCM-SIV could also be used (it has higher performance but not available in OpenSSL 3.0)
2. On-Disk Layout
- Data is processed in 4KB chunks and expanded to 4128 bytes on disk.
    - Payload: 4096 bytes (Ciphertext)
    - Metadata: 16 bytes (Auth Tag) + 16 bytes (Nonce)
    - Total: 4128 bytes
- This layout is not compatible with dm-integrity and is not 4KB aligned.
3. Current Limitations (WIP)
- The AEAD format (AES-256-SIV + 4128B size) is currently hardcoded when RBD_ENCRYPTION_FORMAT_LUKS2 is selected.
    - Future work will encode these parameters into the LUKS2 JSON header to allow dynamic initialization.
- Not sure if compatible with other librbd features

4. TODOs (not exhaustive)
- Satisfy existing librbd unit tests i.e. TestMockCryptoCryptoObjectDispatch
- Add unit tests
- Fit code formatting of librbd
- Figure out a LUKS header for the encryption layout used
- Benchmarking
…

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
