### PR TITLE
crimson: add pg subcommands support in CLI

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -677,6 +677,106 @@ EOF
 
 }
 
+#######################################################################
+
+##
+# Create (prepare) and run (activate) a crimson osd by the name osd.**id**
+# with data in **dir**/**id**.
+#
+# The remaining arguments are passed verbatim to crimson-osd.
+#
+# Two mandatory arguments must be provided: --fsid and --mon-host
+# Instead of adding them to every call to run_crimson_osd, they can be
+# set in the CEPH_ARGS environment variable to be read implicitly by
+# every ceph command.
+#
+# Crimson standalone tests also require msgr2 and require setting either
+# crimson_cpu_num or crimson_cpu_set.
+#
+# @param dir path name of the environment
+# @param id osd identifier
+# @param ... can be any option valid for crimson-osd
+# @return 0 on success, 1 on error
+#
+function run_crimson_osd() {
+    local dir=$1
+    shift
+    local id=$1
+    shift
+    local osd_data=$dir/$id
+
+    local ceph_args="$CEPH_ARGS"
+    ceph_args+=" --osd-failsafe-full-ratio=.99"
+    ceph_args+=" --osd-journal-size=100"
+    ceph_args+=" --osd-scrub-load-threshold=2000"
+    ceph_args+=" --osd-data=$osd_data"
+    ceph_args+=" --osd-journal=${osd_data}/journal"
+    ceph_args+=" --chdir="
+    ceph_args+=$EXTRA_OPTS
+    ceph_args+=" --run-dir=$dir"
+    ceph_args+=" --admin-socket=$(get_asok_path)"
+    ceph_args+=" --log-file=$dir/\$name.log"
+    ceph_args+=" --pid-file=$dir/\$name.pid"
+    ceph_args+=" --osd-max-object-name-len=460"
+    ceph_args+=" --osd-max-object-namespace-len=64"
+    # Crimson requires msgr2
+    ceph_args+=" --ms-bind-msgr2=true"
+    ceph_args+=" --ms-bind-msgr1=false"
+    ceph_args+=" "
+    ceph_args+="$@"
+    mkdir -p $osd_data
+
+    # Find crimson-osd binary
+    local crimson_osd=""
+    if [ -f "./bin/crimson-osd" ]; then
+        crimson_osd="./bin/crimson-osd"
+    elif [ -f "$CEPH_ROOT/build/bin/crimson-osd" ]; then
+        crimson_osd="$CEPH_ROOT/build/bin/crimson-osd"
+    else
+        echo "ERROR: crimson-osd binary not found"
+        return 1
+    fi
+
+    # Enable crimson in the cluster
+    ceph config set global enable_experimental_unrecoverable_data_corrupting_features crimson || return 1
+    ceph osd set-allow-crimson --yes-i-really-mean-it || return 1
+
+    # Standalone tests do not set crimson_cpu_set/crimson_cpu_num (vstart.sh does).
+    # Without this, crimson-osd aborts in get_early_config.
+    ceph config set osd.$id crimson_cpu_num 1 || return 1
+
+    local uuid=`uuidgen`
+    echo "add crimson osd$id $uuid"
+    OSD_SECRET=$(ceph-authtool --gen-print-key)
+    echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $osd_data/new.json
+    ceph osd new $uuid -i $osd_data/new.json
+    rm $osd_data/new.json
+
+    # Use crimson-osd for mkfs (not ceph-osd!)
+    echo "Running crimson-osd mkfs..."
+    if ! $crimson_osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid 2>&1; then
+        echo "ERROR: crimson-osd --mkfs failed"
+        return 1
+    fi
+
+    local key_fn=$osd_data/keyring
+    cat > $key_fn<<EOF
+[osd.$id]
+key = $OSD_SECRET
+EOF
+    echo adding osd$id key to auth repository
+    ceph -i "$key_fn" auth add osd.$id osd "allow *" mon "allow profile osd" mgr "allow profile osd"
+
+    echo "start crimson osd.$id"
+    $crimson_osd -i $id $ceph_args &
+
+    # If noup is set, then can't wait for this osd
+    if ceph osd dump --format=json | jq '.flags_set[]' | grep -q '"noup"' ; then
+      return 0
+    fi
+    wait_for_osd up $id || return 1
+}
+
 function run_osd_filestore() {
     local dir=$1
     shift

--- a/qa/standalone/osd/pg-subcommands.sh
+++ b/qa/standalone/osd/pg-subcommands.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+_cmp_json_field() {
+    local a=$1
+    local b=$2
+    local field=$3
+    local name=$4
+    local av
+    local bv
+    av=$(echo "$a" | jq -c "$field") || return 1
+    bv=$(echo "$b" | jq -c "$field") || return 1
+    if [ "$av" != "$bv" ]; then
+        echo "Mismatch for $name at $field: classic=$av vs crimson=$bv"
+        return 1
+    fi
+}
+
+_assert_pg_json_sane() {
+    local pgid=$1
+    local json=$2
+    local kind=$3
+
+    echo "$json" | jq -e . >/dev/null || {
+        echo "Invalid JSON output ($kind): $json"
+        return 1
+    }
+
+    if [ "$kind" = "query" ]; then
+        echo "$json" | jq -e --arg pgid "$pgid" '(.pgid == $pgid) or (.pg.pgid == $pgid) or (.info.pgid == $pgid)' >/dev/null || {
+            echo "Query output missing pgid ($pgid): $json"
+            return 1
+        }
+    fi
+}
+
+_wait_for_pg_query_ok() {
+    local pgid=$1
+    local timeout=${2:-60}
+    local deadline=$(( $(date +%s) + timeout ))
+    local had_xtrace=0
+    case "$-" in
+      *x*) had_xtrace=1; set +x ;;
+    esac
+    while [ $(date +%s) -lt $deadline ]; do
+        local q
+        q=$(_run_pg_json "$pgid" query 2>/dev/null || true)
+        if [ -n "$q" ]; then
+          if _assert_pg_json_sane "$pgid" "$q" query >/dev/null 2>&1; then
+            if [ $had_xtrace -eq 1 ]; then
+              set -x
+            fi
+            return 0
+          fi
+        fi
+        sleep 1
+    done
+    if [ $had_xtrace -eq 1 ]; then
+      set -x
+    fi
+    echo "Timed out waiting for pg $pgid query to succeed"
+    ceph -s || true
+    return 1
+}
+
+# Run a subcommand and return JSON
+# Usage: _run_pg_json <pgid> <subcmd> [offset_json]
+_run_pg_json() {
+    local pgid=$1
+    local subcmd=$2
+    local offset_json=$3
+    if [ -n "$offset_json" ]; then
+        ceph --format json pg $pgid $subcmd "$offset_json" | awk 'BEGIN{p=0} /^[[:space:]]*[\[{]/{p=1} p{print}'
+    else
+        ceph --format json pg $pgid $subcmd | awk 'BEGIN{p=0} /^[[:space:]]*[\[{]/{p=1} p{print}'
+    fi
+}
+
+# Save JSON outputs for a given OSD type
+_save_outputs() {
+    local pgid=$1
+    local outdir=$2
+    local qjson ljson ujson ujson_offset
+    qjson=$(_run_pg_json $pgid query) || return 1
+    _assert_pg_json_sane "$pgid" "$qjson" query || return 1
+    ljson=$(_run_pg_json $pgid log) || return 1
+    _assert_pg_json_sane "$pgid" "$ljson" log || return 1
+    ujson=$(_run_pg_json $pgid list_unfound) || return 1
+    _assert_pg_json_sane "$pgid" "$ujson" list_unfound || return 1
+    # Test offset parameter with a valid json-encoded hobject_t.
+    # '{}' decodes as a default hobject_t and should behave like no offset.
+    ujson_offset=$(_run_pg_json $pgid list_unfound '{}') || return 1
+    _assert_pg_json_sane "$pgid" "$ujson_offset" list_unfound || return 1
+    echo "$qjson" > "$outdir/query.json"
+    echo "$ljson" > "$outdir/log.json"
+    echo "$ujson" > "$outdir/list_unfound.json"
+    echo "$ujson_offset" > "$outdir/list_unfound_offset.json"
+}
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7195" # git grep '\<7195\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--crimson_cpu_num=2 "
+
+    export OUTDIR=${TMPDIR:-/tmp}/pg-subcommands-$$
+    rm -rf "$OUTDIR"
+    mkdir -p "$OUTDIR"
+    trap 'rm -rf "$OUTDIR"' EXIT
+
+    local funcs
+    if [ $# -gt 0 ]; then
+        funcs="$*"
+    elif [ -n "$PG_SUBCOMMANDS_FUNCS" ]; then
+        funcs="$PG_SUBCOMMANDS_FUNCS"
+    else
+        funcs="TEST_a_classic_save_outputs TEST_b_crimson_save_and_compare"
+    fi
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_a_classic_save_outputs() {
+    local dir=$1
+
+    run_mon $dir a --osd_pool_default_size=1 --mon_allow_pool_size_one=true \
+      --osd_pool_default_crimson=false || return 1
+    run_mgr $dir x || return 1
+
+    # Run classic OSD first
+    echo "=== Running Classic OSD ==="
+    run_osd $dir 0 || return 1
+
+    local poolname=foo
+    create_pool $poolname 1 1 || return 1
+
+    local objname=obj-$$
+    local pgid
+    pgid=$(get_pg $poolname $objname) || return 1
+
+    _wait_for_pg_query_ok $pgid 60 || return 1
+
+    mkdir -p "$OUTDIR/classic"
+    _save_outputs $pgid "$OUTDIR/classic" || return 1
+
+    delete_pool $poolname
+}
+
+function TEST_b_crimson_save_and_compare() {
+    local dir=$1
+
+    run_mon $dir a --osd_pool_default_size=1 --mon_allow_pool_size_one=true \
+      --osd_pool_default_crimson=true || return 1
+    run_mgr $dir x || return 1
+
+    echo "=== Running Crimson OSD ==="
+    run_crimson_osd $dir 0 || return 1
+
+    local poolname=foo
+    create_pool $poolname 1 1 || return 1
+    ceph osd pool ls detail --format json |
+      jq -e --arg pool "$poolname" '.[] | select(.pool_name == $pool) | (.flags_names // [] | index("crimson"))' >/dev/null || return 1
+
+    local objname=obj-$$
+    local pgid
+    pgid=$(get_pg $poolname $objname) || return 1
+
+    _wait_for_pg_query_ok $pgid 60 || return 1
+
+    mkdir -p "$OUTDIR/crimson"
+    _save_outputs $pgid "$OUTDIR/crimson" || return 1
+
+    if [ -f "$OUTDIR/classic/query.json" ]; then
+        echo "=== Comparing Classic vs Crimson Outputs ==="
+        local classic_query crimson_query classic_unfound crimson_unfound
+        classic_query=$(cat "$OUTDIR/classic/query.json")
+        crimson_query=$(cat "$OUTDIR/crimson/query.json")
+        classic_unfound=$(cat "$OUTDIR/classic/list_unfound.json")
+        crimson_unfound=$(cat "$OUTDIR/crimson/list_unfound.json")
+
+        _cmp_json_field "$classic_query" "$crimson_query" '(.pgid // .pg.pgid // .info.pgid)' "query.pgid" || return 1
+        _cmp_json_field "$classic_unfound" "$crimson_unfound" '(.missing.num_missing // .num_missing // 0)' "list_unfound.num_missing" || return 1
+        _cmp_json_field "$classic_unfound" "$crimson_unfound" '(.missing.num_unfound // .num_unfound // 0)' "list_unfound.num_unfound" || return 1
+    fi
+
+    # Verify list_unfound with offset behaves same as no offset
+    local t base off
+    for t in classic crimson; do
+      if [ ! -f "$OUTDIR/$t/list_unfound.json" ]; then
+          continue
+      fi
+      base=$(cat "$OUTDIR/$t/list_unfound.json") || return 1
+      off=$(cat "$OUTDIR/$t/list_unfound_offset.json") || return 1
+      _cmp_json_field "$base" "$off" '(.missing.num_missing // .num_missing // 0)' "list_unfound offset vs no offset ($t).num_missing" || return 1
+      _cmp_json_field "$base" "$off" '(.missing.num_unfound // .num_unfound // 0)' "list_unfound offset vs no offset ($t).num_unfound" || return 1
+    done
+
+    delete_pool $poolname
+}
+
+# Run cd build && ../qa/run-standalone.sh osd/pg-subcommands.sh
+main pg-subcommands "$@"

--- a/qa/suites/crimson-rados/singleton/all/pg-subcommands.yaml
+++ b/qa/suites/crimson-rados/singleton/all/pg-subcommands.yaml
@@ -1,0 +1,34 @@
+roles:
+- - mon.a
+  - mon.b
+  - mon.c
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - client.0
+openstack:
+  - volumes: # attached to each instance
+      count: 3
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - but it is still running
+      - overall HEALTH_
+      - \(PG_
+    conf:
+      osd:
+        osd min pg log entries: 5
+        crimson cpu num: 2
+      global:
+- workunit:
+    clients:
+      client.0:
+        - osd/pg-subcommands.sh
+    basedir: qa/standalone
+    env:
+      PG_SUBCOMMANDS_FUNCS: "TEST_b_crimson_save_and_compare"

--- a/qa/suites/crimson-rados/singleton/all/pg-subcommands.yaml
+++ b/qa/suites/crimson-rados/singleton/all/pg-subcommands.yaml
@@ -28,7 +28,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - osd/pg-subcommands.sh
-    basedir: qa/standalone
-    env:
-      PG_SUBCOMMANDS_FUNCS: "TEST_b_crimson_save_and_compare"
+        - crimson/test_pg_subcommands.sh

--- a/qa/workunits/crimson/test_pg_subcommands.sh
+++ b/qa/workunits/crimson/test_pg_subcommands.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+. $(dirname $0)/../../standalone/ceph-helpers.sh
+
+set -x
+
+_cmp_json_field() {
+    local a=$1
+    local b=$2
+    local field=$3
+    local name=$4
+    local av
+    local bv
+    av=$(echo "$a" | jq -c "$field") || return 1
+    bv=$(echo "$b" | jq -c "$field") || return 1
+    if [ "$av" != "$bv" ]; then
+        echo "Mismatch for $name at $field: base=$av vs offset=$bv"
+        return 1
+    fi
+}
+
+_run_pg_json() {
+    local pgid=$1
+    local subcmd=$2
+    local offset_json=$3
+    if [ -n "$offset_json" ]; then
+        ceph --format json pg "$pgid" "$subcmd" "$offset_json" | awk 'BEGIN{p=0} /^[[:space:]]*[\[{]/{p=1} p{print}'
+    else
+        ceph --format json pg "$pgid" "$subcmd" | awk 'BEGIN{p=0} /^[[:space:]]*[\[{]/{p=1} p{print}'
+    fi
+}
+
+_wait_for_pg_query_ok() {
+    local pgid=$1
+    local timeout=${2:-60}
+    local deadline=$(( $(date +%s) + timeout ))
+
+    while [ $(date +%s) -lt $deadline ]; do
+        local q
+        q=$(_run_pg_json "$pgid" query 2>/dev/null || true)
+        if [ -n "$q" ]; then
+            echo "$q" | jq -e . >/dev/null 2>&1 && return 0
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for pg $pgid query to succeed"
+    ceph -s || true
+    return 1
+}
+
+_get_any_pgid() {
+    ceph pg dump pgs_brief --format json | jq -r '.pg_stats[0].pgid'
+}
+
+test_pg_subcommands() {
+    [ "$(ceph osd metadata 0 | jq -r '.osd_type')" = "crimson" ] || return 0
+
+    local pgid
+    pgid=$(_get_any_pgid) || return 1
+    [ -n "$pgid" ] || return 1
+
+    _wait_for_pg_query_ok "$pgid" 120 || return 1
+
+    local qjson
+    qjson=$(_run_pg_json "$pgid" query) || return 1
+    echo "$qjson" | jq -e . >/dev/null || return 1
+
+    local ujson ujson_offset
+    ujson=$(_run_pg_json "$pgid" list_unfound) || return 1
+    echo "$ujson" | jq -e . >/dev/null || return 1
+
+    ujson_offset=$(_run_pg_json "$pgid" list_unfound '{}') || return 1
+    echo "$ujson_offset" | jq -e . >/dev/null || return 1
+
+    _cmp_json_field "$ujson" "$ujson_offset" '(.missing.num_missing // .num_missing // 0)' "list_unfound.num_missing" || return 1
+    _cmp_json_field "$ujson" "$ujson_offset" '(.missing.num_unfound // .num_unfound // 0)' "list_unfound.num_unfound" || return 1
+}
+
+test_pg_subcommands || { echo "test_pg_subcommands failed"; exit 1; }
+
+echo "OK"

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -95,7 +95,18 @@ auto AdminSocket::parse_cmd(const std::vector<std::string>& cmd)
     cmd_getval(cmdmap, "prefix", prefix);
     // tolerate old-style pg <pgid> command <args> style formatting
     if (prefix == "pg") {
-      cmd_getval(cmdmap, "cmd", prefix);
+      std::string pg_subcmd;
+      cmd_getval(cmdmap, "cmd", pg_subcmd);
+      prefix = pg_subcmd;
+
+      if (auto arg = cmd_getval<std::string>(cmdmap, "arg"); arg) {
+        if (pg_subcmd == "list_unfound") {
+          cmdmap["offset"] = std::move(*arg);
+        } else if (pg_subcmd == "mark_unfound_lost") {
+          cmdmap["mulcmd"] = std::move(*arg);
+        }
+        cmdmap.erase("arg");
+      }
     }
   } catch (const bad_cmd_get& e) {
     ERROR("invalid syntax: {}", cmd);

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -196,7 +196,12 @@ auto AdminSocket::execute_command(const std::vector<std::string>& cmd,
         tell_result_t{-EINVAL, "invalid command json", std::move(out)});
     }
     DEBUG("validated {} {}", cmd, os.str());
-    return parsed->hook.call(parsed->params, parsed->format, std::move(buf));
+    auto owned = std::move(*parsed);
+    return seastar::do_with(std::move(owned), std::move(buf),
+                            [](const parsed_command_t& parsed,
+                               ceph::bufferlist& buf) mutable {
+      return parsed.hook.call(parsed.params, parsed.format, std::move(buf));
+    });
   } else {
     DEBUG("failed to parse");
     auto& result = std::get<tell_result_t>(maybe_parsed);

--- a/src/crimson/admin/pg_commands.cc
+++ b/src/crimson/admin/pg_commands.cc
@@ -54,6 +54,10 @@ public:
     }
     // am i the primary for this pg?
     const auto osdmap = osd.get_shard_services().get_map();
+    if (!osdmap || osdmap->get_epoch() == 0) {
+      return seastar::make_ready_future<tell_result_t>(tell_result_t{
+        -EAGAIN, "osdmap is not ready"});
+    }
     spg_t spg_id;
     if (!osdmap->get_primary_shard(pgid, &spg_id)) {
       return seastar::make_ready_future<tell_result_t>(tell_result_t{

--- a/src/crimson/admin/pg_commands.cc
+++ b/src/crimson/admin/pg_commands.cc
@@ -88,6 +88,33 @@ private:
   OSD& osd;
 };
 
+class LogCommand final : public PGCommand {
+public:
+  explicit LogCommand(crimson::osd::OSD& osd) :
+    PGCommand{osd,
+              "log",
+              "name=pgid,type=CephPgid",
+              "dump pg_log of a specific pg"}
+  {}
+private:
+  seastar::future<tell_result_t>
+  do_command(Ref<PG> pg,
+             const cmdmap_t&,
+             std::string_view format,
+             ceph::bufferlist&&) const final
+  {
+    std::unique_ptr<Formatter> f{Formatter::create(format,
+                                                   "json-pretty",
+                                                   "json-pretty")};
+    f->open_object_section("op_log");
+    f->open_object_section("pg_log_t");
+    pg->get_peering_state().get_pg_log().get_log().dump(f.get());
+    f->close_section();
+    f->close_section();
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
+  }
+};
+
 class PGOldFormCommand final : public AdminSocketHook {
 public:
   explicit PGOldFormCommand(crimson::osd::OSD&) :
@@ -134,6 +161,89 @@ private:
   }
 };
 
+class ListUnfoundCommand final : public PGCommand {
+public:
+  explicit ListUnfoundCommand(crimson::osd::OSD& osd) :
+    PGCommand{osd,
+              "list_unfound",
+              "name=pgid,type=CephPgid"
+              " name=offset,type=CephString,req=false",
+              "list unfound objects on this pg, perhaps starting at an offset given in JSON"}
+  {}
+private:
+  seastar::future<tell_result_t>
+  do_command(Ref<PG> pg,
+             const cmdmap_t& cmdmap,
+             std::string_view format,
+             ceph::bufferlist&&) const final
+  {
+    std::unique_ptr<Formatter> f{
+      Formatter::create(format, "json-pretty", "json-pretty")
+    };
+
+    hobject_t offset;
+    std::string offset_json;
+    bool show_offset = false;
+    if (cmd_getval(cmdmap, "offset", offset_json)) {
+      json_spirit::Value v;
+      try {
+        if (!json_spirit::read(offset_json, v)) {
+          throw std::runtime_error("bad json");
+        }
+        offset.decode(v);
+      } catch (std::runtime_error& e) {
+        return seastar::make_ready_future<tell_result_t>(tell_result_t{
+          -EINVAL, fmt::format("error parsing offset: {}", e.what())});
+      }
+      show_offset = true;
+    }
+
+    f->open_object_section("missing");
+    if (show_offset) {
+      f->open_object_section("offset");
+      offset.dump(f.get());
+      f->close_section();
+    }
+
+    const auto& missing_loc = pg->get_peering_state().get_missing_loc();
+    const auto& needs_recovery_map = missing_loc.get_needs_recovery();
+
+    f->dump_int("num_missing", needs_recovery_map.size());
+    f->dump_int("num_unfound", missing_loc.num_unfound());
+
+    auto it = needs_recovery_map.upper_bound(offset);
+    f->open_array_section("objects");
+
+    int32_t num = 0;
+    const auto max_records = pg->get_cct()->_conf->osd_command_max_records;
+    for (; it != needs_recovery_map.end() && num < max_records; ++it) {
+      if (!missing_loc.is_unfound(it->first)) {
+        continue;
+      }
+      f->open_object_section("object");
+      f->open_object_section("oid");
+      it->first.dump(f.get());
+      f->close_section();
+      it->second.dump(f.get());
+      f->open_array_section("locations");
+      for (auto&& r : missing_loc.get_locations(it->first)) {
+        f->dump_stream("shard") << r;
+      }
+      f->close_section();
+      f->close_section();
+      ++num;
+    }
+    f->close_section();
+
+    PeeringState::QueryUnfound q(f.get());
+    pg->get_peering_state().handle_event(q, nullptr);
+
+    f->dump_bool("more", it != needs_recovery_map.end());
+    f->close_section();
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
+  }
+};
+
 class MarkUnfoundLostCommand final : public PGCommand {
 public:
   explicit MarkUnfoundLostCommand(crimson::osd::OSD& osd) :
@@ -173,11 +283,12 @@ public:
 template <bool deep>
 class ScrubCommand : public PGCommand {
 public:
-  explicit ScrubCommand(crimson::osd::OSD& osd) :
+  explicit ScrubCommand(crimson::osd::OSD& osd,
+                        std::string_view name) :
     PGCommand{
       osd,
-      deep ? "deep_scrub" : "scrub",
-      "",
+      name,
+      "name=pgid,type=CephPgid",
       deep ? "deep scrub pg" : "scrub pg"}
   {}
 
@@ -224,11 +335,21 @@ template std::unique_ptr<AdminSocketHook>
 make_asok_hook<crimson::admin::pg::QueryCommand>(crimson::osd::OSD& osd);
 
 template std::unique_ptr<AdminSocketHook>
+make_asok_hook<crimson::admin::pg::LogCommand>(crimson::osd::OSD& osd);
+
+template std::unique_ptr<AdminSocketHook>
+make_asok_hook<crimson::admin::pg::ListUnfoundCommand>(crimson::osd::OSD& osd);
+
+template std::unique_ptr<AdminSocketHook>
 make_asok_hook<crimson::admin::pg::MarkUnfoundLostCommand>(crimson::osd::OSD& osd);
 
 template std::unique_ptr<AdminSocketHook>
-make_asok_hook<crimson::admin::pg::ScrubCommand<true>>(crimson::osd::OSD& osd);
+make_asok_hook<crimson::admin::pg::ScrubCommand<true>,
+               crimson::osd::OSD&, std::string_view>(crimson::osd::OSD& osd,
+                                                    std::string_view&& name);
 template std::unique_ptr<AdminSocketHook>
-make_asok_hook<crimson::admin::pg::ScrubCommand<false>>(crimson::osd::OSD& osd);
+make_asok_hook<crimson::admin::pg::ScrubCommand<false>,
+               crimson::osd::OSD&, std::string_view>(crimson::osd::OSD& osd,
+                                                    std::string_view&& name);
 
 } // namespace crimson::admin

--- a/src/crimson/admin/pg_commands.cc
+++ b/src/crimson/admin/pg_commands.cc
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <fmt/format.h>
 #include <seastar/core/future.hh>
@@ -21,7 +22,6 @@ using crimson::osd::OSD;
 using crimson::osd::PG;
 using namespace crimson::common;
 using ceph::common::cmd_getval;
-
 
 namespace crimson::admin::pg {
 
@@ -88,13 +88,33 @@ private:
   OSD& osd;
 };
 
+class PGOldFormCommand final : public AdminSocketHook {
+public:
+  explicit PGOldFormCommand(crimson::osd::OSD&) :
+    AdminSocketHook{"pg",
+                    "name=pgid,type=CephPgid "
+                    "name=cmd,type=CephChoices,strings=query|log|scrub|deep-scrub|list_unfound|mark_unfound_lost "
+                    "name=arg,type=CephString,req=false",
+                    "old-form wrapper for pg subcommands (query, log, scrub, deep-scrub, list_unfound, mark_unfound_lost)"}
+  {}
+
+  seastar::future<tell_result_t> call(const cmdmap_t&,
+                                      std::string_view,
+                                      ceph::bufferlist&&) const final
+  {
+    // This hook exists only for schema advertisement via get_command_descriptions.
+    // parse_cmd() always rewrites prefix away from "pg" before dispatch.
+    std::unreachable();
+  }
+};
+
 class QueryCommand final : public PGCommand {
 public:
   // TODO: const correctness of osd
   explicit QueryCommand(crimson::osd::OSD& osd) :
     PGCommand{osd,
               "query",
-              "",
+              "name=pgid,type=CephPgid",
               "show details of a specific pg"}
   {}
 private:
@@ -196,6 +216,9 @@ std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args)
 {
   return std::make_unique<Hook>(std::forward<Args>(args)...);
 }
+
+template std::unique_ptr<AdminSocketHook>
+make_asok_hook<crimson::admin::pg::PGOldFormCommand>(crimson::osd::OSD& osd);
 
 template std::unique_ptr<AdminSocketHook>
 make_asok_hook<crimson::admin::pg::QueryCommand>(crimson::osd::OSD& osd);

--- a/src/crimson/admin/pg_commands.h
+++ b/src/crimson/admin/pg_commands.h
@@ -5,6 +5,7 @@
 
 namespace crimson::admin::pg {
 
+class PGOldFormCommand;
 class QueryCommand;
 class MarkUnfoundLostCommand;
 template <bool deep>

--- a/src/crimson/admin/pg_commands.h
+++ b/src/crimson/admin/pg_commands.h
@@ -7,6 +7,8 @@ namespace crimson::admin::pg {
 
 class PGOldFormCommand;
 class QueryCommand;
+class LogCommand;
+class ListUnfoundCommand;
 class MarkUnfoundLostCommand;
 template <bool deep>
 class ScrubCommand;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -833,9 +833,15 @@ seastar::future<> OSD::start_asok_admin()
     // PG commands
     asok->register_command(make_asok_hook<pg::PGOldFormCommand>(*this));
     asok->register_command(make_asok_hook<pg::QueryCommand>(*this));
+    asok->register_command(make_asok_hook<pg::LogCommand>(*this));
+    asok->register_command(make_asok_hook<pg::ListUnfoundCommand>(*this));
     asok->register_command(make_asok_hook<pg::MarkUnfoundLostCommand>(*this));
-    asok->register_command(make_asok_hook<pg::ScrubCommand<true>>(*this));
-    asok->register_command(make_asok_hook<pg::ScrubCommand<false>>(*this));
+    asok->register_command(make_asok_hook<pg::ScrubCommand<true>>(*this,
+                                                                  std::string_view{"deep_scrub"}));
+    asok->register_command(make_asok_hook<pg::ScrubCommand<true>>(*this,
+                                                                  std::string_view{"deep-scrub"}));
+    asok->register_command(make_asok_hook<pg::ScrubCommand<false>>(*this,
+                                                                   std::string_view{"scrub"}));
     // ops commands
     asok->register_command(
       make_asok_hook<DumpInFlightOpsHook>(

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -831,6 +831,7 @@ seastar::future<> OSD::start_asok_admin()
     asok->register_command(make_asok_hook<InjectDataErrorHook>(get_shard_services()));
     asok->register_command(make_asok_hook<InjectMDataErrorHook>(get_shard_services()));
     // PG commands
+    asok->register_command(make_asok_hook<pg::PGOldFormCommand>(*this));
     asok->register_command(make_asok_hook<pg::QueryCommand>(*this));
     asok->register_command(make_asok_hook<pg::MarkUnfoundLostCommand>(*this));
     asok->register_command(make_asok_hook<pg::ScrubCommand<true>>(*this));


### PR DESCRIPTION
This adds missing PG admin socket commands for crimson OSD. Adds old command wrapper to enable classic CLI syntax 'ceph pg'.

Fixes argument parsing ambiguity by remapping generic arg parameter to specific parameters in AdminSocket::parse_cmd().

Fixes: https://tracker.ceph.com/issues/73266


### Testing

Run `cd build && ../qa/run-standalone.sh osd/pg-subcommands.sh`



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
