### PR TITLE
rgw/iam: resource policy granted to account principal still requires identity policy

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -5,6 +5,12 @@
 * RGW: The default value of ``rgw_rest_conn_ip_fail_timeout_secs`` changed
   from ``2`` to ``30`` seconds.
 
+* RGW: Fixed a bug in same-account evaluation of bucket policy statements that
+  allow the account principal. Users and roles in that account now require a
+  corresponding allow from identity policy to match AWS behavior. The evaluation
+  of bucket policy against user or role principals is unchanged and still does
+  not require identity policy.
+
 * ``src/script/ceph-backport.sh`` now runs on macOS in addition to Linux: it
   re-execs under GNU bash >= 4 when the system bash is too old, and honors a
   ``$GETOPT`` environment override so GNU getopt can be selected

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2733,25 +2733,28 @@ bool RGWUserPermHandler::Bucket::verify_bucket_permission(const rgw_obj_key& obj
     if (!ps->identity->is_owner_of(bucket_acl.get_owner().id)) {
       ldpp_dout(dpp, 4) << "cross-account request for bucket owner "
           << bucket_acl.get_owner().id << " != " << ps->identity->get_aclowner().id << dendl;
+      constexpr bool cross_account = true;
       // cross-account requests evaluate the identity-based policies separately
       // from the resource-based policies and require Allow from both
       return ::verify_bucket_permission(dpp, &(*ps), arn, account_root, {}, {}, {},
-                                      info->user_policies, {}, op)
+                                      info->user_policies, {}, op, cross_account)
           && ::verify_bucket_permission(dpp, &(*ps), arn, false, info->user_acl,
-                                      bucket_acl, bucket_policy, {}, {}, op);
+                                      bucket_acl, bucket_policy, {}, {}, op, cross_account);
     } else {
+      constexpr bool cross_account = false;
       // don't consult acls for same-account access. require an Allow from
       // either identity- or resource-based policy
       return ::verify_bucket_permission(dpp, &(*ps), arn, account_root, {}, {},
                                       bucket_policy, info->user_policies,
-                                      {}, op);
+                                      {}, op, cross_account);
     }
   }
   constexpr bool account_root = false;
+  constexpr bool cross_account = false;
   return ::verify_bucket_permission(dpp, &(*ps), arn, account_root,
                                   info->user_acl, bucket_acl,
                                   bucket_policy, info->user_policies,
-                                  {}, op);
+                                  {}, op, cross_account);
 }
 
 rgw::IAM::Effect RGWUserPermHandler::Bucket::evaluate_iam_policies(const rgw_obj_key& obj_key, const uint64_t op) const
@@ -2765,6 +2768,7 @@ rgw::IAM::Effect RGWUserPermHandler::Bucket::evaluate_iam_policies(const rgw_obj
   const auto arn = rgw::ARN(obj);
   const bool account_root = (ps->identity->get_identity_type() == TYPE_ROOT);
 
+  constexpr bool cross_account = false;
   return ::evaluate_iam_policies(dpp,
                                  ps->env,
                                  *ps->identity,
@@ -2772,7 +2776,7 @@ rgw::IAM::Effect RGWUserPermHandler::Bucket::evaluate_iam_policies(const rgw_obj
                                  op, arn,
                                  bucket_policy,
                                  info->user_policies,
-                                 {});
+                                 {}, cross_account);
 }
 
 int RGWUserPermHandler::policy_from_attrs(CephContext *cct,

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -1236,7 +1236,8 @@ bool rgw::auth::RoleApplier::is_identity(const Principal& p) const {
     string role_session = role.name + "/" + token_attrs.role_session_name; //role/role-session
     return p.get_account() == role.tenant
         && p.get_role_session() == role_session;
-  } else {
+  } else if (!role.account) {
+    // non-account roles can match the assuming user principal
     string oidc_id;
     if (token_attrs.user_id.ns.empty()) {
       oidc_id = token_attrs.user_id.id;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -1275,7 +1275,8 @@ bool rgw::auth::RoleApplier::is_identity(const Principal& p) const {
     string role_session = role.name + "/" + token_attrs.role_session_name; //role/role-session
     return p.get_account() == role.tenant
         && p.get_role_session() == role_session;
-  } else {
+  } else if (!role.account) {
+    // non-account roles can match the assuming user principal
     string oidc_id;
     if (token_attrs.user_id.ns.empty()) {
       oidc_id = token_attrs.user_id.id;

--- a/src/rgw/rgw_bucket_logging.cc
+++ b/src/rgw/rgw_bucket_logging.cc
@@ -991,7 +991,8 @@ int verify_target_bucket_policy(const DoutPrefixProvider* dpp,
     const auto source_account = to_string(s->bucket_owner.id);
     s->env.emplace("aws:SourceArn", source_bucket_arn);
     s->env.emplace("aws:SourceAccount", source_account);
-    if (policy.eval(s->env, ident, rgw::IAM::s3PutObject, target_resource_arn) != rgw::IAM::Effect::Allow) {
+    boost::optional<rgw::auth::Principal> principal; // ignored
+    if (policy.eval(s->env, ident, rgw::IAM::s3PutObject, target_resource_arn, principal) != rgw::IAM::Effect::Allow) {
       ldpp_dout(dpp, 1) << "ERROR: logging bucket: '" << target_bucket_id <<
         "' must have a bucket policy that allows logging service principal to put objects in the following resource ARN: '" <<
         target_resource_arn.to_string() << "' from source bucket ARN: '" << source_bucket_arn <<

--- a/src/rgw/rgw_bucket_logging.cc
+++ b/src/rgw/rgw_bucket_logging.cc
@@ -1102,7 +1102,8 @@ int verify_target_bucket_policy(const DoutPrefixProvider* dpp,
     rgw::IAM::Environment env;
     const auto arn_it = env.emplace("aws:SourceArn", std::move(source_bucket_arn));
     const auto acct_it = env.emplace("aws:SourceAccount", std::move(source_account));
-    if (policy.eval(dpp, env, ident, rgw::IAM::s3PutObject, target_resource_arn) != rgw::IAM::Effect::Allow) {
+    boost::optional<rgw::auth::Principal> principal; // ignored
+    if (policy.eval(dpp, env, ident, rgw::IAM::s3PutObject, target_resource_arn, principal) != rgw::IAM::Effect::Allow) {
       ldpp_dout(dpp, 1) << "ERROR: logging bucket: '" << target_bucket_id <<
         "' must have a bucket policy that allows logging service principal to put objects in the following resource ARN: '" <<
         target_resource_arn.to_string() << "' from source bucket ARN: '" << arn_it->second <<

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1213,29 +1213,20 @@ Effect evaluate_iam_policies(
       ldpp_dout(dpp, 10) << __func__ << ": explicit deny from session policy" << dendl;
       return Effect::Deny;
     }
+    if (session_res == Effect::Allow && identity_res == Effect::Allow) {
+      ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
+      return Effect::Allow;
+    }
     if (princ_type == PolicyPrincipal::Role) {
       //Intersection of session policy and identity policy plus intersection of session policy and bucket policy
-      if (session_res == Effect::Allow && identity_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
-        return Effect::Allow;
-      }
       if (session_res == Effect::Allow && resource_res == Effect::Allow) {
         ldpp_dout(dpp, 10) << __func__ << ": allowed by session and resource-based policy" << dendl;
         return Effect::Allow;
       }
     } else if (princ_type == PolicyPrincipal::Session) {
       //Intersection of session policy and identity policy plus bucket policy
-      if (session_res == Effect::Allow && identity_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
-        return Effect::Allow;
-      }
       if (resource_res == Effect::Allow) {
         ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
-        return Effect::Allow;
-      }
-    } else if (princ_type == PolicyPrincipal::Other) {// there was no match in the bucket policy
-      if (session_res == Effect::Allow && identity_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
         return Effect::Allow;
       }
     }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1239,8 +1239,9 @@ Effect evaluate_iam_policies(
     return Effect::Pass;
   }
 
-  // Allow from resource policy overrides implicit deny from identity
-  if (resource_res == Effect::Allow) {
+  // unless granted to the account principal, Allow from resource policy
+  // overrides implicit deny from identity
+  if (resource_res == Effect::Allow && principal && !principal->is_account()) {
     ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
     return Effect::Allow;
   }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -43,7 +43,6 @@ using rgw::ARN;
 using rgw::IAM::Effect;
 using rgw::IAM::op_to_perm;
 using rgw::IAM::Policy;
-using rgw::IAM::PolicyPrincipal;
 
 const uint32_t RGWBucketInfo::NUM_SHARDS_BLIND_BUCKET(UINT32_MAX);
 
@@ -1152,11 +1151,11 @@ Effect eval_or_pass(const DoutPrefixProvider* dpp,
                     boost::optional<const rgw::auth::Identity&> id,
                     const uint64_t op,
                     const ARN& resource,
-                    boost::optional<rgw::IAM::PolicyPrincipal&> princ_type=boost::none) {
+                    boost::optional<rgw::auth::Principal>& principal) {
   if (!policy)
     return Effect::Pass;
   else
-    return policy->eval(env, id, op, resource, princ_type);
+    return policy->eval(env, id, op, resource, principal);
 }
 
 Effect eval_identity_or_session_policies(const DoutPrefixProvider* dpp,
@@ -1166,7 +1165,8 @@ Effect eval_identity_or_session_policies(const DoutPrefixProvider* dpp,
                           const ARN& arn) {
   auto policy_res = Effect::Pass, prev_res = Effect::Pass;
   for (auto& policy : policies) {
-    if (policy_res = eval_or_pass(dpp, policy, env, boost::none, op, arn);
+    boost::optional<rgw::auth::Principal> principal; // ignored
+    if (policy_res = policy.eval(env, boost::none, op, arn, principal);
         policy_res == Effect::Deny) {
       ldpp_dout(dpp, 10) << __func__ << " Deny from " << policy << dendl;
       return policy_res;
@@ -1198,9 +1198,10 @@ Effect evaluate_iam_policies(
     return Effect::Deny;
   }
 
-  PolicyPrincipal princ_type = PolicyPrincipal::Other;
+  // Principal matched by resource policy
+  boost::optional<rgw::auth::Principal> principal;
   auto resource_res = eval_or_pass(dpp, resource_policy, env, identity,
-                                   op, arn, princ_type);
+                                   op, arn, principal);
   if (resource_res == Effect::Deny) {
     ldpp_dout(dpp, 10) << __func__ << ": explicit deny from resource-based policy" << dendl;
     return Effect::Deny;
@@ -1217,17 +1218,21 @@ Effect evaluate_iam_policies(
       ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
       return Effect::Allow;
     }
-    if (princ_type == PolicyPrincipal::Role) {
-      //Intersection of session policy and identity policy plus intersection of session policy and bucket policy
-      if (session_res == Effect::Allow && resource_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and resource-based policy" << dendl;
-        return Effect::Allow;
+    if (principal) {
+      if (principal->is_role()) {
+        //Intersection of session policy and identity policy plus intersection of session policy and bucket policy
+        if (session_res == Effect::Allow && resource_res == Effect::Allow) {
+          ldpp_dout(dpp, 10) << __func__ << ": allowed by session and resource-based policy" << dendl;
+          return Effect::Allow;
+        }
       }
-    } else if (princ_type == PolicyPrincipal::Session) {
-      //Intersection of session policy and identity policy plus bucket policy
-      if (resource_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
-        return Effect::Allow;
+      // tenanted roles may also match the user principal that assumed the role
+      if (principal->is_assumed_role() || principal->is_user()) {
+        //Intersection of session policy and identity policy plus bucket policy
+        if (resource_res == Effect::Allow) {
+          ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
+          return Effect::Allow;
+        }
       }
     }
     ldpp_dout(dpp, 10) << __func__ << ": implicit deny from session policy" << dendl;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1192,7 +1192,8 @@ Effect evaluate_iam_policies(
     bool account_root, uint64_t op, const rgw::ARN& arn,
     const boost::optional<Policy>& resource_policy,
     const vector<Policy>& identity_policies,
-    const vector<Policy>& session_policies)
+    const vector<Policy>& session_policies,
+    bool cross_account)
 {
   auto identity_res = eval_identity_or_session_policies(dpp, identity_policies, env, op, arn);
   if (identity_res == Effect::Deny) {
@@ -1271,9 +1272,11 @@ bool verify_user_permission(const DoutPrefixProvider* dpp,
                             bool mandatory_policy)
 {
   const bool account_root = (s->identity->get_identity_type() == TYPE_ROOT);
+  constexpr bool cross_account = false;
   const auto effect = evaluate_iam_policies(dpp, s->env, *s->identity,
                                             account_root, op, res, {},
-                                            user_policies, session_policies);
+                                            user_policies, session_policies,
+                                            cross_account);
   if (effect == Effect::Deny) {
     return false;
   }
@@ -1362,7 +1365,9 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
 			      const boost::optional<Policy>& bucket_policy,
                               const vector<Policy>& identity_policies,
                               const vector<Policy>& session_policies,
-                              const uint64_t op, bool* granted_by_acl)
+                              const uint64_t op,
+                              bool cross_account,
+                              bool* granted_by_acl)
 {
   if (!verify_requester_payer_permission(s))
     return false;
@@ -1383,7 +1388,7 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
 
   const auto effect = evaluate_iam_policies(
       dpp, s->env, *s->identity, account_root, op, arn,
-      bucket_policy, identity_policies, session_policies);
+      bucket_policy, identity_policies, session_policies, cross_account);
   if (effect == Effect::Deny) {
     return false;
   }
@@ -1418,27 +1423,32 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
     if (!ps.identity->is_owner_of(s->bucket_owner.id)) {
       ldpp_dout(dpp, 4) << "cross-account request for bucket owner "
           << s->bucket_owner.id << " != " << s->owner.id << dendl;
+      constexpr bool cross_account = true;
       // cross-account requests evaluate the identity-based policies separately
       // from the resource-based policies and require Allow from both
       return verify_bucket_permission(dpp, &ps, arn, account_root, {}, {}, {},
                                       user_policies, session_policies, op,
-                                      &s->granted_by_acl)
+                                      cross_account, &s->granted_by_acl)
           && verify_bucket_permission(dpp, &ps, arn, false, user_acl,
                                       bucket_acl, bucket_policy, {}, {}, op,
-                                      &s->granted_by_acl);
+                                      cross_account, &s->granted_by_acl);
     } else {
+      constexpr bool cross_account = false;
       // don't consult acls for same-account access. require an Allow from
       // either identity- or resource-based policy
       return verify_bucket_permission(dpp, &ps, arn, account_root, {}, {},
                                       bucket_policy, user_policies,
-                                      session_policies, op, &s->granted_by_acl);
+                                      session_policies, op,
+                                      cross_account, &s->granted_by_acl);
     }
   }
   constexpr bool account_root = false;
+  constexpr bool cross_account = false;
   return verify_bucket_permission(dpp, &ps, arn, account_root,
                                   user_acl, bucket_acl,
                                   bucket_policy, user_policies,
-                                  session_policies, op, &s->granted_by_acl);
+                                  session_policies, op,
+                                  cross_account, &s->granted_by_acl);
 }
 
 bool verify_bucket_permission_no_policy(const DoutPrefixProvider* dpp,
@@ -1534,7 +1544,9 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, struct perm_state_b
                               const boost::optional<Policy>& bucket_policy,
                               const vector<Policy>& identity_policies,
                               const vector<Policy>& session_policies,
-                              const uint64_t op, bool* granted_by_acl)
+                              const uint64_t op,
+                              bool cross_account,
+                              bool* granted_by_acl)
 {
   if (!verify_requester_payer_permission(ps))
     return false;
@@ -1550,7 +1562,7 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, struct perm_state_b
 
   const auto effect = evaluate_iam_policies(
       dpp, ps->env, *ps->identity, account_root, op, ARN(obj),
-      bucket_policy, identity_policies, session_policies);
+      bucket_policy, identity_policies, session_policies, cross_account);
   if (effect == Effect::Deny) {
     return false;
   }
@@ -1589,28 +1601,33 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, req_state * const s
     if (!ps.identity->is_owner_of(object_owner)) {
       ldpp_dout(dpp, 4) << "cross-account request for object owner "
           << object_owner << " != " << s->owner.id << dendl;
+      constexpr bool cross_account = true;
       // cross-account requests evaluate the identity-based policies separately
       // from the resource-based policies and require Allow from both
       return verify_object_permission(dpp, &ps, obj, account_root, {}, {}, {}, {},
                                       identity_policies, session_policies, op,
-                                      &s->granted_by_acl)
+                                      cross_account, &s->granted_by_acl)
           && verify_object_permission(dpp, &ps, obj, false,
                                       user_acl, bucket_acl, object_acl,
-                                      bucket_policy, {}, {}, op, &s->granted_by_acl);
+                                      bucket_policy, {}, {}, op,
+                                      cross_account, &s->granted_by_acl);
     } else {
+      constexpr bool cross_account = false;
       // don't consult acls for same-account access. require an Allow from
       // either identity- or resource-based policy
       return verify_object_permission(dpp, &ps, obj, account_root, {}, {}, {},
                                       bucket_policy, identity_policies,
-                                      session_policies, op, &s->granted_by_acl);
+                                      session_policies, op,
+                                      cross_account, &s->granted_by_acl);
     }
   }
   constexpr bool account_root = false;
+  constexpr bool cross_account = false;
   return verify_object_permission(dpp, &ps, obj, account_root,
                                   user_acl, bucket_acl,
                                   object_acl, bucket_policy,
                                   identity_policies, session_policies, op,
-                                  &s->granted_by_acl);
+                                  cross_account, &s->granted_by_acl);
 }
 
 bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1215,29 +1215,20 @@ Effect evaluate_iam_policies(
       ldpp_dout(dpp, 10) << __func__ << ": explicit deny from session policy" << dendl;
       return Effect::Deny;
     }
+    if (session_res == Effect::Allow && identity_res == Effect::Allow) {
+      ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
+      return Effect::Allow;
+    }
     if (princ_type == PolicyPrincipal::Role) {
       //Intersection of session policy and identity policy plus intersection of session policy and bucket policy
-      if (session_res == Effect::Allow && identity_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
-        return Effect::Allow;
-      }
       if (session_res == Effect::Allow && resource_res == Effect::Allow) {
         ldpp_dout(dpp, 10) << __func__ << ": allowed by session and resource-based policy" << dendl;
         return Effect::Allow;
       }
     } else if (princ_type == PolicyPrincipal::Session) {
       //Intersection of session policy and identity policy plus bucket policy
-      if (session_res == Effect::Allow && identity_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
-        return Effect::Allow;
-      }
       if (resource_res == Effect::Allow) {
         ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
-        return Effect::Allow;
-      }
-    } else if (princ_type == PolicyPrincipal::Other) {// there was no match in the bucket policy
-      if (session_res == Effect::Allow && identity_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
         return Effect::Allow;
       }
     }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -40,7 +40,6 @@ using rgw::ARN;
 using rgw::IAM::Effect;
 using rgw::IAM::op_to_perm;
 using rgw::IAM::Policy;
-using rgw::IAM::PolicyPrincipal;
 
 const uint32_t RGWBucketInfo::NUM_SHARDS_BLIND_BUCKET(UINT32_MAX);
 
@@ -1153,11 +1152,11 @@ Effect eval_or_pass(const DoutPrefixProvider* dpp,
                     boost::optional<const rgw::auth::Identity&> id,
                     const uint64_t op,
                     const ARN& resource,
-                    boost::optional<rgw::IAM::PolicyPrincipal&> princ_type=boost::none) {
+                    boost::optional<rgw::auth::Principal>& principal) {
   if (!policy) {
     return Effect::Pass;
   } else {
-    return policy->eval(dpp, env, id, op, resource, princ_type);
+    return policy->eval(dpp, env, id, op, resource, principal);
   }
 }
 
@@ -1168,7 +1167,8 @@ Effect eval_identity_or_session_policies(const DoutPrefixProvider* dpp,
                           const ARN& arn) {
   auto policy_res = Effect::Pass, prev_res = Effect::Pass;
   for (auto& policy : policies) {
-    if (policy_res = eval_or_pass(dpp, policy, env, boost::none, op, arn);
+    boost::optional<rgw::auth::Principal> principal; // ignored
+    if (policy_res = policy.eval(env, boost::none, op, arn, principal);
         policy_res == Effect::Deny) {
       ldpp_dout(dpp, 10) << __func__ << " Deny from " << policy << dendl;
       return policy_res;
@@ -1200,9 +1200,10 @@ Effect evaluate_iam_policies(
     return Effect::Deny;
   }
 
-  PolicyPrincipal princ_type = PolicyPrincipal::Other;
+  // Principal matched by resource policy
+  boost::optional<rgw::auth::Principal> principal;
   auto resource_res = eval_or_pass(dpp, resource_policy, env, identity,
-                                   op, arn, princ_type);
+                                   op, arn, principal);
   if (resource_res == Effect::Deny) {
     ldpp_dout(dpp, 10) << __func__ << ": explicit deny from resource-based policy" << dendl;
     return Effect::Deny;
@@ -1219,17 +1220,21 @@ Effect evaluate_iam_policies(
       ldpp_dout(dpp, 10) << __func__ << ": allowed by session and identity-based policy" << dendl;
       return Effect::Allow;
     }
-    if (princ_type == PolicyPrincipal::Role) {
-      //Intersection of session policy and identity policy plus intersection of session policy and bucket policy
-      if (session_res == Effect::Allow && resource_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by session and resource-based policy" << dendl;
-        return Effect::Allow;
+    if (principal) {
+      if (principal->is_role()) {
+        //Intersection of session policy and identity policy plus intersection of session policy and bucket policy
+        if (session_res == Effect::Allow && resource_res == Effect::Allow) {
+          ldpp_dout(dpp, 10) << __func__ << ": allowed by session and resource-based policy" << dendl;
+          return Effect::Allow;
+        }
       }
-    } else if (princ_type == PolicyPrincipal::Session) {
-      //Intersection of session policy and identity policy plus bucket policy
-      if (resource_res == Effect::Allow) {
-        ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
-        return Effect::Allow;
+      // tenanted roles may also match the user principal that assumed the role
+      if (principal->is_assumed_role() || principal->is_user()) {
+        //Intersection of session policy and identity policy plus bucket policy
+        if (resource_res == Effect::Allow) {
+          ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
+          return Effect::Allow;
+        }
       }
     }
     ldpp_dout(dpp, 10) << __func__ << ": implicit deny from session policy" << dendl;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1242,10 +1242,17 @@ Effect evaluate_iam_policies(
     return Effect::Pass;
   }
 
-  // Allow from resource policy overrides implicit deny from identity
+  // unless granted to the account principal, Allow from resource policy
+  // overrides implicit deny from identity. but only same-account evaluation
+  // considers both
   if (resource_res == Effect::Allow) {
-    ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
-    return Effect::Allow;
+    if (!cross_account && principal && principal->is_account()) {
+      ldpp_dout(dpp, 10) << __func__ << ": account principal allowed by "
+          "resource-based policy, but identity-based policy still required" << dendl;
+    } else {
+      ldpp_dout(dpp, 10) << __func__ << ": allowed by resource-based policy" << dendl;
+      return Effect::Allow;
+    }
   }
 
   if (identity_res == Effect::Allow) {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1825,7 +1825,8 @@ rgw::IAM::Effect evaluate_iam_policies(
     bool account_root, uint64_t op, const rgw::ARN& arn,
     const boost::optional<rgw::IAM::Policy>& resource_policy,
     const std::vector<rgw::IAM::Policy>& identity_policies,
-    const std::vector<rgw::IAM::Policy>& session_policies);
+    const std::vector<rgw::IAM::Policy>& session_policies,
+    bool cross_account);
 
 bool verify_user_permission(const DoutPrefixProvider* dpp,
                             req_state * const s,
@@ -1844,7 +1845,9 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
 			      const boost::optional<rgw::IAM::Policy>& bucket_policy,
                               const std::vector<rgw::IAM::Policy>& identity_policies,
                               const std::vector<rgw::IAM::Policy>& session_policies,
-                              const uint64_t op, bool *granted_by_acl = nullptr);
+                              const uint64_t op,
+                              bool cross_account,
+                              bool *granted_by_acl = nullptr);
 bool verify_bucket_permission(
   const DoutPrefixProvider* dpp,
   req_state * const s,

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1879,20 +1879,6 @@ Effect Policy::eval(const Environment& e,
   return allowed ? Effect::Allow : Effect::Pass;
 }
 
-Effect Policy::eval_principal(const Environment& e,
-		    boost::optional<const rgw::auth::Identity&> ida, boost::optional<PolicyPrincipal&> princ_type) const {
-  auto allowed = false;
-  for (auto& s : statements) {
-    auto g = s.eval_principal(e, ida, princ_type);
-    if (g == Effect::Deny) {
-      return g;
-    } else if (g == Effect::Allow) {
-      allowed = true;
-    }
-  }
-  return allowed ? Effect::Allow : Effect::Deny;
-}
-
 Effect Policy::eval_conditions(const Environment& e) const {
   auto allowed = false;
   for (auto& s : statements) {

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1256,9 +1256,9 @@ Statement::eval(
     uint64_t act,
     boost::optional<const ARN&> res,
     const LogOut& eval_log,
-    boost::optional<PolicyPrincipal&> princ_type) const {
+    boost::optional<rgw::auth::Principal>& principal) const {
 
-  if (eval_principal(e, ida, eval_log, princ_type) == Effect::Deny) {
+  if (eval_principal(e, ida, eval_log, principal) == Effect::Deny) {
     eval_log.format("Passing.");
     return Effect::Pass;
   }
@@ -1328,64 +1328,31 @@ Statement::eval(
   return Effect::Pass;
 }
 
-static bool is_identity(const auth::Identity& ida,
-                        const flat_set<auth::Principal>& princ)
-{
-  return std::any_of(princ.begin(), princ.end(),
-      [&ida] (const auth::Principal& p) {
-        return ida.is_identity(p);
-      });
-}
-
 Effect
 Statement::eval_principal(
     const Environment& e,
     boost::optional<const rgw::auth::Identity&> ida,
     const LogOut& eval_log,
-    boost::optional<PolicyPrincipal&> princ_type) const {
-  if (princ_type) {
-    *princ_type = PolicyPrincipal::Other;
-  }
+    boost::optional<rgw::auth::Principal>& principal) const {
   eval_log.format("Evaluating identity `{}`:", ida);
   if (ida) {
-    if (princ.empty() && noprinc.empty()) {
-      eval_log.format("Principal empty and NotPrincipal empty: Denying.");
-      return Effect::Deny;
-    }
-    if (ida->get_identity_type() != TYPE_ROLE &&
-        !princ.empty() && !is_identity(*ida, princ)) {
-      eval_log.format("Identity is not role, Principal is not empty, and "
-                      "the identity is not in Principal.");
-      return Effect::Deny;
-    }
-    eval_log.format("Checking type of Principal match.");
-    if (ida->get_identity_type() == TYPE_ROLE && !princ.empty()) {
-      bool princ_matched = false;
-      // Check each principal to determine the type of the one that has matched
-      for (auto p : princ) {
-        if (ida->is_identity(p)) {
-          if (p.is_assumed_role() || p.is_user()) {
-            if (princ_type) {
-              eval_log.format("Setting principal type to Session.");
-              *princ_type = PolicyPrincipal::Session;
-            }
-          } else {
-            if (princ_type) {
-              eval_log.format("Setting principal type to Role.");
-              *princ_type = PolicyPrincipal::Role;
-            }
-          }
-          princ_matched = true;
-        }
-      }
-      if (!princ_matched) {
-        eval_log.format("No match in Principal, Denying.");
-        return Effect::Deny;
-      }
-    } else if (!noprinc.empty() && is_identity(*ida, noprinc)) {
+    auto is_identity = [&ida] (const auth::Principal& p) {
+        return ida->is_identity(p);
+      };
+
+    auto p = std::find_if(noprinc.begin(), noprinc.end(), is_identity);
+    if (p != noprinc.end()) { // NotPrincipal matched
       eval_log.format("Match in NotPrincipal, Denying.");
       return Effect::Deny;
     }
+
+    p = std::find_if(princ.begin(), princ.end(), is_identity);
+    if (p == princ.end()) { // no Principal matched
+      eval_log.format("No match in Principal, Denying.");
+      return Effect::Deny;
+    }
+
+    principal = *p; // return first match
   }
   return Effect::Allow;
 }
@@ -2034,7 +2001,7 @@ Effect Policy::eval(const Environment& e,
                     std::uint64_t action,
                     boost::optional<const ARN&> resource,
                     const LogOut& eval_log,
-                    boost::optional<PolicyPrincipal&> princ_type) const
+                    boost::optional<rgw::auth::Principal>& principal) const
 {
   auto allowed = false;
   eval_log.format("Evaluating policy:\n```\n{}\n```\n"
@@ -2047,12 +2014,15 @@ Effect Policy::eval(const Environment& e,
 
   for (auto& s : statements) {
     eval_log.format("Evaluating statement `{}`:", s);
-    auto g = s.eval(e, ida, action, resource, eval_log, princ_type);
+    boost::optional<rgw::auth::Principal> princ_tmp;
+    auto g = s.eval(e, ida, action, resource, eval_log, princ_tmp);
     if (g == Effect::Deny) {
       eval_log.format("Denying.");
       return g;
     } else if (g == Effect::Allow) {
       allowed = true;
+      // only overwrite output principal for matching statements
+      principal = std::move(princ_tmp);
     }
   }
   eval_log.format("{}", allowed ? "Allowing." : "Passing.");
@@ -2064,11 +2034,11 @@ Policy::eval_principal(
     const Environment& e,
     boost::optional<const rgw::auth::Identity&> ida,
     const LogOut& eval_log,
-    boost::optional<PolicyPrincipal&> princ_type) const {
+    boost::optional<rgw::auth::Principal>& principal) const {
   auto allowed = false;
   for (auto& s : statements) {
     eval_log.format("Evaluating identity `{}` in statement `{}`:", ida, s);
-    auto g = s.eval_principal(e, ida, eval_log, princ_type);
+    auto g = s.eval_principal(e, ida, eval_log, principal);
     if (g == Effect::Deny) {
       eval_log.format("Denying.");
       return g;

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -339,12 +339,6 @@ inline int op_to_perm(std::uint64_t op) {
 
 const char* action_bit_string(uint64_t action);
 
-enum class PolicyPrincipal {
-  Role,
-  Session,
-  Other
-};
-
 using Environment = std::unordered_multimap<std::string, std::string>;
 
 using Address = std::bitset<128>;
@@ -606,10 +600,12 @@ struct Statement {
 
   Effect eval(const Environment& e,
 	      boost::optional<const rgw::auth::Identity&> ida,
-	      std::uint64_t action, boost::optional<const ARN&> resource, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+	      std::uint64_t action, boost::optional<const ARN&> resource,
+	      boost::optional<rgw::auth::Principal>& principal) const;
 
   Effect eval_principal(const Environment& e,
-		       boost::optional<const rgw::auth::Identity&> ida, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+		       boost::optional<const rgw::auth::Identity&> ida,
+		       boost::optional<rgw::auth::Principal>& principal) const;
 
   Effect eval_conditions(const Environment& e) const;
 };
@@ -652,7 +648,8 @@ struct Policy {
 
   Effect eval(const Environment& e,
 	      boost::optional<const rgw::auth::Identity&> ida,
-	      std::uint64_t action, boost::optional<const ARN&> resource, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+	      std::uint64_t action, boost::optional<const ARN&> resource,
+	      boost::optional<rgw::auth::Principal>& principal) const;
 
   Effect eval_conditions(const Environment& e) const;
 

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -654,9 +654,6 @@ struct Policy {
 	      boost::optional<const rgw::auth::Identity&> ida,
 	      std::uint64_t action, boost::optional<const ARN&> resource, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
 
-  Effect eval_principal(const Environment& e,
-	      boost::optional<const rgw::auth::Identity&> ida, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
-
   Effect eval_conditions(const Environment& e) const;
 
   template <typename F>

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -347,12 +347,6 @@ inline int op_to_perm(std::uint64_t op) {
 
 std::string_view action_bit_string(action_t action);
 
-enum class PolicyPrincipal {
-  Role,
-  Session,
-  Other
-};
-
 using Environment = std::unordered_multimap<std::string, std::string>;
 
 using Address = std::bitset<128>;
@@ -702,13 +696,13 @@ struct Statement {
               std::uint64_t action,
               boost::optional<const ARN&> resource,
               const LogOut& eval_log,
-              boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+              boost::optional<rgw::auth::Principal>& principal) const;
 
   Effect eval_principal(
     const Environment& e,
     boost::optional<const rgw::auth::Identity&> ida,
     const LogOut& eval_log,
-    boost::optional<PolicyPrincipal&> princ_type = boost::none) const;
+    boost::optional<rgw::auth::Principal>& principal) const;
 
   Effect
   eval_conditions(const Environment& e,
@@ -755,16 +749,16 @@ struct Policy {
               boost::optional<const rgw::auth::Identity&> ida,
               std::uint64_t action,
               boost::optional<const ARN&> resource,
-              boost::optional<PolicyPrincipal&> princ_type = boost::none) const {
-    return eval(e, ida, action, resource, out, princ_type);
+              boost::optional<rgw::auth::Principal>& principal) const {
+    return eval(e, ida, action, resource, out, principal);
   }
 
   Effect eval(const Environment& e,
               boost::optional<const rgw::auth::Identity&> ida,
               std::uint64_t action,
               boost::optional<const ARN&> resource,
-              boost::optional<PolicyPrincipal&> princ_type = boost::none) const {
-    return eval(e, ida, action, resource, {}, princ_type);
+              boost::optional<rgw::auth::Principal>& principal) const {
+    return eval(e, ida, action, resource, {}, principal);
   }
 
   Effect eval(const DoutPrefixProvider* dpp,
@@ -772,15 +766,15 @@ struct Policy {
               boost::optional<const rgw::auth::Identity&> ida,
               std::uint64_t action,
               boost::optional<const ARN&> resource,
-              boost::optional<PolicyPrincipal&> princ_type = boost::none) const {
-      return eval(e, ida, action, resource, dpp, princ_type);
+              boost::optional<rgw::auth::Principal>& principal) const {
+      return eval(e, ida, action, resource, dpp, principal);
   }
 
   Effect eval_principal(
       const Environment& e,
       boost::optional<const rgw::auth::Identity&> ida,
       const LogOut& eval_log,
-      boost::optional<PolicyPrincipal&> princ_type = boost::none) const;
+      boost::optional<rgw::auth::Principal>& principal) const;
 
   Effect eval_conditions(const Environment& e,
                          const LogOut& eval_log) const;
@@ -825,7 +819,7 @@ private:
               std::uint64_t action,
               boost::optional<const ARN&> resource,
               const LogOut& eval_log,
-              boost::optional<PolicyPrincipal&> princ_type  =boost::none) const;
+              boost::optional<rgw::auth::Principal>& principal) const;
 
 };
 

--- a/src/rgw/rgw_poltester.cc
+++ b/src/rgw/rgw_poltester.cc
@@ -35,11 +35,12 @@ evaluate(CephContext* cct, const std::string* tenant,
 {
   buffer::list bl;
   bl.append(in);
+  boost::optional<rgw::auth::Principal> ignored;
   try {
     auto p = rgw::IAM::Policy(
       cct, tenant, bl.to_str(),
       cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
-    auto effect = p.eval(std::cout, environment, ida, action, resource);
+    auto effect = p.eval(std::cout, environment, ida, action, resource, ignored);
     std::cout << effect << std::endl;
   } catch (const rgw::IAM::PolicyParseException& e) {
     std::cerr << fname << ": " << e.what() << std::endl;

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -174,30 +174,33 @@ bool verify_topic_permission(const DoutPrefixProvider* dpp, req_state* s,
     if (!s->auth.identity->is_owner_of(owner)) {
       ldpp_dout(dpp, 4) << "cross-account request for resource owner "
           << owner << " != " << s->owner.id << dendl;
+      constexpr bool cross_account = true;
       // cross-account requests evaluate the identity-based policies separately
       // from the resource-based policies and require Allow from both
       const auto identity_res = evaluate_iam_policies(
-          dpp, s->env, *s->auth.identity, account_root, op, arn,
-          {}, s->iam_identity_policies, s->session_policies);
+          dpp, s->env, *s->auth.identity, account_root, op, arn, {},
+          s->iam_identity_policies, s->session_policies, cross_account);
       if (identity_res == Effect::Deny) {
         return false;
       }
       const auto resource_res = evaluate_iam_policies(
           dpp, s->env, *s->auth.identity, false, op, arn,
-          policy, {}, {});
+          policy, {}, {}, cross_account);
       return identity_res == Effect::Allow && resource_res == Effect::Allow;
     } else {
       // require an Allow from either identity- or resource-based policy
+      constexpr bool cross_account = false;
       return Effect::Allow == evaluate_iam_policies(
-          dpp, s->env, *s->auth.identity, account_root, op, arn,
-          policy, s->iam_identity_policies, s->session_policies);
+          dpp, s->env, *s->auth.identity, account_root, op, arn, policy,
+          s->iam_identity_policies, s->session_policies, cross_account);
     }
   }
 
   constexpr bool account_root = false;
+  constexpr bool cross_account = false;
   const auto effect = evaluate_iam_policies(
-      dpp, s->env, *s->auth.identity, account_root, op, arn,
-      policy, s->iam_identity_policies, s->session_policies);
+      dpp, s->env, *s->auth.identity, account_root, op, arn, policy,
+      s->iam_identity_policies, s->session_policies, cross_account);
   if (effect == Effect::Deny) {
     return false;
   }

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -849,7 +849,9 @@ int RGWREST_STS::verify_permission(optional_yield y)
 
     const rgw::IAM::Policy p(s->cct, policy_tenant, policy, false);
     if (!s->principal_tags.empty()) {
-      auto res = p.eval(s->env, *s->auth.identity, rgw::IAM::stsTagSession, boost::none);
+      boost::optional<rgw::auth::Principal> principal; // ignored
+      auto res = p.eval(s->env, *s->auth.identity, rgw::IAM::stsTagSession,
+                        boost::none, principal);
       if (res != rgw::IAM::Effect::Allow) {
         ldout(s->cct, 0) << "evaluating policy for stsTagSession returned deny/pass" << dendl;
         return -EPERM;
@@ -862,7 +864,8 @@ int RGWREST_STS::verify_permission(optional_yield y)
       op = rgw::IAM::stsAssumeRole;
     }
 
-    auto res = p.eval(s->env, *s->auth.identity, op, boost::none);
+    boost::optional<rgw::auth::Principal> principal; // ignored
+    auto res = p.eval(s->env, *s->auth.identity, op, boost::none, principal);
     if (res != rgw::IAM::Effect::Allow) {
       ldout(s->cct, 0) << "evaluating policy for op: " << op << " returned deny/pass" << dendl;
       return -EPERM;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -866,7 +866,9 @@ int RGWREST_STS::verify_permission(optional_yield y)
 
     const rgw::IAM::Policy p(s->cct, policy_tenant, policy, false);
     if (!s->principal_tags.empty()) {
-      auto res = p.eval(this, s->env, *s->auth.identity, rgw::IAM::stsTagSession, boost::none);
+      boost::optional<rgw::auth::Principal> principal; // ignored
+      auto res = p.eval(this, s->env, *s->auth.identity, rgw::IAM::stsTagSession,
+                        boost::none, principal);
       if (res != rgw::IAM::Effect::Allow) {
         ldout(s->cct, 0) << "evaluating policy for stsTagSession returned deny/pass" << dendl;
         return -EPERM;
@@ -879,7 +881,8 @@ int RGWREST_STS::verify_permission(optional_yield y)
       op = rgw::IAM::stsAssumeRole;
     }
 
-    auto res = p.eval(this, s->env, *s->auth.identity, op, boost::none);
+    boost::optional<rgw::auth::Principal> principal; // ignored
+    auto res = p.eval(this, s->env, *s->auth.identity, op, boost::none, principal);
     if (res != rgw::IAM::Effect::Allow) {
       ldout(s->cct, 0) << "evaluating policy for op: " << op << " returned deny/pass" << dendl;
       return -EPERM;

--- a/src/test/rgw/s3-tests/s3tests/functional/test_iam.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_iam.py
@@ -2605,6 +2605,106 @@ def test_verify_update_thumbprintlist_of_oidc(iam_root):
                     )
     assert del_response['ResponseMetadata']['HTTPStatusCode'] == 200
 
+def test_same_account_bucket_policy_allow_user_arn(iam_root):
+    roots3 = get_iam_root_client(service_name='s3')
+    path = get_iam_path_prefix()
+    user_name = make_iam_name('User')
+    response = iam_root.create_user(UserName=user_name, Path=path)
+    user_arn = response['User']['Arn']
+    key = iam_root.create_access_key(UserName=user_name)['AccessKey']
+    s3 = get_iam_s3client(aws_access_key_id=key['AccessKeyId'],
+                          aws_secret_access_key=key['SecretAccessKey'])
+
+    # create a bucket with the root user
+    bucket = get_new_bucket(roots3)
+    try:
+        # the access key may take a bit to start working. retry until it returns
+        # something other than InvalidAccessKeyId
+        e = assert_raises(ClientError, retry_on, 'InvalidAccessKeyId', 10, s3.list_objects, Bucket=bucket)
+        status, error_code = _get_status_and_error_code(e.response)
+        assert status == 403
+        assert error_code == 'AccessDenied'
+
+        # add a bucket policy that allows s3:ListBucket for the iam user's arn
+        roots3.put_bucket_policy(Bucket=bucket, Policy=json.dumps({
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Allow',
+                'Principal': {'AWS': user_arn},
+                'Action': 's3:ListBucket',
+                'Resource': f'arn:aws:s3:::{bucket}'
+                }]
+            }))
+
+        # because the bucket policy names the user's arn, access should not require identity policy
+        retry_on('AccessDenied', 10, s3.list_objects, Bucket=bucket)
+    finally:
+        roots3.delete_bucket(Bucket=bucket)
+
+def _test_same_account_bucket_policy_allow_account(root, user_name, principal):
+    key = root.create_access_key(UserName=user_name)['AccessKey']
+    s3 = get_iam_s3client(aws_access_key_id=key['AccessKeyId'],
+                          aws_secret_access_key=key['SecretAccessKey'])
+
+    # create a bucket with the root user
+    roots3 = get_iam_root_client(service_name='s3')
+    bucket = get_new_bucket(roots3)
+    try:
+        # the access key may take a bit to start working. retry until it returns
+        # something other than InvalidAccessKeyId
+        e = assert_raises(ClientError, retry_on, 'InvalidAccessKeyId', 10, s3.list_objects, Bucket=bucket)
+        status, error_code = _get_status_and_error_code(e.response)
+        assert status == 403
+        assert error_code == 'AccessDenied'
+
+        # add a bucket policy that allows s3:ListBucket for the given principal
+        roots3.put_bucket_policy(Bucket=bucket, Policy=json.dumps({
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Allow',
+                'Principal': {'AWS': principal},
+                'Action': 's3:ListBucket',
+                'Resource': f'arn:aws:s3:::{bucket}'
+                }]
+            }))
+
+        # ListBucket should still fail without identity policy
+        e = assert_raises(ClientError, s3.list_objects, Bucket=bucket)
+        status, error_code = _get_status_and_error_code(e.response)
+        assert status == 403
+        assert error_code == 'AccessDenied'
+
+        # add a user policy that allows s3 actions
+        root.put_user_policy(UserName=user_name, PolicyName='AllowStar', PolicyDocument=json.dumps({
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Allow',
+                'Action': 's3:*',
+                'Resource': '*'
+                }]
+            }))
+
+        # verify that the iam user can eventually access it
+        retry_on('AccessDenied', 10, s3.list_objects, Bucket=bucket)
+    finally:
+        roots3.delete_bucket(Bucket=bucket)
+
+def test_same_account_bucket_policy_allow_account_arn(iam_root):
+    path = get_iam_path_prefix()
+    user_name = make_iam_name('User')
+    response = iam_root.create_user(UserName=user_name, Path=path)
+    user_arn = response['User']['Arn']
+    account_arn = user_arn.replace(f':user{path}{user_name}', ':root')
+    _test_same_account_bucket_policy_allow_account(iam_root, user_name, account_arn)
+
+def test_same_account_bucket_policy_allow_account_id(iam_root):
+    path = get_iam_path_prefix()
+    user_name = make_iam_name('User')
+    response = iam_root.create_user(UserName=user_name, Path=path)
+    user_arn = response['User']['Arn']
+    account_id = get_iam_root_account_id()
+    _test_same_account_bucket_policy_allow_account(iam_root, user_name, account_id)
+
 # test cross-account access, adding user policy before the bucket policy
 def _test_cross_account_user_bucket_policy(roots3, alt_root, alt_name, alt_arn):
     # add a user policy that allows s3 actions

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -194,18 +194,23 @@ TEST_F(PolicyTest, Parse1) {
 TEST_F(PolicyTest, Eval1) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example1, true);
   Environment e;
+  boost::optional<Principal> principal;
 
   ARN arn1(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn1), Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn1, principal),
+            Effect::Allow);
+  EXPECT_FALSE(principal);
 
   ARN arn2(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(p.eval(e, none, s3PutBucketAcl, arn2), Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, s3PutBucketAcl, arn2, principal),
+            Effect::Pass);
 
   ARN arn3(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "erroneous_bucket");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn3), Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn3, principal),
+            Effect::Pass);
 
 }
 
@@ -255,6 +260,7 @@ TEST_F(PolicyTest, Parse2) {
 TEST_F(PolicyTest, Eval2) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example2, true);
   Environment e;
+  boost::optional<Principal> principal;
 
   auto trueacct = PrincipalIdentity(
     Principal::account("ACCOUNT-ID-WITHOUT-HYPHENS"));
@@ -264,22 +270,31 @@ TEST_F(PolicyTest, Eval2) {
   for (auto i = 0ULL; i < s3All; ++i) {
     ARN arn1(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn1), Effect::Allow);
+    EXPECT_EQ(p.eval(e, trueacct, i, arn1, principal),
+              Effect::Allow);
+    ASSERT_TRUE(principal);
+    EXPECT_TRUE(principal->is_account());
     ARN arn2(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket/myobject");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn2), Effect::Allow);
+    EXPECT_EQ(p.eval(e, trueacct, i, arn2, principal),
+              Effect::Allow);
     ARN arn3(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket");
-    EXPECT_EQ(p.eval(e, notacct, i, arn3), Effect::Pass);
+    EXPECT_EQ(p.eval(e, notacct, i, arn3, principal),
+              Effect::Pass);
     ARN arn4(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket/myobject");
-    EXPECT_EQ(p.eval(e, notacct, i, arn4), Effect::Pass);
+    EXPECT_EQ(p.eval(e, notacct, i, arn4, principal),
+              Effect::Pass);
     ARN arn5(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "notyourbucket");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn5), Effect::Pass);
+    EXPECT_EQ(p.eval(e, trueacct, i, arn5, principal),
+              Effect::Pass);
     ARN arn6(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "notyourbucket/notyourobject");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn6), Effect::Pass);
+    EXPECT_EQ(p.eval(e, trueacct, i, arn6, principal),
+              Effect::Pass);
+
   }
 }
 
@@ -408,6 +423,7 @@ TEST_F(PolicyTest, Eval3) {
   Environment em;
   Environment tr = { { "aws:MultiFactorAuthPresent", "true" } };
   Environment fa = { { "aws:MultiFactorAuthPresent", "false" } };
+  boost::optional<Principal> principal;
 
   Action_t s3allow;
   s3allow[s3ListMultipartUploadParts] = 1;
@@ -451,11 +467,14 @@ TEST_F(PolicyTest, Eval3) {
 
   ARN arn1(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket");
-  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn1), Effect::Allow);
+  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn1, principal),
+            Effect::Allow);
+  EXPECT_FALSE(principal);
 
   ARN arn2(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket");
-  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn2), Effect::Allow);
+  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn2, principal),
+            Effect::Allow);
 
 
   for (auto op = 0ULL; op < s3All; ++op) {
@@ -464,45 +483,52 @@ TEST_F(PolicyTest, Eval3) {
     }
     ARN arn3(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data");
-    EXPECT_EQ(p.eval(em, none, op, arn3), Effect::Pass);
+    EXPECT_EQ(p.eval(em, none, op, arn3, principal),
+              Effect::Pass);
     ARN arn4(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data");
-    EXPECT_EQ(p.eval(tr, none, op, arn4), s3allow[op] ? Effect::Allow : Effect::Pass);
+    EXPECT_EQ(p.eval(tr, none, op, arn4, principal),
+              s3allow[op] ? Effect::Allow : Effect::Pass);
     ARN arn5(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data");
-    EXPECT_EQ(p.eval(fa, none, op, arn5), Effect::Pass);
+    EXPECT_EQ(p.eval(fa, none, op, arn5, principal),
+              Effect::Pass);
     ARN arn6(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data/moo");
-    EXPECT_EQ(p.eval(em, none, op, arn6), Effect::Pass);
+    EXPECT_EQ(p.eval(em, none, op, arn6, principal),
+              Effect::Pass);
     ARN arn7(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data/moo");
-    EXPECT_EQ(p.eval(tr, none, op, arn7),
-	      s3allow[op] ? Effect::Allow : Effect::Pass);
+    EXPECT_EQ(p.eval(tr, none, op, arn7, principal),
+              s3allow[op] ? Effect::Allow : Effect::Pass);
     ARN arn8(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data/moo");
-    EXPECT_EQ(p.eval(fa, none, op, arn8),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(fa, none, op, arn8, principal),
+              Effect::Pass);
     ARN arn9(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "really-confidential-data");
-    EXPECT_EQ(p.eval(em, none, op, arn9), Effect::Pass);
+    EXPECT_EQ(p.eval(em, none, op, arn9, principal),
+              Effect::Pass);
     ARN arn10(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "really-confidential-data");
-    EXPECT_EQ(p.eval(tr, none, op, arn10), Effect::Pass);
+    EXPECT_EQ(p.eval(tr, none, op, arn10, principal),
+              Effect::Pass);
     ARN arn11(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "really-confidential-data");
-    EXPECT_EQ(p.eval(fa, none, op, arn11), Effect::Pass);
+    EXPECT_EQ(p.eval(fa, none, op, arn11, principal),
+	      Effect::Pass);
     ARN arn12(Partition::aws, Service::s3,
 			 "", arbitrary_tenant,
 			 "really-confidential-data/moo");
-    EXPECT_EQ(p.eval(em, none, op, arn12), Effect::Pass);
+    EXPECT_EQ(p.eval(em, none, op, arn12, principal), Effect::Pass);
     ARN arn13(Partition::aws, Service::s3,
 			 "", arbitrary_tenant,
 			 "really-confidential-data/moo");
-    EXPECT_EQ(p.eval(tr, none, op, arn13), Effect::Pass);
+    EXPECT_EQ(p.eval(tr, none, op, arn13, principal), Effect::Pass);
     ARN arn14(Partition::aws, Service::s3,
 			 "", arbitrary_tenant,
 			 "really-confidential-data/moo");
-    EXPECT_EQ(p.eval(fa, none, op, arn14), Effect::Pass);
+    EXPECT_EQ(p.eval(fa, none, op, arn14, principal), Effect::Pass);
   }
 }
 
@@ -539,14 +565,18 @@ TEST_F(PolicyTest, Parse4) {
 TEST_F(PolicyTest, Eval4) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example4, true);
   Environment e;
+  boost::optional<Principal> principal;
 
   ARN arn1(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1), Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1, principal),
+            Effect::Allow);
+  EXPECT_FALSE(principal);
 
   ARN arn2(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamDeleteRole, arn2), Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, iamDeleteRole, arn2, principal),
+            Effect::Pass);
 }
 
 TEST_F(PolicyTest, Parse5) {
@@ -582,18 +612,23 @@ TEST_F(PolicyTest, Parse5) {
 TEST_F(PolicyTest, Eval5) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example5, true);
   Environment e;
+  boost::optional<Principal> principal;
 
   ARN arn1(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1), Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1, principal),
+            Effect::Allow);
+  EXPECT_FALSE(principal);
 
   ARN arn2(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2), Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2, principal),
+            Effect::Pass);
 
   ARN arn3(Partition::aws, Service::iam,
 		       "", "", "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn3), Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn3, principal),
+            Effect::Pass);
 }
 
 TEST_F(PolicyTest, Parse6) {
@@ -629,14 +664,18 @@ TEST_F(PolicyTest, Parse6) {
 TEST_F(PolicyTest, Eval6) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example6, true);
   Environment e;
+  boost::optional<Principal> principal;
 
   ARN arn1(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "user/A");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1), Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1, principal),
+            Effect::Allow);
+  EXPECT_FALSE(principal);
 
   ARN arn2(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "user/A");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2), Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2, principal),
+            Effect::Allow);
 }
 
 TEST_F(PolicyTest, Parse7) {
@@ -675,6 +714,7 @@ TEST_F(PolicyTest, Parse7) {
 TEST_F(PolicyTest, Eval7) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example7, true);
   Environment e;
+  boost::optional<Principal> principal;
 
   auto subacct = PrincipalIdentity(
     Principal::user(std::move(""), "A:subA"));
@@ -685,15 +725,20 @@ TEST_F(PolicyTest, Eval7) {
 
   ARN arn1(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket/*");
-  EXPECT_EQ(p.eval(e, subacct, s3ListBucket, arn1), Effect::Allow);
+  EXPECT_EQ(p.eval(e, subacct, s3ListBucket, arn1, principal),
+            Effect::Allow);
+  ASSERT_TRUE(principal);
+  EXPECT_TRUE(principal->is_user());
 
   ARN arn2(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket/*");
-  EXPECT_EQ(p.eval(e, parentacct, s3ListBucket, arn2), Effect::Pass);
+  EXPECT_EQ(p.eval(e, parentacct, s3ListBucket, arn2, principal),
+            Effect::Pass);
 
   ARN arn3(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket/*");
-  EXPECT_EQ(p.eval(e, sub2acct, s3ListBucket, arn3), Effect::Pass);
+  EXPECT_EQ(p.eval(e, sub2acct, s3ListBucket, arn3, principal),
+            Effect::Pass);
 }
 
 
@@ -1172,97 +1217,98 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
   allowedIPv6.emplace("aws:SourceIp", "::1");
   blocklistedIP.emplace("aws:SourceIp", "192.168.1.1");
   blocklistedIPv6.emplace("aws:SourceIp", "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+  boost::optional<Principal> principal;
 
   auto trueacct = PrincipalIdentity(
     Principal::account("ACCOUNT-ID-WITHOUT-HYPHENS"));
   // Without an IP address in the environment then evaluation will always pass
   ARN arn1(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(allowp.eval(e, trueacct, s3ListBucket, arn1),
+  EXPECT_EQ(allowp.eval(e, trueacct, s3ListBucket, arn1, principal),
             Effect::Pass);
   ARN arn2(Partition::aws, Service::s3,
       "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(fullp.eval(e, trueacct, s3ListBucket, arn2),
+  EXPECT_EQ(fullp.eval(e, trueacct, s3ListBucket, arn2, principal),
             Effect::Pass);
 
   ARN arn3(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(allowp.eval(allowedIP, trueacct, s3ListBucket, arn3),
+  EXPECT_EQ(allowp.eval(allowedIP, trueacct, s3ListBucket, arn3, principal),
             Effect::Allow);
   ARN arn4(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(allowp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn4),
+  EXPECT_EQ(allowp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn4, principal),
             Effect::Pass);
 
   ARN arn5(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket, arn5),
+  EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket, arn5, principal),
             Effect::Deny);
   ARN arn6(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket, arn6),
+  EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket, arn6, principal),
             Effect::Deny);
 
   ARN arn7(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket, arn7),
+  EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket, arn7, principal),
             Effect::Pass);
   ARN arn8(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket, arn8),
+  EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket, arn8, principal),
             Effect::Pass);
 
   ARN arn9(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn9),
+  EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn9, principal),
             Effect::Pass);
   ARN arn10(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn10),
+  EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn10, principal),
 	    Effect::Pass);
   ARN arn11(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(denyp.eval(allowedIPv6, trueacct, s3ListBucket, arn11),
+  EXPECT_EQ(denyp.eval(allowedIPv6, trueacct, s3ListBucket, arn11, principal),
 	    Effect::Deny);
   ARN arn12(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(denyp.eval(allowedIPv6, trueacct, s3ListBucket, arn12),
+  EXPECT_EQ(denyp.eval(allowedIPv6, trueacct, s3ListBucket, arn12, principal),
 	    Effect::Deny);
 
   ARN arn13(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(fullp.eval(allowedIP, trueacct, s3ListBucket, arn13),
+  EXPECT_EQ(fullp.eval(allowedIP, trueacct, s3ListBucket, arn13, principal),
 	    Effect::Allow);
   ARN arn14(Partition::aws, Service::s3,
       "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(fullp.eval(allowedIP, trueacct, s3ListBucket, arn14),
+  EXPECT_EQ(fullp.eval(allowedIP, trueacct, s3ListBucket, arn14, principal),
 	    Effect::Allow);
 
   ARN arn15(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(fullp.eval(blocklistedIP, trueacct, s3ListBucket, arn15),
+  EXPECT_EQ(fullp.eval(blocklistedIP, trueacct, s3ListBucket, arn15, principal),
 	    Effect::Pass);
   ARN arn16(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(fullp.eval(blocklistedIP, trueacct, s3ListBucket, arn16),
+  EXPECT_EQ(fullp.eval(blocklistedIP, trueacct, s3ListBucket, arn16, principal),
 	    Effect::Pass);
 
   ARN arn17(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(fullp.eval(allowedIPv6, trueacct, s3ListBucket, arn17),
+  EXPECT_EQ(fullp.eval(allowedIPv6, trueacct, s3ListBucket, arn17, principal),
 	    Effect::Allow);
   ARN arn18(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(fullp.eval(allowedIPv6, trueacct, s3ListBucket, arn18),
+  EXPECT_EQ(fullp.eval(allowedIPv6, trueacct, s3ListBucket, arn18, principal),
 	    Effect::Allow);
 
   ARN arn19(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(fullp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn19),
+  EXPECT_EQ(fullp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn19, principal),
 	    Effect::Pass);
   ARN arn20(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
-  EXPECT_EQ(fullp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn20),
+  EXPECT_EQ(fullp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn20, principal),
 	    Effect::Pass);
 }
 


### PR DESCRIPTION
for same-account access, a resource policy statement that Allows access to an account (or account-root) Principal still requires an Allow from identity-based policy. when resource policy allows access to other more-specific Principal types (user, role, etc), identity-based policy is not required

quoting https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic_policy-eval-denyallow.html:
> If a resource-based policy grants permission directly to the IAM user or the session principal that is making the request, then an implicit deny in an identity-based policy, a permissions boundary, or a session policy does not impact the final decision.

Fixes: https://tracker.ceph.com/issues/74471

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
