### PR TITLE
tentacle: mgr/dashboard: replace traddr with server_address in NVMeoF CLI

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -39,8 +39,11 @@ else:
         @EndpointDoc("Get information about the NVMeoF gateway")
         @convert_to_model(model.GatewayInfo)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_gateway_info(
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
 
@@ -65,8 +68,11 @@ else:
         @EndpointDoc("Get the version of the NVMeoF gateway")
         @convert_to_model(model.GatewayVersion)
         @handle_nvmeof_error
-        def version(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            gw_info = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_gateway_info(
+        def version(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            gw_info = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
             return NVMeoFClient.pb2.gw_version(status=gw_info.status,
@@ -82,9 +88,12 @@ else:
         @EndpointDoc("Get NVMeoF gateway log level information")
         @convert_to_model(model.GatewayLogLevelInfo)
         @handle_nvmeof_error
-        def get_log_level(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            gw_log_level = NVMeoFClient(gw_group=gw_group,
-                                        traddr=traddr).stub.get_gateway_log_level(
+        def get_log_level(self, gw_group: Optional[str] = None,
+                          server_address: Optional[str] = None):
+            gw_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_log_level(
                 NVMeoFClient.pb2.get_gateway_log_level_req()
             )
             return gw_log_level
@@ -97,10 +106,10 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_log_level(self, log_level: str, gw_group: Optional[str] = None,
-                          traddr: Optional[str] = None):
+                          server_address: Optional[str] = None):
             log_level = log_level.lower()
             gw_log_level = NVMeoFClient(gw_group=gw_group,
-                                        traddr=traddr).stub.set_gateway_log_level(
+                                        server_address=server_address).stub.set_gateway_log_level(
                 NVMeoFClient.pb2.set_gateway_log_level_req(log_level=log_level)
             )
             return gw_log_level
@@ -112,9 +121,12 @@ else:
         @EndpointDoc("Get NVMeoF statistics for the gateway")
         @convert_to_model(model.GatewayStatsInfo)
         @handle_nvmeof_error
-        def get_gw_stats(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            gw_stats = NVMeoFClient(gw_group=gw_group,
-                                    traddr=traddr).stub.get_gateway_stats(
+        def get_gw_stats(self, gw_group: Optional[str] = None,
+                         server_address: Optional[str] = None):
+            gw_stats = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_gateway_stats(
                 NVMeoFClient.pb2.get_gateway_stats_req()
             )
             return gw_stats
@@ -128,9 +140,11 @@ else:
         @convert_to_model(model.GatewayListenersInfo)
         @handle_nvmeof_error
         def listener_info(self, nqn: str, gw_group: Optional[str] = None,
-                          traddr: Optional[str] = None):
-            gw_listener_info = NVMeoFClient(gw_group=gw_group,
-                                            traddr=traddr).stub.show_gateway_listeners_info(
+                          server_address: Optional[str] = None):
+            gw_listener_info = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.show_gateway_listeners_info(
                 NVMeoFClient.pb2.show_gateway_listeners_info_req(subsystem_nqn=nqn)
             )
             return gw_listener_info
@@ -146,10 +160,12 @@ else:
         @handle_nvmeof_error
         def get_spdk_log_level(
             self, all_log_flags: Optional[bool] = None,
-            gw_group: Optional[str] = None, traddr: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None
         ):
-            spdk_log_level = NVMeoFClient(gw_group=gw_group,
-                                          traddr=traddr).stub.get_spdk_nvmf_log_flags_and_level(
+            spdk_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_spdk_nvmf_log_flags_and_level(
                 NVMeoFClient.pb2.get_spdk_nvmf_log_flags_and_level_req(all_log_flags=all_log_flags)
             )
             return spdk_log_level
@@ -163,11 +179,14 @@ else:
         def set_spdk_log_level(self, log_level: Optional[str] = None,
                                print_level: Optional[str] = None,
                                extra_log_flags: Optional[List[str]] = None,
-                               gw_group: Optional[str] = None, traddr: Optional[str] = None):
+                               gw_group: Optional[str] = None,
+                               server_address: Optional[str] = None):
             log_level = log_level.upper() if log_level else None
             print_level = print_level.upper() if print_level else None
-            spdk_log_level = NVMeoFClient(gw_group=gw_group,
-                                          traddr=traddr).stub.set_spdk_nvmf_logs(
+            spdk_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.set_spdk_nvmf_logs(
                 NVMeoFClient.pb2.set_spdk_nvmf_logs_req(log_level=log_level,
                                                         print_level=print_level,
                                                         extra_log_flags=extra_log_flags)
@@ -183,10 +202,12 @@ else:
         def disable_spdk_log_level(
             self, extra_log_flags: Optional[List[str]] = None,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            spdk_log_level = NVMeoFClient(gw_group=gw_group,
-                                          traddr=traddr).stub.disable_spdk_nvmf_logs(
+            spdk_log_level = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.disable_spdk_nvmf_logs(
                 NVMeoFClient.pb2.disable_spdk_nvmf_logs_req(extra_log_flags=extra_log_flags)
             )
             return spdk_log_level
@@ -199,8 +220,11 @@ else:
         @EndpointDoc("List all NVMeoF subsystems")
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_subsystems(
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req()
             )
 
@@ -211,12 +235,17 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def get(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_subsystems(
+        def get(self, nqn: str, gw_group: Optional[str] = None,
+                server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req(subsystem_nqn=nqn)
             )
 
@@ -233,7 +262,7 @@ else:
                 "serial_number": Param(int, "Subsystem serial number", True, None),
                 "dhchap_key": Param(int, "Subsystem DH-HMAC-CHAP key", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.SubsystemStatus)
@@ -241,8 +270,11 @@ else:
         def create(self, nqn: str, enable_ha: Optional[bool] = True,
                    max_namespaces: Optional[int] = None, no_group_append: Optional[bool] = False,
                    serial_number: Optional[str] = None, dhchap_key: Optional[str] = None,
-                   gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(
+                   gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
                     subsystem_nqn=nqn, serial_number=serial_number,
                     max_namespaces=max_namespaces, enable_ha=enable_ha,
@@ -258,13 +290,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "force": Param(bool, "Force delete", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, force: Optional[str] = "false", gw_group: Optional[str] = None,
-                   traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.delete_subsystem(
+                   server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.delete_subsystem(
                 NVMeoFClient.pb2.delete_subsystem_req(
                     subsystem_nqn=nqn, force=str_to_bool(force)
                 )
@@ -276,7 +312,7 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "dhchap_key": Param(str, "Subsystem DH-HMAC-CHAP key"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @empty_response
@@ -284,8 +320,11 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(self, nqn: str, dhchap_key: str, gw_group: Optional[str] = None,
-                       traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_subsystem_key(
+                       server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_subsystem_key(
                 NVMeoFClient.pb2.change_subsystem_key_req(
                     subsystem_nqn=nqn, dhchap_key=dhchap_key
                 )
@@ -296,15 +335,19 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @empty_response
         @NvmeofCLICommand("nvmeof subsystem del_key", model.RequestStatus)
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
-        def del_key(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_subsystem_key(
+        def del_key(self, nqn: str, gw_group: Optional[str] = None,
+                    server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_subsystem_key(
                 NVMeoFClient.pb2.change_subsystem_key_req(
                     subsystem_nqn=nqn, dhchap_key=None
                 )
@@ -313,8 +356,15 @@ else:
         @NvmeofCLICommand("nvmeof get_subsystems", model.GetSubsystems)
         @convert_to_model(model.GetSubsystems)
         @handle_nvmeof_error
-        def get_subsystems(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_subsystems(
+        def get_subsystems(
+            self,
+            gw_group: Optional[str] = None,
+            server_address: Optional[str] = None
+        ):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.get_subsystems(
                 NVMeoFClient.pb2.get_subsystems_req()
             )
 
@@ -328,12 +378,17 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.ListenerList)
         @handle_nvmeof_error
-        def list(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_listeners(
+        def list(self, nqn: str, gw_group: Optional[str] = None,
+                 server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_listeners(
                 NVMeoFClient.pb2.list_listeners_req(subsystem=nqn)
             )
 
@@ -348,6 +403,7 @@ else:
                 "trsvcid": Param(int, "NVMeoF transport service port", True, 4420),
                 "adrfam": Param(int, "NVMeoF address family (0 - IPv4, 1 - IPv6)", True, 0),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -359,9 +415,14 @@ else:
             traddr: str,
             trsvcid: int = 4420,
             adrfam: int = 0,  # IPv4,
-            gw_group: Optional[str] = None
+            gw_group: Optional[str] = None,
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_listener(
+            client = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            )
+            return client.stub.create_listener(
                 NVMeoFClient.pb2.create_listener_req(
                     nqn=nqn,
                     host_name=host_name,
@@ -382,6 +443,7 @@ else:
                 "trsvcid": Param(int, "NVMeoF transport service port", True, 4420),
                 "adrfam": Param(int, "NVMeoF address family (0 - IPv4, 1 - IPv6)", True, 0),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -394,9 +456,14 @@ else:
             trsvcid: int = 4420,
             adrfam: int = 0,  # IPv4
             force: bool = False,
-            gw_group: Optional[str] = None
+            gw_group: Optional[str] = None,
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.delete_listener(
+            client = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            )
+            return client.stub.delete_listener(
                 NVMeoFClient.pb2.delete_listener_req(
                     nqn=nqn,
                     host_name=host_name,
@@ -420,13 +487,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN", True, None),
                 "nsid": Param(str, "NVMeoF Namespace ID to filter by", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None, nsid: Optional[str] = None,
-                 gw_group: Optional[str] = None, traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn,
                                                      nsid=int(nsid) if nsid else None)
             )
@@ -440,13 +511,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def get(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
+                server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn, nsid=int(nsid))
             )
 
@@ -462,13 +537,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceIOStats)
         @handle_nvmeof_error
         def io_stats(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                     traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_get_io_stats(
+                     server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_get_io_stats(
                 NVMeoFClient.pb2.namespace_get_io_stats_req(
                     subsystem_nqn=nqn, nsid=int(nsid))
             )
@@ -477,18 +556,15 @@ else:
             "Create a new NVMeoF namespace.",
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
-                "rbd_pool": Param(str, "RBD pool name"),
                 "rbd_image_name": Param(str, "RBD image name"),
+                "rbd_pool": Param(str, "RBD pool name"),
+                "nsid": Param(str, "Create RBD image", True, None),
                 "create_image": Param(bool, "Create RBD image"),
                 "size": Param(int, "Deprecated. Use `rbd_image_size` instead"),
                 "rbd_image_size": Param(int, "RBD image size"),
                 "trash_image": Param(bool, "Trash the RBD image when namespace is removed"),
                 "block_size": Param(int, "NVMeoF namespace block size"),
                 "load_balancing_group": Param(int, "Load balancing group"),
-                "disable_auto_resize": Param(str, "Disable auto resize", True, None),
-                "read_only": Param(str, "Read only namespace", True, None),
-                "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "Target gateway address", True, None),
                 "force": Param(
                     bool,
                     "Force create namespace even it image is used by other namespace"
@@ -496,7 +572,11 @@ else:
                 "no_auto_visible": Param(
                     bool,
                     "Namespace will be visible only for the allowed hosts"
-                )
+                ),
+                "disable_auto_resize": Param(str, "Disable auto resize", True, None),
+                "read_only": Param(str, "Read only namespace", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceCreation)
@@ -518,9 +598,12 @@ else:
             disable_auto_resize: Optional[bool] = False,
             read_only: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
+            server_address: Optional[str] = None,
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_add(
                 NVMeoFClient.pb2.namespace_add_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid) if nsid else None,
@@ -541,6 +624,32 @@ else:
         @NvmeofCLICommand(
             "nvmeof namespace add", model.NamespaceCreation, alias="nvmeof ns add"
         )
+        @EndpointDoc(
+            "Create a new NVMeoF namespace.",
+            parameters={
+                "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "rbd_pool": Param(str, "RBD pool name"),
+                "rbd_image_name": Param(str, "RBD image name"),
+                "create_image": Param(bool, "Create RBD image"),
+                "size": Param(str, "Deprecated. Use `rbd_image_size` instead", True, None),
+                "rbd_image_size": Param(str, "RBD image size", True, None),
+                "trash_image": Param(bool, "Trash the RBD image when namespace is removed"),
+                "block_size": Param(int, "NVMeoF namespace block size"),
+                "load_balancing_group": Param(int, "Load balancing group"),
+                "disable_auto_resize": Param(str, "Disable auto resize", True, None),
+                "read_only": Param(str, "Read only namespace", True, None),
+                "force": Param(
+                    bool,
+                    "Force create namespace even it image is used by other namespace"
+                ),
+                "no_auto_visible": Param(
+                    bool,
+                    "Namespace will be visible only for the allowed hosts"
+                ),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "Target gateway address", True, None),
+            },
+        )
         @convert_to_model(model.NamespaceCreation)
         @handle_nvmeof_error
         def create_cli(
@@ -560,7 +669,7 @@ else:
             disable_auto_resize: Optional[bool] = False,
             read_only: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
+            server_address: Optional[str] = None,
         ):
             if size and rbd_image_size:
                 raise DashboardException(
@@ -575,7 +684,10 @@ else:
                 size_b = convert_to_bytes(size, default_unit='MB')
             if rbd_image_size:
                 rbd_image_size_b = convert_to_bytes(rbd_image_size, default_unit='MB')
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_add(
                 NVMeoFClient.pb2.namespace_add_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid) if nsid else None,
@@ -611,7 +723,7 @@ else:
                     "Set QOS limits even if they were changed by RBD"
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -626,11 +738,11 @@ else:
             w_mbytes_per_second: Optional[int] = None,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.namespace_set_qos_limits(
                 NVMeoFClient.pb2.namespace_set_qos_req(
                     subsystem_nqn=nqn,
@@ -654,9 +766,9 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
-                "load_balancing_group": Param(int, "Load balancing group"),
+                "load_balancing_group": Param(int, "Load balancing group", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -667,11 +779,11 @@ else:
             nsid: str,
             load_balancing_group: Optional[int] = None,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr
+                server_address=server_address
             ).stub.namespace_change_load_balancing_group(
                 NVMeoFClient.pb2.namespace_change_load_balancing_group_req(
                     subsystem_nqn=nqn, nsid=int(nsid), anagrpid=load_balancing_group
@@ -687,7 +799,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "rbd_image_size": Param(int, "RBD image size"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -698,12 +810,15 @@ else:
             nsid: str,
             rbd_image_size: int,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             mib = 1024 * 1024
             new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_resize(
                 NVMeoFClient.pb2.namespace_resize_req(
                     subsystem_nqn=nqn, nsid=int(nsid), new_size=new_size_mib
                 )
@@ -711,6 +826,16 @@ else:
 
         @NvmeofCLICommand("nvmeof namespace resize", model=model.RequestStatus,
                           alias="nvmeof ns resize")
+        @EndpointDoc(
+            "resize the specified NVMeoF namespace",
+            parameters={
+                "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "nsid": Param(str, "NVMeoF Namespace ID"),
+                "rbd_image_size": Param(str, "RBD image size"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+            },
+        )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def resize_cli(
@@ -719,14 +844,17 @@ else:
             nsid: str,
             rbd_image_size: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             if rbd_image_size:
                 rbd_image_size_b = convert_to_bytes(rbd_image_size, default_unit='MB')
             mib = 1024 * 1024
             rbd_image_size_mb = rbd_image_size_b // mib
 
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_resize(
                 NVMeoFClient.pb2.namespace_resize_req(
                     subsystem_nqn=nqn, nsid=int(nsid), new_size=rbd_image_size_mb
                 )
@@ -749,7 +877,7 @@ else:
                     "has no access to the subsystem"
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -761,9 +889,12 @@ else:
             host_nqn: str,
             force: Optional[bool] = None,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add_host(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_add_host(
                 NVMeoFClient.pb2.namespace_add_host_req(subsystem_nqn=nqn,
                                                         nsid=int(nsid),
                                                         host_nqn=host_nqn,
@@ -782,7 +913,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -793,9 +924,12 @@ else:
             nsid: str,
             host_nqn: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_delete_host(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_delete_host(
                 NVMeoFClient.pb2.namespace_delete_host_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -815,8 +949,9 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "auto_visible": Param(bool, 'True if visible to all hosts'),
+                "force": Param(bool, 'True if visible to all hosts', True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -828,9 +963,12 @@ else:
             auto_visible: str,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_change_visibility(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_change_visibility(
                 NVMeoFClient.pb2.namespace_change_visibility_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -856,7 +994,7 @@ else:
                     'namespace when RBD image is resized'
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -867,9 +1005,12 @@ else:
             nsid: str,
             auto_resize_enabled: bool,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_set_auto_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_set_auto_resize(
                 NVMeoFClient.pb2.namespace_set_auto_resize_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -891,7 +1032,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "rbd_trash_image_on_delete": Param(bool, 'True if active'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -902,11 +1043,11 @@ else:
             nsid: str,
             rbd_trash_image_on_delete: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
             return NVMeoFClient(
                 gw_group=gw_group,
-                traddr=traddr,
+                server_address=server_address,
             ).stub.namespace_set_rbd_trash_image(
                 NVMeoFClient.pb2.namespace_set_rbd_trash_image_req(
                     subsystem_nqn=nqn,
@@ -927,7 +1068,7 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -937,9 +1078,12 @@ else:
             nqn: str,
             nsid: str,
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_resize(
                 NVMeoFClient.pb2.namespace_resize_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -962,8 +1106,9 @@ else:
                 "rw_mbytes_per_second": Param(int, "Read/Write MB/s"),
                 "r_mbytes_per_second": Param(int, "Read MB/s"),
                 "w_mbytes_per_second": Param(int, "Write MB/s"),
+                "trash_image": Param(bool, "Trash RBD image after removing namespace"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "trash_image": Param(bool, "Trash RBD image after removing namespace")
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
@@ -978,9 +1123,9 @@ else:
             rw_mbytes_per_second: Optional[int] = None,
             r_mbytes_per_second: Optional[int] = None,
             w_mbytes_per_second: Optional[int] = None,
-            gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
             trash_image: Optional[bool] = None,
+            gw_group: Optional[str] = None,
+            server_address: Optional[str] = None,
         ):
             contains_failure = False
 
@@ -988,7 +1133,10 @@ else:
                 mib = 1024 * 1024
                 new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
-                resp = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
+                resp = NVMeoFClient(
+                    gw_group=gw_group,
+                    server_address=server_address
+                ).stub.namespace_resize(
                     NVMeoFClient.pb2.namespace_resize_req(
                         subsystem_nqn=nqn, nsid=int(nsid), new_size=new_size_mib
                     )
@@ -1034,7 +1182,10 @@ else:
             if contains_failure:
                 cherrypy.response.status = 202
 
-            response = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
+            response = NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn, nsid=int(nsid))
             )
             return response
@@ -1046,8 +1197,9 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "nsid": Param(str, "NVMeoF Namespace ID"),
+                "force": Param(str, "Force remove the RBD image", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
-                "force": Param(str, "Force remove the RBD image")
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1056,11 +1208,14 @@ else:
             self,
             nqn: str,
             nsid: str,
+            force: Optional[str] = "false",
             gw_group: Optional[str] = None,
-            traddr: Optional[str] = None,
-            force: Optional[str] = "false"
+            server_address: Optional[str] = None,
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_delete(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.namespace_delete(
                 NVMeoFClient.pb2.namespace_delete_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -1086,15 +1241,19 @@ else:
                 "clear_alerts": Param(bool, "Clear any host alert signal after getting its value",
                                       True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.HostsInfo, finalize=_update_hosts)
         @handle_nvmeof_error
         def list(
             self, nqn: str, clear_alerts: Optional[bool] = None,
-            gw_group: Optional[str] = None, traddr: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_hosts(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_hosts(
                 NVMeoFClient.pb2.list_hosts_req(subsystem=nqn, clear_alerts=clear_alerts)
             )
 
@@ -1106,15 +1265,20 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def create(
             self, nqn: str, host_nqn: str, dhchap_key: Optional[str] = None,
-            psk: Optional[str] = None, gw_group: Optional[str] = None, traddr: Optional[str] = None
+            psk: Optional[str] = None, gw_group: Optional[str] = None,
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.add_host(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.add_host(
                 NVMeoFClient.pb2.add_host_req(subsystem_nqn=nqn, host_nqn=host_nqn,
                                               dhchap_key=dhchap_key, psk=psk)
             )
@@ -1127,13 +1291,17 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to disallow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-                   traddr: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.remove_host(
+                   server_address: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.remove_host(
                 NVMeoFClient.pb2.remove_host_req(subsystem_nqn=nqn, host_nqn=host_nqn)
             )
 
@@ -1146,15 +1314,19 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN'),
                 "dhchap_key": Param(str, 'Host DH-HMAC-CHAP key'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(
             self, nqn: str, host_nqn: str, dhchap_key: str,
-            gw_group: Optional[str] = None, traddr: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_host_key(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_host_key(
                 NVMeoFClient.pb2.change_host_key_req(subsystem_nqn=nqn,
                                                      host_nqn=host_nqn,
                                                      dhchap_key=dhchap_key)
@@ -1168,15 +1340,19 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "host_nqn": Param(str, 'NVMeoF host NQN.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_key(
             self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-            traddr: Optional[str] = None
+            server_address: Optional[str] = None
         ):
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_host_key(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.change_host_key(
                 NVMeoFClient.pb2.change_host_key_req(subsystem_nqn=nqn,
                                                      host_nqn=host_nqn,
                                                      dhchap_key=None)
@@ -1192,15 +1368,19 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
             },
         )
         @convert_to_model(model.ConnectionList)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None,
-                 gw_group: Optional[str] = None, traddr: Optional[str] = None):
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
             if not nqn:
                 nqn = '*'
-            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_connections(
+            return NVMeoFClient(
+                gw_group=gw_group,
+                server_address=server_address
+            ).stub.list_connections(
                 NVMeoFClient.pb2.list_connections_req(subsystem=nqn)
             )
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9179,7 +9179,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9239,7 +9239,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9272,7 +9272,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9306,7 +9306,7 @@ paths:
                   type: string
                 log_level:
                   type: string
-                traddr:
+                server_address:
                   type: string
               required:
               - log_level
@@ -9346,7 +9346,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9379,7 +9379,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9417,7 +9417,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9455,7 +9455,7 @@ paths:
                   type: string
                 print_level:
                   type: string
-                traddr:
+                server_address:
                   type: string
               type: object
       responses:
@@ -9495,7 +9495,7 @@ paths:
                   type: string
                 gw_group:
                   type: string
-                traddr:
+                server_address:
                   type: string
               type: object
       responses:
@@ -9533,7 +9533,7 @@ paths:
           type: string
       - allowEmptyValue: true
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9586,7 +9586,7 @@ paths:
                 serial_number:
                   description: Subsystem serial number
                   type: integer
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -9639,8 +9639,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9683,8 +9684,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9723,8 +9725,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9769,8 +9772,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9816,7 +9820,8 @@ paths:
                   type: string
                 psk:
                   type: string
-                traddr:
+                server_address:
+                  description: NVMeoF gateway address
                   type: string
               required:
               - host_nqn
@@ -9868,8 +9873,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9913,8 +9919,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -9959,6 +9966,9 @@ paths:
                   type: string
                 host_name:
                   description: NVMeoF hostname
+                  type: string
+                server_address:
+                  description: NVMeoF gateway address
                   type: string
                 traddr:
                   description: NVMeoF transport address
@@ -10040,6 +10050,12 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address
+        in: query
+        name: server_address
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -10087,8 +10103,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10152,6 +10169,7 @@ paths:
                   description: Namespace will be visible only for the allowed hosts
                   type: boolean
                 nsid:
+                  description: Create RBD image
                   type: string
                 rbd_image_name:
                   description: RBD image name
@@ -10167,12 +10185,12 @@ paths:
                   default: false
                   description: Read only namespace
                   type: string
+                server_address:
+                  description: NVMeoF gateway address
+                  type: string
                 size:
                   description: Deprecated. Use `rbd_image_size` instead
                   type: integer
-                traddr:
-                  description: Target gateway address
-                  type: string
                 trash_image:
                   default: false
                   description: Trash the RBD image when namespace is removed
@@ -10220,6 +10238,12 @@ paths:
         required: true
         schema:
           type: string
+      - default: 'false'
+        description: Force remove the RBD image
+        in: query
+        name: force
+        schema:
+          type: string
       - allowEmptyValue: true
         description: NVMeoF gateway group
         in: query
@@ -10227,14 +10251,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
-        schema:
-          type: string
-      - default: 'false'
-        description: Force remove the RBD image
-        in: query
-        name: force
+        name: server_address
         schema:
           type: string
       responses:
@@ -10283,8 +10302,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10344,7 +10364,8 @@ paths:
                 rw_mbytes_per_second:
                   description: Read/Write MB/s
                   type: integer
-                traddr:
+                server_address:
+                  description: NVMeoF gateway address
                   type: string
                 trash_image:
                   description: Trash RBD image after removing namespace
@@ -10403,7 +10424,7 @@ paths:
                 host_nqn:
                   description: NVMeoF host NQN. Use "*" to allow any host.
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -10460,7 +10481,7 @@ paths:
                 load_balancing_group:
                   description: Load balancing group
                   type: integer
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               type: object
@@ -10514,11 +10535,12 @@ paths:
                   type: boolean
                 force:
                   default: false
+                  description: True if visible to all hosts
                   type: boolean
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -10576,7 +10598,7 @@ paths:
                 host_nqn:
                   description: NVMeoF host NQN. Use "*" to allow any host.
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -10629,8 +10651,9 @@ paths:
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
-        name: traddr
+        name: server_address
         schema:
           type: string
       responses:
@@ -10676,7 +10699,7 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               type: object
@@ -10731,7 +10754,7 @@ paths:
                 rbd_image_size:
                   description: RBD image size
                   type: integer
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -10789,7 +10812,7 @@ paths:
                 gw_group:
                   description: NVMeoF gateway group
                   type: string
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:
@@ -10856,7 +10879,7 @@ paths:
                 rw_mbytes_per_second:
                   description: Read/Write MB/s
                   type: integer
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
                 w_mbytes_per_second:
@@ -10914,7 +10937,7 @@ paths:
                 rbd_trash_image_on_delete:
                   description: True if active
                   type: boolean
-                traddr:
+                server_address:
                   description: NVMeoF gateway address
                   type: string
               required:

--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -33,7 +33,7 @@ else:
     class NVMeoFClient(object):
         pb2 = pb2
 
-        def __init__(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+        def __init__(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
             logger.info("Initiating nvmeof gateway connection...")
             try:
                 if not gw_group:
@@ -50,14 +50,14 @@ else:
 
             # While creating listener need to direct request to the gateway
             # address where listener is supposed to be added.
-            if traddr:
+            if server_address:
                 gateways_info = NvmeofGatewaysConfig.get_gateways_config()
                 matched_gateway = next(
                     (
                         gateway
                         for gateways in gateways_info['gateways'].values()
                         for gateway in gateways
-                        if traddr in gateway['service_url']
+                        if server_address in gateway['service_url']
                     ),
                     None
                 )


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74475

---

backport of https://github.com/ceph/ceph/pull/66822
parent tracker: https://tracker.ceph.com/issues/74346

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh