### PR TITLE
doc/radosgw: change all intra-docs links to use ref (4 of 6)

### DIFF
--- a/doc/cephadm/services/index.rst
+++ b/doc/cephadm/services/index.rst
@@ -638,6 +638,8 @@ false. Examples:
       - argument: "--annotation=com.example.note=a simple example"
 
 
+.. _cephadm-container-mount:
+
 Mounting Files with Extra Container Arguments
 ---------------------------------------------
 

--- a/doc/radosgw/d3n_datacache.rst
+++ b/doc/radosgw/d3n_datacache.rst
@@ -1,3 +1,5 @@
+.. _radosgw-d3n-datacache:
+
 ==================
 D3N RGW Data Cache
 ==================
@@ -42,7 +44,7 @@ Implementation
 
 - The D3N cache supports both the `S3` and `Swift` object storage interfaces.
 - D3N currently caches only tail objects, because they are immutable (by default it is parts of objects that are larger than 4MB).
-  (the NGINX `RGW Data cache and CDN`_ supports caching of all object sizes)
+  (the NGINX :ref:`radosgw-data-caching` supports caching of all object sizes)
 
 
 Requirements
@@ -92,7 +94,7 @@ In containerized deployments the cache directory should be mounted as a volume::
       - "-v"
       - "/mnt/nvme0/rgw_datacache/client.rgw.8000/:/mnt/nvme0/rgw_datacache/client.rgw.8000/"
 
-(Reference: `Service Management - Mounting Files with Extra Container Arguments`_)
+(Reference: :ref:`cephadm-container-mount`)
 
 If another RADOS Gateway is co-located on the same host, configure its persistent
 path to a discrete directory, for example in the case of ``client.rgw.8001``:
@@ -125,5 +127,3 @@ The following D3N related settings can be added to the Ceph configuration file
 
 .. _MOC D3N (Datacenter-scale Data Delivery Network): https://massopen.cloud/research-and-development/cloud-research/d3n/
 .. _Red Hat Research D3N Cache for Data Centers: https://research.redhat.com/blog/research_project/d3n-multilayer-cache/
-.. _RGW Data cache and CDN: ../rgw-cache/
-.. _Service Management - Mounting Files with Extra Container Arguments: ../cephadm/services/#mounting-files-with-extra-container-arguments

--- a/doc/radosgw/rgw-cache.rst
+++ b/doc/radosgw/rgw-cache.rst
@@ -1,3 +1,5 @@
+.. _radosgw-data-caching:
+
 ========================
 RGW Data Caching and CDN
 ========================
@@ -17,7 +19,7 @@ and caching-out on subsequent GET requests, passing through transparently PUT,PO
 
 The feature introduces 2 new APIs: Auth and Cache.
 
-.. note:: The `D3N RGW Data Cache`_ is an alternative data caching mechanism implemented natively in the RADOS Gateway.
+.. note:: The :ref:`radosgw-d3n-datacache` is an alternative data caching mechanism implemented natively in the RADOS Gateway.
 
 New APIs
 --------
@@ -146,5 +148,3 @@ This can be done by commenting the following line in ``nginx-default.conf``:
 
  #auth_request /authentication;
 
-
-.. _D3N RGW Data Cache: ../d3n_datacache/


### PR DESCRIPTION
Part 4 of 6 to make backporting easier.

Use the the `:ref:` role for all remaining links in `doc/radosgw/` with the exception of `config-ref.rst` which will depend on changes to `rgw.yaml.in`.

The external link definitions syntax being removed is intended for linking to external websites and not for intra-docs links. Validity of `ref` links will be checked during the docs build process.

Add labels for links targets if necessary.
Remove unused external link definitions in the modified files.

Use `:confval:` instead of literal text for 2 configuration keys in vault.rst`.

- Original: https://docs.ceph.com/en/latest/radosgw/d3n_datacache/#implementation
- Rendered PR: https://ceph--67008.org.readthedocs.build/en/67008/radosgw/d3n_datacache/#implementation
- Original: https://docs.ceph.com/en/latest/radosgw/d3n_datacache/#running
- Rendered PR: https://ceph--67008.org.readthedocs.build/en/67008/radosgw/d3n_datacache/#running
- Original: https://docs.ceph.com/en/latest/radosgw/rgw-cache/#rgw-data-caching-and-cdn
- Rendered PR: https://ceph--67008.org.readthedocs.build/en/67008/radosgw/rgw-cache/#rgw-data-caching-and-cdn





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
