### PR TITLE
tentacle: mgr/dashboard: [RGW-NFS]: User level export creation via UI fails with 500 - Internal Server Error

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -642,8 +642,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
   }
 
   private buildRequest() {
-    const requestModel: any = _.cloneDeep(this.nfsForm.value);
-    requestModel.fsal = this.nfsForm.get('fsal').value;
+    const requestModel: any = _.cloneDeep(this.nfsForm.getRawValue());
     if (this.isEdit) {
       requestModel.export_id = _.parseInt(this.export_id);
       requestModel.path = this.nfsForm.get('path').value;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74480

---

backport of https://github.com/ceph/ceph/pull/66901
parent tracker: https://tracker.ceph.com/issues/74383

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh