### PR TITLE
os/bluestore: add static and runtime object fragmentation tracking

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4850,6 +4850,35 @@ options:
   flags:
   - runtime
   with_legacy: true
+- name: bluestore_frag_runtime
+  type: bool
+  level: advanced
+  desc: Enable tracking of runtime object fragmentation during reads.
+  long_desc: When enabled, BlueStore measures runtime object fragmentation
+    by counting how many physical extents are accessed for a read operation.
+    Higher values indicate more fragmented object data and potential
+    performance impact. The collected metric reflects runtime access patterns
+    rather than static object layout.
+  default: false
+  flags:
+  - runtime
+  with_legacy: true
+  see_also:
+  - bluestore_frag_static
+- name: bluestore_frag_static
+  type: bool
+  level: advanced
+  desc: Enable tracking of static object fragmentation during scrub
+  long_desc: When enabled, BlueStore measures static object fragmentation during
+    scrub by counting the number of disjoint physical extents that make up object's
+    on-disk layout. The collection-level static fragmentation score is computed as
+    the sum of the fragmentation scores of objects visited during the scrub process.
+  default: false
+  flags:
+  - runtime
+  with_legacy: true
+  see_also:
+  - bluestore_frag_runtime
 # Specifies minimum expected amount of saved allocation units
 # per single blob to enable compressed blobs garbage collection
 - name: bluestore_gc_enable_blob_threshold

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -50,6 +50,30 @@ BlueStore::SocketHook::SocketHook(BlueStore& store)
       "print compression stats, per collection");
     ceph_assert(r == 0);
     r = admin_socket->register_command(
+      "bluestore runtime frag score "
+      "name=collection,type=CephString,req=false",
+      this,
+      "print runtime fragmentation score, per collection");
+    ceph_assert(r == 0);
+    r = admin_socket->register_command(
+      "bluestore clear runtime frag "
+      "name=collection,type=CephString,req=false",
+      this,
+      "clear runtime fragmentation score, per collection");
+    ceph_assert(r == 0);
+    r = admin_socket->register_command(
+      "bluestore static frag score "
+      "name=collection,type=CephString,req=false",
+      this,
+      "print static fragmentation score, per collection");
+    ceph_assert(r == 0);
+    r = admin_socket->register_command(
+      "bluestore clear static frag "
+      "name=collection,type=CephString,req=false",
+      this,
+      "clear static fragmentation score, per collection");
+    ceph_assert(r == 0);
+    r = admin_socket->register_command(
       "bluestore show sharding ",
       this,
       "print RocksDB sharding");
@@ -192,6 +216,77 @@ int BlueStore::SocketHook::call(
       ss << "Failed to get sharding" << std::endl;
     }
     return r;
+  } else if (command == "bluestore runtime frag score") {
+    std::shared_lock l(store.coll_lock);
+    std::string coll;
+    cmd_getval(cmdmap, "collection", coll);
+    f->open_array_section("runtime_frag_score");
+    for (const auto& it : store.coll_map) {
+      auto c = it.second;
+      std::shared_lock l(c->lock);
+      if (coll.empty() || coll == c->get_cid().c_str()) {
+        f->open_object_section("collection");
+        f->dump_string("cid", c->get_cid().c_str());
+        auto samples = c->runtime_read_samples.load(std::memory_order_relaxed);
+        auto sum = c->runtime_frag_count.load(std::memory_order_relaxed);
+        f->dump_unsigned("object_read_samples", samples);
+        f->dump_unsigned("runtime_frag_count", sum);
+        if (samples == 0) {
+          f->dump_int("runtime_frag_score", 0);
+        } else {
+          f->dump_float("runtime_frag_score", (float)sum / samples);
+        }
+        f->close_section();
+      }
+    }
+    f->close_section();
+    return 0;
+  } else if (command == "bluestore clear runtime frag") {
+    std::shared_lock l(store.coll_lock);
+    std::string coll;
+    cmd_getval(cmdmap, "collection", coll);
+    for (const auto& it : store.coll_map) {
+      auto c = it.second;
+      std::shared_lock l(c->lock);
+      if (coll.empty() || coll == c->get_cid().c_str()) {
+        c->runtime_frag_count.store(0, std::memory_order_relaxed);
+        c->runtime_read_samples.store(0, std::memory_order_relaxed);
+      }
+    }
+    return 0;
+  } else if (command == "bluestore static frag score") {
+    std::shared_lock l(store.coll_lock);
+    std::string coll;
+    cmd_getval(cmdmap, "collection", coll);
+    f->open_array_section("static_frag_score");
+    for (const auto& it : store.coll_map) {
+      auto c = it.second;
+      std::shared_lock l(c->lock);
+      if (coll.empty() || coll == c->get_cid().c_str()) {
+        f->open_object_section("collection");
+        f->dump_string("cid", c->get_cid().c_str());
+        auto score = c->static_frag_score.load(std::memory_order_relaxed);
+        auto count = c->object_read_samples.load(std::memory_order_relaxed);
+        f->dump_unsigned("static_frag_score", score);
+        f->dump_unsigned("object_read_samples", count);
+        f->close_section();
+      }
+    }
+    f->close_section();
+    return 0;
+  } else if (command == "bluestore clear static frag") {
+    std::shared_lock l(store.coll_lock);
+    std::string coll;
+    cmd_getval(cmdmap, "collection", coll);
+    for (const auto& it : store.coll_map) {
+      auto c = it.second;
+      std::shared_lock l(c->lock);
+      if (coll.empty() || coll == c->get_cid().c_str()) {
+        c->static_frag_score.store(0, std::memory_order_relaxed);
+        c->object_read_samples.store(0, std::memory_order_relaxed);
+      }
+    }
+    return 0;
   } else {
     ss << "Invalid command" << std::endl;
     r = -ENOSYS;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6701,6 +6701,19 @@ void BlueStore::_init_logger()
     "bsal",
     PerfCountersBuilder::PRIO_USEFUL);
 
+  // Fragmentation Tracking counters
+  //****************************************
+  b.add_time_avg(l_bluestore_runtime_frag_lat,
+    "runtime_frag_lat",
+    "Latency of runtime fragmentation measurement",
+    "rfl",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_static_frag_lat,
+    "static_frag_lat",
+    "Latency of static fragmentation measurement during scrub",
+    "sfl",
+    PerfCountersBuilder::PRIO_USEFUL);
+
   logger = b.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
 }
@@ -13072,12 +13085,15 @@ void BlueStore::_measure_runtime_frag(
     c->runtime_read_samples.fetch_add(1, std::memory_order_relaxed);
     c->runtime_frag_count.fetch_add(frag.frag_score, std::memory_order_relaxed);
   }
+  auto finish = mono_clock::now();
+  logger->tinc_with_max(l_bluestore_runtime_frag_lat, finish - start);
 }
 
 void BlueStore::_measure_static_frag(
   Collection *c,
   const OnodeRef& o)
 {
+  auto start = mono_clock::now();
   auto read_samples = c->object_read_samples.load(std::memory_order_relaxed);
   auto frag_score = o->get_fragmentation_score();
   if (read_samples == 0) {
@@ -13087,6 +13103,8 @@ void BlueStore::_measure_static_frag(
     c->static_frag_score.fetch_add(frag_score, std::memory_order_relaxed);
     c->object_read_samples.fetch_add(1, std::memory_order_relaxed);
   }
+  auto finish = mono_clock::now();
+  logger->tinc_with_max(l_bluestore_static_frag_lat, finish - start);
 }
 
 int BlueStore::_do_read(

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5061,6 +5061,68 @@ void BlueStore::Onode::finish_write(TransContext* txc, uint32_t offset, uint32_t
   ldout(c->store->cct, 10) << __func__ << " done " << txc << dendl;
 }
 
+struct FragMetric {
+  // Computes fragmentation as the number of disjoint segments
+  // produced by a stream of mapped ranges.
+  // frag_score == current disjoint segment count.
+
+  std::unordered_set<uint64_t> endpoints;
+  uint64_t frag_score = 0;
+
+  FragMetric() {}
+
+  inline void note(uint64_t offset, uint64_t length) {
+    bool merge_left = endpoints.count(offset);
+    bool merge_right = endpoints.count(offset + length);
+    if (merge_left && merge_right) {
+      endpoints.erase(offset);
+      endpoints.erase(offset + length);
+      frag_score--;
+    } else if (merge_left) {
+      endpoints.erase(offset);
+      endpoints.insert(offset + length);
+    } else if (merge_right) {
+      endpoints.erase(offset + length);
+      endpoints.insert(offset);
+    } else {
+      endpoints.insert(offset);
+      endpoints.insert(offset + length);
+      frag_score++;
+    }
+  }
+};
+
+int BlueStore::Onode::get_fragmentation_score()
+{
+  FragMetric frag;
+
+  std::unordered_set<BlobRef> visited_compressed_blobs;
+
+  for (const auto& e : extent_map.extent_map) {
+    if (e.blob->get_blob().is_compressed()) {
+      if (visited_compressed_blobs.insert(e.blob).second) {
+        e.blob->get_blob().map(
+          0, e.blob->get_blob().get_ondisk_length(),
+          [&](uint64_t offset, uint64_t length) {
+            frag.note(offset, length);
+            return 0;
+          }
+        );
+      }
+    } else {
+      e.blob->get_blob().map(
+        e.blob_offset,
+        e.length,
+        [&](uint64_t phys_offset, uint64_t len) {
+          frag.note(phys_offset, len);
+          return 0;
+        }
+      );
+    }
+  }
+  return frag.frag_score;
+}
+
 // =======================================================
 // WriteContext
  
@@ -12988,6 +13050,45 @@ int BlueStore::_generate_read_result_bl(
   return 0;
 }
 
+void BlueStore::_measure_runtime_frag(
+  Collection *c,
+  const blobs2read_t& blobs2read)
+{
+  auto start = mono_clock::now();
+  FragMetric frag;
+  for (auto& p : blobs2read) {
+    const BlobRef& bptr = p.first;
+    const regions2read_t& r2r = p.second;
+    for (auto req : r2r) {
+      bptr->get_blob().map(
+        req.r_off, req.r_len,
+        [&](uint64_t offset, uint64_t length) {
+          frag.note(offset, length);
+          return 0;
+        });
+    }
+  }
+  if (frag.frag_score > 0) {
+    c->runtime_read_samples.fetch_add(1, std::memory_order_relaxed);
+    c->runtime_frag_count.fetch_add(frag.frag_score, std::memory_order_relaxed);
+  }
+}
+
+void BlueStore::_measure_static_frag(
+  Collection *c,
+  const OnodeRef& o)
+{
+  auto read_samples = c->object_read_samples.load(std::memory_order_relaxed);
+  auto frag_score = o->get_fragmentation_score();
+  if (read_samples == 0) {
+    c->static_frag_score.store(frag_score, std::memory_order_relaxed);
+    c->object_read_samples.store(1, std::memory_order_relaxed);
+  } else {
+    c->static_frag_score.fetch_add(frag_score, std::memory_order_relaxed);
+    c->object_read_samples.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
 int BlueStore::_do_read(
   Collection *c,
   OnodeRef& o,
@@ -13088,6 +13189,21 @@ int BlueStore::_do_read(
       [&](auto lat) { return ", num_ios = " + stringify(num_ios); },
       l_bluestore_slow_read_wait_aio_count
     );
+  }
+
+  if (cct->_conf->bluestore_frag_runtime) {
+    _measure_runtime_frag(c, blobs2read);
+  }
+
+  if ((op_flags & CEPH_OSD_OP_FLAG_SCRUB) && cct->_conf->bluestore_frag_static) {
+    if (!o->extent_map.extent_map.empty()) {
+      o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+      auto it = o->extent_map.extent_map.begin();
+      uint64_t first_extent_offset = it->logical_offset;
+      if (offset <= first_extent_offset && first_extent_offset < offset + length) {
+        _measure_static_frag(c, o);
+      }
+    }
   }
 
   bool csum_error = false;
@@ -13453,6 +13569,9 @@ int BlueStore::_do_readv(
     // we always issue aio for reading, so errors other than EIO are not allowed
     if (r < 0)
       return r;
+    if (cct->_conf->bluestore_frag_runtime) {
+      _measure_runtime_frag(c, std::get<2>(raw_results[i]));
+    }
   }
 
   auto num_ios = m.size();
@@ -13483,6 +13602,24 @@ int BlueStore::_do_readv(
       [&](auto lat) { return ", num_ios = " + stringify(num_ios); },
       l_bluestore_slow_read_wait_aio_count
     );
+  }
+
+  if ((op_flags & CEPH_OSD_OP_FLAG_SCRUB) && cct->_conf->bluestore_frag_static) {
+    if (!o->extent_map.extent_map.empty()) {
+      o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+      auto it = o->extent_map.extent_map.begin();
+      uint64_t first_extent_offset = it->logical_offset;
+      for (auto& p : m) {
+        uint64_t off = p.first;
+        uint64_t len = p.second;
+
+        if (off <= first_extent_offset &&
+            first_extent_offset < off + len) {
+          _measure_static_frag(c, o);
+          break;
+        }
+      }
+    }
   }
 
   ceph_assert(raw_results.size() == (size_t)m.num_intervals());

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -244,6 +244,12 @@ enum {
   l_bluestore_slow_op_normal_count,
   l_bluestore_slow_op_scrub_count,
   //****************************************
+
+  // Fragmentation tracking
+  //****************************************
+  l_bluestore_runtime_frag_lat,
+  l_bluestore_static_frag_lat,
+  //****************************************
   l_bluestore_last
 };
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1452,6 +1452,8 @@ public:
 
     void finish_write(TransContext* txc, uint32_t offset, uint32_t length);
 
+    int get_fragmentation_score();
+
     struct printer : public BlueStore::printer {
       const Onode &onode;
       uint16_t mode;
@@ -1681,6 +1683,11 @@ public:
 
     ContextQueue *commit_queue;
     std::unique_ptr<Estimator> estimator;
+
+    std::atomic<uint64_t> runtime_frag_count{0};
+    std::atomic<uint64_t> runtime_read_samples{0};
+    std::atomic<uint64_t> static_frag_score{0};
+    std::atomic<uint64_t> object_read_samples{0};
 
     OnodeCacheShard* get_onode_cache() const {
       return onode_space.cache;
@@ -3301,6 +3308,10 @@ private:
     bool buffered,
     bool* csum_error,
     ceph::buffer::list& bl);
+
+  void _measure_runtime_frag(Collection *c, const blobs2read_t& blobs2read);
+
+  void _measure_static_frag(Collection *c, const OnodeRef& o);
 
   int _do_read(
     Collection *c,


### PR DESCRIPTION
Object fragmentation can increase metadata overhead and negatively impact performance. BlueStore currently lacks visibility into object-level fragmentation.

This PR introduces tracking for both runtime and static object fragmentation:

- Runtime fragmentation is measured as the number of physical extents accessed during a single read operation.
  Higher values indicate more fragmented object data. Measurement is approximate and optimized for low overhead, and can be toggled on or off at runtime.
 
- Static fragmentation measures how many separate physical extents make up each object.
  This provides insight into object layout on disk and how fragmented it is, independent of actual reads.
  
Both runtime and static fragmentation are tracked at the collection level, giving insight into fragmentation per collection rather than per object.

### Runtime Fragmentation Control

#### Enable tracking
```
./bin/ceph config set osd bluestore_frag_runtime true
```
#### Disable tracking
```
./bin/ceph config set osd bluestore_frag_runtime false
```
#### Get runtime fragmentation stats
```
./bin/ceph tell osd.0 bluestore runtime frag score <cid optional>
````
#### Clear Runtime Fragmentation stats
```
./bin/ceph tell osd.0 bluestore clear runtime frag <cid optional>
```

### Static Fragmentation

#### Enable tracking 
```
./bin/ceph config set osd bluestore_frag_static true
```
#### Disable tracking
```
./bin/ceph config set osd bluestore_frag_static false
```
#### Get Static Fragmentation stats
```
./bin/ceph tell osd.0 bluestore static frag score <cid optional>
```

Fixes : https://tracker.ceph.com/issues/74012


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
