### PR TITLE
mgr/PyFormatter: prevent segfault on non-printable characters

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -758,7 +758,15 @@ PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
   PyFormatter f;
   for (auto p = store_cache.lower_bound(global_prefix);
        p != store_cache.end() && p->first.find(global_prefix) == 0; ++p) {
-    f.dump_string(p->first.c_str() + base_prefix.size(), p->second);
+    PyObject *value = PyUnicode_FromStringAndSize(
+      p->second.c_str(), p->second.size());
+    if (!value) {
+      dout(1) << __func__ << " skipping key " << p->first
+              << " due to PyUnicode_FromStringAndSize failure" << dendl;
+      PyErr_Clear();
+      continue;
+    }
+    f.dump_pyobject(p->first.substr(base_prefix.size()).c_str(), value);
   }
   return f.get();
 }

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -759,7 +759,15 @@ PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
   PyFormatter f;
   for (auto p = store_cache.lower_bound(global_prefix);
        p != store_cache.end() && p->first.find(global_prefix) == 0; ++p) {
-    f.dump_string(p->first.c_str() + base_prefix.size(), p->second);
+    PyObject *value = PyUnicode_FromStringAndSize(
+      p->second.c_str(), p->second.size());
+    if (!value) {
+      dout(1) << __func__ << " skipping key " << p->first
+              << " due to PyUnicode_FromStringAndSize failure" << dendl;
+      PyErr_Clear();
+      continue;
+    }
+    f.dump_pyobject(p->first.substr(base_prefix.size()).c_str(), value);
   }
   return f.get();
 }

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -71,7 +71,12 @@ void PyFormatter::dump_float(std::string_view name, double d)
 
 void PyFormatter::dump_string(std::string_view name, std::string_view s)
 {
-  dump_pyobject(name, PyUnicode_FromString(s.data()));
+  PyObject *p = PyUnicode_FromStringAndSize(s.data(), s.size());
+  if (!p) {
+    PyErr_Clear();
+    return;
+  }
+  dump_pyobject(name, p);
 }
 
 void PyFormatter::dump_bool(std::string_view name, bool b)
@@ -112,6 +117,9 @@ void PyFormatter::dump_format_va(std::string_view name, const char *ns, bool quo
  */
 void PyFormatter::dump_pyobject(std::string_view name, PyObject *p)
 {
+  if (!p) {
+    ceph_abort_msg("PyFormatter::dump_pyobject received null PyObject");
+  }
   if (PyList_Check(cursor)) {
     PyList_Append(cursor, p);
     Py_DECREF(p);

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -125,11 +125,12 @@ public:
 
   void finish_pending_streams();
 
+  void dump_pyobject(std::string_view name, PyObject *p);
+
 protected:
   PyObject *root;
   PyObject *cursor;
   std::stack<PyObject *> stack;
-  void dump_pyobject(std::string_view name, PyObject *p);
 private:
   class PendingStream {
     public:

--- a/src/test/mgr/test_pyformatter.cc
+++ b/src/test/mgr/test_pyformatter.cc
@@ -373,6 +373,76 @@ TEST(PyFormatter, EmptySectionName)
 
 /* End Negative Tests */
 
+TEST(PyFormatter, DumpPyObject_StoresPrebuiltObject)
+{
+  // Verify that dump_pyobject inserts a caller-owned PyObject into the dict
+  // without re-encoding, which is the pattern used in get_store_prefix.
+  PyFormatter py_f;
+  PyObject *value = PyUnicode_FromString("hello");
+  ASSERT_NE(value, nullptr);
+  py_f.dump_pyobject("key", value);
+
+  PyObject *result = py_f.get();
+  ASSERT_NE(result, nullptr);
+  ASSERT_TRUE(PyDict_Check(result));
+
+  PyObject *item = PyDict_GetItemString(result, "key");
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(PyUnicode_Check(item));
+  ASSERT_STREQ(PyUnicode_AsUTF8(item), "hello");
+
+  Py_DECREF(result);
+}
+
+TEST(PyFormatter, DumpString_SkipsNonUtf8Value)
+{
+  // dump_string uses PyUnicode_FromStringAndSize which fails on invalid UTF-8.
+  // The method must not crash and must simply skip the key.
+  PyFormatter py_f;
+  // "\x80\xff" is invalid UTF-8
+  std::string bad_utf8("\x80\xff", 2);
+  py_f.dump_string("bad_key", bad_utf8);
+
+  PyObject *result = py_f.get();
+  ASSERT_NE(result, nullptr);
+  ASSERT_TRUE(PyDict_Check(result));
+
+  // Key must be absent — dump_string skips on encoding failure
+  PyObject *item = PyDict_GetItemString(result, "bad_key");
+  ASSERT_EQ(item, nullptr);
+
+  Py_DECREF(result);
+}
+
+TEST(PyFormatter, DumpPyObject_NonUtf8ViLatin1Fallback)
+{
+  // This is the pattern used in get_store_prefix to handle crash metadata
+  // containing non-printable / non-UTF-8 bytes: try UTF-8, fall back to
+  // Latin-1, then call dump_pyobject directly with the validated PyObject*.
+  PyFormatter py_f;
+  std::string bad_utf8("\x80\xff", 2);
+
+  PyObject *value = PyUnicode_FromStringAndSize(bad_utf8.c_str(), bad_utf8.size());
+  if (!value) {
+    PyErr_Clear();
+    value = PyUnicode_DecodeLatin1(bad_utf8.c_str(), bad_utf8.size(), nullptr);
+  }
+  ASSERT_NE(value, nullptr);  // Latin-1 must always succeed
+  py_f.dump_pyobject("latin1_key", value);
+
+  PyObject *result = py_f.get();
+  ASSERT_NE(result, nullptr);
+  ASSERT_TRUE(PyDict_Check(result));
+
+  // Key must be present — Latin-1 fallback succeeded
+  PyObject *item = PyDict_GetItemString(result, "latin1_key");
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(PyUnicode_Check(item));
+
+  Py_DECREF(result);
+}
+
+
 /*
  * Tests for PyFormatterRO (read-only-on-the-fly builder):
  *  - lists -> tuples, sets -> frozensets


### PR DESCRIPTION
If PyFormatter::dump_string attempting to format non-printable characters can result in a nullptr being passed to dump_pyobject, causing a segfault.

It occured in the following case - crash module tried to load the crash entries containing matedata with non-printable characters. when these were passed to PyFormatter, the resulting crash prevented ceph-mgr from starting.

Fix this by attempting to create a python object using PyUnicode_FromString. If it returns nullptr (indicating a decoding failure), the code now falls back to decoding using Latin1.
Additionally, add a guard in dump_pyobject to prevent processing nullptr objects, providing a secondary layer of protection against segfaults.

Fixes: https://tracker.ceph.com/issues/74379





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
