### PR TITLE
mon/config: add ability to annotate parameters in config database.

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -26,6 +26,9 @@
   scan_extents, scan_inodes, and other state-changing operations.
   Related Tracker: https://tracker.ceph.com/issues/63191
 
+* common: Optional annotation provisioning has been added for "ceph config set" command.
+  Annotations attached to options are accessible through "ceph config dump/get" commands.
+
 >=20.0.0
 
 * RADOS: The lead Monitor and stretch mode status are now displayed by `ceph status`.

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -504,7 +504,7 @@ The following CLI commands are used to configure the cluster:
   (for example, ``mds.a``), or, if that value is not present in the Monitor
   configuration database, the compiled-in default value.
 
-* ``ceph config set <who> <option> <value>`` sets a configuration
+* ``ceph config set <who> <option> <value> [annotation]`` sets a configuration
   option in the Monitor's configuration database. If a value for this
   option was previously set, it will be overwritten.  Take care to
   set values with appropriate ``who`` and optional mask attributes. If,
@@ -513,7 +513,7 @@ The following CLI commands are used to configure the cluster:
   form ``ceph config set global someoption somevalue`` is executed,
   the central database will retain both.  This may be useful in
   certain situations, but it can lead to confusion and is often best
-  avoided.
+  avoided. Optional annotation could be provided for the new option instance.
 
 * ``ceph config show <who>`` shows configuration values for a running daemon.
   These settings might differ from those stored by the monitors if there are

--- a/qa/workunits/mon/config.sh
+++ b/qa/workunits/mon/config.sh
@@ -73,6 +73,22 @@ ceph config rm client.foo debug_asok
 ceph config set client.foo debug_asok 66
 ceph config rm client.foo 'debug asok'
 
+# annotations
+ceph config set client.foo debug_asok 10 "set debug_asok to 10"
+ceph config set client.foo debug_client 10 "set debug_client to 10"
+ceph config get client.foo | grep debug_asok | grep "set debug_asok to 10"
+ceph config get client.foo | grep debug_client | grep "set debug_client to 10"
+
+ceph config set client.foo debug_asok 20 "set debug_asok to 20"
+ceph config set client.foo debug_client 20 "set debug_client to 20"
+ceph config get client.foo | grep debug_asok | grep "set debug_asok to 20"
+ceph config get client.foo | grep debug_client | grep "set debug_client to 20"
+
+ceph config set client.foo debug_asok 30
+ceph config rm client.foo debug_client
+ceph config get client.foo | grep debug_asok | expect_false grep "set debug_asok to 20"
+ceph config get client.foo | expect_false grep debug_client
+
 # help
 ceph config help debug_asok | grep debug_asok
 

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -832,10 +832,11 @@ void ActivePyModules::_refresh_config_map()
     string value = p->second;
     string name;
     string who;
+    string dummy_annotation;
     config_map.parse_key(key, &name, &who);
 
     config_map.add_option(
-      g_ceph_context, name, who, value,
+      g_ceph_context, name, who, value, dummy_annotation,
       [&](const std::string& name) {
 	return  g_conf().find_option(name);
       });

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1327,19 +1327,6 @@ bool DaemonServer::_handle_command(
     return true;
   }
 
-  if (prefix == "config set") {
-    std::string key;
-    std::string val;
-    cmd_getval(cmdctx->cmdmap, "key", key);
-    cmd_getval(cmdctx->cmdmap, "value", val);
-    r = cct->_conf.set_val(key, val, &ss);
-    if (r == 0) {
-      cct->_conf.apply_changes(nullptr);
-    }
-    cmdctx->reply(0, ss);
-    return true;
-  }
-
   // -----------
   // PG commands
 

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -141,7 +141,7 @@ ConfigMap::generate_entity_map(
   const map<std::string,std::string>& crush_location,
   const CrushWrapper *crush,
   const std::string& device_class,
-  std::unordered_map<std::string, ValueSource> *src)
+  std::map<std::string, ValueSource,std::less<>> *src)
 {
   // global, then by type, then by name prefix component(s), then name.
   // name prefix components are .-separated,

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -67,6 +67,7 @@ struct MaskedOption {
   OptionMask mask;
   std::unique_ptr<const Option> unknown_opt; ///< if fabricated for an unknown option
   std::string localized_name;     ///< localized name for the option
+  std::string annotation;         ///< annotation for the option
 
   MaskedOption(const Option *o, bool fab=false) : opt(o) {
     if (fab) {
@@ -79,6 +80,7 @@ struct MaskedOption {
     mask = std::move(o.mask);
     unknown_opt = std::move(o.unknown_opt);
     localized_name = std::move(o.localized_name);
+    annotation = std::move(o.annotation);
   }
   const MaskedOption& operator=(const MaskedOption& o) = delete;
   const MaskedOption& operator=(MaskedOption&& o) = delete;
@@ -158,6 +160,7 @@ struct ConfigMap {
     const std::string& name,
     const std::string& who,
     const std::string& value,
+    const std::string& annotation,
     std::function<const Option *(const std::string&)> get_opt);
 };
 
@@ -169,6 +172,8 @@ struct ConfigChangeSet {
 
   // key -> (old value, new value)
   std::map<std::string,std::pair<std::optional<std::string>,std::optional<std::string>>> diff;
+  // key -> (old annotation, new annotation)
+  std::map<std::string, std::pair<std::optional<std::string>, std::optional<std::string>>> adiff;
 
   void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -142,7 +142,7 @@ struct ConfigMap {
     const std::map<std::string,std::string>& crush_location,
     const CrushWrapper *crush,
     const std::string& device_class,
-    std::unordered_map<std::string,ValueSource> *src = nullptr);
+    std::map<std::string,ValueSource,std::less<>> *src = nullptr);
 
   void parse_key(
     const std::string& key,

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -315,7 +315,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	       << " class " << device_class << dendl;
     }
 
-    std::unordered_map<std::string,ConfigMap::ValueSource> src;
+    std::map<std::string,ConfigMap::ValueSource,std::less<>> src;
     auto config = config_map.generate_entity_map(
       entity,
       crush_location,

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -16,11 +16,12 @@ class ConfigMonitor : public PaxosService
 {
   version_t version = 0;
   ConfigMap config_map;
-  std::map<std::string,std::optional<ceph::buffer::list>> pending;
+  using annotated_value = std::pair<ceph::buffer::list, ceph::buffer::list>;
+  std::map<std::string,std::optional<annotated_value>> pending;
   std::string pending_description;
   std::map<std::string,std::optional<ceph::buffer::list>> pending_cleanup;
 
-  std::map<std::string,ceph::buffer::list> current;
+  std::map<std::string,annotated_value> current;
 
   void encode_pending_to_kvmon();
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1396,7 +1396,8 @@ COMMAND("config set"
 	" name=who,type=CephString"
 	" name=name,type=CephString"
 	" name=value,type=CephString"
-	" name=force,type=CephBool,req=false",
+	" name=force,type=CephBool,req=false"
+	" name=annotation,type=CephString,req=false",
 	"Set a configuration option for one or more entities",
 	"config", "rw")
 COMMAND("config rm"


### PR DESCRIPTION
Now one can annotate configuration parameter change while using "ceph config set" command, e.g.
   `ceph config set osd debug_osd 10 "some comment"`

Attached annotations are reported by ceph config dump/get commands, e.g.
```
#ceph config get osd

WHO     MASK  LEVEL     OPTION                     VALUE        RO  ANNOTATION
osd           advanced  debug_osd                  10/10            some comment

```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
