### PR TITLE
tentacle: qa: add 'refresh' config to cephadm.wait_for_service

### DIFF
--- a/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
@@ -12,6 +12,7 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True
 
 - workunit:
     no_coverage_and_limits: true

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_mtls.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_mtls.yaml
@@ -13,6 +13,7 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True
 
 - workunit:
     no_coverage_and_limits: true

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_namespaces.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_namespaces.yaml
@@ -12,6 +12,7 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True
 
 - workunit:
     no_coverage_and_limits: true

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
@@ -12,6 +12,7 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True
 
 ## Enable gateway in DEBUG mode
 # - cephadm.exec:

--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/10-subsys-90-namespace-no_huge_pages.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/10-subsys-90-namespace-no_huge_pages.yaml
@@ -12,6 +12,7 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True
 
 - cephadm.exec:
     host.a:
@@ -25,6 +26,7 @@ tasks:
       
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True
 
 - workunit:
     no_coverage_and_limits: true

--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/16-subsys-4-namespace.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/16-subsys-4-namespace.yaml
@@ -12,6 +12,7 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True
 
 - workunit:
     no_coverage_and_limits: true

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1634,14 +1634,15 @@ def apply(ctx, config):
 
 
 
-def _orch_ls(ctx, cluster_name):
+def _orch_ls(ctx, cluster_name, refresh=False):
+    args = ['ceph', 'orch', 'ls', '-f', 'json']
+    if refresh:
+        args += ['--refresh']
     r = _shell(
         ctx=ctx,
         cluster_name=cluster_name,
         remote=ctx.ceph[cluster_name].bootstrap_remote,
-        args=[
-            'ceph', 'orch', 'ls', '-f', 'json',
-        ],
+        args=args,
         stdout=StringIO(),
     )
     return json.loads(r.stdout.getvalue())
@@ -1655,11 +1656,13 @@ def wait_for_service(ctx, config):
         - cephadm.wait_for_service:
             service: rgw.foo
             timeout: 60    # defaults to 300
+            refresh: True  # defaults to False
 
     """
     cluster_name = config.get('cluster', 'ceph')
     timeout = config.get('timeout', 300)
     service = config.get('service')
+    refresh = config.get('refresh', False)
     assert service
 
     log.info(
@@ -1667,7 +1670,7 @@ def wait_for_service(ctx, config):
     )
     with contextutil.safe_while(sleep=1, tries=timeout) as proceed:
         while proceed():
-            j = _orch_ls(ctx, cluster_name)
+            j = _orch_ls(ctx, cluster_name, refresh)
             svc = None
             for s in j:
                 if s['service_name'] == service:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74483

---

backport of https://github.com/ceph/ceph/pull/65941
parent tracker: https://tracker.ceph.com/issues/73538

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh