### PR TITLE
squid: doc/radosgw: change all intra-docs links to use ref (1 of 6)

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _man-radosgw-admin:
+
 =================================================================
  radosgw-admin -- rados REST gateway user administration utility
 =================================================================

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -1,3 +1,5 @@
+.. _radosgw-admin-guide:
+
 =============
  Admin Guide
 =============
@@ -431,6 +433,8 @@ To remove the admin flag from an existing user:
 
    radosgw-admin user modify --uid={username} --admin=0
 
+.. _radosgw-quota-management:
+
 Quota Management
 ================
 
@@ -617,6 +621,8 @@ commands, as in the following examples:
    update --commit``. If no period is present, the RGW instances must
    be restarted for the changes to take effect.
 
+
+.. _radosgw-rate-limit-management:
 
 Rate Limit Management
 =====================

--- a/doc/radosgw/barbican.rst
+++ b/doc/radosgw/barbican.rst
@@ -1,3 +1,5 @@
+.. _radosgw-barbican:
+
 ==============================
 OpenStack Barbican Integration
 ==============================

--- a/doc/radosgw/elastic-sync-module.rst
+++ b/doc/radosgw/elastic-sync-module.rst
@@ -1,3 +1,5 @@
+.. _radosgw-elastic-sync-module:
+
 =========================
 ElasticSearch Sync Module
 =========================

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -41,8 +41,8 @@ This is implemented in S3 according to the `Amazon SSE-KMS`_ specification.
 In principle, any key management service could be used here.  Currently
 integration with `Barbican`_, `Vault`_, and `KMIP`_ are implemented.
 
-See `OpenStack Barbican Integration`_, `HashiCorp Vault Integration`_,
-and `KMIP Integration`_.
+See :ref:`radosgw-barbican`, :ref:`radosgw-vault`,
+and :ref:`radosgw-kmip`.
 
 SSE-S3
 ======
@@ -57,7 +57,7 @@ This is implemented in S3 according to the `Amazon SSE-S3`_ specification.
 In principle, any key management service could be used here.  Currently
 only integration with `Vault`_, is implemented.
 
-See `HashiCorp Vault Integration`_.
+See :ref:`radosgw-vault`.
 
 Bucket Encryption APIs
 ======================
@@ -91,6 +91,3 @@ The configuration expects a base64-encoded 256 bit key. For example::
 .. _PutBucketEncryption: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html
 .. _GetBucketEncryption: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html
 .. _DeleteBucketEncryption: https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html
-.. _OpenStack Barbican Integration: ../barbican
-.. _HashiCorp Vault Integration: ../vault
-.. _KMIP Integration: ../kmip

--- a/doc/radosgw/iam.rst
+++ b/doc/radosgw/iam.rst
@@ -1,3 +1,5 @@
+.. _radosgw-iam:
+
 =============================
  Ceph Object Gateway IAM API
 =============================
@@ -8,7 +10,7 @@ The Ceph Object Gateway supports a subset of the `Amazon IAM API`_ for
 the RESTful management of account users, roles, and associated policies.
 
 This REST API is served by the same HTTP endpoint as the
-`Ceph Object Gateway S3 API`_.
+:ref:`radosgw s3`.
 
 Authorization
 =============
@@ -185,4 +187,3 @@ AmazonS3ReadOnlyAccess
 
 
 .. _Amazon IAM API: https://docs.aws.amazon.com/IAM/latest/APIReference/welcome.html
-.. _Ceph Object Gateway S3 API: ../s3/

--- a/doc/radosgw/kmip.rst
+++ b/doc/radosgw/kmip.rst
@@ -1,3 +1,5 @@
+.. _radosgw-kmip:
+
 ================
 KMIP Integration
 ================

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -122,12 +122,12 @@ Requirements and Assumptions
 ============================
 
 A multi-site configuration requires at least two Ceph storage clusters. The
-multi-site configuration must have at least two Ceph object gateway instances
+multi-site configuration must have at least two Ceph Object Gateway instances
 (one for each Ceph storage cluster).
 
 This guide assumes that at least two Ceph storage clusters are in
 geographically separate locations; however, the configuration can work on the
-same site. This guide also assumes two Ceph object gateway servers named
+same site. This guide also assumes two Ceph Object Gateway servers named
 ``rgw1`` and ``rgw2``.
 
 .. important:: Running a single geographically-distributed Ceph storage cluster
@@ -141,8 +141,8 @@ In this guide, the ``rgw1`` host will serve as the master zone of the master
 zonegroup; and, the ``rgw2`` host will serve as the secondary zone of the
 master zonegroup.
 
-See `Pools`_ for instructions on creating and tuning pools for Ceph Object
-Storage.
+See :ref:`radosgw-pools` for instructions on creating and tuning pools for the
+Ceph Object Gateway.
 
 See :ref:`Sync Policy Config <radosgw-multisite-sync-policy>` for instructions
 on defining fine-grained bucket sync policy rules.
@@ -1382,7 +1382,9 @@ Zones
 -----
 
 A zone defines a logical group that consists of one or more Ceph Object Gateway
-instances. All Ceph Object Gateways in a given zone serve S3 objects that are backed by RADOS objects that are stored in the same set of pools in the same cluster. Ceph Object Gateway supports zones.
+instances. All Ceph Object Gateways in a given zone serve S3 objects that are
+backed by RADOS objects that are stored in the same set of pools in the same
+cluster. Ceph Object Gateway supports zones.
 
 The procedure for configuring zones differs from typical configuration
 procedures, because not all of the settings end up in a Ceph configuration
@@ -1602,5 +1604,3 @@ instance.
 |                                     | changing this setting.            |         |                       |
 +-------------------------------------+-----------------------------------+---------+-----------------------+
 
-
-.. _`Pools`: ../pools

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -1,3 +1,5 @@
+.. _radosgw-notifications:
+
 ====================
 Bucket Notifications
 ====================

--- a/doc/radosgw/orphans.rst
+++ b/doc/radosgw/orphans.rst
@@ -113,5 +113,3 @@ RGW. When larger objects are copied from bucket to bucket, only the
 shared. Those shared objects will contain the marker of the original
 bucket.
 
-.. _Data Layout in RADOS : ../layout
-.. _Pool Placement and Storage Classes : ../placement

--- a/doc/radosgw/placement.rst
+++ b/doc/radosgw/placement.rst
@@ -9,7 +9,7 @@ Placement Targets
 
 .. versionadded:: Jewel
 
-Placement targets control which `Pools`_ are associated with a particular
+Placement targets control which :ref:`radosgw-pools` are associated with a particular
 bucket. A bucket's placement target is selected on creation, and cannot be
 modified. The ``radosgw-admin bucket stats`` command will display its
 ``placement_rule``.
@@ -266,4 +266,3 @@ names be used with Ceph, including ``INTELLIGENT-TIERING``, ``STANDARD_IA``,
 ``CHEAPNDEEP`` are accepted by Ceph but might not be by some clients and
 libraries.
 
-.. _`Pools`: ../pools

--- a/doc/radosgw/pools.rst
+++ b/doc/radosgw/pools.rst
@@ -1,3 +1,5 @@
+.. _radosgw-pools:
+
 =====
 Pools
 =====

--- a/doc/radosgw/role.rst
+++ b/doc/radosgw/role.rst
@@ -1,3 +1,5 @@
+.. _radosgw-role:
+
 ======
  Role
 ======

--- a/doc/radosgw/swift/auth.rst
+++ b/doc/radosgw/swift/auth.rst
@@ -10,9 +10,7 @@ To obtain a token from RADOS Gateway, you must create a user. For example::
     sudo radosgw-admin user create --subuser="{username}:{subusername}" --uid="{username}" 
     --display-name="{Display Name}" --key-type=swift --secret="{password}" --access=full
 
-For details on RADOS Gateway administration, see `radosgw-admin`_. 
-
-.. _radosgw-admin: ../../../man/8/radosgw-admin/ 
+For details on RADOS Gateway administration, see :ref:`man-radosgw-admin`. 
 
 .. note::
   For those used to the Swift API this is implementing the Swift auth v1.0 API, as such

--- a/doc/radosgw/swift/tutorial.rst
+++ b/doc/radosgw/swift/tutorial.rst
@@ -8,9 +8,9 @@ client and the RADOS Gateway server. Then, you may follow a natural
 container and object lifecycle, including adding and retrieving object 
 metadata. See example code for the following languages:
 
-- `Java`_
-- `Python`_
-- `Ruby`_
+- :ref:`Java <java_swift>`
+- :ref:`Python <python_swift>`
+- :ref:`Ruby <ruby_swift>`
 
 
 .. ditaa::
@@ -57,6 +57,3 @@ metadata. See example code for the following languages:
            |                            |        |                             |
            +----------------------------+        +-----------------------------+
 
-.. _Java: ../java
-.. _Python: ../python
-.. _Ruby: ../ruby

--- a/doc/radosgw/vault.rst
+++ b/doc/radosgw/vault.rst
@@ -1,3 +1,5 @@
+.. _radosgw-vault:
+
 ===========================
 HashiCorp Vault Integration
 ===========================
@@ -157,9 +159,9 @@ Vault instances, or you could use either separately mounted
 transit instances, or different branches under a common transit
 point.  If you are not using separate Vault instances, you can
 use these to point SSE-KMS and SSE-S3 to separate containers:
-``rgw_crypt_vault_prefix``
+:confval:`rgw_crypt_vault_prefix`
 and/or
-``rgw_crypt_sse_s3_vault_prefix``.
+:confval:`rgw_crypt_sse_s3_vault_prefix`.
 When granting Vault permissions to SSE-KMS bucket owners, you should
 not give them permission to muck around with SSE-S3 keys;
 only Ceph itself should be doing that.

--- a/doc/radosgw/zone-features.rst
+++ b/doc/radosgw/zone-features.rst
@@ -1,3 +1,5 @@
+.. _radosgw-zone-features:
+
 =============
 Zone Features
 =============


### PR DESCRIPTION
Part 1 of 6 to make backporting easier. Many of the following parts depend on this.

Use the the ref role for all remaining links in doc/radosgw/ with the exception of config-ref.rst which will depend on changes to rgw.yaml.in.

The external link definitions syntax being removed is intended for linking to external websites and not for intra-docs links. Validity of ref links will be checked during the docs build process.

Add labels for links targets if necessary.
Remove unused external link definitions in the modified files.

Use confval instead of literal text for 2 configuration keys in vault.rst.
Use Ceph Object Gateway consistently in multisite.rst.

(cherry picked from commit c89f8a0 in PR #66944)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
