### PR TITLE
tentacle: rgw: rgw-orphan-list can continue with empty intermediate file(s)

### DIFF
--- a/src/rgw/rgw-orphan-list
+++ b/src/rgw/rgw-orphan-list
@@ -240,9 +240,8 @@ radosgw_radoslist
 
 for myfile in $rados_out $rgwadmin_out; do
   if [ ! -s "${myfile}" ]; then
-    log "ERROR: Empty file detected: ${myfile}"
-    log "ERROR: RESULTS ARE INCOMPLETE - DO NOT USE"
-    exit 1
+    log "WARNING: Empty file detected: ${myfile}"
+    log "         RESULTS MAY BE INCOMPLETE, USE WITH CAUTION"
   fi 
 done
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74500

---

backport of https://github.com/ceph/ceph/pull/66938
parent tracker: https://tracker.ceph.com/issues/74420

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh