### PR TITLE
Add space to second line in ceph-volume text output to prevent the wo…

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -50,7 +50,7 @@ common_args = {
     },
     '--data-slots': {
         'help': ('Intended number of slots on data device. The new OSD gets one'
-              'of those slots or 1/nth of the available capacity'),
+              ' of those slots or 1/nth of the available capacity'),
         'type': int,
         'default': 1,
     },
@@ -102,7 +102,7 @@ bluestore_args = {
     '--block.db-slots': {
         'dest': 'block_db_slots',
         'help': ('Intended number of slots on db device. The new OSD gets one'
-              'of those slots or 1/nth of the available capacity'),
+              ' of those slots or 1/nth of the available capacity'),
         'type': int,
         'default': 1,
     },
@@ -120,7 +120,7 @@ bluestore_args = {
     '--block.wal-slots': {
         'dest': 'block_wal_slots',
         'help': ('Intended number of slots on wal device. The new OSD gets one'
-              'of those slots or 1/nth of the available capacity'),
+              ' of those slots or 1/nth of the available capacity'),
         'type': int,
         'default': 1,
     },
@@ -142,7 +142,7 @@ filestore_args = {
     },
     '--journal-slots': {
         'help': ('Intended number of slots on journal device. The new OSD gets one'
-              'of those slots or 1/nth of the available capacity'),
+              ' of those slots or 1/nth of the available capacity'),
         'type': int,
         'default': 1,
     },


### PR DESCRIPTION
ceph-volume: whitespace issue in output for multiline strings




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
