### PR TITLE
squid: doc/radosgw: Cosmetic improvements and ref links in account.rst

### DIFF
--- a/doc/radosgw/account.rst
+++ b/doc/radosgw/account.rst
@@ -16,13 +16,13 @@ Account Root User
 
 Each account is managed by an *account root user*. Like normal users and roles,
 accounts and account root users must be created by an administrator using
-``radosgw-admin`` or the `Admin Ops API`_.
+``radosgw-admin`` or the :ref:`Admin Ops API <radosgw admin ops>`.
 
 The account root user has default permissions on all resources owned by
 the account. The root user's credentials (access and secret keys) can be
 used with the `Ceph Object Gateway IAM API`_ to create additional IAM users
-and roles for use with the `Ceph Object Gateway S3 API`_, as well as to
-manage their associated access keys and policies.
+and roles for use with the :ref:`Ceph Object Gateway S3 API <radosgw s3>`, as
+well as to manage their associated access keys and policies.
 
 Account owners are encouraged to use this account root user for management
 only, and create users and roles with fine-grained permissions for specific
@@ -128,45 +128,45 @@ Create an Account
 
 To create an account::
 
-	radosgw-admin account create [--account-name={name}] [--account-id={id}] [--email={email}]
+    radosgw-admin account create [--account-name={name}] [--account-id={id}] [--email={email}]
 
 Create an Account Root User
 ---------------------------
 
 To create an account root user::
 
-	radosgw-admin user create --uid={userid} --display-name={name} --account-id={accountid} --account-root --gen-secret --gen-access-key
+    radosgw-admin user create --uid={userid} --display-name={name} --account-id={accountid} --account-root --gen-secret --gen-access-key
 
 Delete an Account
 -----------------
 
 To delete an account::
 
-	radosgw-admin account rm --account-id={accountid}
+    radosgw-admin account rm --account-id={accountid}
 
 Account Stats/Quota
 -------------------
 
 To view account stats::
 
-	radosgw-admin account stats --account-id={accountid} --sync-stats
+    radosgw-admin account stats --account-id={accountid} --sync-stats
 
 To enable an account quota::
 
-	radosgw-admin quota set --quota-scope=account --account-id={accountid} --max-size=10G
-	radosgw-admin quota enable --quota-scope=account --account-id={accountid}
+    radosgw-admin quota set --quota-scope=account --account-id={accountid} --max-size=10G
+    radosgw-admin quota enable --quota-scope=account --account-id={accountid}
 
 To enable a bucket quota for the account::
 
-	radosgw-admin quota set --quota-scope=bucket --account-id={accountid} --max-objects=1000000
-	radosgw-admin quota enable --quota-scope=bucket --account-id={accountid}
+    radosgw-admin quota set --quota-scope=bucket --account-id={accountid} --max-objects=1000000
+    radosgw-admin quota enable --quota-scope=bucket --account-id={accountid}
 
-Migrate an existing User into an Account
+Migrate an Existing User into an Account
 ----------------------------------------
 
 An existing user can be adopted into an account with ``user modify``::
 
-	radosgw-admin user modify --uid={userid} --account-id={accountid}
+    radosgw-admin user modify --uid={userid} --account-id={accountid}
 
 .. note:: Ownership of all of the user's buckets will be transferred to
    the account.
@@ -198,99 +198,97 @@ Migrating Notification Topics
 Account topics are supported only when the ``notification_v2`` feature is enabled,
 as described in `Bucket Notifications`_ and `Supported Zone Features`_.
 
-1. ``Migration Impact``: When a non-account user is migrated to an account, the
-the existing notification topics remain accessible through the RadosGW admin API,
-but the user loses access to them via the SNS Topic API. Despite this, the topics
-remain functional, and bucket notifications will continue to be delivered as expected.
+#. **Migration Impact:** When a non-account user is migrated to an account, the
+   the existing notification topics remain accessible through the RADOS Gateway admin API,
+   but the user loses access to them via the SNS Topic API. Despite this, the topics
+   remain functional, and bucket notifications will continue to be delivered as expected.
 
-2. ``Re-creation of Topics``: The account user should re-create the topics using
-the same names. The old topics (now inaccessible) and the new account-owned topics
-will coexist without interference.
+#. **Re-creation of Topics:** The account user should re-create the topics using
+   the same names. The old topics (now inaccessible) and the new account-owned topics
+   will coexist without interference.
 
-3. ``Updating Bucket Notification Configurations``: Buckets that are subscribed to
-the old user-owned topics should be updated to use the new account-owned topics.
-To prevent duplicate notifications, maintain the same notification IDs.
-For example, if a bucket's existing notification configuration is:
+#. **Updating Bucket Notification Configurations:** Buckets that are subscribed to
+   the old user-owned topics should be updated to use the new account-owned topics.
+   To prevent duplicate notifications, maintain the same notification IDs.
+   For example, if a bucket's existing notification configuration is:
 
-    .. code-block:: json
+   .. code-block:: json
 
         {"TopicConfigurations": [{ "Id": "ID1", "TopicArn": "arn:aws:sns:default::topic1", "Events": ["s3:ObjectCreated:*"]}]}
 
-The updated configuration would be:
+   The updated configuration would be:
 
-    .. code-block:: json
+   .. code-block:: json
 
         {"TopicConfigurations": [{ "Id": "ID1", "TopicArn": "arn:aws:sns:default:RGW00000000000000001:topic1", "Events": ["s3:ObjectCreated:*"]}]}
 
-In this example, `RGW00000000000000001` is the account ID, `topic1` is the
-topic name and `ID1` is the notification ID.
+   In this example, ``RGW00000000000000001`` is the account ID, ``topic1`` is the
+   topic name and ``ID1`` is the notification ID.
 
-4. ``Removing Old Topics``: Once no buckets are subscribed to the old user-owned topics,
-they can be removed by an admin::
+#. **Removing Old Topics:** Once no buckets are subscribed to the old user-owned topics,
+   they can be removed by an admin::
 
-	$ radosgw-admin topic rm --topic topic1
+     $ radosgw-admin topic rm --topic topic1
 
-Account Root example
+Account Root Example
 --------------------
 
 The account root user's credentials unlock the `Ceph Object Gateway IAM API`_.
 
 This example uses `awscli`_ to create an IAM user for S3 operations.
 
-1. Create a profile for the account root user::
+#. Create a profile for the account root user::
 
-	$ aws --profile rgwroot configure set endpoint_url http://localhost:8000
-	$ aws --profile rgwroot configure
-	AWS Access Key ID [None]: {root access key}
-	AWS Secret Access Key [None]: {root secret key}
-	Default region name [None]: default
-	Default output format [None]:
+    $ aws --profile rgwroot configure set endpoint_url http://localhost:8000
+    $ aws --profile rgwroot configure
+    AWS Access Key ID [None]: {root access key}
+    AWS Secret Access Key [None]: {root secret key}
+    Default region name [None]: default
+    Default output format [None]:
 
-2. Create an IAM user, add credentials, and attach a policy for S3 access::
+#. Create an IAM user, add credentials, and attach a policy for S3 access::
 
-	$ aws --profile rgwroot iam create-user --user-name Alice
-	{
-	    "User": {
-	        "Path": "/",
-	        "UserName": "Alice",
-	        "UserId": "b580aa8e-14c7-4b6a-9dac-a30c640244b6",
-	        "Arn": "arn:aws:iam::RGW63136524507535818:user/Alice",
-	        "CreateDate": "2024-02-07T00:15:45.162786+00:00"
-	    }
-	}
-	$ aws --profile rgwroot iam create-access-key --user-name Alice
-	{
-	    "AccessKey": {
-	        "UserName": "Alice",
-	        "AccessKeyId": "JBNLYD5BDNRVV64J02E8",
-	        "Status": "Active",
-	        "SecretAccessKey": "SnHoE700kdNuT22K8Bhy2iL3DwZU0sUSDI1gUXHr",
-	        "CreateDate": "2024-02-07T00:16:34.679316+00:00"
-	    }
-	}
-	$ aws --profile rgwroot iam attach-user-policy --user-name Alice \
-	      --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess
+    $ aws --profile rgwroot iam create-user --user-name Alice
+    {
+        "User": {
+            "Path": "/",
+            "UserName": "Alice",
+            "UserId": "b580aa8e-14c7-4b6a-9dac-a30c640244b6",
+            "Arn": "arn:aws:iam::RGW63136524507535818:user/Alice",
+            "CreateDate": "2024-02-07T00:15:45.162786+00:00"
+        }
+    }
+    $ aws --profile rgwroot iam create-access-key --user-name Alice
+    {
+        "AccessKey": {
+            "UserName": "Alice",
+            "AccessKeyId": "JBNLYD5BDNRVV64J02E8",
+            "Status": "Active",
+            "SecretAccessKey": "SnHoE700kdNuT22K8Bhy2iL3DwZU0sUSDI1gUXHr",
+            "CreateDate": "2024-02-07T00:16:34.679316+00:00"
+        }
+    }
+    $ aws --profile rgwroot iam attach-user-policy --user-name Alice \
+          --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess
 
-3. Create a profile for the S3 user::
+#. Create a profile for the S3 user::
 
-	$ aws --profile rgws3 configure set endpoint_url http://localhost:8000
-	$ aws --profile rgws3 configure
-	AWS Access Key ID [None]: JBNLYD5BDNRVV64J02E8
-	AWS Secret Access Key [None]: SnHoE700kdNuT22K8Bhy2iL3DwZU0sUSDI1gUXHr
-	Default region name [None]: default
-	Default output format [None]:
+    $ aws --profile rgws3 configure set endpoint_url http://localhost:8000
+    $ aws --profile rgws3 configure
+    AWS Access Key ID [None]: JBNLYD5BDNRVV64J02E8
+    AWS Secret Access Key [None]: SnHoE700kdNuT22K8Bhy2iL3DwZU0sUSDI1gUXHr
+    Default region name [None]: default
+    Default output format [None]:
 
-4. Use the S3 user profile to create a bucket::
+#. Use the S3 user profile to create a bucket::
 
-	$ aws --profile rgws3 s3 mb s3://testbucket
-	make_bucket: testbucket
+    $ aws --profile rgws3 s3 mb s3://testbucket
+    make_bucket: testbucket
 
 
 .. _Roles: ../role/
 .. _AWS Identity and Access Management: https://aws.amazon.com/iam/
 .. _Ceph Object Gateway IAM API: ../iam/
-.. _Admin Ops API: ../adminops/
-.. _Ceph Object Gateway S3 API: ../s3/
 .. _Amazon Resource Names: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
 .. _Evaluating policies within a single account: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics
 .. _Cross-account policy evaluation logic: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic-cross-account.html


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/63426

---

Use double backticks consistently when referring to data, commands etc.

Change links pointing to existing labels to use ref.

Use title case consistently in section titles.

Use ordered lists instead of hardcoding list numbers.

Use inline strong for emphasis instead of inline preformatted.

Change several tab to four spaces for indent.

Call it RADOS Gateway instead of RadosGW.


Before: https://docs.ceph.com/en/latest/radosgw/account/

Rendered PR: https://ceph--63426.org.readthedocs.build/en/63426/radosgw/account/