### PR TITLE
cephfs: snapdiff and blockdiff commands

### DIFF
--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -481,3 +481,15 @@ You may want to do this when an application expects the file system's ID to be
 stable after it has been recovered, e.g., after Monitor databases are lost and
 rebuilt. Consequently, file system IDs don't always keep increasing with newer
 file systems.
+
+::
+   ceph fs snapdiff <fs_name> <root_path> <rel_path> <snapshot1> <snapshot2>
+
+This command shows the difference between two snapshots. This is useful when using ``rsync``
+for mirroring snapshots manually.
+
+::
+   ceph fs blockdiff <fs_name> <root_path> <filename> <snapshot1> <snapshot2>
+
+This command shows the blockdiff of a file between two snapshots as ``numblocks``, ``offset`` and ``length``.
+This is useful when using ``rsync`` for mirroring snapshots manually.

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -482,6 +482,22 @@ COMMAND("fs swap "
 	"name=swap_fscids,type=CephChoices,strings=yes|no,req=true "
 	"name=yes_i_really_mean_it,type=CephBool,req=false",
 	"swap ceph file system names", "mds", "rw")
+COMMAND("fs snapdiff "
+        "name=fs_name,type=CephString "
+        "name=root_path,type=CephString "
+        "name=rel_path,type=CephString "
+        "name=snap1,type=CephString "
+        "name=snap2,type=CephString ",
+        "list directories and files showing differences between two snapshots",
+        "fs", "r")
+COMMAND("fs blockdiff "
+        "name=fs_name,type=CephString "
+        "name=root_path,type=CephString "
+        "name=rel_path,type=CephString "
+        "name=snap1,type=CephString "
+        "name=snap2,type=CephString ",
+        "show the blockdiff between two files",
+        "fs", "r")
 
 /*
  * Monmap commands

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1632,15 +1632,64 @@ def send_command(cluster,
                 cluster.pg_command, pgid, cmd, inbuf, timeout=timeout)
 
         elif target[0] == 'mon':
-            if verbose:
-                print('{0} to {1}'.format(cmd, target[0]),
-                      file=sys.stderr)
-            if len(target) < 2 or target[1] == '':
-                ret, outbuf, outs = run_in_thread(
-                    cluster.mon_command, cmd, inbuf, timeout=timeout)
-            else:
-                ret, outbuf, outs = run_in_thread(
-                    cluster.mon_command, cmd, inbuf, timeout=timeout, target=target[1])
+            if cmd:
+                cmddict = json.loads(cmd)
+                if cmddict['prefix'] == "fs snapdiff":
+                    fsname = cmddict['fs_name']
+                    root_path = cmddict['root_path']
+                    rel_path = cmddict['rel_path']
+                    snap1 = cmddict['snap1']
+                    snap2 = cmddict['snap2']
+                    try:
+                        from cephfs import LibCephFS
+                    except ImportError:
+                        raise RuntimeError("CephFS unavailable, have you installed libcephfs?")
+                    fs = LibCephFS(conffile='')
+                    fs.mount(filesystem_name=fsname)
+                    diff = fs.opensnapdiff(root_path, rel_path, snap1, snap2)
+                    if not diff:
+                        raise RuntimeError("Error getting snapdiff handle")
+                    entry = diff.readdir()
+                    while entry is not None:
+                        d_name = entry.d_name.decode("utf-8")
+                        if (d_name != '.' and d_name != '..'):
+                            print(d_name)
+                        entry = diff.readdir()
+                    diff.close()
+                    ret, outbuf, outs = 0, "", ""
+                elif cmddict['prefix'] == "fs blockdiff":
+                    fsname = cmddict['fs_name']
+                    root_path = cmddict['root_path']
+                    rel_path = cmddict['rel_path']
+                    snap1 = cmddict['snap1']
+                    snap2 = cmddict['snap2']
+                    try:
+                        from cephfs import LibCephFS
+                    except ImportError:
+                        raise RuntimeError("CephFS unavailable, have you installed libcephfs?")
+                    fs = LibCephFS(conffile='')
+                    fs.mount(filesystem_name=fsname)
+                    diff = fs.openblockdiff(root_path, rel_path, snap1, snap2)
+                    if not diff:
+                        raise RuntimeError("Error getting blockdiff handle")
+                    entry = diff.readblock()
+                    while not entry.count(None):
+                        print(json.loads(f'{{"numblocks":{entry[0]}, '
+                                         f'"offset":{entry[1]}, '
+                                         f'"length":{entry[2]}}}'))
+                        entry = diff.readblock()
+                    diff.closeblockdiff()
+                    ret, outbuf, outs = 0, "", ""
+                else:
+                    if verbose:
+                        print('{0} to {1}'.format(cmd, target[0]),
+                              file=sys.stderr)
+                    if len(target) < 2 or target[1] == '':
+                        ret, outbuf, outs = run_in_thread(
+                            cluster.mon_command, cmd, inbuf, timeout=timeout)
+                    else:
+                        ret, outbuf, outs = run_in_thread(
+                            cluster.mon_command, cmd, inbuf, timeout=timeout, target=target[1])
         elif target[0] == 'mds':
             mds_spec = target[1]
 


### PR DESCRIPTION
Implement `snapdiff` and `blockdiff` commands. These are not mirroring commands.
Fixes: https://tracker.ceph.com/issues/74083


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
