### PR TITLE
mgr/cephadm: Allow colocation of NFS daemon to support active-active mode

### DIFF
--- a/doc/cephadm/services/nfs.rst
+++ b/doc/cephadm/services/nfs.rst
@@ -167,8 +167,8 @@ In this configuration, 4 daemons total are deployed (2 per host), distributed ac
      ``monitoring_port`` from the spec.
    * The number of entries in ``colocation_ports`` should be ``count - 1``,
      to cover the node down scenario (or ``count_per_host - 1`` when using ``count_per_host``).
-   * Each entry must specify both ``data_port`` and ``monitoring_port``. When
-     ``enable_rdma`` is true, each entry must also include ``rdma_port``.
+   * Each entry must specify ``data_port``, ``monitoring_port``, and ``qos_cluster_port``.
+     When ``enable_rdma`` is true, each entry must also include ``rdma_port``.
    * If ``colocation_ports`` is not specified, ports will be automatically
      incremented for colocated daemons (e.g., 2049 → 2050 → 2051 for data ports,
      and 9587 → 9588 → 9589 for monitoring ports).


### PR DESCRIPTION
Allow colocation of NFS daemons to support NFS active-active deployments. In the current setup, if I/O is in progress and a host goes down, the client can hang indefinitely. Enabling colocation helps avoid this issue.

Added colocation_ports field in spec to accept ports for colocating daemons, First daemon will use the default or provided ports (port and monitoring_port) and second daemon will start using the ports mentioned in colocation_ports.
  
Fixes: https://tracker.ceph.com/issues/74479
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing done:
```
[ceph: root@ceph-node-0 /]# ceph orch ps | grep nfs
haproxy.nfs.test.ceph-node-0.hhgxcm     ceph-node-0  *:2049,9049   running (30s)      22s ago   6m    3069k        -  2.3.17-d1c9119         e85424b0d443  ecf9fddcd427  
haproxy.nfs.test.ceph-node-1.kifcya     ceph-node-1  *:2049,9049   running (26s)      22s ago   6m    3003k        -  2.3.17-d1c9119         e85424b0d443  23dc80c7f71d  
haproxy.nfs.test.ceph-node-2.gguzjk     ceph-node-2  *:2049,9049   host is offline     2m ago   6m    3091k        -  2.3.17-d1c9119         e85424b0d443  da4ed6e7b1b3  
keepalived.nfs.test.ceph-node-0.qynzxj  ceph-node-0                running (5m)       22s ago   5m    1610k        -  2.2.4                  4a3a1ff181d9  77e6d3dd1e8d  
keepalived.nfs.test.ceph-node-1.inxzoa  ceph-node-1                running (5m)       22s ago   5m    1614k        -  2.2.4                  4a3a1ff181d9  36a3fdc8f23f  
keepalived.nfs.test.ceph-node-2.trxpoy  ceph-node-2                host is offline     2m ago   5m    1618k        -  2.2.4                  4a3a1ff181d9  08ca5d95f73f  
nfs.test.0.0.ceph-node-0.lgxqkb         ceph-node-0  *:12049,9587  running (7m)       22s ago   7m    43.4M        -  5.9                    f313d1fb88fd  0f6f0e7d0ba2  
nfs.test.1.0.ceph-node-1.wrfjdc         ceph-node-1  *:12049,9587  running (7m)       22s ago   7m    43.5M        -  5.9                    f313d1fb88fd  defc83870049  
nfs.test.2.0.ceph-node-2.murhpg         ceph-node-2  *:12049,9587  host is offline     2m ago   7m    43.2M        -  5.9                    f313d1fb88fd  901fc423e868  
nfs.test.2.1.ceph-node-0.loeqxr         ceph-node-0  *:12050,9588  running (44s)      22s ago  43s    42.6M        -  5.9                    f313d1fb88fd  0ef4d9325ef8  
[ceph: root@ceph-node-0 /]# 



backend backend
    mode        tcp
    balance     roundrobin
    stick-table type ip size 200k expire 30m peers haproxy_peers
    stick on src
    hash-type   consistent
    server nfs.test.0 192.168.100.100:12049 check
    server nfs.test.1 192.168.100.101:12049 check
    server nfs.test.2 192.168.100.100:12050 check
```

```
[ceph: root@ceph-node-0 /]# cat nfs.yml 
service_type: nfs
service_id: mynfs
placement:
  count: 3
spec:
  port: 12345
  colocation_ports: [[6000, 61000], [7000, 7100]]
[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# ceph orch ps | grep nfs
nfs.mynfs.0.0.ceph-node-2.mrohyf  ceph-node-2  *:12345,9587  host is offline     8m ago   9m    42.7M        -  5.9                    df2f6085f8c0  a8c4774198e9  
nfs.mynfs.0.1.ceph-node-1.jeybvr  ceph-node-1  *:6000,61000  running (7m)       43s ago   7m    43.5M        -  5.9                    df2f6085f8c0  1ef0ab5d14d5  
nfs.mynfs.1.0.ceph-node-1.wwhebt  ceph-node-1  *:12345,9587  running (9m)       43s ago   9m    43.4M        -  5.9                    df2f6085f8c0  0f14d6841862  
nfs.mynfs.2.0.ceph-node-0.ofywby  ceph-node-0  *:12345,9587  running (8m)       44s ago   8m    43.3M        -  5.9                    df2f6085f8c0  dbd068ad7410  

```
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
