### PR TITLE
mgr/cephadm: Adds a way for custom container to auto register with prometheus

### DIFF
--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -2748,6 +2748,9 @@ class CustomContainerSpec(ServiceSpec):
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
                  init_containers: Optional[List[Union['InitContainerSpec', Dict[str, Any]]]] = None,
+                 prometheus_sd: bool = False,
+                 prometheus_sd_port_index: int = 0,
+                 prometheus_sd_labels: Optional[Dict[str, str]] = None,
                  ):
         assert service_type == 'container'
         assert service_id is not None
@@ -2778,6 +2781,9 @@ class CustomContainerSpec(ServiceSpec):
             self.init_containers = InitContainerSpec.import_values(
                 init_containers
             )
+        self.prometheus_sd = prometheus_sd
+        self.prometheus_sd_port_index = prometheus_sd_port_index
+        self.prometheus_sd_labels = prometheus_sd_labels or {}
 
     def config_json(self) -> Dict[str, Any]:
         """
@@ -2809,6 +2815,15 @@ class CustomContainerSpec(ServiceSpec):
             raise SpecValidationError(
                 '"files" and "custom_configs" are mutually exclusive '
                 '(and both serve the same purpose)')
+
+        if self.prometheus_sd:
+            if not self.ports:
+                raise SpecValidationError(
+                    'prometheus_sd requires at least one port to be specified')
+            if self.prometheus_sd_port_index >= len(self.ports):
+                raise SpecValidationError(
+                    f'prometheus_sd_port_index ({self.prometheus_sd_port_index}) '
+                    f'is out of range for ports list (length {len(self.ports)})')
 
     # use quotes for OrderedDict, getting this to work across py 3.6, 3.7
     # and 3.7+ is suprisingly difficult


### PR DESCRIPTION
If I want to add a custom exporter to be managed by cephadm, this https://tracker.ceph.com/issues/70482 feature enabled that, but I would still need to edit prometheus.yml file to tell it to scrape my new exporter by specifying something like:

```yml
  - job_name: 'container.ebpf-exporter'
    relabel_configs:
    - source_labels: [__address__]
      target_label: cluster
      replacement: 049dd428-fb3c-11f0-bfa8-bc24115d4997
    honor_labels: true
    http_sd_configs:
    - url: http://mgr1:8765/sd/prometheus/sd-config?service=container.ebpf-exporter
    - url: http://mgr2:8765/sd/prometheus/sd-config?service=container.ebpf-exporter
```
Editing prometheus.yml manually means cephadm overwrites it whenever it redeploys the prometheus daemon 

This PR adds a way for this to be automatically generated for custom containers if we specify it with `prometheus_sd: true` in the service spec. 

Syntax: 
```
spec:
  ports:
  - 9435
  prometheus_sd: true
  prometheus_sd_labels:
    job: <name>
```

Fixes:  https://tracker.ceph.com/issues/74597

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
