### PR TITLE
rbd-mirror: Fix removal of group snapshots

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_group.sh
+++ b/qa/workunits/rbd/rbd_mirror_group.sh
@@ -271,6 +271,7 @@ mirror_group_snapshot_and_wait_for_sync_complete ${CLUSTER1} ${CLUSTER2} ${POOL}
 compare_images ${CLUSTER1} ${CLUSTER2} ${POOL} ${POOL} ${image1}
 
 testlog " - failover (unmodified)"
+snap_id=''
 mirror_group_demote ${CLUSTER2} ${POOL}/${group}
 test_fields_in_group_info ${CLUSTER2} ${POOL}/${group} 'snapshot' 'enabled' 'false'
 wait_for_group_replay_stopped ${CLUSTER1} ${POOL}/${group} 0
@@ -279,6 +280,8 @@ wait_for_group_status_in_pool_dir ${CLUSTER2} ${POOL}/${group} 'up+unknown' 0
 mirror_group_promote ${CLUSTER1} ${POOL}/${group}
 test_fields_in_group_info ${CLUSTER1} ${POOL}/${group} 'snapshot' 'enabled' 'true'
 wait_for_group_replay_started ${CLUSTER2} ${POOL}/${group} 1
+wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type ${CLUSTER1} ${POOL}/${group} 'primary' snap_id
+wait_for_test_group_snap_present ${CLUSTER2} ${POOL}/${group} ${snap_id} 1
 
 testlog " - failback (unmodified)"
 mirror_group_demote ${CLUSTER1} ${POOL}/${group}
@@ -286,6 +289,8 @@ test_fields_in_group_info ${CLUSTER1} ${POOL}/${group} 'snapshot' 'enabled' 'fal
 wait_for_group_replay_stopped ${CLUSTER2} ${POOL}/${group} 0
 wait_for_group_status_in_pool_dir ${CLUSTER1} ${POOL}/${group} 'up+unknown' 0
 wait_for_group_status_in_pool_dir ${CLUSTER2} ${POOL}/${group} 'up+unknown' 0
+# tests removal of non-primary snapshot
+wait_for_test_group_snap_present ${CLUSTER2} ${POOL}/${group} ${snap_id} 0
 mirror_group_promote ${CLUSTER2} ${POOL}/${group}
 test_fields_in_group_info ${CLUSTER2} ${POOL}/${group} 'snapshot' 'enabled' 'true'
 wait_for_group_replay_started ${CLUSTER1} ${POOL}/${group} 1

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2954,6 +2954,122 @@ test_force_promote_before_initial_sync()
   start_mirrors "${secondary_cluster}"
 }
 
+# test demote snapshot unlink and removal post relocation
+declare -a test_demote_snap_unlink_and_removal_post_relocation_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128)
+
+test_demote_snap_unlink_and_removal_post_relocation_scenarios=1
+
+test_demote_snap_unlink_and_removal_post_relocation()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_count=$1 ; shift
+  local image_size=$1 ; shift
+
+  local group0=test-group0
+  local image_prefix="test_image"
+  # UUID of ${primary_cluster} used by ${secondary_cluster}
+  local primary_cluster_uuid
+  # UUID of ${secondary_cluster} used by ${primary_cluster}
+  local secondary_cluster_uuid
+  local promote_snap_id_old demote_snap_id_old
+  local promote_snap_id_new demote_snap_id_new
+  local group_snap_id
+
+  start_mirrors "${primary_cluster}"
+  start_mirrors "${secondary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}" "${image_size}"
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+
+  get_peer_uuid "${secondary_cluster}" "${pool}" primary_cluster_uuid
+  get_peer_uuid "${primary_cluster}" "${pool}" secondary_cluster_uuid
+
+  for i in $(seq 1 10); do
+    # relocation: demote primary and promote secondary
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'primary' group_snap_id
+    mirror_group_demote "${primary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    # get newest demote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'demoted' demote_snap_id_old
+    # wait for presence of demote snapshot on secondary
+    wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${demote_snap_id_old}" 1
+    # test unlinking of previous primary snapshot
+    wait_for_peer_uuid_not_in_group_snap_peers "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" "${secondary_cluster_uuid}"
+    # test for UUID presence in demote snapshot
+    test_peer_uuid_in_group_snap_peers "${secondary_cluster}" "${pool}/${group0}" "${demote_snap_id_old}" "${primary_cluster_uuid}"
+
+    mirror_group_promote "${secondary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+replaying' ${image_count}
+    # get newest promote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${secondary_cluster}" "${pool}/${group0}" 'primary' promote_snap_id_old
+    # wait for presence of promote snapshot on primary
+    wait_for_test_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${promote_snap_id_old}" 1
+    wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}" 0
+    wait_for_peer_uuid_not_in_group_snap_peers "${secondary_cluster}" "${pool}/${group0}" "${demote_snap_id_old}" "${primary_cluster_uuid}"
+
+    mirror_group_demote "${secondary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    # get newest demote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${secondary_cluster}" "${pool}/${group0}" 'demoted' demote_snap_id_new
+    # wait for presence of demote snapshot on primary
+    wait_for_test_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${demote_snap_id_new}" 1
+    # test for UUID presence in demote snapshot
+    wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${demote_snap_id_old}" 0
+    wait_for_peer_uuid_not_in_group_snap_peers "${secondary_cluster}" "${pool}/${group0}" "${promote_snap_id_old}" "${primary_cluster_uuid}"
+    test_peer_uuid_in_group_snap_peers "${primary_cluster}" "${pool}/${group0}" "${demote_snap_id_new}" "${secondary_cluster_uuid}"
+
+    # go back to original state
+    mirror_group_promote "${primary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' ${image_count}
+    # get newest promote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'primary' promote_snap_id_new
+    # wait for presence of promote snapshot on secondary
+    wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${promote_snap_id_new}" 1
+    # wait for old demote snapshot's peer_uuid to be removed
+    wait_for_peer_uuid_not_in_group_snap_peers "${primary_cluster}" "${pool}/${group0}" "${demote_snap_id_old}" "${secondary_cluster_uuid}"
+    wait_for_peer_uuid_not_in_group_snap_peers "${primary_cluster}" "${pool}/${group0}" "${demote_snap_id_new}" "${secondary_cluster_uuid}"
+    wait_for_test_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" 0
+
+    # cleanup
+    promote_snap_id_old=''
+    demote_snap_id_old=''
+    promote_snap_id_new=''
+    demote_snap_id_new=''
+  done
+
+  local count
+  # FIXME: change the count comparison to 3 when all snap cleanup is implemented correctly
+  # After each iteration:
+  # A cluster can have three mirror group snapshots:
+  # 1. demote primary, 2. demote non-primary or non-primary and 3. primary
+  # Hence at most 3 snapshots can be present in each cluster
+  get_group_snap_count "${primary_cluster}" "${pool}"/"${group0}" '*' count
+  test "${count}" -gt 4 && { fail "unexpected snap count=${count} after multiple relocation cycles"; return 1; }
+  get_group_snap_count "${secondary_cluster}" "${pool}"/"${group0}" '*' count
+  test "${count}" -gt 4 && { fail "unexpected snap count=${count} after multiple relocation cycles"; return 1; }
+
+  # cleanup
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+}
+
 # test group snapshot resync after relocate and force promote of primary
 declare -a test_resync_after_relocate_and_force_promote_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128)
 
@@ -3978,6 +4094,7 @@ run_all_tests()
   run_test_all_scenarios test_interrupted_sync_restarted_daemon
   run_test_all_scenarios test_interrupted_sync
   run_test_all_scenarios test_resync_after_relocate_and_force_promote
+  run_test_all_scenarios test_demote_snap_unlink_and_removal_post_relocation
   run_test_all_scenarios test_multiple_mirror_group_snapshot_unlink_time
   run_test_all_scenarios test_force_promote_delete_group
   run_test_all_scenarios test_create_group_stop_daemon_then_recreate

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -986,6 +986,121 @@ mirror_image_snapshot()
     rbd --cluster "${cluster}" mirror image snapshot "${pool}/${image}"
 }
 
+# get the uuid of the remote cluster from the ${cluster}'s pool info'
+# FIXME: works only for single peer, return uuid of first peer from list
+get_peer_uuid()
+{
+    local cluster=$1
+    local pool=$2
+    local -n _uuid=$3
+
+    run_cmd "rbd --cluster ${cluster} mirror pool info --pool ${pool} --format xml --pretty-format"
+    _uuid=$(xmlstarlet sel -t -v "//peers/peer/uuid[1]" < "$CMD_STDOUT" )
+    if [[ -z "${_uuid}" ]]; then
+        fail "failed to get uuid of pool ${pool}"
+	return 1
+    fi
+}
+
+# wait until a newest/last complete snapshot id is found by snapshot type
+# snap_type values: "demoted", "primary", "non-primary"
+wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_type=$3
+    local -n _new_snap_id=$4
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
+        sleep ${s}
+        _new_snap_id=""
+        if get_newest_complete_mirror_group_snapshot_id_by_snap_type \
+                "${cluster}" "${group_spec}" "${snap_type}" _new_snap_id; then
+            [[ -n "${_new_snap_id}" ]] && return 0
+        fi
+    done
+
+    fail "wait for newest complete mirror group snapshot id failed on ${cluster}"
+    return 1
+}
+
+# get newest/last complete snapshot id by snapshot type
+# snap_type values: "demoted", "primary", "non-primary"
+# "demoted" can be primary or non-primary depending on which cluster it is run against
+get_newest_complete_mirror_group_snapshot_id_by_snap_type()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_type=$3
+    local -n _snap_id=$4
+
+    run_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format"
+    _snap_id=$(xmlstarlet sel -t -v "(//group_snaps/group_snap[last()][namespace/complete='true' and namespace/state='${snap_type}']/id)" "$CMD_STDOUT" )
+    [[ -n "${_snap_id}" ]]
+}
+
+# get the list of peer UUIDs for a specific group snapshot
+get_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local -n _peers=$4
+
+    run_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format"
+    _peers=$(xmlstarlet sel -t -v "//group_snap[id='${snap_id}']/namespace/mirror_peer_uuids/peer_uuid" "$CMD_STDOUT")
+}
+
+test_peer_uuid_in_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local peer_uuid=$4
+
+    test -n "${peer_uuid}" || { fail "peer_uuid is empty"; return 1; }
+    local peers
+    get_group_snap_peers "${cluster}" "${group_spec}" "${snap_id}" peers
+    echo "${peers}" | grep -qxF "${peer_uuid}" || { fail; return 1; }
+}
+
+wait_for_peer_uuid_in_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local peer_uuid=$4
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32 32 32 32; do
+        sleep ${s}
+        test_peer_uuid_in_group_snap_peers "${cluster}" "${group_spec}" "${snap_id}" "${peer_uuid}" && return 0
+    done
+
+    fail "wait for peer_uuid ${peer_uuid} in group snap peers failed on ${cluster}"
+    return 1
+}
+
+wait_for_peer_uuid_not_in_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local peer_uuid=$4
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32 32 32 32; do
+        sleep ${s}
+        if ! test_peer_uuid_in_group_snap_peers "${cluster}" "${group_spec}" "${snap_id}" "${peer_uuid}"; then
+            return 0
+        fi
+    done
+
+    fail "failed to wait to unlink peer_uuid ${peer_uuid} from group snap ${snap_id} on ${cluster}"
+    return 1
+}
+
 # get the primary_snap_id for the most recent complete snap on the secondary cluster
 get_primary_snap_id_for_newest_mirror_snapshot_on_secondary()
 {

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -1728,7 +1728,6 @@ bool Replayer<I>::prune_all_image_snapshots(
       derr << "failed getting snap info for snap id: " << spec.snap_id
            << ", : " << cpp_strerror(r) << dendl;
     }
-    prune_done = false;
     auto ir = std::find_if(
         m_replayers_by_image_id.begin(),
         m_replayers_by_image_id.end(),
@@ -1739,6 +1738,7 @@ bool Replayer<I>::prune_all_image_snapshots(
       ImageReplayer<I>* image_replayer = ir->second;
       dout(10) << "pruning snapshot " << spec.snap_id
                << " for image " << spec.image_id << dendl;
+      prune_done = false;
       // The ImageReplayer can have m_replayer empty, so no guaranty that
       // this will succeed in one shot, but we keep retry for this and
       // acheive anyway.
@@ -1875,10 +1875,15 @@ template <typename I>
 void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     const std::vector<cls::rbd::GroupSnapshot>& prune_group_snaps) {
-  int r = 0;
   {
     std::unique_lock locker{m_lock};
     for (const auto& local_snap : prune_group_snaps) {
+      if (m_pruning_group_snaps_inflight.count(local_snap.id) == 0) {
+        m_pruning_group_snaps_inflight.insert(local_snap.id);
+        m_in_flight_op_tracker.start_op();
+        dout(10) << "starting pruning of group snap: "
+                 << local_snap.name << ", with id: " << local_snap.id << dendl;
+      }
       if (!prune_all_image_snapshots_by_gsid(
             local_snap.id, local_images, &locker)) {
         // still pending image snapshots; retry later
@@ -1886,14 +1891,10 @@ void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
       }
       dout(10) << "all image snapshots pruned; removing creating group snapshot: "
                << local_snap.id << dendl;
-      r = librbd::cls_client::group_snap_remove(
-          &m_local_io_ctx,
-          librbd::util::group_header_name(m_local_group_id),
-          local_snap.id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot "
-             << local_snap.id << ": "
-             << cpp_strerror(r) << dendl;
+      remove_group_snapshot(&local_snap);
+      if (m_pruning_group_snaps_inflight.count(local_snap.id) != 0) {
+        m_pruning_group_snaps_inflight.erase(local_snap.id);
+        m_in_flight_op_tracker.finish_op();
       }
     }
   }
@@ -1903,7 +1904,6 @@ void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
 template <typename I>
 void Replayer<I>::prune_user_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
   for (auto local_snap = m_local_group_snaps.begin();
       local_snap != m_local_group_snaps.end(); ++local_snap) {
     auto snap_type = cls::rbd::get_group_snap_namespace_type(
@@ -1919,28 +1919,42 @@ void Replayer<I>::prune_user_group_snapshots(
       if (!prune_user_snap) {
         continue;
       }
-      dout(10) << "pruning user group snap in-progress: "
-               << local_snap->name << ", with id: " << local_snap->id << dendl;
+      if (m_pruning_group_snaps_inflight.count(local_snap->id) == 0) {
+        m_pruning_group_snaps_inflight.insert(local_snap->id);
+        m_in_flight_op_tracker.start_op();
+        dout(10) << "starting pruning of user group snap: "
+                 << local_snap->name << ", with id: " << local_snap->id << dendl;
+      }
       // prune all the image snaps of the group snap locally
       if (!prune_all_image_snapshots(&(*local_snap), locker)) {
         continue;
       }
       dout(10) << "all image snaps are pruned, finally pruning user group snap: "
                << local_snap->id << dendl;
-      r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-             librbd::util::group_header_name(m_local_group_id), local_snap->id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot : "
-             << local_snap->id << " : " << cpp_strerror(r) << dendl;
+      remove_group_snapshot(&(*local_snap));
+      if (m_pruning_group_snaps_inflight.count(local_snap->id) != 0) {
+        m_pruning_group_snaps_inflight.erase(local_snap->id);
+        m_in_flight_op_tracker.finish_op();
       }
     }
   }
 }
 
 template <typename I>
+void Replayer<I>::remove_group_snapshot(const cls::rbd::GroupSnapshot *local_snap) {
+  dout(10) << "pruning group snap: "
+           << local_snap->name << ", with id: " << local_snap->id << dendl;
+  int r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
+      librbd::util::group_header_name(m_local_group_id), local_snap->id);
+  if (r < 0) {
+    derr << "failed to remove group snapshot: "
+         << local_snap->id << " : " << cpp_strerror(r) << dendl;
+  }
+}
+
+template <typename I>
 void Replayer<I>::prune_mirror_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
   bool is_prior_snap_user = false;
   bool skip_next_snap_check = false;
   cls::rbd::GroupSnapshot *prune_snap = nullptr;
@@ -2014,25 +2028,35 @@ void Replayer<I>::prune_mirror_group_snapshots(
         }
       }
     }
+    skip_next_snap_check = false;
     mirror_group_snapshot_unlink_peer(prune_snap->id);
     const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
         prune_snap->snapshot_namespace);
-    if (ns.is_primary() ||
-        !prune_all_image_snapshots(prune_snap, locker)) {
+
+    if (ns.is_primary()) {
       prune_snap = nullptr;
-      skip_next_snap_check = false;
+      continue;
+    }
+    if (m_pruning_group_snaps_inflight.count(prune_snap->id) == 0) {
+      m_pruning_group_snaps_inflight.insert(prune_snap->id);
+      m_in_flight_op_tracker.start_op();
+      dout(10) << "starting pruning of mirror group snap: "
+               << prune_snap->name << ", with id: " << prune_snap->id << dendl;
+    }
+    if (!prune_all_image_snapshots(prune_snap, locker)) {
+      prune_snap = nullptr;
       continue;
     }
     dout(10) << "all image snaps are pruned, finally pruning mirror group snap: "
              << prune_snap->id << dendl;
-    r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-        librbd::util::group_header_name(m_local_group_id), prune_snap->id);
-    if (r < 0) {
-      derr << "failed to remove group snapshot : "
-           << prune_snap->id << " : " << cpp_strerror(r) << dendl;
+
+    remove_group_snapshot(prune_snap);
+
+    if (m_pruning_group_snaps_inflight.count(prune_snap->id) != 0) {
+      m_pruning_group_snaps_inflight.erase(prune_snap->id);
+      m_in_flight_op_tracker.finish_op();
     }
     prune_snap = nullptr;
-    skip_next_snap_check = false;
   }
 }
 
@@ -2137,6 +2161,37 @@ void Replayer<I>::set_image_replayer_limits(const std::string &image_id,
 }
 
 template <typename I>
+void Replayer<I>::finish_pending_snapshot_pruning() {
+  dout(10) << dendl;
+  std::unique_lock locker{m_lock};
+  while (!m_pruning_group_snaps_inflight.empty()) {
+    std::string snap_id = *m_pruning_group_snaps_inflight.begin();
+    cls::rbd::GroupSnapshot prune_snap;
+    auto it = std::find_if(
+        m_local_group_snaps.begin(), m_local_group_snaps.end(),
+        [&snap_id](const cls::rbd::GroupSnapshot &s) {
+          return s.id == snap_id;
+        });
+    if (it == m_local_group_snaps.end()) {
+      // snapshot not found locally, skip it
+      m_pruning_group_snaps_inflight.erase(snap_id);
+      m_in_flight_op_tracker.finish_op();
+      continue;
+    }
+    prune_snap = *it;
+    if (prune_all_image_snapshots(&prune_snap, &locker)) {
+      remove_group_snapshot(&prune_snap);
+      m_pruning_group_snaps_inflight.erase(snap_id);
+      m_in_flight_op_tracker.finish_op();
+    } else {
+      locker.unlock();
+      // need to unlock and lock to allow other ops to proceed
+      locker.lock();
+    }
+  }
+}
+
+template <typename I>
 void Replayer<I>::shut_down(Context* on_finish) {
   dout(10) << dendl;
 
@@ -2160,6 +2215,17 @@ void Replayer<I>::shut_down(Context* on_finish) {
 template <typename I>
 void Replayer<I>::wait_for_in_flight_ops() {
   dout(10) << dendl;
+
+  // Ensure all pending snapshot pruning is completed.
+  // This is required before m_in_flight_op_tracker.wait_for_ops(); otherwise,
+  // the wait may block indefinitely if the group snapshot is not fully pruned.
+  {
+    std::unique_lock locker{m_lock};
+    if (!m_pruning_group_snaps_inflight.empty()) {
+      locker.unlock();
+      finish_pending_snapshot_pruning();
+    }
+  }
 
   auto ctx = create_async_context_callback(
     m_threads->work_queue, create_context_callback<

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -662,7 +662,8 @@ void Replayer<I>::handle_load_remote_group_snapshots(int r) {
     schedule_load_group_snapshots();
     return;
   }
-
+  std::string unlink_snap_id;
+  bool has_newer_snap = false;
   for (auto remote_snap = m_remote_group_snaps.begin();
        remote_snap != m_remote_group_snaps.end(); ) {
     auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
@@ -677,9 +678,44 @@ void Replayer<I>::handle_load_remote_group_snapshots(int r) {
                << remote_snap_ns->mirror_peer_uuids << " (expected: "
                << m_remote_mirror_peer_uuid << ")" << dendl;
       remote_snap = m_remote_group_snaps.erase(remote_snap);
-    } else {
-      ++remote_snap;
+      continue;
     }
+    if (!has_newer_snap) {
+      if (!unlink_snap_id.empty()) {
+        // check if next remote snap has a matching complete local snap
+        auto itr = std::find_if(
+          m_local_group_snaps.begin(), m_local_group_snaps.end(),
+          [remote_snap](const cls::rbd::GroupSnapshot &s) {
+          return s.id == remote_snap->id;
+        });
+        if (itr == m_local_group_snaps.end()) {
+          dout(10) << "Local mirror group snapshot not found for remote_snap_id: " << remote_snap->id << dendl;
+          ++remote_snap;
+          continue;
+        }
+        auto next_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+          &itr->snapshot_namespace);
+        if (!is_mirror_group_snapshot_complete(itr->state,
+                                              next_local_snap_ns->complete)) {
+          dout(10) << "Next local mirror snapshot is incomplete: "
+                   << itr->id << dendl;
+          ++remote_snap;
+          continue;
+        }
+        has_newer_snap = true;
+      }
+      if (remote_snap_ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
+        unlink_snap_id = remote_snap->id;
+      }
+    }
+    ++remote_snap;
+  }
+  if (has_newer_snap) {
+    ceph_assert(!unlink_snap_id.empty());
+    mirror_group_snapshot_unlink_peer(unlink_snap_id);
+    locker.unlock();
+    schedule_load_group_snapshots();
+    return;
   }
   check_local_group_snapshots(&locker);
 }

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -130,6 +130,7 @@ private:
 
   bool m_check_creating_snaps = true; // check and identify creating snaps just after restart
   bool m_resync_requested = false;
+  std::set<std::string> m_pruning_group_snaps_inflight;
 
   bool is_replay_interrupted(std::unique_lock<ceph::mutex>* locker);
 
@@ -252,6 +253,8 @@ private:
   void prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_mirror_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  void remove_group_snapshot(const cls::rbd::GroupSnapshot *local_snap);
+  void finish_pending_snapshot_pruning();
   void prune_creating_group_snapshots_if_any(
       std::unique_lock<ceph::mutex>* locker);
   void handle_prune_creating_group_snapshots_if_any(


### PR DESCRIPTION
rbd-mirror: Fix removal of group snapshots
When remote primary group is demoted/disabled/removed, these changes allows
the group replayer to wait until all pending group snapshots
and the corresponding image snapshots are fully removed.
This ensures proper cleanup order and prevents orphaned snapshots.

Added test to check for removal of non-primary snapshot.

Signed-off-by: Miki Patel <miki.patel132@gmail.com>

NOTE:
Here Commit [[rbd-mirror: Fix removal of group snapshots](https://github.com/ceph/ceph/pull/67105/changes/251f6128b55562c5800b11382863288420e8c003)](https://github.com/ceph/ceph/pull/67105/changes/251f6128b55562c5800b11382863288420e8c003) contains actual changes in group replayer. 
Commit [[Added test case changes](https://github.com/ceph/ceph/pull/67105/changes/7bfe374068c045db45a0b47680145c6804918fbc)](https://github.com/ceph/ceph/pull/67105/changes/7bfe374068c045db45a0b47680145c6804918fbc) tests the above changes and has dependency on PR: [66812](https://github.com/ceph/ceph/pull/66812). Hence Commit [[rbd-mirror: Fix demoted primary snapshots not being removed after relocation](https://github.com/ceph/ceph/pull/67105/changes/6dee30fd81ec765d429c4854c33b4cfc6e169a21)](https://github.com/ceph/ceph/pull/67105/changes/6dee30fd81ec765d429c4854c33b4cfc6e169a21) is cherry-picked from PR. 

For this PR, please review changes in [[rbd-mirror: Fix removal of group snapshots](https://github.com/ceph/ceph/pull/67105/changes/251f6128b55562c5800b11382863288420e8c003)](https://github.com/ceph/ceph/pull/67105/changes/251f6128b55562c5800b11382863288420e8c003) and [[Added test case changes](https://github.com/ceph/ceph/pull/67105/changes/7bfe374068c045db45a0b47680145c6804918fbc)](https://github.com/ceph/ceph/pull/67105/changes/7bfe374068c045db45a0b47680145c6804918fbc)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
