### PR TITLE
mgr/dashboard: add CephFS Mirroring snapshot dir list

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -63,6 +63,8 @@ DAEMON_STATUS_SCHEMA = [{
     }], 'List of filesystems on daemon'),
 }]
 
+LIST_SNAPSHOT_DIRS_SCHEMA = [str]
+
 
 # pylint: disable=R0904
 @APIRouter('/cephfs', Scope.CEPHFS)
@@ -1323,6 +1325,23 @@ class CephFSMirror(RESTController):
         if error_code != 0:
             raise DashboardException(
                 msg=f'Failed to get Cephfs mirror daemon status: {err}',
+                code=error_code,
+                component='cephfs.mirror'
+            )
+        return json.loads(out)
+
+    @EndpointDoc("List snapshot mirrored directories",
+                 parameters={
+                     'fs_name': (str, 'File system name'),
+                 },
+                 responses={200: LIST_SNAPSHOT_DIRS_SCHEMA})
+    @Endpoint('GET', path='/snapshot/ls')
+    @ReadPermission
+    def snapshot_ls(self, fs_name: str):
+        error_code, out, err = mgr.remote('mirroring', 'snapshot_mirror_ls', fs_name)
+        if error_code != 0:
+            raise DashboardException(
+                msg=f'Failed to get Cephfs snapshot list: {err}',
                 code=error_code,
                 component='cephfs.mirror'
             )

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.e2e-spec.ts
@@ -1,0 +1,111 @@
+import { CephfsMirroringPageHelper } from './cephfs-mirroring.po';
+
+describe('CephFS Mirroring', () => {
+  const cephfsMirroring = new CephfsMirroringPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  describe('mirroring list page', () => {
+    beforeEach(() => {
+      cephfsMirroring.navigateToList();
+    });
+
+    it('should open and show breadcrumb', () => {
+      cephfsMirroring.expectBreadcrumbText('Mirroring');
+    });
+
+    it('should show the mirroring list component', () => {
+      cy.get('cd-cephfs-mirroring-list').should('exist');
+    });
+
+    it('should show the mirroring daemon status table', () => {
+      cy.get('cd-cephfs-mirroring-list cd-table').should('exist');
+    });
+  });
+
+  describe('mirroring paths page', () => {
+    const fsName = 'fs1';
+
+    beforeEach(() => {
+      cephfsMirroring.navigateToPaths(fsName);
+    });
+
+    it('should open and show breadcrumb File / Mirroring / fsName / paths', () => {
+      cephfsMirroring.expectBreadcrumbText('paths');
+      cephfsMirroring.expectBreadcrumbSegments(['File', 'Mirroring', fsName, 'paths']);
+    });
+
+    it('should show the mirroring paths component', () => {
+      cy.get('cd-cephfs-mirroring-paths').should('exist');
+    });
+
+    it('should show Local filesystem, Remote filesystem and Remote cluster sections', () => {
+      cy.get('cd-cephfs-mirroring-paths').within(() => {
+        cy.contains('Local filesystem').should('be.visible');
+        cy.contains('Remote filesystem').should('be.visible');
+        cy.contains('Remote cluster').should('be.visible');
+      });
+    });
+
+    it('should show Mirroring paths table section', () => {
+      cy.get('cd-cephfs-mirroring-paths').within(() => {
+        cy.contains('Mirroring paths').should('be.visible');
+        cy.get('cd-table').should('exist');
+      });
+    });
+  });
+
+  describe('navigation from list to paths', () => {
+    const mockFsName = 'fs1';
+    const mockDaemonStatus = [
+      {
+        daemon_id: 1,
+        filesystems: [
+          {
+            filesystem_id: 10,
+            name: mockFsName,
+            directory_count: 1,
+            peers: [
+              {
+                uuid: 'peer-uuid',
+                remote: {
+                  client_name: 'client.mirror',
+                  cluster_name: 'remote-cluster',
+                  fs_name: 'remote-fs'
+                },
+                stats: { failure_count: 0, recovery_count: 0 }
+              }
+            ],
+            id: '1-10'
+          }
+        ]
+      }
+    ];
+
+    beforeEach(() => {
+      cy.intercept('GET', '**/api/cephfs/mirror/daemon-status', {
+        statusCode: 200,
+        body: mockDaemonStatus
+      }).as('daemonStatus');
+      cephfsMirroring.navigateToList();
+      cy.wait('@daemonStatus');
+    });
+
+    it('should navigate to paths when clicking local filesystem link in a row', () => {
+      cy.get('cd-cephfs-mirroring-list').within(() => {
+        cy.get('[cdstablerow]').should('have.length.at.least', 1);
+      });
+      cephfsMirroring.clickLocalFsLink(mockFsName);
+      cy.url().should('include', `/cephfs/mirroring/${mockFsName}`);
+      cy.get('cd-cephfs-mirroring-paths').should('exist');
+      cephfsMirroring.expectBreadcrumbSegments(['File', 'Mirroring', mockFsName]);
+      cy.get('cd-cephfs-mirroring-paths').within(() => {
+        cy.contains('Local filesystem').should('be.visible');
+        cy.contains(mockFsName).should('be.visible');
+        cy.contains('Mirroring paths').should('be.visible');
+      });
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.po.ts
@@ -1,0 +1,42 @@
+import { PageHelper } from '../page-helper.po';
+
+const pages = {
+  list: { url: '#/cephfs/mirroring', id: 'cd-cephfs-mirroring-list' },
+  paths: (fsName: string) => ({
+    url: `#/cephfs/mirroring/${fsName}`,
+    id: 'cd-cephfs-mirroring-paths'
+  })
+};
+
+export class CephfsMirroringPageHelper extends PageHelper {
+  pages = {
+    list: pages.list,
+    index: pages.list
+  };
+
+  navigateToList() {
+    cy.visit(pages.list.url);
+    cy.get(pages.list.id);
+  }
+
+  navigateToPaths(fsName: string) {
+    const page = pages.paths(fsName);
+    cy.visit(page.url);
+    cy.get(page.id);
+  }
+
+  clickLocalFsLink(localFsName: string) {
+    this.searchTable(localFsName);
+    cy.contains('[cdstablerow] [cdstabledata] a', localFsName).click();
+    cy.get(pages.paths(localFsName).id);
+  }
+
+  expectBreadcrumbSegments(segments: string[]) {
+    cy.get('cds-breadcrumb-item').then(($items) => {
+      const texts = $items.toArray().map((el) => el.textContent?.trim() ?? '');
+      segments.forEach((segment, _) => {
+        expect(texts).to.include(segment);
+      });
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -64,6 +64,7 @@ import { SmbUsersgroupsListComponent } from './ceph/smb/smb-usersgroups-list/smb
 import { SmbOverviewComponent } from './ceph/smb/smb-overview/smb-overview.component';
 import { MultiClusterFormComponent } from './ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component';
 import { CephfsMirroringListComponent } from './ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component';
+import { CephfsMirroringPathsComponent } from './ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component';
 import { NotificationsPageComponent } from './core/navigation/notification-panel/notifications-page/notifications-page.component';
 import { CephfsMirroringWizardComponent } from './ceph/cephfs/cephfs-mirroring-wizard/cephfs-mirroring-wizard.component';
 import { CephfsMirroringErrorComponent } from './ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component';
@@ -97,6 +98,21 @@ export class StartCaseBreadcrumbsResolver extends BreadcrumbsResolver {
     const path = route.params.name;
     const text = _.startCase(path);
     return [{ text: `${text}/Edit`, path: path }];
+  }
+}
+
+@Injectable()
+export class CephfsMirroringPathsBreadcrumbsResolver extends BreadcrumbsResolver {
+  resolve(route: ActivatedRouteSnapshot): IBreadcrumb[] {
+    const fsName = route.params['fsName'] || '-';
+    const cephfsPath = this.getFullPath(route.parent);
+    const fsPath = `${cephfsPath}/fs`;
+    const mirroringPath = `${cephfsPath}/mirroring`;
+    return [
+      { text: 'File', path: fsPath },
+      { text: 'Mirroring', path: mirroringPath },
+      { text: fsName, path: null }
+    ];
   }
 }
 
@@ -460,6 +476,11 @@ const routes: Routes = [
             data: { breadcrumbs: ActionLabels.CREATE }
           },
           {
+            path: 'mirroring/:fsName',
+            component: CephfsMirroringPathsComponent,
+            data: { breadcrumbs: CephfsMirroringPathsBreadcrumbsResolver }
+          },
+          {
             path: 'nfs',
             canActivateChild: [FeatureTogglesGuardService, ModuleStatusGuardService],
             data: {
@@ -641,6 +662,10 @@ const routes: Routes = [
     })
   ],
   exports: [RouterModule],
-  providers: [StartCaseBreadcrumbsResolver, PerformanceCounterBreadcrumbsResolver]
+  providers: [
+    StartCaseBreadcrumbsResolver,
+    PerformanceCounterBreadcrumbsResolver,
+    CephfsMirroringPathsBreadcrumbsResolver
+  ]
 })
 export class AppRoutingModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
@@ -14,3 +14,9 @@
     </cd-table-actions>
   </cd-table>
 }
+
+<ng-template #localFsLinkTpl
+             let-row="data.row"
+             let-value="data.value">
+  <a (click)="navigateToPaths(row)">{{ value }}</a>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, ViewChild, OnInit } from '@angular/core';
+import { Component, TemplateRef, ViewChild, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
@@ -24,6 +25,7 @@ export const MIRRORING_PATH = 'cephfs/mirroring';
 })
 export class CephfsMirroringListComponent implements OnInit {
   @ViewChild('table', { static: true }) table: TableComponent;
+  @ViewChild('localFsLinkTpl', { static: true }) localFsLinkTpl: TemplateRef<any>;
 
   columns: CdTableColumn[];
   selection = new CdTableSelection();
@@ -37,7 +39,8 @@ export class CephfsMirroringListComponent implements OnInit {
     public actionLabels: ActionLabelsI18n,
     private authStorageService: AuthStorageService,
     private cephfsService: CephfsService,
-    private urlBuilder: URLBuilderService
+    private urlBuilder: URLBuilderService,
+    private router: Router
   ) {
     this.permission = this.authStorageService.getPermissions().cephfs;
   }
@@ -49,7 +52,12 @@ export class CephfsMirroringListComponent implements OnInit {
         prop: 'remote_cluster_name',
         flexGrow: 2
       },
-      { name: $localize`Local filesystem`, prop: 'local_fs_name', flexGrow: 2 },
+      {
+        name: $localize`Local filesystem`,
+        prop: 'local_fs_name',
+        flexGrow: 2,
+        cellTemplate: this.localFsLinkTpl
+      },
       { name: $localize`Remote filesystem`, prop: 'fs_name', flexGrow: 2 },
       { name: $localize`Remote client`, prop: 'client_name', flexGrow: 2 },
       { name: $localize`Snapshot directories`, prop: 'directory_count', flexGrow: 1 }
@@ -73,7 +81,7 @@ export class CephfsMirroringListComponent implements OnInit {
             daemons.forEach((d) => {
               d.filesystems.forEach((fs) => {
                 if (!fs.peers || fs.peers.length === 0) {
-                  result.push({
+                  const row: MirroringRow = {
                     remote_cluster_name: '-',
                     local_fs_name: fs.name,
                     fs_name: fs.name,
@@ -81,17 +89,19 @@ export class CephfsMirroringListComponent implements OnInit {
                     directory_count: fs.directory_count,
                     peerId: '-',
                     id: `${d.daemon_id}-${fs.filesystem_id}`
-                  });
+                  };
+                  result.push(row);
                 } else {
                   fs.peers.forEach((peer) => {
-                    result.push({
+                    const row: MirroringRow = {
                       remote_cluster_name: peer.remote.cluster_name,
                       local_fs_name: fs.name,
                       fs_name: peer.remote.fs_name,
                       client_name: peer.remote.client_name,
                       directory_count: fs.directory_count,
                       id: `${d.daemon_id}-${fs.filesystem_id}`
-                    });
+                    };
+                    result.push(row);
                   });
                 }
               });
@@ -115,5 +125,15 @@ export class CephfsMirroringListComponent implements OnInit {
 
   updateSelection(selection: CdTableSelection) {
     this.selection = selection;
+  }
+
+  navigateToPaths(row: MirroringRow) {
+    this.router.navigate([MIRRORING_PATH, row.local_fs_name], {
+      state: {
+        localFsName: row.local_fs_name,
+        remoteFsName: row.fs_name,
+        remoteClusterName: row.remote_cluster_name
+      }
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.html
@@ -1,0 +1,48 @@
+<div cdsTheme="g10"
+     [cdsLayer]="0">
+  <div cdsGrid
+       [fullWidth]="true">
+    <div cdsRow
+         class="cds-mb-5">
+      <div cdsCol
+           [columnNumbers]="{lg: 5}">
+        <cds-tile [cdsLayer]="1">
+          <div class="cds--type-heading-compact-02"
+               i18n>Local filesystem</div>
+          <div class="cds--type-body-02">{{ localFsName }}</div>
+        </cds-tile>
+      </div>
+      <div cdsCol
+           [columnNumbers]="{lg: 5}">
+        <cds-tile [cdsLayer]="1">
+          <div class="cds--type-heading-compact-02"
+               i18n>Remote filesystem</div>
+          <div class="cds--type-body-02">{{ remoteFsName }}</div>
+        </cds-tile>
+      </div>
+      <div cdsCol
+           [columnNumbers]="{lg: 6}">
+        <cds-tile [cdsLayer]="1">
+          <div class="cds--type-heading-compact-02"
+               i18n>Remote cluster</div>
+          <div class="cds--type-body-02">{{ remoteClusterName }}</div>
+        </cds-tile>
+      </div>
+    </div>
+
+    <div cdsRow
+         class="cds-mt-5">
+      <div cdsCol
+           [columnNumbers]="{lg: 16}">
+        <cds-tile [cdsLayer]="1">
+          <h3 class="cds--type-expressive-heading-03 cds-mb-3"
+              i18n>Mirroring paths</h3>
+          <cd-table
+            [data]="(mirroringPaths$ | async) || []"
+            [columns]="columns">
+          </cd-table>
+        </cds-tile>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.scss
@@ -1,0 +1,3 @@
+.cds--grid {
+  padding-inline: 0;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { CephfsMirroringPathsComponent } from './cephfs-mirroring-paths.component';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('CephfsMirroringPathsComponent', () => {
+  let component: CephfsMirroringPathsComponent;
+  let fixture: ComponentFixture<CephfsMirroringPathsComponent>;
+  let listSnapshotDirsSpy: jest.SpyInstance;
+
+  const createActivatedRoute = (params: { fsName?: string } = {}) => ({
+    snapshot: { params }
+  });
+
+  const createRouterWithState = (state: Record<string, string> | null) => ({
+    getCurrentNavigation: () => (state ? { extras: { state } } : null)
+  });
+
+  const cephfsServiceMock = {
+    listSnapshotDirs: jest.fn()
+  };
+
+  configureTestBed({
+    declarations: [CephfsMirroringPathsComponent],
+    imports: [RouterTestingModule],
+    providers: [
+      { provide: ActivatedRoute, useValue: createActivatedRoute({ fsName: 'fs1' }) },
+      { provide: Router, useValue: createRouterWithState(null) },
+      { provide: CephfsService, useValue: cephfsServiceMock }
+    ]
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(CephfsMirroringPathsComponent);
+    component = fixture.componentInstance;
+    listSnapshotDirsSpy = cephfsServiceMock.listSnapshotDirs;
+    return fixture;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cephfsServiceMock.listSnapshotDirs.mockReturnValue(of(['/']));
+    createComponent();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should set localFsName from route params on init', () => {
+    fixture.detectChanges();
+    expect(component.localFsName).toBe('fs1');
+  });
+
+  it('should call listSnapshotDirs with localFsName', () => {
+    fixture.detectChanges();
+    expect(listSnapshotDirsSpy).toHaveBeenCalledWith('fs1');
+  });
+
+  it('should map snapshot dirs to table rows and expose via mirroringPaths$', (done) => {
+    listSnapshotDirsSpy.mockReturnValue(of(['/path1', '/path2']));
+    fixture.detectChanges();
+    component.mirroringPaths$.subscribe((rows) => {
+      expect(rows.length).toBe(2);
+      expect(rows[0]).toEqual({
+        path: '/path1',
+        type: '',
+        status: '',
+        snapshot_schedule: '',
+        last_sync: ''
+      });
+      expect(rows[1].path).toBe('/path2');
+      done();
+    });
+  });
+
+  it('should display localFsName, remoteFsName and remoteClusterName in the template', () => {
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('fs1');
+    expect(el.textContent).toContain('-');
+    expect(el.textContent).toContain('Local filesystem');
+    expect(el.textContent).toContain('Remote filesystem');
+    expect(el.textContent).toContain('Remote cluster');
+    expect(el.textContent).toContain('Mirroring paths');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.ts
@@ -1,0 +1,73 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { CdTableColumn } from '~/app/shared/models/cd-table-column';
+
+interface CephfsMirroringPathRow {
+  path: string;
+  type: string;
+  status: string;
+  snapshot_schedule: string;
+  last_sync: string;
+}
+
+@Component({
+  selector: 'cd-cephfs-mirroring-paths',
+  templateUrl: './cephfs-mirroring-paths.component.html',
+  styleUrls: ['./cephfs-mirroring-paths.component.scss'],
+  standalone: false
+})
+export class CephfsMirroringPathsComponent implements OnInit {
+  remoteFsName: string;
+  localFsName: string;
+  remoteClusterName: string;
+
+  columns: CdTableColumn[];
+  mirroringPaths$: Observable<CephfsMirroringPathRow[]>;
+
+  private navigationState: Record<string, string> | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private cephfsService: CephfsService
+  ) {
+    const nav = this.router.getCurrentNavigation();
+    if (nav?.extras?.state) {
+      this.navigationState = nav.extras.state as Record<string, string>;
+    }
+  }
+
+  ngOnInit() {
+    const state = this.navigationState;
+    this.localFsName = this.route.snapshot.params['fsName'] || state?.localFsName || '-';
+    this.remoteFsName = state?.remoteFsName ?? '-';
+    this.remoteClusterName = state?.remoteClusterName ?? '-';
+
+    this.columns = [
+      { name: $localize`Path`, prop: 'path', flexGrow: 2 },
+      { name: $localize`Type`, prop: 'type', flexGrow: 1 },
+      { name: $localize`Status`, prop: 'status', flexGrow: 1 },
+      { name: $localize`Snapshot schedule`, prop: 'snapshot_schedule', flexGrow: 1 },
+      { name: $localize`Last sync`, prop: 'last_sync', flexGrow: 1 }
+    ];
+
+    // TODO: Update data displayed when new interface is implemented.
+    this.mirroringPaths$ = this.cephfsService.listSnapshotDirs(this.localFsName).pipe(
+      map((paths: string[]): CephfsMirroringPathRow[] =>
+        paths.map(
+          (path: string): CephfsMirroringPathRow => ({
+            path,
+            type: '',
+            status: '',
+            snapshot_schedule: '',
+            last_sync: ''
+          })
+        )
+      ),
+      catchError((): Observable<CephfsMirroringPathRow[]> => of([]))
+    );
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -33,6 +33,7 @@ import { CephfsMountDetailsComponent } from './cephfs-mount-details/cephfs-mount
 import { CephfsAuthModalComponent } from './cephfs-auth-modal/cephfs-auth-modal.component';
 import { CephfsMirroringListComponent } from './cephfs-mirroring-list/cephfs-mirroring-list.component';
 import { CephfsMirroringErrorComponent } from './cephfs-mirroring-error/cephfs-mirroring-error.component';
+import { CephfsMirroringPathsComponent } from './cephfs-mirroring-paths/cephfs-mirroring-paths.component';
 import {
   ButtonModule,
   CheckboxModule,
@@ -44,15 +45,17 @@ import {
   IconService,
   InputModule,
   LayoutModule,
+  LayerModule,
   ModalModule,
   NumberModule,
   PlaceholderModule,
+  RadioModule,
   SelectModule,
+  ThemeModule,
   TimePickerModule,
   TilesModule,
   TreeviewModule,
   TabsModule,
-  RadioModule,
   NotificationModule
 } from 'carbon-components-angular';
 
@@ -80,7 +83,10 @@ import { CephfsFilesystemSelectorComponent } from './cephfs-filesystem-selector/
     NgbTypeaheadModule,
     GridModule,
     InputModule,
+    LayerModule,
+    ThemeModule,
     CheckboxModule,
+    RadioModule,
     SelectModule,
     DropdownModule,
     ModalModule,
@@ -120,7 +126,8 @@ import { CephfsFilesystemSelectorComponent } from './cephfs-filesystem-selector/
     CephfsMirroringListComponent,
     CephfsMirroringWizardComponent,
     CephfsFilesystemSelectorComponent,
-    CephfsMirroringErrorComponent
+    CephfsMirroringErrorComponent,
+    CephfsMirroringPathsComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -131,4 +131,8 @@ export class CephfsService {
   listDaemonStatus(): Observable<Daemon[]> {
     return this.http.get<Daemon[]>(`${this.baseURL}/mirror/daemon-status`);
   }
+
+  listSnapshotDirs(fsName: string): Observable<string[]> {
+    return this.http.get<string[]>(`${this.baseURL}/mirror/snapshot/ls/${fsName}`);
+  }
 }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3322,6 +3322,45 @@ paths:
       summary: Get mirror daemon and peers information
       tags:
       - CephfsMirror
+  /api/cephfs/mirror/snapshot/ls/{fs_name}:
+    get:
+      parameters:
+      - description: File system name
+        in: path
+        name: fs_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties: {}
+                  type: object
+                type: array
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                items:
+                  properties: {}
+                  type: object
+                type: array
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: List snapshot mirrored directories
+      tags:
+      - CephfsMirror
   /api/cephfs/mirror/token:
     post:
       parameters: []


### PR DESCRIPTION
Colors/paddings will be properly set once global color schemes is properly changed to cdsTheme g10.

[screen-capture (65).webm](https://github.com/user-attachments/assets/9ed203a8-1bec-4244-ad02-65258314a516)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
