### PR TITLE
mgr: fix assertion failure in get_perf_schema_python for empty perf counters

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1151,6 +1151,12 @@ PyObject* ActivePyModules::get_perf_schema_python(
   if (!daemons.empty()) {
     for (auto &[key, state] : daemons) {
       std::lock_guard l(state->lock);
+      // Skip daemons with no perf counter instances (e.g., destroyed OSDs)
+      // to avoid closing sections that were never opened
+      // Fixes: https://tracker.ceph.com/issues/74693
+      if (state->perf_counters.instances.empty()) {
+        continue;
+      }
       with_gil(no_gil, [&, key = ceph::to_string(key), state = state] {
 	std::string_view key_name, prev_key_name;
 	perf_counter_label_pairs prev_key_labels;


### PR DESCRIPTION
## Problem

When a daemon exists in `daemon_state` but has no perf counter instances (e.g., a destroyed OSD with null FSID `00000000-0000-0000-0000-000000000000`), the `get_perf_schema_python()` function crashes with an assertion failure:

```
/ceph/rpmbuild/BUILD/ceph-20.2.0/src/mgr/PyFormatter.h: 84: FAILED ceph_assert(cursor != root)
```

**Call stack:**
```
ceph::__ceph_assert_fail()
  -> PyFormatter::close_section()
    -> ActivePyModules::get_perf_schema_python()
```

This causes MGR daemons to crash every 60-90 seconds when the telemetry module iterates through all OSDs and encounters a destroyed one.

## Root Cause

In `get_perf_schema_python()`, when iterating through daemons:

1. The function enters the daemon loop since `daemons` is not empty
2. It creates a `Formatter::ObjectSection` for the daemon key (RAII-managed)
3. The inner loop over `state->perf_counters.instances` never executes because the collection is empty
4. Lines 1253-1254 unconditionally call `f.close_section()` twice
5. These calls try to close 'counters' and 'counter object' sections that were never opened
6. This violates the assertion `cursor != root` in `PyFormatter::close_section()`

## Solution

Add an early `continue` to skip daemons with empty `perf_counters.instances` before entering the `with_gil` block. This prevents the crash while still properly handling daemons that do have perf counters.

## Reproduction

1. Have a Ceph cluster with telemetry module enabled
2. Destroy an OSD without purging it:
   ```bash
   ceph osd destroy 123 --yes-i-really-mean-it
   ```
3. Wait 60-90 seconds for telemetry to query perf schema
4. MGR crashes with assertion failure

## Testing

- Verified that destroyed OSDs (with null FSID) are skipped
- Normal OSDs with perf counters continue to work as expected
- No assertion failures after the fix

## Comparison with Similar Code

`get_unlabeled_perf_schema_python()` handles this case correctly because it opens a section *before* the loop and closes it *after* - properly balanced even if the loop is empty. This fix aligns `get_perf_schema_python()` with that pattern by avoiding the problematic code path entirely.

Fixes: https://tracker.ceph.com/issues/74693