### PR TITLE
doc/rgw: Update keystone.rst

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -13,40 +13,33 @@ token that Keystone validates will be considered as valid by the gateway.
 The following configuration options are available for Keystone integration::
 
 	[client.radosgw.gateway]
-	rgw keystone api version = {keystone api version}
-	rgw keystone url = {keystone server url:keystone server admin port}
-	rgw keystone admin token = {keystone admin token}
-	rgw keystone admin token path = {path to keystone admin token} #preferred
-	rgw keystone accepted roles = {accepted user roles}
-	rgw keystone token cache size = {number of tokens to cache}
-	rgw keystone implicit tenants = {true for private tenant for each new user}
+        rgw keystone api version = {keystone api version}
+        rgw keystone url = {keystone server url:keystone server port}
+        rgw keystone accepted roles = {accepted user roles}
+        rgw keystone token cache size = {number of tokens to cache}
+        rgw keystone implicit tenants = {true for private tenant for each new user}
+        rgw keystone admin user = {keystone service user name}
+        rgw keystone admin password = {keystone service user password}
+        rgw keystone admin password path = {keystone service user password path} # preferred
+        rgw keystone admin domain = {keystone service user domain}
+        rgw keystone admin project = {keystone service project name}
 
-It is also possible to configure a Keystone service tenant, user & password for
-Keystone (for v2.0 version of the OpenStack Identity API), similar to the way
-OpenStack services tend to be configured, this avoids the need for setting the
-shared secret ``rgw keystone admin token`` in the configuration file, which is
-recommended to be disabled in production environments. The service tenant
-credentials should have admin privileges, for more details refer the `OpenStack
-Keystone documentation`_, which explains the process in detail. The requisite
-configuration options are::
+You need to configure credentials to use against the Keystone service. You need
+a project (tenant), username, and password credentials must be configured to use
+the Keystone v3 API.
 
-   rgw keystone admin user = {keystone service tenant user name}
-   rgw keystone admin password = {keystone service tenant user password}
-   rgw keystone admin password path = {keystone service tenant user password path} # preferred
-   rgw keystone admin tenant = {keystone service tenant name}
+The service credentials needs to have the ``admin`` and ``service`` roles in Keystone to
+allow ``POST /v3/s3tokens`` and ``GET /v3/users/<user>/OS-EC2/<credential>`` requests. You
+can lock down the service credentials to only need the ``service`` role and avoid granting
+the ``admin`` role in Keystone by changing the changing the ``identity:ec2_get_credential``
+policy.
 
+A Ceph Object Gateway user is mapped to a Keystone ``project``. A Keystone
+user may have multiple roles asssigned, possibly for multiple projects.
 
-A Ceph Object Gateway user is mapped into a Keystone ``tenant``. A Keystone user
-has different roles assigned to it on possibly more than a single tenant. When
-the Ceph Object Gateway gets the ticket, it looks at the tenant, and the user
-roles that are assigned to that ticket, and accepts/rejects the request
-according to the ``rgw keystone accepted roles`` configurable.
-
-For a v3 version of the OpenStack Identity API you should replace
-``rgw keystone admin tenant`` with::
-
-   rgw keystone admin domain = {keystone admin domain name}
-   rgw keystone admin project = {keystone admin project name}
+When the Ceph Object Gateway processes tokens retrieved from Keystone, it looks at the
+project, and the user roles that are assigned to that token, and accepts/rejects the
+request according to the ``rgw keystone accepted roles`` configurable.
 
 For compatibility with previous versions of ceph, it is also
 possible to set ``rgw keystone implicit tenants`` to either
@@ -56,8 +49,8 @@ only use implicit tenants, and the other protocol will
 never use implicit tenants.  Some older versions of ceph
 only supported implicit tenants with swift.
 
-Ocata (and Later)
------------------
+Configuring Keystone service and endpoints
+------------------------------------------
 
 Keystone itself needs to be configured to point to the Ceph Object Gateway as an
 object-storage endpoint:


### PR DESCRIPTION
The patches [1] [2] changed logic in the Keystone
implementation by removing the legacy v2.0 API
support and the legacy admin token support but
didn't update the documentation.

Also add more information about the permissions/access that the service credentials need to the Keystone API.

[1] https://github.com/ceph/ceph/pull/57956
[2] https://github.com/ceph/ceph/pull/62201





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
