### PR TITLE
WIP: Add tracing to pg_scrubber

### DIFF
--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -25,7 +25,7 @@
 
 class MOSDRepScrub final : public MOSDFastDispatchOp {
 public:
-  static constexpr int HEAD_VERSION = 9;
+  static constexpr int HEAD_VERSION = 10;
   static constexpr int COMPAT_VERSION = 6;
 
   spg_t pgid;             // PG to scrub
@@ -108,6 +108,7 @@ public:
     encode(allow_preemption, payload);
     encode(priority, payload);
     encode(high_priority, payload);
+    encode_otel_trace(payload, features);
   }
   void decode_payload() override {
     using ceph::decode;
@@ -136,6 +137,9 @@ public:
     if (header.version >= 9) {
       decode(priority, p);
       decode(high_priority, p);
+    }
+    if (header.version >= 10) {
+      decode_otel_trace(p);
     }
   }
 };

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -29,6 +29,7 @@ set(osd_srcs
   scrubber/scrub_resources.cc
   scrubber/ScrubStore.cc
   scrubber/scrub_backend.cc
+  scrubber/scrubber_tracer.cc
   Watch.cc
   Session.cc
   SnapMapper.cc

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -29,6 +29,8 @@
 #include "scrub_backend.h"
 #include "scrub_machine.h"
 
+#include "scrubber_tracer.h"
+
 using std::list;
 using std::pair;
 using std::stringstream;
@@ -2678,7 +2680,9 @@ PgScrubber::PgScrubber(PG* pg)
 	m_osds->cct->_conf, "osd_stats_update_period_not_scrubbing"}
     , preemption_data{pg}
 {
-  m_fsm = std::make_unique<ScrubMachine>(m_pg, this);
+  tracing::scrubber::tracer.init(m_osds->cct, "pg_scrubber");
+  auto scrubber_parent_span = tracing::scrubber::tracer.add_span("pg-scrubber-initialized");
+  m_fsm = std::make_unique<ScrubMachine>(m_pg, this, scrubber_parent_span);
   m_fsm->initiate();
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());
 }

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2681,7 +2681,7 @@ PgScrubber::PgScrubber(PG* pg)
     , preemption_data{pg}
 {
   tracing::scrubber::tracer.init(m_osds->cct, "pg_scrubber");
-  auto scrubber_parent_span = tracing::scrubber::tracer.add_span("pg-scrubber-initialized");
+  auto scrubber_parent_span = tracing::scrubber::tracer.start_trace("pg-scrubber-initialized");
   m_fsm = std::make_unique<ScrubMachine>(m_pg, this, scrubber_parent_span);
   m_fsm->initiate();
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1663,7 +1663,8 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos = ScrubMapBuilder{};
 
-  m_fsm->m_replica_parent_ctx = msg->otel_trace;
+  // m_fsm->m_replica_parent_ctx = msg->otel_trace;
+  m_fsm->set_replica_parent_ctx(msg->otel_trace);
   m_replica_min_epoch = msg->min_epoch;
   m_start = msg->start;
   m_end = msg->end;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1176,7 +1176,8 @@ eversion_t PgScrubber::search_log_for_updates() const
     return p->version;
 }
 
-void PgScrubber::get_replicas_maps(bool replica_can_preempt)
+void PgScrubber::get_replicas_maps(bool replica_can_preempt,
+				   const jspan_context& parent_ctx)
 {
   dout(10) << __func__ << " started in epoch/interval: " << m_epoch_start << "/"
 	   << m_interval_start << " pg same_interval_since: "
@@ -1196,7 +1197,8 @@ void PgScrubber::get_replicas_maps(bool replica_can_preempt)
 		       m_start,
 		       m_end,
 		       m_is_deep,
-		       replica_can_preempt);
+		       replica_can_preempt,
+		       parent_ctx);
   }
 
   dout(10) << __func__ << " awaiting" << m_maps_status << dendl;
@@ -1248,7 +1250,8 @@ void PgScrubber::_request_scrub_map(pg_shard_t replica,
 				    hobject_t start,
 				    hobject_t end,
 				    bool deep,
-				    bool allow_preemption)
+				    bool allow_preemption,
+				    const jspan_context& parent_ctx)
 {
   ceph_assert(replica != m_pg_whoami);
   dout(10) << __func__ << " scrubmap from osd." << replica
@@ -1264,6 +1267,7 @@ void PgScrubber::_request_scrub_map(pg_shard_t replica,
 				     allow_preemption,
 				     m_flags.priority,
 				     m_pg->ops_blocked_by_scrub());
+  repscrubop->otel_trace = parent_ctx;
 
   // default priority. We want the replica-scrub processed prior to any recovery
   // or client io messages (we are holding a lock!)
@@ -1659,6 +1663,7 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos = ScrubMapBuilder{};
 
+  m_fsm->m_replica_parent_ctx = msg->otel_trace;
   m_replica_min_epoch = msg->min_epoch;
   m_start = msg->start;
   m_end = msg->end;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -511,7 +511,8 @@ class PgScrubber : public ScrubPgIF,
   std::chrono::milliseconds get_scrub_sleep_time() const final;
   void queue_for_scrub_resched(Scrub::scrub_prio_t prio) final;
 
-  void get_replicas_maps(bool replica_can_preempt) final;
+  void get_replicas_maps(bool replica_can_preempt,
+			 const jspan_context& parent_ctx) final;
 
   void on_digest_updates() final;
 
@@ -952,7 +953,8 @@ class PgScrubber : public ScrubPgIF,
 			  hobject_t start,
 			  hobject_t end,
 			  bool deep,
-			  bool allow_preemption);
+			  bool allow_preemption,
+			  const jspan_context& parent_ctx);
 
 
   Scrub::MapsCollectionStatus m_maps_status;

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -751,7 +751,7 @@ sc::result WaitDigestUpdate::react(const ScrubFinished&)
 ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr parent_span)
     : m_pg_id{pg->pg_id}
     , m_scrbr{pg_scrub}
-    , m_tracer{tracer}
+    , m_tracer{parent_span}
 {}
 
 ScrubMachine::~ScrubMachine() = default;

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -625,7 +625,9 @@ sc::result WaitLastUpdate::react(const InternalAllUpdates&)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "WaitLastUpdate::react(const InternalAllUpdates&)" << dendl;
 
-  scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable());
+  auto& tracer = context<ScrubMachine>().m_tracer;
+  auto ctx = tracer ? tracer->GetContext() : jspan_context{false, false};
+  scrbr->get_replicas_maps(scrbr->get_preemptor().is_preemptable(), ctx);
   return transit<BuildMap>();
 }
 
@@ -1074,15 +1076,15 @@ ReplicaActiveOp::ReplicaActiveOp(my_context ctx)
   dout(10) << "-- state -->> ReplicaActive/ReplicaActiveOp" << dendl;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   auto span_label = fmt::format("{}_replica_ReplicaActive/ReplicaActiveOp", pg_id.pgid);
-  if (context<ScrubMachine>().m_tracer && context<ScrubMachine>().m_tracer->IsRecording()){
-    auto text = "REPLICA TRACE SPAN " + span_label + " active";
-    dout(10) << text<< dendl;
+  // Use the trace context propagated from the primary via MOSDRepScrub so that
+  // replica spans are linked under the same trace as the primary.
+  auto& primary_ctx = context<ScrubMachine>().m_replica_parent_ctx;
+  auto span = tracing::scrubber::tracer.add_span(span_label, primary_ctx);
+  if (span && span->IsRecording()) {
+    dout(10) << "REPLICA TRACE SPAN " << span_label << " active" << dendl;
   } else {
-    auto text = "REPLICA TRACE SPAN " + span_label + " inactive";
-    dout(10) << text<< dendl;
+    dout(10) << "REPLICA TRACE SPAN " << span_label << " inactive (no primary context)" << dendl;
   }
-  
-  auto span = tracing::scrubber::tracer.add_span(span_label, context<ScrubMachine>().m_tracer);
   context<ScrubMachine>().m_parent_trace = context<ScrubMachine>().m_tracer;
   std::swap(span, context<ScrubMachine>().m_tracer);
   scrbr->on_replica_init();

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -300,6 +300,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
   spg_t m_pg_id;
   ScrubMachineListener* m_scrbr;
   jspan_ptr m_tracer;
+  jspan_ptr m_parent_trace;
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -29,6 +29,9 @@
 #include "scrub_machine_lstnr.h"
 #include "scrub_reservations.h"
 
+#include "common/tracer.h"
+
+
 /// a wrapper that sets the FSM state description used by the
 /// PgScrubber
 /// \todo consider using the full NamedState as in Peering
@@ -291,11 +294,12 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
  public:
   friend class PgScrubber;
 
-  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub);
+  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspn_ptr tracer);
   virtual ~ScrubMachine();
 
   spg_t m_pg_id;
   ScrubMachineListener* m_scrbr;
+  jspan_ptr m_tracer;
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -294,7 +294,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
  public:
   friend class PgScrubber;
 
-  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspn_ptr tracer);
+  explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub, jspan_ptr tracer);
   virtual ~ScrubMachine();
 
   spg_t m_pg_id;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -321,6 +321,10 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
     sc::state_machine<ScrubMachine, NotActive>::process_event(evt);
   }
 
+  void set_replica_parent_ctx(const jspan_context& ctx){
+    m_replica_parent_ctx = ctx;
+  }
+
   /// the time when the session was initiated
   std::optional<ScrubTimePoint> m_session_started_at;
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -301,6 +301,7 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
   ScrubMachineListener* m_scrbr;
   jspan_ptr m_tracer;
   jspan_ptr m_parent_trace;
+  jspan_context m_replica_parent_ctx{false, false};  ///< trace context received from primary via MOSDRepScrub
   std::ostream& gen_prefix(std::ostream& out) const;
 
   void assert_not_in_session() const final;

--- a/src/osd/scrubber/scrub_machine_if.h
+++ b/src/osd/scrubber/scrub_machine_if.h
@@ -11,6 +11,7 @@
 #include <boost/statechart/state.hpp>
 #include <boost/statechart/state_machine.hpp>
 
+#include "common/tracer.h"
 #include "osd/scrubber_common.h"
 
 namespace Scrub {
@@ -53,6 +54,8 @@ class ScrubFsmIf {
 
   /// "initiate" the state machine (an internal state_chart function)
   virtual void initiate() = 0;
+
+  virtual void set_replica_parent_ctx(const jspan_context& ctx) = 0;
 };
 
 }  // namespace Scrub

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -6,6 +6,7 @@
  * \file the PgScrubber interface used by the scrub FSM
  */
 #include "common/LogClient.h"
+#include "common/tracer.h"
 #include "common/version.h"
 #include "include/Context.h"
 #include "osd/osd_types.h"
@@ -162,7 +163,8 @@ struct ScrubMachineListener {
   /**
    * Ask all replicas for their scrub maps for the current chunk.
    */
-  virtual void get_replicas_maps(bool replica_can_preempt) = 0;
+  virtual void get_replicas_maps(bool replica_can_preempt,
+				 const jspan_context& parent_ctx) = 0;
 
   virtual void on_digest_updates() = 0;
 

--- a/src/osd/scrubber/scrubber_tracer.cc
+++ b/src/osd/scrubber/scrubber_tracer.cc
@@ -1,0 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "common/tracer.h"
+
+namespace tracing {
+namespace scrubber {
+
+tracing::Tracer tracer;
+
+} // namespace scrubber
+} // namespace tracing

--- a/src/osd/scrubber/scrubber_tracer.h
+++ b/src/osd/scrubber/scrubber_tracer.h
@@ -1,0 +1,14 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include "common/tracer.h"
+
+namespace tracing {
+namespace scrubber {
+
+extern tracing::Tracer tracer;
+
+} // namespace scrubber
+} // namespace tracing


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
