### PR TITLE
mgr/nfs: lock rados obj when writing nfs-config and exports

### DIFF
--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -18,7 +18,8 @@ from .utils import (
     available_clusters,
     conf_obj_name,
     restart_nfs_service,
-    user_conf_obj_name)
+    user_conf_obj_name,
+)
 from .export import NFSRados
 
 if TYPE_CHECKING:
@@ -148,7 +149,10 @@ class NFSCluster:
 
     def create_empty_rados_obj(self, cluster_id: str) -> None:
         common_conf = conf_obj_name(cluster_id)
-        self._rados(cluster_id).write_obj('', conf_obj_name(cluster_id))
+        self._rados(cluster_id).write_obj(
+            '',
+            conf_obj_name(cluster_id),
+        )
         log.info("Created empty object:%s", common_conf)
 
     def delete_config_obj(self, cluster_id: str) -> None:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -1,7 +1,10 @@
+import contextlib
 import errno
 import hashlib
 import json
 import logging
+import time
+import uuid
 from typing import (
     List,
     Any,
@@ -11,13 +14,15 @@ from typing import (
     TypeVar,
     Callable,
     Set,
-    cast)
+    cast,
+    Iterator,
+)
 from os.path import normpath
 from ceph.fs.earmarking import EarmarkTopScope
 import cephfs
 
 from mgr_util import CephFSEarmarkResolver
-from rados import TimedOut, ObjectNotFound, Rados
+from rados import TimedOut, ObjectNotFound, Rados, Ioctx
 
 from object_format import ErrorResponse
 from mgr_module import NFS_POOL_NAME as POOL_NAME, NFS_GANESHA_SUPPORTED_FSALS
@@ -38,7 +43,11 @@ from .utils import (
     conf_obj_name,
     available_clusters,
     check_fs,
-    restart_nfs_service, cephfs_path_is_dir)
+    restart_nfs_service,
+    cephfs_path_is_dir,
+    NFSRadosObjectType,
+    CONF_PREFIX,
+)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -100,21 +109,55 @@ class NFSRados:
     def _create_url_block(self, obj_name: str) -> RawBlock:
         return RawBlock('%url', values={'value': self._make_rados_url(obj_name)})
 
-    def write_obj(self, conf_block: str, obj: str, config_obj: str = '') -> None:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            ioctx.write_full(obj, conf_block.encode('utf-8'))
-            if not config_obj:
-                # Return after creating empty common config object
-                return
-            log.debug("write configuration into rados object %s/%s/%s",
-                      self.pool, self.namespace, obj)
+    @contextlib.contextmanager
+    def _get_locked_obj(self, obj_name: str, obj_type: NFSRadosObjectType) -> Iterator[Ioctx]:
 
-            # Add created obj url to common config obj
+        def _acquire_lock(max_retry_attempts: int, ioctx: Ioctx, name: str, type: NFSRadosObjectType) -> str:
+            cookie = f'mgr:nfs:{uuid.uuid4()}'
+            for i in range(max_retry_attempts):
+                try:
+                    ioctx.lock_exclusive(
+                        name, type.value, cookie
+                    )
+                    break
+                except self.rados.ObjectBusy as err:
+                    log.debug("object busy: %r, %r, %r", name, self.namespace, cookie)
+                    time.sleep(2)
+                    if i == (max_retry_attempts - 1):
+                        raise err
+            return cookie
+
+        with self.rados.open_ioctx(self.pool) as ioctx_obj:
+            ioctx_obj.set_namespace(self.namespace)
+            cookie_str = _acquire_lock(3, ioctx_obj, obj_name, obj_type)
+            try:
+                yield ioctx_obj
+            finally:
+                ioctx_obj.unlock(obj_name, obj_type.value, cookie_str)
+
+    def write_obj(self, conf_block: str, obj: str, config_obj: str = '') -> None:
+        if obj.startswith(EXPORT_PREFIX):
+            obj_type = NFSRadosObjectType.export
+        elif obj.startswith(CONF_PREFIX) or obj.startswith(USER_CONF_PREFIX):
+            obj_type = NFSRadosObjectType.nfs_config
+        else:
+            obj_type = NFSRadosObjectType.common_config
+
+        with self._get_locked_obj(obj, obj_type) as ioctx:
+            ioctx.write_full(obj, conf_block.encode('utf-8'))
+
+        if not config_obj:
+            # Return after creating empty common config object
+            return
+        log.debug("write configuration into rados object %s/%s/%s",
+                  self.pool, self.namespace, obj)
+
+        # Add created obj url to common config obj
+        with self._get_locked_obj(obj, NFSRadosObjectType.common_config) as ioctx:
             ioctx.append(config_obj, format_block(
                          self._create_url_block(obj)).encode('utf-8'))
             _check_rados_notify(ioctx, config_obj)
-            log.debug("Added %s url to %s", obj, config_obj)
+        log.debug("Added %s url to %s", obj, config_obj)
 
     def read_obj(self, obj: str) -> Optional[str]:
         with self.rados.open_ioctx(self.pool) as ioctx:
@@ -126,25 +169,24 @@ class NFSRados:
 
     def update_obj(self, conf_block: str, obj: str, config_obj: str,
                    should_notify: Optional[bool] = True) -> None:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
+        with self._get_locked_obj(obj, NFSRadosObjectType.export) as ioctx:
             ioctx.write_full(obj, conf_block.encode('utf-8'))
-            log.debug("write configuration into rados object %s/%s/%s",
-                      self.pool, self.namespace, obj)
-            if should_notify:
-                _check_rados_notify(ioctx, config_obj)
-            log.debug("Update export %s in %s", obj, config_obj)
+        log.debug("write configuration into rados object %s/%s/%s",
+                  self.pool, self.namespace, obj)
+        if should_notify:
+            _check_rados_notify(ioctx, config_obj)
+        log.debug("Update export %s in %s", obj, config_obj)
 
     def remove_obj(self, obj: str, config_obj: str) -> None:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
+        with self._get_locked_obj(obj, NFSRadosObjectType.export) as ioctx:
             export_urls = ioctx.read(config_obj)
             url = '%url "{}"\n\n'.format(self._make_rados_url(obj))
             export_urls = export_urls.replace(url.encode('utf-8'), b'')
             ioctx.remove_object(obj)
+        with self._get_locked_obj(obj, NFSRadosObjectType.nfs_config) as ioctx:
             ioctx.write_full(config_obj, export_urls)
-            _check_rados_notify(ioctx, config_obj)
-            log.debug("Object deleted: %s", url)
+        _check_rados_notify(ioctx, config_obj)
+        log.debug("Object deleted: %s", url)
 
     def remove_all_obj(self) -> None:
         with self.rados.open_ioctx(self.pool) as ioctx:

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -1,3 +1,4 @@
+import enum
 import functools
 import logging
 import stat
@@ -128,3 +129,10 @@ def cephfs_path_is_dir(mgr: 'Module', fs: str, path: str) -> None:
                               cephfs.AT_SYMLINK_NOFOLLOW)
         if not stat.S_ISDIR(stx.get('mode')):
             raise NotADirectoryError()
+
+
+class NFSRadosObjectType(enum.Enum):
+    # class for the type of things the nfs module writes to rados
+    export = 'export'
+    nfs_config = 'nfs_config'  # primarily for pointing to ganesha towards its exports
+    common_config = 'common_config'


### PR DESCRIPTION
It's possible with a lot of nfs export create commands to cause an issue where multiple writes to the same rados obj overwrite each other causing a malformed config. For example

'''
%url "rados://.nfs/df0564dd126042ebb03e0224728ce939/qosconf-nfs.df0564dd126042ebb03e0224728ce939"

%url "rados://.nfs/df0564dd126042ebb03e0224728ce939/export-1"

%url "rados://.nfs/df0564dd126042ebb03e0224728ce939/export-2"

%url "rados://.nfs/df0564dd126042ebb03e0224728ce939/export-3" ...
%url "rados://.nfs/df0564dd126042ebb03e0224728ce939/export-126"

%url "rados%url "rados://.nfs/df0564dd126042ebb03e0224728ce939/export-202"

%url "rados://.nfs/df0564dd126042ebb03e0224728ce939/export-203" '''

where the "%url "rados%url "rados:" bit will cause failures in ganesha





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
