### PR TITLE
tentacle: qa/suite/rados/encoder: update release N-2 for ceph-dencoder tests

### DIFF
--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -113,6 +113,7 @@ QA suite
 - [x] update qa/ upgrade suites require-osd-release calls to tentacle
 - [x] create qa/releases/X.yaml
 - [x] create qa/suites/rados/thrash-old-clients/1-install/(X-1).yaml
+- [x] update qa/suites/rados/encoder/1-task.yaml to remove (X-3) and add X
 
 
 ceph-build

--- a/qa/suites/rados/encoder/1-tasks.yaml
+++ b/qa/suites/rados/encoder/1-tasks.yaml
@@ -1,49 +1,20 @@
 tasks:
-- print: "**** install version -2 (quincy) ****"
-- install:
-    branch: quincy
-    exclude_packages:
-      - ceph-volume
-- print: "**** done install task..."
-
-- print: "**** start installing quincy cephadm ..."
-- cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:quincy
-    compiled_cephadm_branch: quincy
-    conf:
-      osd:
-        #set config option for which cls modules are allowed to be loaded / used
-        osd_class_load_list: "*"
-        osd_class_default_list: "*"
-- print: "**** done end installing quincy cephadm ..."
-
-- print: "**** done start cephadm.shell ceph config set mgr..."
-- cephadm.shell:
-    mon.a:
-      - ceph config set mgr mgr/cephadm/use_repo_digest true --force
-- print: "**** done cephadm.shell ceph config set mgr..."
-
-- print: "**** start dencoder quincy... ****"
-- workunit:
-    clients:
-      client.0:
-        - dencoder/test-dencoder.sh
-- print: "**** done end dencoder quincy... ****"
-
-- print: "**** installing N-1 version (reef) ****"
+- print: "**** install version -2 (reef) ****"
 - install:
     branch: reef
     exclude_packages:
       - ceph-volume
-- print: "**** done end installing task..."
-
+      - ceph-osd-classic
+      - ceph-osd-crimson
+- print: "**** done install task..."
 - print: "**** start dencoder reef... ****"
 - workunit:
     clients:
       client.0:
         - dencoder/test-dencoder.sh
 - print: "**** done end dencoder reef... ****"
-- print: "**** installing N version (squid) ****"
+
+- print: "**** installing N-1 version (squid) ****"
 - install:
     branch: squid
     exclude_packages:
@@ -51,9 +22,24 @@ tasks:
       - ceph-osd-classic
       - ceph-osd-crimson
 - print: "**** done end installing task..."
+
 - print: "**** start dencoder squid... ****"
 - workunit:
     clients:
       client.0:
         - dencoder/test-dencoder.sh
 - print: "**** done end dencoder squid... ****"
+
+- print: "**** installing N version (Tentacle) ****"
+- install:
+    branch: tentacle
+    exclude_packages:
+      - ceph-volume
+      - ceph-osd-classic
+- print: "**** done end installing task..."
+- print: "**** start dencoder tentacle... ****"
+- workunit:
+    clients:
+      client.0:
+        - dencoder/test-dencoder.sh
+- print: "**** done end dencoder tentacle... ****"

--- a/qa/suites/rados/encoder/1-tasks.yaml
+++ b/qa/suites/rados/encoder/1-tasks.yaml
@@ -48,6 +48,8 @@ tasks:
     branch: squid
     exclude_packages:
       - ceph-volume
+      - ceph-osd-classic
+      - ceph-osd-crimson
 - print: "**** done end installing task..."
 - print: "**** start dencoder squid... ****"
 - workunit:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74722

---

backport of https://github.com/ceph/ceph/pull/66337
parent tracker: https://tracker.ceph.com/issues/73921

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh