### PR TITLE
[WIP] [DO NOT REVIEW] mgr/cephadm: Add customer intermediate CA support for cephadm-signed

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -443,6 +443,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='This flag controls whether cephadm automatically rotates certificates upon expiration.',
         ),
         Option(
+            'certificate_use_customer_ca_for_cephadm_signed',
+            type='bool',
+            default=False,
+            desc='When enabled, cephadm uses the stored customer-provided signing CA (customer_signing_ca_cert/key) to issue cephadm-signed certificates instead of the cephadm root CA.',
+        ),
+        Option(
             'certificate_check_period',
             type='int',
             default=1,  # Default to checking certificates once per day
@@ -611,6 +617,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.certificate_automated_rotation_enabled = False
             self.certificate_check_debug_mode = False
             self.certificate_check_period = 0
+            self.certificate_use_customer_ca_for_cephadm_signed = False
 
         self.notify(NotifyType.mon_map, None)
         self.config_notify()
@@ -3393,6 +3400,31 @@ Then run the following:
     def cert_store_reload(self) -> str:
         self.cert_mgr.load()
         return "OK"
+
+    @orchestrator._cli_write_command('orch certmgr reissue')
+    def _certmgr_reissue(
+            self,
+            by_service: Optional[str] = None,
+    ) -> HandleCommandResult:
+        """
+        Reissue cephadm-signed certificate/key pairs for a service
+        """
+        if not by_service:
+            raise OrchestratorError('Missing required argument: --by-service <svc-name>')
+        removed = self.cert_mgr.reissue_by_service(by_service)
+        if not removed.get('certs_removed') and not removed.get('keys_removed'):
+            return HandleCommandResult(stdout=f'No cephadm-signed certificates found for service "{by_service}"')
+        actions = self.perform_service_action('reconfig', by_service)
+        hosts = removed.get('hosts', [])
+        hosts_str = ','.join(hosts) if hosts else ''
+        msg = (
+            f"Reissued cephadm-signed cert/key pairs for service '{by_service}': "
+            f"removed {removed.get('certs_removed', 0)} cert(s) and {removed.get('keys_removed', 0)} key(s)"
+        )
+        if hosts_str:
+            msg += f" on hosts: {hosts_str}"
+        msg += f". Scheduled reconfig for {len(actions)} daemon(s)."
+        return HandleCommandResult(stdout=msg)
 
     @handle_orch_error
     def cert_store_cert_check(self) -> List[str]:


### PR DESCRIPTION
This PR allows operators to configure a customer-provided intermediate CA (cert+key) to sign cephadm-signed certificates, behind an explicit enablement flag, and adds a convenience command to reissue certs by service.

- Add new GLOBAL TLS objects:
  - `customer_signing_ca_cert`
  - `customer_signing_ca_key`

- New config option:
  - `certificate_use_customer_ca_for_cephadm_signed` (default: `false`)
  - When enabled, cephadm uses the customer CA to issue cephadm-signed leaf certs instead of the cephadm root CA.

- Safe renewal across issuer switch:
  - If a cert’s issuer doesn’t match the active signer, cert+key are
  - removed to force regeneration under the new CA.

- New operator command:
  - `ceph orch certmgr reissue --by-service <svc-name>`
  - Purges matching cephadm-signed cert/key objects and triggers
  - service redeploy to regenerate/install new certs.

- Prevent private key leakage:
  - `key_ls` redacts `customer_signing_ca_key` (same as `cephadm_root_ca_key`).

- Backwards compatible: default behavior remains unchanged unless the new flag is enabled.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
