### PR TITLE
cephadm: allow lo routes on loopback interface, allow bgp-routes for list-networks

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5019,6 +5019,18 @@ def _get_parser():
 
     parser_list_networks = subparsers.add_parser(
         'list-networks', help='list IP networks')
+    parser_list_networks.add_argument(
+        '--allow-lo-routes',
+        action='store_true',
+        default=False,
+        help='Reserved for future filtering of loopback-related routes',
+    )
+    parser_list_networks.add_argument(
+        '--allow-bgp-routes',
+        action='store_true',
+        default=False,
+        help='Reserved for future filtering of BGP-derived routes',
+    )
     parser_list_networks.set_defaults(func=command_list_networks)
 
     parser_list_rdma = subparsers.add_parser(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5023,13 +5023,13 @@ def _get_parser():
         '--allow-lo-routes',
         action='store_true',
         default=False,
-        help='Reserved for future filtering of loopback-related routes',
+        help='Include loopback (lo) routes in the listing (default: omit)',
     )
     parser_list_networks.add_argument(
         '--allow-bgp-routes',
         action='store_true',
         default=False,
-        help='Reserved for future filtering of BGP-derived routes',
+        help='Merge BGP routes from ip -j route ls proto bgp (default: omit)',
     )
     parser_list_networks.set_defaults(func=command_list_networks)
 

--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -849,14 +849,18 @@ class HostFacts:
 def list_networks(ctx):
     # type: (CephadmContext) -> Dict[str,Dict[str, Set[str]]]
 
-    # sadly, 18.04's iproute2 4.15.0-2ubun doesn't support the -j flag,
-    # so we'll need to use a regex to parse 'ip' command output.
-    #
-    # out, _, _ = call_throws(['ip', '-j', 'route', 'ls'])
-    # j = json.loads(out)
-    # for x in j:
-    res = _list_ipv4_networks(ctx)
-    res.update(_list_ipv6_networks(ctx))
+    # Main route tables use text ``ip route ls`` (regex parsers). BGP supplements
+    # use ``ip -j route ls proto bgp`` on supported platforms (iproute2 >= 4.18).
+    allow_lo = getattr(ctx, 'allow_lo_routes', False)
+    allow_bgp = getattr(ctx, 'allow_bgp_routes', False)
+    res = _list_ipv4_networks(
+        ctx, allow_lo_routes=allow_lo, allow_bgp_routes=allow_bgp
+    )
+    res.update(
+        _list_ipv6_networks(
+            ctx, allow_lo_routes=allow_lo, allow_bgp_routes=allow_bgp
+        )
+    )
     return res
 
 
@@ -905,21 +909,50 @@ def list_rdma(ctx: CephadmContext) -> List[Dict[str, str]]:
     return result
 
 
-def _list_ipv4_networks(
-    ctx: CephadmContext,
-) -> Dict[str, Dict[str, Set[str]]]:
-    execstr: Optional[str] = find_executable('ip')
-    if not execstr:
-        raise FileNotFoundError("unable to find 'ip' command")
-    out, _, _ = call_throws(
-        ctx,
-        [execstr, 'route', 'ls'],
-        verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+_IPV4_LOOPBACK_SPACE = ipaddress.ip_network('127.0.0.0/8')
+_IPV6_LOOPBACK_HOST = ipaddress.ip_network('::1/128')
+
+
+def _is_ipv4_loopback(net_s: str) -> bool:
+    """True if *net_s* is an IPv4 prefix wholly within host loopback 127.0.0.0/8."""
+    try:
+        n = ipaddress.ip_network(net_s, strict=False)
+    except ValueError:
+        return False
+    return (
+        n.version == 4
+        and n.network_address in _IPV4_LOOPBACK_SPACE
+        and n.broadcast_address in _IPV4_LOOPBACK_SPACE
     )
-    return _parse_ipv4_route(out)
 
 
-def _parse_ipv4_route(out: str) -> Dict[str, Dict[str, Set[str]]]:
+def _is_ipv6_loopback(net_s: str) -> bool:
+    """True if *net_s* is exactly the host loopback prefix ::1/128."""
+    try:
+        n = ipaddress.ip_network(net_s, strict=False)
+    except ValueError:
+        return False
+    if n.version != 6:
+        return False
+    return n == _IPV6_LOOPBACK_HOST
+
+
+def _merge_ipv4_network_dicts(
+    dst: Dict[str, Dict[str, Set[str]]], add: Dict[str, Dict[str, Set[str]]]
+) -> None:
+    """Merge *add* into *dst* (nested sets)."""
+    for net, ifaces in add.items():
+        if net not in dst:
+            dst[net] = {}
+        for iface, ips in ifaces.items():
+            if iface not in dst[net]:
+                dst[net][iface] = set()
+            dst[net][iface].update(ips)
+
+
+def _parse_ipv4_route(
+    out: str, allow_lo_routes: bool = False
+) -> Dict[str, Dict[str, Set[str]]]:
     r = {}  # type: Dict[str, Dict[str, Set[str]]]
     p = re.compile(
         r'^(\S+) (?:via \S+)? ?dev (\S+) (.*)scope link (.*)src (\S+)'
@@ -931,8 +964,13 @@ def _parse_ipv4_route(out: str) -> Dict[str, Dict[str, Set[str]]]:
         net = m[0][0]
         if '/' not in net:  # aggregate /32 mask for single host sub-networks
             net += '/32'
-        iface = m[0][1]
+        # Strip iproute2 ``@`` suffix (e.g. ``brx.0@eno1`` → ``brx.0``).
+        iface = m[0][1].split('@')[0]
+        if iface == 'lo' and not allow_lo_routes:
+            continue
         ip = m[0][4]
+        if _is_ipv4_loopback(net):
+            continue
         if net not in r:
             r[net] = {}
         if iface not in r[net]:
@@ -941,9 +979,199 @@ def _parse_ipv4_route(out: str) -> Dict[str, Dict[str, Set[str]]]:
     return r
 
 
+def _parse_ipv4_lo_route(out: str) -> Dict[str, Dict[str, Set[str]]]:
+    """``lo`` /32 without ``src``, and ``scope host`` + ``src`` (e.g. dummy /32)."""
+    r = {}  # type: Dict[str, Dict[str, Set[str]]]
+    p_lo_no_src = re.compile(
+        r'^(\S+) (?:via \S+)? ?dev (lo(?:@\S+)?) (.*)scope (?:link|host)\s*(?!src\b).*$'
+    )
+    p_host_src = re.compile(
+        r'^(\S+) (?:via \S+)? ?dev (\S+) (.*)scope host (.*)src (\S+)'
+    )
+
+    def put(net: str, iface: str, ip: str) -> None:
+        if _is_ipv4_loopback(net):
+            return
+        if net not in r:
+            r[net] = {}
+        if iface not in r[net]:
+            r[net][iface] = set()
+        r[net][iface].add(ip)
+
+    for line in out.splitlines():
+        m = p_lo_no_src.findall(line)
+        if not m:
+            continue
+        net = m[0][0]
+        if '/' not in net:
+            net += '/32'
+        iface = m[0][1].split('@')[0]
+        try:
+            n = ipaddress.ip_network(net, strict=False)
+        except ValueError:
+            continue
+        if n.prefixlen != 32:
+            continue
+        put(net, iface, str(n.network_address))
+
+    for line in out.splitlines():
+        m = p_host_src.findall(line)
+        if not m:
+            continue
+        net = m[0][0]
+        if '/' not in net:
+            net += '/32'
+        iface = m[0][1].split('@')[0]
+        ip = m[0][4]
+        put(net, iface, ip)
+
+    return r
+
+
+def _route_iface_name(dev: str) -> str:
+    """Strip iproute2 ``child@parent`` interface suffix."""
+    return dev.split('@')[0]
+
+
+def _route_dst_to_network(dst: str, version: int) -> str:
+    if '/' in dst:
+        return dst
+    return f'{dst}/{"32" if version == 4 else "128"}'
+
+
+def _parse_bgp_routes_json(
+    out: str,
+    version: int,
+    allow_lo_routes: bool = False,
+) -> Dict[str, Dict[str, Set[str]]]:
+    """Parse JSON from ``ip -j route ls proto bgp`` (or ``ip -6 -j route ls proto bgp``)."""
+    r: Dict[str, Dict[str, Set[str]]] = {}
+    try:
+        routes = json.loads(out)
+    except (json.JSONDecodeError, TypeError):
+        logger.debug('failed to parse ip -j route output as JSON')
+        return r
+    if not isinstance(routes, list):
+        return r
+
+    is_v4 = version == 4
+    host_plen = 32 if is_v4 else 128
+
+    def put(net: str, iface: str, ip: str) -> None:
+        if _is_ipv4_loopback(net) if is_v4 else _is_ipv6_loopback(net):
+            return
+        if net not in r:
+            r[net] = {}
+        if iface not in r[net]:
+            r[net][iface] = set()
+        r[net][iface].add(ip)
+
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        dst = route.get('dst')
+        if not dst:
+            continue
+
+        net = _route_dst_to_network(dst, version)
+        nexthops = route.get('nexthops')
+        prefsrc = route.get('prefsrc')
+
+        if nexthops and prefsrc:
+            for nh in nexthops:
+                if not isinstance(nh, dict):
+                    continue
+                dev = nh.get('dev')
+                if not dev:
+                    continue
+                iface = _route_iface_name(dev)
+                if iface == 'lo' and not allow_lo_routes:
+                    continue
+                put(net, iface, prefsrc)
+            continue
+
+        dev = route.get('dev', '')
+        iface = _route_iface_name(dev) if dev else ''
+
+        if iface == 'lo' and not prefsrc:
+            if not allow_lo_routes:
+                continue
+            try:
+                n = ipaddress.ip_network(net, strict=False)
+            except ValueError:
+                continue
+            if n.prefixlen != host_plen:
+                continue
+            put(net, 'lo', str(n.network_address))
+            continue
+
+        if prefsrc and iface:
+            if iface == 'lo' and not allow_lo_routes:
+                continue
+            put(net, iface, prefsrc)
+
+    return r
+
+
+def _parse_ipv4_bgp_route(
+    out: str, allow_lo_routes: bool = False
+) -> Dict[str, Dict[str, Set[str]]]:
+    """Parse JSON from ``ip -j route ls proto bgp``."""
+    return _parse_bgp_routes_json(out, 4, allow_lo_routes)
+
+
+def _parse_ipv6_bgp_route(
+    out: str, allow_lo_routes: bool = False
+) -> Dict[str, Dict[str, Set[str]]]:
+    """Parse JSON from ``ip -6 -j route ls proto bgp``."""
+    return _parse_bgp_routes_json(out, 6, allow_lo_routes)
+
+
+def _list_ipv4_networks(
+    ctx: CephadmContext,
+    allow_lo_routes: bool = False,
+    allow_bgp_routes: bool = False,
+) -> Dict[str, Dict[str, Set[str]]]:
+    """IPv4 networks from ``ip route ls`` (and optional ``proto bgp`` supplement).
+
+    When *allow_lo_routes* is false, routes on ``lo`` are ignored by the parsers.
+    When true, ``_parse_ipv4_lo_route`` supplements the base table.
+    """
+    execstr: Optional[str] = find_executable('ip')
+    if not execstr:
+        raise FileNotFoundError("unable to find 'ip' command")
+    out, _, _ = call_throws(
+        ctx,
+        [execstr, 'route', 'ls'],
+        verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+    )
+    res = _parse_ipv4_route(out, allow_lo_routes)
+    if allow_lo_routes:
+        _merge_ipv4_network_dicts(res, _parse_ipv4_lo_route(out))
+    if allow_bgp_routes:
+        bgp_out, _, _ = call_throws(
+            ctx,
+            [execstr, '-j', 'route', 'ls', 'proto', 'bgp'],
+            verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+        )
+        _merge_ipv4_network_dicts(
+            res, _parse_ipv4_bgp_route(bgp_out, allow_lo_routes)
+        )
+    return res
+
+
 def _list_ipv6_networks(
     ctx: CephadmContext,
+    allow_lo_routes: bool = False,
+    allow_bgp_routes: bool = False,
 ) -> Dict[str, Dict[str, Set[str]]]:
+    """IPv6 networks from ``ip -6 route`` and ``ip -6 addr``.
+
+    When *allow_lo_routes* is false, routes on ``lo`` are ignored so loopback globals
+    are not listed. When *allow_bgp_routes* is true, ``ip -6 route ls proto bgp``
+    is merged into the same shape as the main table (respecting *allow_lo_routes*
+    for ``lo`` BGP paths).
+    """
     execstr: Optional[str] = find_executable('ip')
     if not execstr:
         raise FileNotFoundError("unable to find 'ip' command")
@@ -957,11 +1185,23 @@ def _list_ipv6_networks(
         [execstr, '-6', 'addr', 'ls'],
         verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
     )
-    return _parse_ipv6_route(routes, ips)
+    res = _parse_ipv6_route(routes, ips, allow_lo_routes)
+    if allow_bgp_routes:
+        bgp_out, _, _ = call_throws(
+            ctx,
+            [execstr, '-6', '-j', 'route', 'ls', 'proto', 'bgp'],
+            verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+        )
+        _merge_ipv4_network_dicts(
+            res, _parse_ipv6_bgp_route(bgp_out, allow_lo_routes)
+        )
+    return res
 
 
 def _parse_ipv6_route(
-    routes: str, ips: str
+    routes: str,
+    ips: str,
+    allow_lo_routes: bool = False,
 ) -> Dict[str, Dict[str, Set[str]]]:
     r = {}  # type: Dict[str, Dict[str, Set[str]]]
     route_p = re.compile(
@@ -976,8 +1216,10 @@ def _parse_ipv6_route(
         net = m[0][0]
         if '/' not in net:  # aggregate /128 mask for single host sub-networks
             net += '/128'
-        iface = m[0][1]
-        if iface == 'lo':  # skip loopback devices
+        iface = m[0][1].split('@')[0]
+        if iface == 'lo' and not allow_lo_routes:
+            continue
+        if _is_ipv6_loopback(net):
             continue
         if net not in r:
             r[net] = {}

--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -909,45 +909,37 @@ def list_rdma(ctx: CephadmContext) -> List[Dict[str, str]]:
     return result
 
 
-_IPV4_LOOPBACK_SPACE = ipaddress.ip_network('127.0.0.0/8')
-_IPV6_LOOPBACK_HOST = ipaddress.ip_network('::1/128')
+def _list_ipv4_networks(
+    ctx: CephadmContext,
+    allow_lo_routes: bool = False,
+    allow_bgp_routes: bool = False,
+) -> Dict[str, Dict[str, Set[str]]]:
+    """IPv4 networks from ``ip route ls`` (and optional ``proto bgp`` supplement).
 
-
-def _is_ipv4_loopback(net_s: str) -> bool:
-    """True if *net_s* is an IPv4 prefix wholly within host loopback 127.0.0.0/8."""
-    try:
-        n = ipaddress.ip_network(net_s, strict=False)
-    except ValueError:
-        return False
-    return (
-        n.version == 4
-        and n.network_address in _IPV4_LOOPBACK_SPACE
-        and n.broadcast_address in _IPV4_LOOPBACK_SPACE
+    When *allow_lo_routes* is false, routes on ``lo`` are ignored by the parsers.
+    When true, ``_parse_ipv4_lo_route`` supplements the base table.
+    """
+    execstr: Optional[str] = find_executable('ip')
+    if not execstr:
+        raise FileNotFoundError("unable to find 'ip' command")
+    out, _, _ = call_throws(
+        ctx,
+        [execstr, 'route', 'ls'],
+        verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
     )
-
-
-def _is_ipv6_loopback(net_s: str) -> bool:
-    """True if *net_s* is exactly the host loopback prefix ::1/128."""
-    try:
-        n = ipaddress.ip_network(net_s, strict=False)
-    except ValueError:
-        return False
-    if n.version != 6:
-        return False
-    return n == _IPV6_LOOPBACK_HOST
-
-
-def _merge_ipv4_network_dicts(
-    dst: Dict[str, Dict[str, Set[str]]], add: Dict[str, Dict[str, Set[str]]]
-) -> None:
-    """Merge *add* into *dst* (nested sets)."""
-    for net, ifaces in add.items():
-        if net not in dst:
-            dst[net] = {}
-        for iface, ips in ifaces.items():
-            if iface not in dst[net]:
-                dst[net][iface] = set()
-            dst[net][iface].update(ips)
+    res = _parse_ipv4_route(out, allow_lo_routes)
+    if allow_lo_routes:
+        _merge_ipv4_network_dicts(res, _parse_ipv4_lo_route(out))
+    if allow_bgp_routes:
+        bgp_out, _, _ = call_throws(
+            ctx,
+            [execstr, '-j', 'route', 'ls', 'proto', 'bgp'],
+            verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+        )
+        _merge_ipv4_network_dicts(
+            res, _parse_ipv4_bgp_route(bgp_out, allow_lo_routes)
+        )
+    return res
 
 
 def _parse_ipv4_route(
@@ -1056,9 +1048,10 @@ def _parse_bgp_routes_json(
 
     is_v4 = version == 4
     host_plen = 32 if is_v4 else 128
+    is_loopback_net = _is_ipv4_loopback if is_v4 else _is_ipv6_loopback
 
     def put(net: str, iface: str, ip: str) -> None:
-        if _is_ipv4_loopback(net) if is_v4 else _is_ipv6_loopback(net):
+        if is_loopback_net(net):
             return
         if net not in r:
             r[net] = {}
@@ -1070,7 +1063,7 @@ def _parse_bgp_routes_json(
         if not isinstance(route, dict):
             continue
         dst = route.get('dst')
-        if not dst:
+        if not dst or dst == 'default':
             continue
 
         net = _route_dst_to_network(dst, version)
@@ -1125,39 +1118,6 @@ def _parse_ipv6_bgp_route(
 ) -> Dict[str, Dict[str, Set[str]]]:
     """Parse JSON from ``ip -6 -j route ls proto bgp``."""
     return _parse_bgp_routes_json(out, 6, allow_lo_routes)
-
-
-def _list_ipv4_networks(
-    ctx: CephadmContext,
-    allow_lo_routes: bool = False,
-    allow_bgp_routes: bool = False,
-) -> Dict[str, Dict[str, Set[str]]]:
-    """IPv4 networks from ``ip route ls`` (and optional ``proto bgp`` supplement).
-
-    When *allow_lo_routes* is false, routes on ``lo`` are ignored by the parsers.
-    When true, ``_parse_ipv4_lo_route`` supplements the base table.
-    """
-    execstr: Optional[str] = find_executable('ip')
-    if not execstr:
-        raise FileNotFoundError("unable to find 'ip' command")
-    out, _, _ = call_throws(
-        ctx,
-        [execstr, 'route', 'ls'],
-        verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
-    )
-    res = _parse_ipv4_route(out, allow_lo_routes)
-    if allow_lo_routes:
-        _merge_ipv4_network_dicts(res, _parse_ipv4_lo_route(out))
-    if allow_bgp_routes:
-        bgp_out, _, _ = call_throws(
-            ctx,
-            [execstr, '-j', 'route', 'ls', 'proto', 'bgp'],
-            verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
-        )
-        _merge_ipv4_network_dicts(
-            res, _parse_ipv4_bgp_route(bgp_out, allow_lo_routes)
-        )
-    return res
 
 
 def _list_ipv6_networks(
@@ -1247,3 +1207,44 @@ def _parse_ipv6_route(
             r[net[0]][iface].add(ip)
 
     return r
+
+
+_IPV4_LOOPBACK_SPACE = ipaddress.ip_network('127.0.0.0/8')
+_IPV6_LOOPBACK_HOST = ipaddress.ip_network('::1/128')
+
+
+def _is_ipv4_loopback(net_s: str) -> bool:
+    """True if *net_s* is an IPv4 prefix wholly within host loopback 127.0.0.0/8."""
+    try:
+        n = ipaddress.ip_network(net_s, strict=False)
+    except ValueError:
+        return False
+    return (
+        n.version == 4
+        and n.network_address in _IPV4_LOOPBACK_SPACE
+        and n.broadcast_address in _IPV4_LOOPBACK_SPACE
+    )
+
+
+def _is_ipv6_loopback(net_s: str) -> bool:
+    """True if *net_s* is exactly the host loopback prefix ::1/128."""
+    try:
+        n = ipaddress.ip_network(net_s, strict=False)
+    except ValueError:
+        return False
+    if n.version != 6:
+        return False
+    return n == _IPV6_LOOPBACK_HOST
+
+
+def _merge_ipv4_network_dicts(
+    dst: Dict[str, Dict[str, Set[str]]], add: Dict[str, Dict[str, Set[str]]]
+) -> None:
+    """Merge *add* into *dst* (nested sets)."""
+    for net, ifaces in add.items():
+        if net not in dst:
+            dst[net] = {}
+        for iface, ips in ifaces.items():
+            if iface not in dst[net]:
+                dst[net][iface] = set()
+            dst[net][iface].update(ips)

--- a/src/cephadm/tests/test_networks.py
+++ b/src/cephadm/tests/test_networks.py
@@ -48,6 +48,8 @@ class TestEndPoint:
 
 
 class TestCommandListNetworks:
+    # fmt: off
+    # Keep table-style parametrization unchanged for reviewable diffs (see PR discussion).
     @pytest.mark.parametrize("test_input, expected", [
         (
             dedent("""
@@ -106,9 +108,11 @@ class TestCommandListNetworks:
             }
         ),
     ])
+    # fmt: on
     def test_parse_ipv4_route(self, test_input, expected):
         assert _parse_ipv4_route(test_input) == expected
 
+    # fmt: off
     @pytest.mark.parametrize("test_routes, test_ips, expected", [
         (
             dedent("""
@@ -236,7 +240,8 @@ class TestCommandListNetworks:
             ::1 dev lo proto kernel metric 256 pref medium
             fe80::/64 dev ceph-brx proto kernel metric 256 pref medium
             fe80::/64 dev brx.0 proto kernel metric 256 pref medium
-            default via fe80::327c:5e00:6487:71e0 dev enp3s0f1 proto ra metric 1024 expires 1790sec hoplimit 64 pref medium            """),
+            default via fe80::327c:5e00:6487:71e0 dev enp3s0f1 proto ra metric 1024 expires 1790sec hoplimit 64 pref medium
+            """),
             dedent("""
             1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1000
                 inet6 ::1/128 scope host
@@ -259,8 +264,37 @@ class TestCommandListNetworks:
             }
         ),
     ])
+    # fmt: on
     def test_parse_ipv6_route(self, test_routes, test_ips, expected):
         assert _parse_ipv6_route(test_routes, test_ips) == expected
+
+    def test_parse_ipv6_route_includes_lo_global_not_slaac(self):
+        test_routes = dedent(
+            """
+        ::1 dev lo proto kernel metric 256 pref medium
+        2620:52:0:1304::71 dev lo proto kernel metric 256 pref medium
+        """
+        )
+        test_ips = dedent(
+            """
+        1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1000
+            inet6 ::1/128 scope host
+               valid_lft forever preferred_lft forever
+            inet6 2620:52:0:1304::71/128 scope global
+               valid_lft forever preferred_lft forever
+        """
+        )
+        expected = {
+            '2620:52:0:1304::71/128': {'lo': {'2620:52:0:1304::71'}},
+        }
+        assert (
+            _parse_ipv6_route(test_routes, test_ips, allow_lo_routes=False)
+            == {}
+        )
+        assert (
+            _parse_ipv6_route(test_routes, test_ips, allow_lo_routes=True)
+            == expected
+        )
 
     @mock.patch('cephadmlib.net_utils.read_file')
     def test_get_ipv6_addr(self, _read_file):
@@ -277,8 +311,18 @@ fe80000000000000505400fffe04c154 03 40 20 80     eth1
 
     @mock.patch('cephadmlib.host_facts.call_throws')
     @mock.patch('cephadmlib.host_facts.find_executable')
-    def test_command_list_networks(self, _find_exe, _call_throws, cephadm_fs, capsys):
-        _call_throws.return_value = ('10.4.0.1 dev tun0 proto kernel scope link src 10.4.0.2 metric 50\n', '', '')
+    def test_command_list_networks(
+        self, _find_exe, _call_throws, cephadm_fs, capsys
+    ):
+        _call_throws.side_effect = [
+            (
+                '10.4.0.1 dev tun0 proto kernel scope link src 10.4.0.2 metric 50\n',
+                '',
+                '',
+            ),
+            ('', '', ''),
+            ('', '', ''),
+        ]
         _find_exe.return_value = 'ip'
         with with_cephadm_ctx([]) as ctx:
             _cephadm.command_list_networks(ctx)

--- a/src/cephadm/tests/test_networks.py
+++ b/src/cephadm/tests/test_networks.py
@@ -48,8 +48,6 @@ class TestEndPoint:
 
 
 class TestCommandListNetworks:
-    # fmt: off
-    # Keep table-style parametrization unchanged for reviewable diffs (see PR discussion).
     @pytest.mark.parametrize("test_input, expected", [
         (
             dedent("""
@@ -108,11 +106,9 @@ class TestCommandListNetworks:
             }
         ),
     ])
-    # fmt: on
     def test_parse_ipv4_route(self, test_input, expected):
         assert _parse_ipv4_route(test_input) == expected
 
-    # fmt: off
     @pytest.mark.parametrize("test_routes, test_ips, expected", [
         (
             dedent("""
@@ -240,8 +236,7 @@ class TestCommandListNetworks:
             ::1 dev lo proto kernel metric 256 pref medium
             fe80::/64 dev ceph-brx proto kernel metric 256 pref medium
             fe80::/64 dev brx.0 proto kernel metric 256 pref medium
-            default via fe80::327c:5e00:6487:71e0 dev enp3s0f1 proto ra metric 1024 expires 1790sec hoplimit 64 pref medium
-            """),
+            default via fe80::327c:5e00:6487:71e0 dev enp3s0f1 proto ra metric 1024 expires 1790sec hoplimit 64 pref medium            """),
             dedent("""
             1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1000
                 inet6 ::1/128 scope host
@@ -264,7 +259,6 @@ class TestCommandListNetworks:
             }
         ),
     ])
-    # fmt: on
     def test_parse_ipv6_route(self, test_routes, test_ips, expected):
         assert _parse_ipv6_route(test_routes, test_ips) == expected
 
@@ -311,18 +305,8 @@ fe80000000000000505400fffe04c154 03 40 20 80     eth1
 
     @mock.patch('cephadmlib.host_facts.call_throws')
     @mock.patch('cephadmlib.host_facts.find_executable')
-    def test_command_list_networks(
-        self, _find_exe, _call_throws, cephadm_fs, capsys
-    ):
-        _call_throws.side_effect = [
-            (
-                '10.4.0.1 dev tun0 proto kernel scope link src 10.4.0.2 metric 50\n',
-                '',
-                '',
-            ),
-            ('', '', ''),
-            ('', '', ''),
-        ]
+    def test_command_list_networks(self, _find_exe, _call_throws, cephadm_fs, capsys):
+        _call_throws.return_value = ('10.4.0.1 dev tun0 proto kernel scope link src 10.4.0.2 metric 50\n', '', '')
         _find_exe.return_value = 'ip'
         with with_cephadm_ctx([]) as ctx:
             _cephadm.command_list_networks(ctx)

--- a/src/cephadm/tests/test_networks_lo_routes.py
+++ b/src/cephadm/tests/test_networks_lo_routes.py
@@ -1,0 +1,349 @@
+import json
+from textwrap import dedent
+
+from cephadmlib.host_facts import (
+    _merge_ipv4_network_dicts,
+    _parse_ipv4_bgp_route,
+    _parse_ipv4_lo_route,
+    _parse_ipv4_route,
+    _parse_ipv6_bgp_route,
+)
+
+
+def _merged_ipv4(out: str, *, allow_lo: bool = False):
+    r = _parse_ipv4_route(out, allow_lo)
+    if allow_lo:
+        _merge_ipv4_network_dicts(r, _parse_ipv4_lo_route(out))
+    return r
+
+
+class TestLoopbackRouteParsing:
+    def test_parse_ipv4_route_omits_127_on_lo(self):
+        test_input = dedent(
+            """
+            192.168.1.0/24 dev eth0 proto kernel scope link src 192.168.1.1
+            127.0.0.0/8 dev lo proto kernel scope link src 127.0.0.1
+            """
+        )
+        expected = {'192.168.1.0/24': {'eth0': {'192.168.1.1'}}}
+        assert _parse_ipv4_route(test_input) == expected
+
+    def test_parse_ipv4_route_includes_non_loopback_on_lo(self):
+        test_input = dedent(
+            """
+            192.168.1.0/24 dev eth0 proto kernel scope link src 192.168.1.1
+            10.168.100.0/24 dev lo proto kernel scope link src 10.168.100.10
+            """
+        )
+        expected_with_lo = {
+            '192.168.1.0/24': {'eth0': {'192.168.1.1'}},
+            '10.168.100.0/24': {'lo': {'10.168.100.10'}},
+        }
+        assert _parse_ipv4_route(test_input) == {'192.168.1.0/24': {'eth0': {'192.168.1.1'}}}
+        assert _parse_ipv4_route(test_input, allow_lo_routes=True) == expected_with_lo
+
+    def test_parse_ipv4_lo_route_adds_lo_host_route_without_src(self):
+        # ``ip route add …/32 dev lo proto bgp`` prints no ``src`` line.
+        test_input = dedent(
+            """
+            192.168.100.0/24 dev ens3 proto kernel scope link src 192.168.100.100
+            10.168.100.10 dev lo proto bgp scope link
+            """
+        )
+        expected = {
+            '192.168.100.0/24': {'ens3': {'192.168.100.100'}},
+            '10.168.100.10/32': {'lo': {'10.168.100.10'}},
+        }
+        assert _merged_ipv4(test_input, allow_lo=True) == expected
+
+    def test_parse_ipv4_lo_route_scope_host_on_lo(self):
+        test_input = dedent(
+            """
+            192.168.100.0/24 dev ens3 proto kernel scope link src 192.168.100.100
+            10.10.10.90 dev lo proto kernel scope host
+            """
+        )
+        assert _parse_ipv4_route(test_input) == {
+            '192.168.100.0/24': {'ens3': {'192.168.100.100'}},
+        }
+        assert _merged_ipv4(test_input, allow_lo=True) == {
+            '192.168.100.0/24': {'ens3': {'192.168.100.100'}},
+            '10.10.10.90/32': {'lo': {'10.10.10.90'}},
+        }
+
+    def test_parse_ipv4_lo_route_bgp_scope_host_on_lo(self):
+        test_input = dedent(
+            """
+            10.10.10.10 dev lo proto bgp scope host
+            """
+        )
+        assert _parse_ipv4_route(test_input) == {}
+        assert _parse_ipv4_lo_route(test_input) == {
+            '10.10.10.10/32': {'lo': {'10.10.10.10'}},
+        }
+
+    def test_parse_ipv4_lo_route_dummy_scope_host(self):
+        # Host-scoped /32 on dummy (tracker.ceph.com/issues/76229).
+        test_input = dedent(
+            """
+            192.168.100.0/24 dev ens3 proto kernel scope link src 192.168.100.100
+            10.1.0.40 dev dummy0 proto kernel scope host src 10.1.0.40
+            """
+        )
+        expected = {
+            '192.168.100.0/24': {'ens3': {'192.168.100.100'}},
+            '10.1.0.40/32': {'dummy0': {'10.1.0.40'}},
+        }
+        assert _merged_ipv4(test_input, allow_lo=True) == expected
+
+    def test_parse_ipv4_bgp_route_ecmp_nexthops(self):
+        # From ``ip -j route ls proto bgp`` on a BGP host (ceph-node-0).
+        bgp_input = json.dumps(
+            [
+                {
+                    'dst': '192.168.100.5',
+                    'protocol': 'bgp',
+                    'prefsrc': '192.168.100.11',
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f1np1',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                    ],
+                },
+                {
+                    'dst': '192.168.100.6',
+                    'protocol': 'bgp',
+                    'prefsrc': '192.168.100.11',
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f1np1',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                    ],
+                },
+                {
+                    'dst': '10.0.1.11',
+                    'protocol': 'bgp',
+                    'prefsrc': '10.0.1.11',
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f1np1',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                    ],
+                },
+            ]
+        )
+        expected = {
+            '192.168.100.5/32': {
+                'ens1f0np0': {'192.168.100.11'},
+                'ens1f1np1': {'192.168.100.11'},
+            },
+            '192.168.100.6/32': {
+                'ens1f0np0': {'192.168.100.11'},
+                'ens1f1np1': {'192.168.100.11'},
+            },
+            '10.0.1.11/32': {
+                'ens1f0np0': {'10.0.1.11'},
+                'ens1f1np1': {'10.0.1.11'},
+            },
+        }
+        assert _parse_ipv4_bgp_route(bgp_input) == expected
+
+    def test_parse_ipv4_bgp_route_ecmp_without_protocol_field(self):
+        # ``ip -j route ls proto bgp`` may omit ``protocol`` on filtered output.
+        bgp_input = json.dumps(
+            [
+                {
+                    'dst': '192.168.100.5',
+                    'prefsrc': '192.168.100.11',
+                    'metric': 20,
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f1np1',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                    ],
+                },
+                {
+                    'dst': '192.168.100.6',
+                    'prefsrc': '192.168.100.11',
+                    'metric': 20,
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f1np1',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                    ],
+                },
+            ]
+        )
+        expected = {
+            '192.168.100.5/32': {
+                'ens1f0np0': {'192.168.100.11'},
+                'ens1f1np1': {'192.168.100.11'},
+            },
+            '192.168.100.6/32': {
+                'ens1f0np0': {'192.168.100.11'},
+                'ens1f1np1': {'192.168.100.11'},
+            },
+        }
+        assert _parse_ipv4_bgp_route(bgp_input) == expected
+
+    def test_parse_ipv4_bgp_route_lo_without_src(self):
+        bgp_input = json.dumps(
+            [
+                {
+                    'dst': '10.168.100.10',
+                    'dev': 'lo',
+                    'protocol': 'bgp',
+                    'scope': 'link',
+                    'flags': [],
+                }
+            ]
+        )
+        assert _parse_ipv4_bgp_route(bgp_input) == {}
+        assert _parse_ipv4_bgp_route(bgp_input, allow_lo_routes=True) == {
+            '10.168.100.10/32': {'lo': {'10.168.100.10'}},
+        }
+
+    def test_parse_ipv4_bgp_route_lo_from_full_table(self):
+        # ``ip -j route ls`` entry for ``10.10.10.10 dev lo proto bgp``.
+        bgp_input = json.dumps(
+            [
+                {
+                    'dst': '10.10.10.10',
+                    'dev': 'lo',
+                    'protocol': 'bgp',
+                    'scope': 'link',
+                    'flags': [],
+                }
+            ]
+        )
+        assert _parse_ipv4_bgp_route(bgp_input, allow_lo_routes=True) == {
+            '10.10.10.10/32': {'lo': {'10.10.10.10'}},
+        }
+
+    def test_parse_ipv6_bgp_route_ecmp_nexthops(self):
+        bgp_input = json.dumps(
+            [
+                {
+                    'dst': '2001:db8:100::5',
+                    'protocol': 'bgp',
+                    'prefsrc': '2001:db8:100::11',
+                    'metric': 20,
+                    'pref': 'medium',
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': 'fe80::1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': [],
+                        },
+                        {
+                            'gateway': 'fe80::2',
+                            'dev': 'ens1f1np1',
+                            'weight': 1,
+                            'flags': [],
+                        },
+                    ],
+                },
+                {
+                    'dst': '2001:db8:200::1:11',
+                    'protocol': 'bgp',
+                    'prefsrc': '2001:db8:200::1:11',
+                    'metric': 20,
+                    'pref': 'medium',
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': 'fe80::a',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': [],
+                        },
+                        {
+                            'gateway': 'fe80::b',
+                            'dev': 'ens1f1np1',
+                            'weight': 1,
+                            'flags': [],
+                        },
+                    ],
+                },
+            ]
+        )
+        expected = {
+            '2001:db8:100::5/128': {
+                'ens1f0np0': {'2001:db8:100::11'},
+                'ens1f1np1': {'2001:db8:100::11'},
+            },
+            '2001:db8:200::1:11/128': {
+                'ens1f0np0': {'2001:db8:200::1:11'},
+                'ens1f1np1': {'2001:db8:200::1:11'},
+            },
+        }
+        assert _parse_ipv6_bgp_route(bgp_input) == expected
+
+    def test_parse_ipv6_bgp_route_lo_without_src(self):
+        bgp_input = json.dumps(
+            [
+                {
+                    'dst': '2001:db8:bad:10::10',
+                    'dev': 'lo',
+                    'protocol': 'bgp',
+                    'scope': 'link',
+                    'flags': [],
+                }
+            ]
+        )
+        assert _parse_ipv6_bgp_route(bgp_input) == {}
+        assert _parse_ipv6_bgp_route(bgp_input, allow_lo_routes=True) == {
+            '2001:db8:bad:10::10/128': {'lo': {'2001:db8:bad:10::10'}},
+        }

--- a/src/cephadm/tests/test_networks_lo_routes.py
+++ b/src/cephadm/tests/test_networks_lo_routes.py
@@ -253,6 +253,43 @@ class TestLoopbackRouteParsing:
             '10.168.100.10/32': {'lo': {'10.168.100.10'}},
         }
 
+    def test_parse_ipv4_bgp_route_skips_default(self):
+        bgp_input = json.dumps(
+            [
+                {
+                    'dst': 'default',
+                    'protocol': 'bgp',
+                    'prefsrc': '192.168.100.11',
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                    ],
+                },
+                {
+                    'dst': '192.168.100.5',
+                    'protocol': 'bgp',
+                    'prefsrc': '192.168.100.11',
+                    'flags': [],
+                    'nexthops': [
+                        {
+                            'gateway': '169.254.0.1',
+                            'dev': 'ens1f0np0',
+                            'weight': 1,
+                            'flags': ['onlink'],
+                        },
+                    ],
+                },
+            ]
+        )
+        assert _parse_ipv4_bgp_route(bgp_input) == {
+            '192.168.100.5/32': {'ens1f0np0': {'192.168.100.11'}},
+        }
+
     def test_parse_ipv4_bgp_route_lo_from_full_table(self):
         # ``ip -j route ls`` entry for ``10.10.10.10 dev lo proto bgp``.
         bgp_input = json.dumps(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -200,6 +200,23 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Seconds for which to cache host facts data',
         ),
         Option(
+            'allow_lo_routes',
+            type='bool',
+            default=False,
+            desc='If true, cephadm list-networks is run with --allow-lo-routes so '
+            'loopback (lo) routes are included in host network facts; if false, '
+            'they are omitted (default).',
+        ),
+        Option(
+            'allow_bgp_routes',
+            type='bool',
+            default=False,
+            desc='If true, cephadm list-networks is run with --allow-bgp-routes so '
+            'BGP routes from ``ip route ls proto bgp`` and '
+            '``ip -6 route ls proto bgp`` are merged into host network facts; if '
+            'false (default), only the main IPv4 and IPv6 tables are used.',
+        ),
+        Option(
             'host_check_interval',
             type='secs',
             default=10 * 60,
@@ -543,6 +560,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.device_cache_timeout = 0
             self.daemon_cache_timeout = 0
             self.facts_cache_timeout = 0
+            self.allow_lo_routes = False
+            self.allow_bgp_routes = False
             self.host_check_interval = 0
             self.stray_daemon_check_interval = 0
             self.max_count_per_host = 0

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -438,9 +438,20 @@ class CephadmServe:
 
     def _refresh_host_networks(self, host: str) -> Optional[str]:
         try:
+            list_net_args: List[str] = []
+            if self.mgr.allow_lo_routes:
+                list_net_args.append('--allow-lo-routes')
+            if self.mgr.allow_bgp_routes:
+                list_net_args.append('--allow-bgp-routes')
             with self.mgr.async_timeout_handler(host, 'cephadm list-networks'):
                 networks = self.mgr.wait_async(self._run_cephadm_json(
-                    host, 'mon', 'list-networks', [], no_fsid=True, log_output=self.mgr.log_refresh_metadata))
+                    host,
+                    'mon',
+                    'list-networks',
+                    list_net_args,
+                    no_fsid=True,
+                    log_output=self.mgr.log_refresh_metadata,
+                ))
         except OrchestratorError as e:
             return str(e)
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62195
Signed-off-by: Kobi Ginon <kginon@redhat.com>

Extend cephadm list-networks (and the cephadm mgr module options that pass
flags through to it) so hosts can expose loopback and BGP-derived routes
when operators need them, while keeping the default conservative for
orchestrator network discovery.

**Very Important:**  this 2 options were added as a requirement from he maintainer not to affect the production behavior , while still gives out the option to those who uses mainly bgp and routes on the loopback interface to have this flags to enable them to see those in list networks and eventually to be able to install ceph monitor and ceph mgr
without failing since the list-networks will filter out those networks.

- Add cephadm flags --allow-lo-routes and --allow-bgp-routes (after the
  list-networks subcommand). Wire mgr options allow_lo_routes and
  allow_bgp_routes to the remote cephadm invocation.

- IPv4: build from ``ip route ls`` (scope link + src). When allow_lo_routes
  is true, merge extra lines from the same output via _parse_ipv4_lo_route
  (lo /32 without src, host-scoped routes including dummy-style /32 from
  76229). Always omit prefixes wholly inside 127.0.0.0/8. When
  allow_lo_routes is false, skip any route whose device is lo at parse time.
  When allow_bgp_routes is true, merge ``ip route ls proto bgp`` (ECMP
  nexthops and lo BGP /32), again respecting allow_lo_routes for lo.

- IPv6: build from ``ip -6 route ls`` and ``ip -6 addr ls``; omit ::1/128.
  When allow_lo_routes is false, skip routes on lo (including global /128 on
  lo). When allow_bgp_routes is true, merge ``ip -6 route ls proto bgp`` in
  the same way as IPv4, including lo BGP /128 when allow_lo_routes is true.

**Tests results with the implementation**
root@ceph-node-0 ~]# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 2001:db8:3000:1010::2002/128 scope global
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:43:fc:1c brd ff:ff:ff:ff:ff:ff
    altname enp0s3
    altname enx52540043fc1c
    inet 192.168.100.100/24 brd 192.168.100.255 scope global dynamic noprefixroute ens3
       valid_lft 2476sec preferred_lft 2476sec
    inet 192.168.100.11/24 scope global secondary ens3
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fe43:fc1c/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
3: ens1f0np0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 12:26:d3:6e:db:c8 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::1026:d3ff:fe6e:dbc8/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
4: ens1f1np1: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 52:35:f5:36:3c:2d brd ff:ff:ff:ff:ff:ff
    inet6 fe80::5035:f5ff:fe36:3c2d/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
5: dummy0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 1e:6e:e8:44:fc:de brd ff:ff:ff:ff:ff:ff
    inet 10.1.0.40/32 scope global dummy0
       valid_lft forever preferred_lft forever
    inet6 fe80::c841:afff:fe47:6f7e/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
       
[root@ceph-node-0 ~]# ip -4 route ls
default via 192.168.100.1 dev ens3 proto dhcp src 192.168.100.100 metric 100
10.0.0.0/24 dev ens3 scope link src 192.168.100.11
10.1.0.40 dev dummy0 scope link src 10.1.0.40
10.10.10.10 dev lo proto bgp scope host
10.10.10.90 dev lo proto kernel scope host
192.168.100.0/24 dev ens3 proto kernel scope link src 192.168.100.100 metric 100
192.168.100.5 proto bgp src 192.168.100.11 metric 20
        nexthop via 169.254.0.1 dev ens1f0np0 weight 1 onlink
        nexthop via 169.254.0.1 dev ens1f1np1 weight 1 onlink
192.168.100.6 proto bgp src 192.168.100.11 metric 20
        nexthop via 169.254.0.1 dev ens1f0np0 weight 1 onlink
        nexthop via 169.254.0.1 dev ens1f1np1 weight 1 onlink
        
[root@ceph-node-0 ~]# ip -6 route ls
2001:db8:3000:1010::2001 via fe80::9a19:2cff:fee5:b280 dev ens3 proto static metric 20 pref medium
2001:db8:3000:1010::2002 dev lo proto kernel metric 256 pref medium
fe80::/64 dev ens1f0np0 proto kernel metric 256 pref medium
fe80::/64 dev ens1f1np1 proto kernel metric 256 pref medium
fe80::/64 dev dummy0 proto kernel metric 256 pref medium
fe80::/64 dev ens3 proto kernel metric 1024 pref medium

[root@ceph-node-0 ~]# cephadm list-networks
{
    "10.0.0.0/24": {
        "ens3": [
            "192.168.100.11"
        ]
    },
    "10.1.0.40/32": {
        "dummy0": [
            "10.1.0.40"
        ]
    },
    "192.168.100.0/24": {
        "ens3": [
            "192.168.100.100"
        ]
    },
    "fe80::/64": {
        "ens1f0np0": [
            "fe80::1026:d3ff:fe6e:dbc8"
        ],
        "ens1f1np1": [
            "fe80::5035:f5ff:fe36:3c2d"
        ],
        "dummy0": [
            "fe80::c841:afff:fe47:6f7e"
        ],
        "ens3": [
            "fe80::5054:ff:fe43:fc1c"
        ]
    }
}

[root@ceph-node-0 ~]# cephadm list-networks --allow-lo-routes
{
    "10.0.0.0/24": {
        "ens3": [
            "192.168.100.11"
        ]
    },
    "10.1.0.40/32": {
        "dummy0": [
            "10.1.0.40"
        ]
    },
    "192.168.100.0/24": {
        "ens3": [
            "192.168.100.100"
        ]
    },
    "10.10.10.10/32": {
        "lo": [
            "10.10.10.10"
        ]
    },
    "10.10.10.90/32": {
        "lo": [
            "10.10.10.90"
        ]
    },
    "2001:db8:3000:1010::2002/128": {
        "lo": [
            "2001:db8:3000:1010::2002"
        ]
    },
    "fe80::/64": {
        "ens1f0np0": [
            "fe80::1026:d3ff:fe6e:dbc8"
        ],
        "ens1f1np1": [
            "fe80::5035:f5ff:fe36:3c2d"
        ],
        "dummy0": [
            "fe80::c841:afff:fe47:6f7e"
        ],
        "ens3": [
            "fe80::5054:ff:fe43:fc1c"
        ]
    }
}

[root@ceph-node-0 ~]# cephadm list-networks --allow-lo-routes --allow-bgp-routes
{
    "10.0.0.0/24": {
        "ens3": [
            "192.168.100.11"
        ]
    },
    "10.1.0.40/32": {
        "dummy0": [
            "10.1.0.40"
        ]
    },
    "192.168.100.0/24": {
        "ens3": [
            "192.168.100.100"
        ]
    },
    "10.10.10.10/32": {
        "lo": [
            "10.10.10.10"
        ]
    },
    "10.10.10.90/32": {
        "lo": [
            "10.10.10.90"
        ]
    },
    "192.168.100.5/32": {
        "ens1f0np0": [
            "192.168.100.11"
        ],
        "ens1f1np1": [
            "192.168.100.11"
        ]
    },
    "192.168.100.6/32": {
        "ens1f0np0": [
            "192.168.100.11"
        ],
        "ens1f1np1": [
            "192.168.100.11"
        ]
    },
    "2001:db8:3000:1010::2002/128": {
        "lo": [
            "2001:db8:3000:1010::2002"
        ]
    },
    "fe80::/64": {
        "ens1f0np0": [
            "fe80::1026:d3ff:fe6e:dbc8"
        ],
        "ens1f1np1": [
            "fe80::5035:f5ff:fe36:3c2d"
        ],
        "dummy0": [
            "fe80::c841:afff:fe47:6f7e"
        ],
        "ens3": [
            "fe80::5054:ff:fe43:fc1c"
        ]
    }
}
       

**End Testing results**



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
