### PR TITLE
squid: qa/tests: wait for module to be available for connection

### DIFF
--- a/qa/tasks/mgr/dashboard/test_feedback.py
+++ b/qa/tasks/mgr/dashboard/test_feedback.py
@@ -1,15 +1,20 @@
 import time
 
-from .helper import DashboardTestCase
+from .helper import DashboardTestCase, MgrModuleTestCase
 
 
-class FeedbackTest(DashboardTestCase):
+class FeedbackTest(DashboardTestCase, MgrModuleTestCase):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._ceph_cmd(['mgr', 'module', 'enable', 'feedback'])
-        time.sleep(10)
+        cls._ceph_cmd(['mgr', 'module', 'enable', 'feedback'], wait=3)
+        cls._get(
+            '/api/mgr/module',
+            retries=2,
+            wait_func=lambda:  # pylint: disable=unnecessary-lambda
+            cls.wait_until_rest_api_accessible()
+        )
 
     def test_create_api_key(self):
         self._post('/api/feedback/api_key', {'api_key': 'testapikey'}, version='0.1')

--- a/qa/tasks/mgr/dashboard/test_feedback.py
+++ b/qa/tasks/mgr/dashboard/test_feedback.py
@@ -1,9 +1,7 @@
-import time
-
-from .helper import DashboardTestCase, MgrModuleTestCase
+from .test_mgr_module import MgrModuleTestCase
 
 
-class FeedbackTest(DashboardTestCase, MgrModuleTestCase):
+class FeedbackTest(MgrModuleTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -11,9 +9,9 @@ class FeedbackTest(DashboardTestCase, MgrModuleTestCase):
         cls._ceph_cmd(['mgr', 'module', 'enable', 'feedback'], wait=3)
         cls._get(
             '/api/mgr/module',
-            retries=2,
+            retries=5,
             wait_func=lambda:  # pylint: disable=unnecessary-lambda
-            cls.wait_until_rest_api_accessible()
+            MgrModuleTestCase.wait_until_rest_api_accessible(cls)
         )
 
     def test_create_api_key(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74741

---

backport of https://github.com/ceph/ceph/pull/67177
parent tracker: https://tracker.ceph.com/issues/74731

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh