### PR TITLE
squid: rgw/iam: fix NotEquals handling for multiple values

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -888,7 +888,7 @@ bool Condition::eval(const Environment& env) const {
     return multimap_any(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEquals:
-    return multimap_any(std::not_fn(std::equal_to<std::string>()),
+    return multimap_none(std::equal_to<std::string>(),
      itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringEqualsIgnoreCase:
@@ -896,14 +896,14 @@ bool Condition::eval(const Environment& env) const {
     return multimap_any(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEqualsIgnoreCase:
-    return multimap_any(std::not_fn(ci_equal_to()), itr, isruntime? runtime_vals : vals);
+    return multimap_none(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringLike:
   case TokenID::StringLike:
     return multimap_any(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotLike:
-    return multimap_any(std::not_fn(string_like()), itr, isruntime? runtime_vals : vals);
+    return multimap_none(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringEquals:
     return multimap_all(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
@@ -919,7 +919,7 @@ bool Condition::eval(const Environment& env) const {
     return typed_any(std::equal_to<double>(), as_number, s, vals);
 
   case TokenID::NumericNotEquals:
-    return typed_any(std::not_fn(std::equal_to<double>()),
+    return typed_none(std::equal_to<double>(),
        as_number, s, vals);
 
 
@@ -942,7 +942,7 @@ bool Condition::eval(const Environment& env) const {
     return typed_any(std::equal_to<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateNotEquals:
-    return typed_any(std::not_fn(std::equal_to<ceph::real_time>()),
+    return typed_none(std::equal_to<ceph::real_time>(),
        as_date, s, vals);
   case TokenID::DateLessThan:
     return typed_any(std::less<ceph::real_time>(), as_date, s, vals);
@@ -972,24 +972,8 @@ bool Condition::eval(const Environment& env) const {
     return typed_any(std::equal_to<MaskedIP>(), as_network, s, vals);
 
   case TokenID::NotIpAddress:
-    {
-      auto xc = as_network(s);
-      if (!xc) {
-	return false;
-      }
-
-      for (const string& d : vals) {
-	auto xd = as_network(d);
-	if (!xd) {
-	  continue;
-	}
-
-	if (xc == xd) {
-	  return false;
-	}
-      }
-      return true;
-    }
+    return typed_none(std::equal_to<MaskedIP>(),
+      as_network, s, vals);
 
     // Amazon Resource Names!
     // The ArnEquals and ArnLike condition operators behave identically.
@@ -998,7 +982,7 @@ bool Condition::eval(const Environment& env) const {
     return multimap_any(arn_like, itr, isruntime? runtime_vals : vals);
   case TokenID::ArnNotEquals:
   case TokenID::ArnNotLike:
-    return multimap_any(std::not_fn(arn_like), itr, isruntime? runtime_vals : vals);
+    return multimap_none(arn_like, itr, isruntime? runtime_vals : vals);
 
   default:
     return false;

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -885,91 +885,91 @@ bool Condition::eval(const Environment& env) const {
     // String!
   case TokenID::ForAnyValueStringEquals:
   case TokenID::StringEquals:
-    return orrible(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEquals:
-    return orrible(std::not_fn(std::equal_to<std::string>()),
-		   itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(std::equal_to<std::string>()),
+     itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringEqualsIgnoreCase:
   case TokenID::StringEqualsIgnoreCase:
-    return orrible(ci_equal_to(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEqualsIgnoreCase:
-    return orrible(std::not_fn(ci_equal_to()), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(ci_equal_to()), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringLike:
   case TokenID::StringLike:
-    return orrible(string_like(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotLike:
-    return orrible(std::not_fn(string_like()), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(string_like()), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringEquals:
-    return andible(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringLike:
-    return andible(string_like(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringEqualsIgnoreCase:
-    return andible(ci_equal_to(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
     // Numeric
   case TokenID::NumericEquals:
-    return shortible(std::equal_to<double>(), as_number, s, vals);
+    return typed_any(std::equal_to<double>(), as_number, s, vals);
 
   case TokenID::NumericNotEquals:
-    return shortible(std::not_fn(std::equal_to<double>()),
-		     as_number, s, vals);
+    return typed_any(std::not_fn(std::equal_to<double>()),
+       as_number, s, vals);
 
 
   case TokenID::NumericLessThan:
-    return shortible(std::less<double>(), as_number, s, vals);
+    return typed_any(std::less<double>(), as_number, s, vals);
 
 
   case TokenID::NumericLessThanEquals:
-    return shortible(std::less_equal<double>(), as_number, s, vals);
+    return typed_any(std::less_equal<double>(), as_number, s, vals);
 
   case TokenID::NumericGreaterThan:
-    return shortible(std::greater<double>(), as_number, s, vals);
+    return typed_any(std::greater<double>(), as_number, s, vals);
 
   case TokenID::NumericGreaterThanEquals:
-    return shortible(std::greater_equal<double>(), as_number, s, vals);
+    return typed_any(std::greater_equal<double>(), as_number, s,
+       vals);
 
     // Date!
   case TokenID::DateEquals:
-    return shortible(std::equal_to<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::equal_to<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateNotEquals:
-    return shortible(std::not_fn(std::equal_to<ceph::real_time>()),
-		     as_date, s, vals);
-
+    return typed_any(std::not_fn(std::equal_to<ceph::real_time>()),
+       as_date, s, vals);
   case TokenID::DateLessThan:
-    return shortible(std::less<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::less<ceph::real_time>(), as_date, s, vals);
 
 
   case TokenID::DateLessThanEquals:
-    return shortible(std::less_equal<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::less_equal<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateGreaterThan:
-    return shortible(std::greater<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::greater<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateGreaterThanEquals:
-    return shortible(std::greater_equal<ceph::real_time>(), as_date, s,
+    return typed_any(std::greater_equal<ceph::real_time>(), as_date, s,
 		     vals);
 
     // Bool!
   case TokenID::Bool:
-    return shortible(std::equal_to<bool>(), as_bool, s, vals);
+    return typed_any(std::equal_to<bool>(), as_bool, s, vals);
 
     // Binary!
   case TokenID::BinaryEquals:
-    return shortible(std::equal_to<ceph::bufferlist>(), as_binary, s,
+    return typed_any(std::equal_to<ceph::bufferlist>(), as_binary, s,
 		     vals);
 
     // IP Address!
   case TokenID::IpAddress:
-    return shortible(std::equal_to<MaskedIP>(), as_network, s, vals);
+    return typed_any(std::equal_to<MaskedIP>(), as_network, s, vals);
 
   case TokenID::NotIpAddress:
     {
@@ -995,10 +995,10 @@ bool Condition::eval(const Environment& env) const {
     // The ArnEquals and ArnLike condition operators behave identically.
   case TokenID::ArnEquals:
   case TokenID::ArnLike:
-    return orrible(arn_like, itr, isruntime? runtime_vals : vals);
+    return multimap_any(arn_like, itr, isruntime? runtime_vals : vals);
   case TokenID::ArnNotEquals:
   case TokenID::ArnNotLike:
-    return orrible(std::not_fn(arn_like), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(arn_like), itr, isruntime? runtime_vals : vals);
 
   default:
     return false;

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -464,8 +464,8 @@ struct Condition {
   using unordered_multimap_it_pair = std::pair <std::unordered_multimap<std::string,std::string>::const_iterator, std::unordered_multimap<std::string,std::string>::const_iterator>;
 
   template<typename F>
-  static bool andible(F&& f, const unordered_multimap_it_pair& it,
-		      const std::vector<std::string>& v) {
+  static bool multimap_all(F&& f, const unordered_multimap_it_pair& it,
+                           const std::vector<std::string>& v) {
     for (auto itr = it.first; itr != it.second; itr++) {
       bool matched = false;
       for (const auto& d : v) {
@@ -480,8 +480,8 @@ struct Condition {
   }
 
   template<typename F>
-  static bool orrible(F&& f, const unordered_multimap_it_pair& it,
-		      const std::vector<std::string>& v) {
+  static bool multimap_any(F&& f, const unordered_multimap_it_pair& it,
+                           const std::vector<std::string>& v) {
     for (auto itr = it.first; itr != it.second; itr++) {
       for (const auto& d : v) {
         if (f(itr->second, d)) {
@@ -492,9 +492,22 @@ struct Condition {
     return false;
   }
 
+  template<typename F>
+  static bool multimap_none(F&& f, const unordered_multimap_it_pair& it,
+                            const std::vector<std::string>& v) {
+    for (auto itr = it.first; itr != it.second; itr++) {
+      for (const auto& d : v) {
+        if (f(itr->second, d)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   template<typename F, typename X>
-  static bool shortible(F&& f, X& x, const std::string& c,
-			const std::vector<std::string>& v) {
+  static bool typed_any(F&& f, X& x, const std::string& c,
+                        const std::vector<std::string>& v) {
     auto xc = std::forward<X>(x)(c);
     if (!xc) {
       return false;
@@ -511,6 +524,27 @@ struct Condition {
       }
     }
     return false;
+  }
+
+  template<typename F, typename X>
+  static bool typed_none(F&& f, X& x, const std::string& c,
+                         const std::vector<std::string>& v) {
+    auto xc = std::forward<X>(x)(c);
+    if (!xc) {
+      return false;
+    }
+
+    for (const auto& d : v) {
+      auto xd = x(d);
+      if (!xd) {
+        continue;
+      }
+
+      if (f(*xc, *xd)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   template <typename F>

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -1507,3 +1507,199 @@ TEST(Condition, ArnLike)
     EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::user"}}));
   }
 }
+
+
+class ConditionTest : public ::testing::Test {
+protected:
+  intrusive_ptr<CephContext> cct;
+  
+  ConditionTest() {
+    cct.reset(new CephContext(CEPH_ENTITY_TYPE_CLIENT), false);
+  }
+};
+
+// Test cases for NotEquals condition logic fix
+// These tests verify that NotEquals conditions use correct AND logic
+// instead of incorrect OR logic (requiring mismatch with ALL values, not ANY)
+
+TEST_F(ConditionTest, StringNotEqualsLogic)
+{
+  std::string key = "aws:UserName";
+  
+  // Test case: value matches one of multiple condition values
+  // Should return false because value equals at least one condition value
+  {
+    Condition stringNotEquals{TokenID::StringNotEquals, key.data(), key.size(), false};
+    stringNotEquals.vals.push_back("alice");
+    stringNotEquals.vals.push_back("bob");
+    stringNotEquals.vals.push_back("charlie");
+
+    // Input "bob" matches second condition value, should return false
+    EXPECT_FALSE(stringNotEquals.eval({{key, "bob"}}));
+    // Input "alice" matches first condition value, should return false  
+    EXPECT_FALSE(stringNotEquals.eval({{key, "alice"}}));
+  }
+  
+  // Test case: value doesn't match any condition values
+  // Should return true because value differs from all condition values
+  {
+    Condition stringNotEquals{TokenID::StringNotEquals, key.data(), key.size(), false};
+    stringNotEquals.vals.push_back("alice");
+    stringNotEquals.vals.push_back("bob");
+    stringNotEquals.vals.push_back("charlie");
+
+    // Input "david" doesn't match any condition value, should return true
+    EXPECT_TRUE(stringNotEquals.eval({{key, "david"}}));
+  }
+}
+
+TEST_F(ConditionTest, NumericNotEqualsLogic)
+{
+  std::string key = "aws:RequestedRegion";
+  
+  // Test case: value matches one of multiple condition values
+  // Should return false because value equals at least one condition value
+  {
+    Condition numericNotEquals{TokenID::NumericNotEquals, key.data(), key.size(), false};
+    numericNotEquals.vals.push_back("10");
+    numericNotEquals.vals.push_back("20");
+    numericNotEquals.vals.push_back("30");
+
+    // Input "20" matches second condition value, should return false
+    EXPECT_FALSE(numericNotEquals.eval({{key, "20"}}));
+    // Input "10" matches first condition value, should return false
+    EXPECT_FALSE(numericNotEquals.eval({{key, "10"}}));
+  }
+  
+  // Test case: value doesn't match any condition values
+  // Should return true because value differs from all condition values
+  {
+    Condition numericNotEquals{TokenID::NumericNotEquals, key.data(), key.size(), false};
+    numericNotEquals.vals.push_back("10");
+    numericNotEquals.vals.push_back("20");
+    numericNotEquals.vals.push_back("30");
+
+    // Input "40" doesn't match any condition value, should return true
+    EXPECT_TRUE(numericNotEquals.eval({{key, "40"}}));
+  }
+}
+
+TEST_F(ConditionTest, DateNotEqualsLogic)
+{
+  std::string key = "aws:CurrentTime";
+  
+  // Test case: value matches one of multiple condition values
+  // Should return false because value equals at least one condition value
+  {
+    Condition dateNotEquals{TokenID::DateNotEquals, key.data(), key.size(), false};
+    dateNotEquals.vals.push_back("2023-01-01T00:00:00Z");
+    dateNotEquals.vals.push_back("2023-06-01T00:00:00Z");
+    dateNotEquals.vals.push_back("2023-12-01T00:00:00Z");
+
+    // Input matches second condition value, should return false
+    EXPECT_FALSE(dateNotEquals.eval({{key, "2023-06-01T00:00:00Z"}}));
+  }
+  
+  // Test case: value doesn't match any condition values
+  // Should return true because value differs from all condition values
+  {
+    Condition dateNotEquals{TokenID::DateNotEquals, key.data(), key.size(), false};
+    dateNotEquals.vals.push_back("2023-01-01T00:00:00Z");
+    dateNotEquals.vals.push_back("2023-06-01T00:00:00Z");
+    dateNotEquals.vals.push_back("2023-12-01T00:00:00Z");
+
+    // Input doesn't match any condition value, should return true
+    EXPECT_TRUE(dateNotEquals.eval({{key, "2024-01-01T00:00:00Z"}}));
+  }
+}
+
+TEST_F(ConditionTest, NotIpAddressLogic)
+{
+  std::string key = "aws:SourceIp";
+  
+  // Test case: value matches one of multiple condition values
+  // Should return false because value equals at least one condition value
+  {
+    Condition notIpAddress{TokenID::NotIpAddress, key.data(), key.size(), false};
+    notIpAddress.vals.push_back("192.168.1.1");
+    notIpAddress.vals.push_back("10.0.0.1");
+    notIpAddress.vals.push_back("172.16.0.1");
+
+    // Input matches second condition value, should return false
+    EXPECT_FALSE(notIpAddress.eval({{key, "10.0.0.1"}}));
+    // Input matches first condition value, should return false
+    EXPECT_FALSE(notIpAddress.eval({{key, "192.168.1.1"}}));
+  }
+  
+  // Test case: value doesn't match any condition values
+  // Should return true because value differs from all condition values
+  {
+    Condition notIpAddress{TokenID::NotIpAddress, key.data(), key.size(), false};
+    notIpAddress.vals.push_back("192.168.1.1");
+    notIpAddress.vals.push_back("10.0.0.1");
+    notIpAddress.vals.push_back("172.16.0.1");
+
+    // Input doesn't match any condition value, should return true
+    EXPECT_TRUE(notIpAddress.eval({{key, "8.8.8.8"}}));
+  }
+}
+
+TEST_F(ConditionTest, ArnNotEqualsLogic)
+{
+  std::string key = "aws:SourceArn";
+  
+  // Test case: value matches one of multiple condition values
+  // Should return false because value equals at least one condition value
+  {
+    Condition arnNotEquals{TokenID::ArnNotEquals, key.data(), key.size(), false};
+    arnNotEquals.vals.push_back("arn:aws:s3:::bucket1");
+    arnNotEquals.vals.push_back("arn:aws:s3:::bucket2");
+    arnNotEquals.vals.push_back("arn:aws:s3:::bucket3");
+
+    // Input matches second condition value, should return false
+    EXPECT_FALSE(arnNotEquals.eval({{key, "arn:aws:s3:::bucket2"}}));
+  }
+  
+  // Test case: value doesn't match any condition values
+  // Should return true because value differs from all condition values
+  {
+    Condition arnNotEquals{TokenID::ArnNotEquals, key.data(), key.size(), false};
+    arnNotEquals.vals.push_back("arn:aws:s3:::bucket1");
+    arnNotEquals.vals.push_back("arn:aws:s3:::bucket2");
+    arnNotEquals.vals.push_back("arn:aws:s3:::bucket3");
+
+    // Input doesn't match any condition value, should return true
+    EXPECT_TRUE(arnNotEquals.eval({{key, "arn:aws:s3:::other-bucket"}}));
+  }
+}
+
+TEST_F(ConditionTest, StringNotLikeLogic)
+{
+  std::string key = "s3:prefix";
+  
+  // Test case: value matches one of multiple condition patterns
+  // Should return false because value matches at least one condition pattern
+  {
+    Condition stringNotLike{TokenID::StringNotLike, key.data(), key.size(), false};
+    stringNotLike.vals.push_back("user/*");
+    stringNotLike.vals.push_back("admin/*");
+    stringNotLike.vals.push_back("temp/*");
+
+    // Input matches second condition pattern, should return false
+    EXPECT_FALSE(stringNotLike.eval({{key, "admin/config.txt"}}));
+    // Input matches first condition pattern, should return false
+    EXPECT_FALSE(stringNotLike.eval({{key, "user/profile.jpg"}}));
+  }
+  
+  // Test case: value doesn't match any condition patterns
+  // Should return true because value differs from all condition patterns
+  {
+    Condition stringNotLike{TokenID::StringNotLike, key.data(), key.size(), false};
+    stringNotLike.vals.push_back("user/*");
+    stringNotLike.vals.push_back("admin/*");
+    stringNotLike.vals.push_back("temp/*");
+
+    // Input doesn't match any condition pattern, should return true
+    EXPECT_TRUE(stringNotLike.eval({{key, "public/document.pdf"}}));
+  }
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73365

---

backport of https://github.com/ceph/ceph/pull/65606
parent tracker: https://tracker.ceph.com/issues/73146

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh