### PR TITLE
kv/RocksDB: Add instrumentation to BinnedLRUCache + dual output

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -546,7 +546,26 @@ void AdminSocket::execute_command(
     }
   }
 
-  Formatter* f;
+  auto [retval, hook] = find_matched_hook(prefix, cmdmap);
+  switch (retval) {
+  case ENOENT:
+    lderr(m_cct) << "AdminSocket: request '" << cmdvec
+		 << "' not defined" << dendl;
+    return on_finish(-EINVAL, "unknown command prefix "s + prefix, empty);
+  case EINVAL:
+    return on_finish(-EINVAL, "invalid command json", empty);
+  default:
+    assert(retval == 0);
+    ceph_assert(hook);
+  }
+
+  auto hook_sign_off = make_scope_guard([&] {
+    std::unique_lock l(lock);
+    in_hook = false;
+    in_hook_cond.notify_all();
+  });
+
+  Formatter* f = nullptr;
   if (!output.empty()) {
     if (!(format == "json" || format == "json-pretty")) {
       return on_finish(-EINVAL, "unsupported format for --output-file", empty);
@@ -561,24 +580,15 @@ void AdminSocket::execute_command(
     }
     f = jff;
   } else {
-    f = Formatter::create(format, "json-pretty", "json-pretty");
+    if (format.empty() && (hook->flags & AdminSocket::flag_t::accepts_null_formatter)) {
+      // Hook is ok with formatter null
+    } else {
+      // Rescue formatter for hooks that need formatter set (most of them)
+      f = Formatter::create(format, "json-pretty", "json-pretty");
+    }
   }
 
-  auto [retval, hook] = find_matched_hook(prefix, cmdmap);
-  switch (retval) {
-  case ENOENT:
-    lderr(m_cct) << "AdminSocket: request '" << cmdvec
-		 << "' not defined" << dendl;
-    delete f;
-    return on_finish(-EINVAL, "unknown command prefix "s + prefix, empty);
-  case EINVAL:
-    delete f;
-    return on_finish(-EINVAL, "invalid command json", empty);
-  default:
-    assert(retval == 0);
-  }
-
-  hook->call_async(
+  hook->hook->call_async(
     prefix, cmdmap, f, inbl,
     [f, output, on_finish, m_cct=m_cct](int r, std::string_view err, bufferlist& out) {
       // handle either existing output in bufferlist *or* via formatter
@@ -605,13 +615,9 @@ void AdminSocket::execute_command(
       delete f;
       on_finish(r, err, out);
     });
-
-  std::unique_lock l(lock);
-  in_hook = false;
-  in_hook_cond.notify_all();
 }
 
-std::pair<int, AdminSocketHook*>
+std::pair<int, const AdminSocket::hook_info*>
 AdminSocket::find_matched_hook(std::string& prefix,
 			       const cmdmap_t& cmdmap)
 {
@@ -629,7 +635,7 @@ AdminSocket::find_matched_hook(std::string& prefix,
   for (auto hook = hooks_begin; hook != hooks_end; ++hook) {
     if (validate_cmd(hook->second.desc, cmdmap, errss)) {
       in_hook = true;
-      return {0, hook->second.hook};
+      return {0, &hook->second};
     }
   }
   return {EINVAL, nullptr};
@@ -652,7 +658,8 @@ void AdminSocket::queue_tell_command(cref_t<MMonCommand> m)
 
 int AdminSocket::register_command(std::string_view cmddesc,
 				  AdminSocketHook *hook,
-				  std::string_view help)
+				  std::string_view help,
+                                  flag_t flags)
 {
   int ret;
   std::unique_lock l(lock);
@@ -670,7 +677,7 @@ int AdminSocket::register_command(std::string_view cmddesc,
     hooks.emplace_hint(i,
 		       std::piecewise_construct,
 		       std::forward_as_tuple(prefix),
-		       std::forward_as_tuple(hook, cmddesc, help));
+		       std::forward_as_tuple(hook, cmddesc, help, flags));
     ret = 0;
   }
   return ret;

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -124,6 +124,11 @@ public:
   AdminSocket(AdminSocket&&) = delete;
   AdminSocket& operator =(AdminSocket&&) = delete;
 
+/// Specifies requirements for AdminSocketHook registration / invocation
+  enum flag_t : uint8_t {
+    baseline_default = 0,        /// default behaviours apply
+    accepts_null_formatter = 1   /// do not create fallback formatter (json-pretty)
+  };
   /**
    * register an admin socket command
    *
@@ -145,7 +150,8 @@ public:
    */
   int register_command(std::string_view cmddesc,
 		       AdminSocketHook *hook,
-		       std::string_view help);
+		       std::string_view help,
+                       flag_t flags = flag_t::baseline_default);
 
   /*
    * unregister all commands belong to hook.
@@ -210,14 +216,15 @@ private:
     AdminSocketHook* hook;
     std::string desc;
     std::string help;
+    AdminSocket::flag_t flags;
 
     hook_info(AdminSocketHook* hook, std::string_view desc,
-	      std::string_view help)
-      : hook(hook), desc(desc), help(help) {}
+	      std::string_view help, flag_t flags)
+      : hook(hook), desc(desc), help(help), flags(flags) {}
   };
 
   /// find the first hook which matches the given prefix and cmdmap
-  std::pair<int, AdminSocketHook*> find_matched_hook(
+  std::pair<int, const hook_info*> find_matched_hook(
     std::string& prefix,
     const cmdmap_t& cmdmap);
 

--- a/src/kv/rocksdb_cache/BinnedLRUCache.cc
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.cc
@@ -333,12 +333,13 @@ void BinnedLRUCacheShard::ClearStats() {
   }
 }
 
-void BinnedLRUCacheShard::print_bins(std::stringstream& out) const
+void BinnedLRUCacheShard::get_age_bins(std::vector<uint64_t>& bins) const
 {
+  bins.clear();
+  bins.reserve(age_bins.size());
   for (const auto& i : age_bins) {
-    out << *i << " ";
+    bins.push_back(*i);
   }
-  out << std::endl;
 }
 
 void BinnedLRUCacheShard::SetStrictCapacityLimit(bool strict_capacity_limit) {
@@ -580,7 +581,7 @@ public:
     if (admin_socket) {
       int r = admin_socket->register_command(
         std::string("rocksdb show cache ") + cache.name + std::string(" name=shard_no,type=CephInt,req=false"),
-        this, "show details of cache " + cache.name);
+        this, "show details of cache " + cache.name, AdminSocket::flag_t::accepts_null_formatter);
       if (r != 0) {
         dout(1) << __func__ << " cannot register SocketHook" << dendl;
         return;
@@ -609,21 +610,54 @@ public:
       int64_t shard_no;
       std::stringstream outstr;
       if (!ceph::common::cmd_getval(cmdmap, "shard_no", shard_no)) {
-        outstr << fmt::format("{:>5}", "shard");
-        for (int j = 0; j < stat_cnt; j++) {
-          outstr << fmt::format("{:>10}", ShardStats::stat_name[j]);
-        }
-        outstr << std::endl;
-        for (int i = 0; i < cache.num_shards_; i++) {
-          outstr << fmt::format("{:>5}", i);
-          ShardStats s = cache.shards_[i].GetStats();
+        if (f == nullptr) {
+          // human readable output
+          outstr << fmt::format("{:>5}", "shard");
           for (int j = 0; j < stat_cnt; j++) {
-            outstr << fmt::format("{:>10}", s[j]);
+            outstr << fmt::format("{:>10}", ShardStats::stat_name[j]);
           }
           outstr << std::endl;
+          for (int i = 0; i < cache.num_shards_; i++) {
+            outstr << fmt::format("{:>5}", i);
+            ShardStats s = cache.shards_[i].GetStats();
+            for (int j = 0; j < stat_cnt; j++) {
+              outstr << fmt::format("{:>10}", s[j]);
+            }
+            outstr << std::endl;
+          }
+        } else {
+          // formatted output
+          f->open_array_section("cache_shards_stats");
+          for (int i = 0; i < cache.num_shards_; i++) {
+            f->open_object_section(std::to_string(i));
+            ShardStats s = cache.shards_[i].GetStats();
+            f->dump_int("shard", i);
+            for (int j = 0; j < stat_cnt; j++) {
+              f->dump_int(ShardStats::stat_name[j], s[j]);
+            }
+            f->close_section();
+          }
+          f->close_section();
         }
       } else {
-        cache.printshard(shard_no, outstr);
+        std::vector<uint64_t> age_bins;
+        cache.get_age_bins(shard_no, age_bins);
+        if (f == nullptr) {
+          outstr << "age bins for shard " << shard_no << " (newest first):" << std::endl;
+          for (const auto& i : age_bins) {
+            outstr << i << " ";
+          }
+          outstr << std::endl;
+        } else {
+          f->open_object_section("age_bins_for_shard");
+          f->dump_int("shard_no", shard_no);
+          f->open_array_section("age_bins");
+          for (const auto& i : age_bins) {
+            f->dump_int("bin", i);
+          }
+          f->close_section();
+          f->close_section();
+        }
       }
       out.append(outstr.str());
     } else if(command == std::string("rocksdb reset cache ") + cache.name) {
@@ -840,9 +874,9 @@ void BinnedLRUCache::UpdatePerfCounters() {
   prev_stats = stats;
 }
 
-void BinnedLRUCache::printshard(int shard_no, std::stringstream& out) {
+void BinnedLRUCache::get_age_bins(int shard_no, std::vector<uint64_t>& bins) {
   if (shard_no < num_shards_) {
-    shards_[shard_no].print_bins(out);
+    shards_[shard_no].get_age_bins(bins);
   }
 }
 

--- a/src/kv/rocksdb_cache/BinnedLRUCache.h
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.h
@@ -297,8 +297,7 @@ class alignas(CACHE_LINE_SIZE) BinnedLRUCacheShard : public CacheShard {
 
   ShardStats GetStats();
   void ClearStats();
-  void print_bins(std::stringstream& out) const;
-
+  void get_age_bins(std::vector<uint64_t>& bins) const;
  private:
   CephContext *cct;
   void LRU_Remove(BinnedLRUHandle* e);
@@ -417,7 +416,7 @@ class BinnedLRUCache : public ShardedCache {
  private:
   void SetupPerfCounters();
   void UpdatePerfCounters();
-  void printshard(int shard_no, std::stringstream& out);
+  void get_age_bins(int shard_no, std::vector<uint64_t>& bins);
  private:
   CephContext *cct;
   std::string name;


### PR DESCRIPTION
This work is based on #64819.

The problem addressed here is that I wanted to have 2 modes of output for admin socket hook:
- formatted
- human readable

Unfortunately, I was always getting `Formatter* f` initialized.
The solution was to extent interface of `AdminSocket::register_command` to pass a flag that effectively changed admin socket daemon behaviour - with `accepts_null_formatter` flag ON, it no longer felt obligated to create json-pretty formatter for me.

The change is transparent in the sense that other `register_command` invocations do not need to be textually modified.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
