### PR TITLE
mgr/dashboard: sanitize HTML content for toasts and notifications

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -405,7 +405,7 @@
 
       <cd-form-button-panel (submitActionEvent)="submit()"
                             [form]="formDir"
-                            [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                            [submitText]="'Save'"
                             wrappingClass="text-right"></cd-form-button-panel>
 
     </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -1148,7 +1148,7 @@
       <cd-form-button-panel
         (submitActionEvent)="submit()"
         [form]="form"
-        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+        [submitText]="'Save'"
         wrappingClass="text-right form-button"
       >
       </cd-form-button-panel>


### PR DESCRIPTION
Sanitizes HTML content used in dashboard toast messages and notifications
before passing it to Carbon components. This avoids unsafe usage of
`innerHTML` and ensures that only sanitized HTML is rendered in the UI.

## Bug reference

Fixes: https://tracker.ceph.com/issues/74770
