### PR TITLE
mon, osd, crimson/osd: cluster_osdmap_trim_lower_bound set to min_last_epoch_started

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1131,12 +1131,15 @@ seastar::future<MessageURef> OSD::get_stats()
     return pg_shard_manager.get_pg_stats();
   }).then([this, m=std::move(m)](auto &&stats) mutable {
     min_last_epoch_clean = osdmap->get_epoch();
-    min_last_epoch_clean_pgs.clear();
+    min_last_epoch_started = osdmap->get_epoch();
+    pgs_for_beacon.clear();
     std::set<int64_t> pool_set;
     for (auto [pgid, stat] : stats) {
       min_last_epoch_clean = std::min(min_last_epoch_clean,
                                       stat.get_effective_last_epoch_clean());
-      min_last_epoch_clean_pgs.push_back(pgid);
+      min_last_epoch_started = std::min(min_last_epoch_started,
+                                        stat.get_effective_last_epoch_started());
+      pgs_for_beacon.push_back(pgid);
       int64_t pool_id = pgid.pool();
       pool_set.emplace(pool_id);
     }
@@ -1640,9 +1643,10 @@ seastar::future<> OSD::send_beacon()
   }
   auto beacon = crimson::make_message<MOSDBeacon>(osdmap->get_epoch(),
                                     min_last_epoch_clean,
+                                    min_last_epoch_started,
                                     superblock.last_purged_snaps_scrub,
                                     local_conf()->osd_beacon_report_interval);
-  beacon->pgs = min_last_epoch_clean_pgs;
+  beacon->pgs = pgs_for_beacon;
   DEBUG("{}", *beacon);
   return monc->send_message(std::move(beacon));
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -538,6 +538,9 @@ seastar::future<> OSD::start()
     if (!superblock.cluster_osdmap_trim_lower_bound) {
       superblock.cluster_osdmap_trim_lower_bound = superblock.get_oldest_map();
     }
+    if (!superblock.cluster_oldest_map) {
+      superblock.cluster_oldest_map = superblock.get_oldest_map();
+    }
     return pg_shard_manager.set_superblock(superblock);
   }).then([this] {
     return pg_shard_manager.get_local_map(superblock.current_epoch);
@@ -913,6 +916,7 @@ void OSD::dump_status(Formatter* f) const
   f->dump_stream("newest_map") << superblock.get_newest_map();
   f->dump_unsigned("cluster_osdmap_trim_lower_bound",
                    superblock.cluster_osdmap_trim_lower_bound);
+  f->dump_unsigned("cluster_oldest_map", superblock.cluster_oldest_map);
   f->dump_unsigned("num_pgs", pg_shard_manager.get_num_pgs());
 }
 
@@ -921,6 +925,7 @@ void OSD::print(std::ostream& out) const
   out << "{osd." << superblock.whoami << " "
       << superblock.osd_fsid << " maps " << superblock.get_maps()
       << " tlb:" << superblock.cluster_osdmap_trim_lower_bound
+      << " cluster_oldest_map:" << superblock.cluster_oldest_map
       << " pgs:" << pg_shard_manager.get_num_pgs()
       << "}";
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1216,9 +1216,10 @@ seastar::future<> OSD::_handle_osd_map(Ref<MOSDMap> m)
 
   const auto first = m->get_first();
   const auto last = m->get_last();
-  INFO(" epochs [{}..{}], i have {}, src has [{}..{}]",
+  INFO(" epochs [{}..{}], i have {}, src has [{}..{}], trim_lower_bound {}",
        first, last, superblock.get_newest_map(),
-       m->cluster_osdmap_trim_lower_bound, m->newest_map);
+       m->oldest_map, m->newest_map,
+       m->cluster_osdmap_trim_lower_bound);
 
   if (superblock.cluster_osdmap_trim_lower_bound <
       m->cluster_osdmap_trim_lower_bound) {
@@ -1239,16 +1240,16 @@ seastar::future<> OSD::_handle_osd_map(Ref<MOSDMap> m)
   if (first > start) {
     INFO("message skips epochs {}..{}",
 	 start, first - 1);
-    if (m->cluster_osdmap_trim_lower_bound <= start) {
+    if (m->oldest_map <= start) {
       co_return co_await get_shard_services().osdmap_subscribe(start, false);
     }
     // always try to get the full range of maps--as many as we can.  this
     //  1- is good to have
     //  2- is at present the only way to ensure that we get a *full* map as
     //     the first map!
-    if (m->cluster_osdmap_trim_lower_bound < first) {
+    if (m->oldest_map < first) {
       co_return co_await get_shard_services().osdmap_subscribe(
-        m->cluster_osdmap_trim_lower_bound - 1, true);
+        m->oldest_map - 1, true);
     }
   }
 
@@ -1264,6 +1265,7 @@ seastar::future<> OSD::_handle_osd_map(Ref<MOSDMap> m)
 
   superblock.insert_osdmap_epochs(first, last);
   superblock.current_epoch = last;
+  superblock.cluster_oldest_map = m->oldest_map;
 
   // note in the superblock that we were clean thru the prior epoch
   if (boot_epoch && boot_epoch >= superblock.mounted) {

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -107,8 +107,9 @@ class OSD final : public crimson::net::Dispatcher,
   // mgr::WithStats methods
   // pg statistics including osd ones
   epoch_t min_last_epoch_clean = 0;
+  epoch_t min_last_epoch_started = 0;
   // which pgs were scanned for min_lec
-  std::vector<pg_t> min_last_epoch_clean_pgs;
+  std::vector<pg_t> pgs_for_beacon;
   void update_stats();
   seastar::future<MessageURef> get_stats() final;
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -575,6 +575,10 @@ public:
     return shard_services.get_osdmap_tlb();
   }
 
+  epoch_t cluster_oldest_map() final {
+    return shard_services.get_cluster_oldest_map();
+  }
+
   void on_backfill_reserved() final {
     recovery_handler->on_backfill_reserved();
   }

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -862,6 +862,7 @@ seastar::future<MURef<MOSDMap>> OSDSingletonState::build_incremental_map_msg(
                                                       auto &m) {
     m->cluster_osdmap_trim_lower_bound = superblock.cluster_osdmap_trim_lower_bound;
     m->newest_map = superblock.get_newest_map();
+    m->oldest_map = superblock.cluster_oldest_map;
     auto maybe_handle_mapgap = seastar::now();
     if (first < superblock.cluster_osdmap_trim_lower_bound) {
       INFO("cluster osdmap lower bound: {}  > first {}, starting with full map",

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -86,6 +86,10 @@ class PerShardState {
     return per_shard_superblock.cluster_osdmap_trim_lower_bound;
   }
 
+  const epoch_t& get_cluster_oldest_map() {
+    return per_shard_superblock.cluster_oldest_map;
+  }
+
   // Op Management
   OSDOperationRegistry registry;
   OperationThrottler throttler;
@@ -671,6 +675,7 @@ public:
   FORWARD_TO_LOCAL(get_hb_stamps)
   FORWARD_TO_LOCAL(update_shard_superblock)
   FORWARD_TO_LOCAL(get_osdmap_tlb)
+  FORWARD_TO_LOCAL(get_cluster_oldest_map)
 
   FORWARD(pg_created, pg_created, local_state.pg_map)
 

--- a/src/messages/MOSDBeacon.h
+++ b/src/messages/MOSDBeacon.h
@@ -7,11 +7,12 @@
 
 class MOSDBeacon : public PaxosServiceMessage {
 private:
-  static constexpr int HEAD_VERSION = 3;
+  static constexpr int HEAD_VERSION = 4;
   static constexpr int COMPAT_VERSION = 1;
 public:
   std::vector<pg_t> pgs;
   epoch_t min_last_epoch_clean = 0;
+  epoch_t min_last_epoch_started = 0;
   utime_t last_purged_snaps_scrub;
   int osd_beacon_report_interval = 0;
 
@@ -19,10 +20,12 @@ public:
     : PaxosServiceMessage{MSG_OSD_BEACON, 0,
 			  HEAD_VERSION, COMPAT_VERSION}
   {}
-  MOSDBeacon(epoch_t e, epoch_t min_lec, utime_t ls, int interval)
+  MOSDBeacon(
+    epoch_t e, epoch_t min_lec, epoch_t min_les, utime_t ls, int interval)
     : PaxosServiceMessage{MSG_OSD_BEACON, e,
 			  HEAD_VERSION, COMPAT_VERSION},
       min_last_epoch_clean(min_lec),
+      min_last_epoch_started(min_les),
       last_purged_snaps_scrub(ls),
       osd_beacon_report_interval(interval)
   {}
@@ -33,6 +36,9 @@ public:
     encode(min_last_epoch_clean, payload);
     encode(last_purged_snaps_scrub, payload);
     encode(osd_beacon_report_interval, payload);
+    if (header.version >= 4) {
+      encode(min_last_epoch_started, payload);
+    }
   }
   void decode_payload() override {
     auto p = payload.cbegin();
@@ -48,12 +54,18 @@ public:
     } else {
       osd_beacon_report_interval = 0;
     }
+    if (header.version >= 4) {
+      decode(min_last_epoch_started, p);
+    } else {
+      min_last_epoch_started = min_last_epoch_clean;
+    }
   }
   std::string_view get_type_name() const override { return "osd_beacon"; }
   void print(std::ostream &out) const {
     out << get_type_name()
         << "(pgs " << pgs
         << " lec " << min_last_epoch_clean
+        << " lea " << min_last_epoch_started
         << " last_purged_snaps_scrub " << last_purged_snaps_scrub
         << " osd_beacon_report_interval " << osd_beacon_report_interval
         << " v" << version << ")";

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -24,7 +24,7 @@
 
 class MOSDMap final : public Message {
 private:
-  static constexpr int HEAD_VERSION = 4;
+  static constexpr int HEAD_VERSION = 5;
   static constexpr int COMPAT_VERSION = 3;
 
 public:
@@ -51,6 +51,7 @@ public:
    */
   epoch_t cluster_osdmap_trim_lower_bound = 0;
   epoch_t newest_map = 0;
+  epoch_t oldest_map = 0;
 
   epoch_t get_first() const {
     epoch_t e = 0;
@@ -75,7 +76,8 @@ public:
   MOSDMap(const uuid_d &f, const uint64_t features)
     : Message{CEPH_MSG_OSD_MAP, HEAD_VERSION, COMPAT_VERSION},
       fsid(f), encode_features(features),
-      cluster_osdmap_trim_lower_bound(0), newest_map(0) { }
+      cluster_osdmap_trim_lower_bound(0),
+      newest_map(0), oldest_map(0) { }
 private:
   ~MOSDMap() final {}
 public:
@@ -97,6 +99,11 @@ public:
       // removed in octopus
       mempool::osdmap::map<int64_t,snap_interval_set_t> gap_removed_snaps;
       decode(gap_removed_snaps, p);
+    }
+    if (header.version >= 5) {
+      decode(oldest_map, p);
+    } else {
+      oldest_map = cluster_osdmap_trim_lower_bound;
     }
   }
   void encode_payload(uint64_t features) override {
@@ -162,14 +169,18 @@ public:
     if (header.version >= 4) {
       encode((uint32_t)0, payload);
     }
+    if (header.version >= 5) {
+      encode(oldest_map, payload);
+    }
   }
 
   std::string_view get_type_name() const override { return "osdmap"; }
   void print(std::ostream& out) const override {
     out << "osd_map(" << get_first() << ".." << get_last();
-    if (cluster_osdmap_trim_lower_bound || newest_map)
-      out << " src has " << cluster_osdmap_trim_lower_bound
-          << ".." << newest_map;
+    if (oldest_map || newest_map)
+      out << " src has " << oldest_map
+          << ".." << newest_map
+          << " tlb=" << cluster_osdmap_trim_lower_bound;
     out << ")";
   }
 private:

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2935,6 +2935,7 @@ bool OSDMonitor::preprocess_get_osdmap(MonOpRequestRef op)
   }
   reply->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
   reply->newest_map = last;
+  reply->oldest_map = first;
   mon.send_reply(op, reply);
   return true;
 }
@@ -4552,6 +4553,7 @@ MOSDMap *OSDMonitor::build_latest_full(uint64_t features)
   get_version_full(osdmap.get_epoch(), features, r->maps[osdmap.get_epoch()]);
   r->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
   r->newest_map = osdmap.get_epoch();
+  r->oldest_map = get_first_committed();
   return r;
 }
 
@@ -4562,6 +4564,7 @@ MOSDMap *OSDMonitor::build_incremental(epoch_t from, epoch_t to, uint64_t featur
   MOSDMap *m = new MOSDMap(mon.monmap->fsid, features);
   m->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
   m->newest_map = osdmap.get_epoch();
+  m->oldest_map = get_first_committed();
 
   for (epoch_t e = to; e >= from && e > 0; e--) {
     bufferlist bl;
@@ -4640,6 +4643,7 @@ void OSDMonitor::send_incremental(epoch_t first,
     MOSDMap *m = new MOSDMap(osdmap.get_fsid(), features);
     m->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
     m->newest_map = osdmap.get_epoch();
+    m->oldest_map = get_first_committed();
 
     first = get_first_committed();
     bufferlist bl;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -364,53 +364,82 @@ bool is_unmanaged_snap_op_permitted(CephContext* cct,
 
 } // anonymous namespace
 
-void LastEpochClean::Lec::report(unsigned pg_num, ps_t ps,
-				 epoch_t last_epoch_clean)
+void LastEpochCleanStarted::Lecs::report(
+  unsigned pg_num, ps_t ps,
+  epoch_t last_epoch_clean,
+  epoch_t last_epoch_started)
 {
   if (ps >= pg_num) {
     // removed PG
     return;
   }
-  epoch_by_pg.resize(pg_num, 0);
-  const auto old_lec = epoch_by_pg[ps];
-  if (old_lec >= last_epoch_clean) {
-    // stale lec
-    return;
+  epoch_by_pg.resize(pg_num, {0, 0});
+  const auto old_lecs = epoch_by_pg[ps];
+  if (old_lecs.last_epoch_clean < last_epoch_clean) {
+    epoch_by_pg[ps].last_epoch_clean = last_epoch_clean;
+    if (last_epoch_clean < clean_floor) {
+      clean_floor = last_epoch_clean;
+    } else if (last_epoch_clean > clean_floor) {
+      if (old_lecs.last_epoch_clean == clean_floor) {
+        // probably should increase floor?
+        auto new_floor = std::min_element(
+          std::begin(epoch_by_pg),
+          std::end(epoch_by_pg),
+          [](const auto &l, const auto &r) {
+            return l.last_epoch_clean < r.last_epoch_clean;
+          });
+        clean_floor = new_floor->last_epoch_clean;
+      }
+    }
   }
-  epoch_by_pg[ps] = last_epoch_clean;
-  if (last_epoch_clean < floor) {
-    floor = last_epoch_clean;
-  } else if (last_epoch_clean > floor) {
-    if (old_lec == floor) {
-      // probably should increase floor?
-      auto new_floor = std::min_element(std::begin(epoch_by_pg),
-					std::end(epoch_by_pg));
-      floor = *new_floor;
+  if (old_lecs.last_epoch_started < last_epoch_started) {
+    epoch_by_pg[ps].last_epoch_started = last_epoch_started;
+    if (last_epoch_started < started_floor) {
+      started_floor = last_epoch_started;
+    } else if (last_epoch_started > started_floor) {
+      if (old_lecs.last_epoch_started == started_floor) {
+        // probably should increase floor?
+        auto new_floor = std::min_element(
+          std::begin(epoch_by_pg),
+          std::end(epoch_by_pg),
+          [](const auto &l, const auto &r) {
+            return l.last_epoch_started < r.last_epoch_started;
+          });
+        started_floor = new_floor->last_epoch_started;
+      }
     }
   }
   if (ps != next_missing) {
     return;
   }
   for (; next_missing < epoch_by_pg.size(); next_missing++) {
-    if (epoch_by_pg[next_missing] == 0) {
+    if (epoch_by_pg[next_missing].last_epoch_clean == 0 ||
+        epoch_by_pg[next_missing].last_epoch_started == 0) {
       break;
     }
   }
 }
 
-void LastEpochClean::remove_pool(uint64_t pool)
+void LastEpochCleanStarted::remove_pool(uint64_t pool)
 {
   report_by_pool.erase(pool);
 }
 
-void LastEpochClean::report(unsigned pg_num, const pg_t& pg,
-			    epoch_t last_epoch_clean)
+void LastEpochCleanStarted::report(
+  unsigned pg_num,
+  const pg_t& pg,
+  epoch_t last_epoch_clean,
+  epoch_t last_epoch_started)
 {
   auto& lec = report_by_pool[pg.pool()];
-  return lec.report(pg_num, pg.ps(), last_epoch_clean);
+  return lec.report(
+    pg_num, pg.ps(),
+    last_epoch_clean,
+    last_epoch_started);
 }
 
-epoch_t LastEpochClean::get_lower_bound_by_pool(const OSDMap& latest) const
+epoch_t LastEpochCleanStarted::get_started_lower_bound_by_pool(
+  const OSDMap& latest) const
 {
   auto floor = latest.get_epoch();
   for (auto& pool : latest.get_pools()) {
@@ -421,21 +450,41 @@ epoch_t LastEpochClean::get_lower_bound_by_pool(const OSDMap& latest) const
     if (reported->second.next_missing < pool.second.get_pg_num()) {
       return 0;
     }
-    if (reported->second.floor < floor) {
-      floor = reported->second.floor;
+    if (reported->second.started_floor < floor) {
+      floor = reported->second.started_floor;
     }
   }
   return floor;
 }
 
-void LastEpochClean::dump(Formatter *f) const
+epoch_t LastEpochCleanStarted::get_clean_lower_bound_by_pool(
+  const OSDMap& latest) const
+{
+  auto floor = latest.get_epoch();
+  for (auto& pool : latest.get_pools()) {
+    auto reported = report_by_pool.find(pool.first);
+    if (reported == report_by_pool.end()) {
+      return 0;
+    }
+    if (reported->second.next_missing < pool.second.get_pg_num()) {
+      return 0;
+    }
+    if (reported->second.clean_floor < floor) {
+      floor = reported->second.clean_floor;
+    }
+  }
+  return floor;
+}
+
+void LastEpochCleanStarted::dump(Formatter *f) const
 {
   f->open_array_section("per_pool");
 
   for (auto& [pool, lec] : report_by_pool) {
     f->open_object_section("pool");
     f->dump_unsigned("poolid", pool);
-    f->dump_unsigned("floor", lec.floor);
+    f->dump_unsigned("clean_floor", lec.clean_floor);
+    f->dump_unsigned("started_floor", lec.started_floor);
     f->close_section();
   }
 
@@ -1000,6 +1049,9 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
   } else {
     mon.try_disable_stretch_mode();
   }
+  auto tlb = mon.store->get(get_service_name(), cluster_osdmap_tlb_name);
+  ceph_assert(tlb >= cluster_osdmap_trim_lower_bound);
+  cluster_osdmap_trim_lower_bound = tlb;
 }
 
 int OSDMonitor::register_cache_with_pcm()
@@ -1234,7 +1286,7 @@ OSDMonitor::update_pending_pgs(const OSDMap::Incremental& inc,
       dout(10) << __func__ << " " << removed
                << " pg removed because containing pool deleted: "
                << deleted_pool << dendl;
-      last_epoch_clean.remove_pool(deleted_pool);
+      last_epoch_clean_started.remove_pool(deleted_pool);
     }
     // pgmon updates its creating_pgs in check_osd_map() which is called by
     // on_active() and check_osd_map() could be delayed if lease expires, so its
@@ -2294,18 +2346,44 @@ version_t OSDMonitor::get_trim_to() const
   return 0;
 }
 
+epoch_t OSDMonitor::get_cluster_trim_lower_bound() const {
+  epoch_t floor = get_min_last_epoch_started();
+  unsigned min = g_conf()->mon_min_osdmap_epochs;
+  if (floor + min > get_last_committed()) {
+    if (min < get_last_committed())
+      floor = get_last_committed() - min;
+    else
+      floor = 0;
+  }
+  dout(10) << __func__ << " cluster_trim_lower_bound = " << floor << dendl;
+  return floor;
+}
+
 /* There are two constraints on trimming:
  * 1. we must not trim past the last_epoch_clean for any pg
  * 2. we must not trim past the last reported epoch for any up
  *    osds.
  *
- * LastEpochClean::get_lower_bound_by_pool gives a value <= constraint 1.
- * For constraint 2, we take the min over osd_epochs, which is populated with
- * MOSDBeacon::version, see OSDMonitor::prepare_beacon
+ * LastEpochCleanStarted::get_clean_lower_bound_by_pool gives
+ * a value <= constraint 1. For constraint 2, we take the min
+ * over osd_epochs, which is populated with MOSDBeacon::version,
+ * see OSDMonitor::prepare_beacon
  */
 epoch_t OSDMonitor::get_min_last_epoch_clean() const
 {
-  auto floor = last_epoch_clean.get_lower_bound_by_pool(osdmap);
+  auto floor = last_epoch_clean_started.get_clean_lower_bound_by_pool(osdmap);
+  for (auto [osd, epoch] : osd_epochs) {
+    if (epoch < floor) {
+      ceph_assert(osdmap.is_up(osd));
+      floor = epoch;
+    }
+  }
+  return floor;
+}
+
+epoch_t OSDMonitor::get_min_last_epoch_started() const
+{
+  auto floor = last_epoch_clean_started.get_started_lower_bound_by_pool(osdmap);
   for (auto [osd, epoch] : osd_epochs) {
     if (epoch < floor) {
       ceph_assert(osdmap.is_up(osd));
@@ -2855,7 +2933,7 @@ bool OSDMonitor::preprocess_get_osdmap(MonOpRequestRef op)
     ceph_assert(r >= 0);
     max_bytes -= bl.length();
   }
-  reply->cluster_osdmap_trim_lower_bound = first;
+  reply->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
   reply->newest_map = last;
   mon.send_reply(op, reply);
   return true;
@@ -4433,7 +4511,10 @@ bool OSDMonitor::prepare_beacon(MonOpRequestRef op)
   for (const auto& pg : beacon->pgs) {
     if (auto* pool = osdmap.get_pg_pool(pg.pool()); pool != nullptr) {
       unsigned pg_num = pool->get_pg_num();
-      last_epoch_clean.report(pg_num, pg, beacon->min_last_epoch_clean);
+      last_epoch_clean_started.report(
+        pg_num, pg,
+        beacon->min_last_epoch_clean,
+        beacon->min_last_epoch_started);
     }
   }
 
@@ -4469,7 +4550,7 @@ MOSDMap *OSDMonitor::build_latest_full(uint64_t features)
 {
   MOSDMap *r = new MOSDMap(mon.monmap->fsid, features);
   get_version_full(osdmap.get_epoch(), features, r->maps[osdmap.get_epoch()]);
-  r->cluster_osdmap_trim_lower_bound = get_first_committed();
+  r->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
   r->newest_map = osdmap.get_epoch();
   return r;
 }
@@ -4479,7 +4560,7 @@ MOSDMap *OSDMonitor::build_incremental(epoch_t from, epoch_t to, uint64_t featur
   dout(10) << "build_incremental [" << from << ".." << to << "] with features "
 	   << std::hex << features << std::dec << dendl;
   MOSDMap *m = new MOSDMap(mon.monmap->fsid, features);
-  m->cluster_osdmap_trim_lower_bound = get_first_committed();
+  m->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
   m->newest_map = osdmap.get_epoch();
 
   for (epoch_t e = to; e >= from && e > 0; e--) {
@@ -4557,7 +4638,7 @@ void OSDMonitor::send_incremental(epoch_t first,
 
   if (first < get_first_committed()) {
     MOSDMap *m = new MOSDMap(osdmap.get_fsid(), features);
-    m->cluster_osdmap_trim_lower_bound = get_first_committed();
+    m->cluster_osdmap_trim_lower_bound = cluster_osdmap_trim_lower_bound;
     m->newest_map = osdmap.get_epoch();
 
     first = get_first_committed();
@@ -5142,6 +5223,12 @@ void OSDMonitor::tick()
 
   if (!mon.is_leader()) return;
 
+  if (auto tlb = get_cluster_trim_lower_bound();
+      tlb > cluster_osdmap_trim_lower_bound) {
+    auto t = paxos.get_pending_transaction();
+    put_cluster_osdmap_trim_lower_bound(t, tlb);
+  }
+
   bool do_propose = false;
   utime_t now = ceph_clock_now();
 
@@ -5385,9 +5472,10 @@ void OSDMonitor::dump_info(Formatter *f)
 
   f->open_object_section("osdmap_clean_epochs");
   f->dump_unsigned("min_last_epoch_clean", get_min_last_epoch_clean());
+  f->dump_unsigned("min_last_epoch_started", get_min_last_epoch_clean());
 
-  f->open_object_section("last_epoch_clean");
-  last_epoch_clean.dump(f);
+  f->open_object_section("last_epoch_clean_started");
+  last_epoch_clean_started.dump(f);
   f->close_section();
 
   f->open_array_section("osd_epochs");

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -103,24 +103,45 @@ struct failure_info_t {
 };
 
 
-class LastEpochClean {
-  struct Lec {
-    std::vector<epoch_t> epoch_by_pg;
-    ps_t next_missing = 0;
-    epoch_t floor = std::numeric_limits<epoch_t>::max();
-    void report(unsigned pg_num, ps_t pg, epoch_t last_epoch_clean);
+class LastEpochCleanStarted {
+  struct clean_started_epoch_t {
+    epoch_t last_epoch_clean = 0;
+    epoch_t last_epoch_started = 0;
   };
-  std::map<uint64_t, Lec> report_by_pool;
+  struct Lecs {
+    std::vector<clean_started_epoch_t> epoch_by_pg;
+    ps_t next_missing = 0;
+    epoch_t clean_floor = std::numeric_limits<epoch_t>::max();
+    epoch_t started_floor = std::numeric_limits<epoch_t>::max();
+    void report(
+      unsigned pg_num,
+      ps_t pg,
+      epoch_t last_epoch_clean,
+      epoch_t last_epoch_started);
+  };
+  std::map<uint64_t, Lecs> report_by_pool;
 public:
-  void report(unsigned pg_num, const pg_t& pg, epoch_t last_epoch_clean);
+  void report(
+    unsigned pg_num,
+    const pg_t& pg,
+    epoch_t last_epoch_clean,
+    epoch_t last_epoch_started);
   void remove_pool(uint64_t pool);
   /**
-   * get_lower_bound_by_pool
+   * get_clean_lower_bound_by_pool
    *
    * Returns epoch e such that e <= pg.last_epoch_clean for all pgs in cluster.
    * May return 0 if any pool does not have comprehensive values for all pgs.
   */
-  epoch_t get_lower_bound_by_pool(const OSDMap& latest) const;
+  epoch_t get_clean_lower_bound_by_pool(const OSDMap& latest) const;
+
+  /**
+   * get_started_lower_bound_by_pool
+   *
+   * The same as get_clean_lower_bound_by_pool with the only difference
+   * that it returns the lower bound of last_epoch_started
+   */
+  epoch_t get_started_lower_bound_by_pool(const OSDMap& latest) const;
 
   void dump(Formatter *f) const;
 };
@@ -403,6 +424,7 @@ private:
   bool should_propose(double &delay) override;
 
   version_t get_trim_to() const override;
+  epoch_t get_cluster_trim_lower_bound() const;
 
   bool can_mark_down(int o);
   bool can_mark_up(int o);
@@ -647,6 +669,13 @@ public:
   void count_metadata(const std::string& field, std::map<std::string,int> *out);
   void get_versions(std::map<std::string, std::list<std::string>> &versions);
 protected:
+  const std::string cluster_osdmap_tlb_name;
+  void put_cluster_osdmap_trim_lower_bound(
+    MonitorDBStore::TransactionRef t,
+    version_t ver)
+  {
+    t->put(get_service_name(), cluster_osdmap_tlb_name, ver);
+  }
   int get_osd_objectstore_type(int osd, std::string *type);
   bool is_pool_currently_all_bluestore(int64_t pool_id, const pg_pool_t &pool,
 				       std::ostream *err);
@@ -666,10 +695,11 @@ protected:
     * need to upgrade from pre-luminous releases.
     */
   std::map<int,epoch_t> osd_epochs;
-  LastEpochClean last_epoch_clean;
+  LastEpochCleanStarted last_epoch_clean_started;
   bool preprocess_beacon(MonOpRequestRef op);
   bool prepare_beacon(MonOpRequestRef op);
   epoch_t get_min_last_epoch_clean() const;
+  epoch_t get_min_last_epoch_started() const;
 
   friend class C_UpdateCreatingPGs;
   std::map<int, std::map<epoch_t, std::set<spg_t>>> creating_pgs_by_osd_epoch;
@@ -920,6 +950,7 @@ public:
   int get_replicated_stretch_crush_rule();
 private:
   utime_t stretch_recovery_triggered; // what time we committed a switch to recovery mode
+  version_t cluster_osdmap_trim_lower_bound = 0;
 };
 
 #endif

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7365,9 +7365,10 @@ void OSD::send_beacon(const ceph::coarse_mono_clock::time_point& now)
       std::lock_guard l{min_last_epoch_clean_lock};
       beacon = new MOSDBeacon(get_osdmap_epoch(),
 			      min_last_epoch_clean,
+                              min_last_epoch_started,
 			      superblock.last_purged_snaps_scrub,
 			      cct->_conf->osd_beacon_report_interval);
-      beacon->pgs = min_last_epoch_clean_pgs;
+      beacon->pgs = pgs_for_beacon;
       last_sent_beacon = now;
     }
     monc->send_mon_message(beacon);
@@ -7895,7 +7896,8 @@ MPGStats* OSD::collect_pg_stats()
 
   std::lock_guard lec{min_last_epoch_clean_lock};
   min_last_epoch_clean = get_osdmap_epoch();
-  min_last_epoch_clean_pgs.clear();
+  min_last_epoch_started = get_osdmap_epoch();
+  pgs_for_beacon.clear();
 
   auto now_is = ceph::coarse_real_clock::now();
 
@@ -7908,10 +7910,13 @@ MPGStats* OSD::collect_pg_stats()
     if (!pg->is_primary()) {
       continue;
     }
-    pg->with_pg_stats(now_is, [&](const pg_stat_t& s, epoch_t lec) {
+    pg->with_pg_stats(
+      now_is,
+      [&](const pg_stat_t& s, epoch_t lec, epoch_t lea) {
 	m->pg_stat[pg->pg_id.pgid] = s;
 	min_last_epoch_clean = std::min(min_last_epoch_clean, lec);
-	min_last_epoch_clean_pgs.push_back(pg->pg_id.pgid);
+	min_last_epoch_started = std::min(min_last_epoch_started, lea);
+	pgs_for_beacon.push_back(pg->pg_id.pgid);
       });
   }
   store_statfs_t st;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3840,6 +3840,9 @@ int OSD::init()
     if (!superblock.cluster_osdmap_trim_lower_bound) {
       superblock.cluster_osdmap_trim_lower_bound = superblock.get_oldest_map();
     }
+    if (!superblock.cluster_oldest_map) {
+      superblock.cluster_oldest_map = superblock.get_oldest_map();
+    }
 
     ObjectStore::Transaction t;
     write_superblock(cct, superblock, t);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1430,6 +1430,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
 			   osdmap->get_encoding_features());
   m->cluster_osdmap_trim_lower_bound = sblock.cluster_osdmap_trim_lower_bound;
   m->newest_map = sblock.get_newest_map();
+  m->oldest_map = sblock.cluster_oldest_map;
 
   int max = cct->_conf->osd_map_message_max;
   ssize_t max_bytes = cct->_conf->osd_map_message_max_bytes;
@@ -8248,8 +8249,9 @@ void OSD::handle_osd_map(MOSDMap *m)
   epoch_t last = m->get_last();
   dout(3) << "handle_osd_map epochs [" << first << "," << last << "], i have "
 	  << superblock.get_newest_map()
-	  << ", src has [" << m->cluster_osdmap_trim_lower_bound
+	  << ", src has [" << m->oldest_map
           << "," << m->newest_map << "]"
+          << ", trim_lower_bound " << m->cluster_osdmap_trim_lower_bound
 	  << dendl;
 
   logger->inc(l_osd_map);
@@ -8290,7 +8292,7 @@ void OSD::handle_osd_map(MOSDMap *m)
   if (first > superblock.get_newest_map() + 1) {
     dout(10) << "handle_osd_map message skips epochs "
 	     << superblock.get_newest_map() + 1 << ".." << (first-1) << dendl;
-    if (m->cluster_osdmap_trim_lower_bound <= superblock.get_newest_map() + 1) {
+    if (m->oldest_map <= superblock.get_newest_map() + 1) {
       osdmap_subscribe(superblock.get_newest_map() + 1, false);
       m->put();
       return;
@@ -8299,8 +8301,8 @@ void OSD::handle_osd_map(MOSDMap *m)
     //  1- is good to have
     //  2- is at present the only way to ensure that we get a *full* map as
     //     the first map!
-    if (m->cluster_osdmap_trim_lower_bound < first) {
-      osdmap_subscribe(m->cluster_osdmap_trim_lower_bound - 1, true);
+    if (m->oldest_map < first) {
+      osdmap_subscribe(m->oldest_map - 1, true);
       m->put();
       return;
     }
@@ -8423,6 +8425,8 @@ void OSD::handle_osd_map(MOSDMap *m)
     rerequest_full_maps();
   }
 
+  ceph_assert(superblock.cluster_oldest_map <= m->oldest_map);
+  superblock.cluster_oldest_map = m->oldest_map;
   track_pools_and_pg_num_changes(added_maps, t);
 
   if (!superblock.is_maps_empty()) {
@@ -8510,7 +8514,7 @@ void OSD::track_pools_and_pg_num_changes(
     lastmap = added_maps.at(first);
   } else {
     if (first > superblock.get_newest_map() + 1) {
-      ceph_assert(first == superblock.cluster_osdmap_trim_lower_bound);
+      ceph_assert(first == superblock.cluster_oldest_map);
       dout(20) << __func__ << " can't get previous map "
                << superblock.get_newest_map()
                << " first start of this osd after a map gap" << dendl;
@@ -8833,7 +8837,7 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
   }
   else if (is_preboot()) {
     if (m->get_source().is_mon())
-      _preboot(m->cluster_osdmap_trim_lower_bound, m->newest_map);
+      _preboot(m->oldest_map, m->newest_map);
     else
       start_boot();
   }
@@ -11359,6 +11363,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, uint32_t shard_index, hea
   if (qi.is_peering()) {
     OSDMapRef osdmap = sdata->shard_osdmap;
     if (qi.get_map_epoch() > osdmap->get_epoch()) {
+      dout(20) << __func__ << " requeuing " << qi << dendl;
       _add_slot_waiter(token, slot, std::move(qi));
       sdata->shard_lock.unlock();
       pg->unlock();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2043,8 +2043,9 @@ protected:
   ceph::coarse_mono_clock::time_point last_sent_beacon;
   ceph::mutex min_last_epoch_clean_lock = ceph::make_mutex("OSD::min_last_epoch_clean_lock");
   epoch_t min_last_epoch_clean = 0;
+  epoch_t min_last_epoch_started = 0;
   // which pgs were scanned for min_lec
-  std::vector<pg_t> min_last_epoch_clean_pgs;
+  std::vector<pg_t> pgs_for_beacon;
   void send_beacon(const ceph::coarse_mono_clock::time_point& now);
   void maybe_send_beacon();
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1349,6 +1349,9 @@ void PG::on_new_interval()
 epoch_t PG::cluster_osdmap_trim_lower_bound() {
   return osd->get_superblock().cluster_osdmap_trim_lower_bound;
 }
+epoch_t PG::cluster_oldest_map() {
+  return osd->get_superblock().cluster_oldest_map;
+}
 
 OstreamTemp PG::get_clog_info() {
   return osd->clog->info();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2442,8 +2442,9 @@ void PG::dump_missing(Formatter *f)
   }
 }
 
-void PG::with_pg_stats(ceph::coarse_real_clock::time_point now_is,
-		       std::function<void(const pg_stat_t&, epoch_t lec)>&& f)
+void PG::with_pg_stats(
+  ceph::coarse_real_clock::time_point now_is,
+  std::function<void(const pg_stat_t&, epoch_t lec, epoch_t les)>&& f)
 {
   dout(30) << __func__ << dendl;
   // possibly update the scrub state & timers
@@ -2456,7 +2457,9 @@ void PG::with_pg_stats(ceph::coarse_real_clock::time_point now_is,
   // now - the actual publishing
   std::lock_guard l{pg_stats_publish_lock};
   if (pg_stats_publish) {
-    f(*pg_stats_publish, pg_stats_publish->get_effective_last_epoch_clean());
+    f(*pg_stats_publish,
+      pg_stats_publish->get_effective_last_epoch_clean(),
+      pg_stats_publish->get_effective_last_epoch_started());
   }
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -583,6 +583,7 @@ public:
   void clear_primary_state() override;
 
   epoch_t cluster_osdmap_trim_lower_bound() override;
+  epoch_t cluster_oldest_map() override;
   OstreamTemp get_clog_error() override;
   OstreamTemp get_clog_info() override;
   OstreamTemp get_clog_debug() override;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -692,8 +692,9 @@ public:
   void dump_pgstate_history(ceph::Formatter *f);
   void dump_missing(ceph::Formatter *f);
 
-  void with_pg_stats(ceph::coarse_real_clock::time_point now_is,
-		     std::function<void(const pg_stat_t&, epoch_t lec)>&& f);
+  void with_pg_stats(
+    ceph::coarse_real_clock::time_point now_is,
+    std::function<void(const pg_stat_t&, epoch_t lec, epoch_t les)>&& f);
   void with_heartbeat_peers(std::function<void(int)>&& f);
 
   void shutdown();

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -776,7 +776,7 @@ void PeeringState::start_peering_interval(
     psdout(10) << ": check_new_interval output: "
 	       << debug.str() << dendl;
     if (new_interval) {
-      if (osdmap->get_epoch() == pl->cluster_osdmap_trim_lower_bound() &&
+      if (osdmap->get_epoch() == pl->cluster_oldest_map() &&
 	  info.history.last_epoch_clean < osdmap->get_epoch()) {
 	psdout(10) << " map gap, clearing past_intervals and faking" << dendl;
 	// our information is incomplete and useless; someone else was clean
@@ -1087,9 +1087,9 @@ void PeeringState::check_past_interval_bounds() const
   if (cct->_conf.get_val<bool>("osd_skip_check_past_interval_bounds")) {
     return;
   }
-  // cluster_osdmap_trim_lower_bound gives us a bound on needed
-  // intervals, see doc/dev/osd_internals/past_intervals.rst
-  auto oldest_epoch = pl->cluster_osdmap_trim_lower_bound();
+  // cluster_oldest_map gives us a bound on needed intervals,
+  // see doc/dev/osd_internals/past_intervals.rst
+  auto oldest_epoch = pl->cluster_oldest_map();
   auto rpib = get_required_past_interval_bounds(
     info,
     oldest_epoch);

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4055,6 +4055,7 @@ void PeeringState::update_calc_stats()
   info.stats.last_deep_scrub_stamp = info.history.last_deep_scrub_stamp;
   info.stats.last_clean_scrub_stamp = info.history.last_clean_scrub_stamp;
   info.stats.last_epoch_clean = info.history.last_epoch_clean;
+  info.stats.last_epoch_started = info.history.last_epoch_started;
 
   info.stats.log_size = pg_log.get_head().version - pg_log.get_tail().version;
   info.stats.log_dups_size = pg_log.get_log().dups.size();

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -421,6 +421,7 @@ public:
     virtual void on_active_actmap() = 0;
     virtual void on_active_advmap(const OSDMapRef &osdmap) = 0;
     virtual epoch_t cluster_osdmap_trim_lower_bound() = 0;
+    virtual epoch_t cluster_oldest_map() = 0;
 
     // ============ recovery reservation notifications ==========
     virtual void on_backfill_reserved() = 0;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2934,6 +2934,7 @@ void pg_stat_t::dump(Formatter *f) const
   f->dump_stream("ondisk_log_start") << ondisk_log_start;
   f->dump_unsigned("created", created);
   f->dump_unsigned("last_epoch_clean", last_epoch_clean);
+  f->dump_unsigned("last_epoch_started", last_epoch_started);
   f->dump_stream("parent") << parent;
   f->dump_unsigned("parent_split_bits", parent_split_bits);
   f->dump_stream("last_scrub") << last_scrub;
@@ -3071,7 +3072,7 @@ bool operator==(const pg_scrubbing_status_t& l, const pg_scrubbing_status_t& r)
 
 void pg_stat_t::encode(ceph::buffer::list &bl) const
 {
-  ENCODE_START(30, 22, bl);
+  ENCODE_START(31, 22, bl);
   encode(version, bl);
   encode(reported_seq, bl);
   encode(reported_epoch, bl);
@@ -3134,6 +3135,7 @@ void pg_stat_t::encode(ceph::buffer::list &bl) const
   encode(scrub_sched_status.m_osd_to_respond, bl);
   encode(scrub_sched_status.m_ordinal_of_requested_replica, bl);
   encode(scrub_sched_status.m_num_to_reserve, bl);
+  encode(last_epoch_started, bl);
 
   ENCODE_FINISH(bl);
 }
@@ -3142,7 +3144,7 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
 {
   bool tmp;
   uint32_t old_state;
-  DECODE_START(30, bl);
+  DECODE_START(31, bl);
   decode(version, bl);
   decode(reported_seq, bl);
   decode(reported_epoch, bl);
@@ -3244,6 +3246,9 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
     } else {
       scrub_sched_status.m_num_to_reserve = 0;
     }
+    if (struct_v >= 31) {
+      decode(last_epoch_started, bl);
+    }
   }
   DECODE_FINISH(bl);
 }
@@ -3271,6 +3276,7 @@ list<pg_stat_t> pg_stat_t::generate_test_instances()
   a.ondisk_log_start = eversion_t(1, 5);
   a.created = 6;
   a.last_epoch_clean = 7;
+  a.last_epoch_started = 6;
   a.parent = pg_t(1, 2);
   a.parent_split_bits = 12;
   a.last_scrub = eversion_t(9, 10);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5926,7 +5926,7 @@ void OSDSuperblock::GuardedMap::decode(ceph::buffer::list::const_iterator &bl)
 
 void OSDSuperblock::encode(ceph::buffer::list &bl) const
 {
-  ENCODE_START(11, 5, bl);
+  ENCODE_START(12, 5, bl);
   encode(cluster_fsid, bl);
   encode(whoami, bl);
   encode(current_epoch, bl);
@@ -5943,12 +5943,13 @@ void OSDSuperblock::encode(ceph::buffer::list &bl) const
   encode(last_purged_snaps_scrub, bl);
   encode(cluster_osdmap_trim_lower_bound, bl);
   mapc.encode(bl);
+  encode(cluster_oldest_map, bl);
   ENCODE_FINISH(bl);
 }
 
 void OSDSuperblock::decode(ceph::buffer::list::const_iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(11, 5, 5, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(12, 5, 5, bl);
   if (struct_v < 3) {
     string magic;
     decode(magic, bl);
@@ -5993,6 +5994,11 @@ void OSDSuperblock::decode(ceph::buffer::list::const_iterator &bl)
   } else {
     insert_osdmap_epochs(oldest_map, newest_map);
   }
+  if (struct_v >= 12) {
+    decode(cluster_oldest_map, bl);
+  } else {
+    cluster_oldest_map = cluster_osdmap_trim_lower_bound;
+  }
   DECODE_FINISH(bl);
 }
 
@@ -6012,6 +6018,7 @@ void OSDSuperblock::dump(Formatter *f) const
   f->dump_stream("last_purged_snaps_scrub") << last_purged_snaps_scrub;
   f->dump_int("cluster_osdmap_trim_lower_bound",
               cluster_osdmap_trim_lower_bound);
+  f->dump_int("cluster_oldest_map", cluster_oldest_map);
   f->dump_stream("maps") << get_maps();
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2314,6 +2314,7 @@ struct pg_stat_t {
 
   epoch_t created;
   epoch_t last_epoch_clean;
+  epoch_t last_epoch_started;
   pg_t parent;
   __u32 parent_split_bits;
 
@@ -2371,6 +2372,7 @@ struct pg_stat_t {
       reported_epoch(0),
       state(0),
       created(0), last_epoch_clean(0),
+      last_epoch_started(0),
       parent_split_bits(0),
       log_size(0), log_dups_size(0),
       ondisk_log_size(0),
@@ -2398,6 +2400,16 @@ struct pg_stat_t {
       return reported_epoch;
     } else {
       return last_epoch_clean;
+    }
+  }
+
+  epoch_t get_effective_last_epoch_started() const {
+    if (state & PG_STATE_ACTIVE) {
+      // we are clean as of this report, and should thus take the
+      // reported epoch
+      return reported_epoch;
+    } else {
+      return last_epoch_started;
     }
   }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5914,6 +5914,7 @@ public:
   utime_t last_purged_snaps_scrub;
 
   epoch_t cluster_osdmap_trim_lower_bound = 0;
+  epoch_t cluster_oldest_map = 0;
 
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
@@ -5935,6 +5936,7 @@ inline std::ostream& operator<<(std::ostream& out, const OSDSuperblock& sb)
              << " osd." << sb.whoami
 	     << " " << sb.osd_fsid
              << " e" << sb.current_epoch
+             << " cluster_oldest_map e" << sb.cluster_oldest_map
              << " maps " << sb.get_maps()
 	     << " lci=[" << sb.mounted << "," << sb.clean_thru << "]"
              << " tlb=" << sb.cluster_osdmap_trim_lower_bound

--- a/src/test/osd/MockPeeringListener.h
+++ b/src/test/osd/MockPeeringListener.h
@@ -402,6 +402,10 @@ class MockPeeringListener : public PeeringState::PeeringListener {
     return 1;
   }
 
+  epoch_t cluster_oldest_map() override {
+    return 1;
+  }
+
   void on_backfill_suspended() override {
     backfill_suspended = true;
   }


### PR DESCRIPTION
This draft is a POC one for the possibility of setting `cluster_osdmap_trim_lower_bound` to `min_last_epoch_started`.

The motive was that, with `cluster_osdmap_trim_lower_bound` set to `min_last_epoch_clean`, the cluster may accumulate large amounts of osdmsps across pools when some pools in the clusters are experiencing backfills for a relatively long time (maybe weeks/months), which could be cause pools with small-capacity disks to be filled up when the cluster is relatively large.

This draft PR basically intend to trim osdmaps on OSDs by `min_last_epoch_started` while keeping the osdmaps on monitors back to `min_last_epoch_clean`, which leads to newly added fields, `MOSDMap::oldest_map` and `OSDSuperblock::cluster_oldest_map`, to represent the lower bound of osdmaps kept by monitors.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
