### PR TITLE
qa/tasks: avoid podman TTY flake, verify gateway/host creation

### DIFF
--- a/qa/workunits/cephadm/test_iscsi_setup.sh
+++ b/qa/workunits/cephadm/test_iscsi_setup.sh
@@ -39,22 +39,71 @@ ISCSI_POOL=$(sudo cephadm shell -- ceph orch ls iscsi --format json | jq -r '.[]
 ISCSI_USER="adminadmin"
 ISCSI_PASSWORD="adminadminadmin"
 
+ISCSI_INITIATOR_IQN="iqn.1994-05.com.redhat:client1"
+
 # gateway setup
 container_gwcli() {
-    sudo podman exec -it ${ISCSI_CONT_ID} gwcli "$@"
+    sudo podman exec -i ${ISCSI_CONT_ID} gwcli "$@"
 }
+
+# Some helpers to avoid race/flakes and improve debuggability ---
+dump_gwcli_state() {
+    # best-effort debug; do not fail the script from here
+    set +e
+    container_gwcli / ls
+    container_gwcli /iscsi-targets ls
+    container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw ls
+    container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways ls
+    container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts ls
+    set -e
+}
+
+wait_for_ls_contains() {
+    # Usage: wait_for_ls_contains <path> <needle> [retries] [sleep_s]
+    local path="$1"
+    local needle="$2"
+    local retries="${3:-30}"
+    local sleep_s="${4:-1}"
+
+    for ((i=1; i<=retries; i++)); do
+        if container_gwcli "${path}" ls 2>/dev/null | grep -qF "${needle}"; then
+            return 0
+        fi
+        sleep "${sleep_s}"
+    done
+    return 1
+}
+
+# dump gwcli state if anything fails
+trap 'rc=$?; echo "ERROR: script failed with rc=${rc}"; dump_gwcli_state; exit $rc' ERR
 
 container_gwcli /iscsi-targets create iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
 # I've seen this give a nonzero error code with an error message even when
 # creating the gateway successfully, so this command is allowed to fail
 # If it actually failed to make the gateway, some of the follow up commands will fail
 container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways create ${FQDN} ${NODE_IP} || true
+
+# verify gateway shows up
+if ! wait_for_ls_contains /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways "${FQDN}" 30 1; then
+    echo "Gateway ${FQDN} not visible in gwcli after create; failing early."
+    dump_gwcli_state
+    exit 1
+fi
+
 container_gwcli /disks create pool=${ISCSI_POOL} image=disk_1 size=2G
 container_gwcli /disks create pool=${ISCSI_POOL} image=disk_2 size=2G
-container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts create iqn.1994-05.com.redhat:client1
-container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts/iqn.1994-05.com.redhat:client1 auth username=${ISCSI_USER}  password=${ISCSI_PASSWORD}
-container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts/iqn.1994-05.com.redhat:client1 disk add ${ISCSI_POOL}/disk_1
-container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts/iqn.1994-05.com.redhat:client1 disk add ${ISCSI_POOL}/disk_2
+container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts create ${ISCSI_INITIATOR_IQN}
+
+# wait for host to appear before configuring it
+if ! wait_for_ls_contains /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts "${ISCSI_INITIATOR_IQN}" 30 1; then
+    echo "Host ${ISCSI_INITIATOR_IQN} not visible in gwcli after create; failing."
+    dump_gwcli_state
+    exit 1
+fi
+
+container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts/${ISCSI_INITIATOR_IQN} auth username=${ISCSI_USER}  password=${ISCSI_PASSWORD}
+container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts/${ISCSI_INITIATOR_IQN} disk add ${ISCSI_POOL}/disk_1
+container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts/${ISCSI_INITIATOR_IQN} disk add ${ISCSI_POOL}/disk_2
 
 # set up multipath and some iscsi config options
 sudo dnf install -y iscsi-initiator-utils device-mapper-multipath
@@ -62,7 +111,7 @@ sudo dnf install -y iscsi-initiator-utils device-mapper-multipath
 # this next line is purposely being done without "-a" on the tee command to
 # overwrite the current initiatorname.iscsi file if it is there
 echo "GenerateName=no" | sudo tee /etc/iscsi/initiatorname.iscsi
-echo "InitiatorName=iqn.1994-05.com.redhat:client1" | sudo tee -a /etc/iscsi/initiatorname.iscsi
+echo "InitiatorName=${ISCSI_INITIATOR_IQN}" | sudo tee -a /etc/iscsi/initiatorname.iscsi
 
 echo "node.session.auth.authmethod = CHAP" | sudo tee -a /etc/iscsi/iscsid.conf
 echo "node.session.auth.username = ${ISCSI_USER}" | sudo tee -a /etc/iscsi/iscsid.conf

--- a/qa/workunits/cephadm/test_iscsi_setup.sh
+++ b/qa/workunits/cephadm/test_iscsi_setup.sh
@@ -81,7 +81,8 @@ container_gwcli /iscsi-targets create iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
 # I've seen this give a nonzero error code with an error message even when
 # creating the gateway successfully, so this command is allowed to fail
 # If it actually failed to make the gateway, some of the follow up commands will fail
-container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways create ${FQDN} ${NODE_IP} || true
+container_gwcli /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways create ${FQDN} ${NODE_IP}  2>&1 | tee /tmp/gw_create.log || true
+cat /tmp/gw_create.log
 
 # verify gateway shows up
 if ! wait_for_ls_contains /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways "${FQDN}" 30 1; then


### PR DESCRIPTION
This PR applies minimal changes to test_iscsi_setup.sh to reduce intermittent gwcli failures.

Changes:
- Introduce ISCSI_INITIATOR_IQN variable (replace repeated literal IQN)
- Use podman exec -i (drop -t) for more reliable non-interactive runs
- Add small waits to confirm gateway and host appear in gwcli before configuring CHAP / adding disks
- Add a best-effort gwcli state dump on failure via trap ERR





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
