### PR TITLE
doc: Add op_mask field to Response Entities in adminops.rst

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -367,6 +367,12 @@ If successful, the response contains the user information.
 :Type: Container
 :Parent: ``user``
 
+``op_mask``
+
+:Description: The operation mask for the user, specifying which operations are allowed.
+:Type: String
+:Parent: ``user``
+
 Special Error Responses
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1258,6 +1264,12 @@ If successful, the response contains the user information.
 :Type: Container
 :Parent: ``user``
 
+``op_mask``
+
+:Description: The operation mask for the user, specifying which operations are allowed.
+:Type: String
+:Parent: ``user``
+
 Special Error Responses
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1466,6 +1478,12 @@ If successful, the response contains the user information.
 
 :Description: User capabilities.
 :Type: Container
+:Parent: ``user``
+
+``op_mask``
+
+:Description: The operation mask for the user, specifying which operations are allowed.
+:Type: String
 :Parent: ``user``
 
 


### PR DESCRIPTION
The op_mask field is returned by the API but was missing from the documentation.

- Added op_mask to Get User Info response entities
- Added op_mask to Create User response entities
- Added op_mask to Modify User response entities

ref: https://github.com/hrchu/ceph/blob/master/src/rgw/driver/rados/rgw_user.cc#L132
tested in https://github.com/twonote/radosgw-admin4j/blob/4682bd97ee4644e931a58edf55c1c2cbdf6149de/src/test/java/org/twonote/rgwadmin4j/impl/RgwAdminImplTest.java#L720


