### PR TITLE
mgr/dasboard: Update CephFS Mirroring page colors

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -63,6 +63,8 @@ DAEMON_STATUS_SCHEMA = [{
     }], 'List of filesystems on daemon'),
 }]
 
+LIST_SNAPSHOT_DIRS_SCHEMA = [str]
+
 
 # pylint: disable=R0904
 @APIRouter('/cephfs', Scope.CEPHFS)
@@ -1323,6 +1325,23 @@ class CephFSMirror(RESTController):
         if error_code != 0:
             raise DashboardException(
                 msg=f'Failed to get Cephfs mirror daemon status: {err}',
+                code=error_code,
+                component='cephfs.mirror'
+            )
+        return json.loads(out)
+
+    @EndpointDoc("List snapshot mirrored directories",
+                 parameters={
+                     'fs_name': (str, 'File system name'),
+                 },
+                 responses={200: LIST_SNAPSHOT_DIRS_SCHEMA})
+    @Endpoint('GET', path='/snapshot/ls')
+    @ReadPermission
+    def snapshot_ls(self, fs_name: str):
+        error_code, out, err = mgr.remote('mirroring', 'snapshot_mirror_ls', fs_name)
+        if error_code != 0:
+            raise DashboardException(
+                msg=f'Failed to get Cephfs snapshot list: {err}',
                 code=error_code,
                 component='cephfs.mirror'
             )

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.e2e-spec.ts
@@ -1,0 +1,111 @@
+import { CephfsMirroringPageHelper } from './cephfs-mirroring.po';
+
+describe('CephFS Mirroring', () => {
+  const cephfsMirroring = new CephfsMirroringPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  describe('mirroring list page', () => {
+    beforeEach(() => {
+      cephfsMirroring.navigateToList();
+    });
+
+    it('should open and show breadcrumb', () => {
+      cephfsMirroring.expectBreadcrumbText('Mirroring');
+    });
+
+    it('should show the mirroring list component', () => {
+      cy.get('cd-cephfs-mirroring-list').should('exist');
+    });
+
+    it('should show the mirroring daemon status table', () => {
+      cy.get('cd-cephfs-mirroring-list cd-table').should('exist');
+    });
+  });
+
+  describe('mirroring paths page', () => {
+    const fsName = 'fs1';
+
+    beforeEach(() => {
+      cephfsMirroring.navigateToPaths(fsName);
+    });
+
+    it('should open and show breadcrumb File / Mirroring / fsName / paths', () => {
+      cephfsMirroring.expectBreadcrumbText('paths');
+      cephfsMirroring.expectBreadcrumbSegments(['File', 'Mirroring', fsName, 'paths']);
+    });
+
+    it('should show the mirroring paths component', () => {
+      cy.get('cd-cephfs-mirroring-paths').should('exist');
+    });
+
+    it('should show Local filesystem, Remote filesystem and Remote cluster sections', () => {
+      cy.get('cd-cephfs-mirroring-paths').within(() => {
+        cy.contains('Local filesystem').should('be.visible');
+        cy.contains('Remote filesystem').should('be.visible');
+        cy.contains('Remote cluster').should('be.visible');
+      });
+    });
+
+    it('should show Mirroring paths table section', () => {
+      cy.get('cd-cephfs-mirroring-paths').within(() => {
+        cy.contains('Mirroring paths').should('be.visible');
+        cy.get('cd-table').should('exist');
+      });
+    });
+  });
+
+  describe('navigation from list to paths', () => {
+    const mockFsName = 'fs1';
+    const mockDaemonStatus = [
+      {
+        daemon_id: 1,
+        filesystems: [
+          {
+            filesystem_id: 10,
+            name: mockFsName,
+            directory_count: 1,
+            peers: [
+              {
+                uuid: 'peer-uuid',
+                remote: {
+                  client_name: 'client.mirror',
+                  cluster_name: 'remote-cluster',
+                  fs_name: 'remote-fs'
+                },
+                stats: { failure_count: 0, recovery_count: 0 }
+              }
+            ],
+            id: '1-10'
+          }
+        ]
+      }
+    ];
+
+    beforeEach(() => {
+      cy.intercept('GET', '**/api/cephfs/mirror/daemon-status', {
+        statusCode: 200,
+        body: mockDaemonStatus
+      }).as('daemonStatus');
+      cephfsMirroring.navigateToList();
+      cy.wait('@daemonStatus');
+    });
+
+    it('should navigate to paths when clicking local filesystem link in a row', () => {
+      cy.get('cd-cephfs-mirroring-list').within(() => {
+        cy.get('[cdstablerow]').should('have.length.at.least', 1);
+      });
+      cephfsMirroring.clickLocalFsLink(mockFsName);
+      cy.url().should('include', `/cephfs/mirroring/${mockFsName}`);
+      cy.get('cd-cephfs-mirroring-paths').should('exist');
+      cephfsMirroring.expectBreadcrumbSegments(['File', 'Mirroring', mockFsName]);
+      cy.get('cd-cephfs-mirroring-paths').within(() => {
+        cy.contains('Local filesystem').should('be.visible');
+        cy.contains(mockFsName).should('be.visible');
+        cy.contains('Mirroring paths').should('be.visible');
+      });
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/cephfs-mirroring.po.ts
@@ -1,0 +1,42 @@
+import { PageHelper } from '../page-helper.po';
+
+const pages = {
+  list: { url: '#/cephfs/mirroring', id: 'cd-cephfs-mirroring-list' },
+  paths: (fsName: string) => ({
+    url: `#/cephfs/mirroring/${fsName}`,
+    id: 'cd-cephfs-mirroring-paths'
+  })
+};
+
+export class CephfsMirroringPageHelper extends PageHelper {
+  pages = {
+    list: pages.list,
+    index: pages.list
+  };
+
+  navigateToList() {
+    cy.visit(pages.list.url);
+    cy.get(pages.list.id);
+  }
+
+  navigateToPaths(fsName: string) {
+    const page = pages.paths(fsName);
+    cy.visit(page.url);
+    cy.get(page.id);
+  }
+
+  clickLocalFsLink(localFsName: string) {
+    this.searchTable(localFsName);
+    cy.contains('[cdstablerow] [cdstabledata] a', localFsName).click();
+    cy.get(pages.paths(localFsName).id);
+  }
+
+  expectBreadcrumbSegments(segments: string[]) {
+    cy.get('cds-breadcrumb-item').then(($items) => {
+      const texts = $items.toArray().map((el) => el.textContent?.trim() ?? '');
+      segments.forEach((segment, _) => {
+        expect(texts).to.include(segment);
+      });
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/page-header.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/page-header.e2e-spec.ts
@@ -1,0 +1,26 @@
+import { PageHeaderPageHelper } from './page-header.po';
+
+describe('Page header component', () => {
+  const pageHeader = new PageHeaderPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    pageHeader.navigateToCephfsMirroring();
+  });
+
+  it('should display the page header on CephFS Mirroring page', () => {
+    pageHeader.getPageHeader().should('be.visible');
+  });
+
+  it('should show the expected title in the page header', () => {
+    pageHeader.getHeaderTitle().then((text) => {
+      expect(text.trim()).to.equal('CephFS Mirroring');
+    });
+  });
+
+  it('should show the expected description in the page header', () => {
+    pageHeader.getHeaderDescription().then((text) => {
+      expect(text.trim()).to.equal('Centralised view of all CephFS Mirroring relationships.');
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/page-header.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/page-header.po.ts
@@ -1,0 +1,26 @@
+import { PageHelper } from '../page-helper.po';
+
+const pages = {
+  cephfsMirroring: { url: '#/cephfs/mirroring', id: 'cd-cephfs-mirroring-list' }
+};
+
+export class PageHeaderPageHelper extends PageHelper {
+  pages = pages;
+
+  navigateToCephfsMirroring() {
+    cy.visit(pages.cephfsMirroring.url);
+    cy.get(pages.cephfsMirroring.id, { timeout: 10000 });
+  }
+
+  getPageHeader() {
+    return cy.get('[data-testid="page-header"]');
+  }
+
+  getHeaderTitle() {
+    return this.getPageHeader().find('.cds--type-heading-04').invoke('text');
+  }
+
+  getHeaderDescription() {
+    return this.getPageHeader().find('.cds--type-body-01').invoke('text');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -60,6 +60,7 @@ import { SmbUsersgroupsListComponent } from './ceph/smb/smb-usersgroups-list/smb
 import { SmbOverviewComponent } from './ceph/smb/smb-overview/smb-overview.component';
 import { MultiClusterFormComponent } from './ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component';
 import { CephfsMirroringListComponent } from './ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component';
+import { CephfsMirroringPathsComponent } from './ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component';
 import { NotificationsPageComponent } from './core/navigation/notification-panel/notifications-page/notifications-page.component';
 
 @Injectable()
@@ -91,6 +92,22 @@ export class StartCaseBreadcrumbsResolver extends BreadcrumbsResolver {
     const path = route.params.name;
     const text = _.startCase(path);
     return [{ text: `${text}/Edit`, path: path }];
+  }
+}
+
+@Injectable()
+export class CephfsMirroringPathsBreadcrumbsResolver extends BreadcrumbsResolver {
+  resolve(route: ActivatedRouteSnapshot): IBreadcrumb[] {
+    const fsName = route.params['fsName'] || '-';
+    const cephfsPath = this.getFullPath(route.parent);
+    const fsPath = `${cephfsPath}/fs`;
+    const mirroringPath = `${cephfsPath}/mirroring`;
+    return [
+      { text: 'File', path: fsPath },
+      { text: 'Mirroring', path: mirroringPath },
+      { text: fsName, path: null },
+      { text: 'paths', path: null }
+    ];
   }
 }
 
@@ -430,6 +447,11 @@ const routes: Routes = [
             data: { breadcrumbs: 'File/Mirroring' }
           },
           {
+            path: 'mirroring/:fsName',
+            component: CephfsMirroringPathsComponent,
+            data: { breadcrumbs: CephfsMirroringPathsBreadcrumbsResolver }
+          },
+          {
             path: 'nfs',
             canActivateChild: [FeatureTogglesGuardService, ModuleStatusGuardService],
             data: {
@@ -611,6 +633,10 @@ const routes: Routes = [
     })
   ],
   exports: [RouterModule],
-  providers: [StartCaseBreadcrumbsResolver, PerformanceCounterBreadcrumbsResolver]
+  providers: [
+    StartCaseBreadcrumbsResolver,
+    PerformanceCounterBreadcrumbsResolver,
+    CephfsMirroringPathsBreadcrumbsResolver
+  ]
 })
 export class AppRoutingModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -110,8 +110,7 @@ export class CephfsMirroringPathsBreadcrumbsResolver extends BreadcrumbsResolver
     return [
       { text: 'File', path: fsPath },
       { text: 'Mirroring', path: mirroringPath },
-      { text: fsName, path: null },
-      { text: 'paths', path: null }
+      { text: fsName, path: null }
     ];
   }
 }
@@ -473,7 +472,8 @@ const routes: Routes = [
           {
             path: 'mirroring/:fsName',
             component: CephfsMirroringPathsComponent,
-            data: { breadcrumbs: CephfsMirroringPathsBreadcrumbsResolver }
+            data: { breadcrumbs: CephfsMirroringPathsBreadcrumbsResolver,               pageHeader: CEPHFS_MIRRORING_PAGE_HEADER
+            }
           },
           {
             path: 'nfs',

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -35,7 +35,11 @@ import { BlankLayoutComponent } from './core/layouts/blank-layout/blank-layout.c
 import { LoginLayoutComponent } from './core/layouts/login-layout/login-layout.component';
 import { WorkbenchLayoutComponent } from './core/layouts/workbench-layout/workbench-layout.component';
 import { ApiDocsComponent } from './core/navigation/api-docs/api-docs.component';
-import { ActionLabels, URLVerbs } from './shared/constants/app.constants';
+import {
+  ActionLabels,
+  CEPHFS_MIRRORING_PAGE_HEADER,
+  URLVerbs
+} from './shared/constants/app.constants';
 import { CrudFormComponent } from './shared/forms/crud-form/crud-form.component';
 import { CRUDTableComponent } from './shared/datatable/crud-table/crud-table.component';
 import { BreadcrumbsResolver, IBreadcrumb } from './shared/models/breadcrumbs';
@@ -62,6 +66,7 @@ import { MultiClusterFormComponent } from './ceph/cluster/multi-cluster/multi-cl
 import { CephfsMirroringListComponent } from './ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component';
 import { CephfsMirroringPathsComponent } from './ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component';
 import { NotificationsPageComponent } from './core/navigation/notification-panel/notifications-page/notifications-page.component';
+import { CephfsMirroringErrorComponent } from './ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component';
 
 @Injectable()
 export class PerformanceCounterBreadcrumbsResolver extends BreadcrumbsResolver {
@@ -123,6 +128,15 @@ const routes: Routes = [
     children: [
       { path: 'overview', component: DashboardComponent },
       { path: 'error', component: ErrorComponent },
+      {
+        path: 'cephfs/mirroring/error',
+        component: CephfsMirroringErrorComponent,
+        data: {
+          breadcrumbs: 'File/Mirroring',
+          pageHeader: CEPHFS_MIRRORING_PAGE_HEADER
+        }
+      },
+
       // Cluster
       {
         path: 'notifications',
@@ -443,8 +457,18 @@ const routes: Routes = [
           },
           {
             path: 'mirroring',
+            canActivate: [ModuleStatusGuardService],
             component: CephfsMirroringListComponent,
-            data: { breadcrumbs: 'File/Mirroring' }
+            data: {
+              moduleStatusGuardConfig: {
+                uiApiPath: 'cephfs/mirror',
+                redirectTo: 'cephfs/mirroring/error',
+                module_name: 'mirroring',
+                navigate_to: 'File/Mirroring'
+              },
+              breadcrumbs: 'File/Mirroring',
+              pageHeader: CEPHFS_MIRRORING_PAGE_HEADER
+            }
           },
           {
             path: 'mirroring/:fsName',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.html
@@ -1,0 +1,24 @@
+<cds-inline-notification
+  [notificationObj]="{
+                      type: 'warning',
+                      title: 'CephFS Mirroring module is not enabled',
+                      message: 'To create mirror links and configure replication, the CephFS Mirroring module must be enabled on this cluster.',
+                      lowContrast: true,
+                      showClose: false
+                    }"
+  class="mt-2 mb-2 full-width padding-inline-0"></cds-inline-notification>
+
+<div cdsGrid
+     class="mt-5">
+  <div cdsRow>
+    <div cdsCol>
+      <cd-icon type="deploy"
+               [size]="iconSize.size32"></cd-icon>
+    </div>
+  </div>
+  <div cdsRow>
+    <div cdsCol>
+      <p class="cds--body-compact-02">No CephFS mirror links available</p>
+    </div>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.scss
@@ -1,0 +1,18 @@
+.full-width {
+  max-inline-size: 100%;
+}
+
+// Stack title above description when notification is full-width (Carbon lays them
+// in a row by default).
+::ng-deep cds-inline-notification.full-width {
+  [class*='inline-notification__text-wrapper'] {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  [class*='inline-notification__title'],
+  [class*='inline-notification__subtitle'] {
+    display: block;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.spec.ts
@@ -1,0 +1,93 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { CephfsMirroringErrorComponent } from './cephfs-mirroring-error.component';
+import { DocService } from '~/app/shared/services/doc.service';
+import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('CephfsMirroringErrorComponent', () => {
+  let component: CephfsMirroringErrorComponent;
+  let fixture: ComponentFixture<CephfsMirroringErrorComponent>;
+
+  const routerMock = {
+    events: of({}),
+    onSameUrlNavigation: 'reload' as const,
+    navigate: jest.fn()
+  };
+
+  const docServiceMock = {
+    urlGenerator: jest.fn().mockReturnValue('https://docs.ceph.com/en/main/cephfs/')
+  };
+
+  const mgrModuleServiceMock = {
+    updateModuleState: jest.fn()
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    Object.defineProperty(history, 'state', { value: {}, configurable: true });
+
+    await TestBed.configureTestingModule({
+      declarations: [CephfsMirroringErrorComponent],
+      imports: [SharedModule, RouterTestingModule],
+      providers: [
+        { provide: Router, useValue: routerMock },
+        { provide: DocService, useValue: docServiceMock },
+        { provide: MgrModuleService, useValue: mgrModuleServiceMock }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CephfsMirroringErrorComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should set default header and section when history.state is empty', () => {
+    fixture.detectChanges();
+    expect(component.header).toBe('Mirroring module is not enabled');
+    expect(component.sectionInfo).toBe('CephFS Mirroring');
+    expect(component.section).toBe('cephfs-mirroring');
+  });
+
+  it('should read header and message from history.state when available', () => {
+    Object.defineProperty(history, 'state', {
+      value: {
+        header: 'Custom header',
+        message: 'Custom message',
+        section: 'custom-section',
+        section_info: 'Custom Section'
+      },
+      configurable: true
+    });
+    component.fetchData();
+    expect(component.header).toBe('Custom header');
+    expect(component.message).toBe('Custom message');
+    expect(component.section).toBe('custom-section');
+    expect(component.sectionInfo).toBe('Custom Section');
+  });
+
+  it('should call docService.urlGenerator with section', () => {
+    component.fetchData();
+    expect(docServiceMock.urlGenerator).toHaveBeenCalledWith('cephfs-mirroring');
+  });
+
+  it('should call mgrModuleService.updateModuleState when enableModule is called', () => {
+    fixture.detectChanges();
+    component.enableModule();
+    expect(mgrModuleServiceMock.updateModuleState).toHaveBeenCalledWith(
+      'mirroring',
+      false,
+      null,
+      'File/Mirroring'
+    );
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { IconSize } from '~/app/shared/enum/icons.enum';
+
+@Component({
+  selector: 'cd-cephfs-mirroring-error',
+  templateUrl: './cephfs-mirroring-error.component.html',
+  styleUrls: ['./cephfs-mirroring-error.component.scss'],
+  standalone: false
+})
+export class CephfsMirroringErrorComponent {
+  iconSize = IconSize;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
@@ -1,3 +1,8 @@
+<cd-page-header
+  title="CephFS Mirroring"
+  description="Centralised view of all CephFS Mirroring relationships.">
+</cd-page-header>
+
 <ng-container *ngIf="daemonStatus$ | async as daemonStatus">
   <cd-table
     [data]="daemonStatus"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
@@ -1,8 +1,3 @@
-<cd-page-header
-  title="CephFS Mirroring"
-  description="Centralised view of all CephFS Mirroring relationships.">
-</cd-page-header>
-
 <ng-container *ngIf="daemonStatus$ | async as daemonStatus">
   <cd-table
     [data]="daemonStatus"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.html
@@ -10,3 +10,9 @@
   >
   </cd-table>
 </ng-container>
+
+<ng-template #localFsLinkTpl
+             let-row="data.row"
+             let-value="data.value">
+  <a (click)="navigateToPaths(row)">{{ value }}</a>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, ViewChild, OnInit } from '@angular/core';
+import { Component, TemplateRef, ViewChild, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
@@ -21,6 +22,7 @@ export const MIRRORING_PATH = 'cephfs/mirroring';
 })
 export class CephfsMirroringListComponent implements OnInit {
   @ViewChild('table', { static: true }) table: TableComponent;
+  @ViewChild('localFsLinkTpl', { static: true }) localFsLinkTpl: TemplateRef<any>;
 
   columns: CdTableColumn[];
   selection = new CdTableSelection();
@@ -29,7 +31,11 @@ export class CephfsMirroringListComponent implements OnInit {
   context: CdTableFetchDataContext;
   tableActions: CdTableAction[];
 
-  constructor(public actionLabels: ActionLabelsI18n, private cephfsService: CephfsService) {}
+  constructor(
+    public actionLabels: ActionLabelsI18n,
+    private cephfsService: CephfsService,
+    private router: Router
+  ) {}
 
   ngOnInit() {
     this.columns = [
@@ -38,7 +44,12 @@ export class CephfsMirroringListComponent implements OnInit {
         prop: 'remote_cluster_name',
         flexGrow: 2
       },
-      { name: $localize`Local filesystem`, prop: 'local_fs_name', flexGrow: 2 },
+      {
+        name: $localize`Local filesystem`,
+        prop: 'local_fs_name',
+        flexGrow: 2,
+        cellTemplate: this.localFsLinkTpl
+      },
       { name: $localize`Remote filesystem`, prop: 'fs_name', flexGrow: 2 },
       { name: $localize`Remote client`, prop: 'client_name', flexGrow: 2 },
       { name: $localize`Snapshot directories`, prop: 'directory_count', flexGrow: 1 }
@@ -53,7 +64,7 @@ export class CephfsMirroringListComponent implements OnInit {
             daemons.forEach((d) => {
               d.filesystems.forEach((fs) => {
                 if (!fs.peers || fs.peers.length === 0) {
-                  result.push({
+                  const row: MirroringRow = {
                     remote_cluster_name: '-',
                     local_fs_name: fs.name,
                     fs_name: fs.name,
@@ -61,17 +72,19 @@ export class CephfsMirroringListComponent implements OnInit {
                     directory_count: fs.directory_count,
                     peerId: '-',
                     id: `${d.daemon_id}-${fs.filesystem_id}`
-                  });
+                  };
+                  result.push(row);
                 } else {
                   fs.peers.forEach((peer) => {
-                    result.push({
+                    const row: MirroringRow = {
                       remote_cluster_name: peer.remote.cluster_name,
                       local_fs_name: fs.name,
                       fs_name: peer.remote.fs_name,
                       client_name: peer.remote.client_name,
                       directory_count: fs.directory_count,
                       id: `${d.daemon_id}-${fs.filesystem_id}`
-                    });
+                    };
+                    result.push(row);
                   });
                 }
               });
@@ -96,5 +109,15 @@ export class CephfsMirroringListComponent implements OnInit {
 
   updateSelection(selection: CdTableSelection) {
     this.selection = selection;
+  }
+
+  navigateToPaths(row: MirroringRow) {
+    this.router.navigate([MIRRORING_PATH, row.local_fs_name, 'paths'], {
+      state: {
+        localFsName: row.local_fs_name,
+        remoteFsName: row.fs_name,
+        remoteClusterName: row.remote_cluster_name
+      }
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -112,7 +112,7 @@ export class CephfsMirroringListComponent implements OnInit {
   }
 
   navigateToPaths(row: MirroringRow) {
-    this.router.navigate([MIRRORING_PATH, row.local_fs_name, 'paths'], {
+    this.router.navigate([MIRRORING_PATH, row.local_fs_name], {
       state: {
         localFsName: row.local_fs_name,
         remoteFsName: row.fs_name,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.html
@@ -1,0 +1,48 @@
+<div cdsTheme="g10"
+     [cdsLayer]="0">
+  <div cdsGrid
+       [fullWidth]="true">
+    <div cdsRow
+         class="cds-mb-5">
+      <div cdsCol
+           [columnNumbers]="{lg: 5}">
+        <cds-tile [cdsLayer]="1">
+          <div class="cds--type-heading-compact-02"
+               i18n>Local filesystem</div>
+          <div class="cds--type-body-02">{{ localFsName }}</div>
+        </cds-tile>
+      </div>
+      <div cdsCol
+           [columnNumbers]="{lg: 5}">
+        <cds-tile [cdsLayer]="1">
+          <div class="cds--type-heading-compact-02"
+               i18n>Remote filesystem</div>
+          <div class="cds--type-body-02">{{ remoteFsName }}</div>
+        </cds-tile>
+      </div>
+      <div cdsCol
+           [columnNumbers]="{lg: 6}">
+        <cds-tile [cdsLayer]="1">
+          <div class="cds--type-heading-compact-02"
+               i18n>Remote cluster</div>
+          <div class="cds--type-body-02">{{ remoteClusterName }}</div>
+        </cds-tile>
+      </div>
+    </div>
+
+    <div cdsRow
+         class="cds-mt-5">
+      <div cdsCol
+           [columnNumbers]="{lg: 16}">
+        <cds-tile [cdsLayer]="1">
+          <h3 class="cds--type-expressive-heading-03 cds-mb-3"
+              i18n>Mirroring paths</h3>
+          <cd-table
+            [data]="(mirroringPaths$ | async) || []"
+            [columns]="columns">
+          </cd-table>
+        </cds-tile>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.html
@@ -29,20 +29,21 @@
         </cds-tile>
       </div>
     </div>
-
     <div cdsRow
-         class="cds-mt-5">
-      <div cdsCol
-           [columnNumbers]="{lg: 16}">
-        <cds-tile [cdsLayer]="1">
-          <h3 class="cds--type-expressive-heading-03 cds-mb-3"
-              i18n>Mirroring paths</h3>
-          <cd-table
-            [data]="(mirroringPaths$ | async) || []"
-            [columns]="columns">
-          </cd-table>
-        </cds-tile>
-      </div>
-    </div>
+    class="cds-mt-5">
+ <div cdsCol
+      [columnNumbers]="{lg: 16}">
+   <cds-tile [cdsLayer]="1">
+     <h3 class="cds--type-expressive-heading-03 cds-mb-3"
+         i18n>Mirroring paths</h3>
+      <cd-table
+         [data]="(mirroringPaths$ | async) || []"
+         [columns]="columns"
+         selectionType="single"
+         [toolHeader]="false">
+       </cd-table>
+   </cds-tile>
+ </div>
+</div>
   </div>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.scss
@@ -1,0 +1,3 @@
+.cds--grid {
+  padding-inline: 0;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.scss
@@ -1,3 +1,11 @@
+// Full page gray background (from layout), white tiles
+@use './src/styles/vendor/variables' as vv;
+
+// White tiles on gray page background
+cds-tile {
+  background-color: vv.$white !important;
+}
+
 .cds--grid {
   padding-inline: 0;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { CephfsMirroringPathsComponent } from './cephfs-mirroring-paths.component';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('CephfsMirroringPathsComponent', () => {
+  let component: CephfsMirroringPathsComponent;
+  let fixture: ComponentFixture<CephfsMirroringPathsComponent>;
+  let listSnapshotDirsSpy: jest.SpyInstance;
+
+  const createActivatedRoute = (params: { fsName?: string } = {}) => ({
+    snapshot: { params }
+  });
+
+  const createRouterWithState = (state: Record<string, string> | null) => ({
+    getCurrentNavigation: () => (state ? { extras: { state } } : null)
+  });
+
+  const cephfsServiceMock = {
+    listSnapshotDirs: jest.fn()
+  };
+
+  configureTestBed({
+    declarations: [CephfsMirroringPathsComponent],
+    imports: [RouterTestingModule],
+    providers: [
+      { provide: ActivatedRoute, useValue: createActivatedRoute({ fsName: 'fs1' }) },
+      { provide: Router, useValue: createRouterWithState(null) },
+      { provide: CephfsService, useValue: cephfsServiceMock }
+    ]
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(CephfsMirroringPathsComponent);
+    component = fixture.componentInstance;
+    listSnapshotDirsSpy = cephfsServiceMock.listSnapshotDirs;
+    return fixture;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cephfsServiceMock.listSnapshotDirs.mockReturnValue(of(['/']));
+    createComponent();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should set localFsName from route params on init', () => {
+    fixture.detectChanges();
+    expect(component.localFsName).toBe('fs1');
+  });
+
+  it('should call listSnapshotDirs with localFsName', () => {
+    fixture.detectChanges();
+    expect(listSnapshotDirsSpy).toHaveBeenCalledWith('fs1');
+  });
+
+  it('should map snapshot dirs to table rows and expose via mirroringPaths$', (done) => {
+    listSnapshotDirsSpy.mockReturnValue(of(['/path1', '/path2']));
+    fixture.detectChanges();
+    component.mirroringPaths$.subscribe((rows) => {
+      expect(rows.length).toBe(2);
+      expect(rows[0]).toEqual({
+        path: '/path1',
+        type: '',
+        status: '',
+        snapshot_schedule: '',
+        last_sync: ''
+      });
+      expect(rows[1].path).toBe('/path2');
+      done();
+    });
+  });
+
+  it('should display localFsName, remoteFsName and remoteClusterName in the template', () => {
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('fs1');
+    expect(el.textContent).toContain('-');
+    expect(el.textContent).toContain('Local filesystem');
+    expect(el.textContent).toContain('Remote filesystem');
+    expect(el.textContent).toContain('Remote cluster');
+    expect(el.textContent).toContain('Mirroring paths');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { CdTableColumn } from '~/app/shared/models/cd-table-column';
+
+@Component({
+  selector: 'cd-cephfs-mirroring-paths',
+  templateUrl: './cephfs-mirroring-paths.component.html',
+  styleUrls: ['./cephfs-mirroring-paths.component.scss'],
+  standalone: false
+})
+export class CephfsMirroringPathsComponent implements OnInit {
+  remoteFsName: string;
+  localFsName: string;
+  remoteClusterName: string;
+
+  columns: CdTableColumn[];
+  mirroringPaths$: Observable<any[]>;
+
+  private navigationState: Record<string, string> | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private cephfsService: CephfsService
+  ) {
+    const nav = this.router.getCurrentNavigation();
+    if (nav?.extras?.state) {
+      this.navigationState = nav.extras.state as Record<string, string>;
+    }
+  }
+
+  ngOnInit() {
+    const state = this.navigationState;
+    this.localFsName = this.route.snapshot.params['fsName'] || state?.localFsName || '-';
+    this.remoteFsName = state?.remoteFsName ?? '-';
+    this.remoteClusterName = state?.remoteClusterName ?? '-';
+
+    this.columns = [
+      { name: $localize`Path`, prop: 'path', flexGrow: 2 },
+      { name: $localize`Type`, prop: 'type', flexGrow: 1 },
+      { name: $localize`Status`, prop: 'status', flexGrow: 1 },
+      { name: $localize`Snapshot schedule`, prop: 'snapshot_schedule', flexGrow: 1 },
+      { name: $localize`Last sync`, prop: 'last_sync', flexGrow: 1 }
+    ];
+
+    // TODO: Update data displayed when new interface is implemented.
+    this.mirroringPaths$ = this.cephfsService.listSnapshotDirs(this.localFsName).pipe(
+      map((paths) =>
+        paths.map((path) => ({
+          path,
+          type: '',
+          status: '',
+          snapshot_schedule: '',
+          last_sync: ''
+        }))
+      ),
+      catchError(() => of([]))
+    );
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-paths/cephfs-mirroring-paths.component.ts
@@ -4,6 +4,8 @@ import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
+import { Permissions } from '~/app/shared/models/permissions';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 
 @Component({
   selector: 'cd-cephfs-mirroring-paths',
@@ -18,14 +20,17 @@ export class CephfsMirroringPathsComponent implements OnInit {
 
   columns: CdTableColumn[];
   mirroringPaths$: Observable<any[]>;
+  permissions: Permissions;
 
   private navigationState: Record<string, string> | null = null;
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private cephfsService: CephfsService
+    private cephfsService: CephfsService,
+    private authStorageService: AuthStorageService
   ) {
+    this.permissions = this.authStorageService.getPermissions();
     const nav = this.router.getCurrentNavigation();
     if (nav?.extras?.state) {
       this.navigationState = nav.extras.state as Record<string, string>;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -32,6 +32,7 @@ import { CephfsSnapshotscheduleFormComponent } from './cephfs-snapshotschedule-f
 import { CephfsMountDetailsComponent } from './cephfs-mount-details/cephfs-mount-details.component';
 import { CephfsAuthModalComponent } from './cephfs-auth-modal/cephfs-auth-modal.component';
 import { CephfsMirroringListComponent } from './cephfs-mirroring-list/cephfs-mirroring-list.component';
+import { CephfsMirroringPathsComponent } from './cephfs-mirroring-paths/cephfs-mirroring-paths.component';
 import {
   ButtonModule,
   CheckboxModule,
@@ -43,13 +44,17 @@ import {
   IconService,
   InputModule,
   LayoutModule,
+  LayerModule,
   ModalModule,
   NumberModule,
   PlaceholderModule,
+  RadioModule,
   SelectModule,
+  ThemeModule,
   TimePickerModule,
   TreeviewModule,
-  TabsModule
+  TabsModule,
+  TilesModule
 } from 'carbon-components-angular';
 
 import AddIcon from '@carbon/icons/es/add/32';
@@ -74,7 +79,10 @@ import Trash from '@carbon/icons/es/trash-can/32';
     NgbTypeaheadModule,
     GridModule,
     InputModule,
+    LayerModule,
+    ThemeModule,
     CheckboxModule,
+    RadioModule,
     SelectModule,
     DropdownModule,
     ModalModule,
@@ -87,7 +95,8 @@ import Trash from '@carbon/icons/es/trash-can/32';
     ComboBoxModule,
     IconModule,
     BaseChartDirective,
-    TabsModule
+    TabsModule,
+    TilesModule
   ],
   declarations: [
     CephfsDetailComponent,
@@ -108,7 +117,8 @@ import Trash from '@carbon/icons/es/trash-can/32';
     CephfsSubvolumeSnapshotsFormComponent,
     CephfsMountDetailsComponent,
     CephfsAuthModalComponent,
-    CephfsMirroringListComponent
+    CephfsMirroringListComponent,
+    CephfsMirroringPathsComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -33,6 +33,7 @@ import { CephfsMountDetailsComponent } from './cephfs-mount-details/cephfs-mount
 import { CephfsAuthModalComponent } from './cephfs-auth-modal/cephfs-auth-modal.component';
 import { CephfsMirroringListComponent } from './cephfs-mirroring-list/cephfs-mirroring-list.component';
 import { CephfsMirroringPathsComponent } from './cephfs-mirroring-paths/cephfs-mirroring-paths.component';
+import { CephfsMirroringErrorComponent } from './cephfs-mirroring-error/cephfs-mirroring-error.component';
 import {
   ButtonModule,
   CheckboxModule,
@@ -54,7 +55,8 @@ import {
   TimePickerModule,
   TreeviewModule,
   TabsModule,
-  TilesModule
+  TilesModule,
+  NotificationModule
 } from 'carbon-components-angular';
 
 import AddIcon from '@carbon/icons/es/add/32';
@@ -96,7 +98,8 @@ import Trash from '@carbon/icons/es/trash-can/32';
     IconModule,
     BaseChartDirective,
     TabsModule,
-    TilesModule
+    TilesModule,
+    NotificationModule
   ],
   declarations: [
     CephfsDetailComponent,
@@ -118,7 +121,8 @@ import Trash from '@carbon/icons/es/trash-can/32';
     CephfsMountDetailsComponent,
     CephfsAuthModalComponent,
     CephfsMirroringListComponent,
-    CephfsMirroringPathsComponent
+    CephfsMirroringPathsComponent,
+    CephfsMirroringErrorComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
@@ -15,6 +15,10 @@
       <div class="breadcrumbs--padding">
         <cd-breadcrumbs></cd-breadcrumbs>
       </div>
+      <cd-page-header *ngIf="pageHeaderTitle"
+                      [title]="pageHeaderTitle"
+                      [description]="pageHeaderDescription">
+      </cd-page-header>
       <router-outlet></router-outlet>
       <cds-placeholder></cds-placeholder>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
@@ -1,7 +1,7 @@
 <block-ui name="global">
   <cd-navigation>
     <div class="container-fluid h-100"
-         [ngClass]="{'overview': (router.url == '/overview' || router.url == '/dashboard_3' || router.url == '/multi-cluster/overview'), 'rgw-dashboard': (router.url == '/rgw/overview')}">
+         [ngClass]="{'overview': (router.url == '/overview' || router.url == '/dashboard_3' || router.url == '/multi-cluster/overview'), 'rgw-dashboard': (router.url == '/rgw/overview'), 'cephfs-mirroring-page': router.url.includes('cephfs/mirroring')}">
       <!-- ************************ -->
       <!-- ALERTS BANNER     -->
       <!-- ************************ -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
@@ -1,4 +1,5 @@
 @use './src/styles/vendor/variables' as vv;
+@use '@carbon/colors';
 
 .overview {
   background-color: vv.$body-bg-alt;
@@ -18,12 +19,22 @@
 
     .breadcrumbs--padding {
       padding-left: var(--cds-spacing-07);
+      background-color: vv.$white;
+
     }
   }
 }
 
 .rgw-dashboard {
   background-color: vv.$body-bg-alt;
+}
+
+.cephfs-mirroring-page {
+  background-color: colors.$gray-10;
+
+  .breadcrumbs--padding {
+    background-color: vv.$white;
+  }
 }
 
 .cd-alert-container {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -131,4 +131,8 @@ export class CephfsService {
   listDaemonStatus(): Observable<Daemon[]> {
     return this.http.get<Daemon[]>(`${this.baseURL}/mirror/daemon-status`);
   }
+
+  listSnapshotDirs(fsName: string): Observable<string[]> {
+    return this.http.get<string[]>(`${this.baseURL}/mirror/snapshot/ls/${fsName}`);
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -109,6 +109,7 @@ import NotificationFilledIcon from '@carbon/icons/es/notification--filled/16';
 import CloseIcon from '@carbon/icons/es/close/16';
 import { TearsheetStepComponent } from './tearsheet-step/tearsheet-step.component';
 import { ProductiveCardComponent } from './productive-card/productive-card.component';
+import { PageHeaderComponent } from './page-header/page-header.component';
 
 @NgModule({
   imports: [
@@ -206,7 +207,8 @@ import { ProductiveCardComponent } from './productive-card/productive-card.compo
     ToastComponent,
     TearsheetComponent,
     TearsheetStepComponent,
-    ProductiveCardComponent
+    ProductiveCardComponent,
+    PageHeaderComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())],
   exports: [
@@ -252,7 +254,8 @@ import { ProductiveCardComponent } from './productive-card/productive-card.compo
     ToastComponent,
     TearsheetComponent,
     TearsheetStepComponent,
-    ProductiveCardComponent
+    ProductiveCardComponent,
+    PageHeaderComponent
   ]
 })
 export class ComponentsModule {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.html
@@ -1,11 +1,12 @@
 <header data-testid="page-header">
   <div cdsGrid
        [fullWidth]="true"
-       [narrow]="true">
+       [narrow]="true"
+       class="border-top padding-inline-0">
     <div cdsRow>
       <div cdsCol
            [columnNumbers]="{ sm: 16, md: 16, lg: 16 }">
-        <cds-tile class="border-top padding-inline-0">
+        <cds-tile>
           <p class="cds--type-heading-04"
              i18n>{{ title }}</p>
           @if(description) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.html
@@ -1,0 +1,19 @@
+<header data-testid="page-header">
+  <div cdsGrid
+       [fullWidth]="true"
+       [narrow]="true">
+    <div cdsRow>
+      <div cdsCol
+           [columnNumbers]="{ sm: 16, md: 16, lg: 16 }">
+        <cds-tile class="border-top padding-inline-0">
+          <p class="cds--type-heading-04"
+             i18n>{{ title }}</p>
+          @if(description) {
+          <p class="cds--type-body-01"
+             i18n>{{ description }}</p>
+          }
+        </cds-tile>
+      </div>
+    </div>
+  </div>
+</header>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.html
@@ -1,20 +1,12 @@
 <header data-testid="page-header">
-  <div cdsGrid
-       [fullWidth]="true"
-       [narrow]="true"
-       class="border-top padding-inline-0">
-    <div cdsRow>
-      <div cdsCol
-           [columnNumbers]="{ sm: 16, md: 16, lg: 16 }">
-        <cds-tile>
-          <p class="cds--type-heading-04"
-             i18n>{{ title }}</p>
-          @if(description) {
-          <p class="cds--type-body-01"
-             i18n>{{ description }}</p>
-          }
-        </cds-tile>
-      </div>
-    </div>
+  <div>
+    <cds-tile class="border-top padding-inline-0 cds-mb-5">
+      <p class="cds--type-heading-04"
+         i18n>{{ title }}</p>
+      @if(description) {
+      <p class="cds--type-body-01"
+         i18n>{{ description }}</p>
+      }
+    </cds-tile>
   </div>
 </header>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.scss
@@ -1,7 +1,3 @@
-.padding-inline-0 {
-  padding-inline: 0;
-}
-
 .border-top {
   border-top: 1px solid var(--cds-border-subtle-01);
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.scss
@@ -1,0 +1,7 @@
+.padding-inline-0 {
+  padding-inline: 0;
+}
+
+.border-top {
+  border-top: 1px solid var(--cds-border-subtle-01);
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.scss
@@ -1,3 +1,19 @@
+@use '../../../../styles/vendor/variables' as vv;
+
+/* Extend to viewport edges so top border goes full width */
+:host ::ng-deep .border-top.padding-inline-0 {
+  margin-left: calc(-1 * vv.$grid-gutter-width);
+  margin-right: calc(-1 * vv.$grid-gutter-width);
+  width: calc(100% + 2 * vv.$grid-gutter-width);
+
+  /* Restore horizontal padding so content stays aligned with rest of page */
+  padding-inline: vv.$grid-gutter-width;
+}
+
 .border-top {
   border-top: 1px solid var(--cds-border-subtle-01);
+}
+
+cds-tile {
+  background-color: vv.$white !important;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.spec.ts
@@ -1,0 +1,24 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PageHeaderComponent } from './page-header.component';
+
+describe('PageHeaderComponent', () => {
+  let component: PageHeaderComponent;
+  let fixture: ComponentFixture<PageHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PageHeaderComponent],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * Page header component inspired by the Carbon Design System Page Header react component.
+ * @see https://ibm-products.carbondesignsystem.com/?path=/docs/components-pageheader--overview
+ *
+ * Usage:
+ * <cd-page-header title="Page title" description="Optional description">
+ * </cd-page-header>
+ */
+@Component({
+  selector: 'cd-page-header',
+  templateUrl: './page-header.component.html',
+  styleUrls: ['./page-header.component.scss'],
+  standalone: false
+})
+export class PageHeaderComponent {
+  @Input() title = '';
+  @Input() description = '';
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -383,3 +383,8 @@ export const SSL_CIPHERS = [
 
 export const USER = 'user';
 export const VERSION_PREFIX = 'ceph version';
+
+export const CEPHFS_MIRRORING_PAGE_HEADER = {
+  title: 'CephFS Mirroring',
+  description: 'Centralised view of all CephFS Mirroring relationships.'
+};

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -169,6 +169,10 @@ Forms
   padding-inline: 0;
 }
 
+.padding-inline-0 {
+  padding-inline: 0;
+}
+
 /******************************************
 Breadcrumbs
 ******************************************/

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -2691,6 +2691,39 @@ paths:
       summary: Get mirror daemon and peers information
       tags:
       - CephfsMirror
+  /api/cephfs/mirror/snapshot/ls/{fs_name}:
+    get:
+      parameters:
+      - description: File system name
+        in: path
+        name: fs_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                items:
+                  properties: {}
+                  type: object
+                type: array
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: List snapshot mirrored directories
+      tags:
+      - CephfsMirror
   /api/cephfs/mirror/token:
     post:
       parameters: []


### PR DESCRIPTION

<img width="1696" height="726" alt="image" src="https://github.com/user-attachments/assets/3ee72bd8-fc53-4799-9032-321560312a62" />



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
