### PR TITLE
os/bluestore: Add ENOSPC vault feature

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -173,13 +173,20 @@ Commands
    Changes WAL files from envelope mode to the legacy plain mode.
    Useful for downgrades, or if you might want to disable this new feature (bluefs_wal_envelope_mode).
 
-:command:`create-bdev-labels` --path *osd path* --dev *device*
+:command: `create-bdev-labels` --path *osd path* --dev *device*
 
    Writes a bdev label to BlueStore devices that originally did not support labeling.
    Reads metadata (e.g., fsid, ceph version) from --path and writes it to the device at --dev.
    Only the main device (block) gets full metadata; block.db or block.wal do not.
    The --dev path must be inside the --path directory, as its name determines the device role.
    Use --yes-i-really-really-mean-it to recreate corrupted labels.
+
+:command: `vault-add`     --path *osd path* --size *vault operation size*
+:command: `vault-release` --path *osd path* --size *vault operation size*
+
+   Adds or releases space from vault. Having some extra space in vault allows to recover OSD
+   from -ENOSPC in less intrusive prevents most cases than redeploying.
+   Most useful for compressing drives.
 
 Options
 =======
@@ -270,7 +277,7 @@ BlueFS log rescue
 =====================
 
 Some versions of BlueStore were susceptible to BlueFS log growing extremely large -
-beyond the point of making booting OSD impossible. This state is indicated by
+beyond the point of making booting OSD possible. This state is indicated by
 booting that takes very long and fails in _replay function.
 
 This can be fixed by::
@@ -281,6 +288,30 @@ It is advised to first check if rescue process would be successful::
   --bluefs_replay_recovery=true --bluefs_replay_recovery_disable_compact=true
 
 If above fsck is successful fix procedure can be applied.
+
+BlueStore extra disk space vault
+================================
+
+OSD running out of disk space (-ENOSPC error) is a critical failure.
+As a general rule OSD tires to avoid it. There are config safeguards that disable
+disk hungry operations: 'mon_osd_backfillfull_ratio', 'mon_osd_nearfull_ratio',
+'mon_osd_full_ratio', and 'osd_failsafe_full_ratio'.
+However, there are actions that cannot be disabled. Unsupervised OSD that has engaged
+backoffs due to '_full_ratio' can still walk into -ENOSPC.
+It is usually impossible to revive such OSD. One needs to redeploy an OSD;
+sometimes also to recover PG using ceph-objectstore-tool.
+Vault is a solution that reserves some disk space upfront to release it when support/recovery
+team is recovering from -ENOSPC failure. Vault is always fed from BlueStore main (slow) device;
+this disk space can be used by both BlueStore and BlueFS. Vault is most useful for compressing
+drives; -ENOSPC makes them unable to overwrite data in place.
+
+Reserve space::
+  ceph-bluestore-tool --path *osd path* --size *size* vault-add
+
+Release space::
+  ceph-bluestore-tool --path *osd path* --size *size* vault-release
+
+Above commands are also available via admin socket: 'bluefs vault add' and 'bluefs vault release'.
 
 Availability
 ============

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6870,6 +6870,35 @@ options:
   flags:
   - startup
   with_legacy: false
+- name: bluestore_vault_mode
+  type: str
+  level: basic
+  desc: Selects method of filling reserved disk space.
+  long_desc: Value "0" selects disk reserve filled with 0s. "random" selects disk reserve filled with random values (useful for compressing h/w)
+    "reserve" selects to just allocate; do not touch the area.
+  default: 'random'
+  enum_values:
+  - '0'
+  - 'random'
+  - 'reserve'
+  see_also:
+  - bluestore_vault_size
+  flags:
+  - runtime
+  with_legacy: false
+- name: bluestore_vault_size
+  type: size
+  level: basic
+  desc: The size of disk space vault
+  long_desc: Some deployments have difficulty to recover from ENOSPC error.
+    Saving some extra disk space and release it before manual recovery significantly
+    increases chances of successful recover.
+  default: 0
+  see_also:
+  - bluestore_vault_mode
+  flags:
+  - create
+  with_legacy: false
 - name: jaeger_tracing_enable
   type: bool
   level: advanced

--- a/src/os/bluestore/BlueEnv.cc
+++ b/src/os/bluestore/BlueEnv.cc
@@ -3,9 +3,12 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <cstddef>
 #include <filesystem>
 #include <iostream>
 #include <fstream>
+#include <memory>
+#include <boost/random/mersenne_twister.hpp>
 #include <time.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -16,6 +19,7 @@
 #include "common/safe_io.h"
 
 #include "os/bluestore/BlueStore.h"
+#include "common/debug.h"
 
 using namespace std;
 
@@ -110,4 +114,153 @@ int BlueStore::create_bdev_labels(CephContext *cct,
     }
   }
   return wrote_at_least_one ? 0 : -EIO;
+}
+
+static constexpr std::string vault_dir = "vault.slow";
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_bluefs
+#undef dout_prefix
+#define dout_prefix *_dout << "bluefs-vault "
+
+int BlueFS::vault_add(size_t new_reserve)
+{
+  static constexpr size_t MB_1 = 1024 * 1024;
+  new_reserve = p2roundup<size_t>(new_reserve, MB_1); //operate in MBs
+  size_t reserves;
+  int last_file;
+  int r;
+  r = vault_inspect(reserves, last_file);
+  if (r != 0) {
+    r = mkdir(vault_dir);
+    if (r != 0) {
+      // cannot create dir, complain!
+      derr << "Unable to create " << vault_dir << ", error=" << r << " " << strerror(r) << dendl;
+      return -EIO;
+    }
+  }
+  std::string mode = cct->_conf.get_val<std::string>("bluestore_vault_mode");
+  if (mode != "0" && mode != "random" && mode != "reserve") {
+    // bad mode, complain
+    derr << "Unrecognized mode='" << mode << "'" << dendl;
+    return -EINVAL;
+  }
+
+  BlueFS::FileWriter *h = nullptr;
+  r = open_for_write(vault_dir, to_string(last_file + 1), &h, false);
+  if (r != 0) {
+    // report error and exit function
+    derr << "Cannot create " << vault_dir << "/" << to_string(last_file + 1)
+         << ", error=" << r << " " << strerror(r) << dendl;
+    return -EIO;
+  }
+  ceph_assert(h != nullptr);
+  if (mode == "0")
+  {
+    std::vector<char> buffer(MB_1);
+    ceph_assert(buffer.size() == MB_1);
+    size_t done_size = 0;
+    reserve_on_main(h->file, new_reserve, false);
+    while (done_size < new_reserve) {
+      append_try_flush(h, buffer.data(), MB_1);
+      done_size += MB_1;
+    }
+    close_writer(h);
+  }
+  else if (mode == "random")
+  {
+    boost::mt19937 random_source(0);
+    std::vector<char> buffer(MB_1);
+    ceph_assert(buffer.size() == MB_1);
+    size_t done_size = 0;
+    reserve_on_main(h->file, new_reserve, false);
+    while (done_size < new_reserve) {
+      random_source.generate(buffer.begin(), buffer.end());
+      append_try_flush(h, buffer.data(), MB_1);
+      done_size += MB_1;
+    }
+    close_writer(h);
+  }
+  else if (mode == "reserve")
+  {
+    reserve_on_main(h->file, new_reserve, true);
+    close_writer(h);
+  }
+  else
+  {
+    ceph_abort();
+  }
+  vault_size += new_reserve;
+  return 0;
+}
+
+int BlueFS::vault_release(size_t to_release, bool safe_mode)
+{
+  size_t released = 0;
+  std::vector<std::string> files;
+  readdir(vault_dir, &files);
+
+  BlueFS::FileWriter* h = nullptr;
+  // 1. Collect extents to discard into dirty.pending_release.
+  for (auto& x : files) {
+    size_t s;
+    int r = stat(vault_dir, x, &s, nullptr);
+    if (r != 0) {
+      // skip dirs
+      continue;
+    }
+    if (s + released <= to_release) {
+      unlink(vault_dir, x);
+      released += s;
+    } else {
+      // Truncate at proper offset to get proper release size.
+      size_t offset = s - (to_release - released);
+      open_for_write(vault_dir, x, &h, true);
+      truncate(h, offset);
+      if (safe_mode) {
+        close_writer(h);
+        h = nullptr;
+      } else {
+        // Have to wait to close writer to after we finish discarding.
+        // The logic is to discard and release before we would (maybe) require allocation.
+      }
+      released += (s - offset);
+      break;
+    }
+  }
+  if (!safe_mode) {
+    // 2. bluefs->dirty.pending_release has all pending allocations
+    //    Instead of releasing it, just do discard, for now.
+    discard_dirty_pending_release();
+  }
+  if (h) {
+    // finally, close the writer
+    close_writer(h);
+    h = nullptr;
+  }
+  // Hopefully there is enough disk space to finish the transaction.
+  sync_metadata(true);
+  vault_size -= released;
+  return 0;
+}
+
+int BlueFS::vault_inspect(size_t& reserve_size, int& last_file)
+{
+  std::vector<std::string> files;
+  int r;
+  reserve_size = 0;
+  last_file = -1;
+  r = readdir(vault_dir, &files);
+  if (r != 0) {
+    return r;
+  }
+  for (auto& x : files) {
+    size_t s;
+    if (stat(vault_dir, x, &s, nullptr) == 0) {
+      // only interested in files, not dirs
+      reserve_size += s;
+      last_file = std::max(std::stoi(x), last_file);
+    }
+  }
+  return 0;
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -105,6 +105,14 @@ public:
 	r = admin_socket->register_command("bluefs files list", hook,
 					   "print files in bluefs");
 	ceph_assert(r == 0);
+        r = admin_socket->register_command(
+          "bluefs vault add name=size,type=CephString,req=false", hook,
+          "Expand disk space reserve in emergency vault. Size accepts K,M,.. suffixes.");
+        ceph_assert(r == 0);
+        r = admin_socket->register_command(
+          "bluefs vault release name=size,type=CephString,req=false", hook,
+          "Release space from the vault. Size accepts K,M,.. suffixes.");
+        ceph_assert(r == 0);
 	r = admin_socket->register_command("bluefs debug_inject_read_zeros", hook,
 					   "Injects 8K zeros into next BlueFS read. Debug only.");
 	ceph_assert(r == 0);
@@ -195,7 +203,35 @@ private:
       f->flush(out);
     } else if (command == "bluefs debug_inject_read_zeros") {
       bluefs->inject_read_zeros++;
-    } else {
+    }
+    else if (command == "bluefs vault add" || command == "bluefs vault release") {
+      std::string size_str;
+      uint64_t size_val = 0;
+      cmd_getval(cmdmap, "size", size_str);
+      if (!size_str.empty()) {
+        std::string err;
+        size_val = strict_iecstrtoll(size_str, &err);
+        if (!err.empty()) {
+          errss << "Invalid 'size':" << err << std::endl;
+          return -EINVAL;
+        }
+      }
+      size_t before = bluefs->vault_getsize();
+      std::string action;
+      if (command == "bluefs vault add") {
+        action = "Added";
+        bluefs->vault_add(size_val);
+      } else {
+        action = "Released";
+        bluefs->vault_release(size_val);
+      }
+      size_t after = bluefs->vault_getsize();
+      std::ostringstream ss;
+      ss << action << " 0x" << std::hex << size_val << "; vault: 0x"
+         << before << "->0x" << after << std::dec << std::endl;
+      out.append(ss.str());
+    }
+    else {
       errss << "Invalid command" << std::endl;
       return -ENOSYS;
     }
@@ -1172,6 +1208,10 @@ int BlueFS::mount()
            << dendl;
   // update log size
   logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
+
+  // update vault size
+  int last_file;
+  vault_inspect(vault_size, last_file);
   return 0;
 
  out:
@@ -3727,6 +3767,21 @@ void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_rel
     }
   }
 }
+// Special, it breaks BlueFS consistency requirements.
+// Definitely not for use except in controlled conditions.
+void BlueFS::discard_dirty_pending_release() {
+  vector<interval_set<uint64_t>> to_release;
+  std::swap(dirty.pending_release, to_release);
+  for (unsigned i = 0; i < to_release.size(); ++i) {
+    if (!to_release[i].empty()) {
+      bdev[i]->try_discard(to_release[i], false, true);
+      alloc[i]->release(to_release[i]);
+      if (is_shared_alloc(i)) {
+        shared_alloc->bluefs_used -= to_release[i].size();
+      }
+    }
+  }
+}
 
 int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
 {
@@ -4559,6 +4614,37 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)/*_LF*/
     log.t.op_file_update_inc(f->fnode);
     f->is_dirty = true;
   }
+  return 0;
+}
+
+int BlueFS::reserve_on_main(FileRef f, uint64_t size_to_allocate, bool update_file_size)
+{
+  std::lock_guard ll(log.lock);
+  std::lock_guard fl(f->lock);
+  dout(10) << __func__ << " file " << f->fnode << " 0x"
+           << std::hex << size_to_allocate << std::dec << dendl;
+  if (f->deleted) {
+    dout(10) << __func__ << " deleted, no-op" << dendl;
+    return 0;
+  }
+  if (size_to_allocate == 0) {
+    return 0;
+  }
+  ceph_assert(f->fnode.ino > 1);
+  uint64_t allocated = f->fnode.get_allocated();
+  uint8_t dev = bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB;
+  int r = _allocate(dev, size_to_allocate, 0, &f->fnode,
+    [&](const bluefs_extent_t& e) {
+      allocated += e.length;
+      vselector->add_usage(f->vselector_hint, e);
+    });
+  if (r < 0)
+    return r;
+  if (update_file_size) {
+    f->fnode.size = allocated;
+  }
+  log.t.op_file_update(f->fnode);
+  f->is_dirty = true;
   return 0;
 }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -661,6 +661,22 @@ uint64_t BlueFS::get_used(unsigned id)
   return _get_used(id);
 }
 
+// Returns spillover size to main (SLOW) device.
+// This only reports BlueFS files that could be placed on DB or WAL.
+// ENOSPC_vault is not reported here, since it is always on SLOW.
+uint64_t BlueFS::get_spillover_size()
+{
+  uint64_t s;
+  if (bdev[BDEV_SLOW]) {
+    // vault does not count towards used by bluefs
+    s = _get_used(BDEV_SLOW) - vault_size;
+  } else {
+    // no slow, no spillover
+    s = 0;
+  }
+  return s;
+}
+
 uint64_t BlueFS::_get_block_device_size(unsigned id) const
 {
   ceph_assert(id < bdev.size());
@@ -738,6 +754,8 @@ void BlueFS::dump_block_extents(ostream& out)
             << "(" << byte_u_t(total - free) << ")"
           << " : bluefs used 0x" << bluefs_used
             << "(" << byte_u_t(bluefs_used) << ")"
+          << " : vault 0x" << vault_size
+            << "(" << byte_u_t(vault_size) << ")"
           << " : non-bluefs used 0x" << non_bluefs_used
             << "(" << byte_u_t(non_bluefs_used) << ")"
           << std::dec << std::endl;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -816,6 +816,7 @@ public:
   uint64_t get_block_device_size(unsigned id);
   uint64_t get_free(unsigned id);
   uint64_t get_used(unsigned id);
+  uint64_t get_spillover_size();
   uint64_t get_full_reserved(unsigned id);
   void dump_perf_counters(ceph::Formatter *f);
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -917,6 +917,18 @@ public:
 
   size_t probe_alloc_avail(int dev, uint64_t alloc_size);
 
+  /// ENOSPC vault methods
+  int vault_add(size_t reserve);
+  int vault_release(size_t to_release, bool safe_mode = true);
+  size_t vault_getsize() {
+    return vault_size;
+  }
+private:
+  size_t vault_size = 0;
+  int vault_inspect(size_t& reserve_size, int& last_file);
+  int reserve_on_main(FileRef f, uint64_t size_to_allocate, bool update_file_size);
+  void discard_dirty_pending_release();
+public:
   /// test purpose methods
   const PerfCounters* get_perf_counters() const {
     return logger;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -19268,8 +19268,7 @@ void BlueStore::_record_onode(OnodeRef& o, KeyValueDB::Transaction &txn)
 void BlueStore::_log_alerts(osd_alert_list_t& alerts)
 {
   std::lock_guard l(qlock);
-  size_t used = bluefs && bluefs_layout.shared_bdev == BlueFS::BDEV_SLOW ?
-    bluefs->get_used(BlueFS::BDEV_SLOW) : 0;
+  size_t used = bluefs ? bluefs->get_spillover_size() : 0;
   if (used > 0) {
       auto db_used = bluefs->get_used(BlueFS::BDEV_DB);
       auto db_total = bluefs->get_block_device_size(BlueFS::BDEV_DB);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8727,6 +8727,13 @@ int BlueStore::mkfs()
   if (r < 0)
     goto out_close_fm;
 
+  {
+    size_t vault_size = cct->_conf.get_val<Option::size_t>("bluestore_vault_size");
+    if (vault_size > 0 && get_bluefs()) {
+      get_bluefs()->vault_add(vault_size);
+    }
+  }
+
   if (fsid != old_fsid) {
     r = _write_fsid();
     if (r < 0) {

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <fstream>
@@ -312,6 +313,8 @@ int main(int argc, char **argv)
   int log_level = 30;
   bool fsck_deep = false;
   uint64_t disk_offset;
+  string size_str;
+  uint64_t size_val = 0;
   po::options_description po_options("Options");
   po_options.add_options()
     ("help,h", "produce help message")
@@ -336,6 +339,7 @@ int main(int argc, char **argv)
     ("sharding", po::value<string>(&new_sharding), "new sharding to apply")
     ("resharding-ctrl", po::value<string>(&resharding_ctrl), "gives control over resharding procedure details")
     ("offset", po::value<uint64_t>(&disk_offset), "disk location")
+    ("size", po::value<string>(&size_str), "size, 1M 20K allowed")
     ("op", po::value<string>(&action_aux),
       "--command alias, ignored if the latter is present")
     ;
@@ -358,7 +362,7 @@ int main(int argc, char **argv)
         "show-label, "
         "show-label-at, "
         "set-label-key, "
-	"create-bdev-labels, "
+        "create-bdev-labels, "
         "rm-label-key, "
         "prime-osd-dir, "
         "bluefs-super-dump, "
@@ -372,6 +376,8 @@ int main(int argc, char **argv)
         "trim, "
         "zap-device, "
         "revert-wal-to-plain"
+        ", vault-add"
+        ", vault-release"
     );
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -413,6 +419,14 @@ int main(int argc, char **argv)
     }
   };
 
+  if (!size_str.empty()) {
+    string err;
+    size_val = strict_iecstrtoll(size_str, &err);
+    if (!err.empty()) {
+      std::cerr << "Invalid 'size':" << err << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
   // normalize path (remove ending '/' if any)
   if (path.size() > 1 && *(path.end() - 1) == '/') {
     path.resize(path.size() - 1);
@@ -491,7 +505,10 @@ int main(int argc, char **argv)
   if (action == "fsck" || action == "repair" ||
       action == "quick-fix" || action == "allocmap" ||
       action == "qfsck" || action == "restore_cfb" ||
-      action == "revert-wal-to-plain") {
+      action == "revert-wal-to-plain"
+      || action == "vault-add"
+      || action == "vault-release"
+    ) {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -1411,7 +1428,40 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
       }
     }
-  } else {
+  }
+  else if (action == "vault-add")
+  {
+    BlueStore bluestore(cct.get(), path);
+    int r = bluestore.cold_open();
+    if (r < 0) {
+      cerr << "Cannot access BlueStore: " << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    BlueFS* bluefs = bluestore.get_bluefs();
+    size_t before = bluefs->vault_getsize();
+    bluefs->vault_add(size_val);
+    size_t after = bluefs->vault_getsize();
+    cout << "Added 0x" << std::hex << size_val << "; vault: 0x"
+         << before << "->0x" << after << std::dec << std::endl;
+    bluestore.cold_close();
+  }
+  else if (action == "vault-release")
+  {
+    BlueStore bluestore(cct.get(), path);
+    int r = bluestore.cold_open();
+    if (r < 0) {
+      cerr << "Cannot access BlueStore: " << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    BlueFS* bluefs = bluestore.get_bluefs();
+    size_t before = bluefs->vault_getsize();
+    bluefs->vault_release(size_val, false);
+    size_t after = bluefs->vault_getsize();
+    cout << "Released 0x" << std::hex << size_val << "; vault: 0x"
+         << before << "->0x" << after << std::dec << std::endl;
+    bluestore.cold_close();
+  }
+  else {
     cerr << "unrecognized action " << action << std::endl;
     return 1;
   }


### PR DESCRIPTION
Vault - new optional feature to BlueStore.
The vault takes some disk space from main device.
If OSD gets into -ENOSPC condition, releasing space from
the vault opens additional recovery options.

New config options:
- bluestore_vault_mode (default random)
0 = write "0" to reserved space
random = write uncompressible data to reserved space
reserve = do not write, just allocate disk
- bluestore_vault_size (default 0)
  Size of vault to create on mkfs

New admin socket commands:
- bluestore vault add <size>
- bluestore vault release <size>

New commands in ceph-bluestore-tool:
- vault-add
- vault-release



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
