### PR TITLE
tentacle: qa/cephfs: lua to respect missing kernel in yaml

### DIFF
--- a/qa/cephfs/begin/3-kernel.yaml
+++ b/qa/cephfs/begin/3-kernel.yaml
@@ -2,22 +2,27 @@
 # all nodes (also, the kernel is "distro" when the --kernel option is not set).
 # We don't generally want to use a custom kernel for all tests, so unset it.
 # The k-testing.yaml will set it, if given, for only the client nodes.
+# When the --kernel option is "none" there is no "kernel" dictionary created
+# in the job base config and there is no need to unset anything.
 #
 # Allow overriding this by using a branch ending in "-all".
 
 teuthology:
   postmerge:
     - |
-      local branch = yaml.kernel.branch
-      if branch and not yaml.kernel.branch:find "-all$" then
-        log.debug("removing default kernel specification: %s", yaml.kernel)
-        py_attrgetter(yaml.kernel).pop('branch', nil)
-        py_attrgetter(yaml.kernel).pop('deb', nil)
-        py_attrgetter(yaml.kernel).pop('flavor', nil)
-        py_attrgetter(yaml.kernel).pop('kdb', nil)
-        py_attrgetter(yaml.kernel).pop('koji', nil)
-        py_attrgetter(yaml.kernel).pop('koji_task', nil)
-        py_attrgetter(yaml.kernel).pop('rpm', nil)
-        py_attrgetter(yaml.kernel).pop('sha1', nil)
-        py_attrgetter(yaml.kernel).pop('tag', nil)
+      local kernel = py_attrgetter(yaml).get('kernel')
+      if kernel ~= nil then
+        local branch = py_attrgetter(kernel).get('branch')
+        if branch and not kernel.branch:find "-all$" then
+          log.debug("removing default kernel specification: %s", kernel)
+          py_attrgetter(kernel).pop('branch', nil)
+          py_attrgetter(kernel).pop('deb', nil)
+          py_attrgetter(kernel).pop('flavor', nil)
+          py_attrgetter(kernel).pop('kdb', nil)
+          py_attrgetter(kernel).pop('koji', nil)
+          py_attrgetter(kernel).pop('koji_task', nil)
+          py_attrgetter(kernel).pop('rpm', nil)
+          py_attrgetter(kernel).pop('sha1', nil)
+          py_attrgetter(kernel).pop('tag', nil)
+        end
       end

--- a/qa/cephfs/mount/kclient/overrides/distro/testing/k-testing.yaml
+++ b/qa/cephfs/mount/kclient/overrides/distro/testing/k-testing.yaml
@@ -2,7 +2,7 @@ teuthology:
   premerge: |
     log.debug("base kernel %s", base_config.kernel)
     local kernel = base_config.kernel
-    if kernel.branch ~= "distro" then
+    if kernel ~= nil and kernel.branch ~= "distro" then
       log.debug("overriding testing kernel with %s", kernel)
       yaml_fragment.kernel.client = kernel
     end


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74852

---

backport of https://github.com/ceph/ceph/pull/66092
parent tracker: https://tracker.ceph.com/issues/73676

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh