### PR TITLE
cephadm: Resolve "I/O operation on closed file" warnings in cephadm's TestBootstrap::test_mon_ip

### DIFF
--- a/src/cephadm/cephadmlib/file_utils.py
+++ b/src/cephadm/cephadmlib/file_utils.py
@@ -9,7 +9,17 @@ import json
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Any, Union, Tuple, Optional, Generator, IO, List
+from typing import (
+    Dict,
+    Any,
+    Union,
+    Tuple,
+    Optional,
+    Generator,
+    IO,
+    List,
+    Protocol,
+)
 
 from .constants import DEFAULT_MODE, DATEFMT
 from .data_utils import dict_get_join
@@ -73,13 +83,56 @@ def touch(
         os.chown(file_path, uid, gid)
 
 
-def write_tmp(s: str, uid: int, gid: int) -> IO[str]:
-    tmp_f = tempfile.NamedTemporaryFile(mode='w', prefix='ceph-tmp')
-    os.fchown(tmp_f.fileno(), uid, gid)
-    tmp_f.write(s)
-    tmp_f.flush()
+class TempFileLike(Protocol):
+    name: str
 
-    return tmp_f
+    def fileno(self) -> int:  # pragma: no cover - typing-only
+        ...
+
+    def close(self) -> None:  # pragma: no cover - typing-only
+        ...
+
+
+class _TempFileRef:
+    def __init__(self, fd: int, path: str):
+        self._fd = fd
+        self.name = path
+
+    def fileno(self) -> int:
+        return self._fd
+
+    def close(self) -> None:
+        if self._fd is not None and self._fd >= 0:
+            try:
+                os.close(self._fd)
+            except Exception:
+                pass
+            self._fd = -1
+
+
+def write_tmp(s: str, uid: int, gid: int) -> TempFileLike:
+    fd, path = tempfile.mkstemp(prefix='ceph-tmp')
+    try:
+        # set ownership on the FD before writing
+        os.fchown(fd, uid, gid)
+        # write bytes directly to the FD to avoid creating a Python file
+        # object that may interact poorly with pyfakefs destructors.
+        data = s.encode('utf-8') if isinstance(s, str) else s
+        os.write(fd, data)
+        os.fsync(fd)
+        # keep the fd open and return a lightweight wrapper exposing
+        # .fileno() and .name so callers behave like NamedTemporaryFile.
+        return _TempFileRef(fd, path)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError as e:
+            logger.debug(f"Failed to close fd {fd}: {e}")
+        try:
+            os.unlink(path)
+        except OSError as e:
+            logger.debug(f"Failed to unlink {path}: {e}")
+        raise
 
 
 def makedirs(dest: Union[Path, str], uid: int, gid: int, mode: int) -> None:


### PR DESCRIPTION
On execution of the following test:
`tox -e py3 -- ./tests/test_cephadm.py::TestBootstrap::test_mon_ip`

The following warnings are produced:
```
tests/test_cephadm.py::TestBootstrap::test_mon_ip[::ffff:c0a8:101-list_networks9-True]
  /home/zaken/ceph/src/cephadm/.tox/py3/lib/python3.10/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning: Exception ignored in: <function _TemporaryFileCloser.__del__ at 0x78a92ca3b400>

  Traceback (most recent call last):
    File "/usr/lib/python3.10/tempfile.py", line 605, in __del__
      self.close()
    File "/usr/lib/python3.10/tempfile.py", line 598, in close
      self.file.close()
    File "/home/zaken/ceph/src/cephadm/.tox/py3/lib/python3.10/site-packages/pyfakefs/fake_file.py", line 816, in close
      self.flush()
    File "/home/zaken/ceph/src/cephadm/.tox/py3/lib/python3.10/site-packages/pyfakefs/fake_file.py", line 853, in flush
      contents = self._io.getvalue()
    File "/home/zaken/ceph/src/cephadm/.tox/py3/lib/python3.10/site-packages/pyfakefs/helpers.py", line 412, in getvalue
      return self._bytestream.getvalue()
  ValueError: I/O operation on closed file.

```

The tests passes successfully but I was interested in resolving the warnings.

I think the reason we are hitting this warning is that calling the `cephadmlib.file_utils.write_tmp`  creates a file handle object which in the case of  `admin_keyring  `and `tmp_config ` are being captured by a closure created by the function `def cli` which is defined in def `command_bootstrap(ctx)`: .
I managed to validate this by printing the `NamedTemporaryFile  `objects in the following function in fixtures.py:
```
@pytest.fixture()
def cephadm_fs(
    fs: fake_filesystem.FakeFilesystem,
):
...
yield fs
...
```

Printing the paths that were generated for adming_keyring  and tmp_config  in command_bootstrap(ctx) and adding prints of the garbage collector objects after the yield fs  call, I managed to validate that indeed these two were producing the warning. I think that since the closure in def cli captured these objects aren't marked as "closed" and later when the pyfakefs teardown happens we hit this warning: ValueError: I/O operation on closed file.

As a test I added explicit calls to close the files handles of these objects (admin_keyring and tmp_config) in command_bootstrap(ctx) and the warnings were resolved.

Using direct os calls in a wrapper class during teardown resolved these warnings.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
