### PR TITLE
[rgw] RGW attributes map optimization 

### DIFF
--- a/src/rgw/driver/dbstore/common/dbstore.cc
+++ b/src/rgw/driver/dbstore/common/dbstore.cc
@@ -1367,7 +1367,7 @@ int DB::Object::Read::prepare(const DoutPrefixProvider *dpp)
     *params.target_obj = state.obj;
   }
   if (params.attrs) {
-    *params.attrs = astate->attrset;
+    *params.attrs = astate->attrset.get_full_map();
     if (cct->_conf->subsys.should_gather<ceph_subsys_rgw, 20>()) {
       for (iter = params.attrs->begin(); iter != params.attrs->end(); ++iter) {
         ldpp_dout(dpp, 20) << "Read xattr rgw_rados: " << iter->first << dendl;
@@ -1824,7 +1824,7 @@ out:
 }
 
 int DB::Object::Write::write_meta(const DoutPrefixProvider *dpp, uint64_t size, uint64_t accounted_size,
-    map<string, bufferlist>& attrs)
+    rgw::sal::Attrs& attrs)
 {
   bool assume_noent = false;
   /* handle assume_noent */

--- a/src/rgw/driver/dbstore/common/dbstore.cc
+++ b/src/rgw/driver/dbstore/common/dbstore.cc
@@ -2,7 +2,9 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "dbstore.h"
+#include "include/buffer_fwd.h"
 #include "log/Log.h"
+#include "rgw_common.h"
 
 using namespace std;
 
@@ -268,7 +270,7 @@ int DB::ProcessOp(const DoutPrefixProvider *dpp, std::string_view Op, DBOpParams
 
 int DB::get_user(const DoutPrefixProvider *dpp,
     const std::string& query_str, const std::string& query_str_val,
-    RGWUserInfo& uinfo, map<string, bufferlist> *pattrs,
+    RGWUserInfo& uinfo, rgw::sal::Attrs *pattrs,
     RGWObjVersionTracker *pobjv_tracker) {
   int ret = 0;
 
@@ -638,7 +640,7 @@ int DB::update_bucket(const DoutPrefixProvider *dpp, const std::string& query_st
     RGWBucketInfo& info,
     bool exclusive,
     const rgw_owner* powner,
-    map<std::string, bufferlist>* pattrs,
+    rgw::sal::Attrs* pattrs,
     ceph::real_time* pmtime,
     RGWObjVersionTracker* pobjv)
 {
@@ -646,7 +648,7 @@ int DB::update_bucket(const DoutPrefixProvider *dpp, const std::string& query_st
   DBOpParams params = {};
   obj_version bucket_version;
   RGWBucketInfo orig_info;
-  map<std::string, bufferlist> attrs;
+  rgw::sal::Attrs attrs;
 
   /* Check if the bucket already exists and return the old info, caller will have a use for it */
   orig_info.bucket.name = info.bucket.name;
@@ -1081,8 +1083,8 @@ out:
 }
 
 int DB::Object::set_attrs(const DoutPrefixProvider *dpp,
-                          map<string, bufferlist>& setattrs,
-                          map<string, bufferlist>* rmattrs)
+                          rgw::sal::Attrs& setattrs,
+                          rgw::sal::Attrs* rmattrs)
 {
   int ret = 0;
 
@@ -1106,13 +1108,10 @@ int DB::Object::set_attrs(const DoutPrefixProvider *dpp,
   params.op.obj.state = *state;
   attrs = &params.op.obj.state.attrset;
   if (rmattrs) {
-    for (iter = rmattrs->begin(); iter != rmattrs->end(); ++iter) {
-      (*attrs).erase(iter->first);
-    }
+    (*attrs).erase(*rmattrs);
   }
-  for (iter = setattrs.begin(); iter != setattrs.end(); ++iter) {
-    (*attrs)[iter->first] = iter->second;
-  }
+
+  (*attrs).set_attrs(setattrs);
 
   params.op.query_str = "attrs";
   /* As per https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html, 
@@ -1139,7 +1138,9 @@ int DB::Object::transition(const DoutPrefixProvider *dpp,
   int ret = 0;
 
   DBOpParams params = {};
-  map<string, bufferlist> *attrset;
+  rgw::sal::Attrs* attrset;
+
+  *attrset;
 
   store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
@@ -1372,6 +1373,9 @@ int DB::Object::Read::prepare(const DoutPrefixProvider *dpp)
         ldpp_dout(dpp, 20) << "Read xattr rgw_rados: " << iter->first << dendl;
       }
     }
+
+
+    
   }
 
   if (conds.if_match || conds.if_nomatch) {
@@ -1696,13 +1700,13 @@ int DB::Object::Write::write_data(const DoutPrefixProvider* dpp,
 /* Write metadata & head object data */
 int DB::Object::Write::_do_write_meta(const DoutPrefixProvider *dpp,
     uint64_t size, uint64_t accounted_size,
-    map<string, bufferlist>& attrs,
+    rgw::sal::Attrs& attrs,
     bool assume_noent, bool modify_tail)
 {
   DB *store = target->get_store();
 
   RGWObjState* state = &obj_state;
-  map<string, bufferlist> *attrset;
+  rgw::sal::Attrs* attrset;
   DBOpParams params = {};
   int ret = 0;
   string etag;
@@ -1724,8 +1728,8 @@ int DB::Object::Write::_do_write_meta(const DoutPrefixProvider *dpp,
   attrset = &state->attrset;
   if (target->bucket_info.obj_lock_enabled() && target->bucket_info.obj_lock.has_rule()) {
     // && meta.flags == PUT_OBJ_CREATE) {
-    auto iter = attrs.find(RGW_ATTR_OBJECT_RETENTION);
-    if (iter == attrs.end()) {
+    auto val = attrs.find(RGW_ATTR_OBJECT_RETENTION);
+    if (val == nullptr) {
       real_time lock_until_date = target->bucket_info.obj_lock.get_lock_until_date(meta.set_mtime);
       string mode = target->bucket_info.obj_lock.get_mode();
       RGWObjectRetention obj_retention(mode, lock_until_date);
@@ -1744,42 +1748,34 @@ int DB::Object::Write::_do_write_meta(const DoutPrefixProvider *dpp,
   }
 
   if (meta.rmattrs) {
-    for (iter = meta.rmattrs->begin(); iter != meta.rmattrs->end(); ++iter) {
-      const string& name = iter->first;
-      (*attrset).erase(name.c_str());
-    }
+      (*attrset).erase(*(meta.rmattrs));
   }
 
   if (meta.manifest) {
     storage_class = meta.manifest->get_tail_placement().placement_rule.storage_class;
 
     /* remove existing manifest attr */
-    iter = attrs.find(RGW_ATTR_MANIFEST);
-    if (iter != attrs.end())
-      attrs.erase(iter);
+    attrs.erase(RGW_ATTR_MANIFEST);
 
     bufferlist bl;
     encode(*meta.manifest, bl);
     (*attrset)[RGW_ATTR_MANIFEST] = bl;
   }
 
-  for (iter = attrs.begin(); iter != attrs.end(); ++iter) {
-    const string& name = iter->first;
-    bufferlist& bl = iter->second;
 
-    if (!bl.length())
-      continue;
 
-    (*attrset)[name.c_str()] = bl;
+  (*attrset).set_attrs(attrs);
 
-    if (name.compare(RGW_ATTR_ETAG) == 0) {
-      etag = rgw_bl_str(bl);
-      params.op.obj.etag = etag;
-    } else if (name.compare(RGW_ATTR_CONTENT_TYPE) == 0) {
-      content_type = rgw_bl_str(bl);
-    } else if (name.compare(RGW_ATTR_ACL) == 0) {
-      acl_bl = bl;
-    }
+  if (auto acl = attrs.find(RGW_ATTR_ETAG)) {
+      acl_bl = *acl;
+  }
+
+  if (auto etag_bl = attrs.find(RGW_ATTR_CONTENT_TYPE)) {
+      params.op.obj.etag = rgw_bl_str(*etag_bl);
+  }
+
+  if (auto ct_bl = attrs.find(RGW_ATTR_ACL)) {
+      content_type = rgw_bl_str(*ct_bl);
   }
 
   if (!storage_class.empty()) {

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -1582,7 +1582,7 @@ class DB {
 
     int get_user(const DoutPrefixProvider *dpp,
         const std::string& query_str, const std::string& query_str_val,
-        RGWUserInfo& uinfo, std::map<std::string, bufferlist> *pattrs,
+        RGWUserInfo& uinfo, rgw::sal::Attrs *pattrs,
         RGWObjVersionTracker *pobjv_tracker);
     int store_user(const DoutPrefixProvider *dpp,
         RGWUserInfo& uinfo, bool exclusive, std::map<std::string, bufferlist> *pattrs,
@@ -1618,7 +1618,7 @@ class DB {
         bool *is_truncated);
     int update_bucket(const DoutPrefixProvider *dpp, const std::string& query_str,
         RGWBucketInfo& info, bool exclusive,
-        const rgw_owner* powner, std::map<std::string, bufferlist>* pattrs,
+        const rgw_owner* powner, rgw::sal::Attrs* pattrs,
         ceph::real_time* pmtime, RGWObjVersionTracker* pobjv);
 
     uint64_t get_max_head_size() { return ObjHeadSize; }
@@ -1840,7 +1840,7 @@ class DB {
         struct Params {
           ceph::real_time *lastmod;
           uint64_t *obj_size;
-	  std::map<std::string, bufferlist> *attrs;
+	        std::map<std::string, bufferlist> *attrs;
           rgw_obj *target_obj;
 
           Params() : lastmod(nullptr), obj_size(nullptr), attrs(nullptr),
@@ -1863,7 +1863,7 @@ class DB {
 
         struct MetaParams {
           ceph::real_time *mtime;
-	  std::map<std::string, bufferlist>* rmattrs;
+	        rgw::sal::Attrs *rmattrs;
           const bufferlist *data;
           RGWObjManifest *manifest;
           const std::string *ptag;
@@ -1897,7 +1897,7 @@ class DB {
                                bufferlist& data, uint64_t ofs);
         int _do_write_meta(const DoutPrefixProvider *dpp,
             uint64_t size, uint64_t accounted_size,
-	    std::map<std::string, bufferlist>& attrs,
+	    rgw::sal::Attrs& attrs,
             bool assume_noent, bool modify_tail);
         int write_meta(const DoutPrefixProvider *dpp, uint64_t size,
 	    uint64_t accounted_size, std::map<std::string, bufferlist>& attrs);
@@ -1957,8 +1957,8 @@ class DB {
       RGWBucketInfo& get_bucket_info() { return bucket_info; }
 
       int InitializeParamsfromObject(const DoutPrefixProvider *dpp, DBOpParams* params);
-      int set_attrs(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist>& setattrs,
-          std::map<std::string, bufferlist>* rmattrs);
+      int set_attrs(const DoutPrefixProvider *dpp, rgw::sal::Attrs& setattrs,
+          rgw::sal::Attrs* rmattrs);
       int transition(const DoutPrefixProvider *dpp,
                      const rgw_placement_rule& rule, const real_time& mtime,
                      uint64_t olh_epoch);

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -1900,7 +1900,7 @@ class DB {
 	    rgw::sal::Attrs& attrs,
             bool assume_noent, bool modify_tail);
         int write_meta(const DoutPrefixProvider *dpp, uint64_t size,
-	    uint64_t accounted_size, std::map<std::string, bufferlist>& attrs);
+	    uint64_t accounted_size, rgw::sal::Attrs& attrs);
       };
 
       struct Delete {

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -123,12 +123,16 @@ static int load_group_policies(const DoutPrefixProvider* dpp,
   }
 
   CephContext* cct = dpp->get_cct();
-  if (auto i = attrs.find(RGW_ATTR_IAM_POLICY); i != attrs.end()) {
-    load_inline_policy(cct, i->second, tenant, policies);
+  auto iam_policy_val = attrs.find(RGW_ATTR_IAM_POLICY);
+  if (iam_policy_val != nullptr) {
+      load_inline_policy(cct, *iam_policy_val, tenant, policies);
   }
-  if (auto i = attrs.find(RGW_ATTR_MANAGED_POLICY); i != attrs.end()) {
-    load_managed_policy(cct, i->second, policies);
+
+  auto managed_policy_val = attrs.find(RGW_ATTR_MANAGED_POLICY);
+  if (managed_policy_val != nullptr) {
+      load_managed_policy(cct, *managed_policy_val, policies);
   }
+  
   return 0;
 }
 
@@ -160,11 +164,14 @@ int load_account_and_policies(const DoutPrefixProvider* dpp,
 
   // load user policies from user attrs
   CephContext* cct = dpp->get_cct();
-  if (auto bl = attrs.find(RGW_ATTR_USER_POLICY); bl != attrs.end()) {
-    load_inline_policy(cct, bl->second, policy_tenant, policies);
+  auto user_policy_val = attrs.find(RGW_ATTR_USER_POLICY);
+  if (user_policy_val != nullptr) {
+      load_inline_policy(cct, *user_policy_val, policy_tenant, policies);
   }
-  if (auto bl = attrs.find(RGW_ATTR_MANAGED_POLICY); bl != attrs.end()) {
-    load_managed_policy(cct, bl->second, policies);
+
+  auto managed_policy_val = attrs.find(RGW_ATTR_MANAGED_POLICY);
+  if (managed_policy_val != nullptr) {
+      load_managed_policy(cct, *managed_policy_val, policies);
   }
 
   // load each group and its policies

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1704,11 +1704,11 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, req_state *s, uint6
 
 
 int verify_object_lock(const DoutPrefixProvider* dpp, const rgw::sal::Attrs& attrs, const bool bypass_perm, const bool bypass_governance_mode) {
-  auto aiter = attrs.find(RGW_ATTR_OBJECT_RETENTION);
-  if (aiter != attrs.end()) {
+  auto aval = attrs.find(RGW_ATTR_OBJECT_RETENTION);
+  if (aval != nullptr) {
     RGWObjectRetention obj_retention;
     try {
-      decode(obj_retention, aiter->second);
+      decode(obj_retention, *aval);
     } catch (buffer::error& err) {
       ldpp_dout(dpp, 0) << "ERROR: failed to decode RGWObjectRetention" << dendl;
       return -EIO;
@@ -1719,11 +1719,11 @@ int verify_object_lock(const DoutPrefixProvider* dpp, const rgw::sal::Attrs& att
       }
     }
   }
-  aiter = attrs.find(RGW_ATTR_OBJECT_LEGAL_HOLD);
-  if (aiter != attrs.end()) {
+  aval = attrs.find(RGW_ATTR_OBJECT_LEGAL_HOLD);
+  if (aval != nullptr) {
     RGWObjectLegalHold obj_legal_hold;
     try {
-      decode(obj_legal_hold, aiter->second);
+      decode(obj_legal_hold, *aval);
     } catch (buffer::error& err) {
       ldpp_dout(dpp, 0) << "ERROR: failed to decode RGWObjectLegalHold" << dendl;
       return -EIO;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -282,6 +282,16 @@ void set_attrs(const Attrs& rmattrs) {
     }
 }
 
+void operator=(std::map<std::string, ceph::bufferlist>& other){
+    defaultMap = other;
+}
+
+void operator=(const std::map<std::string, ceph::bufferlist>& other){
+    defaultMap = other;
+
+}
+
+
 void dump(const DoutPrefixProvider *dpp) const {
     // Iterate through the fast array
     for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {
@@ -301,6 +311,7 @@ void dump(const DoutPrefixProvider *dpp) const {
         ldpp_dout(dpp, 20) << "Read xattr rgw_rados (map): " << it->first << dendl;
     }
 }
+
 
 
     void encode(ceph::bufferlist& bl) const {
@@ -324,160 +335,6 @@ void dump(const DoutPrefixProvider *dpp) const {
         }
     }
 };
-
-
-
-// static inline const std::map<Const_RGW_Attrs, std::string> Const_RGW_Attrs_To_String{
-//     {Const_RGW_Attrs::RGW_ATTR_ACL_CONST, "0"},
-//     {Const_RGW_Attrs::RGW_ATTR_RATELIMIT_CONST, "1"},
-//     {Const_RGW_Attrs::RGW_ATTR_LC_CONST, "2"}
-// };
-
-  //using Attrs = std::map<std::string, ceph::buffer::list>;
-
-//   class Attrs {
-// public:
-//   using iterator = std::map<std::string, ceph::buffer::list>::iterator;
-//   using const_iterator = std::map<std::string, ceph::buffer::list>::const_iterator;
-//   using value_type = std::map<std::string, ceph::buffer::list>::value_type;
-//   using key_type = std::string;
-//   using mapped_type = ceph::buffer::list;
-
-//   Attrs() = default;
-  
-//   Attrs& operator=(const std::map<std::string, ceph::buffer::list>& other) {
-//     items = other;
-//     return *this;
-//   }
-
-//   // Assignment from another Attrs object
-//   Attrs& operator=(const Attrs& other) = default;
-
-//   // Move assignment
-//   Attrs& operator=(std::map<std::string, ceph::buffer::list>&& other) {
-//     items = std::move(other);
-//     return *this;
-//   }
-
-//   operator std::map<std::string, ceph::buffer::list>&() { return items; }
-//   operator const std::map<std::string, ceph::buffer::list>&() const { return items; }
-
-//   std::map<std::string, ceph::buffer::list>* operator&() { return &items; }
-//   const std::map<std::string, ceph::buffer::list>* operator&() const { return &items; }
-
-//   operator std::map<std::string, ceph::buffer::list>*() { return &items; }
-//   operator const std::map<std::string, ceph::buffer::list>*() const { return &items; }
-
-//   iterator begin() { return items.begin(); }
-//   iterator end() { return items.end(); }
-//   const_iterator begin() const { return items.begin(); }
-//   const_iterator end() const { return items.end(); }
-//   const_iterator cbegin() const { return items.cbegin(); }
-//   const_iterator cend() const { return items.cend(); }
-
-//   bool empty() const { return items.empty(); }
-//   size_t size() const { return items.size(); }
-//   size_t max_size() const { return items.max_size(); }
-
-//   void clear() { items.clear(); }
-//   iterator erase(const_iterator pos) { return items.erase(pos); }
-//   size_t erase(const std::string& key) { return items.erase(key); }
-
-//   std::pair<iterator, bool> insert(const value_type& value) { return items.insert(value); }
-//   template <class... Args>
-//   std::pair<iterator, bool> emplace(Args&&... args) { return items.emplace(std::forward<Args>(args)...); }
-
-//   ceph::buffer::list& operator[](const std::string& k) { return items[k]; }
-//   ceph::buffer::list& at(const std::string& k) { return items.at(k); }
-//   const ceph::buffer::list& at(const std::string& k) const { return items.at(k); }
-
-//   iterator find(const std::string& s) { return items.find(s); }
-//   const_iterator find(const std::string& s) const { return items.find(s); }
-
-//   iterator find(Const_RGW_Attrs key) {
-//     auto it = Const_RGW_Attrs_To_String.find(key);
-//     if (it != Const_RGW_Attrs_To_String.end()) {
-//       return items.find(it->second);
-//     }
-//     return items.end();
-//   }
-
-//   const_iterator find(Const_RGW_Attrs key) const {
-//     auto it = Const_RGW_Attrs_To_String.find(key);
-//     if (it != Const_RGW_Attrs_To_String.end()) {
-//       return items.find(it->second);
-//     }
-//     return items.end();
-//   }
-
-//   void encode(ceph::buffer::list& bl) const { ::encode(items, bl); }
-//   void encode(ceph::buffer::list& bl, uint64_t f) const { ::encode(items, bl, f); }
-//   void decode(ceph::buffer::list::const_iterator& p) { ::decode(items, p); }
-
-// private:
-//   std::map<std::string, ceph::buffer::list> items;
-
-//   static inline const std::map<Const_RGW_Attrs, std::string> Const_RGW_Attrs_To_String{
-//     {Const_RGW_Attrs::RGW_ATTR_ACL_CONST, RGW_ATTR_ACL},
-//     {Const_RGW_Attrs::RGW_ATTR_RATELIMIT_CONST, RGW_ATTR_RATELIMIT},
-//     {Const_RGW_Attrs::RGW_ATTR_LC_CONST, RGW_ATTR_LC}
-//   };
-// };
-
-
-//////////////////////////////////////////////
-
-
-//   class Attrs : public std::map<std::string, ceph::buffer::list> {
-//   public:
-//       using std::map<std::string, ceph::buffer::list>::find;
-//       using std::map<std::string, ceph::buffer::list>::operator=;
-
-//       Attrs() = default;
-//       Attrs(const std::map<std::string, ceph::buffer::list>& other) : std::map<std::string, ceph::buffer::list>(other) {}
-
-//       Attrs& operator=(const std::map<std::string, ceph::buffer::list>& other) {
-//           std::map<std::string, ceph::buffer::list>::operator=(other);
-//           return *this;
-//       }
-
-
-//       const_iterator find(Const_RGW_Attrs key) {
-//           auto it = Const_RGW_Attrs_To_String.find(key);
-//           if (it != Const_RGW_Attrs_To_String.end()) {
-//               return it->second;
-//           }
-//           return end();
-//       }
-
-//       std::string find(Const_RGW_Attrs key) const {
-//           auto it = Const_RGW_Attrs_To_String.find(key);
-//           if (it != Const_RGW_Attrs_To_String.end()) {
-//               return std::map<std::string, ceph::buffer::list>::find(it->second);
-//           }
-//           return std::map<std::string, ceph::buffer::list>::find(it->second);
-//       }
-
-//   private:
-
-//   };
-
-
-//   inline void encode(const Attrs& o, ::ceph::bufferlist& bl, uint64_t f) {
-//     const std::map<std::string, ceph::buffer::list>& base = o;
-//     ::ceph::encode(base, bl, f);
-//   }
-
-//   inline void encode(const Attrs& o, ::ceph::bufferlist& bl) {
-//     const std::map<std::string, ceph::buffer::list>& base = o;
-//     ::ceph::encode(base, bl);
-//   }
-
-//   inline void decode(Attrs& o, ::ceph::bufferlist::const_iterator& p) {
-//     std::map<std::string, ceph::buffer::list>& base = o;
-//     using ::ceph::decode;
-//     decode(base, p);
-//   }
 
 }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -269,6 +269,27 @@ void erase(const Attrs& rmattrs) {
     }
 }
 
+void erase(std::string& key) {
+    if (key == RGW_ATTR_ACL) { fastAttrArray[RGW_ATTR_ACL_CONST].clear();
+    } else if (key == RGW_ATTR_RATELIMIT) { fastAttrArray[RGW_ATTR_RATELIMIT_CONST].clear();
+    } else if (key == RGW_ATTR_LC) { fastAttrArray[RGW_ATTR_LC_CONST].clear();
+    } else {
+        defaultMap.erase(key);
+    }
+}
+
+void erase(Const_RGW_Attrs index) {
+    if (index >= 0 && index < RGW_ATTR_COUNT) {
+        fastAttrArray[index].clear();
+    }
+}
+
+void erase(const char* key) {
+    if (!key) return;
+  
+    defaultMap.erase(std::string(key));
+}
+
 
 void set_attrs(const Attrs& rmattrs) {
     for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -59,10 +59,6 @@ namespace ceph {
   class Formatter;
 }
 
-namespace rgw::sal {
-  using Attrs = std::map<std::string, ceph::buffer::list>;
-}
-
 namespace rgw::lua {
   class Background;
 }
@@ -70,6 +66,8 @@ namespace rgw::lua {
 struct RGWProcessEnv;
 
 using ceph::crypto::MD5;
+
+
 
 #define RGW_ATTR_PREFIX  "user.rgw."
 
@@ -203,6 +201,299 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_BUCKET_NOTIFICATION RGW_ATTR_PREFIX "bucket-notification"
 
 #define RGW_ATTR_INTERNAL_MTIME RGW_ATTR_PREFIX "rgw-internal-mtime"
+
+namespace rgw::sal {
+
+
+
+enum Const_RGW_Attrs{
+  RGW_ATTR_ACL_CONST = 0,
+  RGW_ATTR_RATELIMIT_CONST = 1,
+  RGW_ATTR_LC_CONST = 2,
+  RGW_ATTR_COUNT = 3,
+};
+
+class Attrs {
+
+    std::array<ceph::bufferlist, RGW_ATTR_COUNT> fastAttrArray;
+    std::map<std::string, ceph::bufferlist> defaultMap;
+
+public:
+
+    using iterator = std::map<std::string, ceph::buffer::list>::iterator;
+    using const_iterator = std::map<std::string, ceph::buffer::list>::const_iterator;
+
+    ceph::bufferlist* find(Const_RGW_Attrs key) {
+        return &fastAttrArray[static_cast<size_t>(key)];
+    }
+
+    const ceph::bufferlist* find(Const_RGW_Attrs key) const {
+        return &fastAttrArray[static_cast<size_t>(key)];
+    }
+    
+
+    ceph::bufferlist* find(const std::string& key) {
+        // Currently for backward comp - in case someone calls one of the array objects with string.
+        if (key == RGW_ATTR_ACL) return &fastAttrArray[RGW_ATTR_ACL_CONST];
+        if (key == RGW_ATTR_RATELIMIT)  return &fastAttrArray[RGW_ATTR_RATELIMIT_CONST];
+        if (key == RGW_ATTR_LC)  return &fastAttrArray[RGW_ATTR_LC_CONST];
+        
+        auto it = defaultMap.find(key);
+        return (it != defaultMap.end()) ? &it->second : nullptr;
+    }
+
+    const ceph::bufferlist* find(const std::string& key) const {
+        if (key == RGW_ATTR_ACL) return &fastAttrArray[0];
+        if (key == RGW_ATTR_RATELIMIT)  return &fastAttrArray[1];
+        if (key == RGW_ATTR_LC)  return &fastAttrArray[2];
+        
+        auto it = defaultMap.find(key);
+        return (it != defaultMap.end()) ? &it->second : nullptr;
+    }
+
+    ceph::bufferlist& operator[](const std::string& key) {
+    return defaultMap[key];
+}
+
+void erase(const Attrs& rmattrs) {
+    // Clear the corresponding entries in the fast array
+    for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {
+        if (rmattrs.fastAttrArray[i].length() > 0) {
+            fastAttrArray[i].clear();
+        }
+    }
+
+    // Remove keys from the default map
+    for (const auto& [key, _] : rmattrs.defaultMap) {
+        defaultMap.erase(key);
+    }
+}
+
+
+void set_attrs(const Attrs& rmattrs) {
+    for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {
+        if (rmattrs.fastAttrArray[i].length() > 0) {
+            this->fastAttrArray[i] = rmattrs.fastAttrArray[i];
+        }
+    }
+
+    for (const auto& it : rmattrs.defaultMap) {
+        this->defaultMap[it.first] = it.second;
+    }
+}
+
+void dump(const DoutPrefixProvider *dpp) const {
+    // Iterate through the fast array
+    for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {
+        if (fastAttrArray[i].length() > 0) {
+            const char* name = "";
+            // Mapping the index back to the RGW string constant
+            if (i == RGW_ATTR_ACL_CONST) name = RGW_ATTR_ACL;
+            else if (i == RGW_ATTR_RATELIMIT_CONST) name = RGW_ATTR_RATELIMIT;
+            else if (i == RGW_ATTR_LC_CONST) name = RGW_ATTR_LC;
+            
+            ldpp_dout(dpp, 20) << "Read xattr rgw_rados (fast): " << name << dendl;
+        }
+    }
+
+    // Iterate through the default map
+    for (auto it = defaultMap.begin(); it != defaultMap.end(); ++it) {
+        ldpp_dout(dpp, 20) << "Read xattr rgw_rados (map): " << it->first << dendl;
+    }
+}
+
+
+    void encode(ceph::bufferlist& bl) const {
+        std::map<std::string, ceph::bufferlist> to_encode = defaultMap;
+        if (fastAttrArray[0].length() > 0) to_encode[RGW_ATTR_ACL] = fastAttrArray[RGW_ATTR_ACL_CONST];
+        if (fastAttrArray[1].length() > 0) to_encode[RGW_ATTR_RATELIMIT]  = fastAttrArray[RGW_ATTR_RATELIMIT_CONST];
+        if (fastAttrArray[2].length() > 0) to_encode[RGW_ATTR_LC]  = fastAttrArray[RGW_ATTR_LC_CONST];
+
+        ::ceph::encode(to_encode, bl);
+    }
+
+    void decode(ceph::bufferlist::const_iterator& bl) {
+        std::map<std::string, ceph::bufferlist> decoded_map;
+        ::ceph::decode(decoded_map, bl);
+
+        for (auto& [key, val] : decoded_map) {
+            if (key == RGW_ATTR_ACL)      fastAttrArray[RGW_ATTR_ACL_CONST] = std::move(val);
+            else if (key == RGW_ATTR_RATELIMIT)  fastAttrArray[RGW_ATTR_RATELIMIT_CONST] = std::move(val);
+            else if (key == RGW_ATTR_LC)  fastAttrArray[RGW_ATTR_LC_CONST] = std::move(val);
+            else defaultMap[key] = std::move(val);
+        }
+    }
+};
+
+
+
+// static inline const std::map<Const_RGW_Attrs, std::string> Const_RGW_Attrs_To_String{
+//     {Const_RGW_Attrs::RGW_ATTR_ACL_CONST, "0"},
+//     {Const_RGW_Attrs::RGW_ATTR_RATELIMIT_CONST, "1"},
+//     {Const_RGW_Attrs::RGW_ATTR_LC_CONST, "2"}
+// };
+
+  //using Attrs = std::map<std::string, ceph::buffer::list>;
+
+//   class Attrs {
+// public:
+//   using iterator = std::map<std::string, ceph::buffer::list>::iterator;
+//   using const_iterator = std::map<std::string, ceph::buffer::list>::const_iterator;
+//   using value_type = std::map<std::string, ceph::buffer::list>::value_type;
+//   using key_type = std::string;
+//   using mapped_type = ceph::buffer::list;
+
+//   Attrs() = default;
+  
+//   Attrs& operator=(const std::map<std::string, ceph::buffer::list>& other) {
+//     items = other;
+//     return *this;
+//   }
+
+//   // Assignment from another Attrs object
+//   Attrs& operator=(const Attrs& other) = default;
+
+//   // Move assignment
+//   Attrs& operator=(std::map<std::string, ceph::buffer::list>&& other) {
+//     items = std::move(other);
+//     return *this;
+//   }
+
+//   operator std::map<std::string, ceph::buffer::list>&() { return items; }
+//   operator const std::map<std::string, ceph::buffer::list>&() const { return items; }
+
+//   std::map<std::string, ceph::buffer::list>* operator&() { return &items; }
+//   const std::map<std::string, ceph::buffer::list>* operator&() const { return &items; }
+
+//   operator std::map<std::string, ceph::buffer::list>*() { return &items; }
+//   operator const std::map<std::string, ceph::buffer::list>*() const { return &items; }
+
+//   iterator begin() { return items.begin(); }
+//   iterator end() { return items.end(); }
+//   const_iterator begin() const { return items.begin(); }
+//   const_iterator end() const { return items.end(); }
+//   const_iterator cbegin() const { return items.cbegin(); }
+//   const_iterator cend() const { return items.cend(); }
+
+//   bool empty() const { return items.empty(); }
+//   size_t size() const { return items.size(); }
+//   size_t max_size() const { return items.max_size(); }
+
+//   void clear() { items.clear(); }
+//   iterator erase(const_iterator pos) { return items.erase(pos); }
+//   size_t erase(const std::string& key) { return items.erase(key); }
+
+//   std::pair<iterator, bool> insert(const value_type& value) { return items.insert(value); }
+//   template <class... Args>
+//   std::pair<iterator, bool> emplace(Args&&... args) { return items.emplace(std::forward<Args>(args)...); }
+
+//   ceph::buffer::list& operator[](const std::string& k) { return items[k]; }
+//   ceph::buffer::list& at(const std::string& k) { return items.at(k); }
+//   const ceph::buffer::list& at(const std::string& k) const { return items.at(k); }
+
+//   iterator find(const std::string& s) { return items.find(s); }
+//   const_iterator find(const std::string& s) const { return items.find(s); }
+
+//   iterator find(Const_RGW_Attrs key) {
+//     auto it = Const_RGW_Attrs_To_String.find(key);
+//     if (it != Const_RGW_Attrs_To_String.end()) {
+//       return items.find(it->second);
+//     }
+//     return items.end();
+//   }
+
+//   const_iterator find(Const_RGW_Attrs key) const {
+//     auto it = Const_RGW_Attrs_To_String.find(key);
+//     if (it != Const_RGW_Attrs_To_String.end()) {
+//       return items.find(it->second);
+//     }
+//     return items.end();
+//   }
+
+//   void encode(ceph::buffer::list& bl) const { ::encode(items, bl); }
+//   void encode(ceph::buffer::list& bl, uint64_t f) const { ::encode(items, bl, f); }
+//   void decode(ceph::buffer::list::const_iterator& p) { ::decode(items, p); }
+
+// private:
+//   std::map<std::string, ceph::buffer::list> items;
+
+//   static inline const std::map<Const_RGW_Attrs, std::string> Const_RGW_Attrs_To_String{
+//     {Const_RGW_Attrs::RGW_ATTR_ACL_CONST, RGW_ATTR_ACL},
+//     {Const_RGW_Attrs::RGW_ATTR_RATELIMIT_CONST, RGW_ATTR_RATELIMIT},
+//     {Const_RGW_Attrs::RGW_ATTR_LC_CONST, RGW_ATTR_LC}
+//   };
+// };
+
+
+//////////////////////////////////////////////
+
+
+//   class Attrs : public std::map<std::string, ceph::buffer::list> {
+//   public:
+//       using std::map<std::string, ceph::buffer::list>::find;
+//       using std::map<std::string, ceph::buffer::list>::operator=;
+
+//       Attrs() = default;
+//       Attrs(const std::map<std::string, ceph::buffer::list>& other) : std::map<std::string, ceph::buffer::list>(other) {}
+
+//       Attrs& operator=(const std::map<std::string, ceph::buffer::list>& other) {
+//           std::map<std::string, ceph::buffer::list>::operator=(other);
+//           return *this;
+//       }
+
+
+//       const_iterator find(Const_RGW_Attrs key) {
+//           auto it = Const_RGW_Attrs_To_String.find(key);
+//           if (it != Const_RGW_Attrs_To_String.end()) {
+//               return it->second;
+//           }
+//           return end();
+//       }
+
+//       std::string find(Const_RGW_Attrs key) const {
+//           auto it = Const_RGW_Attrs_To_String.find(key);
+//           if (it != Const_RGW_Attrs_To_String.end()) {
+//               return std::map<std::string, ceph::buffer::list>::find(it->second);
+//           }
+//           return std::map<std::string, ceph::buffer::list>::find(it->second);
+//       }
+
+//   private:
+
+//   };
+
+
+//   inline void encode(const Attrs& o, ::ceph::bufferlist& bl, uint64_t f) {
+//     const std::map<std::string, ceph::buffer::list>& base = o;
+//     ::ceph::encode(base, bl, f);
+//   }
+
+//   inline void encode(const Attrs& o, ::ceph::bufferlist& bl) {
+//     const std::map<std::string, ceph::buffer::list>& base = o;
+//     ::ceph::encode(base, bl);
+//   }
+
+//   inline void decode(Attrs& o, ::ceph::bufferlist::const_iterator& p) {
+//     std::map<std::string, ceph::buffer::list>& base = o;
+//     using ::ceph::decode;
+//     decode(base, p);
+//   }
+
+}
+
+
+inline void encode(const rgw::sal::Attrs &p, bufferlist &bl)
+{
+  p.encode( bl);
+}
+
+inline void decode(rgw::sal::Attrs &o, const bufferlist& bl)
+{
+  auto p = bl.begin();
+  o.decode(p);
+  ceph_assert(p.end());
+}
+
 
 enum class RGWFormat : int8_t {
   BAD_FORMAT = -1,

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -298,10 +298,11 @@ void erase(Const_RGW_Attrs index) {
     }
 }
 
-void erase(const char* key) {
-    if (!key) return;
+bool erase(const char* key) {
+    if (!key) return false;
   
     defaultMap.erase(std::string(key));
+    return true;
 }
 
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -312,6 +312,15 @@ void operator=(const std::map<std::string, ceph::bufferlist>& other){
 
 }
 
+std::map<std::string, ceph::bufferlist> get_full_map(){
+  std::map<std::string, ceph::bufferlist> fullMap = defaultMap;
+  fullMap[RGW_ATTR_ACL] = fastAttrArray[RGW_ATTR_ACL_CONST];
+  fullMap[RGW_ATTR_RATELIMIT] = fastAttrArray[RGW_ATTR_RATELIMIT_CONST];
+  fullMap[RGW_ATTR_LC] = fastAttrArray[RGW_ATTR_LC_CONST];
+  return fullMap;
+
+}
+
 
 void dump(const DoutPrefixProvider *dpp) const {
     // Iterate through the fast array

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -317,6 +317,10 @@ void set_attrs(const Attrs& rmattrs) {
     }
 }
 
+void emplace_attr_to_map(std::string&& key, buffer::list&& bl){
+  defaultMap.emplace(std::move(key), std::move(bl));
+}
+
 void operator=(std::map<std::string, ceph::bufferlist>& other){
     defaultMap = other;
 }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -206,16 +206,22 @@ namespace rgw::sal {
 
 
 
-enum Const_RGW_Attrs{
+enum class Const_RGW_Attrs{
   RGW_ATTR_ACL_CONST = 0,
   RGW_ATTR_RATELIMIT_CONST = 1,
   RGW_ATTR_LC_CONST = 2,
   RGW_ATTR_COUNT = 3,
 };
 
+constexpr std::array<std::string_view, static_cast<size_t>(Const_RGW_Attrs::RGW_ATTR_COUNT)> rgw_attrs_array = {
+  RGW_ATTR_ACL,
+  RGW_ATTR_RATELIMIT,
+  RGW_ATTR_LC,
+};
+
 class Attrs {
 
-    std::array<ceph::bufferlist, RGW_ATTR_COUNT> fastAttrArray;
+    std::array<ceph::bufferlist, static_cast<size_t>(Const_RGW_Attrs::RGW_ATTR_COUNT)> fastAttrArray;
     std::map<std::string, ceph::bufferlist> defaultMap;
 
 public:
@@ -234,18 +240,22 @@ public:
 
     ceph::bufferlist* find(const std::string& key) {
         // Currently for backward comp - in case someone calls one of the array objects with string.
-        if (key == RGW_ATTR_ACL) return &fastAttrArray[RGW_ATTR_ACL_CONST];
-        if (key == RGW_ATTR_RATELIMIT)  return &fastAttrArray[RGW_ATTR_RATELIMIT_CONST];
-        if (key == RGW_ATTR_LC)  return &fastAttrArray[RGW_ATTR_LC_CONST];
+        for(int i = 0; i < static_cast<size_t>(Const_RGW_Attrs::RGW_ATTR_COUNT); i++){
+            if(rgw_attrs_array[i] == key){
+                return &fastAttrArray[i];
+        }
+      }
         
         auto it = defaultMap.find(key);
         return (it != defaultMap.end()) ? &it->second : nullptr;
     }
 
     const ceph::bufferlist* find(const std::string& key) const {
-        if (key == RGW_ATTR_ACL) return &fastAttrArray[0];
-        if (key == RGW_ATTR_RATELIMIT)  return &fastAttrArray[1];
-        if (key == RGW_ATTR_LC)  return &fastAttrArray[2];
+        for(int i = 0; i < static_cast<size_t>(Const_RGW_Attrs::RGW_ATTR_COUNT); i++){
+            if(rgw_attrs_array[i] == key){
+                return &fastAttrArray[i];
+        }
+      }
         
         auto it = defaultMap.find(key);
         return (it != defaultMap.end()) ? &it->second : nullptr;
@@ -257,7 +267,7 @@ public:
 
 void erase(const Attrs& rmattrs) {
     // Clear the corresponding entries in the fast array
-    for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {
+    for(int i = 0; i < static_cast<size_t>(Const_RGW_Attrs::RGW_ATTR_COUNT); i++){
         if (rmattrs.fastAttrArray[i].length() > 0) {
             fastAttrArray[i].clear();
         }
@@ -270,17 +280,21 @@ void erase(const Attrs& rmattrs) {
 }
 
 void erase(std::string& key) {
-    if (key == RGW_ATTR_ACL) { fastAttrArray[RGW_ATTR_ACL_CONST].clear();
-    } else if (key == RGW_ATTR_RATELIMIT) { fastAttrArray[RGW_ATTR_RATELIMIT_CONST].clear();
-    } else if (key == RGW_ATTR_LC) { fastAttrArray[RGW_ATTR_LC_CONST].clear();
-    } else {
-        defaultMap.erase(key);
+      for(int i = 0; i < static_cast<size_t>(Const_RGW_Attrs::RGW_ATTR_COUNT); i++){
+            if(rgw_attrs_array[i] == key){
+                fastAttrArray[i].clear();
+                return;
+      }
     }
+
+      defaultMap.erase(key);
+    
 }
 
 void erase(Const_RGW_Attrs index) {
-    if (index >= 0 && index < RGW_ATTR_COUNT) {
-        fastAttrArray[index].clear();
+    const size_t idx = static_cast<size_t>(index);
+    if (idx < fastAttrArray.size()) {
+        fastAttrArray[idx].clear();
     }
 }
 
@@ -292,7 +306,7 @@ void erase(const char* key) {
 
 
 void set_attrs(const Attrs& rmattrs) {
-    for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {
+    for (size_t i = 0; i < fastAttrArray.size(); ++i) {
         if (rmattrs.fastAttrArray[i].length() > 0) {
             this->fastAttrArray[i] = rmattrs.fastAttrArray[i];
         }
@@ -314,9 +328,11 @@ void operator=(const std::map<std::string, ceph::bufferlist>& other){
 
 std::map<std::string, ceph::bufferlist> get_full_map(){
   std::map<std::string, ceph::bufferlist> fullMap = defaultMap;
-  fullMap[RGW_ATTR_ACL] = fastAttrArray[RGW_ATTR_ACL_CONST];
-  fullMap[RGW_ATTR_RATELIMIT] = fastAttrArray[RGW_ATTR_RATELIMIT_CONST];
-  fullMap[RGW_ATTR_LC] = fastAttrArray[RGW_ATTR_LC_CONST];
+  for (size_t i = 0; i < rgw_attrs_array.size(); ++i) {
+        if (fastAttrArray[i].length() > 0) {
+            fullMap[std::string(rgw_attrs_array[i])] = fastAttrArray[i];
+        }
+  }
   return fullMap;
 
 }
@@ -324,15 +340,10 @@ std::map<std::string, ceph::bufferlist> get_full_map(){
 
 void dump(const DoutPrefixProvider *dpp) const {
     // Iterate through the fast array
-    for (size_t i = 0; i < RGW_ATTR_COUNT; ++i) {
+for (size_t i = 0; i < rgw_attrs_array.size(); ++i) {
         if (fastAttrArray[i].length() > 0) {
-            const char* name = "";
-            // Mapping the index back to the RGW string constant
-            if (i == RGW_ATTR_ACL_CONST) name = RGW_ATTR_ACL;
-            else if (i == RGW_ATTR_RATELIMIT_CONST) name = RGW_ATTR_RATELIMIT;
-            else if (i == RGW_ATTR_LC_CONST) name = RGW_ATTR_LC;
-            
-            ldpp_dout(dpp, 20) << "Read xattr rgw_rados (fast): " << name << dendl;
+            // Use the constexpr array to get the name
+            ldpp_dout(dpp, 20) << "Read xattr rgw_rados (fast): " << rgw_attrs_array[i] << dendl;
         }
     }
 
@@ -346,9 +357,11 @@ void dump(const DoutPrefixProvider *dpp) const {
 
     void encode(ceph::bufferlist& bl) const {
         std::map<std::string, ceph::bufferlist> to_encode = defaultMap;
-        if (fastAttrArray[0].length() > 0) to_encode[RGW_ATTR_ACL] = fastAttrArray[RGW_ATTR_ACL_CONST];
-        if (fastAttrArray[1].length() > 0) to_encode[RGW_ATTR_RATELIMIT]  = fastAttrArray[RGW_ATTR_RATELIMIT_CONST];
-        if (fastAttrArray[2].length() > 0) to_encode[RGW_ATTR_LC]  = fastAttrArray[RGW_ATTR_LC_CONST];
+        for (size_t i = 0; i < rgw_attrs_array.size(); ++i) {
+          if (fastAttrArray[i].length() > 0) {
+              to_encode[std::string(rgw_attrs_array[i])] = fastAttrArray[i];
+          }
+        }
 
         ::ceph::encode(to_encode, bl);
     }
@@ -358,10 +371,17 @@ void dump(const DoutPrefixProvider *dpp) const {
         ::ceph::decode(decoded_map, bl);
 
         for (auto& [key, val] : decoded_map) {
-            if (key == RGW_ATTR_ACL)      fastAttrArray[RGW_ATTR_ACL_CONST] = std::move(val);
-            else if (key == RGW_ATTR_RATELIMIT)  fastAttrArray[RGW_ATTR_RATELIMIT_CONST] = std::move(val);
-            else if (key == RGW_ATTR_LC)  fastAttrArray[RGW_ATTR_LC_CONST] = std::move(val);
-            else defaultMap[key] = std::move(val);
+            bool isFoundInFastArray = false;
+            for (size_t i = 0; i < rgw_attrs_array.size(); ++i) {
+                if (key == rgw_attrs_array[i]) {
+                    fastAttrArray[i] = std::move(val);
+                    isFoundInFastArray = true;
+                    break;
+                }
+            }
+            if (!isFoundInFastArray) {
+                defaultMap[key] = std::move(val);
+            }
         }
     }
 };

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -2015,8 +2015,8 @@ public:
   }
 
   buffer::list* get_attr(const std::string& k) {
-    auto iter = attrs.find(k);
-    return (iter != attrs.end()) ? &(iter->second) : nullptr;
+    auto val = attrs.find(k);
+    return (val != nullptr) ? &(*val) : nullptr;
   }
 
 }; /* RGWPutObjRequest */
@@ -2199,11 +2199,11 @@ public:
   uint64_t get_size() { return _size; }
   real_time ctime() { return mod_time; } // XXX
   real_time mtime() { return mod_time; }
-  std::map<string, bufferlist>& get_attrs() { return attrs; }
+  rgw::sal::Attrs& get_attrs() { return attrs; }
 
   buffer::list* get_attr(const std::string& k) {
-    auto iter = attrs.find(k);
-    return (iter != attrs.end()) ? &(iter->second) : nullptr;
+    auto val = attrs.find(k);
+    return (val != nullptr) ? &(*val) : nullptr;
   }
 
   bool only_bucket() override { return false; }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -311,11 +311,11 @@ static bool pass_object_lock_check(rgw::sal::Driver* driver, rgw::sal::Object* o
       return false;
     }
   } else {
-    auto iter = obj->get_attrs().find(RGW_ATTR_OBJECT_RETENTION);
-    if (iter != obj->get_attrs().end()) {
+    auto val = obj->get_attrs().find(RGW_ATTR_OBJECT_RETENTION);
+    if (val != nullptr) {
       RGWObjectRetention retention;
       try {
-        decode(retention, iter->second);
+        decode(retention, *val);
       } catch (buffer::error& err) {
         ldpp_dout(dpp, 0) << "ERROR: failed to decode RGWObjectRetention"
 			       << dendl;
@@ -326,11 +326,11 @@ static bool pass_object_lock_check(rgw::sal::Driver* driver, rgw::sal::Object* o
         return false;
       }
     }
-    iter = obj->get_attrs().find(RGW_ATTR_OBJECT_LEGAL_HOLD);
-    if (iter != obj->get_attrs().end()) {
+    val = obj->get_attrs().find(RGW_ATTR_OBJECT_LEGAL_HOLD);
+    if (val != nullptr) {
       RGWObjectLegalHold obj_legal_hold;
       try {
-        decode(obj_legal_hold, iter->second);
+        decode(obj_legal_hold, *val);
       } catch (buffer::error& err) {
         ldpp_dout(dpp, 0) << "ERROR: failed to decode RGWObjectLegalHold"
 			       << dendl;
@@ -657,9 +657,9 @@ static int remove_expired_obj(const DoutPrefixProvider* dpp,
   auto have_notify = !event_types.empty();
   if (have_notify) {
     auto attrset = obj->get_attrs();
-    auto iter = attrset.find(RGW_ATTR_ETAG);
-    if (iter != attrset.end()) {
-      etag = rgw_bl_str(iter->second);
+    auto val = attrset.find(RGW_ATTR_ETAG);
+    if (val != nullptr) {
+      etag = rgw_bl_str(*val);
     }
   }
   auto size = obj->get_size();
@@ -1338,9 +1338,9 @@ public:
     }
 
     auto attrset = obj->get_attrs();
-    auto iter = attrset.find(RGW_ATTR_ETAG);
-    if (iter != attrset.end()) {
-      etag = rgw_bl_str(iter->second);
+    auto val = attrset.find(RGW_ATTR_ETAG);
+    if (val != nullptr) {
+      etag = rgw_bl_str(*val);
     }
 
     rgw::notify::EventTypeList event_types;
@@ -1617,16 +1617,15 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
     return -ENOENT;
   }
 
-  map<string, bufferlist>::iterator aiter
-    = bucket->get_attrs().find(RGW_ATTR_LC);
-  if (aiter == bucket->get_attrs().end()) {
+  auto val= bucket->get_attrs().find(RGW_ATTR_LC);
+  if (val == nullptr) {
     ldpp_dout(this, 0) << "WARNING: bucket_attrs.find(RGW_ATTR_LC) failed for "
 		       << bucket_name << " (terminates bucket_lc_process(...))"
 		       << dendl;
     return 0;
   }
 
-  bufferlist::const_iterator iter{&aiter->second};
+  bufferlist::const_iterator iter{&(*val)};
   try {
       config.decode(iter);
     } catch (const buffer::error& e) {
@@ -2655,8 +2654,8 @@ int fix_lc_shard_entry(const DoutPrefixProvider *dpp,
 		       rgw::sal::Lifecycle* sal_lc,
 		       rgw::sal::Bucket* bucket)
 {
-  if (auto aiter = bucket->get_attrs().find(RGW_ATTR_LC);
-      aiter == bucket->get_attrs().end()) {
+  if (auto val = bucket->get_attrs().find(RGW_ATTR_LC);
+      val == nullptr) {
     return 0;    // No entry, nothing to fix
   }
 

--- a/src/rgw/rgw_object_ownership.cc
+++ b/src/rgw/rgw_object_ownership.cc
@@ -91,14 +91,14 @@ void decode(OwnershipControls& c, bufferlist::const_iterator& bl)
 ObjectOwnership get_object_ownership(const sal::Attrs& attrs)
 {
   auto i = attrs.find(RGW_ATTR_OWNERSHIP_CONTROLS);
-  if (i == attrs.end()) {
+  if (i == nullptr) {
     // default to ObjectWriter for backward compat
     return ObjectOwnership::ObjectWriter;
   }
 
   try {
     OwnershipControls ownership;
-    auto p = i->second.cbegin();
+    auto p = (*i).cbegin();
     decode(ownership, p);
     return ownership.object_ownership;
   } catch (const buffer::error&) {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1190,7 +1190,7 @@ class RGWCreateBucket : public RGWOp {
 
  public:
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    createparams.attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
+    createparams.attrs.emplace_attr_to_map(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
@@ -1357,7 +1357,7 @@ public:
   virtual int init_processing(optional_yield y) override;
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
+    attrs.emplace_attr_to_map(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
   int verify_permission(optional_yield y) override;
@@ -1502,7 +1502,7 @@ public:
   {}
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
+    attrs.emplace_attr_to_map(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
   int verify_permission(optional_yield y) override;
@@ -1684,7 +1684,7 @@ public:
                                   req_state *s);
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(std::move(key), std::move(bl));
+    attrs.emplace_attr_to_map(std::move(key), std::move(bl));
   }
 
   int init_processing(optional_yield y) override;
@@ -2570,7 +2570,7 @@ public:
   virtual ~RGWRMAttrs() {}
 
   void emplace_key(std::string&& key) {
-    attrs.emplace(std::move(key), buffer::list());
+    attrs.emplace_attr_to_map(std::move(key), buffer::list());
   }
 
   int verify_permission(optional_yield y);

--- a/src/rgw/rgw_restore.cc
+++ b/src/rgw/rgw_restore.cc
@@ -474,9 +474,9 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
   target_placement.inherit_from(bucket->get_placement_rule());
 
   auto& attrs = obj->get_attrs();
-  auto attr_iter = attrs.find(RGW_ATTR_RESTORE_STATUS);
-  if (attr_iter != attrs.end()) {
-    bufferlist bl = attr_iter->second;
+  auto attr_val = attrs.find(RGW_ATTR_RESTORE_STATUS);
+  if (attr_val != nullptr) {
+    bufferlist bl = *attr_val;
     auto iter = bl.cbegin();
     using ceph::decode;
     decode(restore_status, iter);
@@ -490,9 +490,9 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
     return 0;
   }
 
-  attr_iter = attrs.find(RGW_ATTR_STORAGE_CLASS);
-  if (attr_iter != attrs.end()) {
-    target_placement.storage_class = attr_iter->second.to_str();
+  attr_val = attrs.find(RGW_ATTR_STORAGE_CLASS);
+  if (attr_val != nullptr) {
+    target_placement.storage_class = (*attr_val).to_str();
   } else {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: Attr RGW_ATTR_STORAGE_CLASS not found for object: " << obj->get_key() << dendl;
   }
@@ -536,9 +536,9 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
     entry.status = rgw::sal::RGWRestoreStatus::CloudRestored;
     
     string etag;
-    attr_iter = attrs.find(RGW_ATTR_ETAG);
-    if (attr_iter != attrs.end()) {
-      etag = rgw_bl_str(attr_iter->second);
+    attr_val = attrs.find(RGW_ATTR_ETAG);
+    if (attr_val != nullptr) {
+      etag = rgw_bl_str(*attr_val);
     }
 
     // send notification in case the restore is successfully completed
@@ -733,9 +733,9 @@ int Restore::restore_obj_from_cloud(rgw::sal::Bucket* pbucket,
   if (notify) {
     auto& attrs = pobj->get_attrs();
     string etag;
-    auto attr_iter = attrs.find(RGW_ATTR_ETAG);
-    if (attr_iter != attrs.end()) {
-      etag = rgw_bl_str(attr_iter->second);
+    auto attr_val = attrs.find(RGW_ATTR_ETAG);
+    if (attr_val != nullptr) {
+      etag = rgw_bl_str(*attr_val);
     }
 
     ret = notify->publish_commit(dpp, pobj->get_size(), ceph::real_clock::now(), etag,
@@ -782,14 +782,13 @@ int Restore::list(const DoutPrefixProvider* dpp, RestoreEntry& entry,
           ldpp_dout(dpp, 0) << "ERROR: failed to stat object, returned error: " << cpp_strerror(-ret) << dendl;
           return -ret;
         }
-        for (map<string, bufferlist>::iterator getattriter = obj->get_attrs().begin(); getattriter != obj->get_attrs().end(); ++getattriter) {
-          bufferlist& bl = getattriter->second;
-          if (getattriter->first == RGW_ATTR_RESTORE_STATUS) {
+          auto attr_val = obj->get_attrs().find(RGW_ATTR_RESTORE_STATUS);
+          if (attr_val != nullptr) {
             rgw::sal::RGWRestoreStatus rs;
             {
               using ceph::decode;
               try {
-                decode(rs, bl);
+                decode(rs, *attr_val);
               } catch (const JSONDecoder::err& e) {
                 ldpp_dout(dpp, 0) << "failed to decode JSON input: " << e.what() << dendl;
                 return EINVAL;
@@ -802,7 +801,6 @@ int Restore::list(const DoutPrefixProvider* dpp, RestoreEntry& entry,
             } else {
               f->dump_string(iter->key.name, rgw::sal::rgw_restore_status_dump(rs));
             }
-          }
         }
       }
     }
@@ -836,7 +834,9 @@ int Restore::status(const DoutPrefixProvider* dpp, RestoreEntry& entry,
       return -ret;
     }
     map<string, bufferlist>::iterator iter;
-    for (iter = obj->get_attrs().begin(); iter != obj->get_attrs().end(); ++iter) {
+    // Getting full map from the Attrs class. So assuming the RGW_ATTR here are in the map and not in the array of the class.
+    auto attrsMap = obj->get_attrs().get_full_map();
+    for (iter = attrsMap.begin(); iter != attrsMap.end(); ++iter) {
       bufferlist& bl = iter->second;
       {
         using ceph::decode;

--- a/src/rgw/rgw_sal_fwd.h
+++ b/src/rgw/rgw_sal_fwd.h
@@ -34,8 +34,7 @@ inline auto AccessListFilterPrefix(std::string prefix) {
 namespace sal {
 
 /** A list of key-value attributes */
-using Attrs = std::map<std::string, ceph::buffer::list>;
-
+  class Attrs;
   class Driver;
   class User;
   struct UserList;

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "include/buffer_fwd.h"
+#include "rgw_common.h"
 #include "rgw_sal.h"
 
 /**
@@ -48,7 +50,7 @@ struct RGWObjState {
 
   RGWObjVersionTracker objv_tracker;
 
-  std::map<std::string, ceph::buffer::list> attrset;
+  rgw::sal::Attrs attrset;
 
   RGWObjState() {};
   RGWObjState(const RGWObjState &rhs) : obj(rhs.obj) {
@@ -82,9 +84,9 @@ struct RGWObjState {
   ~RGWObjState() {};
 
   bool get_attr(std::string name, bufferlist& dest) {
-    auto iter = attrset.find(name);
-    if (iter != attrset.end()) {
-      dest = iter->second;
+    ceph::bufferlist* val = attrset.find(name);
+    if (val != nullptr) {
+      dest = *val;
       return true;
     }
     return false;
@@ -322,9 +324,9 @@ class StoreObject : public Object {
     virtual bool get_attr(const std::string& name, bufferlist &dest) override {
       if (!has_attrs())
 	return false;
-      auto iter = state.attrset.find(name);
-      if (iter != state.attrset.end()) {
-        dest = iter->second;
+      ceph::bufferlist* val = state.attrset.find(name);
+      if (val != nullptr) {
+        dest = *val;
         return true;
       }
       return false;
@@ -384,8 +386,9 @@ class StoreObject : public Object {
     virtual int get_torrent_info(const DoutPrefixProvider* dpp,
                                  optional_yield y, bufferlist& bl) override {
       const auto& attrs = get_attrs();
-      if (auto i = attrs.find(RGW_ATTR_TORRENT); i != attrs.end()) {
-        bl = i->second;
+      const auto val =  attrs.find(RGW_ATTR_TORRENT);
+      if (val != nullptr) {
+        bl = *val;
         return 0;
       }
       return -ENOENT;

--- a/src/rgw/rgw_tracer.h
+++ b/src/rgw/rgw_tracer.h
@@ -24,7 +24,7 @@ extern tracing::Tracer tracer;
 } // namespace rgw
 } // namespace tracing
 
-static inline void extract_span_context(const rgw::sal::Attrs& attr, jspan_context& span_ctx) {
+static inline void extract_span_context(const std::map<std::string, ceph::bufferlist>& attr, jspan_context& span_ctx) {
   auto trace_iter = attr.find(RGW_ATTR_TRACE);
   if (trace_iter != attr.end()) {
     try {


### PR DESCRIPTION
Replacing implementation of rgw::sal::Attrs from 'std::map<std::string, ceph::bufferlist>' to a class 'Attrs' supporting fast search of static strings, with back compatibility.

Currently doesn't compile as we are looking for a demarcation line between code that should have this optimization and code that does not need it.

@yuvalif 