### PR TITLE
mgr/cephadm: track TLS spec changes in deps and cleanup stale certmgr entries on cert source transitions

### DIFF
--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -6,7 +6,7 @@ from enum import Enum
 from cephadm.ssl_cert_utils import SSLCerts, SSLConfigException
 from mgr_util import verify_tls, certificate_days_to_expire, ServerConfigException
 from cephadm.ssl_cert_utils import get_certificate_info, get_private_key_info
-from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectScope, TLSObjectException, TLSCredentials
+from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectScope, TLSObjectException, TLSObjectProtocol, TLSCredentials
 from cephadm.tlsobject_store import TLSObjectStore
 
 if TYPE_CHECKING:
@@ -371,6 +371,46 @@ class CertMgr:
         self.cert_store.save_tlsobject(ss_cert_name, tls_creds.cert, host=host, user_made=False)
         self.key_store.save_tlsobject(ss_key_name, tls_creds.key, host=host, user_made=False)
 
+    def _is_inline_saved_tlsobject(self, obj: Optional[TLSObjectProtocol]) -> bool:
+        # Inline-saved credentials are persisted as user_made=True but editable=False.
+        return bool(obj and getattr(obj, 'user_made', False) and not getattr(obj, 'editable', True))
+
+    def rm_inline_saved_cert_key_pair(
+        self,
+        cert_name: str,
+        key_name: str,
+        service_name: Optional[str] = None,
+        host: Optional[str] = None,
+        ca_cert_name: Optional[str] = None,
+    ) -> None:
+        """Remove inline-saved (non-editable) TLS objects for a given service/host.
+        This intentionally does *not* remove user-provisioned certmgr entries
+        (editable=True), which are considered reusable references.
+        """
+        context = f"service={service_name!r}, host={host!r}" if host else f"service={service_name!r}"
+
+        cert_obj = cast(Cert, self.cert_store.get_tlsobject_if_exists(cert_name, service_name, host))
+        if self._is_inline_saved_tlsobject(cert_obj):
+            logger.info("Removing inline-saved cert %r (%s)", cert_name, context)
+            self.rm_cert_if_present(cert_name, service_name, host)
+        elif cert_obj:
+            logger.info("Skipping cert removal for %r — exists but is not inline-saved (editable=True) (%s)", cert_name, context)
+
+        key_obj = cast(PrivKey, self.key_store.get_tlsobject_if_exists(key_name, service_name, host))
+        if self._is_inline_saved_tlsobject(key_obj):
+            logger.info("Removing inline-saved private key %r (%s)", key_name, context)
+            self.rm_key_if_present(key_name, service_name, host)
+        elif key_obj:
+            logger.info("Skipping key removal for %r — exists but is not inline-saved (editable=True) (%s)", key_name, context)
+
+        if ca_cert_name:
+            ca_obj = cast(Cert, self.cert_store.get_tlsobject_if_exists(ca_cert_name, service_name, host))
+            if self._is_inline_saved_tlsobject(ca_obj):
+                logger.info("Removing inline-saved CA cert %r (%s)", ca_cert_name, context)
+                self.rm_cert_if_present(ca_cert_name, service_name, host)
+            elif ca_obj:
+                logger.info("Skipping CA cert removal for %r — exists but is not inline-saved (editable=True) (%s)", ca_cert_name, context)
+
     def rm_cert(self, cert_name: str, service_name: Optional[str] = None, host: Optional[str] = None) -> bool:
         return self.cert_store.rm_tlsobject(cert_name, service_name, host)
 
@@ -385,25 +425,22 @@ class CertMgr:
         try:
             return self.rm_cert(cert_name, service_name, host)
         except TLSObjectException:
-            logger.debug(
-                "TLS cert %s for service=%s host=%s not found; nothing to remove",
-                cert_name, service_name, host,
-            )
             return False
 
     def rm_key_if_present(self, key_name: str, service_name: Optional[str] = None, host: Optional[str] = None) -> bool:
         try:
             return self.rm_key(key_name, service_name, host)
         except TLSObjectException:
-            logger.debug(
-                "TLS key %s for service=%s host=%s not found; nothing to remove",
-                key_name, service_name, host,
-            )
             return False
 
-    def rm_self_signed_cert_key_pair_if_present(self, service_name: str, host: str, label: Optional[str] = None) -> None:
-        self.rm_cert_if_present(self.self_signed_cert(service_name, label), service_name, host)
-        self.rm_key_if_present(self.self_signed_key(service_name, label), service_name, host)
+    def try_rm_self_signed_cert_key_pair(self, service_name: str, host: str, label: Optional[str] = None) -> None:
+        cert_removed = self.rm_cert_if_present(self.self_signed_cert(service_name, label), service_name, host)
+        key_removed = self.rm_key_if_present(self.self_signed_key(service_name, label), service_name, host)
+        if cert_removed or key_removed:
+            logger.info(
+                f"Removing cephadm-signed cert/key for service: {service_name}, host: {host}: "
+                f"key/cert removed: {key_removed}/{cert_removed}"
+            )
 
     def cert_ls(self, filter_by: str = '',
                 include_details: bool = False,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3912,11 +3912,29 @@ Then run the following:
         if spec.is_using_certificates_source(CertificateSource.REFERENCE):
             svc = service_registry.get_service(spec.service_type)
             if svc.SCOPE == TLSObjectScope.SERVICE:
+                # If the service was previously configured with INLINE, the cert/key
+                # may exist in the certmgr store as non-editable (inline-saved).
+                # When switching to REFERENCE, those inline-saved entries must be
+                # removed to avoid "pinning" the service to the old inline values and
+                # to allow the user to provision editable entries via the certmgr CLI.
+                if self.cert_mgr.cert_exists(svc.cert_name, service_name=spec.service_name(), host=None) and \
+                        not self.cert_mgr.is_cert_editable(svc.cert_name, service_name=spec.service_name(), host=None):
+                    self.log.info(
+                        f"Removing inline-saved (non-editable) cert/key for '{spec.service_name()}' "
+                        f"before switching to '{CertificateSource.REFERENCE.value}'."
+                    )
+                    self.cert_mgr.rm_inline_saved_cert_key_pair(
+                        svc.cert_name,
+                        svc.key_name,
+                        service_name=spec.service_name(),
+                        host=None,
+                        ca_cert_name=getattr(svc, 'ca_cert_name', None),
+                    )
                 if not self.cert_mgr.cert_exists(svc.cert_name, service_name=spec.service_name(), host=None):
                     raise OrchestratorError(
                         f"\n\nSSL is configured with '{CertificateSource.REFERENCE.value}', but cannot find an entry for the service '{spec.service_name()}'"
                         f"\nunder the certificate '{svc.cert_name}' within the certmgr store. To set the certificate, use:\n"
-                        f"\n  > ceph orch certmgr cert set --cert-name {svc.cert_name} --service-name {spec.service_name()} -i <cert-key-pem-file> \n"
+                        f"\n  > ceph orch certmgr cert-key set --consumer {spec.service_type} --service-name {spec.service_name()} -i <cert-key-pem-file> \n"
                     )
             else:
                 cert_warning += (

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3889,6 +3889,26 @@ Then run the following:
 
     def _check_cert_source(self, spec: ServiceSpec) -> str:
         cert_warning = ''
+        # Warn the user when certificate_source is changing, as this will
+        # trigger a service reconfiguration that may cause client disconnections,
+        # CA trust chain changes, or temporary TLS downtime.
+        if spec.service_name() in self.spec_store:
+            old_spec = self.spec_store[spec.service_name()].spec
+            old_source = getattr(old_spec, 'certificate_source', None)
+            new_source = getattr(spec, 'certificate_source', None)
+            if old_source and new_source and old_source != new_source:
+                cert_warning = (
+                    f"\n\nWarning: 'certificate_source' changed from '{old_source}' to "
+                    f"'{new_source}' for service '{spec.service_name()}'.\n"
+                    f"This will trigger a service reconfiguration on the next reconciliation cycle, which may cause\n"
+                    f"temporary client disconnections and/or a change in the TLS certificate authority trust chain.\n"
+                )
+                self.log.warning(
+                    f"certificate_source changed from '{old_source}' to '{new_source}' "
+                    f"for service '{spec.service_name()}'. This will trigger a service "
+                    f"reconfiguration."
+                )
+
         if spec.is_using_certificates_source(CertificateSource.REFERENCE):
             svc = service_registry.get_service(spec.service_type)
             if svc.SCOPE == TLSObjectScope.SERVICE:
@@ -3899,7 +3919,7 @@ Then run the following:
                         f"\n  > ceph orch certmgr cert set --cert-name {svc.cert_name} --service-name {spec.service_name()} -i <cert-key-pem-file> \n"
                     )
             else:
-                cert_warning = (
+                cert_warning += (
                     f"\n\n\nWarning: SSL is configured with '{CertificateSource.REFERENCE.value}', and this service uses per-host certificates.\n\n"
                     f"To configure keys/certificates, run the following commands for each host daemons are deployed on:\n"
                     f"  > ceph orch certmgr cert set --cert-name {svc.cert_name} --service-name {spec.service_name()} --hostname <host>  -i <cert-file>\n"

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -423,6 +423,28 @@ class CephadmService(metaclass=ABCMeta):
         cert_source = getattr(svc_spec, cert_source_attr, None)
         logger.debug(f'Getting certificate for {svc_spec.service_name()} using source: {cert_source}')
 
+        # Reconcile TLS objects when switching certificate sources.
+        #
+        # - Inline-saved certs/keys are persisted in the certmgr store as user_made=True
+        #   but editable=False. These should be garbage-collected once the service no
+        #   longer uses INLINE.
+        # - Cephadm-signed certs/keys are stored under cephadm-signed_* entities and
+        #   should be removed when the service no longer uses CEPHADM_SIGNED.
+        svc_name = svc_spec.service_name()
+        host = daemon_spec.host
+        if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value):
+            self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
+                cert_name,
+                key_name,
+                service_name=svc_name,
+                host=host,
+                ca_cert_name=ca_cert_name,
+            )
+        if cert_source != CertificateSource.CEPHADM_SIGNED.value:
+            # Best-effort: the cephadm-signed entities might not be registered if the
+            # service never used CEPHADM_SIGNED (or after a manager restart).
+            self.mgr.cert_mgr.try_rm_self_signed_cert_key_pair(svc_name, host)
+
         if cert_source == CertificateSource.INLINE.value:
             return self._get_certificates_from_spec(svc_spec, daemon_spec, cert_attr, key_attr, cert_name, key_name, ca_cert_attr, ca_cert_name)
         elif cert_source == CertificateSource.REFERENCE.value:
@@ -828,66 +850,74 @@ class CephadmService(metaclass=ABCMeta):
         Called after the daemon is removed.
         """
 
-        def _cleanup_tls_creds_for_host(svc_name: str, host: str, cert_source: Optional[str]) -> None:
+        def _cleanup_tls_creds_for_host(svc_name: str, host: str, cert_source: Optional[str], other_daemons_in_service: bool) -> None:
 
-            if cert_source == CertificateSource.CEPHADM_SIGNED.value:
-                logger.info(f"Removing cephadm-signed certificate/key for service: {svc_name}, host: {host}")
-                self.mgr.cert_mgr.rm_self_signed_cert_key_pair(svc_name, host)
-            elif cert_source == CertificateSource.INLINE.value:
-                logger.info(f"Removing inline-saved certificate/key for service: {svc_name}, host: {host}")
-                self.mgr.cert_mgr.rm_cert(self.cert_name, svc_name, host)
-                self.mgr.cert_mgr.rm_key(self.key_name, svc_name, host)
-                if self.ca_cert_name:
-                    self.mgr.cert_mgr.rm_cert(self.ca_cert_name, svc_name, host)
-            elif cert_source == CertificateSource.REFERENCE.value:
+            # Daemons can be removed after the service has switched certificate sources. Let's Clean up
+            # any cephadm-signed leftovers for this host regardless of the *current* source:
+            self.mgr.cert_mgr.try_rm_self_signed_cert_key_pair(svc_name, host)
+
+            # Inline-saved cleanup depends on TLS object scope:
+            # - HOST scope: safe to remove for this host when no other daemons remain on this host
+            # - SERVICE/GLOBAL scope: only remove when this is the last daemon of the service
+            if self.SCOPE in (TLSObjectScope.SERVICE, TLSObjectScope.GLOBAL):
+                if other_daemons_in_service:
+                    return
+                self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
+                    self.cert_name,
+                    self.key_name,
+                    service_name=svc_name,
+                    host=None,
+                    ca_cert_name=self.ca_cert_name,
+                )
+            else: # Host Scope
+                self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
+                    self.cert_name,
+                    self.key_name,
+                    service_name=svc_name,
+                    host=host,
+                    ca_cert_name=self.ca_cert_name,
+                )
+
+            if cert_source == CertificateSource.REFERENCE.value:
                 # It's a reference cert/key to the certmgr so we must keep them as user may want to use them later
-                logger.info(f"Keeping referenced certificate/key for service: {svc_name}, host: {host}")
-            elif cert_source is None:
-                # This could happen when TLS is being disabled in spec by the user, so we lose the value
-                # of the certificate source but we still have to do our best to cleanup the TLS credentials.
-                logger.info(f"Removing certificate/key for service: {svc_name}, host: {host}")
-                self.mgr.cert_mgr.rm_self_signed_cert_key_pair_if_present(svc_name, host)
-                # try to remove inline certs (if any)
-                if not self.mgr.cert_mgr.is_cert_editable(self.cert_name, svc_name, host):
-                    self.mgr.cert_mgr.rm_cert_if_present(self.cert_name, svc_name, host)
-                    self.mgr.cert_mgr.rm_key_if_present(self.key_name, svc_name, host)
-                    if self.ca_cert_name:
-                        self.mgr.cert_mgr.rm_cert_if_present(self.ca_cert_name, svc_name, host)
-            else:
-                logger.error(f"Unknown cert-source {cert_source}. Cannot remove cert/key for: {svc_name}, host: {host}")
+                logger.info(
+                    "Certificate source is 'reference'; user-provided certmgr entries (if present) will be kept for service: %s, host: %s",
+                    svc_name, host
+                )
 
         assert daemon.daemon_type is not None
         assert daemon.hostname
         assert self.TYPE == daemon_type_to_service(daemon.daemon_type)
         logger.debug(f'Post remove daemon {self.TYPE}.{daemon.daemon_id}')
 
-        if self.requires_certificates:
+        if not self.requires_certificates:
+            # no certificates cleanup actions are needed
+            return
 
-            svc_name = daemon.service_name()
-            if svc_name not in self.mgr.spec_store:
-                return
+        svc_name = daemon.service_name()
+        if svc_name not in self.mgr.spec_store:
+            return
 
-            host = daemon.hostname
-            spec = self.mgr.spec_store[svc_name].spec
-            if not spec.ssl:
-                # Service no longer uses TLS; safe to clean up TLS credentials for this host
-                _cleanup_tls_creds_for_host(svc_name, host, spec.certificate_source)
-                return
+        host = daemon.hostname
+        spec = self.mgr.spec_store[svc_name].spec
 
-            remaining = [
-                d for d in self.mgr.cache.get_daemons_by_service(svc_name)
-                if d.hostname == host
-            ]
-            if remaining:
-                # The service still has daemons running on this host (e.g. during an HTTP -> HTTPS
-                # transition the daemons running on :80 are removed but new daemons running on :443
-                # area created), so the TLS cert/key may still be in use. Do not remove it yet.
-                logger.info(
-                    "Not removing TLS cert/key for %s on %s: still %d daemons present",
-                    svc_name, host, len(remaining)
-                )
-            else:
-                _cleanup_tls_creds_for_host(svc_name, host, spec.certificate_source)
+        # If TLS is disabled, we may not have a meaningful source anymore
+        cert_source = spec.certificate_source if spec.ssl else None
+
+        daemons = [
+            d for d in self.mgr.cache.get_daemons_by_service(svc_name)
+            if d.name() != daemon.name()
+        ]
+        remaining_on_host = [d for d in daemons if d.hostname == host]
+        if remaining_on_host:
+            logger.info(
+                "Not removing TLS cert/key for %s on %s: still %d daemons present",
+                svc_name, host, len(remaining_on_host)
+            )
+            return
+
+        _cleanup_tls_creds_for_host(svc_name, host, cert_source, other_daemons_in_service=bool(daemons))
+
 
     def purge(self, service_name: str) -> None:
         """Called to carry out any purge tasks following service removal"""

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -341,10 +341,10 @@ class CephadmService(metaclass=ABCMeta):
         if cert_source:
             deps.append(f'certificate_source: {cert_source}')
         if spec.ssl_cert and spec.ssl_key:
-            deps.append(f'ssl_cert: {str(utils.md5_hash(spec.ssl_cert))}')
-            deps.append(f'ssl_key: {str(utils.md5_hash(spec.ssl_key))}')
+            deps.append(f'ssl_cert: {str(utils.config_hash(spec.ssl_cert))}')
+            deps.append(f'ssl_key: {str(utils.config_hash(spec.ssl_key))}')
         if spec.ssl_ca_cert:
-            deps.append(f'ssl_ca_cert: {str(utils.md5_hash(spec.ssl_ca_cert))}')
+            deps.append(f'ssl_ca_cert: {str(utils.config_hash(spec.ssl_ca_cert))}')
 
         return sorted(deps)
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -367,7 +367,7 @@ class CephadmService(metaclass=ABCMeta):
         svc_name = svc_spec.service_name()
         ip = ip_addr or self.mgr.inventory.get_addr(daemon_spec.host)
         host_fqdn = self.mgr.get_fqdn(daemon_spec.host)
-        tls_creds = self.mgr.cert_mgr.get_self_signed_tls_credentials(svc_name, host_fqdn, label)
+        tls_creds = self.mgr.cert_mgr.get_self_signed_tls_credentials(svc_name, daemon_spec.host, label)
         if not tls_creds:
             tls_creds = self.mgr.cert_mgr.generate_cert(host_fqdn, ip)
             self.mgr.cert_mgr.save_self_signed_cert_key_pair(svc_name, tls_creds, host=daemon_spec.host, label=label)
@@ -869,7 +869,7 @@ class CephadmService(metaclass=ABCMeta):
                     host=None,
                     ca_cert_name=self.ca_cert_name,
                 )
-            else: # Host Scope
+            else:  # Host Scope
                 self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
                     self.cert_name,
                     self.key_name,
@@ -917,7 +917,6 @@ class CephadmService(metaclass=ABCMeta):
             return
 
         _cleanup_tls_creds_for_host(svc_name, host, cert_source, other_daemons_in_service=bool(daemons))
-
 
     def purge(self, service_name: str) -> None:
         """Called to carry out any purge tasks following service removal"""

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -331,7 +331,22 @@ class CephadmService(metaclass=ABCMeta):
         spec: Optional[ServiceSpec] = None,
         daemon_type: Optional[str] = None,
     ) -> List[str]:
-        return []
+
+        ssl_enabled = getattr(spec, 'ssl', False)
+        if not spec or not ssl_enabled:
+            return []
+
+        deps = []
+        cert_source = getattr(spec, 'certificate_source', None)
+        if cert_source:
+            deps.append(f'certificate_source: {cert_source}')
+        if spec.ssl_cert and spec.ssl_key:
+            deps.append(f'ssl_cert: {str(utils.md5_hash(spec.ssl_cert))}')
+            deps.append(f'ssl_key: {str(utils.md5_hash(spec.ssl_key))}')
+        if spec.ssl_ca_cert:
+            deps.append(f'ssl_ca_cert: {str(utils.md5_hash(spec.ssl_ca_cert))}')
+
+        return sorted(deps)
 
     @classmethod
     def sorted_dependencies(
@@ -1341,6 +1356,9 @@ class RgwService(CephService):
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
+        # we keep the following deps calculation for backward compatibility
+        # as old RGW specs use rgw_frontend_ssl_certificate instead of modern
+        # ssl_cert/ssl_key fields
         rgw_spec = cast(RGWSpec, spec)
         ssl_cert = getattr(rgw_spec, 'rgw_frontend_ssl_certificate', None)
         if ssl_cert:
@@ -1348,7 +1366,8 @@ class RgwService(CephService):
                 ssl_cert = '\n'.join(ssl_cert)
             deps.append(f'ssl-cert:{utils.config_hash(ssl_cert)}')
 
-        return sorted(deps)
+        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
+        return sorted(deps + parent_deps)
 
     def set_realm_zg_zone(self, spec: RGWSpec) -> None:
         assert self.TYPE == spec.service_type

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -423,28 +423,6 @@ class CephadmService(metaclass=ABCMeta):
         cert_source = getattr(svc_spec, cert_source_attr, None)
         logger.debug(f'Getting certificate for {svc_spec.service_name()} using source: {cert_source}')
 
-        # Reconcile TLS objects when switching certificate sources.
-        #
-        # - Inline-saved certs/keys are persisted in the certmgr store as user_made=True
-        #   but editable=False. These should be garbage-collected once the service no
-        #   longer uses INLINE.
-        # - Cephadm-signed certs/keys are stored under cephadm-signed_* entities and
-        #   should be removed when the service no longer uses CEPHADM_SIGNED.
-        svc_name = svc_spec.service_name()
-        host = daemon_spec.host
-        if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value):
-            self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
-                cert_name,
-                key_name,
-                service_name=svc_name,
-                host=host,
-                ca_cert_name=ca_cert_name,
-            )
-        if cert_source != CertificateSource.CEPHADM_SIGNED.value:
-            # Best-effort: the cephadm-signed entities might not be registered if the
-            # service never used CEPHADM_SIGNED (or after a manager restart).
-            self.mgr.cert_mgr.try_rm_self_signed_cert_key_pair(svc_name, host)
-
         if cert_source == CertificateSource.INLINE.value:
             return self._get_certificates_from_spec(svc_spec, daemon_spec, cert_attr, key_attr, cert_name, key_name, ca_cert_attr, ca_cert_name)
         elif cert_source == CertificateSource.REFERENCE.value:
@@ -621,8 +599,38 @@ class CephadmService(metaclass=ABCMeta):
         if spec.is_using_certificates_source(CertificateSource.CEPHADM_SIGNED):
             self.mgr.cert_mgr.register_self_signed_cert_key_pair(spec.service_name())
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> None:
         self.register_for_certificates(daemon_spec)
+        self.reconcile_certificates(daemon_spec)
+
+    def reconcile_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> None:
+        """Garbage-collect stale TLS objects when the certificate source has changed."""
+        if not self.requires_certificates:
+            return
+        spec = self.mgr.spec_store[daemon_spec.service_name].spec
+        cert_source = getattr(spec, 'certificate_source', None)
+        svc_name = spec.service_name()
+        host = daemon_spec.host
+
+        # Inline-saved certs/keys are persisted in the certmgr store as user_made=True
+        # but editable=False. These should be garbage-collected once the service no
+        # longer uses INLINE.
+        if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value):
+            self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
+                self.cert_name,
+                self.key_name,
+                service_name=svc_name,
+                host=host,
+                ca_cert_name=self.ca_cert_name,
+            )
+
+        # Cephadm-signed certs/keys are stored under cephadm-signed_* entities and
+        # should be removed when the service no longer uses CEPHADM_SIGNED.
+        if cert_source != CertificateSource.CEPHADM_SIGNED.value:
+            self.mgr.cert_mgr.try_rm_self_signed_cert_key_pair(svc_name, host)
+
+    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+        self.prepare_certificates(daemon_spec)
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         return daemon_spec
 
@@ -1510,7 +1518,7 @@ class RgwService(CephService):
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        self.register_for_certificates(daemon_spec)
+        super().prepare_certificates(daemon_spec)
         rgw_id, _ = daemon_spec.daemon_id, daemon_spec.host
         spec = cast(RGWSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
 
@@ -1921,7 +1929,7 @@ class CephExporterService(CephService):
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        self.register_for_certificates(daemon_spec)
+        super().prepare_certificates(daemon_spec)
         spec = cast(CephExporterSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         keyring = self.get_keyring_with_caps(self.get_auth_entity(daemon_spec.daemon_id),
                                              ['mon', 'profile ceph-exporter',

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -9,7 +9,7 @@ from ceph.deployment.utils import is_ipv6
 from mgr_util import build_url
 from cephadm import utils
 from orchestrator import OrchestratorError, DaemonDescription
-from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService, CephadmService
 from .service_registry import register_cephadm_service
 from cephadm.tlsobject_types import TLSCredentials
 from cephadm.schedule import get_placement_hosts
@@ -123,7 +123,6 @@ class IngressService(CephService):
             hosts = get_placement_hosts(spec, mgr.cache.get_schedulable_hosts(), mgr.cache.get_draining_hosts())
             deps.append(f'placement_hosts:{",".join(sorted(h.hostname for h in hosts))}')
 
-        from cephadm.services.cephadmservice import CephadmService
         parent_deps = CephadmService.get_dependencies(mgr, spec)
         return sorted(deps + parent_deps)
 

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -118,16 +118,14 @@ class IngressService(CephService):
         assert ingress_spec.backend_service
         daemons = mgr.cache.get_daemons_by_service(ingress_spec.backend_service)
         deps = [d.name() for d in daemons]
-        for attr in ['ssl_cert', 'ssl_key']:
-            ssl_cert_key = getattr(ingress_spec, attr, None)
-            if ssl_cert_key:
-                assert isinstance(ssl_cert_key, str)
-                deps.append(f'ssl-cert-key:{utils.config_hash(ssl_cert_key)}')
         backend_spec = mgr.spec_store[ingress_spec.backend_service].spec
         if backend_spec.service_type == 'nfs':
             hosts = get_placement_hosts(spec, mgr.cache.get_schedulable_hosts(), mgr.cache.get_draining_hosts())
             deps.append(f'placement_hosts:{",".join(sorted(h.hostname for h in hosts))}')
-        return sorted(deps)
+
+        from cephadm.services.cephadmservice import CephadmService
+        parent_deps = CephadmService.get_dependencies(mgr, spec)
+        return sorted(deps + parent_deps)
 
     def haproxy_generate_config(
             self,

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -56,7 +56,7 @@ class IscsiService(CephService):
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
 
-        self.register_for_certificates(daemon_spec)
+        super().prepare_certificates(daemon_spec)
 
         spec = cast(IscsiServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         igw_id = daemon_spec.daemon_id

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -43,11 +43,15 @@ class IscsiService(CephService):
     def get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
+        deps = []
         if spec:
             iscsi_spec = cast(IscsiServiceSpec, spec)
-            return [get_trusted_ips(mgr, iscsi_spec)]
+            deps = [get_trusted_ips(mgr, iscsi_spec)]
         else:
-            return [mgr.get_mgr_ip()]
+            deps = [mgr.get_mgr_ip()]
+
+        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
+        return sorted(deps + parent_deps)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -26,7 +26,7 @@ class MgmtGatewayService(CephadmService):
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        super().register_for_certificates(daemon_spec)
+        super().prepare_certificates(daemon_spec)
         self.mgr.cert_mgr.register_self_signed_cert_key_pair(MgmtGatewayService.TYPE, INTERNAL_CERT_LABEL)
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         return daemon_spec

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -86,7 +86,8 @@ class MgmtGatewayService(CephadmService):
             for service in ['mgr']
             for d in mgr.cache.get_daemons_by_service(service)
         ]
-        return deps
+        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
+        return sorted(deps + parent_deps)
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -120,7 +120,8 @@ class GrafanaService(CephadmService):
         for service in ['prometheus', 'loki', 'mgmt-gateway', 'oauth2-proxy']:
             deps += [d.name() for d in mgr.cache.get_daemons_by_service(service)]
 
-        return sorted(deps)
+        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
+        return sorted(deps + parent_deps)
 
     def generate_prom_services(self, security_enabled: bool, mgmt_gw_enabled: bool) -> List[str]:
 
@@ -199,7 +200,7 @@ class GrafanaService(CephadmService):
                     dashboard = f.read()
                     config_file['files'][f'/etc/grafana/provisioning/dashboards/{file_name}'] = dashboard
 
-        return config_file, self.get_dependencies(self.mgr)
+        return config_file, self.get_dependencies(self.mgr, spec)
 
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
         # Use the least-created one as the active daemon

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -8,7 +8,7 @@ from threading import Lock
 from typing import Dict, Tuple, Any, List, cast, Optional, TYPE_CHECKING
 from configparser import ConfigParser
 from io import StringIO
-
+from cephadm import utils
 from mgr_module import HandleCommandResult
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -146,8 +146,7 @@ class NFSService(CephService):
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-
-        super().register_for_certificates(daemon_spec)
+        super().prepare_certificates(daemon_spec)
         daemon_type = daemon_spec.daemon_type
         daemon_id = daemon_spec.daemon_id
         host = daemon_spec.host

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -16,7 +16,6 @@ from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec
 from .service_registry import register_cephadm_service
 
 from orchestrator import DaemonDescription, OrchestratorError
-from cephadm import utils
 from cephadm.services.cephadmservice import AuthEntity, CephadmDaemonDeploySpec, CephService
 from cephadm.schedule import get_placement_hosts
 if TYPE_CHECKING:
@@ -131,18 +130,14 @@ class NFSService(CephService):
         assert spec
         deps: List[str] = []
         nfs_spec = cast(NFSServiceSpec, spec)
-        # add dependency of tls fields
-        if (spec.ssl and spec.ssl_cert and spec.ssl_key and spec.ssl_ca_cert):
-            deps.append(f'ssl_cert: {utils.config_hash(spec.ssl_cert)}')
-            deps.append(f'ssl_key: {utils.config_hash(spec.ssl_key)}')
-            deps.append(f'ssl_ca_cert: {utils.config_hash(spec.ssl_ca_cert)}')
+        deps.append(f'enable_rdma: {nfs_spec.enable_rdma}')
+        deps.append(f'rdma_port: {nfs_spec.rdma_port}')
         deps.append(f'tls_ktls: {nfs_spec.tls_ktls}')
         deps.append(f'tls_debug: {nfs_spec.tls_debug}')
         deps.append(f'tls_min_version: {nfs_spec.tls_min_version}')
         deps.append(f'tls_ciphers: {nfs_spec.tls_ciphers}')
-        deps.append(f'enable_rdma: {nfs_spec.enable_rdma}')
-        deps.append(f'rdma_port: {nfs_spec.rdma_port}')
-        return sorted(deps)
+        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
+        return sorted(deps + parent_deps)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/node_proxy.py
+++ b/src/pybind/mgr/cephadm/services/node_proxy.py
@@ -26,7 +26,7 @@ class NodeProxy(CephService):
         if not self.mgr.http_server.agent:
             raise OrchestratorError('Cannot deploy node-proxy before creating cephadm endpoint')
 
-        super().register_for_certificates(daemon_spec)
+        super().prepare_certificates(daemon_spec)
         keyring = self.get_keyring_with_caps(self.get_auth_entity(daemon_id, host=host), [])
         daemon_spec.keyring = keyring
         self.mgr.node_proxy_cache.update_keyring(host, keyring)

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -120,7 +120,7 @@ class NvmeofService(CephService):
                                              ['mon', 'profile rbd',
                                               'osd', 'profile rbd'])
 
-        super().register_for_certificates(daemon_spec)
+        super().prepare_certificates(daemon_spec)
         self.mgr.cert_mgr.register_self_signed_cert_key_pair(spec.service_name(), NVMEOF_CLIENT_CERT_LABEL)
         self.configure_tls(spec, daemon_spec)
 

--- a/src/pybind/mgr/cephadm/services/oauth2_proxy.py
+++ b/src/pybind/mgr/cephadm/services/oauth2_proxy.py
@@ -34,7 +34,8 @@ class OAuth2ProxyService(CephadmService):
             for service in ['mgmt-gateway']
             for d in mgr.cache.get_daemons_by_service(service)
         ]
-        return deps
+        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
+        return sorted(deps + parent_deps)
 
     def get_service_ips_and_hosts(self, service_name: str) -> List[str]:
         entries = set()

--- a/src/pybind/mgr/cephadm/tests/services/test_iscsi.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_iscsi.py
@@ -10,7 +10,6 @@ from cephadm.tests.fixtures import with_host, with_service, async_side_effect
 from cephadm.tlsobject_types import TLSCredentials
 from orchestrator._interface import DaemonDescription
 
-
 ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaLJzmvntjukjMA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzEzMTE0NzA3WhcN\nMzIwNzEwMTE0NzA3WjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyyMe4DMA+MeYK7BHZMHB\nq7zjliEOcNgxomjU8qbf5USF7Mqrf6+/87XWqj4pCyAW8x0WXEr6A56a+cmBVmt+\nqtWDzl020aoId6lL5EgLLn6/kMDCCJLq++Lg9cEofMSvcZh+lY2f+1p+C+00xent\nrLXvXGOilAZWaQfojT2BpRnNWWIFbpFwlcKrlg2G0cFjV5c1m6a0wpsQ9JHOieq0\nSvwCixajwq3CwAYuuiU1wjI4oJO4Io1+g8yB3nH2Mo/25SApCxMXuXh4kHLQr/T4\n4hqisvG4uJYgKMcSIrWj5o25mclByGi1UI/kZkCUES94i7Z/3ihx4Bad0AMs/9tw\nFwIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQAf+pwz7Gd7mDwU2LY0TQXsK6/8KGzh\nHuX+ErOb8h5cOAbvCnHjyJFWf6gCITG98k9nxU9NToG0WYuNm/max1y/54f0dtxZ\npUo6KSNl3w6iYCfGOeUIj8isi06xMmeTgMNzv8DYhDt+P2igN6LenqWTVztogkiV\nxQ5ZJFFLEw4sN0CXnrZX3t5ruakxLXLTLKeE0I91YJvjClSBGkVJq26wOKQNHMhx\npWxeydQ5EgPZY+Aviz5Dnxe8aB7oSSovpXByzxURSabOuCK21awW5WJCGNpmqhWK\nZzACBDEstccj57c4OGV0eayHJRsluVr2e9NHRINZA3qdB37e6gsI1xHo\n-----END CERTIFICATE-----\n"""
 
 ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
@@ -78,9 +77,10 @@ class TestISCSIService:
     mgr.spec_store = MagicMock()
     mgr.spec_store.all_specs.get.return_value = iscsi_spec
 
+    @patch("cephadm.services.cephadmservice.CephadmService.get_dependencies", return_value=[])
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
            lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
-    def test_iscsi_client_caps(self):
+    def test_iscsi_client_caps(self, _get_deps):
 
         iscsi_daemon_spec = CephadmDaemonDeploySpec(
             host='host', daemon_id='a', service_name=self.iscsi_spec.service_name())

--- a/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
@@ -4,7 +4,7 @@ import json
 import urllib.parse
 import yaml
 import pytest
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch, ANY, MagicMock
 
 from cephadm.serve import CephadmServe
 from cephadm.services.service_registry import service_registry
@@ -1187,6 +1187,58 @@ class TestMonitoring:
                     use_current_daemon_image=False,
                 )
 
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_no_op_when_other_daemons_remain_on_same_host_host_scope(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        HOST-scope service: when a sibling daemon is still running on the same
+        """
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        host = 'host1'
+
+        with with_host(cephadm_module, host):
+            grafana_svc = service_registry.get_service('grafana')
+            svc_name = 'grafana'
+
+            # Seed a HOST-scoped inline cert for this host
+            cm.save_cert(grafana_svc.cert_name, ceph_generated_cert,
+                         host=host, user_made=True, editable=False)
+            cm.save_key(grafana_svc.key_name, ceph_generated_key,
+                        host=host, user_made=True, editable=False)
+
+            assert cm.get_cert(grafana_svc.cert_name, host=host) is not None
+            assert cm.get_key(grafana_svc.key_name, host=host) is not None
+
+            mock_entry = MagicMock()
+            mock_entry.spec = MagicMock()
+            mock_entry.spec.ssl = True
+            mock_entry.spec.certificate_source = 'inline'
+            mock_spec_store = MagicMock()
+            mock_spec_store.__contains__ = MagicMock(return_value=True)
+            mock_spec_store.__getitem__ = MagicMock(return_value=mock_entry)
+
+            daemon = MagicMock()
+            daemon.daemon_type = 'grafana'
+            daemon.daemon_id = 'host1.0'
+            daemon.hostname = host
+            daemon.name.return_value = f'grafana.{daemon.daemon_id}'
+            daemon.service_name.return_value = svc_name
+
+            # Sibling still on the same host
+            sibling = MagicMock()
+            sibling.hostname = host
+            sibling.name.return_value = 'grafana.host1.1'
+
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon, sibling]):
+                grafana_svc.post_remove(daemon, is_failed_deploy=False)
+
+            # Cert must still be present — sibling is still on host1
+            assert cm.get_cert(grafana_svc.cert_name, host=host) is not None
+            assert cm.get_key(grafana_svc.key_name, host=host) is not None
+
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1::4')
     @patch("cephadm.module.CephadmOrchestrator.get_fqdn", lambda a, b: 'host_fqdn')
@@ -1693,7 +1745,7 @@ class TestMonitoring:
                                     '    editable: false\n'
                                     '    options:\n'
                                     "      path: '/etc/grafana/provisioning/dashboards'"
-                            }}, ['secure_monitoring_stack:False'])
+                            }}, ['certificate_source: cephadm-signed', 'secure_monitoring_stack:False'])
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_grafana_no_anon_access(self, cephadm_module: CephadmOrchestrator):
@@ -1762,7 +1814,7 @@ class TestMonitoring:
                                     '    editable: false\n'
                                     '    options:\n'
                                     "      path: '/etc/grafana/provisioning/dashboards'"
-                            }}, ['secure_monitoring_stack:False'])
+                            }}, ['certificate_source: cephadm-signed', 'secure_monitoring_stack:False'])
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_monitoring_ports(self, _run_cephadm, cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -259,7 +259,7 @@ class TestNFS:
                                 'balance static-rr\n    '
                                 'option httpchk HEAD / HTTP/1.0\n    '
                                 'server '
-                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                                + haproxy_generated_conf[1][1] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
                         }
                 }
                 gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]
@@ -351,7 +351,7 @@ class TestNFS:
                                 'balance static-rr\n    '
                                 'option httpchk HEAD / HTTP/1.0\n    '
                                 'server '
-                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                                + haproxy_generated_conf[1][1] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
                         }
                 }
                 gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]

--- a/src/pybind/mgr/cephadm/tests/services/test_rgw.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_rgw.py
@@ -1,10 +1,19 @@
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
+from cephadm.services.service_registry import service_registry
 from cephadm.module import CephadmOrchestrator
-from ceph.deployment.service_spec import RGWSpec
+from ceph.deployment.service_spec import RGWSpec, CertificateSource
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm
+from cephadm.tlsobject_types import TLSCredentials
+
+
+cephadm_root_ca = """-----BEGIN CERTIFICATE-----\nMIIE7DCCAtSgAwIBAgIUE8b2zZ64geu2ns3Zfn3/4L+Cf6MwDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MB4XDTI0MDYyNjE0NDA1M1oXDTM0\nMDYyNzE0NDA1M1owFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsZRJsdtTr9GLG1lWFql5SGc46ldFanNJd1Gl\nqXq5vgZVKRDTmNgAb/XFuNEEmbDAXYIRZolZeYKMHfn0pouPRSel0OsC6/02ZUOW\nIuN89Wgo3IYleCFpkVIumD8URP3hwdu85plRxYZTtlruBaTRH38lssyCqxaOdEt7\nAUhvYhcMPJThB17eOSQ73mb8JEC83vB47fosI7IhZuvXvRSuZwUW30rJanWNhyZq\neS2B8qw2RSO0+77H6gA4ftBnitfsE1Y8/F9Z/f92JOZuSMQXUB07msznPbRJia3f\nueO8gOc32vxd1A1/Qzp14uX34yEGY9ko2lW226cZO29IVUtXOX+LueQttwtdlpz8\ne6Npm09pXhXAHxV/OW3M28MdXmobIqT/m9MfkeAErt5guUeC5y8doz6/3VQRjFEn\nRpN0WkblgnNAQ3DONPc+Qd9Fi/wZV2X7bXoYpNdoWDsEOiE/eLmhG1A2GqU/mneP\nzQ6u79nbdwTYpwqHpa+PvusXeLfKauzI8lLUJotdXy9EK8iHUofibB61OljYye6B\nG3b8C4QfGsw8cDb4APZd/6AZYyMx/V3cGZ+GcOV7WvsC8k7yx5Uqasm/kiGQ3EZo\nuNenNEYoGYrjb8D/8QzqNUTwlEh27/ps80tO7l2GGTvWVZL0PRZbmLDvO77amtOf\nOiRXMoUCAwEAAaMwMC4wGwYDVR0RBBQwEocQAAAAAAAAAAAAAAAAAAAAATAPBgNV\nHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAxwzX5AhYEWhTV4VUwUj5+\nqPdl4Q2tIxRokqyE+cDxoSd+6JfGUefUbNyBxDt0HaBq8obDqqrbcytxnn7mpnDu\nhtiauY+I4Amt7hqFOiFA4cCLi2mfok6g2vL53tvhd9IrsfflAU2wy7hL76Ejm5El\nA+nXlkJwps01Whl9pBkUvIbOn3pXX50LT4hb5zN0PSu957rjd2xb4HdfuySm6nW4\n4GxtVWfmGA6zbC4XMEwvkuhZ7kD2qjkAguGDF01uMglkrkCJT3OROlNBuSTSBGqt\ntntp5VytHvb7KTF7GttM3ha8/EU2KYaHM6WImQQTrOfiImAktOk4B3lzUZX3HYIx\n+sByO4P4dCvAoGz1nlWYB2AvCOGbKf0Tgrh4t4jkiF8FHTXGdfvWmjgi1pddCNAy\nn65WOCmVmLZPERAHOk1oBwqyReSvgoCFo8FxbZcNxJdlhM0Z6hzKggm3O3Dl88Xl\n5euqJjh2STkBW8Xuowkg1TOs5XyWvKoDFAUzyzeLOL8YSG+gXV22gPTUaPSVAqdb\nwd0Fx2kjConuC5bgTzQHs8XWA930U3XWZraj21Vaa8UxlBLH4fUro8H5lMSYlZNE\nJHRNW8BkznAClaFSDG3dybLsrzrBFAu/Qb5zVkT1xyq0YkepGB7leXwq6vjWA5Pw\nmZbKSphWfh0qipoqxqhfkw==\n-----END CERTIFICATE-----\n"""
+
+ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaLJzmvntjukjMA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzEzMTE0NzA3WhcN\nMzIwNzEwMTE0NzA3WjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyyMe4DMA+MeYK7BHZMHB\nq7zjliEOcNgxomjU8qbf5USF7Mqrf6+/87XWqj4pCyAW8x0WXEr6A56a+cmBVmt+\nqtWDzl020aoId6lL5EgLLn6/kMDCCJLq++Lg9cEofMSvcZh+lY2f+1p+C+00xent\nrLXvXGOilAZWaQfojT2BpRnNWWIFbpFwlcKrlg2G0cFjV5c1m6a0wpsQ9JHOieq0\nSvwCixajwq3CwAYuuiU1wjI4oJO4Io1+g8yB3nH2Mo/25SApCxMXuXh4kHLQr/T4\n4hqisvG4uJYgKMcSIrWj5o25mclByGi1UI/kZkCUES94i7Z/3ihx4Bad0AMs/9tw\nFwIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQAf+pwz7Gd7mDwU2LY0TQXsK6/8KGzh\nHuX+ErOb8h5cOAbvCnHjyJFWf6gCITG98k9nxU9NToG0WYuNm/max1y/54f0dtxZ\npUo6KSNl3w6iYCfGOeUIj8isi06xMmeTgMNzv8DYhDt+P2igN6LenqWTVztogkiV\nxQ5ZJFFLEw4sN0CXnrZX3t5ruakxLXLTLKeE0I91YJvjClSBGkVJq26wOKQNHMhx\npWxeydQ5EgPZY+Aviz5Dnxe8aB7oSSovpXByzxURSabOuCK21awW5WJCGNpmqhWK\nZzACBDEstccj57c4OGV0eayHJRsluVr2e9NHRINZA3qdB37e6gsI1xHo\n-----END CERTIFICATE-----\n"""
+
+ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
 
 
 class TestRGWService:
@@ -61,3 +70,429 @@ class TestRGWService:
                     'key': 'rgw_run_sync_thread',
                 })
                 assert f == ('false' if disable_sync_traffic else 'true')
+
+    def _make_rgw_post_remove_fixtures(self, cephadm_module, host='host1', ssl=True, certificate_source='inline'):
+        """
+        Returns (cm, svc_name, spec, daemon, mock_spec_store) with all common
+        setup done.  The caller is responsible for patching spec_store and
+        cache.get_daemons_by_service.
+        """
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+
+        spec = RGWSpec(
+            service_id='foo',
+            ssl=ssl,
+            certificate_source=certificate_source,
+            rgw_frontend_type='beast',
+        )
+        svc_name = spec.service_name()  # 'rgw.foo'
+
+        daemon = MagicMock()
+        daemon.daemon_type = 'rgw'
+        daemon.daemon_id = f'foo.{host}.0'
+        daemon.hostname = host
+        daemon.name.return_value = f'rgw.{daemon.daemon_id}'
+        daemon.service_name.return_value = svc_name
+
+        mock_entry = MagicMock()
+        mock_entry.spec = spec
+        mock_spec_store = MagicMock()
+        mock_spec_store.__contains__ = MagicMock(return_value=True)
+        mock_spec_store.__getitem__ = MagicMock(return_value=mock_entry)
+
+        return cm, svc_name, spec, daemon, mock_spec_store
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_no_op_when_requires_certificates_is_false(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        When requires_certificates is False, post_remove() must return
+        immediately without touching cert_mgr at all.
+        """
+        _, svc_name, _, daemon, _ = self._make_rgw_post_remove_fixtures(cephadm_module)
+
+        rgw_svc = service_registry.get_service('rgw')
+
+        with patch.object(type(rgw_svc), 'requires_certificates',
+                          new_callable=lambda: property(lambda self: False)):
+            with patch.object(rgw_svc.mgr.cert_mgr,
+                              'rm_inline_saved_cert_key_pair') as rm_mock:
+                rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                rm_mock.assert_not_called()
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_no_op_when_svc_not_in_spec_store(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        When the service is not found in spec_store, post_remove() must return
+        immediately without touching cert_mgr.
+        """
+        cephadm_module._init_cert_mgr()
+
+        spec = RGWSpec(service_id='foo', ssl=True, rgw_frontend_type='beast')
+        daemon = MagicMock()
+        daemon.daemon_type = 'rgw'
+        daemon.daemon_id = 'foo.host1.0'
+        daemon.hostname = 'host1'
+        daemon.name.return_value = 'rgw.foo.host1.0'
+        daemon.service_name.return_value = spec.service_name()
+
+        # spec_store explicitly does NOT contain the service
+        mock_spec_store = MagicMock()
+        mock_spec_store.__contains__ = MagicMock(return_value=False)
+
+        rgw_svc = service_registry.get_service('rgw')
+
+        with with_host(cephadm_module, 'host1'):
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cert_mgr,
+                              'rm_inline_saved_cert_key_pair') as rm_mock:
+                rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                rm_mock.assert_not_called()
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_no_op_when_other_daemons_remain_on_same_host(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        When another daemon of the same service is still running on the same
+        host, post_remove() must NOT clean up certs for that host yet.
+        """
+        host = 'host1'
+        cm, svc_name, _, daemon, mock_spec_store = \
+            self._make_rgw_post_remove_fixtures(cephadm_module, host=host)
+
+        # A sibling daemon still on the same host
+        sibling = MagicMock()
+        sibling.hostname = host
+        sibling.name.return_value = 'rgw.foo.host1.1'   # different name
+
+        rgw_svc = service_registry.get_service('rgw')
+
+        with with_host(cephadm_module, host):
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon, sibling]), \
+                 patch.object(cm, 'rm_inline_saved_cert_key_pair') as rm_mock:
+                rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                rm_mock.assert_not_called()
+
+    # SERVICE-scope cleanup branches
+
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_inline_cleanup_called_when_last_daemon_in_service(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        When the removed daemon is the very last one in the service (SERVICE
+        scope), rm_inline_saved_cert_key_pair() must be called with
+        service_name=svc_name and host=None.
+        """
+        host = 'host1'
+        cm, svc_name, _, daemon, mock_spec_store = \
+            self._make_rgw_post_remove_fixtures(cephadm_module, host=host)
+
+        rgw_svc = service_registry.get_service('rgw')
+
+        with with_host(cephadm_module, host):
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon]):   # only the daemon being removed
+                with patch.object(cm, 'rm_inline_saved_cert_key_pair') as rm_mock:
+                    rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                    rm_mock.assert_called_once_with(
+                        rgw_svc.cert_name,
+                        rgw_svc.key_name,
+                        service_name=svc_name,
+                        host=None,
+                        ca_cert_name=rgw_svc.ca_cert_name,
+                    )
+
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_inline_cleanup_skipped_when_other_daemons_on_other_hosts(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        SERVICE scope: when other daemons of the same service still exist on
+        OTHER hosts, the service-level cert must NOT be removed yet
+        (other_daemons_in_service=True → early return from _cleanup).
+        """
+        host = 'host1'
+        cm, svc_name, _, daemon, mock_spec_store = \
+            self._make_rgw_post_remove_fixtures(cephadm_module, host=host)
+
+        # A peer daemon on a different host
+        peer = MagicMock()
+        peer.hostname = 'host2'
+        peer.name.return_value = 'rgw.foo.host2.0'
+
+        rgw_svc = service_registry.get_service('rgw')
+
+        with with_host(cephadm_module, host):
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon, peer]):
+                with patch.object(cm, 'rm_inline_saved_cert_key_pair') as rm_mock:
+                    rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                    rm_mock.assert_not_called()
+
+    # ssl=False branch
+
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_cert_source_is_none_when_ssl_disabled(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        When spec.ssl=False, cert_source is forced to None inside post_remove().
+        Cleanup should still run (SERVICE scope, last daemon) but cert_source
+        passed to _cleanup_tls_creds_for_host must be None.
+        """
+        host = 'host1'
+        cm, svc_name, _, daemon, mock_spec_store = \
+            self._make_rgw_post_remove_fixtures(cephadm_module, host=host, ssl=False)
+
+        rgw_svc = service_registry.get_service('rgw')
+
+        with with_host(cephadm_module, host):
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon]):
+                with patch.object(cm, 'rm_inline_saved_cert_key_pair') as rm_mock:
+                    rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                    # cleanup still fires (last daemon), cert_source=None doesn't block it
+                    rm_mock.assert_called_once_with(
+                        rgw_svc.cert_name,
+                        rgw_svc.key_name,
+                        service_name=svc_name,
+                        host=None,
+                        ca_cert_name=rgw_svc.ca_cert_name,
+                    )
+
+    # Reference cert-source branch
+
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_reference_source_logs_and_still_cleans(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        When certificate_source='reference', post_remove() must still call
+        rm_inline_saved_cert_key_pair (the reference note is informational
+        only) AND emit the expected INFO log.
+        """
+        host = 'host1'
+        cm, svc_name, _, daemon, mock_spec_store = \
+            self._make_rgw_post_remove_fixtures(
+                cephadm_module, host=host,
+                certificate_source=CertificateSource.REFERENCE.value)
+
+        rgw_svc = service_registry.get_service('rgw')
+
+        with with_host(cephadm_module, host):
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon]):
+                with patch.object(cm, 'rm_inline_saved_cert_key_pair') as rm_mock, \
+                     patch('cephadm.services.cephadmservice.logger') as log_mock:
+                    rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                    rm_mock.assert_called_once()
+                    # The "reference; user-provided" info log must have fired
+                    assert any(
+                        'reference' in str(call_args)
+                        for call_args in log_mock.info.call_args_list
+                    )
+
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_cleans_cephadm_signed_leftovers_for_host(self, cephadm_module: CephadmOrchestrator):
+        """
+        Ensures RGW service post_remove() removes cephadm-signed
+        cert/key leftovers for (service, host) even if the CURRENT cert source
+        is not cephadm-signed.
+        """
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+
+        host = 'host1'
+
+        with with_host(cephadm_module, host):
+            spec = RGWSpec(
+                service_id="foo",
+                ssl=True,
+                certificate_source="inline",
+                rgw_frontend_type="beast",
+            )
+            svc_name = spec.service_name()  # typically "rgw.foo"
+
+            # Register the self-signed cert/key pair
+            cm.register_self_signed_cert_key_pair(svc_name)
+
+            # Build a mock spec_store that satisfies the two access patterns
+            # post_remove() needs:
+            #   if svc_name not in self.mgr.spec_store: return
+            #   spec = self.mgr.spec_store[svc_name].spec
+            mock_entry = MagicMock()
+            mock_entry.spec = spec
+
+            mock_spec_store = MagicMock()
+            mock_spec_store.__contains__ = MagicMock(return_value=True)
+            mock_spec_store.__getitem__ = MagicMock(return_value=mock_entry)
+
+            # Minimal daemon mock used by post_remove()
+            daemon = MagicMock()
+            daemon.daemon_type = 'rgw'
+            daemon.daemon_id = 'foo.host1.0'
+            daemon.hostname = host
+            daemon.name.return_value = f'rgw.{daemon.daemon_id}'
+            daemon.service_name.return_value = svc_name
+
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service', return_value=[daemon]):
+
+                # Seed cephadm-signed leftovers for this host
+                cm.save_self_signed_cert_key_pair(
+                    svc_name,
+                    TLSCredentials(ceph_generated_cert, ceph_generated_key),
+                    host=host,
+                )
+
+                cert_name = cm.self_signed_cert(svc_name)
+                key_name = cm.self_signed_key(svc_name)
+
+                # Sanity: leftovers exist pre-cleanup
+                assert cm.get_cert(cert_name, host=host) is not None
+                assert cm.get_key(key_name, host=host) is not None
+
+                # Get RGW service instance
+                rgw_svc = service_registry.get_service('rgw')
+
+                # Ensure the call site is exercised + cleanup actually happens
+                with patch.object(cm, "try_rm_self_signed_cert_key_pair",
+                                  wraps=cm.try_rm_self_signed_cert_key_pair) as rm_mock:
+                    rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                    rm_mock.assert_called_once_with(svc_name, host)
+
+                # Assert cephadm-signed leftovers are gone
+                assert cm.get_cert(cert_name, host=host) is None
+                assert cm.get_key(key_name, host=host) is None
+
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_cleans_inline_certs_for_last_daemon_in_service(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        Ensures RGW service post_remove() actually removes
+        inline-saved cert/key from the cert store when the last daemon of the
+        service is removed (SERVICE scope → host=None cleanup).
+        """
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        host = 'host1'
+
+        with with_host(cephadm_module, host):
+            spec = RGWSpec(
+                service_id='foo',
+                ssl=True,
+                certificate_source='inline',
+                rgw_frontend_type='beast',
+            )
+            svc_name = spec.service_name()  # 'rgw.foo'
+
+            rgw_svc = service_registry.get_service('rgw')
+
+            # Seed inline cert/key for this service (SERVICE scope → service_name=svc_name)
+            cm.save_cert(rgw_svc.cert_name, ceph_generated_cert,
+                         service_name=svc_name, user_made=True, editable=False)
+            cm.save_key(rgw_svc.key_name, ceph_generated_key,
+                        service_name=svc_name, user_made=True, editable=False)
+
+            # Sanity: inline certs exist pre-cleanup
+            assert cm.get_cert(rgw_svc.cert_name, service_name=svc_name) is not None
+            assert cm.get_key(rgw_svc.key_name, service_name=svc_name) is not None
+
+            mock_entry = MagicMock()
+            mock_entry.spec = spec
+            mock_spec_store = MagicMock()
+            mock_spec_store.__contains__ = MagicMock(return_value=True)
+            mock_spec_store.__getitem__ = MagicMock(return_value=mock_entry)
+
+            daemon = MagicMock()
+            daemon.daemon_type = 'rgw'
+            daemon.daemon_id = f'foo.{host}.0'
+            daemon.hostname = host
+            daemon.name.return_value = f'rgw.{daemon.daemon_id}'
+            daemon.service_name.return_value = svc_name
+
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon]):   # only this daemon → last one
+                with patch.object(cm, 'rm_inline_saved_cert_key_pair',
+                                  wraps=cm.rm_inline_saved_cert_key_pair) as rm_mock:
+                    rgw_svc.post_remove(daemon, is_failed_deploy=False)
+                    rm_mock.assert_called_once_with(
+                        rgw_svc.cert_name,
+                        rgw_svc.key_name,
+                        service_name=svc_name,
+                        host=None,
+                        ca_cert_name=rgw_svc.ca_cert_name,
+                    )
+
+            # Assert inline certs are actually gone from the store
+            assert cm.get_cert(rgw_svc.cert_name, service_name=svc_name) is None
+            assert cm.get_key(rgw_svc.key_name, service_name=svc_name) is None
+
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_post_remove_preserves_inline_certs_when_other_daemons_remain_in_service(
+            self, cephadm_module: CephadmOrchestrator):
+        """
+        When other daemons of the same service still exist on other hosts,
+        inline certs must NOT be removed from the store (SERVICE scope cert
+        is shared across the whole service).
+        """
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        host = 'host1'
+
+        with with_host(cephadm_module, host):
+            spec = RGWSpec(
+                service_id='foo',
+                ssl=True,
+                certificate_source='inline',
+                rgw_frontend_type='beast',
+            )
+            svc_name = spec.service_name()
+
+            rgw_svc = service_registry.get_service('rgw')
+
+            # Seed inline cert/key
+            cm.save_cert(rgw_svc.cert_name, ceph_generated_cert,
+                         service_name=svc_name, user_made=True, editable=False)
+            cm.save_key(rgw_svc.key_name, ceph_generated_key,
+                        service_name=svc_name, user_made=True, editable=False)
+
+            mock_entry = MagicMock()
+            mock_entry.spec = spec
+            mock_spec_store = MagicMock()
+            mock_spec_store.__contains__ = MagicMock(return_value=True)
+            mock_spec_store.__getitem__ = MagicMock(return_value=mock_entry)
+
+            daemon = MagicMock()
+            daemon.daemon_type = 'rgw'
+            daemon.daemon_id = f'foo.{host}.0'
+            daemon.hostname = host
+            daemon.name.return_value = f'rgw.{daemon.daemon_id}'
+            daemon.service_name.return_value = svc_name
+
+            # A peer daemon still running on a different host
+            peer = MagicMock()
+            peer.hostname = 'host2'
+            peer.name.return_value = 'rgw.foo.host2.0'
+
+            with patch.object(cephadm_module, 'spec_store', mock_spec_store), \
+                 patch.object(cephadm_module.cache, 'get_daemons_by_service',
+                              return_value=[daemon, peer]):
+                rgw_svc.post_remove(daemon, is_failed_deploy=False)
+
+            # Inline certs must still be present — the service is still running on host2
+            assert cm.get_cert(rgw_svc.cert_name, service_name=svc_name) is not None
+            assert cm.get_key(rgw_svc.key_name, service_name=svc_name) is not None

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -1117,6 +1117,721 @@ class TestCertMgr(object):
             )
             assert rm_mock.call_count == 2
 
+    def test_cleanup_leftovers_after_cert_source_switch(self, cephadm_module: CephadmOrchestrator, caplog):
+        """Validate the combined cleanup used by post_remove after cert-source switches.
+
+        Scenario:
+        - Service previously used cephadm-signed certs (leftover host-scoped cephadm-signed pair exists)
+        - Service previously used inline certs (leftover non-editable service-scoped objects exist)
+
+        After a cert-source switch, post_remove should be able to clean both kinds of
+        cephadm-managed leftovers regardless of the *current* cert source.
+        """
+        cephadm_module._init_cert_mgr()
+        cm: CertMgr = cephadm_module.cert_mgr
+
+        svc = 'ingress.foo'
+        host = 'host1'
+
+        # Seed a cephadm-signed (host-scoped) pair
+        cm.register_self_signed_cert_key_pair(svc)
+        cm.save_self_signed_cert_key_pair(
+            svc,
+            TLSCredentials(CEPHADM_SELF_GENERATED_CERT_1, CEPHADM_SELF_GENERATED_KEY_2048),
+            host=host,
+        )
+
+        cephadm_cert = cm.self_signed_cert(svc)
+        cephadm_key = cm.self_signed_key(svc)
+        assert cm.get_cert(cephadm_cert, host=host) == CEPHADM_SELF_GENERATED_CERT_1
+        assert cm.get_key(cephadm_key, host=host) == CEPHADM_SELF_GENERATED_KEY_2048
+
+        # Seed inline-saved (service-scoped) objects for the same service
+        cm.save_cert('ingress_ssl_cert', 'inline-cert', service_name=svc, user_made=True, editable=False)
+        cm.save_key('ingress_ssl_key', 'inline-key', service_name=svc, user_made=True, editable=False)
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'inline-cert'
+        assert cm.get_key('ingress_ssl_key', service_name=svc) == 'inline-key'
+
+        # Combined cleanup (as in post_remove)
+        with caplog.at_level(logging.INFO):
+            cm.try_rm_self_signed_cert_key_pair(svc, host)
+        cm.rm_inline_saved_cert_key_pair(
+            'ingress_ssl_cert',
+            'ingress_ssl_key',
+            service_name=svc,
+            host=host,
+        )
+
+        # Both categories removed
+        assert cm.get_cert(cephadm_cert, host=host) is None
+        assert cm.get_key(cephadm_key, host=host) is None
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) is None
+        assert cm.get_key('ingress_ssl_key', service_name=svc) is None
+
+        # The INFO log should have been emitted for the cephadm-signed cleanup
+        assert any(
+            f"Removing cephadm-signed cert/key for service: {svc}, host: {host}" in r.getMessage()
+            for r in caplog.records
+        )
+
+        # If referenced creds are present (editable=True), inline cleanup must not remove them.
+        cm.save_cert('ingress_ssl_cert', 'ref-cert', service_name=svc, user_made=True, editable=True)
+        cm.save_key('ingress_ssl_key', 'ref-key', service_name=svc, user_made=True, editable=True)
+        cm.rm_inline_saved_cert_key_pair(
+            'ingress_ssl_cert',
+            'ingress_ssl_key',
+            service_name=svc,
+            host=host,
+        )
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+        assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key'
+
+    def test_try_rm_self_signed_cert_key_pair_best_effort_and_logs(self, cephadm_module: CephadmOrchestrator, caplog):
+        cephadm_module._init_cert_mgr()
+        cm: CertMgr = cephadm_module.cert_mgr
+
+        svc = "rgw.foo"
+        host = "host1"
+
+        cm.register_self_signed_cert_key_pair(svc)
+        cm.save_self_signed_cert_key_pair(
+            svc,
+            TLSCredentials(CEPHADM_SELF_GENERATED_CERT_1, CEPHADM_SELF_GENERATED_KEY_2048),
+            host=host,
+        )
+
+        cert_name = cm.self_signed_cert(svc)
+        key_name = cm.self_signed_key(svc)
+        assert cm.get_cert(cert_name, host=host) == CEPHADM_SELF_GENERATED_CERT_1
+        assert cm.get_key(key_name, host=host) == CEPHADM_SELF_GENERATED_KEY_2048
+
+        with caplog.at_level(logging.INFO):
+            cm.try_rm_self_signed_cert_key_pair(svc, host)
+        assert cm.get_cert(cert_name, host=host) is None
+        assert cm.get_key(key_name, host=host) is None
+        assert any("Removing cephadm-signed cert/key" in r.getMessage() for r in caplog.records)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            cm.try_rm_self_signed_cert_key_pair(svc, host)
+        assert not any("Removing cephadm-signed cert/key" in r.getMessage() for r in caplog.records)
+
+    def test_rm_inline_saved_cert_key_pair_best_effort_and_editable(self, cephadm_module: CephadmOrchestrator):
+
+        cephadm_module._init_cert_mgr()
+        cm: CertMgr = cephadm_module.cert_mgr
+
+        svc = "nfs.foo"
+
+        # 1) unknown/unregistered names should never raise (best-effort cleanup)
+        cm.rm_inline_saved_cert_key_pair(
+            "totally_unknown_cert",
+            "totally_unknown_key",
+            service_name=svc,
+            host="host1",
+            ca_cert_name="totally_unknown_ca",
+        )
+
+        # 2) inline-saved objects (user_made=True, editable=False) should be removed
+        cm.save_cert("nfs_ssl_cert", "inline-cert", service_name=svc, user_made=True, editable=False)
+        cm.save_key("nfs_ssl_key", "inline-key", service_name=svc, user_made=True, editable=False)
+        cm.save_cert("nfs_ssl_ca_cert", "inline-ca", service_name=svc, user_made=True, editable=False)
+
+        cm.rm_inline_saved_cert_key_pair(
+            "nfs_ssl_cert",
+            "nfs_ssl_key",
+            service_name=svc,
+            host="host1",  # host passed even though SERVICE scope (should be ignored by store)
+            ca_cert_name="nfs_ssl_ca_cert",
+        )
+        assert cm.get_cert("nfs_ssl_cert", service_name=svc) is None
+        assert cm.get_key("nfs_ssl_key", service_name=svc) is None
+        assert cm.get_cert("nfs_ssl_ca_cert", service_name=svc) is None
+
+        # 3) referenced/user-managed entries (editable=True) must NOT be removed
+        cm.save_cert("nfs_ssl_cert", "ref-cert", service_name=svc, user_made=True, editable=True)
+        cm.save_key("nfs_ssl_key", "ref-key", service_name=svc, user_made=True, editable=True)
+        cm.save_cert("nfs_ssl_ca_cert", "ref-ca", service_name=svc, user_made=True, editable=True)
+
+        cm.rm_inline_saved_cert_key_pair(
+            "nfs_ssl_cert",
+            "nfs_ssl_key",
+            service_name=svc,
+            host="host1",
+            ca_cert_name="nfs_ssl_ca_cert",
+        )
+        assert cm.get_cert("nfs_ssl_cert", service_name=svc) == "ref-cert"
+        assert cm.get_key("nfs_ssl_key", service_name=svc) == "ref-key"
+        assert cm.get_cert("nfs_ssl_ca_cert", service_name=svc) == "ref-ca"
+
+    # ------------------------------------------------------------------ #
+    #  Tests for certificate_source as a dependency + user warning        #
+    # ------------------------------------------------------------------ #
+
+    def test_base_get_dependencies_includes_certificate_source(self, cephadm_module: CephadmOrchestrator):
+        """CephadmService.get_dependencies should include certificate_source in deps when ssl=True."""
+        from cephadm.services.cephadmservice import CephadmService
+
+        spec = mock.MagicMock()
+        spec.ssl = True
+        spec.certificate_source = 'cephadm-signed'
+        spec.ssl_cert = None
+        spec.ssl_key = None
+        spec.ssl_ca_cert = None
+
+        deps = CephadmService.get_dependencies(cephadm_module, spec)
+        assert 'certificate_source: cephadm-signed' in deps
+
+    def test_base_get_dependencies_no_certificate_source_when_ssl_false(self, cephadm_module: CephadmOrchestrator):
+        """When ssl=False, get_dependencies should return [] — no certificate_source dep."""
+        from cephadm.services.cephadmservice import CephadmService
+
+        spec = mock.MagicMock()
+        spec.ssl = False
+        spec.certificate_source = 'inline'
+
+        deps = CephadmService.get_dependencies(cephadm_module, spec)
+        assert deps == []
+
+    def test_base_get_dependencies_no_spec(self, cephadm_module: CephadmOrchestrator):
+        """When spec is None, get_dependencies should return []."""
+        from cephadm.services.cephadmservice import CephadmService
+
+        deps = CephadmService.get_dependencies(cephadm_module, None)
+        assert deps == []
+
+    def test_base_get_dependencies_certificate_source_changes_detected(self, cephadm_module: CephadmOrchestrator):
+        """Changing certificate_source should produce different deps, triggering reconfig."""
+        from cephadm.services.cephadmservice import CephadmService
+
+        spec_signed = mock.MagicMock()
+        spec_signed.ssl = True
+        spec_signed.certificate_source = 'cephadm-signed'
+        spec_signed.ssl_cert = None
+        spec_signed.ssl_key = None
+        spec_signed.ssl_ca_cert = None
+
+        spec_ref = mock.MagicMock()
+        spec_ref.ssl = True
+        spec_ref.certificate_source = 'reference'
+        spec_ref.ssl_cert = None
+        spec_ref.ssl_key = None
+        spec_ref.ssl_ca_cert = None
+
+        spec_inline = mock.MagicMock()
+        spec_inline.ssl = True
+        spec_inline.certificate_source = 'inline'
+        spec_inline.ssl_cert = 'some-cert'
+        spec_inline.ssl_key = 'some-key'
+        spec_inline.ssl_ca_cert = None
+
+        deps_signed = CephadmService.get_dependencies(cephadm_module, spec_signed)
+        deps_ref = CephadmService.get_dependencies(cephadm_module, spec_ref)
+        deps_inline = CephadmService.get_dependencies(cephadm_module, spec_inline)
+
+        # All three should differ from each other
+        assert deps_signed != deps_ref
+        assert deps_signed != deps_inline
+        assert deps_ref != deps_inline
+
+        # cephadm-signed <-> reference: previously had identical (empty) deps, now differ
+        assert 'certificate_source: cephadm-signed' in deps_signed
+        assert 'certificate_source: reference' in deps_ref
+
+    def test_base_get_dependencies_includes_cert_key_hashes_with_certificate_source(self, cephadm_module: CephadmOrchestrator):
+        """When ssl=True with inline cert/key, deps should include both certificate_source AND hashes."""
+        from cephadm.services.cephadmservice import CephadmService
+        from cephadm import utils
+
+        spec = mock.MagicMock()
+        spec.ssl = True
+        spec.certificate_source = 'inline'
+        spec.ssl_cert = 'my-cert-data'
+        spec.ssl_key = 'my-key-data'
+        spec.ssl_ca_cert = None
+
+        deps = CephadmService.get_dependencies(cephadm_module, spec)
+        assert 'certificate_source: inline' in deps
+        assert f'ssl_cert: {utils.md5_hash("my-cert-data")}' in deps
+        assert f'ssl_key: {utils.md5_hash("my-key-data")}' in deps
+
+    def test_grafana_get_dependencies_includes_parent_tls_deps(self, cephadm_module: CephadmOrchestrator):
+        """GrafanaService.get_dependencies should include parent TLS deps (certificate_source)
+        since Grafana has user_cert_allowed=True."""
+        from cephadm.services.monitoring import GrafanaService
+
+        spec = mock.MagicMock()
+        spec.ssl = True
+        spec.certificate_source = 'inline'
+        spec.ssl_cert = 'grafana-cert'
+        spec.ssl_key = 'grafana-key'
+        spec.ssl_ca_cert = None
+
+        deps = GrafanaService.get_dependencies(cephadm_module, spec)
+        assert 'certificate_source: inline' in deps
+
+    def test_grafana_get_dependencies_no_tls_deps_when_ssl_false(self, cephadm_module: CephadmOrchestrator):
+        """When ssl=False, GrafanaService should not include any TLS deps from parent."""
+        from cephadm.services.monitoring import GrafanaService
+
+        spec = mock.MagicMock()
+        spec.ssl = False
+        spec.certificate_source = 'cephadm-signed'
+
+        deps = GrafanaService.get_dependencies(cephadm_module, spec)
+        assert not any('certificate_source' in d for d in deps)
+
+    def test_grafana_get_dependencies_consistent_with_and_without_spec(self, cephadm_module: CephadmOrchestrator):
+        """Calling get_dependencies without spec should return no TLS deps (spec=None → [])
+        while calling with spec and ssl=True should include TLS deps."""
+        from cephadm.services.monitoring import GrafanaService
+
+        # Without spec — should not crash and should not include TLS deps
+        deps_no_spec = GrafanaService.get_dependencies(cephadm_module)
+        assert not any('certificate_source' in d for d in deps_no_spec)
+
+        # With spec and ssl=True
+        spec = mock.MagicMock()
+        spec.ssl = True
+        spec.certificate_source = 'reference'
+        spec.ssl_cert = None
+        spec.ssl_key = None
+        spec.ssl_ca_cert = None
+
+        deps_with_spec = GrafanaService.get_dependencies(cephadm_module, spec)
+        assert 'certificate_source: reference' in deps_with_spec
+
+    def test_check_cert_source_warns_on_certificate_source_change(self, cephadm_module: CephadmOrchestrator):
+        """_check_cert_source should return a warning when certificate_source changes."""
+        import datetime
+
+        old_spec = mock.MagicMock()
+        old_spec.certificate_source = 'cephadm-signed'
+        old_spec.service_name.return_value = 'grafana'
+        old_spec.service_type = 'grafana'
+
+        new_spec = mock.MagicMock()
+        new_spec.certificate_source = 'inline'
+        new_spec.service_name.return_value = 'grafana'
+        new_spec.service_type = 'grafana'
+        new_spec.is_using_certificates_source.return_value = False
+
+        # Seed the spec_store so _check_cert_source can find the old spec
+        cephadm_module.spec_store._specs['grafana'] = old_spec
+        cephadm_module.spec_store.spec_created['grafana'] = datetime.datetime.utcnow()
+
+        warning = cephadm_module._check_cert_source(new_spec)
+        assert "certificate_source" in warning
+        assert "cephadm-signed" in warning
+        assert "inline" in warning
+        assert "reconfiguration" in warning
+
+    def test_check_cert_source_no_warning_when_source_unchanged(self, cephadm_module: CephadmOrchestrator):
+        """_check_cert_source should return no warning when certificate_source stays the same."""
+        import datetime
+
+        old_spec = mock.MagicMock()
+        old_spec.certificate_source = 'cephadm-signed'
+        old_spec.service_name.return_value = 'grafana'
+        old_spec.service_type = 'grafana'
+
+        new_spec = mock.MagicMock()
+        new_spec.certificate_source = 'cephadm-signed'
+        new_spec.service_name.return_value = 'grafana'
+        new_spec.service_type = 'grafana'
+        new_spec.is_using_certificates_source.return_value = False
+
+        cephadm_module.spec_store._specs['grafana'] = old_spec
+        cephadm_module.spec_store.spec_created['grafana'] = datetime.datetime.utcnow()
+
+        warning = cephadm_module._check_cert_source(new_spec)
+        assert "certificate_source" not in warning
+
+    def test_check_cert_source_no_warning_for_new_service(self, cephadm_module: CephadmOrchestrator):
+        """_check_cert_source should return no source-change warning for a brand new service."""
+        new_spec = mock.MagicMock()
+        new_spec.certificate_source = 'inline'
+        new_spec.service_name.return_value = 'grafana'
+        new_spec.service_type = 'grafana'
+        new_spec.is_using_certificates_source.return_value = False
+
+        # spec_store does NOT contain 'grafana'
+        warning = cephadm_module._check_cert_source(new_spec)
+        assert "certificate_source" not in warning
+
+    def test_check_cert_source_warning_stacks_with_reference_warning(self, cephadm_module: CephadmOrchestrator):
+        """When switching to 'reference' on a per-host service, both the source-change
+        warning and the reference provisioning instructions should be present (+=)."""
+        import datetime
+        from cephadm.services.service_registry import service_registry
+
+        old_spec = mock.MagicMock()
+        old_spec.certificate_source = 'cephadm-signed'
+        old_spec.service_name.return_value = 'grafana'
+        old_spec.service_type = 'grafana'
+
+        new_spec = mock.MagicMock()
+        new_spec.certificate_source = 'reference'
+        new_spec.service_name.return_value = 'grafana'
+        new_spec.service_type = 'grafana'
+        new_spec.is_using_certificates_source.return_value = True
+
+        cephadm_module.spec_store._specs['grafana'] = old_spec
+        cephadm_module.spec_store.spec_created['grafana'] = datetime.datetime.utcnow()
+
+        # Mock the service registry instance to return a service with HOST scope
+        svc_mock = mock.MagicMock()
+        svc_mock.SCOPE = TLSObjectScope.HOST
+        svc_mock.cert_name = 'grafana_ssl_cert'
+        svc_mock.key_name = 'grafana_ssl_key'
+        with mock.patch.object(service_registry, 'get_service', return_value=svc_mock):
+            warning = cephadm_module._check_cert_source(new_spec)
+
+        # Both warnings should be present
+        assert "certificate_source" in warning
+        assert "cephadm-signed" in warning
+        assert "reference" in warning
+        assert "per-host certificates" in warning
+        assert "ceph orch certmgr cert set" in warning
+
+    def test_check_cert_source_all_transitions_warn(self, cephadm_module: CephadmOrchestrator):
+        """Every cross-source transition should produce a certificate_source warning."""
+        import datetime
+
+        sources = ['cephadm-signed', 'inline', 'reference']
+
+        for old_source in sources:
+            for new_source in sources:
+                if old_source == new_source:
+                    continue
+
+                old_spec = mock.MagicMock()
+                old_spec.certificate_source = old_source
+                old_spec.service_name.return_value = 'rgw.foo'
+                old_spec.service_type = 'rgw'
+
+                new_spec = mock.MagicMock()
+                new_spec.certificate_source = new_source
+                new_spec.service_name.return_value = 'rgw.foo'
+                new_spec.service_type = 'rgw'
+                new_spec.is_using_certificates_source.return_value = False
+
+                cephadm_module.spec_store._specs['rgw.foo'] = old_spec
+                cephadm_module.spec_store.spec_created['rgw.foo'] = datetime.datetime.utcnow()
+
+                warning = cephadm_module._check_cert_source(new_spec)
+                assert "certificate_source" in warning, \
+                    f"Expected warning for {old_source} -> {new_source}, got: {warning!r}"
+                assert old_source in warning
+                assert new_source in warning
+
+    # ------------------------------------------------------------------ #
+    #  Cleanup tests for certificate_source transitions                   #
+    #                                                                     #
+    #  These tests verify the reconciliation logic in                     #
+    #  get_certificates_generic: for each cross-source transition we      #
+    #  seed the "old" cert artifacts and then call the cleanup routines   #
+    #  exactly as get_certificates_generic does, asserting that:          #
+    #    - stale artifacts are removed                                    #
+    #    - user-provisioned reference certs (editable=True) are NEVER     #
+    #      removed                                                        #
+    # ------------------------------------------------------------------ #
+
+    def _seed_inline_certs(self, cm, svc, host):
+        """Seed inline-saved certs (user_made=True, editable=False) for a service-scoped service."""
+        cm.save_cert('ingress_ssl_cert', 'inline-cert', service_name=svc, user_made=True, editable=False)
+        cm.save_key('ingress_ssl_key', 'inline-key', service_name=svc, user_made=True, editable=False)
+
+    def _seed_cephadm_signed_certs(self, cm, svc, host):
+        """Seed cephadm-signed certs for a service."""
+        cm.register_self_signed_cert_key_pair(svc)
+        cm.save_self_signed_cert_key_pair(
+            svc,
+            TLSCredentials(CEPHADM_SELF_GENERATED_CERT_1, CEPHADM_SELF_GENERATED_KEY_2048),
+            host=host,
+        )
+
+    def _seed_reference_certs(self, cm, svc):
+        """Seed user-provisioned reference certs (editable=True) for a service."""
+        cm.save_cert('ingress_ssl_cert', 'ref-cert', service_name=svc, user_made=True, editable=True)
+        cm.save_key('ingress_ssl_key', 'ref-key', service_name=svc, user_made=True, editable=True)
+
+    def _run_reconciliation_cleanup(self, cm, cert_source, svc, host,
+                                    cert_name='ingress_ssl_cert', key_name='ingress_ssl_key'):
+        """Simulate the reconciliation cleanup from get_certificates_generic."""
+        if cert_source in ('reference', 'cephadm-signed'):
+            cm.rm_inline_saved_cert_key_pair(
+                cert_name, key_name,
+                service_name=svc, host=host,
+            )
+        if cert_source != 'cephadm-signed':
+            cm.try_rm_self_signed_cert_key_pair(svc, host)
+
+    def test_cleanup_inline_to_cephadm_signed(self, cephadm_module: CephadmOrchestrator):
+        """inline -> cephadm-signed: inline-saved certs removed, reference certs untouched."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        self._seed_inline_certs(cm, svc, host)
+        self._seed_reference_certs(cm, svc)  # should survive
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'  # editable overwrites non-editable
+
+        # Re-seed inline on top (simulating actual inline-saved state before switch)
+        cm.save_cert('ingress_ssl_cert', 'inline-cert', service_name=svc, user_made=True, editable=False)
+        cm.save_key('ingress_ssl_key', 'inline-key', service_name=svc, user_made=True, editable=False)
+
+        self._run_reconciliation_cleanup(cm, 'cephadm-signed', svc, host)
+
+        # Inline-saved removed
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) is None
+        assert cm.get_key('ingress_ssl_key', service_name=svc) is None
+
+    def test_cleanup_inline_to_reference(self, cephadm_module: CephadmOrchestrator):
+        """inline -> reference: inline-saved removed, cephadm-signed removed, reference survives."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        self._seed_inline_certs(cm, svc, host)
+        self._seed_cephadm_signed_certs(cm, svc, host)
+
+        cephadm_cert = cm.self_signed_cert(svc)
+        cephadm_key = cm.self_signed_key(svc)
+
+        self._run_reconciliation_cleanup(cm, 'reference', svc, host)
+
+        # Inline-saved removed
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) is None
+        assert cm.get_key('ingress_ssl_key', service_name=svc) is None
+        # Cephadm-signed removed
+        assert cm.get_cert(cephadm_cert, host=host) is None
+        assert cm.get_key(cephadm_key, host=host) is None
+
+    def test_cleanup_cephadm_signed_to_inline(self, cephadm_module: CephadmOrchestrator):
+        """cephadm-signed -> inline: cephadm-signed removed."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        self._seed_cephadm_signed_certs(cm, svc, host)
+        cephadm_cert = cm.self_signed_cert(svc)
+        cephadm_key = cm.self_signed_key(svc)
+
+        self._run_reconciliation_cleanup(cm, 'inline', svc, host)
+
+        # Cephadm-signed removed
+        assert cm.get_cert(cephadm_cert, host=host) is None
+        assert cm.get_key(cephadm_key, host=host) is None
+
+    def test_cleanup_cephadm_signed_to_reference(self, cephadm_module: CephadmOrchestrator):
+        """cephadm-signed -> reference: cephadm-signed removed, reference untouched."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        self._seed_cephadm_signed_certs(cm, svc, host)
+        self._seed_reference_certs(cm, svc)
+
+        cephadm_cert = cm.self_signed_cert(svc)
+        cephadm_key = cm.self_signed_key(svc)
+
+        self._run_reconciliation_cleanup(cm, 'reference', svc, host)
+
+        # Cephadm-signed removed
+        assert cm.get_cert(cephadm_cert, host=host) is None
+        assert cm.get_key(cephadm_key, host=host) is None
+        # Reference survives
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+        assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key'
+
+    def test_cleanup_reference_to_inline(self, cephadm_module: CephadmOrchestrator):
+        """reference -> inline: cephadm-signed removed, reference certs NOT removed."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        self._seed_reference_certs(cm, svc)
+        self._seed_cephadm_signed_certs(cm, svc, host)
+
+        cephadm_cert = cm.self_signed_cert(svc)
+        cephadm_key = cm.self_signed_key(svc)
+
+        self._run_reconciliation_cleanup(cm, 'inline', svc, host)
+
+        # Cephadm-signed removed
+        assert cm.get_cert(cephadm_cert, host=host) is None
+        assert cm.get_key(cephadm_key, host=host) is None
+        # Reference NOT removed (editable=True)
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+        assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key'
+
+    def test_cleanup_reference_to_cephadm_signed(self, cephadm_module: CephadmOrchestrator):
+        """reference -> cephadm-signed: reference certs NOT removed (editable=True preserved)."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        self._seed_reference_certs(cm, svc)
+
+        self._run_reconciliation_cleanup(cm, 'cephadm-signed', svc, host)
+
+        # Reference NOT removed — rm_inline_saved skips editable=True
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+        assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key'
+
+    def test_cleanup_reference_never_removed_in_any_transition(self, cephadm_module: CephadmOrchestrator):
+        """Reference certs (editable=True) must survive ALL transitions."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        for target_source in ['inline', 'cephadm-signed', 'reference']:
+            # Reset: seed fresh reference certs
+            cm.save_cert('ingress_ssl_cert', 'ref-cert', service_name=svc, user_made=True, editable=True)
+            cm.save_key('ingress_ssl_key', 'ref-key', service_name=svc, user_made=True, editable=True)
+
+            self._run_reconciliation_cleanup(cm, target_source, svc, host)
+
+            assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert', \
+                f"Reference cert removed during transition to {target_source}"
+            assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key', \
+                f"Reference key removed during transition to {target_source}"
+
+    # ------------------------------------------------------------------ #
+    #  post_remove cleanup tests                                          #
+    #                                                                     #
+    #  These tests verify that CephadmService.post_remove correctly       #
+    #  cleans up TLS artifacts when a daemon is removed, respecting       #
+    #  scope, remaining daemons, and reference cert preservation.         #
+    # ------------------------------------------------------------------ #
+
+    def test_post_remove_cleans_cephadm_signed_regardless_of_source(self, cephadm_module: CephadmOrchestrator):
+        """post_remove always calls try_rm_self_signed_cert_key_pair, even when
+        the current certificate_source is 'inline' or 'reference'."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        for current_source in ['inline', 'reference', 'cephadm-signed']:
+            # Seed cephadm-signed leftovers
+            self._seed_cephadm_signed_certs(cm, svc, host)
+            cephadm_cert = cm.self_signed_cert(svc)
+            cephadm_key = cm.self_signed_key(svc)
+            assert cm.get_cert(cephadm_cert, host=host) is not None
+
+            # post_remove always does try_rm_self_signed unconditionally
+            cm.try_rm_self_signed_cert_key_pair(svc, host)
+
+            assert cm.get_cert(cephadm_cert, host=host) is None, \
+                f"cephadm-signed cert not cleaned when source={current_source}"
+            assert cm.get_key(cephadm_key, host=host) is None, \
+                f"cephadm-signed key not cleaned when source={current_source}"
+
+    def test_post_remove_inline_saved_cleanup_service_scope(self, cephadm_module: CephadmOrchestrator):
+        """For SERVICE-scoped services, inline-saved certs are only removed when
+        it's the last daemon (other_daemons_in_service=False)."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc = 'ingress.foo'
+
+        # Seed inline-saved (service scope: service_name, host=None)
+        cm.save_cert('ingress_ssl_cert', 'inline-cert', service_name=svc, user_made=True, editable=False)
+        cm.save_key('ingress_ssl_key', 'inline-key', service_name=svc, user_made=True, editable=False)
+
+        # Simulate: other daemons still exist → cleanup should NOT happen
+        # (post_remove returns early if other_daemons_in_service=True for SERVICE scope)
+        # Just verify the certs are still there (no cleanup call made)
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'inline-cert'
+
+        # Simulate: last daemon removed → cleanup should happen (service_name scope, host=None)
+        cm.rm_inline_saved_cert_key_pair(
+            'ingress_ssl_cert', 'ingress_ssl_key',
+            service_name=svc, host=None,
+        )
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) is None
+        assert cm.get_key('ingress_ssl_key', service_name=svc) is None
+
+    def test_post_remove_inline_saved_cleanup_host_scope(self, cephadm_module: CephadmOrchestrator):
+        """For HOST-scoped services (like grafana), inline-saved certs are removed
+        per-host when the last daemon on that host is removed."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc = 'grafana'
+        host1, host2 = 'host1', 'host2'
+
+        # Seed inline-saved per host
+        cm.save_cert('grafana_ssl_cert', 'cert-host1', host=host1, user_made=True, editable=False)
+        cm.save_cert('grafana_ssl_cert', 'cert-host2', host=host2, user_made=True, editable=False)
+
+        # Remove from host1 only
+        cm.rm_inline_saved_cert_key_pair(
+            'grafana_ssl_cert', 'grafana_ssl_key',
+            service_name=svc, host=host1,
+        )
+        # host1 removed, host2 untouched
+        assert cm.get_cert('grafana_ssl_cert', host=host1) is None
+        assert cm.get_cert('grafana_ssl_cert', host=host2) == 'cert-host2'
+
+    def test_post_remove_preserves_reference_certs(self, cephadm_module: CephadmOrchestrator):
+        """post_remove must never remove user-provisioned reference certs (editable=True),
+        even when the service is fully removed."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        # Seed reference certs
+        self._seed_reference_certs(cm, svc)
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+
+        # Simulate full post_remove cleanup: both try_rm_self_signed + rm_inline_saved
+        cm.try_rm_self_signed_cert_key_pair(svc, host)
+        cm.rm_inline_saved_cert_key_pair(
+            'ingress_ssl_cert', 'ingress_ssl_key',
+            service_name=svc, host=None,
+        )
+
+        # Reference certs must survive
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+        assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key'
+
+    def test_post_remove_cleans_all_stale_artifacts_on_full_removal(self, cephadm_module: CephadmOrchestrator):
+        """When the last daemon is removed, both cephadm-signed and inline-saved
+        artifacts should be cleaned up, but reference certs should survive."""
+        cephadm_module._init_cert_mgr()
+        cm = cephadm_module.cert_mgr
+        svc, host = 'ingress.foo', 'host1'
+
+        # Seed all three types of artifacts
+        self._seed_cephadm_signed_certs(cm, svc, host)
+        self._seed_inline_certs(cm, svc, host)
+        self._seed_reference_certs(cm, svc)
+
+        cephadm_cert = cm.self_signed_cert(svc)
+        cephadm_key = cm.self_signed_key(svc)
+
+        # The reference save (editable=True) overwrites the inline save (editable=False)
+        # for the same key. Re-seed inline to have both in a testable state:
+        # First verify reference is in place
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+
+        # Simulate full post_remove (as the code does):
+        # 1) Always clean cephadm-signed
+        cm.try_rm_self_signed_cert_key_pair(svc, host)
+        # 2) Clean inline-saved (service scope, last daemon)
+        cm.rm_inline_saved_cert_key_pair(
+            'ingress_ssl_cert', 'ingress_ssl_key',
+            service_name=svc, host=None,
+        )
+
+        # Cephadm-signed removed
+        assert cm.get_cert(cephadm_cert, host=host) is None
+        assert cm.get_key(cephadm_key, host=host) is None
+
+        # Reference certs survive (editable=True → rm_inline_saved skips them)
+        assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
+        assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key'
+
 
 class MockTLSObject(TLSObjectProtocol):
     STORAGE_PREFIX = "mocktls"
@@ -1187,6 +1902,21 @@ class TestTLSObjectStore(unittest.TestCase):
         scope, target = self.store.get_tlsobject_scope_and_target("global_cert_1")
         self.assertEqual(scope, TLSObjectScope.GLOBAL)
         self.assertEqual(target, None)
+
+    def test_get_tlsobject_if_exists(self):
+        """get_tlsobject_if_exists should never raise and return None on missing/invalid access."""
+        # Unknown entity
+        assert self.store.get_tlsobject_if_exists("unknown_entity") is None
+
+        # Known but missing required target
+        assert self.store.get_tlsobject_if_exists("per_host1") is None
+        assert self.store.get_tlsobject_if_exists("per_service1") is None
+
+        # Existing object returns normally
+        self.store.save_tlsobject("per_host1", "cert_data", host="my_host")
+        obj = self.store.get_tlsobject_if_exists("per_host1", host="my_host")
+        assert obj is not None
+        assert obj.data == "cert_data"
 
     def test_list_tlsobjects(self):
         self.store.save_tlsobject("global_cert_1", "cert_data1")

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -1352,8 +1352,8 @@ class TestCertMgr(object):
 
         deps = CephadmService.get_dependencies(cephadm_module, spec)
         assert 'certificate_source: inline' in deps
-        assert f'ssl_cert: {utils.md5_hash("my-cert-data")}' in deps
-        assert f'ssl_key: {utils.md5_hash("my-key-data")}' in deps
+        assert f'ssl_cert: {utils.config_hash("my-cert-data")}' in deps
+        assert f'ssl_key: {utils.config_hash("my-key-data")}' in deps
 
     def test_grafana_get_dependencies_includes_parent_tls_deps(self, cephadm_module: CephadmOrchestrator):
         """GrafanaService.get_dependencies should include parent TLS deps (certificate_source)

--- a/src/pybind/mgr/cephadm/tlsobject_store.py
+++ b/src/pybind/mgr/cephadm/tlsobject_store.py
@@ -119,6 +119,15 @@ class TLSObjectStore():
         else:
             return TLSObjectScope.UNKNOWN, None
 
+    def get_tlsobject_if_exists(self,
+                                obj_name: str,
+                                service_name: Optional[str] = None,
+                                host: Optional[str] = None) -> Optional[TLSObjectProtocol]:
+        try:
+            return self.get_tlsobject(obj_name, service_name, host)
+        except TLSObjectException:
+            return None
+
     def get_tlsobject(self, obj_name: str,
                       service_name: Optional[str] = None,
                       host: Optional[str] = None) -> Optional[TLSObjectProtocol]:


### PR DESCRIPTION

This PR improves TLS certificate handling for cephadm-managed services:

1. Include TLS-related spec fields in service deps (certificate_source + hashed ssl_cert/ssl_key/ssl_ca_cert) so changes reliably trigger reconciliation/reconfig.

2. When switching to certificate_source: reference, remove inline-saved / non-editable certmgr entries (service-scope) to avoid pinning to old inline values and let users provision editable certs/keys via certmgr.

3. Add best-effort cleanup for leftover TLS credentials during daemon removal and cert source changes, while keeping referenced/user-managed entries.

4. Fix self-signed “with label” lookup to use the host (not FQDN) when fetching stored credentials.

Fixes: https://tracker.ceph.com/issues/75009

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
