### PR TITLE
rgw/posix: fix multipart upload failures and improve error diagnostics

### DIFF
--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -240,11 +240,14 @@ namespace cohort {
             } else {
               lane.q.erase(it);
             }
+            lane.q.push_front(*o);
 	    /* hiwat check */
-	    if (lane.q.size() > lane_hiwat) {
-	      tdo = o;
-	    } else {
-	      lane.q.push_front(*o);
+            if (lane.q.size() > lane_hiwat) {
+              /* discard the actual lane LRU immediately */
+              Object* o2 = &(lane.q.back());
+	      Object::Queue::iterator it = Object::Queue::s_iterator_to(*o2);
+	      lane.q.erase(it);
+	      tdo = o2;
 	    }
 	  }
 	  lane.lock.unlock();

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -524,6 +524,12 @@ set(radosgw_admin_srcs
   radosgw-admin/sync_checkpoint.cc
   radosgw-admin/orphan.cc)
 
+set(radosgw_admin_srcs_without_rados
+  radosgw-admin/radosgw-admin.cc
+  driver/rados/rgw_user.cc
+  driver/rados/rgw_bucket.cc
+  driver/rados/rgw_obj_manifest.cc)
+
 # this is unsatisfying and hopefully temporary; ARROW should not be
 # part of radosgw_admin
 if(WITH_RADOSGW_ARROW_FLIGHT)
@@ -542,6 +548,12 @@ target_link_libraries(radosgw-admin
   OATH::OATH
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES})
 endif()
+
+if(WITH_RADOSGW_POSIX AND NOT WITH_RADOSGW_RADOS)
+add_executable(radosgw-admin ${radosgw_admin_srcs_without_rados})
+target_link_libraries(radosgw-admin
+  ${rgw_libs} librados)
+endif(WITH_RADOSGW_POSIX AND NOT WITH_RADOSGW_RADOS)
 
 # this is unsatisfying and hopefully temporary; ARROW should not be
 # part of radosgw_admin

--- a/src/rgw/driver/posix/Dockerfile.radosgw-posix
+++ b/src/rgw/driver/posix/Dockerfile.radosgw-posix
@@ -1,0 +1,86 @@
+# Dockerfile for Ceph RGW with POSIX/DBStore backend
+# Put the file at the root of the ceph source directory 
+# Build from the ceph source directory after compiling:
+#   podman build -t radosgw-posix:latest -f Dockerfile.radosgw-posix .
+
+FROM quay.io/centos/centos:stream10
+
+# Enable EPEL and CRB repositories for additional packages
+RUN dnf install -y dnf-plugins-core epel-release && \
+    dnf config-manager --set-enabled crb
+
+# Swap libcurl-minimal for full libcurl (required by radosgw)
+RUN dnf swap -y libcurl-minimal libcurl
+
+# Install runtime dependencies
+RUN dnf install -y \
+    gperftools-libs \
+    thrift \
+    lz4-libs \
+    snappy \
+    zlib \
+    liboath \
+    libcap \
+    libblkid \
+    systemd-libs \
+    rdma-core \
+    libibverbs \
+    librdmacm \
+    libicu \
+    expat \
+    lmdb-libs \
+    lua-libs \
+    openssl-libs \
+    librdkafka \
+    librabbitmq \
+    openldap \
+    sqlite-libs \
+    libzstd \
+    cyrus-sasl-lib \
+    libevent \
+    libnghttp2 \
+    libidn2 \
+    libssh \
+    libpsl \
+    krb5-libs \
+    libbrotli \
+    && dnf clean all
+
+# Create ceph user and directories
+RUN groupadd -r ceph && useradd -r -g ceph ceph && \
+    mkdir -p /var/lib/ceph/radosgw /var/log/ceph /etc/ceph /var/run/ceph && \
+    chown -R ceph:ceph /var/lib/ceph /var/log/ceph /etc/ceph /var/run/ceph
+
+# Copy binaries
+COPY --chmod=755 build/bin/radosgw /usr/bin/radosgw
+COPY --chmod=755 build/bin/radosgw-admin /usr/bin/radosgw-admin
+
+# Copy Ceph shared libraries
+COPY build/lib/libceph-common.so.2 /usr/lib64/
+COPY build/lib/librados.so.2.0.0 /usr/lib64/
+RUN ln -s librados.so.2.0.0 /usr/lib64/librados.so.2 && \
+    ln -s librados.so.2 /usr/lib64/librados.so && \
+    ln -s libceph-common.so.2 /usr/lib64/libceph-common.so && \
+    ldconfig
+
+# Default configuration for DBStore/POSIX
+RUN echo '[client.rgw]' > /etc/ceph/ceph.conf && \
+    echo 'rgw backend store = dbstore' >> /etc/ceph/ceph.conf && \
+    echo 'rgw config store = dbstore' >> /etc/ceph/ceph.conf && \
+    echo 'rgw filter = posix' >> /etc/ceph/ceph.conf && \
+    echo 'rgw frontends = beast port=7480' >> /etc/ceph/ceph.conf
+
+# Data directory for POSIX backend
+VOLUME ["/data"]
+
+EXPOSE 7480
+
+USER ceph
+
+ENTRYPOINT ["/usr/bin/radosgw", \
+    "--cluster", "ceph", \
+    "-n", "client.rgw", \
+    "--no-mon-config", \
+    "--default-log-to-stderr=true", \
+    "--err-to-stderr=true", \
+    "--foreground"]

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -67,11 +67,21 @@ struct BucketCacheEntry : public cohort::lru::Object
 
 public:
   BucketCacheEntry(BucketCache<D, B>* bc, const std::string& name, uint64_t hk)
-    : bc(bc), name(name), hk(hk), flags(FLAG_NONE) {}
+    : bc(bc), name(name), env{nullptr}, hk(hk), flags(FLAG_NONE) {}
 
   void set_env(std::shared_ptr<LMDBSafe::MDBEnv>& _env, LMDBSafe::MDBDbi& _dbi) {
     env = _env;
     dbi = _dbi;
+  }
+
+  virtual ~BucketCacheEntry()
+  {
+    /* XXX depends on safe_link -- but I think on balance, built-in safe_link
+     * is preferable to a custom mechanism with likely the same cost */
+    if (name_hook.is_linked()) {
+      bc->cache.remove(hk, this, bucket_avl_cache::FLAG_NONE);
+    }
+    mdb_dbi_close(*env, dbi); // return db handle
   }
 
   inline bool deleted() const {
@@ -152,14 +162,12 @@ public:
 
 	//std::cout << fmt::format("reclaim {}!", name) << std::endl;
 	bc->un->remove_watch(name);
-#if 1
-	// depends on safe_link
+
+	// XXX depends on safe_link
 	if (! name_hook.is_linked()) {
 	  // this should not happen!
 	  abort();
 	}
-#endif
-	bc->cache.remove(hk, this, bucket_avl_cache::FLAG_NONE);
 
 	/* discard lmdb data associated with this bucket */
 	auto txn = env->getRWTransaction();
@@ -622,6 +630,7 @@ public:
       b->flags &= ~BucketCacheEntry<D, B>::FLAG_FILLED;
 
       ulk.unlock();
+      lru.unref(b, cohort::lru::FLAG_NONE);
     } /* b */
 
     return 0;

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -371,12 +371,13 @@ public:
 	  std::string ser_data;
 	  zpp::bits::out out(ser_data);
 	  struct timespec ts{ceph::real_clock::to_timespec(bde.meta.mtime)};
-	  auto errc =
-	    out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
-		bde.ver.pool, bde.ver.epoch, bde.exists,
-		bde.meta.category, bde.meta.size, ts.tv_sec, ts.tv_nsec,
-		bde.meta.owner, bde.meta.owner_display_name, bde.meta.accounted_size,
-		bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+          auto errc =
+              out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
+                  bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
+                  bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
+                  bde.meta.owner_display_name, bde.meta.accounted_size,
+                  bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+                  bde.flags);
 	  /*std::cout << fmt::format("fill: bde.key.name: {}", bde.key.name)
 	    << std::endl;*/
 	  if (errc.code != std::errc{0}) {
@@ -428,12 +429,13 @@ public:
 	std::string ser_v{svv};
 	zpp::bits::in in_v(ser_v);
 	struct timespec ts;
-	errc =
-	  in_v(bde.key.name, bde.key.instance, /* bde.key.ns, */
-	       bde.ver.pool, bde.ver.epoch, bde.exists,
-	       bde.meta.category, bde.meta.size, ts.tv_sec, ts.tv_nsec,
-	       bde.meta.owner, bde.meta.owner_display_name, bde.meta.accounted_size,
-	       bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+        errc = in_v(
+            bde.key.name, bde.key.instance, /* bde.key.ns, */
+            bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
+            bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
+            bde.meta.owner_display_name, bde.meta.accounted_size,
+            bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+            bde.flags);
 	if (errc.code != std::errc{0}) {
 	  abort();
 	}
@@ -511,12 +513,13 @@ public:
 	  std::string ser_data;
 	  zpp::bits::out out(ser_data);
 	  struct timespec ts{ceph::real_clock::to_timespec(bde.meta.mtime)};
-	  auto errc =
-	    out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
-		bde.ver.pool, bde.ver.epoch, bde.exists,
-		bde.meta.category, bde.meta.size, ts.tv_sec, ts.tv_nsec,
-		bde.meta.owner, bde.meta.owner_display_name, bde.meta.accounted_size,
-		bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+          auto errc =
+              out(bde.key.name, bde.key.instance, /* XXX bde.key.ns, */
+                  bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
+                  bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
+                  bde.meta.owner_display_name, bde.meta.accounted_size,
+                  bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+                  bde.flags);
 	  if (errc.code != std::errc{0}) {
 	    abort();
 	  }
@@ -571,7 +574,8 @@ public:
               bde.ver.pool, bde.ver.epoch, bde.exists, bde.meta.category,
               bde.meta.size, ts.tv_sec, ts.tv_nsec, bde.meta.owner,
               bde.meta.owner_display_name, bde.meta.accounted_size,
-              bde.meta.storage_class, bde.meta.appendable, bde.meta.etag);
+              bde.meta.storage_class, bde.meta.appendable, bde.meta.etag,
+              bde.flags);
       if (errc.code != std::errc{0}) {
         abort();
       }

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -399,7 +399,9 @@ public:
 
       txn->commit();
       bucket->flags |= BucketCacheEntry<D, B>::FLAG_FILLED;
-      un->add_watch(bucket->name, bucket);
+      if (bucket->name.find("2~") == std::string::npos) {
+	un->add_watch(bucket->name, bucket);
+      }
       return rc;
     } /* fill */
 
@@ -516,8 +518,13 @@ public:
 	  bde.key.name = *ev.name;
 	  /* XXX will need work (if not straight up magic) to have
 	   * side loading support instance and ns */
-	  auto concat_k = concat_key(bde.key);
 	  rc = driver->mint_listing_entry(b->name, bde);
+	  if (rc < 0) {
+	    // mint_listing_entry failed (object may have been deleted), skip
+	    break;
+	  }
+	  // Calculate key AFTER mint_listing_entry which decodes the filename
+	  auto concat_k = concat_key(bde.key);
 	  std::string ser_data;
 	  zpp::bits::out out(ser_data);
 	  struct timespec ts{ceph::real_clock::to_timespec(bde.meta.mtime)};
@@ -536,8 +543,14 @@ public:
 	  break;
 	case EventType::REMOVE:
 	{
-	  auto& ev_name = *ev.name;
-	  txn->del(b->dbi, ev_name);
+	  // Decode the filename to get the proper key (consistent with ADD)
+	  std::string decoded_name = url_decode(*ev.name);
+	  rgw_obj_key key;
+	  rgw_obj_key::parse_raw_oid(decoded_name, &key);
+	  rgw_obj_index_key idx_key;
+	  key.get_index_key(&idx_key);
+	  auto concat_k = concat_key(idx_key);
+	  txn->del(b->dbi, concat_k);
 	}
 	  break;
 	[[unlikely]] case EventType::INVALIDATE:

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -543,12 +543,12 @@ public:
 	  break;
 	case EventType::REMOVE:
 	{
-	  // Decode the filename to get the proper key (consistent with ADD)
-	  std::string decoded_name = url_decode(*ev.name);
-	  rgw_obj_key key;
-	  rgw_obj_key::parse_raw_oid(decoded_name, &key);
+	  // Let the driver translate the raw filename to a cache key
 	  rgw_obj_index_key idx_key;
-	  key.get_index_key(&idx_key);
+	  rc = driver->decode_listing_key(*ev.name, idx_key);
+	  if (rc < 0) {
+	    break;
+	  }
 	  auto concat_k = concat_key(idx_key);
 	  txn->del(b->dbi, concat_k);
 	}

--- a/src/rgw/driver/posix/notify.h
+++ b/src/rgw/driver/posix/notify.h
@@ -110,7 +110,8 @@ namespace file::listing {
     using wd_callback_map_t = ankerl::unordered_dense::map<int, WatchRecord>;
     using wd_remove_map_t = ankerl::unordered_dense::map<std::string, int>;
 
-    int wfd, efd;
+    int wfd{-1};
+    int efd{-1};
     std::thread thrd;
     std::mutex map_mutex;  // protects wd_callback_map and wd_remove_map
     wd_callback_map_t wd_callback_map;
@@ -211,14 +212,14 @@ namespace file::listing {
 
     Inotify(Notifiable* n, const std::string& bucket_root)
       : Notify(n, bucket_root),
+	wfd(inotify_init1(IN_NONBLOCK)),
+	efd(eventfd(0, EFD_NONBLOCK)),
 	thrd(&Inotify::ev_loop, this)
       {
-	wfd = inotify_init1(IN_NONBLOCK);
 	if (wfd == -1) {
-	  std::cerr << fmt::format("{} inotify_init1 failed with {}", __func__, wfd) << std::endl;
+	  std::cerr << fmt::format("{} inotify_init1 failed", __func__) << std::endl;
 	  exit(1);
 	}
-	efd = eventfd(0, EFD_NONBLOCK);
       }
 
     void signal_shutdown() {
@@ -232,7 +233,9 @@ namespace file::listing {
       sf::path wp{rp / dname};
       int wd = inotify_add_watch(wfd, wp.c_str(), aw_mask);
       if (wd == -1) {
-	std::cerr << fmt::format("{} inotify_add_watch {} failed with {}", __func__, dname, wd) << std::endl;
+	int err = errno;
+	std::cerr << fmt::format("{} inotify_add_watch {} failed (errno={}: {})",
+	    __func__, dname, err, strerror(err)) << std::endl;
       } else {
 	std::lock_guard lock(map_mutex);
 	wd_callback_map.insert(wd_callback_map_t::value_type(wd, WatchRecord(wd, dname, opaque)));

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3452,6 +3452,20 @@ int POSIXObject::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y)
     return -EINVAL;
   }
 
+  ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20)
+        << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
+    return ret;
+  }
+
+  ret = stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20)
+        << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
+    return ret;
+  }
+
   fill_cache( nullptr, null_yield,
       [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
 	driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -754,6 +754,19 @@ int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::s
     return -ret;
   }
 
+  /* note that open() and stat() return already sign-reversed result codes */
+  ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
+    return ret;
+  }
+
+  ret = stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
+    return ret;
+  }
+
   return 0;
 }
 
@@ -4355,18 +4368,6 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   ret = obj->link_temp_file(rctx.dpp, rctx.y);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed writing temp file" << dendl;
-    return ret;
-  }
-
-  ret = obj->open(dpp);
-  if (ret < 0) {
-    ldpp_dout(rctx.dpp, 20) << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
-    return ret;
-  }
-
-  ret = obj->stat(dpp);
-  if (ret < 0) {
-    ldpp_dout(rctx.dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
     return ret;
   }
 

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3822,6 +3822,8 @@ int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   }
 
   mp_obj.upload_info.cksum_type = cksum_type;
+  mp_obj.upload_info.cksum_flags = cksum_flags;
+
   if (obj_retention) {
     mp_obj.upload_info.obj_retention_exist = true;
     mp_obj.upload_info.obj_retention = *obj_retention;
@@ -3830,6 +3832,7 @@ int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
     mp_obj.upload_info.obj_legal_hold_exist = true;
     mp_obj.upload_info.obj_legal_hold = *obj_legal_hold;
   }
+
   mp_obj.upload_info.dest_placement = dest_placement;
   mp_obj.owner = owner;
 
@@ -4117,12 +4120,17 @@ int POSIXMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield
       }
     }
     *rule = &mp_obj.upload_info.dest_placement;
+
     if (mp_obj.upload_info.obj_retention_exist) {
       obj_retention = mp_obj.upload_info.obj_retention;
     }
     if (mp_obj.upload_info.obj_legal_hold_exist) {
       obj_legal_hold = mp_obj.upload_info.obj_legal_hold;
     }
+
+    /* no te olvides los cksum */
+    cksum_type = mp_obj.upload_info.cksum_type;
+    cksum_flags = mp_obj.upload_info.cksum_flags;
   }
 
   return 0;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -4062,15 +4062,17 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     attrs[RGW_ATTR_COMPRESSION] = tmp;
   }
 
-  POSIXManifest manifest;
-  manifest.multipart_part_count = total_parts;
-  buffer::list manifest_bl;
-  manifest.encode(manifest_bl);
-  attrs[RGW_POSIX_ATTR_MANIFEST] = manifest_bl;
+  {
+    POSIXManifest manifest;
+    manifest.multipart_part_count = total_parts;
+    buffer::list manifest_bl;
+    manifest.encode(manifest_bl);
+    attrs[RGW_POSIX_ATTR_MANIFEST] = std::move(manifest_bl);
 
-  ret = shadow->merge_and_store_attrs(dpp, attrs, y);
-  if (ret < 0) {
-    return ret;
+    ret = shadow->merge_and_store_attrs(dpp, attrs, y);
+    if (ret < 0) {
+      return ret;
+    }
   }
 
   // Rename to target_obj

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2910,6 +2910,8 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
 
   cls_rgw_obj_key key;
   get_key().get_index_key(&key);
+
+  /* XXXX we should get bucket cache once, ne? hint:  operate functor */
   driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
 
   if (!key.instance.empty() && !ent->exists()) {

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3804,14 +3804,33 @@ int POSIXMultipartUpload::load(const DoutPrefixProvider *dpp, bool create)
 
 std::unique_ptr<rgw::sal::Object> POSIXMultipartUpload::get_meta_obj()
 {
+  std::unique_ptr<rgw::sal::Object> meta_obj{nullptr};
+
   load(nullptr);
+
   if (!shadow) {
     // This upload doesn't exist, but the API doesn't check this until it calls
     // on the *serializer*. So make a fake object in the parent bucket that
     // doesn't exist.  Put it in the MP namespace just in case.
-    return bucket->get_object(rgw_obj_key(get_meta(), std::string(), mp_ns));
+    meta_obj = bucket->get_object(rgw_obj_key(get_meta(), std::string(), mp_ns));
   }
-  return shadow->get_object(rgw_obj_key(get_meta(), std::string()));
+  meta_obj = shadow->get_object(rgw_obj_key(get_meta(), std::string()));
+
+  auto posix_meta_obj = static_cast<POSIXObject*>(meta_obj.get());
+  rgw::sal::Attrs attrs;
+  if (obj_retention) {
+    buffer::list obj_retention_bl;
+    obj_retention->encode(obj_retention_bl);
+    attrs[RGW_ATTR_OBJECT_RETENTION] = std::move(obj_retention_bl);
+  }
+  if (obj_legal_hold) {
+    buffer::list obj_legal_hold_bl;
+    obj_legal_hold->encode(obj_legal_hold_bl);
+    attrs[RGW_ATTR_OBJECT_LEGAL_HOLD] = std::move(obj_legal_hold_bl);
+  }
+  posix_meta_obj->set_attrs(attrs);
+
+  return meta_obj;
 }
 
 int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
@@ -3839,6 +3858,14 @@ int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   }
 
   mp_obj.upload_info.cksum_type = cksum_type;
+  if (obj_retention) {
+    mp_obj.upload_info.obj_retention_exist = true;
+    mp_obj.upload_info.obj_retention = *obj_retention;
+  }
+  if (obj_legal_hold) {
+    mp_obj.upload_info.obj_legal_hold_exist = true;
+    mp_obj.upload_info.obj_legal_hold = *obj_legal_hold;
+  }
   mp_obj.upload_info.dest_placement = dest_placement;
   mp_obj.owner = owner;
 
@@ -4126,6 +4153,12 @@ int POSIXMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield
       }
     }
     *rule = &mp_obj.upload_info.dest_placement;
+    if (mp_obj.upload_info.obj_retention_exist) {
+      obj_retention = mp_obj.upload_info.obj_retention;
+    }
+    if (mp_obj.upload_info.obj_legal_hold_exist) {
+      obj_legal_hold = mp_obj.upload_info.obj_legal_hold;
+    }
   }
 
   return 0;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -35,6 +35,7 @@ const std::string ATTR_PREFIX = "user.X-RGW-";
 #define RGW_POSIX_ATTR_MPUPLOAD "POSIX-Multipart-Upload"
 #define RGW_POSIX_ATTR_OWNER "POSIX-Owner"
 #define RGW_POSIX_ATTR_OBJECT_TYPE "POSIX-Object-Type"
+#define RGW_POSIX_ATTR_MANIFEST "POSIX-Manifest"
 const std::string mp_ns = "multipart";
 const std::string MP_OBJ_PART_PFX = "part-";
 const std::string MP_OBJ_HEAD_NAME = MP_OBJ_PART_PFX + "00000";
@@ -3496,6 +3497,20 @@ int POSIXObject::POSIXReadOp::prepare(optional_yield y, const DoutPrefixProvider
     return -EINVAL;
   }
 
+  buffer::list manifest_bl;
+  if (source->get_attr(RGW_POSIX_ATTR_MANIFEST, manifest_bl)) {
+    POSIXManifest manifest;
+    auto iter = manifest_bl.cbegin();
+    try {
+      manifest.decode(iter);
+      if (manifest.multipart_part_count > 0) {
+        params.parts_count = manifest.multipart_part_count;
+      }
+    } catch (buffer::error& err) {
+      // pass
+    }
+  }
+
 #if 0 // WIP
   if (params.mod_ptr || params.unmod_ptr) {
     obj_time_weight src_weight;
@@ -4046,6 +4061,12 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     encode(cs_info, tmp);
     attrs[RGW_ATTR_COMPRESSION] = tmp;
   }
+
+  POSIXManifest manifest;
+  manifest.multipart_part_count = total_parts;
+  buffer::list manifest_bl;
+  manifest.encode(manifest_bl);
+  attrs[RGW_POSIX_ATTR_MANIFEST] = manifest_bl;
 
   ret = shadow->merge_and_store_attrs(dpp, attrs, y);
   if (ret < 0) {

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3106,7 +3106,9 @@ int POSIXObject::load_obj_state(const DoutPrefixProvider* dpp, optional_yield y,
     return ret;
   }
 
-  return 0;
+  ret = get_obj_attrs(y, dpp);
+
+  return ret;
 }
 
 int POSIXObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <sys/xattr.h>
 #include <unistd.h>
+#include <cstdint>
 #include "rgw_multi.h"
 #include "include/scope_guard.h"
 #include "common/Clock.h" // for ceph_clock_now()
@@ -145,7 +146,7 @@ static bool decode_attr(Attrs &attrs, const char *name, F &f) {
 
 static inline rgw_obj_key decode_obj_key(const char* fname)
 {
-  std::string dname, oname, ns;
+  std::string dname, oname, ns; // XXX ns is unused?
   dname = url_decode(fname);
   rgw_obj_key key;
   rgw_obj_key::parse_raw_oid(dname, &key);
@@ -433,7 +434,7 @@ int FSEnt::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& at
   return get_x_attrs(y, dpp, get_fd(), attrs, get_name());
 }
 
-int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb)
+int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags)
 {
   rgw_bucket_dir_entry bde{};
 
@@ -449,7 +450,7 @@ int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cach
     case ObjectType::VERSIONED:
       bde.flags = rgw_bucket_dir_entry::FLAG_VER;
       bde.exists = true;
-      if (!key.have_instance()) {
+      if (flags & FSEnt::FLAG_CURRENT) {
 	  bde.flags |= rgw_bucket_dir_entry::FLAG_CURRENT;
       }
       break;
@@ -1081,7 +1082,7 @@ int Directory::get_ent(const DoutPrefixProvider *dpp, optional_yield y, const st
 }
 
 int Directory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                          fill_cache_cb_t &cb)
+                          fill_cache_cb_t &cb, uint32_t flags)
 {
   int ret = for_each(dpp, [this, &cb, &dpp, &y](const char *name) {
     std::unique_ptr<FSEnt> ent;
@@ -1097,7 +1098,7 @@ int Directory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
 
     ent->stat(dpp); // Stat the object to get the type
 
-    ret = ent->fill_cache(dpp, y, cb);
+    ret = ent->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
     if (ret < 0)
       return ret;
     return 0;
@@ -1180,54 +1181,6 @@ int Symlink::stat(const DoutPrefixProvider* dpp, bool force)
 
   exist = true;
   return fill_target(dpp, parent, get_name(), std::string(), target, ctx);
-}
-
-int Symlink::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb)
-{
-  rgw_bucket_dir_entry bde{};
-  int ret;
-
-  rgw_obj_key key = decode_obj_key(get_name());
-  key.get_index_key(&bde.key);
-  bde.ver.pool = 1;
-  bde.ver.epoch = 1;
-
-  bde.flags = rgw_bucket_dir_entry::FLAG_VER;
-  bde.exists = true;
-  bde.flags |= rgw_bucket_dir_entry::FLAG_CURRENT;
-
-  if (!target) {
-    ret = stat(dpp, /*force=*/false);
-    if (ret < 0)
-      return ret;
-  }
-
-  Attrs attrs;
-  ret = target->read_attrs(dpp, y, attrs);
-  if (ret < 0)
-    return ret;
-
-  POSIXOwner o;
-  ret = decode_owner(attrs, o);
-  if (ret < 0) {
-    bde.meta.owner = "unknown";
-    bde.meta.owner_display_name = "unknown";
-  } else {
-    bde.meta.owner = o.user.to_str();
-    bde.meta.owner_display_name = o.display_name;
-  }
-  bde.meta.category = RGWObjCategory::Main;
-  bde.meta.size = stx.stx_size;
-  bde.meta.accounted_size = stx.stx_size;
-  bde.meta.mtime = from_statx_timestamp(stx.stx_mtime);
-  bde.meta.storage_class = RGW_STORAGE_CLASS_STANDARD;
-  bde.meta.appendable = true;
-  bufferlist etag_bl;
-  if (rgw::sal::get_attr(attrs, RGW_ATTR_ETAG, etag_bl)) {
-    bde.meta.etag = etag_bl.to_str();
-  }
-
-  return cb(dpp, bde);
 }
 
 int Symlink::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
@@ -1384,13 +1337,13 @@ std::unique_ptr<File> MPDirectory::get_part_file(int partnum)
 }
 
 int MPDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                          fill_cache_cb_t &cb)
+                            fill_cache_cb_t &cb, uint32_t flags)
 {
-  int ret = FSEnt::fill_cache(dpp, y, cb);
+  int ret = FSEnt::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
   if (ret < 0)
     return ret;
 
-  return Directory::fill_cache(dpp, y, cb);
+  return Directory::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
 }
 
 int VersionedDirectory::open(const DoutPrefixProvider* dpp)
@@ -1796,8 +1749,11 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y, 
 }
 
 int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                          fill_cache_cb_t &cb)
+                                   fill_cache_cb_t &cb, uint32_t flags)
 {
+  /* Fill cur_version */
+  stat(dpp, /*force=*/false);
+
   int ret = for_each(dpp, [this, &cb, &dpp, &y](const char *name) {
     std::unique_ptr<FSEnt> ent;
 
@@ -1812,9 +1768,17 @@ int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield
 
     ent->stat(dpp); // Stat the object to get the type
 
-    ret = ent->fill_cache(dpp, y, cb);
-    if (ret < 0)
-      return ret;
+    if (ent->get_type() != ObjectType::SYMLINK) {
+      uint32_t fill_flags =
+          (cur_version &&
+           (ent->get_name() == cur_version->get_name())) ?
+        FSEnt::FLAG_CURRENT :
+        FSEnt::FLAG_NONE;
+
+      ret = ent->fill_cache(dpp, y, cb, fill_flags);
+      if (ret < 0)
+        return ret;
+    }
     return 0;
   });
 
@@ -2341,7 +2305,7 @@ std::unique_ptr<Object> POSIXBucket::get_object(const rgw_obj_key& k)
 
 int POSIXObject::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb)
 {
-  return ent->fill_cache(dpp, y, cb);
+  return ent->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
 }
 
 int POSIXDriver::mint_listing_entry(const std::string &bname,
@@ -2408,9 +2372,9 @@ std::unique_ptr<RGWRole> POSIXDriver::get_role(const RGWRoleInfo& info)
 }
 
 int POSIXBucket::fill_cache(const DoutPrefixProvider* dpp, optional_yield y,
-			  fill_cache_cb_t& cb)
+                            fill_cache_cb_t& cb)
 {
-return dir->fill_cache(dpp, y, cb);
+  return dir->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
 }
 
 int POSIXBucket::list(const DoutPrefixProvider* dpp, ListParams& params,

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -23,6 +23,8 @@
 #include "include/scope_guard.h"
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/errno.h"
+#include <fmt/format.h>
+#include <iostream>
 
 #define dout_subsys ceph_subsys_rgw
 #define dout_context g_ceph_context
@@ -937,10 +939,24 @@ int Directory::rename(const DoutPrefixProvider* dpp, optional_yield y, Directory
   }
   // swap
   ret = renameat2(parent_fd, src_name.c_str(), dst_dir->get_fd(), dst_name.c_str(), flags);
+  if (ret < 0 && errno == EINVAL && flags == RENAME_EXCHANGE) {
+    ldpp_dout(dpp, 1) << "WARNING: RENAME_EXCHANGE not supported, using fallback" << dendl;
+    struct statx stx;
+    if (statx(dst_dir->get_fd(), dst_name.c_str(), AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx) == 0) {
+      if (S_ISREG(stx.stx_mode)) {
+	unlinkat(dst_dir->get_fd(), dst_name.c_str(), 0);
+      } else if (S_ISDIR(stx.stx_mode)) {
+	delete_directory(dst_dir->get_fd(), dst_name.c_str(), true, dpp);
+      }
+    }
+    ret = renameat2(parent_fd, src_name.c_str(), dst_dir->get_fd(), dst_name.c_str(), 0);
+  }
   if(ret < 0) {
     ret = errno;
     ldpp_dout(dpp, 0) << "ERROR: renameat2 for shadow object could not finish: "
 	<< cpp_strerror(ret) << dendl;
+    std::cerr << fmt::format("ERROR: renameat2 for shadow object could not finish: {}",
+	cpp_strerror(ret)) << std::endl;
     return -ret;
   }
 
@@ -3799,11 +3815,19 @@ int POSIXMultipartUpload::load(const DoutPrefixProvider *dpp, bool create)
 
     std::unique_ptr<Directory> mpdir = std::make_unique<MPDirectory>(bucket_fname(get_meta(), ns), pb->get_dir(), driver->ctx());
 
-    shadow = std::make_unique<POSIXBucket>(driver, std::move(mpdir), rgw_bucket(std::string(), get_meta()), mp_ns);
+    auto tmp_shadow = std::make_unique<POSIXBucket>(driver, std::move(mpdir), rgw_bucket(std::string(), get_meta()), mp_ns);
 
-    ret = shadow->load_bucket(dpp, null_yield);
+    ret = tmp_shadow->load_bucket(dpp, null_yield);
     if (ret == -ENOENT && create) {
-      ret = shadow->create(dpp, null_yield, nullptr);
+      ret = tmp_shadow->create(dpp, null_yield, nullptr);
+    }
+    if (ret >= 0) {
+      shadow = std::move(tmp_shadow);
+    } else {
+      ldpp_dout(dpp, 0) << "ERROR: multipart upload load failed for "
+	<< get_meta() << ": " << cpp_strerror(-ret) << dendl;
+      std::cerr << fmt::format("ERROR: multipart upload load failed for {}: {}",
+	  get_meta(), cpp_strerror(-ret)) << std::endl;
     }
   }
 
@@ -4109,11 +4133,42 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to rename to final name " << target_obj->get_name()
 		      << ": " << cpp_strerror(ret) << dendl;
+    std::cerr << fmt::format("ERROR: failed to rename to final name {}: {}",
+	target_obj->get_name(), cpp_strerror(ret)) << std::endl;
     return ret;
   }
 
   POSIXObject *to = static_cast<POSIXObject*>(target_obj);
   POSIXBucket *sb = static_cast<POSIXBucket*>(target_obj->get_bucket());
+
+  // Open the target object to initialize its ent after the rename
+  ret = to->open(dpp, false, false);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not open completed multipart object "
+                      << to->get_name() << ": " << cpp_strerror(ret) << dendl;
+    std::cerr << fmt::format("ERROR: could not open completed multipart object {}: {}",
+	to->get_name(), cpp_strerror(ret)) << std::endl;
+    return ret;
+  }
+
+  // Force stat to get fresh metadata after multipart completion
+  ret = to->stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not stat completed multipart object "
+                      << to->get_name() << ": " << cpp_strerror(ret) << dendl;
+    std::cerr << fmt::format("ERROR: could not stat completed multipart object {}: {}",
+	to->get_name(), cpp_strerror(ret)) << std::endl;
+    return ret;
+  }
+
+  // Add the completed multipart object to the bucket cache
+  // (following the pattern from POSIXObject::link_temp_file)
+  to->fill_cache(dpp, y,
+      [this, sb](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
+          driver->get_bucket_cache()->add_entry(dpp, sb->get_name(), bde);
+          return 0;
+      });
+
   if (sb->versioned()) {
     ret = to->set_cur_version(dpp);
     if (ret < 0) {
@@ -4142,9 +4197,15 @@ int POSIXMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield
     return 0;
   }
 
+  // Ensure shadow is loaded with valid dpp for proper error logging
+  ret = load(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
   if (attrs) {
       meta_obj = get_meta_obj();
-      int ret = meta_obj->get_obj_attrs(y, dpp);
+      ret = meta_obj->get_obj_attrs(y, dpp);
       if (ret < 0) {
 	ldpp_dout(dpp, 0) << " ERROR: could not get meta object for mp upload "
 	  << get_key() << dendl;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2371,6 +2371,13 @@ int POSIXDriver::mint_listing_entry(const std::string &bname,
     return ret;
 }
 
+int POSIXDriver::decode_listing_key(std::string_view fname,
+                                     rgw_obj_index_key& idx_key) {
+  rgw_obj_key key = decode_obj_key(std::string(fname));
+  key.get_index_key(&idx_key);
+  return 0;
+}
+
 std::unique_ptr<LuaManager> POSIXDriver::get_lua_manager(const std::string& luarocks_path)
 {
   return std::make_unique<POSIXLuaManager>(this);

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -17,6 +17,7 @@
 
 #include "rgw_sal_filter.h"
 #include "rgw_sal_store.h"
+#include <cstdint>
 #include <memory>
 #include "common/dout.h"
 #include "bucket_cache.h"
@@ -106,6 +107,9 @@ protected:
   CephContext* ctx;
 
 public:
+  static constexpr uint32_t FLAG_NONE =      0x0;
+  static constexpr uint32_t FLAG_CURRENT =   0x2;
+
   FSEnt(std::string _name, Directory* _parent, CephContext* _ctx) : fname(_name), parent(_parent), ctx(_ctx) {}
   FSEnt(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : fname(_name), parent(_parent), exist(true), stx(_stx), stat_done(true), ctx(_ctx) {}
   FSEnt(const FSEnt& _e) :
@@ -138,7 +142,7 @@ public:
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) = 0;
   virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) = 0;
   virtual std::unique_ptr<FSEnt> clone_base() = 0;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb);
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags);
   virtual std::string get_cur_version() { return ""; };
 };
 
@@ -210,7 +214,7 @@ public:
   }
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
   virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
 
   int get_ent(const DoutPrefixProvider *dpp, optional_yield y, const std::string& name, const std::string& version, std::unique_ptr<FSEnt>& ent);
 };
@@ -247,7 +251,6 @@ public:
     return std::make_unique<Symlink>(*this);
   }
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
 };
 
 class MPDirectory : public Directory {
@@ -283,7 +286,7 @@ public:
   std::unique_ptr<MPDirectory> clone() {
     return std::make_unique<MPDirectory>(*this);
   }
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
 };
 
 class VersionedDirectory : public Directory {
@@ -344,7 +347,7 @@ public:
     return std::make_unique<VersionedDirectory>(*this);
   }
   virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
 };
 
 std::string get_key_fname(rgw_obj_key& key, bool use_version);

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -872,7 +872,7 @@ public:
     acls(_b.acls),
     ns(_b.ns)
     {
-      dir.reset(static_cast<Directory*>(_b.dir->clone().get()));
+      dir = _b.dir->clone_dir();
     }
 
   virtual ~POSIXBucket() { }

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -964,6 +964,23 @@ private:
   int write_attrs(const DoutPrefixProvider *dpp, optional_yield y);
 }; /* POSIXBucket */
 
+struct POSIXManifest {
+  int64_t  multipart_part_count{-1};
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(multipart_part_count, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(multipart_part_count, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(POSIXManifest);
+
 class POSIXObject : public StoreObject {
 public:
 private:

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -1184,6 +1184,10 @@ struct POSIXMPObj {
       return false;
     oid = meta.substr(0, mid_pos);
     upload_id = meta.substr(mid_pos + 1, end_pos - mid_pos - 1);
+    // Validate upload_id has correct prefix to avoid parsing file extensions
+    if (!is_v2_upload_id(upload_id)) {
+      return false;
+    }
     init(oid, upload_id, _owner);
     return true;
   }

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -782,6 +782,11 @@ public:
    * by inotify or similar */
   int mint_listing_entry(
     const std::string& bucket, rgw_bucket_dir_entry& bde /* OUT */);
+
+  /* called by BucketCache layer to translate a raw filename into a
+   * cache lookup key (for REMOVE events) */
+  int decode_listing_key(
+    std::string_view fname, rgw_obj_index_key& idx_key /* OUT */);
 };
 
 class POSIXNotification : public StoreNotification {

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -17,7 +17,9 @@
 
 #include "account.h"
 #include "buckets.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_metadata_lister.h"
+#endif
 #include "rgw_reshard.h"
 #include "rgw_pubsub.h"
 
@@ -50,6 +52,7 @@ static constexpr size_t listing_max_entries = 1000;
 /*
  * The tenant_name is always returned on purpose. May be empty, of course.
  */
+#ifdef WITH_RADOSGW_RADOS
 static void parse_bucket(const string& bucket,
                          string *tenant_name,
                          string *bucket_name,
@@ -95,6 +98,7 @@ static void dump_multipart_index_results(std::list<rgw_obj_index_key>& objs,
     f->dump_string("object",  o.name);
   }
 }
+#endif
 
 void check_bad_owner_bucket_mapping(rgw::sal::Driver* driver,
                                     const rgw_owner& owner,
@@ -312,6 +316,7 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   formatter->close_section();
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static void dump_index_check(map<RGWObjCategory, RGWStorageStats> existing_stats,
         map<RGWObjCategory, RGWStorageStats> calculated_stats,
         Formatter *formatter)
@@ -482,6 +487,7 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
 
   return 0;
 } // static ::check_bad_index_multipart
+#endif
 
 
 /**
@@ -496,6 +502,7 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
  * 'bucket check' operation over the /admin/bucket api, so we'll want
  * to address this in the future.
  */
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucket::check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
 					 RGWBucketAdminOpState& op_state,
 					 RGWFormatterFlusher& flusher,
@@ -557,6 +564,7 @@ int RGWBucket::check_bad_index_multipart(rgw::sal::RadosStore* const rados_store
 
   return any_error;
 }
+#endif
 
 int RGWBucket::check_object_index(const DoutPrefixProvider *dpp, 
                                   RGWBucketAdminOpState& op_state,
@@ -616,6 +624,7 @@ int RGWBucket::check_object_index(const DoutPrefixProvider *dpp,
  * request left off by calling RGWRados::clear_olh. If the pending log is not
  * empty, we attempt to apply it.
  */
+#ifdef WITH_RADOSGW_RADOS
 static int check_index_olh(rgw::sal::RadosStore* const rados_store,
                            rgw::sal::Bucket* const bucket,
                            const DoutPrefixProvider *dpp,
@@ -701,6 +710,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
   flusher.flush();
   return 0;
 }
+#endif
 
 
 /**
@@ -714,6 +724,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
  * operation over the /admin/bucket api, so we'll want to address
  * this.
  */
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucket::check_index_olh(rgw::sal::RadosStore* const rados_store,
                                const DoutPrefixProvider *dpp,
                                RGWBucketAdminOpState& op_state,
@@ -827,6 +838,7 @@ static int is_versioned_instance_listable(const DoutPrefixProvider *dpp,
   } while (result.is_truncated);
   return 0;
 }
+#endif
 
 /**
  * Loops over all instance entries in a bucket shard and finds ones with
@@ -840,6 +852,7 @@ static int is_versioned_instance_listable(const DoutPrefixProvider *dpp,
  * op_state.fix_index is true, we remove the object that is associated with the
  * instance entry.
  */
+#ifdef WITH_RADOSGW_RADOS
 static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
                                 rgw::sal::Bucket* const bucket,
                                 const DoutPrefixProvider *dpp,
@@ -997,6 +1010,7 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
   }
   return 0;
 }
+#endif
 
 int RGWBucket::check_index(const DoutPrefixProvider *dpp, optional_yield y,
         RGWBucketAdminOpState& op_state,
@@ -1149,6 +1163,7 @@ int RGWBucketAdminOp::dump_s3_policy(rgw::sal::Driver* driver, RGWBucketAdminOpS
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketAdminOp::unlink(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, optional_yield y, string *err)
 {
   rgw_owner owner;
@@ -1338,6 +1353,7 @@ int RGWBucketAdminOp::link(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_s
 
   return 0;
 }
+#endif
 
 int RGWBucketAdminOp::chown(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, optional_yield y, string *err)
 {
@@ -1351,6 +1367,7 @@ int RGWBucketAdminOp::chown(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_
 
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketAdminOp::check_index_olh(rgw::sal::RadosStore* store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp)
 {
@@ -1442,6 +1459,7 @@ int RGWBucketAdminOp::check_index(rgw::sal::Driver* driver,
 
   return 0;
 }
+#endif
 
 int RGWBucketAdminOp::remove_bucket(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
                                     RGWBucketAdminOpState& op_state,
@@ -1968,6 +1986,7 @@ inline auto split_tenant(const std::string& bucket_name){
 }
 
 using bucket_instance_ls = std::vector<RGWBucketInfo>;
+#ifdef WITH_RADOSGW_RADOS
 void get_stale_instances(rgw::sal::Driver* driver, const std::string& bucket_name,
                          const vector<std::string>& lst,
                          bucket_instance_ls& stale_instances,
@@ -2152,6 +2171,7 @@ int RGWBucketAdminOp::clear_stale_instances(rgw::sal::Driver* driver,
 
   return process_stale_instances(driver, op_state, flusher, dpp, process_f, y);
 }
+#endif
 
 static int fix_single_bucket_lc(rgw::sal::Driver* driver,
                                 const std::string& tenant_name,
@@ -2345,6 +2365,7 @@ void RGWBucketCompleteInfo::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("attrs", attrs, obj);
 }
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWBucketMetadataHandler : public RGWMetadataHandler {
  protected:
   librados::Rados& rados;
@@ -2459,6 +2480,7 @@ int RGWBucketMetadataHandler::put(std::string& entry, RGWMetadataObject* obj,
 
   return 0;
 }
+#endif
 
 int update_bucket_topic_mappings(const DoutPrefixProvider* dpp,
                                  const RGWBucketCompleteInfo* orig_bci,
@@ -2546,6 +2568,7 @@ int update_bucket_topic_mappings(const DoutPrefixProvider* dpp,
   return ret;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketMetadataHandler::remove(std::string& entry, RGWObjVersionTracker& objv_tracker,
                                      optional_yield y, const DoutPrefixProvider *dpp)
 {
@@ -2633,6 +2656,7 @@ static void get_md5_digest(const RGWBucketEntryPoint *be, string& md5_digest) {
 
    md5_digest = md5;
 }
+#endif
 
 #define ARCHIVE_META_ATTR RGW_ATTR_PREFIX "zone.archive.info" 
 
@@ -2674,6 +2698,7 @@ struct archive_meta_info {
 };
 WRITE_CLASS_ENCODER(archive_meta_info)
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWArchiveBucketMetadataHandler : public RGWBucketMetadataHandler {
  public:
   RGWArchiveBucketMetadataHandler(librados::Rados& rados,
@@ -2951,6 +2976,7 @@ int RGWBucketInstanceMetadataHandler::put(std::string& entry, RGWMetadataObject*
   // update related state on success
   return put_post(dpp, y, bci, old, objv_tracker);
 }
+#endif
 
 void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
 				const RGWZone& zone,
@@ -2978,6 +3004,7 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
   }
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketInstanceMetadataHandler::put_prepare(
     const DoutPrefixProvider* dpp, optional_yield y,
     const std::string& entry, RGWBucketCompleteInfo& bci,
@@ -3180,7 +3207,6 @@ std::string RGWBucketInstanceMetadataHandler::get_marker(void *handle)
   return lister->get_marker();
 }
 
-
 class RGWArchiveBucketInstanceMetadataHandler : public RGWBucketInstanceMetadataHandler {
  public:
   using RGWBucketInstanceMetadataHandler::RGWBucketInstanceMetadataHandler;
@@ -3194,6 +3220,7 @@ class RGWArchiveBucketInstanceMetadataHandler : public RGWBucketInstanceMetadata
     return 0;
   }
 };
+#endif
 
 RGWBucketCtl::RGWBucketCtl(RGWSI_Zone *zone_svc,
                            RGWSI_Bucket *bucket_svc,
@@ -3223,6 +3250,7 @@ void RGWBucketCtl::init(RGWUserCtl *user_ctl,
     });
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::read_bucket_entrypoint_info(const rgw_bucket& bucket,
                                               RGWBucketEntryPoint *info,
                                               optional_yield y, const DoutPrefixProvider *dpp,
@@ -3493,7 +3521,9 @@ static rgw_raw_obj get_owner_buckets_obj(RGWSI_User* svc_user,
         return rgwrados::account::get_buckets_obj(zone, account_id);
       }), owner);
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::link_bucket(librados::Rados& rados,
                               const rgw_owner& owner,
                               const rgw_bucket& bucket,
@@ -3562,7 +3592,9 @@ done_err:
   }
   return ret;
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::unlink_bucket(librados::Rados& rados, const rgw_owner& owner,
                                 const rgw_bucket& bucket, optional_yield y,
                                 const DoutPrefixProvider *dpp, bool update_entrypoint)
@@ -3598,6 +3630,7 @@ int RGWBucketCtl::unlink_bucket(librados::Rados& rados, const rgw_owner& owner,
   ep.linked = false;
   return svc.bucket->store_bucket_entrypoint_info(meta_key, ep, false, real_time(), &attrs, &ot, y, dpp);
 }
+#endif
 
 int RGWBucketCtl::read_bucket_stats(const rgw_bucket& bucket,
                                     RGWBucketEnt *result,
@@ -3613,6 +3646,7 @@ int RGWBucketCtl::read_buckets_stats(std::vector<RGWBucketEnt>& buckets,
   return svc.bucket->read_buckets_stats(buckets, y, dpp);
 }
 
+#ifdef WITH_RADOSGW_RADOS
 int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
                                    librados::Rados& rados,
                                    const rgw_owner& owner,
@@ -3641,6 +3675,7 @@ int RGWBucketCtl::sync_owner_stats(const DoutPrefixProvider *dpp,
       }), owner);
   return rgwrados::buckets::write_stats(dpp, y, rados, obj, *pent);
 }
+#endif
 
 int RGWBucketCtl::get_sync_policy_handler(std::optional<rgw_zone_id> zone,
                                           std::optional<rgw_bucket> bucket,
@@ -3685,6 +3720,7 @@ int RGWBucketCtl::bucket_imports_data(const rgw_bucket& bucket,
   return handler->bucket_imports_data();
 }
 
+#ifdef WITH_RADOSGW_RADOS
 auto create_bucket_metadata_handler(librados::Rados& rados,
                                     RGWSI_Bucket* svc_bucket,
                                     RGWBucketCtl* ctl_bucket)
@@ -3726,6 +3762,7 @@ auto create_archive_bucket_instance_metadata_handler(rgw::sal::Driver* driver,
                                                                    svc_bucket, svc_bi,
                                                                    svc_datalog);
 }
+#endif
 
 list<RGWBucketEntryPoint> RGWBucketEntryPoint::generate_test_instances()
 {

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -31,7 +31,9 @@
 // define as static when RGWBucket implementation completes
 extern void rgw_get_buckets_obj(const rgw_user& user_id, std::string& buckets_obj_id);
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWBucketMetadataHandler;
+#endif
 class RGWBucketInstanceMetadataHandler;
 class RGWUserCtl;
 class RGWBucketCtl;

--- a/src/rgw/driver/rados/rgw_metadata_lister.h
+++ b/src/rgw/driver/rados/rgw_metadata_lister.h
@@ -65,10 +65,12 @@ class RGWMetadataLister {
     return 0;
   }
 
+#ifdef WITH_RADOSGW_RADOS
   std::string get_marker()
   {
     std::string marker;
     listing.get_marker(&marker);
     return marker;
   }
+#endif
 };

--- a/src/rgw/driver/rados/rgw_obj_manifest.cc
+++ b/src/rgw/driver/rados/rgw_obj_manifest.cc
@@ -457,9 +457,10 @@ rgw_raw_obj rgw_obj_select::get_raw_obj(const RGWZoneGroup& zonegroup, const RGW
   return raw_obj;
 }
 
+#ifdef WITH_RADOSGW_RADOS 
 // returns true on success, false on failure
 bool RGWRados::get_obj_data_pool(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_pool *pool)
 {
   return rgw_get_obj_data_pool(svc.zone->get_zonegroup(), svc.zone->get_zone_params(), placement_rule, obj, pool);
 }
-
+#endif

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -8,7 +8,9 @@
 #include "rgw_account.h"
 #include "rgw_bucket.h"
 #include "rgw_metadata.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_metadata_lister.h"
+#endif
 #include "rgw_quota.h"
 #include "rgw_rest_iam.h" // validate_iam_user_name()
 
@@ -2692,6 +2694,7 @@ public:
   }
 };
 
+#ifdef WITH_RADOSGW_RADOS
 class RGWUserMetadataHandler : public RGWMetadataHandler {
   RGWSI_User *svc_user{nullptr};
  public:
@@ -2845,7 +2848,7 @@ std::string RGWUserMetadataHandler::get_marker(void *handle)
   auto lister = static_cast<RGWMetadataLister*>(handle);
   return lister->get_marker();
 }
-
+#endif
 
 RGWUserCtl::RGWUserCtl(RGWSI_Zone *zone_svc, RGWSI_User *user_svc)
 {
@@ -2975,11 +2978,13 @@ int RGWUserCtl::remove_info(const DoutPrefixProvider *dpp,
   return svc.user->remove_user_info(info, params.objv_tracker, y, dpp);
 }
 
+#ifdef WITH_RADOSGW_RADOS
 auto create_user_metadata_handler(RGWSI_User *user_svc)
     -> std::unique_ptr<RGWMetadataHandler>
 {
   return std::make_unique<RGWUserMetadataHandler>(user_svc);
 }
+#endif
 
 void rgw_user::dump(Formatter *f) const
 {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -39,16 +39,20 @@ extern "C" {
 
 #include "include/util.h"
 
+#ifdef WITH_RADOSGW_RADOS
 #include "cls/rgw/cls_rgw_types.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/2pc_queue/cls_2pc_queue_types.h"
 #include "cls/2pc_queue/cls_2pc_queue_client.h"
+#endif
 
 #include "include/utime.h"
 #include "include/str_list.h"
 
+#ifdef WITH_RADOSGW_RADOS
 #include "radosgw-admin/orphan.h"
 #include "radosgw-admin/sync_checkpoint.h"
+#endif
 
 #include "rgw/async_utils.h"
 
@@ -90,7 +94,9 @@ extern "C" {
 #include "services/svc_zone.h"
 
 #include "driver/rados/rgw_bucket.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "driver/rados/rgw_sal_rados.h"
+#endif
 #include "driver/rados/rgw_bl_rados.h"
 
 #include <iomanip>
@@ -340,12 +346,14 @@ void usage()
   cout << "  reshardlog purge                 trim bucket resharding log\n";
   cout << "  sync error list                  list sync error\n";
   cout << "  sync error trim                  trim sync error\n";
+#ifdef WITH_RADOSGW_RADOS
   cout << "  mfa create                       create a new MFA TOTP token\n";
   cout << "  mfa list                         list MFA TOTP tokens\n";
   cout << "  mfa get                          show MFA TOTP token\n";
   cout << "  mfa remove                       delete MFA TOTP token\n";
   cout << "  mfa check                        check MFA TOTP token\n";
   cout << "  mfa resync                       re-sync MFA TOTP token\n";
+#endif
   cout << "  topic list                       list bucket notifications topics\n";
   cout << "  topic get                        get a bucket notifications topic\n";
   cout << "  topic rm                         remove a bucket notifications topic\n";
@@ -529,7 +537,9 @@ void usage()
   cout << "   --path-prefix                 path prefix for filtering roles\n";
   cout << "   --description                 Role description\n";
   cout << "   --policy-arn                  ARN of a managed policy\n";
+#ifdef WITH_RADOSGW_RADOS
   cout << "\nMFA options:\n";
+#endif
   cout << "   --totp-serial                 a string that represents the ID of a TOTP token\n";
   cout << "   --totp-seed                   the secret seed that is used to calculate the TOTP\n";
   cout << "   --totp-seconds                the time resolution that is being used for TOTP generation\n";
@@ -714,10 +724,13 @@ enum class OPT {
   KEY_RM,
   BUCKETS_LIST,
   BUCKET_LIMIT_CHECK,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_LINK,
   BUCKET_UNLINK,
+#endif
   BUCKET_LAYOUT,
   BUCKET_STATS,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_CHECK,
   BUCKET_CHECK_OLH,
   BUCKET_CHECK_UNLINKED,
@@ -729,22 +742,31 @@ enum class OPT {
   BUCKET_SYNC_RUN,
   BUCKET_SYNC_DISABLE,
   BUCKET_SYNC_ENABLE,
+#endif
   BUCKET_RM,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_REWRITE,
   BUCKET_RESHARD,
+#endif
   BUCKET_SET_MIN_SHARDS,
   BUCKET_CHOWN,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_RADOS_LIST,
+#endif
   BUCKET_SHARD_OBJECTS,
   BUCKET_OBJECT_SHARD,
+#ifdef WITH_RADOSGW_RADOS
   BUCKET_RESYNC_ENCRYPTED_MULTIPART,
+#endif
   BUCKET_LOGGING_FLUSH,
   BUCKET_LOGGING_INFO,
   BUCKET_LOGGING_LIST,
   POLICY,
+#ifdef WITH_RADOSGW_RADOS
   LOG_LIST,
   LOG_SHOW,
   LOG_RM,
+#endif
   USAGE_SHOW,
   USAGE_TRIM,
   USAGE_CLEAR,
@@ -752,21 +774,26 @@ enum class OPT {
   OBJECT_RM,
   OBJECT_UNLINK,
   OBJECT_STAT,
+#ifdef WITH_RADOSGW_RADOS
   OBJECT_MANIFEST,
   OBJECT_REWRITE,
   OBJECT_REINDEX,
+#endif
   OBJECTS_EXPIRE,
   OBJECTS_EXPIRE_STALE_LIST,
   OBJECTS_EXPIRE_STALE_RM,
+#ifdef WITH_RADOSGW_RADOS
   BI_GET,
   BI_PUT,
   BI_LIST,
   BI_PURGE,
   OLH_GET,
   OLH_READLOG,
+#endif
   QUOTA_SET,
   QUOTA_ENABLE,
   QUOTA_DISABLE,
+#ifdef WITH_RADOSGW_RADOS
   DEDUP_STATS,
   DEDUP_ESTIMATE,
   DEDUP_ABORT,
@@ -776,13 +803,18 @@ enum class OPT {
   DEDUP_THROTTLE,
   GC_LIST,
   GC_PROCESS,
+#endif
   LC_LIST,
   LC_GET,
+#ifdef WITH_RADOSGW_RADOS
   LC_PROCESS,
+#endif
   LC_RESHARD_FIX,
+#ifdef WITH_RADOSGW_RADOS
   ORPHANS_FIND,
   ORPHANS_FINISH,
   ORPHANS_LIST_JOBS,
+#endif
   RATELIMIT_GET,
   RATELIMIT_SET,
   RATELIMIT_ENABLE,
@@ -811,13 +843,16 @@ enum class OPT {
   ZONE_LIST,
   ZONE_RENAME,
   ZONE_DEFAULT,
+#ifdef WITH_RADOSGW_RADOS
   ZONE_PLACEMENT_ADD,
+#endif
   ZONE_PLACEMENT_MODIFY,
   ZONE_PLACEMENT_RM,
   ZONE_PLACEMENT_LIST,
   ZONE_PLACEMENT_GET,
   CAPS_ADD,
   CAPS_RM,
+#ifdef WITH_RADOSGW_RADOS
   METADATA_GET,
   METADATA_PUT,
   METADATA_RM,
@@ -832,6 +867,7 @@ enum class OPT {
   MDLOG_STATUS,
   SYNC_ERROR_LIST,
   SYNC_ERROR_TRIM,
+#endif
   SYNC_GROUP_CREATE,
   SYNC_GROUP_MODIFY,
   SYNC_GROUP_GET,
@@ -843,12 +879,14 @@ enum class OPT {
   SYNC_GROUP_PIPE_REMOVE,
   SYNC_POLICY_GET,
   BILOG_LIST,
+#ifdef WITH_RADOSGW_RADOS
   BILOG_TRIM,
   BILOG_STATUS,
   BILOG_AUTOTRIM,
   DATA_SYNC_STATUS,
   DATA_SYNC_INIT,
   DATA_SYNC_RUN,
+#endif
   DATALOG_LIST,
   DATALOG_STATUS,
   DATALOG_AUTOTRIM,
@@ -885,7 +923,9 @@ enum class OPT {
   GLOBAL_RATELIMIT_ENABLE,
   GLOBAL_RATELIMIT_DISABLE,
   SYNC_INFO,
+#ifdef WITH_RADOSGW_RADOS
   SYNC_STATUS,
+#endif
   ROLE_CREATE,
   ROLE_DELETE,
   ROLE_GET,
@@ -899,6 +939,7 @@ enum class OPT {
   ROLE_POLICY_DETACH,
   ROLE_POLICY_LIST_ATTACHED,
   ROLE_UPDATE,
+#ifdef WITH_RADOSGW_RADOS
   RESHARD_ADD,
   RESHARD_LIST,
   RESHARD_STATUS,
@@ -914,14 +955,17 @@ enum class OPT {
   RESHARD_STALE_INSTANCES_DELETE,
   RESHARDLOG_LIST,
   RESHARDLOG_PURGE,
+#endif
   PUBSUB_TOPIC_LIST,
   PUBSUB_TOPIC_GET,
   PUBSUB_TOPIC_RM,
   PUBSUB_NOTIFICATION_LIST,
   PUBSUB_NOTIFICATION_GET,
   PUBSUB_NOTIFICATION_RM,
+#ifdef WITH_RADOSGW_RADOS
   PUBSUB_TOPIC_STATS,
   PUBSUB_TOPIC_DUMP,
+#endif
   SCRIPT_PUT,
   SCRIPT_GET,
   SCRIPT_RM,
@@ -965,10 +1009,13 @@ static SimpleCmd::Commands all_cmds = {
   { "buckets list", OPT::BUCKETS_LIST },
   { "bucket list", OPT::BUCKETS_LIST },
   { "bucket limit check", OPT::BUCKET_LIMIT_CHECK },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket link", OPT::BUCKET_LINK },
   { "bucket unlink", OPT::BUCKET_UNLINK },
+#endif
   { "bucket layout", OPT::BUCKET_LAYOUT },
   { "bucket stats", OPT::BUCKET_STATS },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket check", OPT::BUCKET_CHECK },
   { "bucket check olh", OPT::BUCKET_CHECK_OLH },
   { "bucket check unlinked", OPT::BUCKET_CHECK_UNLINKED },
@@ -980,24 +1027,33 @@ static SimpleCmd::Commands all_cmds = {
   { "bucket sync run", OPT::BUCKET_SYNC_RUN },
   { "bucket sync disable", OPT::BUCKET_SYNC_DISABLE },
   { "bucket sync enable", OPT::BUCKET_SYNC_ENABLE },
+#endif
   { "bucket rm", OPT::BUCKET_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket rewrite", OPT::BUCKET_REWRITE },
   { "bucket reshard", OPT::BUCKET_RESHARD },
+#endif
   { "bucket set-min-shards", OPT::BUCKET_SET_MIN_SHARDS },
   { "bucket chown", OPT::BUCKET_CHOWN },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket radoslist", OPT::BUCKET_RADOS_LIST },
   { "bucket rados list", OPT::BUCKET_RADOS_LIST },
+#endif
   { "bucket shard objects", OPT::BUCKET_SHARD_OBJECTS },
   { "bucket shard object", OPT::BUCKET_SHARD_OBJECTS },
   { "bucket object shard", OPT::BUCKET_OBJECT_SHARD },
+#ifdef WITH_RADOSGW_RADOS
   { "bucket resync encrypted multipart", OPT::BUCKET_RESYNC_ENCRYPTED_MULTIPART },
+#endif
   { "bucket logging flush", OPT::BUCKET_LOGGING_FLUSH },
   { "bucket logging info", OPT::BUCKET_LOGGING_INFO },
   { "bucket logging list", OPT::BUCKET_LOGGING_LIST },
   { "policy", OPT::POLICY },
+#ifdef WITH_RADOSGW_RADOS
   { "log list", OPT::LOG_LIST },
   { "log show", OPT::LOG_SHOW },
   { "log rm", OPT::LOG_RM },
+#endif
   { "usage show", OPT::USAGE_SHOW },
   { "usage trim", OPT::USAGE_TRIM },
   { "usage clear", OPT::USAGE_CLEAR },
@@ -1005,18 +1061,22 @@ static SimpleCmd::Commands all_cmds = {
   { "object rm", OPT::OBJECT_RM },
   { "object unlink", OPT::OBJECT_UNLINK },
   { "object stat", OPT::OBJECT_STAT },
+#ifdef WITH_RADOSGW_RADOS
   { "object manifest", OPT::OBJECT_MANIFEST },
   { "object rewrite", OPT::OBJECT_REWRITE },
   { "object reindex", OPT::OBJECT_REINDEX },
+#endif  
   { "objects expire", OPT::OBJECTS_EXPIRE },
   { "objects expire-stale list", OPT::OBJECTS_EXPIRE_STALE_LIST },
   { "objects expire-stale rm", OPT::OBJECTS_EXPIRE_STALE_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "bi get", OPT::BI_GET },
   { "bi put", OPT::BI_PUT },
   { "bi list", OPT::BI_LIST },
   { "bi purge", OPT::BI_PURGE },
   { "olh get", OPT::OLH_GET },
   { "olh readlog", OPT::OLH_READLOG },
+#endif
   { "quota set", OPT::QUOTA_SET },
   { "quota enable", OPT::QUOTA_ENABLE },
   { "quota disable", OPT::QUOTA_DISABLE },
@@ -1024,6 +1084,7 @@ static SimpleCmd::Commands all_cmds = {
   { "ratelimit set", OPT::RATELIMIT_SET },
   { "ratelimit enable", OPT::RATELIMIT_ENABLE },
   { "ratelimit disable", OPT::RATELIMIT_DISABLE },
+#ifdef WITH_RADOSGW_RADOS
   { "dedup stats", OPT::DEDUP_STATS },
   { "dedup estimate", OPT::DEDUP_ESTIMATE },
   { "dedup abort", OPT::DEDUP_ABORT },
@@ -1034,14 +1095,19 @@ static SimpleCmd::Commands all_cmds = {
   { "dedup throttle", OPT::DEDUP_THROTTLE },
   { "gc list", OPT::GC_LIST },
   { "gc process", OPT::GC_PROCESS },
+#endif
   { "lc list", OPT::LC_LIST },
   { "lc get", OPT::LC_GET },
+#ifdef WITH_RADOSGW_RADOS
   { "lc process", OPT::LC_PROCESS },
+#endif
   { "lc reshard fix", OPT::LC_RESHARD_FIX },
+#ifdef WITH_RADOSGW_RADOS
   { "orphans find", OPT::ORPHANS_FIND },
   { "orphans finish", OPT::ORPHANS_FINISH },
   { "orphans list jobs", OPT::ORPHANS_LIST_JOBS },
   { "orphans list-jobs", OPT::ORPHANS_LIST_JOBS },
+#endif
   { "zonegroup add", OPT::ZONEGROUP_ADD },
   { "zonegroup create", OPT::ZONEGROUP_CREATE },
   { "zonegroup default", OPT::ZONEGROUP_DEFAULT },
@@ -1069,13 +1135,16 @@ static SimpleCmd::Commands all_cmds = {
   { "zones list", OPT::ZONE_LIST },
   { "zone rename", OPT::ZONE_RENAME },
   { "zone default", OPT::ZONE_DEFAULT },
+#ifdef WITH_RADOSGW_RADOS
   { "zone placement add", OPT::ZONE_PLACEMENT_ADD },
+#endif
   { "zone placement modify", OPT::ZONE_PLACEMENT_MODIFY },
   { "zone placement rm", OPT::ZONE_PLACEMENT_RM },
   { "zone placement list", OPT::ZONE_PLACEMENT_LIST },
   { "zone placement get", OPT::ZONE_PLACEMENT_GET },
   { "caps add", OPT::CAPS_ADD },
   { "caps rm", OPT::CAPS_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "metadata get [*]", OPT::METADATA_GET },
   { "metadata put [*]", OPT::METADATA_PUT },
   { "metadata rm [*]", OPT::METADATA_RM },
@@ -1090,6 +1159,7 @@ static SimpleCmd::Commands all_cmds = {
   { "mdlog status", OPT::MDLOG_STATUS },
   { "sync error list", OPT::SYNC_ERROR_LIST },
   { "sync error trim", OPT::SYNC_ERROR_TRIM },
+#endif
   { "sync policy get", OPT::SYNC_POLICY_GET },
   { "sync group create", OPT::SYNC_GROUP_CREATE },
   { "sync group modify", OPT::SYNC_GROUP_MODIFY },
@@ -1101,12 +1171,14 @@ static SimpleCmd::Commands all_cmds = {
   { "sync group pipe modify", OPT::SYNC_GROUP_PIPE_MODIFY },
   { "sync group pipe remove", OPT::SYNC_GROUP_PIPE_REMOVE },
   { "bilog list", OPT::BILOG_LIST },
+#ifdef WITH_RADOSGW_RADOS
   { "bilog trim", OPT::BILOG_TRIM },
   { "bilog status", OPT::BILOG_STATUS },
   { "bilog autotrim", OPT::BILOG_AUTOTRIM },
   { "data sync status", OPT::DATA_SYNC_STATUS },
   { "data sync init", OPT::DATA_SYNC_INIT },
   { "data sync run", OPT::DATA_SYNC_RUN },
+#endif
   { "datalog list", OPT::DATALOG_LIST },
   { "datalog status", OPT::DATALOG_STATUS },
   { "datalog autotrim", OPT::DATALOG_AUTOTRIM },
@@ -1146,7 +1218,9 @@ static SimpleCmd::Commands all_cmds = {
   { "global ratelimit enable", OPT::GLOBAL_RATELIMIT_ENABLE },
   { "global ratelimit disable", OPT::GLOBAL_RATELIMIT_DISABLE },
   { "sync info", OPT::SYNC_INFO },
+#ifdef WITH_RADOSGW_RADOS
   { "sync status", OPT::SYNC_STATUS },
+#endif
   { "role create", OPT::ROLE_CREATE },
   { "role delete", OPT::ROLE_DELETE },
   { "role get", OPT::ROLE_GET },
@@ -1164,6 +1238,7 @@ static SimpleCmd::Commands all_cmds = {
   { "role policy detach", OPT::ROLE_POLICY_DETACH },
   { "role policy list attached", OPT::ROLE_POLICY_LIST_ATTACHED },
   { "role update", OPT::ROLE_UPDATE },
+#ifdef WITH_RADOSGW_RADOS
   { "reshard bucket", OPT::BUCKET_RESHARD },
   { "reshard add", OPT::RESHARD_ADD },
   { "reshard list", OPT::RESHARD_LIST },
@@ -1182,14 +1257,17 @@ static SimpleCmd::Commands all_cmds = {
   { "reshard stale delete", OPT::RESHARD_STALE_INSTANCES_DELETE },
   { "reshardlog list", OPT::RESHARDLOG_LIST},
   { "reshardlog purge", OPT::RESHARDLOG_PURGE},
+#endif
   { "topic list", OPT::PUBSUB_TOPIC_LIST },
   { "topic get", OPT::PUBSUB_TOPIC_GET },
   { "topic rm", OPT::PUBSUB_TOPIC_RM },
   { "notification list", OPT::PUBSUB_NOTIFICATION_LIST },
   { "notification get", OPT::PUBSUB_NOTIFICATION_GET },
   { "notification rm", OPT::PUBSUB_NOTIFICATION_RM },
+#ifdef WITH_RADOSGW_RADOS
   { "topic stats", OPT::PUBSUB_TOPIC_STATS },
   { "topic dump", OPT::PUBSUB_TOPIC_DUMP },
+#endif
   { "script put", OPT::SCRIPT_PUT },
   { "script get", OPT::SCRIPT_GET },
   { "script rm", OPT::SCRIPT_RM },
@@ -1272,6 +1350,7 @@ static void show_policy_arns(const boost::container::flat_set<std::string>& arns
   formatter->close_section();
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static void show_reshard_status(
   const list<cls_rgw_bucket_instance_entry>& status, Formatter *formatter)
 {
@@ -1284,6 +1363,7 @@ static void show_reshard_status(
   formatter->close_section();
   formatter->flush(cout);
 }
+#endif
 
 static void show_topics_info_v2(const rgw_pubsub_topic& topic,
                                 const std::set<std::string>& subscribed_buckets,
@@ -1773,6 +1853,7 @@ int check_min_obj_stripe_size(rgw::sal::Driver* driver, rgw::sal::Object* obj, u
 }
 
 
+#ifdef WITH_RADOSGW_RADOS
 int check_obj_locator_underscore(rgw::sal::Object* obj, bool fix, bool remove_bad, Formatter *f) {
   f->open_object_section("object");
   f->open_object_section("key");
@@ -1814,7 +1895,9 @@ done:
 
   return 0;
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int check_obj_tail_locator_underscore(RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, Formatter *f) {
   f->open_object_section("object");
   f->open_object_section("key");
@@ -1841,7 +1924,9 @@ int check_obj_tail_locator_underscore(RGWBucketInfo& bucket_info, rgw_obj_key& k
 
   return 0;
 }
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
 int do_check_object_locator(const string& tenant_name, const string& bucket_name,
                             bool fix, bool remove_bad, Formatter *f)
 {
@@ -1914,6 +1999,7 @@ int do_check_object_locator(const string& tenant_name, const string& bucket_name
 
   return 0;
 }
+#endif
 
 /// search for a matching zone/zonegroup id and return a connection if found
 static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore* driver,
@@ -2187,6 +2273,7 @@ static int update_period(rgw::sal::ConfigStore* cfgstore,
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int init_bucket_for_sync(const string& tenant, const string& bucket_name,
                                 const string& bucket_id,
 				std::unique_ptr<rgw::sal::Bucket>* bucket)
@@ -2199,6 +2286,7 @@ static int init_bucket_for_sync(const string& tenant, const string& bucket_name,
 
   return 0;
 }
+#endif
 
 static int do_period_pull(rgw::sal::ConfigStore* cfgstore,
                           RGWRESTConn *remote_conn, const string& url,
@@ -2262,6 +2350,7 @@ stringstream& push_ss(stringstream& ss, list<string>& l, int tab = 0)
   return ss;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static void get_md_sync_status(list<string>& status)
 {
   RGWMetaSyncStatusManager sync(static_cast<rgw::sal::RadosStore*>(driver), static_cast<rgw::sal::RadosStore*>(driver)->svc()->async_processor);
@@ -2637,6 +2726,7 @@ static void sync_status(Formatter *formatter)
 
   tab_dump("data sync", width, data_status);
 }
+#endif
 
 struct indented {
   int w; // indent width
@@ -2717,6 +2807,7 @@ struct bucket_source_sync_info {
   }
 };
 
+#ifdef WITH_RADOSGW_RADOS
 static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* driver,
                                      const RGWZone& zone,
                                      const RGWZone& source, RGWRESTConn *conn,
@@ -2831,6 +2922,7 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
   source_sync_info.shards_behind = std::move(shards_behind);
   return 0;
 }
+#endif
 
 void encode_json(const char *name, const RGWBucketSyncFlowManager::pipe_set& pset, Formatter *f)
 {
@@ -3001,6 +3093,7 @@ static int sync_info(std::optional<rgw_zone_id> opt_target_zone, std::optional<r
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int bucket_sync_info(rgw::sal::Driver* driver, const RGWBucketInfo& info,
                               std::ostream& out)
 {
@@ -3038,6 +3131,7 @@ static int bucket_sync_info(rgw::sal::Driver* driver, const RGWBucketInfo& info,
 
   return 0;
 }
+#endif
 
 struct bucket_sync_status_info {
   std::vector<bucket_source_sync_info> source_status_info;
@@ -3102,6 +3196,7 @@ struct bucket_sync_status_info {
 
 };
 
+#ifdef WITH_RADOSGW_RADOS
 static int bucket_sync_status(rgw::sal::Driver* driver, const RGWBucketInfo& info,
                               const rgw_zone_id& source_zone_id,
 			      std::optional<rgw_bucket>& opt_source_bucket,
@@ -3184,6 +3279,7 @@ static int bucket_sync_status(rgw::sal::Driver* driver, const RGWBucketInfo& inf
 
   return 0;
 }
+#endif
 
 static void parse_tier_config_param(const string& s, map<string, string, ltstr_nocase>& out)
 {
@@ -3219,6 +3315,7 @@ static void parse_tier_config_param(const string& s, map<string, string, ltstr_n
   }
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int check_pool_support_omap(const rgw_pool& pool)
 {
   librados::IoCtx io_ctx;
@@ -3236,6 +3333,7 @@ static int check_pool_support_omap(const rgw_pool& pool)
   io_ctx.close();
   return 0;
 }
+#endif
 
 int check_reshard_bucket_params(rgw::sal::Driver* driver,
 				const string& bucket_name,
@@ -3290,6 +3388,7 @@ int check_reshard_bucket_params(rgw::sal::Driver* driver,
   return 0;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static int scan_totp(CephContext *cct, ceph::real_time& now, rados::cls::otp::otp_info_t& totp, vector<string>& pins,
                      time_t *pofs)
 {
@@ -3359,6 +3458,7 @@ static int trim_sync_error_log(int shard_id, const string& marker, int delay_ms)
   }
   // unreachable
 }
+#endif
 
 static bool symmetrical_flow_opt(const string& opt)
 {
@@ -3717,9 +3817,11 @@ int main(int argc, const char **argv)
   list<string> tags;
   list<string> tags_add;
   list<string> tags_rm;
+#ifdef WITH_RADOSGW_RADOS
   int placement_inline_data = true;
   bool placement_inline_data_specified = false;
   bool format_arg_passed = false;
+#endif
 
   int64_t max_objects = -1;
   int64_t max_size = -1;
@@ -3729,8 +3831,10 @@ int main(int argc, const char **argv)
   int64_t max_delete_ops = 0;
   int64_t max_read_bytes = 0;
   int64_t max_write_bytes = 0;
+#ifdef WITH_RADOSGW_RADOS
   uint32_t max_bucket_index_ops = 0;
   uint32_t max_metadata_ops = 0;
+#endif
   bool have_max_objects = false;
   bool have_max_size = false;
   bool have_max_write_ops = false;
@@ -3739,8 +3843,10 @@ int main(int argc, const char **argv)
   bool have_max_delete_ops = false;
   bool have_max_write_bytes = false;
   bool have_max_read_bytes = false;
+#ifdef WITH_RADOSGW_RADOS
   bool have_max_bucket_index_ops = false;
   bool have_max_metadata_ops = false;
+#endif
   int include_all = false;
   int allow_unordered = false;
 
@@ -3754,9 +3860,11 @@ int main(int argc, const char **argv)
 
   int extra_info = false;
 
+#ifdef WITH_RADOSGW_RADOS
   uint64_t min_rewrite_size = 4 * 1024 * 1024;
   uint64_t max_rewrite_size = ULLONG_MAX;
   uint64_t min_rewrite_stripe_size = 0;
+#endif
 
   BIIndexType bi_index_type = BIIndexType::Plain;
   std::optional<log_type> opt_log_type;
@@ -3770,7 +3878,9 @@ int main(int argc, const char **argv)
   ceph::timespan min_age = std::chrono::hours(1);
   bool hide_progress = false;
   bool dump_keys = false;
+#ifdef WITH_RADOSGW_RADOS
   uint64_t orphan_stale_secs = (24 * 3600);
+#endif
   int detail = false;
 
   std::string val;
@@ -3789,8 +3899,10 @@ int main(int argc, const char **argv)
   boost::optional<string> index_pool;
   boost::optional<string> data_pool;
   boost::optional<string> data_extra_pool;
+#ifdef WITH_RADOSGW_RADOS
   rgw::BucketIndexType placement_index_type = rgw::BucketIndexType::Normal;
   bool index_type_specified = false;
+#endif
 
   boost::optional<std::string> compression_type;
 
@@ -3798,9 +3910,11 @@ int main(int argc, const char **argv)
   string totp_seed;
   string totp_seed_type = "hex";
   vector<string> totp_pin;
+#ifdef WITH_RADOSGW_RADOS
   int totp_seconds = 0;
   int totp_window = 0;
   int trim_delay_ms = 0;
+#endif
 
   string topic_name;
   string notification_id;
@@ -3990,12 +4104,14 @@ int main(int argc, const char **argv)
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &commit, NULL, "--commit", (char*)NULL)) {
       // do nothing
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--min-rewrite-size", (char*)NULL)) {
       min_rewrite_size = (uint64_t)atoll(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--max-rewrite-size", (char*)NULL)) {
       max_rewrite_size = (uint64_t)atoll(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--min-rewrite-stripe-size", (char*)NULL)) {
       min_rewrite_stripe_size = (uint64_t)atoll(val.c_str());
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--max-buckets", (char*)NULL)) {
       max_buckets = ceph::parse<int>(val);
       if (!max_buckets) {
@@ -4066,19 +4182,27 @@ int main(int argc, const char **argv)
       }
       have_max_write_bytes = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--max-bucket-index-ops", (char*)NULL)) {
+#ifdef WITH_RADOSGW_RADOS
       max_bucket_index_ops = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+#endif
       if (!err.empty()) {
 	cerr << "ERROR: failed to parse max bucket index ops: " << err << std::endl;
 	return EINVAL;
       }
+#ifdef WITH_RADOSGW_RADOS
       have_max_bucket_index_ops = true;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--max-metadata-ops", (char*)NULL)) {
+#ifdef WITH_RADOSGW_RADOS
       max_metadata_ops = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+#endif
       if (!err.empty()) {
 	cerr << "ERROR: failed to parse max metadata ops: " << err << std::endl;
 	return EINVAL;
       }
+#ifdef WITH_RADOSGW_RADOS
       have_max_metadata_ops = true;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--date", "--time", (char*)NULL)) {
       date = val;
       if (end_date.empty())
@@ -4108,12 +4232,14 @@ int main(int argc, const char **argv)
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--min-age-hours", (char*)NULL)) {
       min_age = std::chrono::hours(atoi(val.c_str()));
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--orphan-stale-secs", (char*)NULL)) {
       orphan_stale_secs = (uint64_t)strict_strtoll(val.c_str(), 10, &err);
       if (!err.empty()) {
         cerr << "ERROR: failed to parse orphan stale secs: " << err << std::endl;
         return EINVAL;
       }
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--shard-id", (char*)NULL)) {
       shard_id = (int)strict_strtol(val.c_str(), 10, &err);
       if (!err.empty()) {
@@ -4154,7 +4280,9 @@ int main(int argc, const char **argv)
       new_bucket_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char*)NULL)) {
       format = val;
+#ifdef WITH_RADOSGW_RADOS
       format_arg_passed = true;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--categories", (char*)NULL)) {
       string cat_str = val;
       list<string> cat_list;
@@ -4203,8 +4331,10 @@ int main(int argc, const char **argv)
       hide_progress = true;
     } else if (ceph_argparse_flag(args, i, "--dump-keys", (char*)NULL)) {
       dump_keys = true;
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_binary_flag(args, i, &placement_inline_data, NULL, "--placement-inline-data", (char*)NULL)) {
       placement_inline_data_specified = true;
+#endif
      // do nothing
     } else if (ceph_argparse_witharg(args, i, &val, "--caps", (char*)NULL)) {
       caps = val;
@@ -4321,6 +4451,7 @@ int main(int argc, const char **argv)
       data_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--data-extra-pool", (char*)NULL)) {
       data_extra_pool = val;
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-index-type", (char*)NULL)) {
       if (val == "normal") {
         placement_index_type = rgw::BucketIndexType::Normal;
@@ -4334,6 +4465,7 @@ int main(int argc, const char **argv)
         }
       }
       index_type_specified = true;
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--compression", (char*)NULL)) {
       compression_type = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--role-name", (char*)NULL)) {
@@ -4362,12 +4494,14 @@ int main(int argc, const char **argv)
       totp_seed = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--totp-seed-type", (char*)NULL)) {
       totp_seed_type = val;
+#ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--totp-seconds", (char*)NULL)) {
       totp_seconds = atoi(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--totp-window", (char*)NULL)) {
       totp_window = atoi(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--trim-delay-ms", (char*)NULL)) {
       trim_delay_ms = atoi(val.c_str());
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "--topic", (char*)NULL)) {
       topic_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--notification-id", (char*)NULL)) {
@@ -4516,12 +4650,14 @@ int main(int argc, const char **argv)
     /* some commands may have an optional extra param */
     if (!extra_args.empty()) {
       switch (opt_cmd) {
+#ifdef WITH_RADOSGW_RADOS
         case OPT::METADATA_GET:
         case OPT::METADATA_PUT:
         case OPT::METADATA_RM:
         case OPT::METADATA_LIST:
           metadata_key = extra_args[0];
           break;
+#endif
         default:
           break;
       }
@@ -4550,7 +4686,10 @@ int main(int argc, const char **argv)
 			 OPT::ZONE_CREATE, OPT::ZONE_DELETE,
 			 OPT::ZONE_GET, OPT::ZONE_SET, OPT::ZONE_RENAME,
 			 OPT::ZONE_LIST, OPT::ZONE_MODIFY, OPT::ZONE_DEFAULT,
-			 OPT::ZONE_PLACEMENT_ADD, OPT::ZONE_PLACEMENT_RM,
+#ifdef WITH_RADOSGW_RADOS
+			 OPT::ZONE_PLACEMENT_ADD, 
+#endif
+			 OPT::ZONE_PLACEMENT_RM,
 			 OPT::ZONE_PLACEMENT_MODIFY, OPT::ZONE_PLACEMENT_LIST,
 			 OPT::ZONE_PLACEMENT_GET,
 			 OPT::REALM_CREATE,
@@ -4578,6 +4717,7 @@ int main(int argc, const char **argv)
 			 OPT::BUCKET_LIMIT_CHECK,
 			 OPT::BUCKET_LAYOUT,
 			 OPT::BUCKET_STATS,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::BUCKET_SYNC_CHECKPOINT,
 			 OPT::BUCKET_SYNC_INFO,
 			 OPT::BUCKET_SYNC_STATUS,
@@ -4586,8 +4726,10 @@ int main(int argc, const char **argv)
 			 OPT::BUCKET_OBJECT_SHARD,
 			 OPT::LOG_LIST,
 			 OPT::LOG_SHOW,
+#endif
 			 OPT::USAGE_SHOW,
 			 OPT::OBJECT_STAT,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::OBJECT_MANIFEST,
 			 OPT::BI_GET,
 			 OPT::BI_LIST,
@@ -4601,8 +4743,11 @@ int main(int argc, const char **argv)
 			 OPT::DEDUP_RESUME,
 			 OPT::DEDUP_THROTTLE,
 			 OPT::GC_LIST,
+#endif
 			 OPT::LC_LIST,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::ORPHANS_LIST_JOBS,
+#endif
 			 OPT::ZONEGROUP_GET,
 			 OPT::ZONEGROUP_LIST,
 			 OPT::ZONEGROUP_PLACEMENT_LIST,
@@ -4611,17 +4756,21 @@ int main(int argc, const char **argv)
 			 OPT::ZONE_LIST,
 			 OPT::ZONE_PLACEMENT_LIST,
 			 OPT::ZONE_PLACEMENT_GET,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::METADATA_GET,
 			 OPT::METADATA_LIST,
 			 OPT::METADATA_SYNC_STATUS,
 			 OPT::MDLOG_LIST,
 			 OPT::MDLOG_STATUS,
 			 OPT::SYNC_ERROR_LIST,
+#endif
 			 OPT::SYNC_GROUP_GET,
 			 OPT::SYNC_POLICY_GET,
 			 OPT::BILOG_LIST,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::BILOG_STATUS,
 			 OPT::DATA_SYNC_STATUS,
+#endif
 			 OPT::DATALOG_LIST,
 			 OPT::DATALOG_SEMAPHORE_LIST,
 			 OPT::DATALOG_STATUS,
@@ -4633,40 +4782,50 @@ int main(int argc, const char **argv)
 			 OPT::PERIOD_GET_CURRENT,
 			 OPT::PERIOD_LIST,
 			 OPT::GLOBAL_QUOTA_GET,
-       OPT::GLOBAL_RATELIMIT_GET,
+		     OPT::GLOBAL_RATELIMIT_GET,
 			 OPT::SYNC_INFO,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::SYNC_STATUS,
+#endif
 			 OPT::ROLE_GET,
 			 OPT::ROLE_LIST,
 			 OPT::ROLE_POLICY_LIST,
 			 OPT::ROLE_POLICY_GET,
 			 OPT::ROLE_POLICY_LIST_ATTACHED,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::RESHARD_LIST,
 			 OPT::RESHARD_STATUS,
+#endif			 
 			 OPT::PUBSUB_TOPIC_LIST,
        OPT::PUBSUB_NOTIFICATION_LIST,
 			 OPT::PUBSUB_TOPIC_GET,
        OPT::PUBSUB_NOTIFICATION_GET,
+#ifdef WITH_RADOSGW_RADOS
        OPT::PUBSUB_TOPIC_STATS  ,
        OPT::PUBSUB_TOPIC_DUMP  ,
+#endif
 			 OPT::SCRIPT_GET,
        OPT::RESTORE_STATUS,
        OPT::RESTORE_LIST,
     };
 
     std::set<OPT> gc_ops_list = {
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::GC_LIST,
 			 OPT::GC_PROCESS,
+#endif
 			 OPT::OBJECT_RM,
 			 OPT::BUCKET_RM,  // --purge-objects
 			 OPT::USER_RM,    // --purge-data
 			 OPT::OBJECTS_EXPIRE,
 			 OPT::OBJECTS_EXPIRE_STALE_RM,
+#ifdef WITH_RADOSGW_RADOS
 			 OPT::LC_PROCESS,
        OPT::BUCKET_SYNC_RUN,
        OPT::DATA_SYNC_RUN,
        OPT::BUCKET_REWRITE,
        OPT::OBJECT_REWRITE
+#endif
     };
 
     raw_storage_op = (raw_storage_ops_list.find(opt_cmd) != raw_storage_ops_list.end() ||
@@ -4745,17 +4904,21 @@ int main(int argc, const char **argv)
                           && opt_cmd != OPT::ROLE_POLICY_DETACH
                           && opt_cmd != OPT::ROLE_POLICY_LIST_ATTACHED
                           && opt_cmd != OPT::ROLE_UPDATE
+#ifdef WITH_RADOSGW_RADOS
                           && opt_cmd != OPT::RESHARD_ADD
                           && opt_cmd != OPT::RESHARD_CANCEL
                           && opt_cmd != OPT::RESHARD_STATUS
+#endif			  
                           && opt_cmd != OPT::PUBSUB_TOPIC_LIST
                           && opt_cmd != OPT::PUBSUB_NOTIFICATION_LIST
                           && opt_cmd != OPT::PUBSUB_TOPIC_GET
                           && opt_cmd != OPT::PUBSUB_NOTIFICATION_GET
                           && opt_cmd != OPT::PUBSUB_TOPIC_RM
                           && opt_cmd != OPT::PUBSUB_NOTIFICATION_RM
+#ifdef WITH_RADOSGW_RADOS
                           && opt_cmd != OPT::PUBSUB_TOPIC_STATS
                           && opt_cmd != OPT::PUBSUB_TOPIC_DUMP
+#endif
 			  && opt_cmd != OPT::SCRIPT_PUT
 			  && opt_cmd != OPT::SCRIPT_GET
 			  && opt_cmd != OPT::SCRIPT_RM
@@ -6610,7 +6773,9 @@ int main(int argc, const char **argv)
 	}
       }
       break;
+#ifdef WITH_RADOSGW_RADOS
     case OPT::ZONE_PLACEMENT_ADD:
+#endif
     case OPT::ZONE_PLACEMENT_MODIFY:
     case OPT::ZONE_PLACEMENT_RM:
       {
@@ -6634,6 +6799,7 @@ int main(int argc, const char **argv)
 	  return -ret;
 	}
 
+#ifdef WITH_RADOSGW_RADOS
         if (opt_cmd == OPT::ZONE_PLACEMENT_ADD ||
 	    opt_cmd == OPT::ZONE_PLACEMENT_MODIFY) {
 	  RGWZoneGroup zonegroup;
@@ -6706,7 +6872,9 @@ int main(int argc, const char **argv)
                  << "' does not support omap" << std::endl;
              return ret;
           }
-        } else if (opt_cmd == OPT::ZONE_PLACEMENT_RM) {
+        } else 
+#endif
+	    if (opt_cmd == OPT::ZONE_PLACEMENT_RM) {
           if (!opt_storage_class ||
               opt_storage_class->empty()) {
             zone.placement_pools.erase(placement_id);
@@ -6784,10 +6952,16 @@ int main(int argc, const char **argv)
                                         OPT::USER_MODIFY, OPT::USER_ENABLE,
                                         OPT::USER_SUSPEND, OPT::SUBUSER_CREATE,
                                         OPT::SUBUSER_MODIFY, OPT::SUBUSER_RM,
+#ifdef WITH_RADOSGW_RADOS
                                         OPT::BUCKET_LINK, OPT::BUCKET_UNLINK,
-                                        OPT::BUCKET_CHOWN, OPT::METADATA_PUT,
-                                        OPT::METADATA_RM, OPT::MFA_CREATE,
+#endif
+                                        OPT::BUCKET_CHOWN, 
+#ifdef WITH_RADOSGW_RADOS
+                                        OPT::METADATA_PUT,
+                                        OPT::METADATA_RM,
+				       	                OPT::MFA_CREATE,
                                         OPT::MFA_REMOVE, OPT::MFA_RESYNC,
+#endif
                                         OPT::CAPS_ADD, OPT::CAPS_RM,
                                         OPT::ROLE_CREATE, OPT::ROLE_DELETE,
                                         OPT::ROLE_POLICY_PUT, OPT::ROLE_POLICY_DELETE,
@@ -7658,6 +7832,7 @@ int main(int argc, const char **argv)
     } /* have bucket_name */
   } /* OPT::BUCKETS_LIST */
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_RADOS_LIST) {
     RGWRadosList lister(static_cast<rgw::sal::RadosStore*>(driver),
 			max_concurrent_ios, orphan_stale_secs, tenant);
@@ -7686,6 +7861,7 @@ int main(int argc, const char **argv)
       return -ret;
     }
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_LAYOUT) {
     if (bucket_name.empty()) {
@@ -7727,6 +7903,7 @@ int main(int argc, const char **argv)
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_LINK) {
     bucket_op.set_bucket_id(bucket_id);
     bucket_op.set_new_bucket_name(new_bucket_name);
@@ -7745,6 +7922,7 @@ int main(int argc, const char **argv)
       return -r;
     }
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_SHARD_OBJECTS) {
     const auto prefix = opt_prefix ? *opt_prefix : "obj"s;
@@ -7809,6 +7987,7 @@ int main(int argc, const char **argv)
     formatter->flush(cout);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_RESYNC_ENCRYPTED_MULTIPART) {
     // repair logic for replication of encrypted multipart uploads:
     // https://tracker.ceph.com/issues/46062
@@ -7849,6 +8028,7 @@ int main(int argc, const char **argv)
     formatter->flush(cout);
     return 0;
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_CHOWN) {
     if (bucket_name.empty()) {
@@ -7957,6 +8137,7 @@ int main(int argc, const char **argv)
     return 0;
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_LOGGING_LIST) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -8139,6 +8320,7 @@ next:
       }
     }
   }
+#endif
 
   if (opt_cmd == OPT::USAGE_SHOW) {
     uint64_t start_epoch = 0;
@@ -8234,6 +8416,7 @@ next:
   }
 
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::OLH_GET || opt_cmd == OPT::OLH_READLOG) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -8474,6 +8657,7 @@ next:
       }
     }
   }
+#endif
 
   if (opt_cmd == OPT::OBJECT_PUT) {
     if (bucket_name.empty()) {
@@ -8532,6 +8716,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::OBJECT_REWRITE) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -8648,6 +8833,7 @@ next:
       } // while
     }
   } // OPT::OBJECT_REINDEX
+#endif
 
   if (opt_cmd == OPT::OBJECTS_EXPIRE) {
     if (!driver->process_expired_objects(dpp(), null_yield)) {
@@ -8672,6 +8858,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_REWRITE) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -9020,6 +9207,7 @@ next:
       return -ret;
     }
   } // OPT_RESHARD_CANCEL
+#endif
 
   if (opt_cmd == OPT::BUCKET_SET_MIN_SHARDS) {
     if (bucket_name.empty()) {
@@ -9174,6 +9362,7 @@ next:
     formatter->flush(cout);
   } // OPT::OBJECT_STAT
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::OBJECT_MANIFEST) {
     int ret = init_bucket(tenant, bucket_name, bucket_id, &bucket);
     if (ret < 0) {
@@ -9263,7 +9452,9 @@ next:
     formatter->close_section(); // outer
     formatter->flush(cout);
   } // OPT::OBJECT_MANIFEST
+#endif
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BUCKET_CHECK) {
     if (check_head_obj_locator) {
       if (bucket_name.empty()) {
@@ -9297,6 +9488,7 @@ next:
     }
     RGWBucketAdminOp::check_index_unlinked(store, bucket_op, stream_flusher, dpp());
   }
+#endif
 
   if (opt_cmd == OPT::BUCKET_RM) {
     if (!inconsistent_index) {
@@ -9311,6 +9503,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::DEDUP_STATS    ||
       opt_cmd == OPT::DEDUP_ESTIMATE ||
       opt_cmd == OPT::DEDUP_ABORT    ||
@@ -9467,6 +9660,7 @@ next:
       return 1;
     }
   }
+#endif
 
   if (opt_cmd == OPT::LC_LIST) {
     formatter->open_array_section("lifecycle_list");
@@ -9536,6 +9730,7 @@ next:
     formatter->flush(cout);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::LC_PROCESS) {
     if ((! bucket_name.empty()) ||
 	(! bucket_id.empty())) {
@@ -9554,6 +9749,7 @@ next:
       return 1;
     }
   }
+#endif
 
   if (opt_cmd == OPT::LC_RESHARD_FIX) {
     ret = RGWBucketAdminOp::fix_lc_shards(driver, bucket_op, stream_flusher, dpp(), null_yield);
@@ -9563,6 +9759,7 @@ next:
 
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::ORPHANS_FIND) {
     if (!yes_i_really_mean_it) {
       cerr << "this command is now deprecated; please consider using the rgw-orphan-list tool; "
@@ -9669,6 +9866,7 @@ next:
     formatter->close_section();
     formatter->flush(cout);
   }
+#endif
 
   if (opt_cmd == OPT::USER_CHECK) {
     check_bad_owner_bucket_mapping(driver, user->get_id(),
@@ -9873,6 +10071,7 @@ next:
     return 0;
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::METADATA_GET) {
     int ret = static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->get(metadata_key, formatter.get(), null_yield, dpp());
     if (ret < 0) {
@@ -9904,8 +10103,12 @@ next:
       return -ret;
     }
   }
+#endif
 
-  if (opt_cmd == OPT::METADATA_LIST ||
+  if (
+#ifdef WITH_RADOSGW_RADOS
+      opt_cmd == OPT::METADATA_LIST ||
+#endif
       opt_cmd == OPT::USER_LIST ||
       opt_cmd == OPT::ACCOUNT_LIST) {
     if (opt_cmd == OPT::USER_LIST) {
@@ -9980,6 +10183,7 @@ next:
     driver->meta_list_keys_complete(handle);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::MDLOG_LIST) {
     if (!start_date.empty()) {
       std::cerr << "start-date not allowed." << std::endl;
@@ -10159,11 +10363,13 @@ next:
       return -ret;
     }
   }
+#endif
 
   if (opt_cmd == OPT::SYNC_INFO) {
     sync_info(opt_effective_zone_id, opt_bucket, zone_formatter.get());
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::SYNC_STATUS) {
     sync_status(formatter.get());
   }
@@ -10729,6 +10935,7 @@ next:
       }
     }
   }
+#endif
 
   if (opt_cmd == OPT::SYNC_GROUP_CREATE ||
       opt_cmd == OPT::SYNC_GROUP_MODIFY) {
@@ -11064,6 +11271,7 @@ next:
     show_result(sync_policy, zone_formatter.get(), cout);
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::BILOG_TRIM) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
@@ -11382,6 +11590,7 @@ next:
       std::cout << "No empty generations." << std::endl;
     }
   }
+#endif
 
   bool quota_op = (opt_cmd == OPT::QUOTA_SET || opt_cmd == OPT::QUOTA_ENABLE || opt_cmd == OPT::QUOTA_DISABLE);
 
@@ -11499,6 +11708,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::MFA_CREATE) {
     rados::cls::otp::otp_info_t config;
 
@@ -11851,6 +12061,7 @@ next:
       return -ret;
     }
   }
+#endif
 
   if (opt_cmd == OPT::PUBSUB_NOTIFICATION_LIST) {
     if (bucket_name.empty()) {
@@ -12077,6 +12288,7 @@ next:
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::PUBSUB_TOPIC_STATS) {
     if (topic_name.empty()) {
       cerr << "ERROR: topic name was not provided (via --topic)" << std::endl;
@@ -12174,6 +12386,7 @@ next:
     formatter->close_section();
     formatter->flush(cout);
   }
+#endif
 
   if (opt_cmd == OPT::SCRIPT_PUT) {
     if (!str_script_ctx) {

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1510,11 +1510,8 @@ namespace rgw {
     if (factory == nullptr) {
       return false;
     }
-    /* make sure the reclaiming object is the same partition with newobject factory,
-     * then we can recycle the object, and replace with newobject */
-    if (!fs->fh_cache.is_same_partition(factory->fhk.fh_hk.object, fh.fh_hk.object)) {
-      return false;
-    }
+    /* XXXX seems like we should use a flag rather than is_linked(),
+     * as we now depend on safe_link mode */
     /* in the non-delete case, handle may still be in handle table */
     if (fh_hook.is_linked()) {
       /* in this case, we are being called from a context which holds

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -1070,7 +1070,7 @@ namespace rgw {
 	/* LATCHED, LOCKED */
 	if (! (flags & RGWFileHandle::FLAG_LOCK))
 	  fh->mtx.unlock(); /* ! LOCKED */
-      }
+      } /* fh */
       lat.lock->unlock(); /* !LATCHED */
       get<0>(fhr) = fh;
       if (fh) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7266,6 +7266,10 @@ void RGWCompleteMultipart::execute(optional_yield y)
   }
 
   upload = s->bucket->get_multipart_upload(s->object->get_name(), upload_id);
+
+  rgw_placement_rule* dest_placement;
+  op_ret = upload->get_info(this, s->yield, &dest_placement);
+
   ldpp_dout(this, 16) <<
     fmt::format("INFO: {}->get_multipart_upload for obj {}, {} cksum_type {}",
 		s->bucket->get_name(),
@@ -7273,8 +7277,6 @@ void RGWCompleteMultipart::execute(optional_yield y)
 		(!!upload) ? to_string(upload->cksum_type) : "nil")
 		<< dendl;
 
-  rgw_placement_rule* dest_placement;
-  op_ret = upload->get_info(this, s->yield, &dest_placement);
   if (op_ret < 0) {
     /* XXX this fails consistently when !checksum */
     ldpp_dout(this, 0) <<

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -419,6 +419,10 @@ protected:
         return false;
       oid = meta.substr(0, mid_pos);
       upload_id = meta.substr(mid_pos + 1, end_pos - mid_pos - 1);
+      // Validate upload_id has correct prefix to avoid parsing file extensions
+      if (!is_v2_upload_id(upload_id)) {
+        return false;
+      }
       init(oid, upload_id, upload_id);
       return true;
     }


### PR DESCRIPTION
**Note**: this patch was written with the huge help of Claude Code while working on the [S4 project](https://github.com/rh-aiservices-bu/s4) (RGW only with Posix backend + UI). The fixes were needed for the different upload scenarios to properly work.

Multipart uploads on the POSIX (and DBStore) backend fail silently at the CompleteMultipartUpload step. Parts upload successfully to the shadow directory (.multipart_*) but the final assembly fails for several reasons, and the errors are invisible in containerized deployments because they are only written to the Ceph log file via ldpp_dout(), never to stderr.

This patch addresses the following issues:

1. load() assigns shadow before validating it via load_bucket(). If load_bucket() fails, the broken shadow pointer persists, silently hiding all subsequent errors. Fix: use a temporary variable and only assign to shadow on success.

2. get_info() accesses shadow without calling load(dpp) first, so errors during loading are swallowed (load(nullptr) suppresses logging). Fix: call load(dpp) explicitly in get_info().

3. from_meta() uses rfind('.') to parse <oid>.<upload_id>, but this matches file extensions when the object name contains dots (e.g., intro.mp4 returns "mp4" as the upload ID instead of the actual 2~<random> ID). Fix: validate that the parsed upload_id has the 2~ prefix via is_v2_upload_id(). Applied to both POSIXMPObj and DBMPObj.

4. renameat2 with RENAME_EXCHANGE is not supported on NFS, FUSE, and overlayfs, causing multipart re-uploads to fail with EINVAL. Fix: if RENAME_EXCHANGE fails with EINVAL, fall back to deleting the existing target and doing a plain rename.

5. After renaming the shadow directory to the final object name in complete(), the object is never added to the bucket cache, making it invisible in listings until the cache is refreshed. Fix: open, stat, and fill_cache after rename.

6. link_temp_file() calls fill_cache() without first refreshing metadata via stat(), which can result in stale attributes in the cache. Fix: force stat(dpp, true) after the rename.

7. In bucket_cache, the ADD operation decodes the URL-encoded filename to compute the cache key, but the REMOVE operation uses the raw filename. This causes stale entries to remain after deletion. Fix: decode and parse the filename in REMOVE consistently with ADD.

8. inotify_add_watch error messages print the watch descriptor (-1) instead of errno, making failures impossible to diagnose. Fix: capture errno before the format call and print it with strerror().

9. inotify watches are registered for shadow buckets (short-lived .multipart_* directories), wasting kernel resources and producing noisy error messages. Fix: skip watches when the bucket name contains the multipart upload ID prefix "2~".

10. wfd and efd are declared without initialization, risking use-of-uninitialized in error paths. Fix: initialize to -1 and move fd creation to the member initializer list.

11. All critical multipart errors (rename, open, stat, load failures) now also log to stderr so they are visible via kubectl logs in containerized deployments.

---

## Checklist
- Tracker (select at least one)
  - [ ] New feature (ticket optional)
- Component impact
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
