### PR TITLE
Add pre-upgrade validation for health/OSDs/PGs

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -335,6 +335,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Automatically convert image tags to image digest to ensure that all daemons use the same image'
         ),
         Option(
+            'upgrade_preflight_checks',
+            type='bool',
+            default=False,
+            desc='Enable pre-upgrade validation (health/OSDs/PGs) before starting an upgrade',
+        ),
+        Option(
             'config_checks_enabled',
             type='bool',
             default=False,

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -1,5 +1,6 @@
 import fnmatch
 import asyncio
+import json
 import sys
 from tempfile import NamedTemporaryFile
 from contextlib import contextmanager
@@ -123,6 +124,24 @@ def with_cephadm_module(module_options=None, store=None):
                     'prometheus': 'http://[::1]:8081'
                 },
                 'modules': ['dashboard', 'prometheus'],
+            })
+        if '_ceph_get/osd_map' not in store:
+            m.mock_store_set('_ceph_get', 'osd_map', {
+                'flags': '',
+                'osds': [],
+                'pools': [],
+            })
+        if '_ceph_get/health' not in store:
+            m.mock_store_set('_ceph_get', 'health', {
+                'json': json.dumps({
+                    'status': 'HEALTH_OK',
+                    'checks': {},
+                })
+            })
+        if '_ceph_get/pg_dump' not in store:
+            m.mock_store_set('_ceph_get', 'pg_dump', {
+                'pg_stats': [],
+                'pool_stats': [],
             })
         for k, v in store.items():
             m._ceph_set_store(k, v)

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -10,7 +10,7 @@ from cephadm.ssh import HostConnectionError
 from cephadm.utils import ContainerInspectInfo
 from orchestrator import OrchestratorError, DaemonDescription
 from .fixtures import _run_cephadm, wait, with_host, with_service, \
-    receive_agent_metadata, async_side_effect
+    with_cephadm_module, receive_agent_metadata, async_side_effect
 
 from typing import List, Tuple, Optional
 
@@ -34,6 +34,54 @@ def test_upgrade_start(cephadm_module: CephadmOrchestrator):
 
                 assert wait(cephadm_module, cephadm_module.upgrade_stop()
                             ) == 'Stopped upgrade to image_id'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_start_preflight_disabled_by_default():
+    with with_cephadm_module() as m:
+        # Provide non-OK health and broken OSD/PG state; preflight is disabled by default so this must not block.
+        m.mock_store_set('_ceph_get', 'health', {
+            'json': json.dumps({
+                'status': 'HEALTH_WARN',
+                'checks': {
+                    'SOME_WARN': {'muted': False},
+                },
+            }),
+        })
+        m.mock_store_set('_ceph_get', 'osd_map', {
+            'osds': [{'osd': 0, 'up': 0, 'in': 0}],
+        })
+        m.mock_store_set('_ceph_get', 'pg_dump', {
+            'pg_stats': [{'pgid': '1.0', 'state': 'active+undersized', 'up': [0], 'acting': [0]}],
+        })
+        with with_host(m, 'test'):
+            with with_host(m, 'test2'):
+                with with_service(m, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    assert wait(m, m.upgrade_start('image_id', None)) == 'Initiating upgrade to image_id'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_start_preflight_enabled_blocks():
+    with with_cephadm_module(module_options={'upgrade_preflight_checks': True}) as m:
+        m.mock_store_set('_ceph_get', 'health', {
+            'json': json.dumps({
+                'status': 'HEALTH_WARN',
+                'checks': {
+                    'SOME_WARN': {'muted': False},
+                },
+            }),
+        })
+        m.mock_store_set('_ceph_get', 'osd_map', {
+            'osds': [{'osd': 0, 'up': 0, 'in': 0}],
+        })
+        m.mock_store_set('_ceph_get', 'pg_dump', {
+            'pg_stats': [{'pgid': '1.0', 'state': 'active+undersized', 'up': [0], 'acting': [0]}],
+        })
+        with with_host(m, 'test'):
+            with with_host(m, 'test2'):
+                with with_service(m, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                    with pytest.raises(OrchestratorError, match=r'Upgrade blocked by pre-upgrade checks'):
+                        wait(m, m.upgrade_start('image_id', None))
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 import uuid
-from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast
+from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
 from cephadm.services.service_registry import service_registry
 
 import orchestrator
@@ -123,6 +123,7 @@ class UpgradeState:
 class CephadmUpgrade:
     UPGRADE_ERRORS = [
         'UPGRADE_NO_STANDBY_MGR',
+        'UPGRADE_PREFLIGHT_CHECK_FAILED',
         'UPGRADE_FAILED_PULL',
         'UPGRADE_REDEPLOY_DAEMON',
         'UPGRADE_BAD_TARGET_VERSION',
@@ -139,6 +140,205 @@ class CephadmUpgrade:
         else:
             self.upgrade_state = None
         self.upgrade_info_str: str = ''
+
+    def _pg_state_ok_for_upgrade(self, state: str) -> bool:
+        # We treat any PG as ok if it contains active+clean and does not have
+        # any of the known bad flags.
+        state_parts = [t for t in (state or '').split('+') if t]
+        if 'active' not in state_parts or 'clean' not in state_parts:
+            return False
+
+        for t in state_parts:
+            # Anything related to recovery/backfill or reduced durability blocks upgrades.
+            if (
+                t in {'degraded', 'undersized', 'recovering', 'remapped', 'stale', 'incomplete', 'peering'}
+                or t.startswith('recovery')  # Handles recovery_* cases (ex: recovery_wait, recovery_toofull, recovery_unfound)
+                or t.startswith('backfill')
+            ):
+                return False
+        return True
+
+    def _pre_upgrade_check_cluster_health(self) -> List[str]:
+        """
+        Return any health-related reasons to block an upgrade.
+
+        # Ignore muted checks and our preflight warning, so upgrades aren’t blocked by non-essential alerts.
+        """
+        health_data = self.mgr.get('health')
+        if not isinstance(health_data, dict):
+            raise OrchestratorError(
+                f'Upgrade blocked: unexpected health payload '
+                f'(expected dict, got {type(health_data)})'
+            )
+
+        if 'json' in health_data:
+            raw = health_data.get('json')
+            if not isinstance(raw, str):
+                # `get('health')` normally returns {'json': '<string>'}
+                raise OrchestratorError(
+                    f'Upgrade blocked: unexpected health json payload '
+                    f'(expected str, got {type(raw)})'
+                )
+            try:
+                health = json.loads(raw)
+            except (TypeError, ValueError) as e:
+                raise OrchestratorError(f'Upgrade blocked: unable to determine cluster health: {e}')
+        else:
+            health = health_data
+
+        if not isinstance(health, dict):
+            raise OrchestratorError(
+                f'Upgrade blocked: unexpected decoded health payload '
+                f'(expected dict, got {type(health)})'
+            )
+
+        health_status = health.get('status')
+        if not isinstance(health_status, str) or not health_status:
+            raise OrchestratorError('Upgrade blocked: unable to determine cluster health status')
+        if health_status == 'HEALTH_OK':
+            return []
+
+        # Health can be WARN/ERR just because of muted checks or our own preflight warning.
+        # Don't block on those, or we might end up blocking on the warning we just set.
+        checks = health.get('checks')
+        if isinstance(checks, dict):
+            unmuted = [
+                check_id for check_id, info in checks.items()
+                if check_id != 'UPGRADE_PREFLIGHT_CHECK_FAILED'
+                and not (isinstance(info, dict) and info.get('muted'))
+            ]
+            if not unmuted:
+                return []
+            # If there are any blocking check IDs, show up to 5 of them in the error to help diagnose.
+            shown = ', '.join(sorted(unmuted)[:5])
+            if len(unmuted) > 5:
+                shown += ', ...'
+            return [f'cluster health is {health_status} (expected HEALTH_OK): {shown}']
+
+        return [f'cluster health is {health_status} (expected HEALTH_OK)']
+
+    def _pre_upgrade_check_osds(self) -> List[str]:
+        # Upgrade only when everything is up+in.
+        osd_map = self.mgr.get('osd_map')
+        if not isinstance(osd_map, dict):
+            raise OrchestratorError(
+                f'Upgrade blocked: unexpected osd_map payload '
+                f'(expected dict, got {type(osd_map)})'
+            )
+
+        down_osds: List[int] = []
+        out_osds: List[int] = []
+        for o in osd_map.get('osds', []):
+            osd_id = o.get('osd')
+            if osd_id is None:
+                continue
+            # Track any OSDs that are currently down or out.
+            # If fields are missing/unexpected, treat the OSD as not OK.
+            if o.get('up', 0) != 1:
+                down_osds.append(int(osd_id))
+            if o.get('in', 0) != 1:
+                out_osds.append(int(osd_id))
+
+        if not down_osds and not out_osds:
+            return []
+
+        msg = 'osds must be up+in'
+        if down_osds:
+            msg += f' (down: {",".join(map(str, sorted(down_osds)))})'
+        if out_osds:
+            msg += f' (out: {",".join(map(str, sorted(out_osds)))})'
+        return [msg]
+
+    def _pre_upgrade_check_pgs_state(self) -> Tuple[List[str], List[str], Set[int]]:
+        pg_dump = self.mgr.get('pg_dump')
+        if not isinstance(pg_dump, dict):
+            raise OrchestratorError(
+                f'Upgrade blocked: unexpected pg_dump payload '
+                f'(expected dict, got {type(pg_dump)})'
+            )
+        pg_stats = pg_dump.get('pg_stats', []) or []
+        if not isinstance(pg_stats, list):
+            raise OrchestratorError(
+                f'Upgrade blocked: unexpected pg_stats payload '
+                f'(expected list, got {type(pg_stats)})'
+            )
+
+        bad_pgs: List[Dict[str, Any]] = []
+        suspect_osds: Set[int] = set()
+        for pg in pg_stats:
+            state = str(pg.get('state') or '')
+            if self._pg_state_ok_for_upgrade(state):
+                continue
+            bad_pgs.append(pg)
+
+            up = pg.get('up') or []
+            acting = pg.get('acting') or []
+            try:
+                # If "up" and "acting" are not the same set, there could be an OSD problem to look into.
+                up_set = {int(x) for x in up if isinstance(x, int) or str(x).lstrip('-').isdigit()}
+                acting_set = {int(x) for x in acting if isinstance(x, int) or str(x).lstrip('-').isdigit()}
+            except (TypeError, ValueError):
+                continue
+            for osd in (up_set ^ acting_set):
+                suspect_osds.add(osd)
+
+        if not bad_pgs:
+            return ([], [], suspect_osds)
+
+        errors = [f'{len(bad_pgs)} PG(s) not in an upgrade safe state']
+        detail: List[str] = []
+        sample = bad_pgs[:10]
+        for pg in sample:
+            pgid = pg.get('pgid', '<unknown>')
+            state = pg.get('state', '<unknown>')
+            up = pg.get('up', [])
+            acting = pg.get('acting', [])
+            detail.append(f'pg {pgid} state={state} up={up} acting={acting}')
+        if len(bad_pgs) > len(sample):
+            detail.append(
+                f'... and {len(bad_pgs) - len(sample)} more PG(s) not shown; '
+                f'use "ceph pg dump_stuck unclean" to see the full list'
+            )
+
+        return (errors, detail, suspect_osds)
+
+    def _pre_upgrade_validate_cluster(self) -> None:
+        """
+        Pre-upgrade validation:
+        - Cluster health must be HEALTH_OK
+        - All OSDs must be up+in
+        - All PGs must be in an upgrade safe state (active+clean, without any bad flags)
+        """
+        # Preflight checks are optional (disabled by default). If they are disabled,
+        # don't block the upgrade and clear any stale warning from earlier runs.
+        if not self.mgr.get_module_option('upgrade_preflight_checks'):
+            self.mgr.remove_health_warning('UPGRADE_PREFLIGHT_CHECK_FAILED')
+            return
+        # Gather errors and details from each pre-upgrade check and summarize them together for a clear report.
+        health_errors = self._pre_upgrade_check_cluster_health()
+        osd_errors = self._pre_upgrade_check_osds()
+        pg_errors, detail, suspect_osds = self._pre_upgrade_check_pgs_state()
+        errors = health_errors + osd_errors + pg_errors
+
+        if not errors:
+            self.mgr.remove_health_warning('UPGRADE_PREFLIGHT_CHECK_FAILED')
+            return
+
+        # Show a health warning so it is visible in `ceph -s` and `ceph health detail`
+        summary = 'Upgrade blocked by pre-upgrade checks'
+        detail_lines = [f'- {e}' for e in errors]
+        if suspect_osds:
+            detail_lines.append(
+                f'- suspect osds from PG up/acting mismatch: {",".join(map(str, sorted(suspect_osds)))}'
+            )
+        detail_lines.extend(detail)
+        detail_lines.append('Fix the above and re-run the upgrade.')
+        detail_lines.append(
+            'Useful commands: ceph health detail; ceph osd stat; ceph pg stat; ceph pg dump_stuck unclean'
+        )
+        self.mgr.set_health_warning('UPGRADE_PREFLIGHT_CHECK_FAILED', summary, 1, detail_lines)
+
+        raise OrchestratorError(f'{summary}: ' + '; '.join(errors))
 
     @property
     def target_image(self) -> str:
@@ -346,6 +546,8 @@ class CephadmUpgrade:
 
         if running_mgr_count < 2:
             raise OrchestratorError('Need at least 2 running mgr daemons for upgrade')
+
+        self._pre_upgrade_validate_cluster()
 
         self.mgr.log.info('Upgrade: Started with target %s' % target_name)
         self.upgrade_state = UpgradeState(


### PR DESCRIPTION
### 1. Problem statement:
Right now, `ceph orch upgrade` start can begin an upgrade even if the cluster isn’t in a stable state - for example, when there are health warnings, OSDs are down, or PGs are not clean. This makes upgrades risky and harder to troubleshoot, since we often end up discovering issues only after the upgrade has already started.

### 2. Proposed change:
Added a pre-upgrade check to the `cephadm upgrade start` flow. The upgrade should only proceed if the cluster is in a healthy baseline state: `HEALTH_OK`, all OSDs up and in, and PGs in safe states like `active+clean` (not degraded, backfilling, recovering, etc).

If the checks fail, block the upgrade and show a single `UPGRADE_PREFLIGHT_CHECK_FAILED` warning with clear details. The warning should automatically disappear once the cluster returns to a healthy state.

### Testing:
Tested the pre-upgrade validation logic on a test cluster under different scenarios to make sure it behaves correctly and blocks upgrades only when it should.

**Case 1: Happy path:**
Brought the cluster to a stable state:
HEALTH_OK
All OSDs up+in
All PGs active+clean

In this condition, `ceph orch upgrade` start starts the upgrade successfully, and `ceph orch upgrade status` shows `in_progress: true`.

**Case 2: Cluster health gate**
Unmuted an existing warning to move the cluster to `HEALTH_WARN`.
`ceph orch upgrade` start was correctly blocked with a clear message saying health is not `HEALTH_OK`.

`ceph health detail` showed `UPGRADE_PREFLIGHT_CHECK_FAILED` with relevant details.

> After fixing the issue and restoring `HEALTH_OK`, the warning cleared automatically and the upgrade could proceed.

**Case 3: OSD up/in gate**
Stopped an OSD to simulate a failure.
Upgrade was blocked as expected.
The error message clearly mentioned which OSDs were not `up+in`.

> After bringing the OSD back and restoring the healthy state, the warning cleared and upgrade start worked again.

**Case 4: PG state gate**
Forced PGs into non upgrade safe states (ex: active+undersized, degraded).
Upgrade was blocked with a message showing how many PGs were not safe.
`ceph health detail` included sample PGs with pgid, state, and up/acting sets for easier debugging.

> Once PGs returned to active+clean, the warning cleared and upgrade was allowed.

**Case 5: OSD mismatch (up-set vs acting-set)**
Created a scenario where PG up and acting sets did not match.
Preflight warning reported suspect OSD IDs.
Example PG entries showed up=[list 1] acting=[list 2], which helped confirm the mismatch detection is working correctly.

**Case 6: Combined failure scenario**
Induced multiple issues at the same time (cluster not healthy + OSD down + PGs not safe).
Upgrade was blocked with a single combined message.
`UPGRADE_PREFLIGHT_CHECK_FAILED` listed all failing conditions together in a proper format.

**Case 7: Upgrade already in progress**
Started an upgrade and confirmed in_progress: true.
Re-running ceph orch upgrade start <same image> returned “Upgrade is in progress”.
It did not restart or override the running upgrade.

> Once any preflight issues were fixed, the warning cleared automatically and normal behavior resumed.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
