### PR TITLE
tentacle: mon/HealthMonitor: avoid MON_DOWN for freshly added Monitor

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -55,6 +55,8 @@ options:
   default: 1_min
   services:
   - mon
+  flags:
+  - runtime
 - name: mon_down_uptime_grace
   type: secs
   level: advanced

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -57,6 +57,15 @@ options:
   - mon
   flags:
   - runtime
+- name: mon_down_added_grace
+  type: secs
+  level: advanced
+  desc: Period in seconds that the cluster may have a newly added mon down
+  default: 3_min
+  services:
+  - mon
+  flags:
+  - runtime
 - name: mon_down_uptime_grace
   type: secs
   level: advanced

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -809,29 +809,37 @@ void HealthMonitor::check_for_mon_down(health_check_map_t *checks, std::set<std:
 {
   int max = mon.monmap->size();
   int actual = mon.get_quorum().size();
+  const auto mon_down_mkfs_grace = g_conf().get_val<std::chrono::seconds>("mon_down_mkfs_grace");
+  const auto mon_down_uptime_grace = g_conf().get_val<std::chrono::seconds>("mon_down_uptime_grace");
+  const auto mon_down_added_grace = g_conf().get_val<std::chrono::seconds>("mon_down_added_grace");
+
   const auto rcnow = ceph::real_clock::now();
   const auto created = mon.monmap->created.to_real_time();
   const auto mcnow = ceph::coarse_mono_clock::now();
   const auto starttime = mon.get_starttime();
 
-  if (actual < max &&
-      (rcnow - created) > g_conf().get_val<std::chrono::seconds>("mon_down_mkfs_grace") &&
-      (mcnow - starttime) > g_conf().get_val<std::chrono::seconds>("mon_down_uptime_grace")) {
-    ostringstream ss;
-    ss << (max-actual) << "/" << max << " mons down, quorum "
-       << mon.get_quorum_names();
-    auto& d = checks->add("MON_DOWN", HEALTH_WARN, ss.str(), max - actual);
-    set<int> q = mon.get_quorum();
+  if (actual < max && ((rcnow - created) > mon_down_mkfs_grace) && ((mcnow - starttime) > mon_down_uptime_grace)) {
+    auto q = mon.get_quorum();
+    std::list<std::string> details;
     for (int i=0; i<max; i++) {
       if (q.count(i) == 0) {
-	ostringstream ss;
-  std::string mon_name = mon.monmap->get_name(i);
-  mon_downs.insert(mon_name);
-	ss << "mon." << mon_name << " (rank " << i
-	   << ") addr " << mon.monmap->get_addrs(i)
-	   << " is down (out of quorum)";
-	d.detail.push_back(ss.str());
+        ostringstream ss;
+        std::string mon_name = mon.monmap->get_name(i);
+        auto const& info = mon.monmap->get(mon_name);
+        if ((rcnow - info.time_added) > mon_down_added_grace) {
+          mon_downs.insert(mon_name);
+	  ss << "mon." << mon_name << " (rank " << i
+	     << ") addr " << mon.monmap->get_addrs(i)
+	     << " is down (out of quorum)";
+	  details.push_back(ss.str());
+        }
       }
+    }
+    if (details.size()) {
+      ostringstream ss;
+      ss << (max-actual) << "/" << max << " mons down, quorum " << mon.get_quorum_names();
+      auto& d = checks->add("MON_DOWN", HEALTH_WARN, ss.str(), max - actual);
+      d.detail = std::move(details);
     }
   }
 }

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -121,7 +121,7 @@ void mon_info_t::dump(ceph::Formatter *f) const
 {
   f->dump_string("name", name);
   f->dump_object("public_addrs", public_addrs);
-  f->dump_stream("addr") << public_addrs; /* sigh: backwards compat */
+  f->dump_stream("addr") << public_addrs.get_legacy_str(); /* sigh: backwards compat */
   f->dump_string("public_addr", public_addrs.get_legacy_str()); /* sighhhhh */
   f->dump_int("priority", priority);
   f->dump_float("weight", weight);

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -50,7 +50,7 @@ namespace {
 
 void mon_info_t::encode(ceph::buffer::list& bl, uint64_t features) const
 {
-  uint8_t v = 5;
+  uint8_t v = 6;
   uint8_t min_v = 1;
   if (!crush_loc.empty()) {
     // we added crush_loc in version 5, but need to let old clients decode it
@@ -82,12 +82,13 @@ void mon_info_t::encode(ceph::buffer::list& bl, uint64_t features) const
   encode(priority, bl);
   encode(weight, bl);
   encode(crush_loc, bl);
+  encode(time_added, bl);
   ENCODE_FINISH(bl);
 }
 
 void mon_info_t::decode(ceph::buffer::list::const_iterator& p)
 {
-  DECODE_START(5, p);
+  DECODE_START(6, p);
   decode(name, p);
   decode(public_addrs, p);
   if (struct_v >= 2) {
@@ -99,24 +100,32 @@ void mon_info_t::decode(ceph::buffer::list::const_iterator& p)
   if (struct_v >= 5) {
     decode(crush_loc, p);
   }
+  if (struct_v >= 6) {
+    decode(time_added, p);
+  }
   DECODE_FINISH(p);
 }
 
 void mon_info_t::print(ostream& out) const
 {
   out << "mon." << name
-      << " addrs " << public_addrs
+      << "(addrs " << public_addrs
       << " priority " << priority
       << " weight " << weight
-      << " crush location " << crush_loc;
+      << " crush_location " << crush_loc
+      << " added " << time_added
+      << ")";
 }
 
 void mon_info_t::dump(ceph::Formatter *f) const
 {
   f->dump_string("name", name);
-  f->dump_stream("addr") << public_addrs;
+  f->dump_object("public_addrs", public_addrs);
+  f->dump_stream("addr") << public_addrs; /* sigh: backwards compat */
+  f->dump_string("public_addr", public_addrs.get_legacy_str()); /* sighhhhh */
   f->dump_int("priority", priority);
   f->dump_float("weight", weight);
+  f->dump_string("time_added", fmt::format("{}", time_added));
   encode_json("crush_location", crush_loc, f);
 }
 
@@ -130,6 +139,7 @@ void mon_info_t::generate_test_instances(list<mon_info_t*>& ls)
   ls.back()->weight = 1.0;
   ls.back()->crush_loc.emplace("root", "default");
   ls.back()->crush_loc.emplace("host", "foo");
+  ls.back()->time_added = ceph::real_clock::from_time_t(1);
 }
 namespace {
   struct rank_cmp {
@@ -325,24 +335,35 @@ void MonMap::decode(ceph::buffer::list::const_iterator& p)
 
 void MonMap::generate_test_instances(list<MonMap*>& o)
 {
-  o.push_back(new MonMap);
-  o.push_back(new MonMap);
-  o.back()->epoch = 1;
-  o.back()->last_changed = utime_t(123, 456);
-  o.back()->created = utime_t(789, 101112);
-  o.back()->add("one", entity_addrvec_t());
+  o.emplace_back(new MonMap); /* empty */
 
-  MonMap *m = new MonMap;
   {
-    m->epoch = 1;
-    m->last_changed = utime_t(123, 456);
+    auto* map = o.emplace_back(new MonMap);
+    map->epoch = 1;
+    map->last_changed = utime_t(123, 456);
+    map->created = utime_t(789, 101112);
+    auto& info = map->add("one", entity_addrvec_t());
+    info.time_added = ceph::real_clock::from_time_t(2468);
+  }
 
-    entity_addrvec_t empty_addr_one = entity_addrvec_t(entity_addr_t());
-    empty_addr_one.v[0].set_nonce(1);
-    m->add("empty_addr_one", empty_addr_one);
-    entity_addrvec_t empty_addr_two = entity_addrvec_t(entity_addr_t());
-    empty_addr_two.v[0].set_nonce(2);
-    m->add("empty_addr_two", empty_addr_two);
+  {
+    MonMap m;
+    m.epoch = 1;
+    m.last_changed = utime_t(123, 456);
+
+    {
+      entity_addrvec_t empty_addr_one = entity_addrvec_t(entity_addr_t());
+      empty_addr_one.v[0].set_nonce(1);
+      auto& info = m.add("empty_addr_one", empty_addr_one);
+      info.time_added = ceph::real_clock::from_time_t(123456);
+    }
+
+    {
+      entity_addrvec_t empty_addr_two = entity_addrvec_t(entity_addr_t());
+      empty_addr_two.v[0].set_nonce(2);
+      auto& info = m.add("empty_addr_two", empty_addr_two);
+      info.time_added = ceph::real_clock::from_time_t(100000);
+    }
 
     const char *local_pub_addr_s = "127.0.1.2";
 
@@ -350,11 +371,17 @@ void MonMap::generate_test_instances(list<MonMap*>& o)
     entity_addrvec_t local_pub_addr;
     local_pub_addr.parse(local_pub_addr_s, &end_p);
 
-    m->add(mon_info_t("filled_pub_addr", entity_addrvec_t(local_pub_addr), 1, 1));
+    {
+      auto& info = m.add(mon_info_t("filled_pub_addr", entity_addrvec_t(local_pub_addr), 1, 1));
+      info.time_added = ceph::real_clock::from_time_t(1);
+    }
 
-    m->add("empty_addr_zero", entity_addrvec_t());
+    {
+      auto& info = m.add("empty_addr_zero", entity_addrvec_t());
+      info.time_added = ceph::real_clock::from_time_t(1);
+    }
+    o.push_back(new MonMap(std::move(m)));
   }
-  o.push_back(m);
 }
 
 // read from/write to a file
@@ -377,6 +404,25 @@ int MonMap::read(const char *fn)
     return r;
   decode(bl);
   return 0;
+}
+
+mon_info_t& MonMap::add(mon_info_t&& m)
+{
+  ceph_assert(mon_info.count(m.name) == 0);
+  for (auto& a : m.public_addrs.v) {
+    ceph_assert(addr_mons.count(a) == 0);
+  }
+  m.time_added = ceph::real_clock::now();
+  auto& info = mon_info[m.name];
+  info = std::move(m);
+  if (get_required_features().contains_all(ceph::features::mon::FEATURE_NAUTILUS)) {
+    ranks.push_back(info.name);
+    ceph_assert(ranks.size() == mon_info.size());
+  } else {
+    calc_legacy_ranks();
+  }
+  calc_addr_mons();
+  return info;
 }
 
 void MonMap::print_summary(ostream& out) const
@@ -415,13 +461,11 @@ void MonMap::print(ostream& out) const
       !disallowed_leaders.empty()) {
     out << "disallowed_leaders " << disallowed_leaders << "\n";
   }
-  unsigned i = 0;
-  for (auto p = ranks.begin(); p != ranks.end(); ++p) {
-    const auto &mi = mon_info.find(*p);
-    ceph_assert(mi != mon_info.end());
-    out << i++ << ": " << mi->second.public_addrs << " mon." << *p;
-    if (!mi->second.crush_loc.empty()) {
-      out << "; crush_location " << mi->second.crush_loc;
+  for (unsigned rank = 0; auto& name : ranks) {
+    auto& info = get(name);
+    out << rank++ << ": " << info.public_addrs << " mon." << name;
+    if (!info.crush_loc.empty()) {
+      out << "; crush_location " << info.crush_loc;
     }
     out << "\n";
   }
@@ -445,20 +489,11 @@ void MonMap::dump(Formatter *f) const
   optional_features.dump(f, "optional");
   f->close_section();
   f->open_array_section("mons");
-  int i = 0;
-  for (auto p = ranks.begin(); p != ranks.end(); ++p, ++i) {
+  for (unsigned rank = 0; auto& name : ranks) {
+    auto const& info = get(name);
     f->open_object_section("mon");
-    f->dump_int("rank", i);
-    f->dump_string("name", *p);
-    f->dump_object("public_addrs", get_addrs(*p));
-    // compat: make these look like pre-nautilus entity_addr_t
-    f->dump_stream("addr") << get_addrs(*p).get_legacy_str();
-    f->dump_stream("public_addr") << get_addrs(*p).get_legacy_str();
-    f->dump_unsigned("priority", get_priority(*p));
-    f->dump_unsigned("weight", get_weight(*p));
-    const auto &mi = mon_info.find(*p);
-    // we don't need to assert this validity as all the get_* functions did
-    f->dump_stream("crush_location") << mi->second.crush_loc;
+    f->dump_int("rank", rank++);
+    info.dump(f);
     f->close_section();
   }
   f->close_section();

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -63,6 +63,8 @@ struct mon_info_t {
   uint16_t priority{0};
   uint16_t weight{0};
 
+  ceph::real_clock::time_point time_added = ceph::real_clock::zero();
+
   /**
    * The location of the monitor, in CRUSH hierarchy terms
    */
@@ -213,26 +215,16 @@ public:
     }
   }
 
+  mon_info_t const& get(std::string const& name) const {
+    return mon_info.at(name);
+  }
+
   /**
    * Add new monitor to the monmap
    *
    * @param m monitor info of the new monitor
    */
-  void add(const mon_info_t& m) {
-    ceph_assert(mon_info.count(m.name) == 0);
-    for (auto& a : m.public_addrs.v) {
-      ceph_assert(addr_mons.count(a) == 0);
-    }
-    mon_info[m.name] = m;
-    if (get_required_features().contains_all(
-	  ceph::features::mon::FEATURE_NAUTILUS)) {
-      ranks.push_back(m.name);
-      ceph_assert(ranks.size() == mon_info.size());
-    } else {
-      calc_legacy_ranks();
-    }
-    calc_addr_mons();
-  }
+  mon_info_t& add(mon_info_t&& m);
 
   /**
    * Add new monitor to the monmap
@@ -240,9 +232,9 @@ public:
    * @param name Monitor name (i.e., 'foo' in 'mon.foo')
    * @param addr Monitor's public address
    */
-  void add(const std::string &name, const entity_addrvec_t &addrv,
+  mon_info_t& add(const std::string &name, const entity_addrvec_t &addrv,
 	   uint16_t priority=0, uint16_t weight=0) {
-    add(mon_info_t(name, addrv, priority, weight));
+    return add(mon_info_t(name, addrv, priority, weight));
   }
 
   /**

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -82,8 +82,7 @@ struct mon_info_t {
     : name(n), public_addrs(p_addrs)
   { }
 
-  mon_info_t() { }
-
+  mon_info_t() = default;
 
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& p);
@@ -100,7 +99,7 @@ inline std::ostream& operator<<(std::ostream& out, const mon_info_t& mon) {
 
 class MonMap {
  public:
-  epoch_t epoch;       // what epoch/version of the monmap
+  epoch_t epoch{0};       // what epoch/version of the monmap
   uuid_d fsid;
   utime_t last_changed;
   utime_t created;
@@ -183,9 +182,7 @@ public:
     }
   }
 
-  MonMap()
-    : epoch(0) {
-  }
+  MonMap() = default;
 
   uuid_d& get_fsid() { return fsid; }
 

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -691,10 +691,10 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
      * we can simply go ahead and add the monitor.
      */
 
-    pending_map.add(name, addrs);
-    pending_map.mon_info[name].crush_loc = loc;
+    auto& info = pending_map.add(name, addrs);
+    info.crush_loc = loc;
     pending_map.last_changed = ceph_clock_now();
-    ss << "adding mon." << name << " at " << addrs;
+    ss << "adding " << info;
     dout(0) << __func__ << " proposing new mon." << name << dendl;
 
   } else if (prefix == "mon remove" ||
@@ -1401,8 +1401,8 @@ bool MonmapMonitor::prepare_join(MonOpRequestRef op)
   }
   if (pending_map.contains(join->name))
     pending_map.remove(join->name);
-  pending_map.add(join->name, join->addrs);
-  pending_map.mon_info[join->name].crush_loc =
+  auto& mon_info = pending_map.add(join->name, join->addrs);
+  mon_info.crush_loc =
     ((join->force_loc || existing_loc.empty()) ?
      join->crush_loc : existing_loc);
   pending_map.last_changed = ceph_clock_now();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74043

---

backport of https://github.com/ceph/ceph/pull/66328
parent tracker: https://tracker.ceph.com/issues/73934

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh