### PR TITLE
tentacle: mgr/dashboard: bump nvmeof submodule to 1.6.5

### DIFF
--- a/src/pybind/mgr/dashboard/services/proto/gateway.proto
+++ b/src/pybind/mgr/dashboard/services/proto/gateway.proto
@@ -10,6 +10,8 @@
 
 syntax = "proto3";
 
+option go_package = "github.com/ceph/ceph-nvmeof/lib/go/nvmeof";
+
 enum AddressFamily {
 	ipv4 = 0;
 	ipv6 = 1;
@@ -45,6 +47,12 @@ service Gateway {
 	// Changes subsystem key
 	rpc change_subsystem_key(change_subsystem_key_req) returns(req_status) {}
 
+	// Add a subsystem network
+	rpc add_subsystem_network(add_subsystem_network_req) returns(req_status) {}
+
+	// Delete a subsystem network
+	rpc del_subsystem_network(del_subsystem_network_req) returns(req_status) {}
+
 	// List namespaces
 	rpc list_namespaces(list_namespaces_req) returns(namespaces_info) {}
 
@@ -62,6 +70,9 @@ service Gateway {
 
 	// Changes namespace's visibility
 	rpc namespace_change_visibility(namespace_change_visibility_req) returns (req_status) {}
+
+	// Changes namespace's location
+	rpc namespace_change_location(namespace_change_location_req) returns (req_status) {}
 
 	// Set namespace's RBD trash image flag
 	rpc namespace_set_rbd_trash_image(namespace_set_rbd_trash_image_req) returns (req_status) {}
@@ -134,6 +145,9 @@ service Gateway {
 
 	// Gets gateway's stats
 	rpc get_gateway_stats(get_gateway_stats_req) returns (gateway_stats_info) {}
+
+	// Gets spdk thread stats
+	rpc get_thread_stats(get_thread_stats_req) returns (thread_stats_info) {}
 }
 
 // Request messages
@@ -153,6 +167,9 @@ message namespace_add_req {
 	optional bool trash_image = 12;
 	optional bool disable_auto_resize = 13;
 	optional bool read_only = 14;
+	optional string rbd_data_pool_name = 15;
+	optional string location = 16;
+	optional string rados_namespace_name = 17;
 }
 
 message namespace_resize_req {
@@ -192,6 +209,12 @@ message namespace_change_visibility_req {
 	uint32 nsid = 2;
 	bool auto_visible = 3;
 	optional bool force = 4;
+}
+
+message namespace_change_location_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	optional string location = 3;
 }
 
 message namespace_set_rbd_trash_image_req {
@@ -234,16 +257,29 @@ message create_subsystem_req {
 	optional bool no_group_append = 5;
 	optional string dhchap_key = 6;
 	optional bool key_encrypted = 7;
+	repeated string network_mask = 8;
+	optional bool secure_listeners = 9;
 }
 
 message delete_subsystem_req {
 	string subsystem_nqn = 1;
 	optional bool force = 2;
+	optional bool i_am_sure = 3;
 }
 
 message change_subsystem_key_req {
 	string subsystem_nqn = 1;
 	optional string dhchap_key = 2;
+}
+
+message add_subsystem_network_req {
+	string subsystem_nqn = 1;
+	string network_mask = 2;
+}
+
+message del_subsystem_network_req {
+	string subsystem_nqn = 1;
+	string network_mask = 2;
 }
 
 message list_namespaces_req {
@@ -259,12 +295,15 @@ message add_host_req {
 	optional string dhchap_key = 4;
 	optional bool psk_encrypted = 5;
 	optional bool key_encrypted = 6;
+	optional string dhchap_ctrlr_key = 7;
+	optional bool ctrlr_key_encrypted = 8;
 }
 
 message change_host_key_req {
 	string subsystem_nqn = 1;
 	string host_nqn = 2;
 	optional string dhchap_key = 3;
+	optional string dhchap_ctrlr_key = 4;
 }
 
 message remove_host_req {
@@ -279,6 +318,7 @@ message list_hosts_req {
 
 message list_connections_req {
 	string subsystem = 1;
+	optional bool clear_alerts = 2;
 }
 
 message create_listener_req {
@@ -342,6 +382,9 @@ message show_gateway_listeners_info_req {
 }
 
 message get_gateway_stats_req {
+}
+
+message get_thread_stats_req {
 }
 
 // From https://nvmexpress.org/wp-content/uploads/NVM-Express-1_4-2019.06.10-Ratified.pdf page 138
@@ -411,6 +454,7 @@ message subsystem {
 	optional uint32 max_cntlid = 10;
 	repeated namespace namespaces = 11;
 	optional bool has_dhchap_key = 12;
+	repeated string network_mask = 13;
 }
 
 message listen_address {
@@ -453,6 +497,7 @@ message subsystem_cli {
 	optional bool has_dhchap_key = 10;
 	optional bool allow_any_host = 11;
 	optional bool created_without_key = 12;
+	repeated string network_mask = 13;
 }
 
 message gateway_info {
@@ -473,6 +518,7 @@ message gateway_info {
 	optional uint32 max_hosts_per_subsystem = 15;
 	optional uint32 max_namespaces_per_subsystem = 16;
 	optional uint32 max_hosts = 17;
+	optional bool gateway_initialization_over = 18;
 }
 
 message cli_version {
@@ -499,14 +545,27 @@ message poll_group_info {
 	uint32 current_io_qpairs = 5;
 	uint64 pending_bdev_io = 6;
 	uint64 completed_nvme_io = 7;
-        repeated poll_group_transport_info transports = 8;
+	repeated poll_group_transport_info transports = 8;
 }
 
 message gateway_stats_info {
 	int32 status = 1;
 	string error_message = 2;
 	uint64 tick_rate = 3;
-        repeated poll_group_info poll_groups = 4;
+	repeated poll_group_info poll_groups = 4;
+}
+
+message thread_stats_info {
+	int32 status = 1;
+	string error_message = 2;
+    repeated spdk_thread_info threads = 3;
+	uint64 tick_rate = 4;
+}
+
+message spdk_thread_info {
+	string name = 1;
+	uint64 busy = 2;
+	uint64 idle = 3;
 }
 
 message listener_info {
@@ -517,6 +576,7 @@ message listener_info {
 	uint32 trsvcid = 5;
 	optional bool secure = 6;
 	optional bool active = 7;
+	optional bool manual = 8;	
 }
 
 message listeners_info {
@@ -563,7 +623,7 @@ message connection {
 	optional bool secure = 9;
 	optional bool use_psk = 10;
 	optional bool use_dhchap = 11;
-        optional string subsystem = 12;
+	optional string subsystem = 12;
 	optional bool disconnected_due_to_keepalive_timeout = 13;
 }
 
@@ -593,9 +653,12 @@ message namespace_cli {
 	optional bool trash_image = 16;
 	optional bool disable_auto_resize = 17;
 	optional bool read_only = 18;
-        optional string cluster_name = 19;
-        optional uint32 configured_load_balancing_group = 20;
+	optional string cluster_name = 19;
+	optional uint32 configured_load_balancing_group = 20;
 	optional bool image_was_shrunk = 21;
+	optional string rbd_data_pool_name = 22;
+	optional string location = 23;
+	optional string rados_namespace_name = 24;
 }
 
 message namespaces_info {
@@ -658,4 +721,3 @@ message gateway_log_level_info {
 	string error_message = 2;
 	GwLogLevel log_level = 3;
 }
-

--- a/src/pybind/mgr/dashboard/services/proto/gateway.proto
+++ b/src/pybind/mgr/dashboard/services/proto/gateway.proto
@@ -34,6 +34,24 @@ enum GwLogLevel {
 	critical = 50;
 }
 
+enum EncryptionFormat {
+	none = 0;
+	luks1 = 1;
+	luks2 = 2;
+}
+
+enum EncryptionAlgorithm {
+	no_algorithm = 0;
+	aes128 = 1;
+	aes256 = 2;
+}
+
+enum DHCHAPControllerKeyOrigin {
+	no_key = 0;
+	host_specific = 1;
+	subsystem_implicit = 2;
+}
+
 service Gateway {
 	// Creates a namespace from an RBD image
 	rpc namespace_add(namespace_add_req) returns (nsid_status) {}
@@ -61,6 +79,9 @@ service Gateway {
 
 	// Gets namespace's IO stats
 	rpc namespace_get_io_stats(namespace_get_io_stats_req) returns (namespace_io_stats_info) {}
+
+	// List namespaces IO stats
+	rpc list_namespaces_io_stats(list_namespaces_io_stats_req) returns (list_namespaces_io_stats_info) {}
 
 	// Sets namespace's qos limits
 	rpc namespace_set_qos_limits(namespace_set_qos_req) returns (req_status) {}
@@ -103,6 +124,9 @@ service Gateway {
 
 	// List connections
 	rpc list_connections(list_connections_req) returns(connections_info) {}
+
+	// Gets connection's IO statistics
+	rpc get_connection_io_statistics(get_connection_io_statistics_req) returns (connection_io_statistics) {}
 
 	// Creates a listener for a subsystem at a given IP/Port
 	rpc create_listener(create_listener_req) returns(req_status) {}
@@ -148,6 +172,9 @@ service Gateway {
 
 	// Gets spdk thread stats
 	rpc get_thread_stats(get_thread_stats_req) returns (thread_stats_info) {}
+
+	// Set gateway IO stats on or off
+	rpc set_gateway_io_stats_mode(set_gateway_io_stats_mode_req) returns (req_status) {}
 }
 
 // Request messages
@@ -170,6 +197,8 @@ message namespace_add_req {
 	optional string rbd_data_pool_name = 15;
 	optional string location = 16;
 	optional string rados_namespace_name = 17;
+	repeated encryption_entry encryption_entries = 18;
+	optional EncryptionAlgorithm encryption_algorithm = 19;
 }
 
 message namespace_resize_req {
@@ -183,6 +212,11 @@ message namespace_get_io_stats_req {
 	string subsystem_nqn = 1;
 	uint32 nsid = 2;
 	optional string OBSOLETE_uuid = 3;
+}
+
+message list_namespaces_io_stats_req {
+	optional string subsystem_nqn = 1;
+	optional uint32 nsid = 2;
 }
 
 message namespace_set_qos_req {
@@ -306,9 +340,16 @@ message change_host_key_req {
 	optional string dhchap_ctrlr_key = 4;
 }
 
+message get_connection_io_statistics_req {
+	string subsystem_nqn = 1;
+	string host_nqn = 2;
+	optional bool reset = 3;
+}
+
 message remove_host_req {
 	string subsystem_nqn = 1;
 	string host_nqn = 2;
+	optional bool force = 3;
 }
 
 message list_hosts_req {
@@ -385,6 +426,10 @@ message get_gateway_stats_req {
 }
 
 message get_thread_stats_req {
+}
+
+message set_gateway_io_stats_mode_req {
+	bool enabled = 1;
 }
 
 // From https://nvmexpress.org/wp-content/uploads/NVM-Express-1_4-2019.06.10-Ratified.pdf page 138
@@ -519,6 +564,7 @@ message gateway_info {
 	optional uint32 max_namespaces_per_subsystem = 16;
 	optional uint32 max_hosts = 17;
 	optional bool gateway_initialization_over = 18;
+	optional bool io_stats_enabled = 19;
 }
 
 message cli_version {
@@ -558,7 +604,7 @@ message gateway_stats_info {
 message thread_stats_info {
 	int32 status = 1;
 	string error_message = 2;
-    repeated spdk_thread_info threads = 3;
+	repeated spdk_thread_info threads = 3;
 	uint64 tick_rate = 4;
 }
 
@@ -601,6 +647,36 @@ message host {
 	optional bool use_psk = 2;
 	optional bool use_dhchap = 3;
 	optional bool disconnected_due_to_keepalive_timeout = 4;
+	optional DHCHAPControllerKeyOrigin dhchap_controller_origin = 5;
+}
+
+message latency_stats {
+	uint64 min = 1;
+	uint64 max = 2;
+	uint64 mean = 3;
+}
+
+message latency_group {
+	uint64 io_count = 1;
+	latency_stats total = 2;
+	latency_stats bdev = 3;
+	latency_stats net = 4;
+	latency_stats qos = 5;
+}
+
+message bucket_info {
+	uint32 size = 1;
+	latency_group read = 2;
+	latency_group write = 3;
+}
+
+message connection_io_statistics {
+	int32 status = 1;
+	string error_message = 2;
+	string subsystem_nqn = 3;
+	string host_nqn = 4;
+	optional uint64 total_num_ios = 5;
+	repeated bucket_info buckets = 6;
 }
 
 message hosts_info {
@@ -625,6 +701,7 @@ message connection {
 	optional bool use_dhchap = 11;
 	optional string subsystem = 12;
 	optional bool disconnected_due_to_keepalive_timeout = 13;
+	optional DHCHAPControllerKeyOrigin dhchap_controller_origin = 14;
 }
 
 message connections_info {
@@ -659,6 +736,8 @@ message namespace_cli {
 	optional string rbd_data_pool_name = 22;
 	optional string location = 23;
 	optional string rados_namespace_name = 24;
+	optional EncryptionAlgorithm encryption_algorithm = 25;
+	repeated encryption_entry encryption_entries = 26;
 }
 
 message namespaces_info {
@@ -671,6 +750,39 @@ message namespaces_info {
 message namespace_io_error {
 	string name = 1;
 	uint32 value = 2;
+}
+
+message list_namespaces_io_stats_info {
+	int32 status = 1;
+	string error_message = 2;
+	uint64 tick_rate = 3;
+	uint64 ticks = 4;
+	repeated bdev_io_stats_info namespaces = 5;
+}
+
+message bdev_io_stats_info {
+	string bdev_name = 1;
+	uint64 bytes_read = 2;
+	uint64 num_read_ops = 3;
+	uint64 bytes_written = 4;
+	uint64 num_write_ops = 5;
+	uint64 bytes_unmapped = 6;
+	uint64 num_unmap_ops = 7;
+	uint64 bytes_copied = 8;
+	uint64 num_copy_ops = 9;
+	uint64 read_latency_ticks = 10;
+	uint64 max_read_latency_ticks = 11;
+	uint64 min_read_latency_ticks = 12;
+	uint64 write_latency_ticks = 13;
+	uint64 max_write_latency_ticks = 14;
+	uint64 min_write_latency_ticks = 15;
+	uint64 unmap_latency_ticks = 16;
+	uint64 max_unmap_latency_ticks = 17;
+	uint64 min_unmap_latency_ticks = 18;
+	uint64 copy_latency_ticks = 19;
+	uint64 max_copy_latency_ticks = 20;
+	uint64 min_copy_latency_ticks = 21;
+	repeated namespace_io_error io_error = 22;
 }
 
 message namespace_io_stats_info {
@@ -720,4 +832,9 @@ message gateway_log_level_info {
 	int32 status = 1;
 	string error_message = 2;
 	GwLogLevel log_level = 3;
+}
+
+message encryption_entry {
+	EncryptionFormat format = 1;
+	string key_id = 2;
 }

--- a/src/pybind/mgr/dashboard/services/proto/gateway.proto
+++ b/src/pybind/mgr/dashboard/services/proto/gateway.proto
@@ -71,6 +71,15 @@ service Gateway {
 	// Delete a subsystem network
 	rpc del_subsystem_network(del_subsystem_network_req) returns(req_status) {}
 
+	// Add KMIP server endpoints
+	rpc add_kmip_server_endpoints(add_kmip_server_endpoints_req) returns(req_status) {}
+
+	// Delete KMIP server endpoints
+	rpc del_kmip_server_endpoints(del_kmip_server_endpoints_req) returns(req_status) {}
+
+	// List KMIP server endpoints
+	rpc list_kmip_server_endpoints(list_kmip_server_endpoints_req) returns(kmip_server_endpoints_info) {}
+
 	// List namespaces
 	rpc list_namespaces(list_namespaces_req) returns(namespaces_info) {}
 
@@ -293,6 +302,7 @@ message create_subsystem_req {
 	optional bool key_encrypted = 7;
 	repeated string network_mask = 8;
 	optional bool secure_listeners = 9;
+	optional uint32 port = 10;
 }
 
 message delete_subsystem_req {
@@ -314,6 +324,41 @@ message add_subsystem_network_req {
 message del_subsystem_network_req {
 	string subsystem_nqn = 1;
 	string network_mask = 2;
+}
+
+message kmip_server_endpoint {
+	string address = 1;
+	optional uint32 port = 2;
+}
+
+message kmip_server_endpoint_cli {
+	string subsystem_nqn = 1;
+	string server_name = 2;
+	string address = 3;
+	uint32 port = 4;
+}
+
+message add_kmip_server_endpoints_req {
+	string subsystem_nqn = 1;
+	string server_name = 2;
+	repeated kmip_server_endpoint endpoints = 3;
+}
+
+message del_kmip_server_endpoints_req {
+	string subsystem_nqn = 1;
+	string server_name = 2;
+	repeated kmip_server_endpoint endpoints = 3;
+}
+
+message list_kmip_server_endpoints_req {
+	optional string subsystem_nqn = 1;
+	optional string server_name = 2;
+}
+
+message kmip_server_endpoints_info {
+	int32 status = 1;
+	string error_message = 2;
+	repeated kmip_server_endpoint_cli endpoints = 3;
 }
 
 message list_namespaces_req {
@@ -370,6 +415,7 @@ message create_listener_req {
 	optional uint32 trsvcid = 6;
 	optional bool secure = 7;
 	optional bool verify_host_name = 8;
+	optional bool force = 9;
 }
 
 message delete_listener_req {
@@ -565,6 +611,7 @@ message gateway_info {
 	optional uint32 max_hosts = 17;
 	optional bool gateway_initialization_over = 18;
 	optional bool io_stats_enabled = 19;
+	optional string location = 20;
 }
 
 message cli_version {

--- a/src/pybind/mgr/dashboard/services/proto/gateway_pb2.py
+++ b/src/pybind/mgr/dashboard/services/proto/gateway_pb2.py
@@ -12,160 +12,162 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+
+
 DESCRIPTOR = _descriptor.FileDescriptor(
-    name='dashboard/services/proto/gateway.proto',
-    package='',
-    syntax='proto3',
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n&dashboard/services/proto/gateway.proto\"\xeb\x03\n\x11namespace_add_req\x12\x15\n\rrbd_pool_name\x18\x01 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x11\n\x04nsid\x18\x04 \x01(\rH\x00\x88\x01\x01\x12\x12\n\nblock_size\x18\x05 \x01(\r\x12\x11\n\x04uuid\x18\x06 \x01(\tH\x01\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x07 \x01(\x05H\x02\x88\x01\x01\x12\x19\n\x0c\x63reate_image\x18\x08 \x01(\x08H\x03\x88\x01\x01\x12\x11\n\x04size\x18\t \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\n \x01(\x08H\x05\x88\x01\x01\x12\x1c\n\x0fno_auto_visible\x18\x0b \x01(\x08H\x06\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x0c \x01(\x08H\x07\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\r \x01(\x08H\x08\x88\x01\x01\x12\x16\n\tread_only\x18\x0e \x01(\x08H\t\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x0f\n\r_create_imageB\x07\n\x05_sizeB\x08\n\x06_forceB\x12\n\x10_no_auto_visibleB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_only\"{\n\x14namespace_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08new_size\x18\x04 \x01(\x04\x42\x10\n\x0e_OBSOLETE_uuid\"o\n\x1anamespace_get_io_stats_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuid\"\xee\x02\n\x15namespace_set_qos_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1e\n\x11rw_ios_per_second\x18\x04 \x01(\x04H\x01\x88\x01\x01\x12!\n\x14rw_mbytes_per_second\x18\x05 \x01(\x04H\x02\x88\x01\x01\x12 \n\x13r_mbytes_per_second\x18\x06 \x01(\x04H\x03\x88\x01\x01\x12 \n\x13w_mbytes_per_second\x18\x07 \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x14\n\x12_rw_ios_per_secondB\x17\n\x15_rw_mbytes_per_secondB\x16\n\x14_r_mbytes_per_secondB\x16\n\x14_w_mbytes_per_secondB\x08\n\x06_force\"\xbe\x01\n)namespace_change_load_balancing_group_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61nagrpid\x18\x04 \x01(\x05\x12\x1a\n\rauto_lb_logic\x18\x05 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x10\n\x0e_auto_lb_logic\"z\n\x1fnamespace_change_visibility_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x14\n\x0c\x61uto_visible\x18\x03 \x01(\x08\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"]\n!namespace_set_rbd_trash_image_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0btrash_image\x18\x03 \x01(\x08\"Y\n\x1dnamespace_set_auto_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0b\x61uto_resize\x18\x03 \x01(\x08\"\x8f\x01\n\x14namespace_delete_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x04 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x0c\n\n_i_am_sure\"m\n\x16namespace_add_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"R\n\x19namespace_delete_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\"\x8f\x02\n\x14\x63reate_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x15\n\rserial_number\x18\x02 \x01(\t\x12\x1b\n\x0emax_namespaces\x18\x03 \x01(\rH\x00\x88\x01\x01\x12\x11\n\tenable_ha\x18\x04 \x01(\x08\x12\x1c\n\x0fno_group_append\x18\x05 \x01(\x08H\x01\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x06 \x01(\tH\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x07 \x01(\x08H\x03\x88\x01\x01\x42\x11\n\x0f_max_namespacesB\x12\n\x10_no_group_appendB\r\n\x0b_dhchap_keyB\x10\n\x0e_key_encrypted\"K\n\x14\x64\x65lete_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x12\n\x05\x66orce\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"Y\n\x18\x63hange_subsystem_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x17\n\ndhchap_key\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\r\n\x0b_dhchap_key\"`\n\x13list_namespaces_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x00\x88\x01\x01\x12\x11\n\x04uuid\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuid\"\xd5\x01\n\x0c\x61\x64\x64_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x10\n\x03psk\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rpsk_encrypted\x18\x05 \x01(\x08H\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x06 \x01(\x08H\x03\x88\x01\x01\x42\x06\n\x04_pskB\r\n\x0b_dhchap_keyB\x10\n\x0e_psk_encryptedB\x10\n\x0e_key_encrypted\"f\n\x13\x63hange_host_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x17\n\ndhchap_key\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\r\n\x0b_dhchap_key\":\n\x0fremove_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\"O\n\x0elist_hosts_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\")\n\x14list_connections_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\"\xeb\x01\n\x13\x63reate_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x13\n\x06secure\x18\x07 \x01(\x08H\x02\x88\x01\x01\x12\x1d\n\x10verify_host_name\x18\x08 \x01(\x08H\x03\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\t\n\x07_secureB\x13\n\x11_verify_host_name\"\xb5\x01\n\x13\x64\x65lete_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x07 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\x08\n\x06_force\"\'\n\x12list_listeners_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\"q\n\x13list_subsystems_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1a\n\rserial_number\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x10\n\x0e_serial_number\"\x14\n\x12get_subsystems_req\"U\n%get_spdk_nvmf_log_flags_and_level_req\x12\x1a\n\rall_log_flags\x18\x01 \x01(\x08H\x00\x88\x01\x01\x42\x10\n\x0e_all_log_flags\"5\n\x1a\x64isable_spdk_nvmf_logs_req\x12\x17\n\x0f\x65xtra_log_flags\x18\x01 \x03(\t\"\x97\x01\n\x16set_spdk_nvmf_logs_req\x12!\n\tlog_level\x18\x01 \x01(\x0e\x32\t.LogLevelH\x00\x88\x01\x01\x12#\n\x0bprint_level\x18\x02 \x01(\x0e\x32\t.LogLevelH\x01\x88\x01\x01\x12\x17\n\x0f\x65xtra_log_flags\x18\x03 \x03(\tB\x0c\n\n_log_levelB\x0e\n\x0c_print_level\"@\n\x14get_gateway_info_req\x12\x18\n\x0b\x63li_version\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_cli_version\"\x1b\n\x19get_gateway_log_level_req\";\n\x19set_gateway_log_level_req\x12\x1e\n\tlog_level\x18\x01 \x01(\x0e\x32\x0b.GwLogLevel\"8\n\x1fshow_gateway_listeners_info_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\"\x17\n\x15get_gateway_stats_req\"<\n\x0f\x61na_group_state\x12\x0e\n\x06grp_id\x18\x01 \x01(\r\x12\x19\n\x05state\x18\x02 \x01(\x0e\x32\n.ana_state\"?\n\x0enqn_ana_states\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12 \n\x06states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"+\n\x08\x61na_info\x12\x1f\n\x06states\x18\x01 \x03(\x0b\x32\x0f.nqn_ana_states\"3\n\nreq_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\"C\n\rsubsys_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0b\n\x03nqn\x18\x03 \x01(\t\"B\n\x0bnsid_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0c\n\x04nsid\x18\x03 \x01(\r\"1\n\x0fsubsystems_info\x12\x1e\n\nsubsystems\x18\x01 \x03(\x0b\x32\n.subsystem\"\xac\x03\n\tsubsystem\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0f\n\x07subtype\x18\x02 \x01(\t\x12)\n\x10listen_addresses\x18\x03 \x03(\x0b\x32\x0f.listen_address\x12\x14\n\x05hosts\x18\x04 \x03(\x0b\x32\x05.host\x12\x16\n\x0e\x61llow_any_host\x18\x05 \x01(\x08\x12\x1a\n\rserial_number\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0cmodel_number\x18\x07 \x01(\tH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x08 \x01(\rH\x02\x88\x01\x01\x12\x17\n\nmin_cntlid\x18\t \x01(\rH\x03\x88\x01\x01\x12\x17\n\nmax_cntlid\x18\n \x01(\rH\x04\x88\x01\x01\x12\x1e\n\nnamespaces\x18\x0b \x03(\x0b\x32\n.namespace\x12\x1b\n\x0ehas_dhchap_key\x18\x0c \x01(\x08H\x05\x88\x01\x01\x42\x10\n\x0e_serial_numberB\x0f\n\r_model_numberB\x11\n\x0f_max_namespacesB\r\n\x0b_min_cntlidB\r\n\x0b_max_cntlidB\x11\n\x0f_has_dhchap_key\"\x97\x01\n\x0elisten_address\x12\x0e\n\x06trtype\x18\x01 \x01(\t\x12\x0e\n\x06\x61\x64rfam\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12\x0f\n\x07trsvcid\x18\x04 \x01(\t\x12\x16\n\ttransport\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x01\x88\x01\x01\x42\x0c\n\n_transportB\t\n\x07_secure\"\x84\x02\n\tnamespace\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x16\n\tbdev_name\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05nguid\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x02\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x12\n\x05nonce\x18\x07 \x01(\tH\x04\x88\x01\x01\x12\x19\n\x0c\x61uto_visible\x18\x08 \x01(\x08H\x05\x88\x01\x01\x12\r\n\x05hosts\x18\t \x03(\tB\x0c\n\n_bdev_nameB\x08\n\x06_nguidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x08\n\x06_nonceB\x0f\n\r_auto_visible\"`\n\x13subsystems_info_cli\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\nsubsystems\x18\x03 \x03(\x0b\x32\x0e.subsystem_cli\"\xe0\x02\n\rsubsystem_cli\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\tenable_ha\x18\x02 \x01(\x08\x12\x15\n\rserial_number\x18\x03 \x01(\t\x12\x14\n\x0cmodel_number\x18\x04 \x01(\t\x12\x12\n\nmin_cntlid\x18\x05 \x01(\r\x12\x12\n\nmax_cntlid\x18\x06 \x01(\r\x12\x17\n\x0fnamespace_count\x18\x07 \x01(\r\x12\x0f\n\x07subtype\x18\x08 \x01(\t\x12\x16\n\x0emax_namespaces\x18\t \x01(\r\x12\x1b\n\x0ehas_dhchap_key\x18\n \x01(\x08H\x00\x88\x01\x01\x12\x1b\n\x0e\x61llow_any_host\x18\x0b \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x63reated_without_key\x18\x0c \x01(\x08H\x02\x88\x01\x01\x42\x11\n\x0f_has_dhchap_keyB\x11\n\x0f_allow_any_hostB\x16\n\x14_created_without_key\"\x99\x04\n\x0cgateway_info\x12\x13\n\x0b\x63li_version\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05group\x18\x04 \x01(\t\x12\x0c\n\x04\x61\x64\x64r\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\t\x12\x13\n\x0b\x62ool_status\x18\x07 \x01(\x08\x12\x0e\n\x06status\x18\x08 \x01(\x05\x12\x15\n\rerror_message\x18\t \x01(\t\x12\x19\n\x0cspdk_version\x18\n \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x14load_balancing_group\x18\x0b \x01(\r\x12\x10\n\x08hostname\x18\x0c \x01(\t\x12\x1b\n\x0emax_subsystems\x18\r \x01(\rH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x0e \x01(\rH\x02\x88\x01\x01\x12$\n\x17max_hosts_per_subsystem\x18\x0f \x01(\rH\x03\x88\x01\x01\x12)\n\x1cmax_namespaces_per_subsystem\x18\x10 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tmax_hosts\x18\x11 \x01(\rH\x05\x88\x01\x01\x42\x0f\n\r_spdk_versionB\x11\n\x0f_max_subsystemsB\x11\n\x0f_max_namespacesB\x1a\n\x18_max_hosts_per_subsystemB\x1f\n\x1d_max_namespaces_per_subsystemB\x0c\n\n_max_hosts\"E\n\x0b\x63li_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"D\n\ngw_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"+\n\x19poll_group_transport_info\x12\x0e\n\x06trtype\x18\x01 \x01(\t\"\xe5\x01\n\x0fpoll_group_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x61\x64min_qpairs\x18\x02 \x01(\r\x12\x11\n\tio_qpairs\x18\x03 \x01(\r\x12\x1c\n\x14\x63urrent_admin_qpairs\x18\x04 \x01(\r\x12\x19\n\x11\x63urrent_io_qpairs\x18\x05 \x01(\r\x12\x17\n\x0fpending_bdev_io\x18\x06 \x01(\x04\x12\x19\n\x11\x63ompleted_nvme_io\x18\x07 \x01(\x04\x12.\n\ntransports\x18\x08 \x03(\x0b\x32\x1a.poll_group_transport_info\"u\n\x12gateway_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12%\n\x0bpoll_groups\x18\x04 \x03(\x0b\x32\x10.poll_group_info\"\xb3\x01\n\rlistener_info\x12\x11\n\thost_name\x18\x01 \x01(\t\x12\x0e\n\x06trtype\x18\x02 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x03 \x01(\x0e\x32\x0e.AddressFamily\x12\x0e\n\x06traddr\x18\x04 \x01(\t\x12\x0f\n\x07trsvcid\x18\x05 \x01(\r\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x00\x88\x01\x01\x12\x13\n\x06\x61\x63tive\x18\x07 \x01(\x08H\x01\x88\x01\x01\x42\t\n\x07_secureB\t\n\x07_active\"Z\n\x0elisteners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12!\n\tlisteners\x18\x03 \x03(\x0b\x32\x0e.listener_info\"^\n\x15gateway_listener_info\x12 \n\x08listener\x18\x01 \x01(\x0b\x32\x0e.listener_info\x12#\n\tlb_states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"m\n\x16gateway_listeners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12,\n\x0cgw_listeners\x18\x03 \x03(\x0b\x32\x16.gateway_listener_info\"\xbb\x01\n\x04host\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x14\n\x07use_psk\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x03 \x01(\x08H\x01\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\x04 \x01(\x08H\x02\x88\x01\x01\x42\n\n\x08_use_pskB\r\n\x0b_use_dhchapB(\n&_disconnected_due_to_keepalive_timeout\"x\n\nhosts_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x16\n\x0e\x61llow_any_host\x18\x03 \x01(\x08\x12\x15\n\rsubsystem_nqn\x18\x04 \x01(\t\x12\x14\n\x05hosts\x18\x05 \x03(\x0b\x32\x05.host\"\x98\x03\n\nconnection\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0e\n\x06traddr\x18\x02 \x01(\t\x12\x0f\n\x07trsvcid\x18\x03 \x01(\r\x12\x0e\n\x06trtype\x18\x04 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamily\x12\x11\n\tconnected\x18\x06 \x01(\x08\x12\x14\n\x0cqpairs_count\x18\x07 \x01(\x05\x12\x15\n\rcontroller_id\x18\x08 \x01(\x05\x12\x13\n\x06secure\x18\t \x01(\x08H\x00\x88\x01\x01\x12\x14\n\x07use_psk\x18\n \x01(\x08H\x01\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x0b \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tsubsystem\x18\x0c \x01(\tH\x03\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\r \x01(\x08H\x04\x88\x01\x01\x42\t\n\x07_secureB\n\n\x08_use_pskB\r\n\x0b_use_dhchapB\x0c\n\n_subsystemB(\n&_disconnected_due_to_keepalive_timeout\"r\n\x10\x63onnections_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12 \n\x0b\x63onnections\x18\x04 \x03(\x0b\x32\x0b.connection\"\xbf\x05\n\rnamespace_cli\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x11\n\tbdev_name\x18\x02 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x03 \x01(\t\x12\x15\n\rrbd_pool_name\x18\x04 \x01(\t\x12\x1c\n\x14load_balancing_group\x18\x05 \x01(\r\x12\x12\n\nblock_size\x18\x06 \x01(\r\x12\x16\n\x0erbd_image_size\x18\x07 \x01(\x04\x12\x0c\n\x04uuid\x18\x08 \x01(\t\x12\x19\n\x11rw_ios_per_second\x18\t \x01(\x04\x12\x1c\n\x14rw_mbytes_per_second\x18\n \x01(\x04\x12\x1b\n\x13r_mbytes_per_second\x18\x0b \x01(\x04\x12\x1b\n\x13w_mbytes_per_second\x18\x0c \x01(\x04\x12\x14\n\x0c\x61uto_visible\x18\r \x01(\x08\x12\r\n\x05hosts\x18\x0e \x03(\t\x12\x1d\n\x10ns_subsystem_nqn\x18\x0f \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x10 \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\x11 \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tread_only\x18\x12 \x01(\x08H\x03\x88\x01\x01\x12\x19\n\x0c\x63luster_name\x18\x13 \x01(\tH\x04\x88\x01\x01\x12,\n\x1f\x63onfigured_load_balancing_group\x18\x14 \x01(\rH\x05\x88\x01\x01\x12\x1d\n\x10image_was_shrunk\x18\x15 \x01(\x08H\x06\x88\x01\x01\x42\x13\n\x11_ns_subsystem_nqnB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x0f\n\r_cluster_nameB\"\n _configured_load_balancing_groupB\x13\n\x11_image_was_shrunk\"s\n\x0fnamespaces_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\"\n\nnamespaces\x18\x04 \x03(\x0b\x32\x0e.namespace_cli\"1\n\x12namespace_io_error\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r\"\xda\x05\n\x17namespace_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x0c\n\x04nsid\x18\x04 \x01(\r\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tbdev_name\x18\x06 \x01(\t\x12\x11\n\ttick_rate\x18\x07 \x01(\x04\x12\r\n\x05ticks\x18\x08 \x01(\x04\x12\x12\n\nbytes_read\x18\t \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\n \x01(\x04\x12\x15\n\rbytes_written\x18\x0b \x01(\x04\x12\x15\n\rnum_write_ops\x18\x0c \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\r \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x0e \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\x0f \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x10 \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x11 \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\x12 \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x13 \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x14 \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x15 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x16 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x17 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x18 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x19 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x1a \x01(\x04\x12%\n\x08io_error\x18\x1b \x03(\x0b\x32\x13.namespace_io_errorB\x07\n\x05_uuid\"3\n\x12spdk_log_flag_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"\xba\x01\n\"spdk_nvmf_log_flags_and_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12+\n\x0envmf_log_flags\x18\x03 \x03(\x0b\x32\x13.spdk_log_flag_info\x12\x1c\n\tlog_level\x18\x04 \x01(\x0e\x32\t.LogLevel\x12\"\n\x0flog_print_level\x18\x05 \x01(\x0e\x32\t.LogLevel\"_\n\x16gateway_log_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x1e\n\tlog_level\x18\x03 \x01(\x0e\x32\x0b.GwLogLevel*#\n\rAddressFamily\x12\x08\n\x04ipv4\x10\x00\x12\x08\n\x04ipv6\x10\x01*C\n\x08LogLevel\x12\t\n\x05\x45RROR\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\n\n\x06NOTICE\x10\x02\x12\x08\n\x04INFO\x10\x03\x12\t\n\x05\x44\x45\x42UG\x10\x04*S\n\nGwLogLevel\x12\n\n\x06notset\x10\x00\x12\t\n\x05\x64\x65\x62ug\x10\n\x12\x08\n\x04info\x10\x14\x12\x0b\n\x07warning\x10\x1e\x12\t\n\x05\x65rror\x10(\x12\x0c\n\x08\x63ritical\x10\x32*J\n\tana_state\x12\t\n\x05UNSET\x10\x00\x12\r\n\tOPTIMIZED\x10\x01\x12\x11\n\rNON_OPTIMIZED\x10\x02\x12\x10\n\x0cINACCESSIBLE\x10\x03\x32\xcd\x11\n\x07Gateway\x12\x33\n\rnamespace_add\x12\x12.namespace_add_req\x1a\x0c.nsid_status\"\x00\x12;\n\x10\x63reate_subsystem\x12\x15.create_subsystem_req\x1a\x0e.subsys_status\"\x00\x12\x38\n\x10\x64\x65lete_subsystem\x12\x15.delete_subsystem_req\x1a\x0b.req_status\"\x00\x12@\n\x14\x63hange_subsystem_key\x12\x19.change_subsystem_key_req\x1a\x0b.req_status\"\x00\x12;\n\x0flist_namespaces\x12\x14.list_namespaces_req\x1a\x10.namespaces_info\"\x00\x12\x38\n\x10namespace_resize\x12\x15.namespace_resize_req\x1a\x0b.req_status\"\x00\x12Q\n\x16namespace_get_io_stats\x12\x1b.namespace_get_io_stats_req\x1a\x18.namespace_io_stats_info\"\x00\x12\x41\n\x18namespace_set_qos_limits\x12\x16.namespace_set_qos_req\x1a\x0b.req_status\"\x00\x12\x62\n%namespace_change_load_balancing_group\x12*.namespace_change_load_balancing_group_req\x1a\x0b.req_status\"\x00\x12N\n\x1bnamespace_change_visibility\x12 .namespace_change_visibility_req\x1a\x0b.req_status\"\x00\x12R\n\x1dnamespace_set_rbd_trash_image\x12\".namespace_set_rbd_trash_image_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_set_auto_resize\x12\x1e.namespace_set_auto_resize_req\x1a\x0b.req_status\"\x00\x12\x38\n\x10namespace_delete\x12\x15.namespace_delete_req\x1a\x0b.req_status\"\x00\x12<\n\x12namespace_add_host\x12\x17.namespace_add_host_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15namespace_delete_host\x12\x1a.namespace_delete_host_req\x1a\x0b.req_status\"\x00\x12(\n\x08\x61\x64\x64_host\x12\r.add_host_req\x1a\x0b.req_status\"\x00\x12.\n\x0bremove_host\x12\x10.remove_host_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x63hange_host_key\x12\x14.change_host_key_req\x1a\x0b.req_status\"\x00\x12,\n\nlist_hosts\x12\x0f.list_hosts_req\x1a\x0b.hosts_info\"\x00\x12>\n\x10list_connections\x12\x15.list_connections_req\x1a\x11.connections_info\"\x00\x12\x36\n\x0f\x63reate_listener\x12\x14.create_listener_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x64\x65lete_listener\x12\x14.delete_listener_req\x1a\x0b.req_status\"\x00\x12\x38\n\x0elist_listeners\x12\x13.list_listeners_req\x1a\x0f.listeners_info\"\x00\x12?\n\x0flist_subsystems\x12\x14.list_subsystems_req\x1a\x14.subsystems_info_cli\"\x00\x12\x39\n\x0eget_subsystems\x12\x13.get_subsystems_req\x1a\x10.subsystems_info\"\x00\x12)\n\rset_ana_state\x12\t.ana_info\x1a\x0b.req_status\"\x00\x12r\n!get_spdk_nvmf_log_flags_and_level\x12&.get_spdk_nvmf_log_flags_and_level_req\x1a#.spdk_nvmf_log_flags_and_level_info\"\x00\x12\x44\n\x16\x64isable_spdk_nvmf_logs\x12\x1b.disable_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12<\n\x12set_spdk_nvmf_logs\x12\x17.set_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12:\n\x10get_gateway_info\x12\x15.get_gateway_info_req\x1a\r.gateway_info\"\x00\x12N\n\x15get_gateway_log_level\x12\x1a.get_gateway_log_level_req\x1a\x17.gateway_log_level_info\"\x00\x12\x42\n\x15set_gateway_log_level\x12\x1a.set_gateway_log_level_req\x1a\x0b.req_status\"\x00\x12Z\n\x1bshow_gateway_listeners_info\x12 .show_gateway_listeners_info_req\x1a\x17.gateway_listeners_info\"\x00\x12\x42\n\x11get_gateway_stats\x12\x16.get_gateway_stats_req\x1a\x13.gateway_stats_info\"\x00\x62\x06proto3'
+  name='dashboard/services/proto/gateway.proto',
+  package='',
+  syntax='proto3',
+  serialized_options=b'Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeof',
+  create_key=_descriptor._internal_create_key,
+  serialized_pb=b'\n&dashboard/services/proto/gateway.proto\"\x83\x05\n\x11namespace_add_req\x12\x15\n\rrbd_pool_name\x18\x01 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x11\n\x04nsid\x18\x04 \x01(\rH\x00\x88\x01\x01\x12\x12\n\nblock_size\x18\x05 \x01(\r\x12\x11\n\x04uuid\x18\x06 \x01(\tH\x01\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x07 \x01(\x05H\x02\x88\x01\x01\x12\x19\n\x0c\x63reate_image\x18\x08 \x01(\x08H\x03\x88\x01\x01\x12\x11\n\x04size\x18\t \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\n \x01(\x08H\x05\x88\x01\x01\x12\x1c\n\x0fno_auto_visible\x18\x0b \x01(\x08H\x06\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x0c \x01(\x08H\x07\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\r \x01(\x08H\x08\x88\x01\x01\x12\x16\n\tread_only\x18\x0e \x01(\x08H\t\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x0f \x01(\tH\n\x88\x01\x01\x12\x15\n\x08location\x18\x10 \x01(\tH\x0b\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x11 \x01(\tH\x0c\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x0f\n\r_create_imageB\x07\n\x05_sizeB\x08\n\x06_forceB\x12\n\x10_no_auto_visibleB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_name\"{\n\x14namespace_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08new_size\x18\x04 \x01(\x04\x42\x10\n\x0e_OBSOLETE_uuid\"o\n\x1anamespace_get_io_stats_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuid\"\xee\x02\n\x15namespace_set_qos_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1e\n\x11rw_ios_per_second\x18\x04 \x01(\x04H\x01\x88\x01\x01\x12!\n\x14rw_mbytes_per_second\x18\x05 \x01(\x04H\x02\x88\x01\x01\x12 \n\x13r_mbytes_per_second\x18\x06 \x01(\x04H\x03\x88\x01\x01\x12 \n\x13w_mbytes_per_second\x18\x07 \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x14\n\x12_rw_ios_per_secondB\x17\n\x15_rw_mbytes_per_secondB\x16\n\x14_r_mbytes_per_secondB\x16\n\x14_w_mbytes_per_secondB\x08\n\x06_force\"\xbe\x01\n)namespace_change_load_balancing_group_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61nagrpid\x18\x04 \x01(\x05\x12\x1a\n\rauto_lb_logic\x18\x05 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x10\n\x0e_auto_lb_logic\"z\n\x1fnamespace_change_visibility_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x14\n\x0c\x61uto_visible\x18\x03 \x01(\x08\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"h\n\x1dnamespace_change_location_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x15\n\x08location\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x0b\n\t_location\"]\n!namespace_set_rbd_trash_image_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0btrash_image\x18\x03 \x01(\x08\"Y\n\x1dnamespace_set_auto_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0b\x61uto_resize\x18\x03 \x01(\x08\"\x8f\x01\n\x14namespace_delete_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x04 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x0c\n\n_i_am_sure\"m\n\x16namespace_add_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"R\n\x19namespace_delete_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\"\xd9\x02\n\x14\x63reate_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x15\n\rserial_number\x18\x02 \x01(\t\x12\x1b\n\x0emax_namespaces\x18\x03 \x01(\rH\x00\x88\x01\x01\x12\x11\n\tenable_ha\x18\x04 \x01(\x08\x12\x1c\n\x0fno_group_append\x18\x05 \x01(\x08H\x01\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x06 \x01(\tH\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x07 \x01(\x08H\x03\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\x08 \x03(\t\x12\x1d\n\x10secure_listeners\x18\t \x01(\x08H\x04\x88\x01\x01\x42\x11\n\x0f_max_namespacesB\x12\n\x10_no_group_appendB\r\n\x0b_dhchap_keyB\x10\n\x0e_key_encryptedB\x13\n\x11_secure_listeners\"q\n\x14\x64\x65lete_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x12\n\x05\x66orce\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x03 \x01(\x08H\x01\x88\x01\x01\x42\x08\n\x06_forceB\x0c\n\n_i_am_sure\"Y\n\x18\x63hange_subsystem_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x17\n\ndhchap_key\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\r\n\x0b_dhchap_key\"H\n\x19\x61\x64\x64_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"H\n\x19\x64\x65l_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"`\n\x13list_namespaces_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x00\x88\x01\x01\x12\x11\n\x04uuid\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuid\"\xc3\x02\n\x0c\x61\x64\x64_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x10\n\x03psk\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rpsk_encrypted\x18\x05 \x01(\x08H\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x06 \x01(\x08H\x03\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x07 \x01(\tH\x04\x88\x01\x01\x12 \n\x13\x63trlr_key_encrypted\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x06\n\x04_pskB\r\n\x0b_dhchap_keyB\x10\n\x0e_psk_encryptedB\x10\n\x0e_key_encryptedB\x13\n\x11_dhchap_ctrlr_keyB\x16\n\x14_ctrlr_key_encrypted\"\x9a\x01\n\x13\x63hange_host_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x17\n\ndhchap_key\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_dhchap_keyB\x13\n\x11_dhchap_ctrlr_key\":\n\x0fremove_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\"O\n\x0elist_hosts_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"U\n\x14list_connections_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"\xeb\x01\n\x13\x63reate_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x13\n\x06secure\x18\x07 \x01(\x08H\x02\x88\x01\x01\x12\x1d\n\x10verify_host_name\x18\x08 \x01(\x08H\x03\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\t\n\x07_secureB\x13\n\x11_verify_host_name\"\xb5\x01\n\x13\x64\x65lete_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x07 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\x08\n\x06_force\"\'\n\x12list_listeners_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\"q\n\x13list_subsystems_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1a\n\rserial_number\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x10\n\x0e_serial_number\"\x14\n\x12get_subsystems_req\"U\n%get_spdk_nvmf_log_flags_and_level_req\x12\x1a\n\rall_log_flags\x18\x01 \x01(\x08H\x00\x88\x01\x01\x42\x10\n\x0e_all_log_flags\"5\n\x1a\x64isable_spdk_nvmf_logs_req\x12\x17\n\x0f\x65xtra_log_flags\x18\x01 \x03(\t\"\x97\x01\n\x16set_spdk_nvmf_logs_req\x12!\n\tlog_level\x18\x01 \x01(\x0e\x32\t.LogLevelH\x00\x88\x01\x01\x12#\n\x0bprint_level\x18\x02 \x01(\x0e\x32\t.LogLevelH\x01\x88\x01\x01\x12\x17\n\x0f\x65xtra_log_flags\x18\x03 \x03(\tB\x0c\n\n_log_levelB\x0e\n\x0c_print_level\"@\n\x14get_gateway_info_req\x12\x18\n\x0b\x63li_version\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_cli_version\"\x1b\n\x19get_gateway_log_level_req\";\n\x19set_gateway_log_level_req\x12\x1e\n\tlog_level\x18\x01 \x01(\x0e\x32\x0b.GwLogLevel\"8\n\x1fshow_gateway_listeners_info_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\"\x17\n\x15get_gateway_stats_req\"\x16\n\x14get_thread_stats_req\"<\n\x0f\x61na_group_state\x12\x0e\n\x06grp_id\x18\x01 \x01(\r\x12\x19\n\x05state\x18\x02 \x01(\x0e\x32\n.ana_state\"?\n\x0enqn_ana_states\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12 \n\x06states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"+\n\x08\x61na_info\x12\x1f\n\x06states\x18\x01 \x03(\x0b\x32\x0f.nqn_ana_states\"3\n\nreq_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\"C\n\rsubsys_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0b\n\x03nqn\x18\x03 \x01(\t\"B\n\x0bnsid_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0c\n\x04nsid\x18\x03 \x01(\r\"1\n\x0fsubsystems_info\x12\x1e\n\nsubsystems\x18\x01 \x03(\x0b\x32\n.subsystem\"\xc2\x03\n\tsubsystem\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0f\n\x07subtype\x18\x02 \x01(\t\x12)\n\x10listen_addresses\x18\x03 \x03(\x0b\x32\x0f.listen_address\x12\x14\n\x05hosts\x18\x04 \x03(\x0b\x32\x05.host\x12\x16\n\x0e\x61llow_any_host\x18\x05 \x01(\x08\x12\x1a\n\rserial_number\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0cmodel_number\x18\x07 \x01(\tH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x08 \x01(\rH\x02\x88\x01\x01\x12\x17\n\nmin_cntlid\x18\t \x01(\rH\x03\x88\x01\x01\x12\x17\n\nmax_cntlid\x18\n \x01(\rH\x04\x88\x01\x01\x12\x1e\n\nnamespaces\x18\x0b \x03(\x0b\x32\n.namespace\x12\x1b\n\x0ehas_dhchap_key\x18\x0c \x01(\x08H\x05\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x10\n\x0e_serial_numberB\x0f\n\r_model_numberB\x11\n\x0f_max_namespacesB\r\n\x0b_min_cntlidB\r\n\x0b_max_cntlidB\x11\n\x0f_has_dhchap_key\"\x97\x01\n\x0elisten_address\x12\x0e\n\x06trtype\x18\x01 \x01(\t\x12\x0e\n\x06\x61\x64rfam\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12\x0f\n\x07trsvcid\x18\x04 \x01(\t\x12\x16\n\ttransport\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x01\x88\x01\x01\x42\x0c\n\n_transportB\t\n\x07_secure\"\x84\x02\n\tnamespace\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x16\n\tbdev_name\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05nguid\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x02\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x12\n\x05nonce\x18\x07 \x01(\tH\x04\x88\x01\x01\x12\x19\n\x0c\x61uto_visible\x18\x08 \x01(\x08H\x05\x88\x01\x01\x12\r\n\x05hosts\x18\t \x03(\tB\x0c\n\n_bdev_nameB\x08\n\x06_nguidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x08\n\x06_nonceB\x0f\n\r_auto_visible\"`\n\x13subsystems_info_cli\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\nsubsystems\x18\x03 \x03(\x0b\x32\x0e.subsystem_cli\"\xf6\x02\n\rsubsystem_cli\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\tenable_ha\x18\x02 \x01(\x08\x12\x15\n\rserial_number\x18\x03 \x01(\t\x12\x14\n\x0cmodel_number\x18\x04 \x01(\t\x12\x12\n\nmin_cntlid\x18\x05 \x01(\r\x12\x12\n\nmax_cntlid\x18\x06 \x01(\r\x12\x17\n\x0fnamespace_count\x18\x07 \x01(\r\x12\x0f\n\x07subtype\x18\x08 \x01(\t\x12\x16\n\x0emax_namespaces\x18\t \x01(\r\x12\x1b\n\x0ehas_dhchap_key\x18\n \x01(\x08H\x00\x88\x01\x01\x12\x1b\n\x0e\x61llow_any_host\x18\x0b \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x63reated_without_key\x18\x0c \x01(\x08H\x02\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x11\n\x0f_has_dhchap_keyB\x11\n\x0f_allow_any_hostB\x16\n\x14_created_without_key\"\xe3\x04\n\x0cgateway_info\x12\x13\n\x0b\x63li_version\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05group\x18\x04 \x01(\t\x12\x0c\n\x04\x61\x64\x64r\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\t\x12\x13\n\x0b\x62ool_status\x18\x07 \x01(\x08\x12\x0e\n\x06status\x18\x08 \x01(\x05\x12\x15\n\rerror_message\x18\t \x01(\t\x12\x19\n\x0cspdk_version\x18\n \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x14load_balancing_group\x18\x0b \x01(\r\x12\x10\n\x08hostname\x18\x0c \x01(\t\x12\x1b\n\x0emax_subsystems\x18\r \x01(\rH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x0e \x01(\rH\x02\x88\x01\x01\x12$\n\x17max_hosts_per_subsystem\x18\x0f \x01(\rH\x03\x88\x01\x01\x12)\n\x1cmax_namespaces_per_subsystem\x18\x10 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tmax_hosts\x18\x11 \x01(\rH\x05\x88\x01\x01\x12(\n\x1bgateway_initialization_over\x18\x12 \x01(\x08H\x06\x88\x01\x01\x42\x0f\n\r_spdk_versionB\x11\n\x0f_max_subsystemsB\x11\n\x0f_max_namespacesB\x1a\n\x18_max_hosts_per_subsystemB\x1f\n\x1d_max_namespaces_per_subsystemB\x0c\n\n_max_hostsB\x1e\n\x1c_gateway_initialization_over\"E\n\x0b\x63li_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"D\n\ngw_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"+\n\x19poll_group_transport_info\x12\x0e\n\x06trtype\x18\x01 \x01(\t\"\xe5\x01\n\x0fpoll_group_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x61\x64min_qpairs\x18\x02 \x01(\r\x12\x11\n\tio_qpairs\x18\x03 \x01(\r\x12\x1c\n\x14\x63urrent_admin_qpairs\x18\x04 \x01(\r\x12\x19\n\x11\x63urrent_io_qpairs\x18\x05 \x01(\r\x12\x17\n\x0fpending_bdev_io\x18\x06 \x01(\x04\x12\x19\n\x11\x63ompleted_nvme_io\x18\x07 \x01(\x04\x12.\n\ntransports\x18\x08 \x03(\x0b\x32\x1a.poll_group_transport_info\"u\n\x12gateway_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12%\n\x0bpoll_groups\x18\x04 \x03(\x0b\x32\x10.poll_group_info\"q\n\x11thread_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\x07threads\x18\x03 \x03(\x0b\x32\x11.spdk_thread_info\x12\x11\n\ttick_rate\x18\x04 \x01(\x04\"<\n\x10spdk_thread_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62usy\x18\x02 \x01(\x04\x12\x0c\n\x04idle\x18\x03 \x01(\x04\"\xd3\x01\n\rlistener_info\x12\x11\n\thost_name\x18\x01 \x01(\t\x12\x0e\n\x06trtype\x18\x02 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x03 \x01(\x0e\x32\x0e.AddressFamily\x12\x0e\n\x06traddr\x18\x04 \x01(\t\x12\x0f\n\x07trsvcid\x18\x05 \x01(\r\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x00\x88\x01\x01\x12\x13\n\x06\x61\x63tive\x18\x07 \x01(\x08H\x01\x88\x01\x01\x12\x13\n\x06manual\x18\x08 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_secureB\t\n\x07_activeB\t\n\x07_manual\"Z\n\x0elisteners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12!\n\tlisteners\x18\x03 \x03(\x0b\x32\x0e.listener_info\"^\n\x15gateway_listener_info\x12 \n\x08listener\x18\x01 \x01(\x0b\x32\x0e.listener_info\x12#\n\tlb_states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"m\n\x16gateway_listeners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12,\n\x0cgw_listeners\x18\x03 \x03(\x0b\x32\x16.gateway_listener_info\"\xbb\x01\n\x04host\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x14\n\x07use_psk\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x03 \x01(\x08H\x01\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\x04 \x01(\x08H\x02\x88\x01\x01\x42\n\n\x08_use_pskB\r\n\x0b_use_dhchapB(\n&_disconnected_due_to_keepalive_timeout\"x\n\nhosts_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x16\n\x0e\x61llow_any_host\x18\x03 \x01(\x08\x12\x15\n\rsubsystem_nqn\x18\x04 \x01(\t\x12\x14\n\x05hosts\x18\x05 \x03(\x0b\x32\x05.host\"\x98\x03\n\nconnection\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0e\n\x06traddr\x18\x02 \x01(\t\x12\x0f\n\x07trsvcid\x18\x03 \x01(\r\x12\x0e\n\x06trtype\x18\x04 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamily\x12\x11\n\tconnected\x18\x06 \x01(\x08\x12\x14\n\x0cqpairs_count\x18\x07 \x01(\x05\x12\x15\n\rcontroller_id\x18\x08 \x01(\x05\x12\x13\n\x06secure\x18\t \x01(\x08H\x00\x88\x01\x01\x12\x14\n\x07use_psk\x18\n \x01(\x08H\x01\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x0b \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tsubsystem\x18\x0c \x01(\tH\x03\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\r \x01(\x08H\x04\x88\x01\x01\x42\t\n\x07_secureB\n\n\x08_use_pskB\r\n\x0b_use_dhchapB\x0c\n\n_subsystemB(\n&_disconnected_due_to_keepalive_timeout\"r\n\x10\x63onnections_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12 \n\x0b\x63onnections\x18\x04 \x03(\x0b\x32\x0b.connection\"\xd7\x06\n\rnamespace_cli\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x11\n\tbdev_name\x18\x02 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x03 \x01(\t\x12\x15\n\rrbd_pool_name\x18\x04 \x01(\t\x12\x1c\n\x14load_balancing_group\x18\x05 \x01(\r\x12\x12\n\nblock_size\x18\x06 \x01(\r\x12\x16\n\x0erbd_image_size\x18\x07 \x01(\x04\x12\x0c\n\x04uuid\x18\x08 \x01(\t\x12\x19\n\x11rw_ios_per_second\x18\t \x01(\x04\x12\x1c\n\x14rw_mbytes_per_second\x18\n \x01(\x04\x12\x1b\n\x13r_mbytes_per_second\x18\x0b \x01(\x04\x12\x1b\n\x13w_mbytes_per_second\x18\x0c \x01(\x04\x12\x14\n\x0c\x61uto_visible\x18\r \x01(\x08\x12\r\n\x05hosts\x18\x0e \x03(\t\x12\x1d\n\x10ns_subsystem_nqn\x18\x0f \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x10 \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\x11 \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tread_only\x18\x12 \x01(\x08H\x03\x88\x01\x01\x12\x19\n\x0c\x63luster_name\x18\x13 \x01(\tH\x04\x88\x01\x01\x12,\n\x1f\x63onfigured_load_balancing_group\x18\x14 \x01(\rH\x05\x88\x01\x01\x12\x1d\n\x10image_was_shrunk\x18\x15 \x01(\x08H\x06\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x16 \x01(\tH\x07\x88\x01\x01\x12\x15\n\x08location\x18\x17 \x01(\tH\x08\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x18 \x01(\tH\t\x88\x01\x01\x42\x13\n\x11_ns_subsystem_nqnB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x0f\n\r_cluster_nameB\"\n _configured_load_balancing_groupB\x13\n\x11_image_was_shrunkB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_name\"s\n\x0fnamespaces_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\"\n\nnamespaces\x18\x04 \x03(\x0b\x32\x0e.namespace_cli\"1\n\x12namespace_io_error\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r\"\xda\x05\n\x17namespace_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x0c\n\x04nsid\x18\x04 \x01(\r\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tbdev_name\x18\x06 \x01(\t\x12\x11\n\ttick_rate\x18\x07 \x01(\x04\x12\r\n\x05ticks\x18\x08 \x01(\x04\x12\x12\n\nbytes_read\x18\t \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\n \x01(\x04\x12\x15\n\rbytes_written\x18\x0b \x01(\x04\x12\x15\n\rnum_write_ops\x18\x0c \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\r \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x0e \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\x0f \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x10 \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x11 \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\x12 \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x13 \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x14 \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x15 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x16 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x17 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x18 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x19 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x1a \x01(\x04\x12%\n\x08io_error\x18\x1b \x03(\x0b\x32\x13.namespace_io_errorB\x07\n\x05_uuid\"3\n\x12spdk_log_flag_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"\xba\x01\n\"spdk_nvmf_log_flags_and_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12+\n\x0envmf_log_flags\x18\x03 \x03(\x0b\x32\x13.spdk_log_flag_info\x12\x1c\n\tlog_level\x18\x04 \x01(\x0e\x32\t.LogLevel\x12\"\n\x0flog_print_level\x18\x05 \x01(\x0e\x32\t.LogLevel\"_\n\x16gateway_log_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x1e\n\tlog_level\x18\x03 \x01(\x0e\x32\x0b.GwLogLevel*#\n\rAddressFamily\x12\x08\n\x04ipv4\x10\x00\x12\x08\n\x04ipv6\x10\x01*C\n\x08LogLevel\x12\t\n\x05\x45RROR\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\n\n\x06NOTICE\x10\x02\x12\x08\n\x04INFO\x10\x03\x12\t\n\x05\x44\x45\x42UG\x10\x04*S\n\nGwLogLevel\x12\n\n\x06notset\x10\x00\x12\t\n\x05\x64\x65\x62ug\x10\n\x12\x08\n\x04info\x10\x14\x12\x0b\n\x07warning\x10\x1e\x12\t\n\x05\x65rror\x10(\x12\x0c\n\x08\x63ritical\x10\x32*J\n\tana_state\x12\t\n\x05UNSET\x10\x00\x12\r\n\tOPTIMIZED\x10\x01\x12\x11\n\rNON_OPTIMIZED\x10\x02\x12\x10\n\x0cINACCESSIBLE\x10\x03\x32\xe2\x13\n\x07Gateway\x12\x33\n\rnamespace_add\x12\x12.namespace_add_req\x1a\x0c.nsid_status\"\x00\x12;\n\x10\x63reate_subsystem\x12\x15.create_subsystem_req\x1a\x0e.subsys_status\"\x00\x12\x38\n\x10\x64\x65lete_subsystem\x12\x15.delete_subsystem_req\x1a\x0b.req_status\"\x00\x12@\n\x14\x63hange_subsystem_key\x12\x19.change_subsystem_key_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x61\x64\x64_subsystem_network\x12\x1a.add_subsystem_network_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x64\x65l_subsystem_network\x12\x1a.del_subsystem_network_req\x1a\x0b.req_status\"\x00\x12;\n\x0flist_namespaces\x12\x14.list_namespaces_req\x1a\x10.namespaces_info\"\x00\x12\x38\n\x10namespace_resize\x12\x15.namespace_resize_req\x1a\x0b.req_status\"\x00\x12Q\n\x16namespace_get_io_stats\x12\x1b.namespace_get_io_stats_req\x1a\x18.namespace_io_stats_info\"\x00\x12\x41\n\x18namespace_set_qos_limits\x12\x16.namespace_set_qos_req\x1a\x0b.req_status\"\x00\x12\x62\n%namespace_change_load_balancing_group\x12*.namespace_change_load_balancing_group_req\x1a\x0b.req_status\"\x00\x12N\n\x1bnamespace_change_visibility\x12 .namespace_change_visibility_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_change_location\x12\x1e.namespace_change_location_req\x1a\x0b.req_status\"\x00\x12R\n\x1dnamespace_set_rbd_trash_image\x12\".namespace_set_rbd_trash_image_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_set_auto_resize\x12\x1e.namespace_set_auto_resize_req\x1a\x0b.req_status\"\x00\x12\x38\n\x10namespace_delete\x12\x15.namespace_delete_req\x1a\x0b.req_status\"\x00\x12<\n\x12namespace_add_host\x12\x17.namespace_add_host_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15namespace_delete_host\x12\x1a.namespace_delete_host_req\x1a\x0b.req_status\"\x00\x12(\n\x08\x61\x64\x64_host\x12\r.add_host_req\x1a\x0b.req_status\"\x00\x12.\n\x0bremove_host\x12\x10.remove_host_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x63hange_host_key\x12\x14.change_host_key_req\x1a\x0b.req_status\"\x00\x12,\n\nlist_hosts\x12\x0f.list_hosts_req\x1a\x0b.hosts_info\"\x00\x12>\n\x10list_connections\x12\x15.list_connections_req\x1a\x11.connections_info\"\x00\x12\x36\n\x0f\x63reate_listener\x12\x14.create_listener_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x64\x65lete_listener\x12\x14.delete_listener_req\x1a\x0b.req_status\"\x00\x12\x38\n\x0elist_listeners\x12\x13.list_listeners_req\x1a\x0f.listeners_info\"\x00\x12?\n\x0flist_subsystems\x12\x14.list_subsystems_req\x1a\x14.subsystems_info_cli\"\x00\x12\x39\n\x0eget_subsystems\x12\x13.get_subsystems_req\x1a\x10.subsystems_info\"\x00\x12)\n\rset_ana_state\x12\t.ana_info\x1a\x0b.req_status\"\x00\x12r\n!get_spdk_nvmf_log_flags_and_level\x12&.get_spdk_nvmf_log_flags_and_level_req\x1a#.spdk_nvmf_log_flags_and_level_info\"\x00\x12\x44\n\x16\x64isable_spdk_nvmf_logs\x12\x1b.disable_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12<\n\x12set_spdk_nvmf_logs\x12\x17.set_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12:\n\x10get_gateway_info\x12\x15.get_gateway_info_req\x1a\r.gateway_info\"\x00\x12N\n\x15get_gateway_log_level\x12\x1a.get_gateway_log_level_req\x1a\x17.gateway_log_level_info\"\x00\x12\x42\n\x15set_gateway_log_level\x12\x1a.set_gateway_log_level_req\x1a\x0b.req_status\"\x00\x12Z\n\x1bshow_gateway_listeners_info\x12 .show_gateway_listeners_info_req\x1a\x17.gateway_listeners_info\"\x00\x12\x42\n\x11get_gateway_stats\x12\x16.get_gateway_stats_req\x1a\x13.gateway_stats_info\"\x00\x12?\n\x10get_thread_stats\x12\x15.get_thread_stats_req\x1a\x12.thread_stats_info\"\x00\x42+Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeofb\x06proto3'
 )
 
 _ADDRESSFAMILY = _descriptor.EnumDescriptor(
-    name='AddressFamily',
-    full_name='AddressFamily',
-    filename=None,
-    file=DESCRIPTOR,
-    create_key=_descriptor._internal_create_key,
-    values=[
-        _descriptor.EnumValueDescriptor(
-            name='ipv4', index=0, number=0,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='ipv6', index=1, number=1,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-    ],
-    containing_type=None,
-    serialized_options=None,
-    serialized_start=10223,
-    serialized_end=10258,
+  name='AddressFamily',
+  full_name='AddressFamily',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='ipv4', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='ipv6', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=11451,
+  serialized_end=11486,
 )
 _sym_db.RegisterEnumDescriptor(_ADDRESSFAMILY)
 
 AddressFamily = enum_type_wrapper.EnumTypeWrapper(_ADDRESSFAMILY)
 _LOGLEVEL = _descriptor.EnumDescriptor(
-    name='LogLevel',
-    full_name='LogLevel',
-    filename=None,
-    file=DESCRIPTOR,
-    create_key=_descriptor._internal_create_key,
-    values=[
-        _descriptor.EnumValueDescriptor(
-            name='ERROR', index=0, number=0,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='WARNING', index=1, number=1,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='NOTICE', index=2, number=2,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='INFO', index=3, number=3,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='DEBUG', index=4, number=4,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-    ],
-    containing_type=None,
-    serialized_options=None,
-    serialized_start=10260,
-    serialized_end=10327,
+  name='LogLevel',
+  full_name='LogLevel',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='ERROR', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='WARNING', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='NOTICE', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='INFO', index=3, number=3,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='DEBUG', index=4, number=4,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=11488,
+  serialized_end=11555,
 )
 _sym_db.RegisterEnumDescriptor(_LOGLEVEL)
 
 LogLevel = enum_type_wrapper.EnumTypeWrapper(_LOGLEVEL)
 _GWLOGLEVEL = _descriptor.EnumDescriptor(
-    name='GwLogLevel',
-    full_name='GwLogLevel',
-    filename=None,
-    file=DESCRIPTOR,
-    create_key=_descriptor._internal_create_key,
-    values=[
-        _descriptor.EnumValueDescriptor(
-            name='notset', index=0, number=0,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='debug', index=1, number=10,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='info', index=2, number=20,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='warning', index=3, number=30,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='error', index=4, number=40,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='critical', index=5, number=50,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-    ],
-    containing_type=None,
-    serialized_options=None,
-    serialized_start=10329,
-    serialized_end=10412,
+  name='GwLogLevel',
+  full_name='GwLogLevel',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='notset', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='debug', index=1, number=10,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='info', index=2, number=20,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='warning', index=3, number=30,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='error', index=4, number=40,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='critical', index=5, number=50,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=11557,
+  serialized_end=11640,
 )
 _sym_db.RegisterEnumDescriptor(_GWLOGLEVEL)
 
 GwLogLevel = enum_type_wrapper.EnumTypeWrapper(_GWLOGLEVEL)
 _ANA_STATE = _descriptor.EnumDescriptor(
-    name='ana_state',
-    full_name='ana_state',
-    filename=None,
-    file=DESCRIPTOR,
-    create_key=_descriptor._internal_create_key,
-    values=[
-        _descriptor.EnumValueDescriptor(
-            name='UNSET', index=0, number=0,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='OPTIMIZED', index=1, number=1,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='NON_OPTIMIZED', index=2, number=2,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-        _descriptor.EnumValueDescriptor(
-            name='INACCESSIBLE', index=3, number=3,
-            serialized_options=None,
-            type=None,
-            create_key=_descriptor._internal_create_key),
-    ],
-    containing_type=None,
-    serialized_options=None,
-    serialized_start=10414,
-    serialized_end=10488,
+  name='ana_state',
+  full_name='ana_state',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='UNSET', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='OPTIMIZED', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='NON_OPTIMIZED', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='INACCESSIBLE', index=3, number=3,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=11642,
+  serialized_end=11716,
 )
 _sym_db.RegisterEnumDescriptor(_ANA_STATE)
 
@@ -189,4402 +191,4872 @@ NON_OPTIMIZED = 2
 INACCESSIBLE = 3
 
 
+
 _NAMESPACE_ADD_REQ = _descriptor.Descriptor(
-    name='namespace_add_req',
-    full_name='namespace_add_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='rbd_pool_name', full_name='namespace_add_req.rbd_pool_name', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rbd_image_name', full_name='namespace_add_req.rbd_image_name', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_add_req.subsystem_nqn', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_add_req.nsid', index=3,
-            number=4, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='block_size', full_name='namespace_add_req.block_size', index=4,
-            number=5, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='uuid', full_name='namespace_add_req.uuid', index=5,
-            number=6, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='anagrpid', full_name='namespace_add_req.anagrpid', index=6,
-            number=7, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='create_image', full_name='namespace_add_req.create_image', index=7,
-            number=8, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='size', full_name='namespace_add_req.size', index=8,
-            number=9, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='force', full_name='namespace_add_req.force', index=9,
-            number=10, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='no_auto_visible', full_name='namespace_add_req.no_auto_visible', index=10,
-            number=11, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trash_image', full_name='namespace_add_req.trash_image', index=11,
-            number=12, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='disable_auto_resize', full_name='namespace_add_req.disable_auto_resize', index=12,
-            number=13, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='read_only', full_name='namespace_add_req.read_only', index=13,
-            number=14, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_nsid', full_name='namespace_add_req._nsid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_uuid', full_name='namespace_add_req._uuid',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_anagrpid', full_name='namespace_add_req._anagrpid',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_create_image', full_name='namespace_add_req._create_image',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_size', full_name='namespace_add_req._size',
-            index=4, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_force', full_name='namespace_add_req._force',
-            index=5, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_no_auto_visible', full_name='namespace_add_req._no_auto_visible',
-            index=6, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_trash_image', full_name='namespace_add_req._trash_image',
-            index=7, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_disable_auto_resize', full_name='namespace_add_req._disable_auto_resize',
-            index=8, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_read_only', full_name='namespace_add_req._read_only',
-            index=9, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=43,
-    serialized_end=534,
+  name='namespace_add_req',
+  full_name='namespace_add_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='rbd_pool_name', full_name='namespace_add_req.rbd_pool_name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rbd_image_name', full_name='namespace_add_req.rbd_image_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_add_req.subsystem_nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_add_req.nsid', index=3,
+      number=4, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='block_size', full_name='namespace_add_req.block_size', index=4,
+      number=5, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='uuid', full_name='namespace_add_req.uuid', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='anagrpid', full_name='namespace_add_req.anagrpid', index=6,
+      number=7, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='create_image', full_name='namespace_add_req.create_image', index=7,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='size', full_name='namespace_add_req.size', index=8,
+      number=9, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='namespace_add_req.force', index=9,
+      number=10, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='no_auto_visible', full_name='namespace_add_req.no_auto_visible', index=10,
+      number=11, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trash_image', full_name='namespace_add_req.trash_image', index=11,
+      number=12, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='disable_auto_resize', full_name='namespace_add_req.disable_auto_resize', index=12,
+      number=13, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='read_only', full_name='namespace_add_req.read_only', index=13,
+      number=14, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rbd_data_pool_name', full_name='namespace_add_req.rbd_data_pool_name', index=14,
+      number=15, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='location', full_name='namespace_add_req.location', index=15,
+      number=16, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rados_namespace_name', full_name='namespace_add_req.rados_namespace_name', index=16,
+      number=17, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_nsid', full_name='namespace_add_req._nsid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_uuid', full_name='namespace_add_req._uuid',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_anagrpid', full_name='namespace_add_req._anagrpid',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_create_image', full_name='namespace_add_req._create_image',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_size', full_name='namespace_add_req._size',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='namespace_add_req._force',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_no_auto_visible', full_name='namespace_add_req._no_auto_visible',
+      index=6, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_trash_image', full_name='namespace_add_req._trash_image',
+      index=7, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_disable_auto_resize', full_name='namespace_add_req._disable_auto_resize',
+      index=8, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_read_only', full_name='namespace_add_req._read_only',
+      index=9, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_rbd_data_pool_name', full_name='namespace_add_req._rbd_data_pool_name',
+      index=10, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_location', full_name='namespace_add_req._location',
+      index=11, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_rados_namespace_name', full_name='namespace_add_req._rados_namespace_name',
+      index=12, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=43,
+  serialized_end=686,
 )
 
 
 _NAMESPACE_RESIZE_REQ = _descriptor.Descriptor(
-    name='namespace_resize_req',
-    full_name='namespace_resize_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_resize_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_resize_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='OBSOLETE_uuid', full_name='namespace_resize_req.OBSOLETE_uuid', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='new_size', full_name='namespace_resize_req.new_size', index=3,
-            number=4, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_OBSOLETE_uuid', full_name='namespace_resize_req._OBSOLETE_uuid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=536,
-    serialized_end=659,
+  name='namespace_resize_req',
+  full_name='namespace_resize_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_resize_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_resize_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='OBSOLETE_uuid', full_name='namespace_resize_req.OBSOLETE_uuid', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='new_size', full_name='namespace_resize_req.new_size', index=3,
+      number=4, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_OBSOLETE_uuid', full_name='namespace_resize_req._OBSOLETE_uuid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=688,
+  serialized_end=811,
 )
 
 
 _NAMESPACE_GET_IO_STATS_REQ = _descriptor.Descriptor(
-    name='namespace_get_io_stats_req',
-    full_name='namespace_get_io_stats_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_get_io_stats_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_get_io_stats_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='OBSOLETE_uuid', full_name='namespace_get_io_stats_req.OBSOLETE_uuid', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_OBSOLETE_uuid', full_name='namespace_get_io_stats_req._OBSOLETE_uuid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=661,
-    serialized_end=772,
+  name='namespace_get_io_stats_req',
+  full_name='namespace_get_io_stats_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_get_io_stats_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_get_io_stats_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='OBSOLETE_uuid', full_name='namespace_get_io_stats_req.OBSOLETE_uuid', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_OBSOLETE_uuid', full_name='namespace_get_io_stats_req._OBSOLETE_uuid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=813,
+  serialized_end=924,
 )
 
 
 _NAMESPACE_SET_QOS_REQ = _descriptor.Descriptor(
-    name='namespace_set_qos_req',
-    full_name='namespace_set_qos_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_set_qos_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_set_qos_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='OBSOLETE_uuid', full_name='namespace_set_qos_req.OBSOLETE_uuid', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rw_ios_per_second', full_name='namespace_set_qos_req.rw_ios_per_second', index=3,
-            number=4, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rw_mbytes_per_second', full_name='namespace_set_qos_req.rw_mbytes_per_second', index=4,
-            number=5, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='r_mbytes_per_second', full_name='namespace_set_qos_req.r_mbytes_per_second', index=5,
-            number=6, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='w_mbytes_per_second', full_name='namespace_set_qos_req.w_mbytes_per_second', index=6,
-            number=7, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='force', full_name='namespace_set_qos_req.force', index=7,
-            number=8, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_OBSOLETE_uuid', full_name='namespace_set_qos_req._OBSOLETE_uuid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_rw_ios_per_second', full_name='namespace_set_qos_req._rw_ios_per_second',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_rw_mbytes_per_second', full_name='namespace_set_qos_req._rw_mbytes_per_second',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_r_mbytes_per_second', full_name='namespace_set_qos_req._r_mbytes_per_second',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_w_mbytes_per_second', full_name='namespace_set_qos_req._w_mbytes_per_second',
-            index=4, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_force', full_name='namespace_set_qos_req._force',
-            index=5, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=775,
-    serialized_end=1141,
+  name='namespace_set_qos_req',
+  full_name='namespace_set_qos_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_set_qos_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_set_qos_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='OBSOLETE_uuid', full_name='namespace_set_qos_req.OBSOLETE_uuid', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rw_ios_per_second', full_name='namespace_set_qos_req.rw_ios_per_second', index=3,
+      number=4, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rw_mbytes_per_second', full_name='namespace_set_qos_req.rw_mbytes_per_second', index=4,
+      number=5, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='r_mbytes_per_second', full_name='namespace_set_qos_req.r_mbytes_per_second', index=5,
+      number=6, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='w_mbytes_per_second', full_name='namespace_set_qos_req.w_mbytes_per_second', index=6,
+      number=7, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='namespace_set_qos_req.force', index=7,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_OBSOLETE_uuid', full_name='namespace_set_qos_req._OBSOLETE_uuid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_rw_ios_per_second', full_name='namespace_set_qos_req._rw_ios_per_second',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_rw_mbytes_per_second', full_name='namespace_set_qos_req._rw_mbytes_per_second',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_r_mbytes_per_second', full_name='namespace_set_qos_req._r_mbytes_per_second',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_w_mbytes_per_second', full_name='namespace_set_qos_req._w_mbytes_per_second',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='namespace_set_qos_req._force',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=927,
+  serialized_end=1293,
 )
 
 
 _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ = _descriptor.Descriptor(
-    name='namespace_change_load_balancing_group_req',
-    full_name='namespace_change_load_balancing_group_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_change_load_balancing_group_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_change_load_balancing_group_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='OBSOLETE_uuid', full_name='namespace_change_load_balancing_group_req.OBSOLETE_uuid', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='anagrpid', full_name='namespace_change_load_balancing_group_req.anagrpid', index=3,
-            number=4, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='auto_lb_logic', full_name='namespace_change_load_balancing_group_req.auto_lb_logic', index=4,
-            number=5, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_OBSOLETE_uuid', full_name='namespace_change_load_balancing_group_req._OBSOLETE_uuid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_auto_lb_logic', full_name='namespace_change_load_balancing_group_req._auto_lb_logic',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=1144,
-    serialized_end=1334,
+  name='namespace_change_load_balancing_group_req',
+  full_name='namespace_change_load_balancing_group_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_change_load_balancing_group_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_change_load_balancing_group_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='OBSOLETE_uuid', full_name='namespace_change_load_balancing_group_req.OBSOLETE_uuid', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='anagrpid', full_name='namespace_change_load_balancing_group_req.anagrpid', index=3,
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='auto_lb_logic', full_name='namespace_change_load_balancing_group_req.auto_lb_logic', index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_OBSOLETE_uuid', full_name='namespace_change_load_balancing_group_req._OBSOLETE_uuid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_auto_lb_logic', full_name='namespace_change_load_balancing_group_req._auto_lb_logic',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=1296,
+  serialized_end=1486,
 )
 
 
 _NAMESPACE_CHANGE_VISIBILITY_REQ = _descriptor.Descriptor(
-    name='namespace_change_visibility_req',
-    full_name='namespace_change_visibility_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_change_visibility_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_change_visibility_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='auto_visible', full_name='namespace_change_visibility_req.auto_visible', index=2,
-            number=3, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='force', full_name='namespace_change_visibility_req.force', index=3,
-            number=4, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_force', full_name='namespace_change_visibility_req._force',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=1336,
-    serialized_end=1458,
+  name='namespace_change_visibility_req',
+  full_name='namespace_change_visibility_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_change_visibility_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_change_visibility_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='auto_visible', full_name='namespace_change_visibility_req.auto_visible', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='namespace_change_visibility_req.force', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='namespace_change_visibility_req._force',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=1488,
+  serialized_end=1610,
+)
+
+
+_NAMESPACE_CHANGE_LOCATION_REQ = _descriptor.Descriptor(
+  name='namespace_change_location_req',
+  full_name='namespace_change_location_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_change_location_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_change_location_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='location', full_name='namespace_change_location_req.location', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_location', full_name='namespace_change_location_req._location',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=1612,
+  serialized_end=1716,
 )
 
 
 _NAMESPACE_SET_RBD_TRASH_IMAGE_REQ = _descriptor.Descriptor(
-    name='namespace_set_rbd_trash_image_req',
-    full_name='namespace_set_rbd_trash_image_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_set_rbd_trash_image_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_set_rbd_trash_image_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trash_image', full_name='namespace_set_rbd_trash_image_req.trash_image', index=2,
-            number=3, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=1460,
-    serialized_end=1553,
+  name='namespace_set_rbd_trash_image_req',
+  full_name='namespace_set_rbd_trash_image_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_set_rbd_trash_image_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_set_rbd_trash_image_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trash_image', full_name='namespace_set_rbd_trash_image_req.trash_image', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1718,
+  serialized_end=1811,
 )
 
 
 _NAMESPACE_SET_AUTO_RESIZE_REQ = _descriptor.Descriptor(
-    name='namespace_set_auto_resize_req',
-    full_name='namespace_set_auto_resize_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_set_auto_resize_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_set_auto_resize_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='auto_resize', full_name='namespace_set_auto_resize_req.auto_resize', index=2,
-            number=3, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=1555,
-    serialized_end=1644,
+  name='namespace_set_auto_resize_req',
+  full_name='namespace_set_auto_resize_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_set_auto_resize_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_set_auto_resize_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='auto_resize', full_name='namespace_set_auto_resize_req.auto_resize', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1813,
+  serialized_end=1902,
 )
 
 
 _NAMESPACE_DELETE_REQ = _descriptor.Descriptor(
-    name='namespace_delete_req',
-    full_name='namespace_delete_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_delete_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_delete_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='OBSOLETE_uuid', full_name='namespace_delete_req.OBSOLETE_uuid', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='i_am_sure', full_name='namespace_delete_req.i_am_sure', index=3,
-            number=4, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_OBSOLETE_uuid', full_name='namespace_delete_req._OBSOLETE_uuid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_i_am_sure', full_name='namespace_delete_req._i_am_sure',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=1647,
-    serialized_end=1790,
+  name='namespace_delete_req',
+  full_name='namespace_delete_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_delete_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_delete_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='OBSOLETE_uuid', full_name='namespace_delete_req.OBSOLETE_uuid', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='i_am_sure', full_name='namespace_delete_req.i_am_sure', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_OBSOLETE_uuid', full_name='namespace_delete_req._OBSOLETE_uuid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_i_am_sure', full_name='namespace_delete_req._i_am_sure',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=1905,
+  serialized_end=2048,
 )
 
 
 _NAMESPACE_ADD_HOST_REQ = _descriptor.Descriptor(
-    name='namespace_add_host_req',
-    full_name='namespace_add_host_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_add_host_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_add_host_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='host_nqn', full_name='namespace_add_host_req.host_nqn', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='force', full_name='namespace_add_host_req.force', index=3,
-            number=4, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_force', full_name='namespace_add_host_req._force',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=1792,
-    serialized_end=1901,
+  name='namespace_add_host_req',
+  full_name='namespace_add_host_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_add_host_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_add_host_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_nqn', full_name='namespace_add_host_req.host_nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='namespace_add_host_req.force', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='namespace_add_host_req._force',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=2050,
+  serialized_end=2159,
 )
 
 
 _NAMESPACE_DELETE_HOST_REQ = _descriptor.Descriptor(
-    name='namespace_delete_host_req',
-    full_name='namespace_delete_host_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_delete_host_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_delete_host_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='host_nqn', full_name='namespace_delete_host_req.host_nqn', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=1903,
-    serialized_end=1985,
+  name='namespace_delete_host_req',
+  full_name='namespace_delete_host_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_delete_host_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_delete_host_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_nqn', full_name='namespace_delete_host_req.host_nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2161,
+  serialized_end=2243,
 )
 
 
 _CREATE_SUBSYSTEM_REQ = _descriptor.Descriptor(
-    name='create_subsystem_req',
-    full_name='create_subsystem_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='create_subsystem_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='serial_number', full_name='create_subsystem_req.serial_number', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_namespaces', full_name='create_subsystem_req.max_namespaces', index=2,
-            number=3, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='enable_ha', full_name='create_subsystem_req.enable_ha', index=3,
-            number=4, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='no_group_append', full_name='create_subsystem_req.no_group_append', index=4,
-            number=5, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='dhchap_key', full_name='create_subsystem_req.dhchap_key', index=5,
-            number=6, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='key_encrypted', full_name='create_subsystem_req.key_encrypted', index=6,
-            number=7, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_max_namespaces', full_name='create_subsystem_req._max_namespaces',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_no_group_append', full_name='create_subsystem_req._no_group_append',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_dhchap_key', full_name='create_subsystem_req._dhchap_key',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_key_encrypted', full_name='create_subsystem_req._key_encrypted',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=1988,
-    serialized_end=2259,
+  name='create_subsystem_req',
+  full_name='create_subsystem_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='create_subsystem_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='serial_number', full_name='create_subsystem_req.serial_number', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_namespaces', full_name='create_subsystem_req.max_namespaces', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='enable_ha', full_name='create_subsystem_req.enable_ha', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='no_group_append', full_name='create_subsystem_req.no_group_append', index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_key', full_name='create_subsystem_req.dhchap_key', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='key_encrypted', full_name='create_subsystem_req.key_encrypted', index=6,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='network_mask', full_name='create_subsystem_req.network_mask', index=7,
+      number=8, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='secure_listeners', full_name='create_subsystem_req.secure_listeners', index=8,
+      number=9, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_max_namespaces', full_name='create_subsystem_req._max_namespaces',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_no_group_append', full_name='create_subsystem_req._no_group_append',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_dhchap_key', full_name='create_subsystem_req._dhchap_key',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_key_encrypted', full_name='create_subsystem_req._key_encrypted',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_secure_listeners', full_name='create_subsystem_req._secure_listeners',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=2246,
+  serialized_end=2591,
 )
 
 
 _DELETE_SUBSYSTEM_REQ = _descriptor.Descriptor(
-    name='delete_subsystem_req',
-    full_name='delete_subsystem_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='delete_subsystem_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='force', full_name='delete_subsystem_req.force', index=1,
-            number=2, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_force', full_name='delete_subsystem_req._force',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=2261,
-    serialized_end=2336,
+  name='delete_subsystem_req',
+  full_name='delete_subsystem_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='delete_subsystem_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='delete_subsystem_req.force', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='i_am_sure', full_name='delete_subsystem_req.i_am_sure', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='delete_subsystem_req._force',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_i_am_sure', full_name='delete_subsystem_req._i_am_sure',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=2593,
+  serialized_end=2706,
 )
 
 
 _CHANGE_SUBSYSTEM_KEY_REQ = _descriptor.Descriptor(
-    name='change_subsystem_key_req',
-    full_name='change_subsystem_key_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='change_subsystem_key_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='dhchap_key', full_name='change_subsystem_key_req.dhchap_key', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_dhchap_key', full_name='change_subsystem_key_req._dhchap_key',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=2338,
-    serialized_end=2427,
+  name='change_subsystem_key_req',
+  full_name='change_subsystem_key_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='change_subsystem_key_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_key', full_name='change_subsystem_key_req.dhchap_key', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_dhchap_key', full_name='change_subsystem_key_req._dhchap_key',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=2708,
+  serialized_end=2797,
+)
+
+
+_ADD_SUBSYSTEM_NETWORK_REQ = _descriptor.Descriptor(
+  name='add_subsystem_network_req',
+  full_name='add_subsystem_network_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='add_subsystem_network_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='network_mask', full_name='add_subsystem_network_req.network_mask', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2799,
+  serialized_end=2871,
+)
+
+
+_DEL_SUBSYSTEM_NETWORK_REQ = _descriptor.Descriptor(
+  name='del_subsystem_network_req',
+  full_name='del_subsystem_network_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='del_subsystem_network_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='network_mask', full_name='del_subsystem_network_req.network_mask', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2873,
+  serialized_end=2945,
 )
 
 
 _LIST_NAMESPACES_REQ = _descriptor.Descriptor(
-    name='list_namespaces_req',
-    full_name='list_namespaces_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem', full_name='list_namespaces_req.subsystem', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='list_namespaces_req.nsid', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='uuid', full_name='list_namespaces_req.uuid', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_nsid', full_name='list_namespaces_req._nsid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_uuid', full_name='list_namespaces_req._uuid',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=2429,
-    serialized_end=2525,
+  name='list_namespaces_req',
+  full_name='list_namespaces_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem', full_name='list_namespaces_req.subsystem', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='list_namespaces_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='uuid', full_name='list_namespaces_req.uuid', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_nsid', full_name='list_namespaces_req._nsid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_uuid', full_name='list_namespaces_req._uuid',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=2947,
+  serialized_end=3043,
 )
 
 
 _ADD_HOST_REQ = _descriptor.Descriptor(
-    name='add_host_req',
-    full_name='add_host_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='add_host_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='host_nqn', full_name='add_host_req.host_nqn', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='psk', full_name='add_host_req.psk', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='dhchap_key', full_name='add_host_req.dhchap_key', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='psk_encrypted', full_name='add_host_req.psk_encrypted', index=4,
-            number=5, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='key_encrypted', full_name='add_host_req.key_encrypted', index=5,
-            number=6, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_psk', full_name='add_host_req._psk',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_dhchap_key', full_name='add_host_req._dhchap_key',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_psk_encrypted', full_name='add_host_req._psk_encrypted',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_key_encrypted', full_name='add_host_req._key_encrypted',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=2528,
-    serialized_end=2741,
+  name='add_host_req',
+  full_name='add_host_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='add_host_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_nqn', full_name='add_host_req.host_nqn', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='psk', full_name='add_host_req.psk', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_key', full_name='add_host_req.dhchap_key', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='psk_encrypted', full_name='add_host_req.psk_encrypted', index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='key_encrypted', full_name='add_host_req.key_encrypted', index=5,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_ctrlr_key', full_name='add_host_req.dhchap_ctrlr_key', index=6,
+      number=7, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='ctrlr_key_encrypted', full_name='add_host_req.ctrlr_key_encrypted', index=7,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_psk', full_name='add_host_req._psk',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_dhchap_key', full_name='add_host_req._dhchap_key',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_psk_encrypted', full_name='add_host_req._psk_encrypted',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_key_encrypted', full_name='add_host_req._key_encrypted',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_dhchap_ctrlr_key', full_name='add_host_req._dhchap_ctrlr_key',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_ctrlr_key_encrypted', full_name='add_host_req._ctrlr_key_encrypted',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3046,
+  serialized_end=3369,
 )
 
 
 _CHANGE_HOST_KEY_REQ = _descriptor.Descriptor(
-    name='change_host_key_req',
-    full_name='change_host_key_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='change_host_key_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='host_nqn', full_name='change_host_key_req.host_nqn', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='dhchap_key', full_name='change_host_key_req.dhchap_key', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_dhchap_key', full_name='change_host_key_req._dhchap_key',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=2743,
-    serialized_end=2845,
+  name='change_host_key_req',
+  full_name='change_host_key_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='change_host_key_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_nqn', full_name='change_host_key_req.host_nqn', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_key', full_name='change_host_key_req.dhchap_key', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_ctrlr_key', full_name='change_host_key_req.dhchap_ctrlr_key', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_dhchap_key', full_name='change_host_key_req._dhchap_key',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_dhchap_ctrlr_key', full_name='change_host_key_req._dhchap_ctrlr_key',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3372,
+  serialized_end=3526,
 )
 
 
 _REMOVE_HOST_REQ = _descriptor.Descriptor(
-    name='remove_host_req',
-    full_name='remove_host_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='remove_host_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='host_nqn', full_name='remove_host_req.host_nqn', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=2847,
-    serialized_end=2905,
+  name='remove_host_req',
+  full_name='remove_host_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='remove_host_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_nqn', full_name='remove_host_req.host_nqn', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3528,
+  serialized_end=3586,
 )
 
 
 _LIST_HOSTS_REQ = _descriptor.Descriptor(
-    name='list_hosts_req',
-    full_name='list_hosts_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem', full_name='list_hosts_req.subsystem', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='clear_alerts', full_name='list_hosts_req.clear_alerts', index=1,
-            number=2, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_clear_alerts', full_name='list_hosts_req._clear_alerts',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=2907,
-    serialized_end=2986,
+  name='list_hosts_req',
+  full_name='list_hosts_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem', full_name='list_hosts_req.subsystem', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='clear_alerts', full_name='list_hosts_req.clear_alerts', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_clear_alerts', full_name='list_hosts_req._clear_alerts',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3588,
+  serialized_end=3667,
 )
 
 
 _LIST_CONNECTIONS_REQ = _descriptor.Descriptor(
-    name='list_connections_req',
-    full_name='list_connections_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem', full_name='list_connections_req.subsystem', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=2988,
-    serialized_end=3029,
+  name='list_connections_req',
+  full_name='list_connections_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem', full_name='list_connections_req.subsystem', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='clear_alerts', full_name='list_connections_req.clear_alerts', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_clear_alerts', full_name='list_connections_req._clear_alerts',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3669,
+  serialized_end=3754,
 )
 
 
 _CREATE_LISTENER_REQ = _descriptor.Descriptor(
-    name='create_listener_req',
-    full_name='create_listener_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='create_listener_req.nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='host_name', full_name='create_listener_req.host_name', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='traddr', full_name='create_listener_req.traddr', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='adrfam', full_name='create_listener_req.adrfam', index=3,
-            number=5, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trsvcid', full_name='create_listener_req.trsvcid', index=4,
-            number=6, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='secure', full_name='create_listener_req.secure', index=5,
-            number=7, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='verify_host_name', full_name='create_listener_req.verify_host_name', index=6,
-            number=8, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_adrfam', full_name='create_listener_req._adrfam',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_trsvcid', full_name='create_listener_req._trsvcid',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_secure', full_name='create_listener_req._secure',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_verify_host_name', full_name='create_listener_req._verify_host_name',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=3032,
-    serialized_end=3267,
+  name='create_listener_req',
+  full_name='create_listener_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='create_listener_req.nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_name', full_name='create_listener_req.host_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='traddr', full_name='create_listener_req.traddr', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='adrfam', full_name='create_listener_req.adrfam', index=3,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trsvcid', full_name='create_listener_req.trsvcid', index=4,
+      number=6, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='secure', full_name='create_listener_req.secure', index=5,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='verify_host_name', full_name='create_listener_req.verify_host_name', index=6,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_adrfam', full_name='create_listener_req._adrfam',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_trsvcid', full_name='create_listener_req._trsvcid',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_secure', full_name='create_listener_req._secure',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_verify_host_name', full_name='create_listener_req._verify_host_name',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3757,
+  serialized_end=3992,
 )
 
 
 _DELETE_LISTENER_REQ = _descriptor.Descriptor(
-    name='delete_listener_req',
-    full_name='delete_listener_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='delete_listener_req.nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='host_name', full_name='delete_listener_req.host_name', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='traddr', full_name='delete_listener_req.traddr', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='adrfam', full_name='delete_listener_req.adrfam', index=3,
-            number=5, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trsvcid', full_name='delete_listener_req.trsvcid', index=4,
-            number=6, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='force', full_name='delete_listener_req.force', index=5,
-            number=7, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_adrfam', full_name='delete_listener_req._adrfam',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_trsvcid', full_name='delete_listener_req._trsvcid',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_force', full_name='delete_listener_req._force',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=3270,
-    serialized_end=3451,
+  name='delete_listener_req',
+  full_name='delete_listener_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='delete_listener_req.nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_name', full_name='delete_listener_req.host_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='traddr', full_name='delete_listener_req.traddr', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='adrfam', full_name='delete_listener_req.adrfam', index=3,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trsvcid', full_name='delete_listener_req.trsvcid', index=4,
+      number=6, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='delete_listener_req.force', index=5,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_adrfam', full_name='delete_listener_req._adrfam',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_trsvcid', full_name='delete_listener_req._trsvcid',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='delete_listener_req._force',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3995,
+  serialized_end=4176,
 )
 
 
 _LIST_LISTENERS_REQ = _descriptor.Descriptor(
-    name='list_listeners_req',
-    full_name='list_listeners_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem', full_name='list_listeners_req.subsystem', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=3453,
-    serialized_end=3492,
+  name='list_listeners_req',
+  full_name='list_listeners_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem', full_name='list_listeners_req.subsystem', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4178,
+  serialized_end=4217,
 )
 
 
 _LIST_SUBSYSTEMS_REQ = _descriptor.Descriptor(
-    name='list_subsystems_req',
-    full_name='list_subsystems_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='list_subsystems_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='serial_number', full_name='list_subsystems_req.serial_number', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_subsystem_nqn', full_name='list_subsystems_req._subsystem_nqn',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_serial_number', full_name='list_subsystems_req._serial_number',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=3494,
-    serialized_end=3607,
+  name='list_subsystems_req',
+  full_name='list_subsystems_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='list_subsystems_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='serial_number', full_name='list_subsystems_req.serial_number', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_subsystem_nqn', full_name='list_subsystems_req._subsystem_nqn',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_serial_number', full_name='list_subsystems_req._serial_number',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=4219,
+  serialized_end=4332,
 )
 
 
 _GET_SUBSYSTEMS_REQ = _descriptor.Descriptor(
-    name='get_subsystems_req',
-    full_name='get_subsystems_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=3609,
-    serialized_end=3629,
+  name='get_subsystems_req',
+  full_name='get_subsystems_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4334,
+  serialized_end=4354,
 )
 
 
 _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ = _descriptor.Descriptor(
-    name='get_spdk_nvmf_log_flags_and_level_req',
-    full_name='get_spdk_nvmf_log_flags_and_level_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='all_log_flags', full_name='get_spdk_nvmf_log_flags_and_level_req.all_log_flags', index=0,
-            number=1, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_all_log_flags', full_name='get_spdk_nvmf_log_flags_and_level_req._all_log_flags',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=3631,
-    serialized_end=3716,
+  name='get_spdk_nvmf_log_flags_and_level_req',
+  full_name='get_spdk_nvmf_log_flags_and_level_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='all_log_flags', full_name='get_spdk_nvmf_log_flags_and_level_req.all_log_flags', index=0,
+      number=1, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_all_log_flags', full_name='get_spdk_nvmf_log_flags_and_level_req._all_log_flags',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=4356,
+  serialized_end=4441,
 )
 
 
 _DISABLE_SPDK_NVMF_LOGS_REQ = _descriptor.Descriptor(
-    name='disable_spdk_nvmf_logs_req',
-    full_name='disable_spdk_nvmf_logs_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='extra_log_flags', full_name='disable_spdk_nvmf_logs_req.extra_log_flags', index=0,
-            number=1, type=9, cpp_type=9, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=3718,
-    serialized_end=3771,
+  name='disable_spdk_nvmf_logs_req',
+  full_name='disable_spdk_nvmf_logs_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='extra_log_flags', full_name='disable_spdk_nvmf_logs_req.extra_log_flags', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4443,
+  serialized_end=4496,
 )
 
 
 _SET_SPDK_NVMF_LOGS_REQ = _descriptor.Descriptor(
-    name='set_spdk_nvmf_logs_req',
-    full_name='set_spdk_nvmf_logs_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='log_level', full_name='set_spdk_nvmf_logs_req.log_level', index=0,
-            number=1, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='print_level', full_name='set_spdk_nvmf_logs_req.print_level', index=1,
-            number=2, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='extra_log_flags', full_name='set_spdk_nvmf_logs_req.extra_log_flags', index=2,
-            number=3, type=9, cpp_type=9, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_log_level', full_name='set_spdk_nvmf_logs_req._log_level',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_print_level', full_name='set_spdk_nvmf_logs_req._print_level',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=3774,
-    serialized_end=3925,
+  name='set_spdk_nvmf_logs_req',
+  full_name='set_spdk_nvmf_logs_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='log_level', full_name='set_spdk_nvmf_logs_req.log_level', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='print_level', full_name='set_spdk_nvmf_logs_req.print_level', index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='extra_log_flags', full_name='set_spdk_nvmf_logs_req.extra_log_flags', index=2,
+      number=3, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_log_level', full_name='set_spdk_nvmf_logs_req._log_level',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_print_level', full_name='set_spdk_nvmf_logs_req._print_level',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=4499,
+  serialized_end=4650,
 )
 
 
 _GET_GATEWAY_INFO_REQ = _descriptor.Descriptor(
-    name='get_gateway_info_req',
-    full_name='get_gateway_info_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='cli_version', full_name='get_gateway_info_req.cli_version', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_cli_version', full_name='get_gateway_info_req._cli_version',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=3927,
-    serialized_end=3991,
+  name='get_gateway_info_req',
+  full_name='get_gateway_info_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='cli_version', full_name='get_gateway_info_req.cli_version', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_cli_version', full_name='get_gateway_info_req._cli_version',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=4652,
+  serialized_end=4716,
 )
 
 
 _GET_GATEWAY_LOG_LEVEL_REQ = _descriptor.Descriptor(
-    name='get_gateway_log_level_req',
-    full_name='get_gateway_log_level_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=3993,
-    serialized_end=4020,
+  name='get_gateway_log_level_req',
+  full_name='get_gateway_log_level_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4718,
+  serialized_end=4745,
 )
 
 
 _SET_GATEWAY_LOG_LEVEL_REQ = _descriptor.Descriptor(
-    name='set_gateway_log_level_req',
-    full_name='set_gateway_log_level_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='log_level', full_name='set_gateway_log_level_req.log_level', index=0,
-            number=1, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4022,
-    serialized_end=4081,
+  name='set_gateway_log_level_req',
+  full_name='set_gateway_log_level_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='log_level', full_name='set_gateway_log_level_req.log_level', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4747,
+  serialized_end=4806,
 )
 
 
 _SHOW_GATEWAY_LISTENERS_INFO_REQ = _descriptor.Descriptor(
-    name='show_gateway_listeners_info_req',
-    full_name='show_gateway_listeners_info_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='show_gateway_listeners_info_req.subsystem_nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4083,
-    serialized_end=4139,
+  name='show_gateway_listeners_info_req',
+  full_name='show_gateway_listeners_info_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='show_gateway_listeners_info_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4808,
+  serialized_end=4864,
 )
 
 
 _GET_GATEWAY_STATS_REQ = _descriptor.Descriptor(
-    name='get_gateway_stats_req',
-    full_name='get_gateway_stats_req',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4141,
-    serialized_end=4164,
+  name='get_gateway_stats_req',
+  full_name='get_gateway_stats_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4866,
+  serialized_end=4889,
+)
+
+
+_GET_THREAD_STATS_REQ = _descriptor.Descriptor(
+  name='get_thread_stats_req',
+  full_name='get_thread_stats_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4891,
+  serialized_end=4913,
 )
 
 
 _ANA_GROUP_STATE = _descriptor.Descriptor(
-    name='ana_group_state',
-    full_name='ana_group_state',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='grp_id', full_name='ana_group_state.grp_id', index=0,
-            number=1, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='state', full_name='ana_group_state.state', index=1,
-            number=2, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4166,
-    serialized_end=4226,
+  name='ana_group_state',
+  full_name='ana_group_state',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='grp_id', full_name='ana_group_state.grp_id', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='state', full_name='ana_group_state.state', index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4915,
+  serialized_end=4975,
 )
 
 
 _NQN_ANA_STATES = _descriptor.Descriptor(
-    name='nqn_ana_states',
-    full_name='nqn_ana_states',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='nqn_ana_states.nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='states', full_name='nqn_ana_states.states', index=1,
-            number=2, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4228,
-    serialized_end=4291,
+  name='nqn_ana_states',
+  full_name='nqn_ana_states',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='nqn_ana_states.nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='states', full_name='nqn_ana_states.states', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4977,
+  serialized_end=5040,
 )
 
 
 _ANA_INFO = _descriptor.Descriptor(
-    name='ana_info',
-    full_name='ana_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='states', full_name='ana_info.states', index=0,
-            number=1, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4293,
-    serialized_end=4336,
+  name='ana_info',
+  full_name='ana_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='states', full_name='ana_info.states', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5042,
+  serialized_end=5085,
 )
 
 
 _REQ_STATUS = _descriptor.Descriptor(
-    name='req_status',
-    full_name='req_status',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='req_status.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='req_status.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4338,
-    serialized_end=4389,
+  name='req_status',
+  full_name='req_status',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='req_status.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='req_status.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5087,
+  serialized_end=5138,
 )
 
 
 _SUBSYS_STATUS = _descriptor.Descriptor(
-    name='subsys_status',
-    full_name='subsys_status',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='subsys_status.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='subsys_status.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='subsys_status.nqn', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4391,
-    serialized_end=4458,
+  name='subsys_status',
+  full_name='subsys_status',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='subsys_status.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='subsys_status.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='subsys_status.nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5140,
+  serialized_end=5207,
 )
 
 
 _NSID_STATUS = _descriptor.Descriptor(
-    name='nsid_status',
-    full_name='nsid_status',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='nsid_status.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='nsid_status.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='nsid_status.nsid', index=2,
-            number=3, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4460,
-    serialized_end=4526,
+  name='nsid_status',
+  full_name='nsid_status',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='nsid_status.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='nsid_status.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='nsid_status.nsid', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5209,
+  serialized_end=5275,
 )
 
 
 _SUBSYSTEMS_INFO = _descriptor.Descriptor(
-    name='subsystems_info',
-    full_name='subsystems_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='subsystems', full_name='subsystems_info.subsystems', index=0,
-            number=1, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=4528,
-    serialized_end=4577,
+  name='subsystems_info',
+  full_name='subsystems_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystems', full_name='subsystems_info.subsystems', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5277,
+  serialized_end=5326,
 )
 
 
 _SUBSYSTEM = _descriptor.Descriptor(
-    name='subsystem',
-    full_name='subsystem',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='subsystem.nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subtype', full_name='subsystem.subtype', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='listen_addresses', full_name='subsystem.listen_addresses', index=2,
-            number=3, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='hosts', full_name='subsystem.hosts', index=3,
-            number=4, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='allow_any_host', full_name='subsystem.allow_any_host', index=4,
-            number=5, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='serial_number', full_name='subsystem.serial_number', index=5,
-            number=6, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='model_number', full_name='subsystem.model_number', index=6,
-            number=7, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_namespaces', full_name='subsystem.max_namespaces', index=7,
-            number=8, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='min_cntlid', full_name='subsystem.min_cntlid', index=8,
-            number=9, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_cntlid', full_name='subsystem.max_cntlid', index=9,
-            number=10, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='namespaces', full_name='subsystem.namespaces', index=10,
-            number=11, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='has_dhchap_key', full_name='subsystem.has_dhchap_key', index=11,
-            number=12, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_serial_number', full_name='subsystem._serial_number',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_model_number', full_name='subsystem._model_number',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_max_namespaces', full_name='subsystem._max_namespaces',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_min_cntlid', full_name='subsystem._min_cntlid',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_max_cntlid', full_name='subsystem._max_cntlid',
-            index=4, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_has_dhchap_key', full_name='subsystem._has_dhchap_key',
-            index=5, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=4580,
-    serialized_end=5008,
+  name='subsystem',
+  full_name='subsystem',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='subsystem.nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subtype', full_name='subsystem.subtype', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='listen_addresses', full_name='subsystem.listen_addresses', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='hosts', full_name='subsystem.hosts', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='allow_any_host', full_name='subsystem.allow_any_host', index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='serial_number', full_name='subsystem.serial_number', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='model_number', full_name='subsystem.model_number', index=6,
+      number=7, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_namespaces', full_name='subsystem.max_namespaces', index=7,
+      number=8, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_cntlid', full_name='subsystem.min_cntlid', index=8,
+      number=9, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_cntlid', full_name='subsystem.max_cntlid', index=9,
+      number=10, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='namespaces', full_name='subsystem.namespaces', index=10,
+      number=11, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='has_dhchap_key', full_name='subsystem.has_dhchap_key', index=11,
+      number=12, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='network_mask', full_name='subsystem.network_mask', index=12,
+      number=13, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_serial_number', full_name='subsystem._serial_number',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_model_number', full_name='subsystem._model_number',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_max_namespaces', full_name='subsystem._max_namespaces',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_min_cntlid', full_name='subsystem._min_cntlid',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_max_cntlid', full_name='subsystem._max_cntlid',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_has_dhchap_key', full_name='subsystem._has_dhchap_key',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=5329,
+  serialized_end=5779,
 )
 
 
 _LISTEN_ADDRESS = _descriptor.Descriptor(
-    name='listen_address',
-    full_name='listen_address',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='trtype', full_name='listen_address.trtype', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='adrfam', full_name='listen_address.adrfam', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='traddr', full_name='listen_address.traddr', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trsvcid', full_name='listen_address.trsvcid', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='transport', full_name='listen_address.transport', index=4,
-            number=5, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='secure', full_name='listen_address.secure', index=5,
-            number=6, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_transport', full_name='listen_address._transport',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_secure', full_name='listen_address._secure',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=5011,
-    serialized_end=5162,
+  name='listen_address',
+  full_name='listen_address',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='trtype', full_name='listen_address.trtype', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='adrfam', full_name='listen_address.adrfam', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='traddr', full_name='listen_address.traddr', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trsvcid', full_name='listen_address.trsvcid', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='transport', full_name='listen_address.transport', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='secure', full_name='listen_address.secure', index=5,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_transport', full_name='listen_address._transport',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_secure', full_name='listen_address._secure',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=5782,
+  serialized_end=5933,
 )
 
 
 _NAMESPACE = _descriptor.Descriptor(
-    name='namespace',
-    full_name='namespace',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace.nsid', index=0,
-            number=1, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='name', full_name='namespace.name', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='bdev_name', full_name='namespace.bdev_name', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nguid', full_name='namespace.nguid', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='uuid', full_name='namespace.uuid', index=4,
-            number=5, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='anagrpid', full_name='namespace.anagrpid', index=5,
-            number=6, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nonce', full_name='namespace.nonce', index=6,
-            number=7, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='auto_visible', full_name='namespace.auto_visible', index=7,
-            number=8, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='hosts', full_name='namespace.hosts', index=8,
-            number=9, type=9, cpp_type=9, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_bdev_name', full_name='namespace._bdev_name',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_nguid', full_name='namespace._nguid',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_uuid', full_name='namespace._uuid',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_anagrpid', full_name='namespace._anagrpid',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_nonce', full_name='namespace._nonce',
-            index=4, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_auto_visible', full_name='namespace._auto_visible',
-            index=5, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=5165,
-    serialized_end=5425,
+  name='namespace',
+  full_name='namespace',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace.nsid', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='name', full_name='namespace.name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bdev_name', full_name='namespace.bdev_name', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nguid', full_name='namespace.nguid', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='uuid', full_name='namespace.uuid', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='anagrpid', full_name='namespace.anagrpid', index=5,
+      number=6, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nonce', full_name='namespace.nonce', index=6,
+      number=7, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='auto_visible', full_name='namespace.auto_visible', index=7,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='hosts', full_name='namespace.hosts', index=8,
+      number=9, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_bdev_name', full_name='namespace._bdev_name',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_nguid', full_name='namespace._nguid',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_uuid', full_name='namespace._uuid',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_anagrpid', full_name='namespace._anagrpid',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_nonce', full_name='namespace._nonce',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_auto_visible', full_name='namespace._auto_visible',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=5936,
+  serialized_end=6196,
 )
 
 
 _SUBSYSTEMS_INFO_CLI = _descriptor.Descriptor(
-    name='subsystems_info_cli',
-    full_name='subsystems_info_cli',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='subsystems_info_cli.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='subsystems_info_cli.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subsystems', full_name='subsystems_info_cli.subsystems', index=2,
-            number=3, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=5427,
-    serialized_end=5523,
+  name='subsystems_info_cli',
+  full_name='subsystems_info_cli',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='subsystems_info_cli.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='subsystems_info_cli.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystems', full_name='subsystems_info_cli.subsystems', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6198,
+  serialized_end=6294,
 )
 
 
 _SUBSYSTEM_CLI = _descriptor.Descriptor(
-    name='subsystem_cli',
-    full_name='subsystem_cli',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='subsystem_cli.nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='enable_ha', full_name='subsystem_cli.enable_ha', index=1,
-            number=2, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='serial_number', full_name='subsystem_cli.serial_number', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='model_number', full_name='subsystem_cli.model_number', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='min_cntlid', full_name='subsystem_cli.min_cntlid', index=4,
-            number=5, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_cntlid', full_name='subsystem_cli.max_cntlid', index=5,
-            number=6, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='namespace_count', full_name='subsystem_cli.namespace_count', index=6,
-            number=7, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subtype', full_name='subsystem_cli.subtype', index=7,
-            number=8, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_namespaces', full_name='subsystem_cli.max_namespaces', index=8,
-            number=9, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='has_dhchap_key', full_name='subsystem_cli.has_dhchap_key', index=9,
-            number=10, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='allow_any_host', full_name='subsystem_cli.allow_any_host', index=10,
-            number=11, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='created_without_key', full_name='subsystem_cli.created_without_key', index=11,
-            number=12, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_has_dhchap_key', full_name='subsystem_cli._has_dhchap_key',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_allow_any_host', full_name='subsystem_cli._allow_any_host',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_created_without_key', full_name='subsystem_cli._created_without_key',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=5526,
-    serialized_end=5878,
+  name='subsystem_cli',
+  full_name='subsystem_cli',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='subsystem_cli.nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='enable_ha', full_name='subsystem_cli.enable_ha', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='serial_number', full_name='subsystem_cli.serial_number', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='model_number', full_name='subsystem_cli.model_number', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_cntlid', full_name='subsystem_cli.min_cntlid', index=4,
+      number=5, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_cntlid', full_name='subsystem_cli.max_cntlid', index=5,
+      number=6, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='namespace_count', full_name='subsystem_cli.namespace_count', index=6,
+      number=7, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subtype', full_name='subsystem_cli.subtype', index=7,
+      number=8, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_namespaces', full_name='subsystem_cli.max_namespaces', index=8,
+      number=9, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='has_dhchap_key', full_name='subsystem_cli.has_dhchap_key', index=9,
+      number=10, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='allow_any_host', full_name='subsystem_cli.allow_any_host', index=10,
+      number=11, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='created_without_key', full_name='subsystem_cli.created_without_key', index=11,
+      number=12, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='network_mask', full_name='subsystem_cli.network_mask', index=12,
+      number=13, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_has_dhchap_key', full_name='subsystem_cli._has_dhchap_key',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_allow_any_host', full_name='subsystem_cli._allow_any_host',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_created_without_key', full_name='subsystem_cli._created_without_key',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=6297,
+  serialized_end=6671,
 )
 
 
 _GATEWAY_INFO = _descriptor.Descriptor(
-    name='gateway_info',
-    full_name='gateway_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='cli_version', full_name='gateway_info.cli_version', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='version', full_name='gateway_info.version', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='name', full_name='gateway_info.name', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='group', full_name='gateway_info.group', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='addr', full_name='gateway_info.addr', index=4,
-            number=5, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='port', full_name='gateway_info.port', index=5,
-            number=6, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='bool_status', full_name='gateway_info.bool_status', index=6,
-            number=7, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='status', full_name='gateway_info.status', index=7,
-            number=8, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='gateway_info.error_message', index=8,
-            number=9, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='spdk_version', full_name='gateway_info.spdk_version', index=9,
-            number=10, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='load_balancing_group', full_name='gateway_info.load_balancing_group', index=10,
-            number=11, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='hostname', full_name='gateway_info.hostname', index=11,
-            number=12, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_subsystems', full_name='gateway_info.max_subsystems', index=12,
-            number=13, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_namespaces', full_name='gateway_info.max_namespaces', index=13,
-            number=14, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_hosts_per_subsystem', full_name='gateway_info.max_hosts_per_subsystem', index=14,
-            number=15, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_namespaces_per_subsystem', full_name='gateway_info.max_namespaces_per_subsystem', index=15,
-            number=16, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_hosts', full_name='gateway_info.max_hosts', index=16,
-            number=17, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_spdk_version', full_name='gateway_info._spdk_version',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_max_subsystems', full_name='gateway_info._max_subsystems',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_max_namespaces', full_name='gateway_info._max_namespaces',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_max_hosts_per_subsystem', full_name='gateway_info._max_hosts_per_subsystem',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_max_namespaces_per_subsystem', full_name='gateway_info._max_namespaces_per_subsystem',
-            index=4, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_max_hosts', full_name='gateway_info._max_hosts',
-            index=5, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=5881,
-    serialized_end=6418,
+  name='gateway_info',
+  full_name='gateway_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='cli_version', full_name='gateway_info.cli_version', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='gateway_info.version', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='name', full_name='gateway_info.name', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='group', full_name='gateway_info.group', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='addr', full_name='gateway_info.addr', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='port', full_name='gateway_info.port', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bool_status', full_name='gateway_info.bool_status', index=6,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='status', full_name='gateway_info.status', index=7,
+      number=8, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='gateway_info.error_message', index=8,
+      number=9, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='spdk_version', full_name='gateway_info.spdk_version', index=9,
+      number=10, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='load_balancing_group', full_name='gateway_info.load_balancing_group', index=10,
+      number=11, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='hostname', full_name='gateway_info.hostname', index=11,
+      number=12, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_subsystems', full_name='gateway_info.max_subsystems', index=12,
+      number=13, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_namespaces', full_name='gateway_info.max_namespaces', index=13,
+      number=14, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_hosts_per_subsystem', full_name='gateway_info.max_hosts_per_subsystem', index=14,
+      number=15, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_namespaces_per_subsystem', full_name='gateway_info.max_namespaces_per_subsystem', index=15,
+      number=16, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_hosts', full_name='gateway_info.max_hosts', index=16,
+      number=17, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='gateway_initialization_over', full_name='gateway_info.gateway_initialization_over', index=17,
+      number=18, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_spdk_version', full_name='gateway_info._spdk_version',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_max_subsystems', full_name='gateway_info._max_subsystems',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_max_namespaces', full_name='gateway_info._max_namespaces',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_max_hosts_per_subsystem', full_name='gateway_info._max_hosts_per_subsystem',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_max_namespaces_per_subsystem', full_name='gateway_info._max_namespaces_per_subsystem',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_max_hosts', full_name='gateway_info._max_hosts',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_gateway_initialization_over', full_name='gateway_info._gateway_initialization_over',
+      index=6, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=6674,
+  serialized_end=7285,
 )
 
 
 _CLI_VERSION = _descriptor.Descriptor(
-    name='cli_version',
-    full_name='cli_version',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='cli_version.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='cli_version.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='version', full_name='cli_version.version', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=6420,
-    serialized_end=6489,
+  name='cli_version',
+  full_name='cli_version',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='cli_version.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='cli_version.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='cli_version.version', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7287,
+  serialized_end=7356,
 )
 
 
 _GW_VERSION = _descriptor.Descriptor(
-    name='gw_version',
-    full_name='gw_version',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='gw_version.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='gw_version.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='version', full_name='gw_version.version', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=6491,
-    serialized_end=6559,
+  name='gw_version',
+  full_name='gw_version',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='gw_version.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='gw_version.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='gw_version.version', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7358,
+  serialized_end=7426,
 )
 
 
 _POLL_GROUP_TRANSPORT_INFO = _descriptor.Descriptor(
-    name='poll_group_transport_info',
-    full_name='poll_group_transport_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='trtype', full_name='poll_group_transport_info.trtype', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=6561,
-    serialized_end=6604,
+  name='poll_group_transport_info',
+  full_name='poll_group_transport_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='trtype', full_name='poll_group_transport_info.trtype', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7428,
+  serialized_end=7471,
 )
 
 
 _POLL_GROUP_INFO = _descriptor.Descriptor(
-    name='poll_group_info',
-    full_name='poll_group_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='name', full_name='poll_group_info.name', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='admin_qpairs', full_name='poll_group_info.admin_qpairs', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='io_qpairs', full_name='poll_group_info.io_qpairs', index=2,
-            number=3, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='current_admin_qpairs', full_name='poll_group_info.current_admin_qpairs', index=3,
-            number=4, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='current_io_qpairs', full_name='poll_group_info.current_io_qpairs', index=4,
-            number=5, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='pending_bdev_io', full_name='poll_group_info.pending_bdev_io', index=5,
-            number=6, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='completed_nvme_io', full_name='poll_group_info.completed_nvme_io', index=6,
-            number=7, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='transports', full_name='poll_group_info.transports', index=7,
-            number=8, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=6607,
-    serialized_end=6836,
+  name='poll_group_info',
+  full_name='poll_group_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='poll_group_info.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='admin_qpairs', full_name='poll_group_info.admin_qpairs', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='io_qpairs', full_name='poll_group_info.io_qpairs', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='current_admin_qpairs', full_name='poll_group_info.current_admin_qpairs', index=3,
+      number=4, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='current_io_qpairs', full_name='poll_group_info.current_io_qpairs', index=4,
+      number=5, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='pending_bdev_io', full_name='poll_group_info.pending_bdev_io', index=5,
+      number=6, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='completed_nvme_io', full_name='poll_group_info.completed_nvme_io', index=6,
+      number=7, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='transports', full_name='poll_group_info.transports', index=7,
+      number=8, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7474,
+  serialized_end=7703,
 )
 
 
 _GATEWAY_STATS_INFO = _descriptor.Descriptor(
-    name='gateway_stats_info',
-    full_name='gateway_stats_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='gateway_stats_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='gateway_stats_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='tick_rate', full_name='gateway_stats_info.tick_rate', index=2,
-            number=3, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='poll_groups', full_name='gateway_stats_info.poll_groups', index=3,
-            number=4, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=6838,
-    serialized_end=6955,
+  name='gateway_stats_info',
+  full_name='gateway_stats_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='gateway_stats_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='gateway_stats_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='tick_rate', full_name='gateway_stats_info.tick_rate', index=2,
+      number=3, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='poll_groups', full_name='gateway_stats_info.poll_groups', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7705,
+  serialized_end=7822,
+)
+
+
+_THREAD_STATS_INFO = _descriptor.Descriptor(
+  name='thread_stats_info',
+  full_name='thread_stats_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='thread_stats_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='thread_stats_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='threads', full_name='thread_stats_info.threads', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='tick_rate', full_name='thread_stats_info.tick_rate', index=3,
+      number=4, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7824,
+  serialized_end=7937,
+)
+
+
+_SPDK_THREAD_INFO = _descriptor.Descriptor(
+  name='spdk_thread_info',
+  full_name='spdk_thread_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='spdk_thread_info.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='busy', full_name='spdk_thread_info.busy', index=1,
+      number=2, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='idle', full_name='spdk_thread_info.idle', index=2,
+      number=3, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7939,
+  serialized_end=7999,
 )
 
 
 _LISTENER_INFO = _descriptor.Descriptor(
-    name='listener_info',
-    full_name='listener_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='host_name', full_name='listener_info.host_name', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trtype', full_name='listener_info.trtype', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='adrfam', full_name='listener_info.adrfam', index=2,
-            number=3, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='traddr', full_name='listener_info.traddr', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trsvcid', full_name='listener_info.trsvcid', index=4,
-            number=5, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='secure', full_name='listener_info.secure', index=5,
-            number=6, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='active', full_name='listener_info.active', index=6,
-            number=7, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_secure', full_name='listener_info._secure',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_active', full_name='listener_info._active',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=6958,
-    serialized_end=7137,
+  name='listener_info',
+  full_name='listener_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='host_name', full_name='listener_info.host_name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trtype', full_name='listener_info.trtype', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='adrfam', full_name='listener_info.adrfam', index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='traddr', full_name='listener_info.traddr', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trsvcid', full_name='listener_info.trsvcid', index=4,
+      number=5, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='secure', full_name='listener_info.secure', index=5,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='active', full_name='listener_info.active', index=6,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='manual', full_name='listener_info.manual', index=7,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_secure', full_name='listener_info._secure',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_active', full_name='listener_info._active',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_manual', full_name='listener_info._manual',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=8002,
+  serialized_end=8213,
 )
 
 
 _LISTENERS_INFO = _descriptor.Descriptor(
-    name='listeners_info',
-    full_name='listeners_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='listeners_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='listeners_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='listeners', full_name='listeners_info.listeners', index=2,
-            number=3, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=7139,
-    serialized_end=7229,
+  name='listeners_info',
+  full_name='listeners_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='listeners_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='listeners_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='listeners', full_name='listeners_info.listeners', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=8215,
+  serialized_end=8305,
 )
 
 
 _GATEWAY_LISTENER_INFO = _descriptor.Descriptor(
-    name='gateway_listener_info',
-    full_name='gateway_listener_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='listener', full_name='gateway_listener_info.listener', index=0,
-            number=1, type=11, cpp_type=10, label=1,
-            has_default_value=False, default_value=None,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='lb_states', full_name='gateway_listener_info.lb_states', index=1,
-            number=2, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=7231,
-    serialized_end=7325,
+  name='gateway_listener_info',
+  full_name='gateway_listener_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='listener', full_name='gateway_listener_info.listener', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='lb_states', full_name='gateway_listener_info.lb_states', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=8307,
+  serialized_end=8401,
 )
 
 
 _GATEWAY_LISTENERS_INFO = _descriptor.Descriptor(
-    name='gateway_listeners_info',
-    full_name='gateway_listeners_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='gateway_listeners_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='gateway_listeners_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='gw_listeners', full_name='gateway_listeners_info.gw_listeners', index=2,
-            number=3, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=7327,
-    serialized_end=7436,
+  name='gateway_listeners_info',
+  full_name='gateway_listeners_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='gateway_listeners_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='gateway_listeners_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='gw_listeners', full_name='gateway_listeners_info.gw_listeners', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=8403,
+  serialized_end=8512,
 )
 
 
 _HOST = _descriptor.Descriptor(
-    name='host',
-    full_name='host',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='host.nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='use_psk', full_name='host.use_psk', index=1,
-            number=2, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='use_dhchap', full_name='host.use_dhchap', index=2,
-            number=3, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='disconnected_due_to_keepalive_timeout', full_name='host.disconnected_due_to_keepalive_timeout', index=3,
-            number=4, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_use_psk', full_name='host._use_psk',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_use_dhchap', full_name='host._use_dhchap',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_disconnected_due_to_keepalive_timeout', full_name='host._disconnected_due_to_keepalive_timeout',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=7439,
-    serialized_end=7626,
+  name='host',
+  full_name='host',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='host.nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='use_psk', full_name='host.use_psk', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='use_dhchap', full_name='host.use_dhchap', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='disconnected_due_to_keepalive_timeout', full_name='host.disconnected_due_to_keepalive_timeout', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_use_psk', full_name='host._use_psk',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_use_dhchap', full_name='host._use_dhchap',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_disconnected_due_to_keepalive_timeout', full_name='host._disconnected_due_to_keepalive_timeout',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=8515,
+  serialized_end=8702,
 )
 
 
 _HOSTS_INFO = _descriptor.Descriptor(
-    name='hosts_info',
-    full_name='hosts_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='hosts_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='hosts_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='allow_any_host', full_name='hosts_info.allow_any_host', index=2,
-            number=3, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='hosts_info.subsystem_nqn', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='hosts', full_name='hosts_info.hosts', index=4,
-            number=5, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=7628,
-    serialized_end=7748,
+  name='hosts_info',
+  full_name='hosts_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='hosts_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='hosts_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='allow_any_host', full_name='hosts_info.allow_any_host', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='hosts_info.subsystem_nqn', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='hosts', full_name='hosts_info.hosts', index=4,
+      number=5, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=8704,
+  serialized_end=8824,
 )
 
 
 _CONNECTION = _descriptor.Descriptor(
-    name='connection',
-    full_name='connection',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nqn', full_name='connection.nqn', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='traddr', full_name='connection.traddr', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trsvcid', full_name='connection.trsvcid', index=2,
-            number=3, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trtype', full_name='connection.trtype', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='adrfam', full_name='connection.adrfam', index=4,
-            number=5, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='connected', full_name='connection.connected', index=5,
-            number=6, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='qpairs_count', full_name='connection.qpairs_count', index=6,
-            number=7, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='controller_id', full_name='connection.controller_id', index=7,
-            number=8, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='secure', full_name='connection.secure', index=8,
-            number=9, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='use_psk', full_name='connection.use_psk', index=9,
-            number=10, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='use_dhchap', full_name='connection.use_dhchap', index=10,
-            number=11, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subsystem', full_name='connection.subsystem', index=11,
-            number=12, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='disconnected_due_to_keepalive_timeout', full_name='connection.disconnected_due_to_keepalive_timeout', index=12,
-            number=13, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_secure', full_name='connection._secure',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_use_psk', full_name='connection._use_psk',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_use_dhchap', full_name='connection._use_dhchap',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_subsystem', full_name='connection._subsystem',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_disconnected_due_to_keepalive_timeout', full_name='connection._disconnected_due_to_keepalive_timeout',
-            index=4, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=7751,
-    serialized_end=8159,
+  name='connection',
+  full_name='connection',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nqn', full_name='connection.nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='traddr', full_name='connection.traddr', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trsvcid', full_name='connection.trsvcid', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trtype', full_name='connection.trtype', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='adrfam', full_name='connection.adrfam', index=4,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='connected', full_name='connection.connected', index=5,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='qpairs_count', full_name='connection.qpairs_count', index=6,
+      number=7, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='controller_id', full_name='connection.controller_id', index=7,
+      number=8, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='secure', full_name='connection.secure', index=8,
+      number=9, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='use_psk', full_name='connection.use_psk', index=9,
+      number=10, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='use_dhchap', full_name='connection.use_dhchap', index=10,
+      number=11, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystem', full_name='connection.subsystem', index=11,
+      number=12, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='disconnected_due_to_keepalive_timeout', full_name='connection.disconnected_due_to_keepalive_timeout', index=12,
+      number=13, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_secure', full_name='connection._secure',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_use_psk', full_name='connection._use_psk',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_use_dhchap', full_name='connection._use_dhchap',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_subsystem', full_name='connection._subsystem',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_disconnected_due_to_keepalive_timeout', full_name='connection._disconnected_due_to_keepalive_timeout',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=8827,
+  serialized_end=9235,
 )
 
 
 _CONNECTIONS_INFO = _descriptor.Descriptor(
-    name='connections_info',
-    full_name='connections_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='connections_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='connections_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='connections_info.subsystem_nqn', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='connections', full_name='connections_info.connections', index=3,
-            number=4, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=8161,
-    serialized_end=8275,
+  name='connections_info',
+  full_name='connections_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='connections_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='connections_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='connections_info.subsystem_nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='connections', full_name='connections_info.connections', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=9237,
+  serialized_end=9351,
 )
 
 
 _NAMESPACE_CLI = _descriptor.Descriptor(
-    name='namespace_cli',
-    full_name='namespace_cli',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_cli.nsid', index=0,
-            number=1, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='bdev_name', full_name='namespace_cli.bdev_name', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rbd_image_name', full_name='namespace_cli.rbd_image_name', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rbd_pool_name', full_name='namespace_cli.rbd_pool_name', index=3,
-            number=4, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='load_balancing_group', full_name='namespace_cli.load_balancing_group', index=4,
-            number=5, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='block_size', full_name='namespace_cli.block_size', index=5,
-            number=6, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rbd_image_size', full_name='namespace_cli.rbd_image_size', index=6,
-            number=7, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='uuid', full_name='namespace_cli.uuid', index=7,
-            number=8, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rw_ios_per_second', full_name='namespace_cli.rw_ios_per_second', index=8,
-            number=9, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='rw_mbytes_per_second', full_name='namespace_cli.rw_mbytes_per_second', index=9,
-            number=10, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='r_mbytes_per_second', full_name='namespace_cli.r_mbytes_per_second', index=10,
-            number=11, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='w_mbytes_per_second', full_name='namespace_cli.w_mbytes_per_second', index=11,
-            number=12, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='auto_visible', full_name='namespace_cli.auto_visible', index=12,
-            number=13, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='hosts', full_name='namespace_cli.hosts', index=13,
-            number=14, type=9, cpp_type=9, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='ns_subsystem_nqn', full_name='namespace_cli.ns_subsystem_nqn', index=14,
-            number=15, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='trash_image', full_name='namespace_cli.trash_image', index=15,
-            number=16, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='disable_auto_resize', full_name='namespace_cli.disable_auto_resize', index=16,
-            number=17, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='read_only', full_name='namespace_cli.read_only', index=17,
-            number=18, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='cluster_name', full_name='namespace_cli.cluster_name', index=18,
-            number=19, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='configured_load_balancing_group', full_name='namespace_cli.configured_load_balancing_group', index=19,
-            number=20, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='image_was_shrunk', full_name='namespace_cli.image_was_shrunk', index=20,
-            number=21, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_ns_subsystem_nqn', full_name='namespace_cli._ns_subsystem_nqn',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_trash_image', full_name='namespace_cli._trash_image',
-            index=1, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_disable_auto_resize', full_name='namespace_cli._disable_auto_resize',
-            index=2, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_read_only', full_name='namespace_cli._read_only',
-            index=3, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_cluster_name', full_name='namespace_cli._cluster_name',
-            index=4, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_configured_load_balancing_group', full_name='namespace_cli._configured_load_balancing_group',
-            index=5, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-        _descriptor.OneofDescriptor(
-            name='_image_was_shrunk', full_name='namespace_cli._image_was_shrunk',
-            index=6, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=8278,
-    serialized_end=8981,
+  name='namespace_cli',
+  full_name='namespace_cli',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_cli.nsid', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bdev_name', full_name='namespace_cli.bdev_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rbd_image_name', full_name='namespace_cli.rbd_image_name', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rbd_pool_name', full_name='namespace_cli.rbd_pool_name', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='load_balancing_group', full_name='namespace_cli.load_balancing_group', index=4,
+      number=5, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='block_size', full_name='namespace_cli.block_size', index=5,
+      number=6, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rbd_image_size', full_name='namespace_cli.rbd_image_size', index=6,
+      number=7, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='uuid', full_name='namespace_cli.uuid', index=7,
+      number=8, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rw_ios_per_second', full_name='namespace_cli.rw_ios_per_second', index=8,
+      number=9, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rw_mbytes_per_second', full_name='namespace_cli.rw_mbytes_per_second', index=9,
+      number=10, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='r_mbytes_per_second', full_name='namespace_cli.r_mbytes_per_second', index=10,
+      number=11, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='w_mbytes_per_second', full_name='namespace_cli.w_mbytes_per_second', index=11,
+      number=12, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='auto_visible', full_name='namespace_cli.auto_visible', index=12,
+      number=13, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='hosts', full_name='namespace_cli.hosts', index=13,
+      number=14, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='ns_subsystem_nqn', full_name='namespace_cli.ns_subsystem_nqn', index=14,
+      number=15, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='trash_image', full_name='namespace_cli.trash_image', index=15,
+      number=16, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='disable_auto_resize', full_name='namespace_cli.disable_auto_resize', index=16,
+      number=17, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='read_only', full_name='namespace_cli.read_only', index=17,
+      number=18, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='cluster_name', full_name='namespace_cli.cluster_name', index=18,
+      number=19, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='configured_load_balancing_group', full_name='namespace_cli.configured_load_balancing_group', index=19,
+      number=20, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='image_was_shrunk', full_name='namespace_cli.image_was_shrunk', index=20,
+      number=21, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rbd_data_pool_name', full_name='namespace_cli.rbd_data_pool_name', index=21,
+      number=22, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='location', full_name='namespace_cli.location', index=22,
+      number=23, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='rados_namespace_name', full_name='namespace_cli.rados_namespace_name', index=23,
+      number=24, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_ns_subsystem_nqn', full_name='namespace_cli._ns_subsystem_nqn',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_trash_image', full_name='namespace_cli._trash_image',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_disable_auto_resize', full_name='namespace_cli._disable_auto_resize',
+      index=2, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_read_only', full_name='namespace_cli._read_only',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_cluster_name', full_name='namespace_cli._cluster_name',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_configured_load_balancing_group', full_name='namespace_cli._configured_load_balancing_group',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_image_was_shrunk', full_name='namespace_cli._image_was_shrunk',
+      index=6, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_rbd_data_pool_name', full_name='namespace_cli._rbd_data_pool_name',
+      index=7, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_location', full_name='namespace_cli._location',
+      index=8, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_rados_namespace_name', full_name='namespace_cli._rados_namespace_name',
+      index=9, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=9354,
+  serialized_end=10209,
 )
 
 
 _NAMESPACES_INFO = _descriptor.Descriptor(
-    name='namespaces_info',
-    full_name='namespaces_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='namespaces_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='namespaces_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespaces_info.subsystem_nqn', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='namespaces', full_name='namespaces_info.namespaces', index=3,
-            number=4, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=8983,
-    serialized_end=9098,
+  name='namespaces_info',
+  full_name='namespaces_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='namespaces_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='namespaces_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespaces_info.subsystem_nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='namespaces', full_name='namespaces_info.namespaces', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=10211,
+  serialized_end=10326,
 )
 
 
 _NAMESPACE_IO_ERROR = _descriptor.Descriptor(
-    name='namespace_io_error',
-    full_name='namespace_io_error',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='name', full_name='namespace_io_error.name', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='value', full_name='namespace_io_error.value', index=1,
-            number=2, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=9100,
-    serialized_end=9149,
+  name='namespace_io_error',
+  full_name='namespace_io_error',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='namespace_io_error.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='namespace_io_error.value', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=10328,
+  serialized_end=10377,
 )
 
 
 _NAMESPACE_IO_STATS_INFO = _descriptor.Descriptor(
-    name='namespace_io_stats_info',
-    full_name='namespace_io_stats_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='namespace_io_stats_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='namespace_io_stats_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='subsystem_nqn', full_name='namespace_io_stats_info.subsystem_nqn', index=2,
-            number=3, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nsid', full_name='namespace_io_stats_info.nsid', index=3,
-            number=4, type=13, cpp_type=3, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='uuid', full_name='namespace_io_stats_info.uuid', index=4,
-            number=5, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='bdev_name', full_name='namespace_io_stats_info.bdev_name', index=5,
-            number=6, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='tick_rate', full_name='namespace_io_stats_info.tick_rate', index=6,
-            number=7, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='ticks', full_name='namespace_io_stats_info.ticks', index=7,
-            number=8, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='bytes_read', full_name='namespace_io_stats_info.bytes_read', index=8,
-            number=9, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='num_read_ops', full_name='namespace_io_stats_info.num_read_ops', index=9,
-            number=10, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='bytes_written', full_name='namespace_io_stats_info.bytes_written', index=10,
-            number=11, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='num_write_ops', full_name='namespace_io_stats_info.num_write_ops', index=11,
-            number=12, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='bytes_unmapped', full_name='namespace_io_stats_info.bytes_unmapped', index=12,
-            number=13, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='num_unmap_ops', full_name='namespace_io_stats_info.num_unmap_ops', index=13,
-            number=14, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='read_latency_ticks', full_name='namespace_io_stats_info.read_latency_ticks', index=14,
-            number=15, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_read_latency_ticks', full_name='namespace_io_stats_info.max_read_latency_ticks', index=15,
-            number=16, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='min_read_latency_ticks', full_name='namespace_io_stats_info.min_read_latency_ticks', index=16,
-            number=17, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='write_latency_ticks', full_name='namespace_io_stats_info.write_latency_ticks', index=17,
-            number=18, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_write_latency_ticks', full_name='namespace_io_stats_info.max_write_latency_ticks', index=18,
-            number=19, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='min_write_latency_ticks', full_name='namespace_io_stats_info.min_write_latency_ticks', index=19,
-            number=20, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='unmap_latency_ticks', full_name='namespace_io_stats_info.unmap_latency_ticks', index=20,
-            number=21, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_unmap_latency_ticks', full_name='namespace_io_stats_info.max_unmap_latency_ticks', index=21,
-            number=22, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='min_unmap_latency_ticks', full_name='namespace_io_stats_info.min_unmap_latency_ticks', index=22,
-            number=23, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='copy_latency_ticks', full_name='namespace_io_stats_info.copy_latency_ticks', index=23,
-            number=24, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='max_copy_latency_ticks', full_name='namespace_io_stats_info.max_copy_latency_ticks', index=24,
-            number=25, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='min_copy_latency_ticks', full_name='namespace_io_stats_info.min_copy_latency_ticks', index=25,
-            number=26, type=4, cpp_type=4, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='io_error', full_name='namespace_io_stats_info.io_error', index=26,
-            number=27, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name='_uuid', full_name='namespace_io_stats_info._uuid',
-            index=0, containing_type=None,
-            create_key=_descriptor._internal_create_key,
-            fields=[]),
-    ],
-    serialized_start=9152,
-    serialized_end=9882,
+  name='namespace_io_stats_info',
+  full_name='namespace_io_stats_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='namespace_io_stats_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='namespace_io_stats_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='namespace_io_stats_info.subsystem_nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='namespace_io_stats_info.nsid', index=3,
+      number=4, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='uuid', full_name='namespace_io_stats_info.uuid', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bdev_name', full_name='namespace_io_stats_info.bdev_name', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='tick_rate', full_name='namespace_io_stats_info.tick_rate', index=6,
+      number=7, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='ticks', full_name='namespace_io_stats_info.ticks', index=7,
+      number=8, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bytes_read', full_name='namespace_io_stats_info.bytes_read', index=8,
+      number=9, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='num_read_ops', full_name='namespace_io_stats_info.num_read_ops', index=9,
+      number=10, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bytes_written', full_name='namespace_io_stats_info.bytes_written', index=10,
+      number=11, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='num_write_ops', full_name='namespace_io_stats_info.num_write_ops', index=11,
+      number=12, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bytes_unmapped', full_name='namespace_io_stats_info.bytes_unmapped', index=12,
+      number=13, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='num_unmap_ops', full_name='namespace_io_stats_info.num_unmap_ops', index=13,
+      number=14, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='read_latency_ticks', full_name='namespace_io_stats_info.read_latency_ticks', index=14,
+      number=15, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_read_latency_ticks', full_name='namespace_io_stats_info.max_read_latency_ticks', index=15,
+      number=16, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_read_latency_ticks', full_name='namespace_io_stats_info.min_read_latency_ticks', index=16,
+      number=17, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='write_latency_ticks', full_name='namespace_io_stats_info.write_latency_ticks', index=17,
+      number=18, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_write_latency_ticks', full_name='namespace_io_stats_info.max_write_latency_ticks', index=18,
+      number=19, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_write_latency_ticks', full_name='namespace_io_stats_info.min_write_latency_ticks', index=19,
+      number=20, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='unmap_latency_ticks', full_name='namespace_io_stats_info.unmap_latency_ticks', index=20,
+      number=21, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_unmap_latency_ticks', full_name='namespace_io_stats_info.max_unmap_latency_ticks', index=21,
+      number=22, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_unmap_latency_ticks', full_name='namespace_io_stats_info.min_unmap_latency_ticks', index=22,
+      number=23, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='copy_latency_ticks', full_name='namespace_io_stats_info.copy_latency_ticks', index=23,
+      number=24, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_copy_latency_ticks', full_name='namespace_io_stats_info.max_copy_latency_ticks', index=24,
+      number=25, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_copy_latency_ticks', full_name='namespace_io_stats_info.min_copy_latency_ticks', index=25,
+      number=26, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='io_error', full_name='namespace_io_stats_info.io_error', index=26,
+      number=27, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_uuid', full_name='namespace_io_stats_info._uuid',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=10380,
+  serialized_end=11110,
 )
 
 
 _SPDK_LOG_FLAG_INFO = _descriptor.Descriptor(
-    name='spdk_log_flag_info',
-    full_name='spdk_log_flag_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='name', full_name='spdk_log_flag_info.name', index=0,
-            number=1, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='enabled', full_name='spdk_log_flag_info.enabled', index=1,
-            number=2, type=8, cpp_type=7, label=1,
-            has_default_value=False, default_value=False,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=9884,
-    serialized_end=9935,
+  name='spdk_log_flag_info',
+  full_name='spdk_log_flag_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='spdk_log_flag_info.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='enabled', full_name='spdk_log_flag_info.enabled', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11112,
+  serialized_end=11163,
 )
 
 
 _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO = _descriptor.Descriptor(
-    name='spdk_nvmf_log_flags_and_level_info',
-    full_name='spdk_nvmf_log_flags_and_level_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='spdk_nvmf_log_flags_and_level_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='spdk_nvmf_log_flags_and_level_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='nvmf_log_flags', full_name='spdk_nvmf_log_flags_and_level_info.nvmf_log_flags', index=2,
-            number=3, type=11, cpp_type=10, label=3,
-            has_default_value=False, default_value=[],
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='log_level', full_name='spdk_nvmf_log_flags_and_level_info.log_level', index=3,
-            number=4, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='log_print_level', full_name='spdk_nvmf_log_flags_and_level_info.log_print_level', index=4,
-            number=5, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=9938,
-    serialized_end=10124,
+  name='spdk_nvmf_log_flags_and_level_info',
+  full_name='spdk_nvmf_log_flags_and_level_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='spdk_nvmf_log_flags_and_level_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='spdk_nvmf_log_flags_and_level_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nvmf_log_flags', full_name='spdk_nvmf_log_flags_and_level_info.nvmf_log_flags', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='log_level', full_name='spdk_nvmf_log_flags_and_level_info.log_level', index=3,
+      number=4, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='log_print_level', full_name='spdk_nvmf_log_flags_and_level_info.log_print_level', index=4,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11166,
+  serialized_end=11352,
 )
 
 
 _GATEWAY_LOG_LEVEL_INFO = _descriptor.Descriptor(
-    name='gateway_log_level_info',
-    full_name='gateway_log_level_info',
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    create_key=_descriptor._internal_create_key,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name='status', full_name='gateway_log_level_info.status', index=0,
-            number=1, type=5, cpp_type=1, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='error_message', full_name='gateway_log_level_info.error_message', index=1,
-            number=2, type=9, cpp_type=9, label=1,
-            has_default_value=False, default_value=b"".decode('utf-8'),
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-        _descriptor.FieldDescriptor(
-            name='log_level', full_name='gateway_log_level_info.log_level', index=2,
-            number=3, type=14, cpp_type=8, label=1,
-            has_default_value=False, default_value=0,
-            message_type=None, enum_type=None, containing_type=None,
-            is_extension=False, extension_scope=None,
-            serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    ],
-    extensions=[
-    ],
-    nested_types=[],
-    enum_types=[
-    ],
-    serialized_options=None,
-    is_extendable=False,
-    syntax='proto3',
-    extension_ranges=[],
-    oneofs=[
-    ],
-    serialized_start=10126,
-    serialized_end=10221,
+  name='gateway_log_level_info',
+  full_name='gateway_log_level_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='gateway_log_level_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='gateway_log_level_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='log_level', full_name='gateway_log_level_info.log_level', index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11354,
+  serialized_end=11449,
 )
 
 _NAMESPACE_ADD_REQ.oneofs_by_name['_nsid'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['nsid'])
+  _NAMESPACE_ADD_REQ.fields_by_name['nsid'])
 _NAMESPACE_ADD_REQ.fields_by_name['nsid'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_nsid']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_uuid'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['uuid'])
+  _NAMESPACE_ADD_REQ.fields_by_name['uuid'])
 _NAMESPACE_ADD_REQ.fields_by_name['uuid'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_uuid']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_anagrpid'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['anagrpid'])
+  _NAMESPACE_ADD_REQ.fields_by_name['anagrpid'])
 _NAMESPACE_ADD_REQ.fields_by_name['anagrpid'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_anagrpid']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_create_image'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['create_image'])
+  _NAMESPACE_ADD_REQ.fields_by_name['create_image'])
 _NAMESPACE_ADD_REQ.fields_by_name['create_image'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_create_image']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_size'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['size'])
+  _NAMESPACE_ADD_REQ.fields_by_name['size'])
 _NAMESPACE_ADD_REQ.fields_by_name['size'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_size']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_force'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['force'])
+  _NAMESPACE_ADD_REQ.fields_by_name['force'])
 _NAMESPACE_ADD_REQ.fields_by_name['force'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_force']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_no_auto_visible'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['no_auto_visible'])
+  _NAMESPACE_ADD_REQ.fields_by_name['no_auto_visible'])
 _NAMESPACE_ADD_REQ.fields_by_name['no_auto_visible'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_no_auto_visible']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_trash_image'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['trash_image'])
+  _NAMESPACE_ADD_REQ.fields_by_name['trash_image'])
 _NAMESPACE_ADD_REQ.fields_by_name['trash_image'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_trash_image']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_disable_auto_resize'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['disable_auto_resize'])
+  _NAMESPACE_ADD_REQ.fields_by_name['disable_auto_resize'])
 _NAMESPACE_ADD_REQ.fields_by_name['disable_auto_resize'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_disable_auto_resize']
 _NAMESPACE_ADD_REQ.oneofs_by_name['_read_only'].fields.append(
-    _NAMESPACE_ADD_REQ.fields_by_name['read_only'])
+  _NAMESPACE_ADD_REQ.fields_by_name['read_only'])
 _NAMESPACE_ADD_REQ.fields_by_name['read_only'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_read_only']
+_NAMESPACE_ADD_REQ.oneofs_by_name['_rbd_data_pool_name'].fields.append(
+  _NAMESPACE_ADD_REQ.fields_by_name['rbd_data_pool_name'])
+_NAMESPACE_ADD_REQ.fields_by_name['rbd_data_pool_name'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_rbd_data_pool_name']
+_NAMESPACE_ADD_REQ.oneofs_by_name['_location'].fields.append(
+  _NAMESPACE_ADD_REQ.fields_by_name['location'])
+_NAMESPACE_ADD_REQ.fields_by_name['location'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_location']
+_NAMESPACE_ADD_REQ.oneofs_by_name['_rados_namespace_name'].fields.append(
+  _NAMESPACE_ADD_REQ.fields_by_name['rados_namespace_name'])
+_NAMESPACE_ADD_REQ.fields_by_name['rados_namespace_name'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_rados_namespace_name']
 _NAMESPACE_RESIZE_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
-    _NAMESPACE_RESIZE_REQ.fields_by_name['OBSOLETE_uuid'])
+  _NAMESPACE_RESIZE_REQ.fields_by_name['OBSOLETE_uuid'])
 _NAMESPACE_RESIZE_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_RESIZE_REQ.oneofs_by_name['_OBSOLETE_uuid']
 _NAMESPACE_GET_IO_STATS_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
-    _NAMESPACE_GET_IO_STATS_REQ.fields_by_name['OBSOLETE_uuid'])
+  _NAMESPACE_GET_IO_STATS_REQ.fields_by_name['OBSOLETE_uuid'])
 _NAMESPACE_GET_IO_STATS_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_GET_IO_STATS_REQ.oneofs_by_name['_OBSOLETE_uuid']
 _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
-    _NAMESPACE_SET_QOS_REQ.fields_by_name['OBSOLETE_uuid'])
+  _NAMESPACE_SET_QOS_REQ.fields_by_name['OBSOLETE_uuid'])
 _NAMESPACE_SET_QOS_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_OBSOLETE_uuid']
 _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_rw_ios_per_second'].fields.append(
-    _NAMESPACE_SET_QOS_REQ.fields_by_name['rw_ios_per_second'])
+  _NAMESPACE_SET_QOS_REQ.fields_by_name['rw_ios_per_second'])
 _NAMESPACE_SET_QOS_REQ.fields_by_name['rw_ios_per_second'].containing_oneof = _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_rw_ios_per_second']
 _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_rw_mbytes_per_second'].fields.append(
-    _NAMESPACE_SET_QOS_REQ.fields_by_name['rw_mbytes_per_second'])
+  _NAMESPACE_SET_QOS_REQ.fields_by_name['rw_mbytes_per_second'])
 _NAMESPACE_SET_QOS_REQ.fields_by_name['rw_mbytes_per_second'].containing_oneof = _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_rw_mbytes_per_second']
 _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_r_mbytes_per_second'].fields.append(
-    _NAMESPACE_SET_QOS_REQ.fields_by_name['r_mbytes_per_second'])
+  _NAMESPACE_SET_QOS_REQ.fields_by_name['r_mbytes_per_second'])
 _NAMESPACE_SET_QOS_REQ.fields_by_name['r_mbytes_per_second'].containing_oneof = _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_r_mbytes_per_second']
 _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_w_mbytes_per_second'].fields.append(
-    _NAMESPACE_SET_QOS_REQ.fields_by_name['w_mbytes_per_second'])
+  _NAMESPACE_SET_QOS_REQ.fields_by_name['w_mbytes_per_second'])
 _NAMESPACE_SET_QOS_REQ.fields_by_name['w_mbytes_per_second'].containing_oneof = _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_w_mbytes_per_second']
 _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_force'].fields.append(
-    _NAMESPACE_SET_QOS_REQ.fields_by_name['force'])
+  _NAMESPACE_SET_QOS_REQ.fields_by_name['force'])
 _NAMESPACE_SET_QOS_REQ.fields_by_name['force'].containing_oneof = _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_force']
 _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
-    _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name['OBSOLETE_uuid'])
-_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name[
-    'OBSOLETE_uuid'].containing_oneof = _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.oneofs_by_name['_OBSOLETE_uuid']
+  _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name['OBSOLETE_uuid'])
+_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.oneofs_by_name['_OBSOLETE_uuid']
 _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.oneofs_by_name['_auto_lb_logic'].fields.append(
-    _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name['auto_lb_logic'])
-_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name[
-    'auto_lb_logic'].containing_oneof = _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.oneofs_by_name['_auto_lb_logic']
+  _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name['auto_lb_logic'])
+_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.fields_by_name['auto_lb_logic'].containing_oneof = _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ.oneofs_by_name['_auto_lb_logic']
 _NAMESPACE_CHANGE_VISIBILITY_REQ.oneofs_by_name['_force'].fields.append(
-    _NAMESPACE_CHANGE_VISIBILITY_REQ.fields_by_name['force'])
+  _NAMESPACE_CHANGE_VISIBILITY_REQ.fields_by_name['force'])
 _NAMESPACE_CHANGE_VISIBILITY_REQ.fields_by_name['force'].containing_oneof = _NAMESPACE_CHANGE_VISIBILITY_REQ.oneofs_by_name['_force']
+_NAMESPACE_CHANGE_LOCATION_REQ.oneofs_by_name['_location'].fields.append(
+  _NAMESPACE_CHANGE_LOCATION_REQ.fields_by_name['location'])
+_NAMESPACE_CHANGE_LOCATION_REQ.fields_by_name['location'].containing_oneof = _NAMESPACE_CHANGE_LOCATION_REQ.oneofs_by_name['_location']
 _NAMESPACE_DELETE_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
-    _NAMESPACE_DELETE_REQ.fields_by_name['OBSOLETE_uuid'])
+  _NAMESPACE_DELETE_REQ.fields_by_name['OBSOLETE_uuid'])
 _NAMESPACE_DELETE_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_DELETE_REQ.oneofs_by_name['_OBSOLETE_uuid']
 _NAMESPACE_DELETE_REQ.oneofs_by_name['_i_am_sure'].fields.append(
-    _NAMESPACE_DELETE_REQ.fields_by_name['i_am_sure'])
+  _NAMESPACE_DELETE_REQ.fields_by_name['i_am_sure'])
 _NAMESPACE_DELETE_REQ.fields_by_name['i_am_sure'].containing_oneof = _NAMESPACE_DELETE_REQ.oneofs_by_name['_i_am_sure']
 _NAMESPACE_ADD_HOST_REQ.oneofs_by_name['_force'].fields.append(
-    _NAMESPACE_ADD_HOST_REQ.fields_by_name['force'])
+  _NAMESPACE_ADD_HOST_REQ.fields_by_name['force'])
 _NAMESPACE_ADD_HOST_REQ.fields_by_name['force'].containing_oneof = _NAMESPACE_ADD_HOST_REQ.oneofs_by_name['_force']
 _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_max_namespaces'].fields.append(
-    _CREATE_SUBSYSTEM_REQ.fields_by_name['max_namespaces'])
+  _CREATE_SUBSYSTEM_REQ.fields_by_name['max_namespaces'])
 _CREATE_SUBSYSTEM_REQ.fields_by_name['max_namespaces'].containing_oneof = _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_max_namespaces']
 _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_no_group_append'].fields.append(
-    _CREATE_SUBSYSTEM_REQ.fields_by_name['no_group_append'])
+  _CREATE_SUBSYSTEM_REQ.fields_by_name['no_group_append'])
 _CREATE_SUBSYSTEM_REQ.fields_by_name['no_group_append'].containing_oneof = _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_no_group_append']
 _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_dhchap_key'].fields.append(
-    _CREATE_SUBSYSTEM_REQ.fields_by_name['dhchap_key'])
+  _CREATE_SUBSYSTEM_REQ.fields_by_name['dhchap_key'])
 _CREATE_SUBSYSTEM_REQ.fields_by_name['dhchap_key'].containing_oneof = _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_dhchap_key']
 _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_key_encrypted'].fields.append(
-    _CREATE_SUBSYSTEM_REQ.fields_by_name['key_encrypted'])
+  _CREATE_SUBSYSTEM_REQ.fields_by_name['key_encrypted'])
 _CREATE_SUBSYSTEM_REQ.fields_by_name['key_encrypted'].containing_oneof = _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_key_encrypted']
+_CREATE_SUBSYSTEM_REQ.oneofs_by_name['_secure_listeners'].fields.append(
+  _CREATE_SUBSYSTEM_REQ.fields_by_name['secure_listeners'])
+_CREATE_SUBSYSTEM_REQ.fields_by_name['secure_listeners'].containing_oneof = _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_secure_listeners']
 _DELETE_SUBSYSTEM_REQ.oneofs_by_name['_force'].fields.append(
-    _DELETE_SUBSYSTEM_REQ.fields_by_name['force'])
+  _DELETE_SUBSYSTEM_REQ.fields_by_name['force'])
 _DELETE_SUBSYSTEM_REQ.fields_by_name['force'].containing_oneof = _DELETE_SUBSYSTEM_REQ.oneofs_by_name['_force']
+_DELETE_SUBSYSTEM_REQ.oneofs_by_name['_i_am_sure'].fields.append(
+  _DELETE_SUBSYSTEM_REQ.fields_by_name['i_am_sure'])
+_DELETE_SUBSYSTEM_REQ.fields_by_name['i_am_sure'].containing_oneof = _DELETE_SUBSYSTEM_REQ.oneofs_by_name['_i_am_sure']
 _CHANGE_SUBSYSTEM_KEY_REQ.oneofs_by_name['_dhchap_key'].fields.append(
-    _CHANGE_SUBSYSTEM_KEY_REQ.fields_by_name['dhchap_key'])
+  _CHANGE_SUBSYSTEM_KEY_REQ.fields_by_name['dhchap_key'])
 _CHANGE_SUBSYSTEM_KEY_REQ.fields_by_name['dhchap_key'].containing_oneof = _CHANGE_SUBSYSTEM_KEY_REQ.oneofs_by_name['_dhchap_key']
 _LIST_NAMESPACES_REQ.oneofs_by_name['_nsid'].fields.append(
-    _LIST_NAMESPACES_REQ.fields_by_name['nsid'])
+  _LIST_NAMESPACES_REQ.fields_by_name['nsid'])
 _LIST_NAMESPACES_REQ.fields_by_name['nsid'].containing_oneof = _LIST_NAMESPACES_REQ.oneofs_by_name['_nsid']
 _LIST_NAMESPACES_REQ.oneofs_by_name['_uuid'].fields.append(
-    _LIST_NAMESPACES_REQ.fields_by_name['uuid'])
+  _LIST_NAMESPACES_REQ.fields_by_name['uuid'])
 _LIST_NAMESPACES_REQ.fields_by_name['uuid'].containing_oneof = _LIST_NAMESPACES_REQ.oneofs_by_name['_uuid']
 _ADD_HOST_REQ.oneofs_by_name['_psk'].fields.append(
-    _ADD_HOST_REQ.fields_by_name['psk'])
+  _ADD_HOST_REQ.fields_by_name['psk'])
 _ADD_HOST_REQ.fields_by_name['psk'].containing_oneof = _ADD_HOST_REQ.oneofs_by_name['_psk']
 _ADD_HOST_REQ.oneofs_by_name['_dhchap_key'].fields.append(
-    _ADD_HOST_REQ.fields_by_name['dhchap_key'])
+  _ADD_HOST_REQ.fields_by_name['dhchap_key'])
 _ADD_HOST_REQ.fields_by_name['dhchap_key'].containing_oneof = _ADD_HOST_REQ.oneofs_by_name['_dhchap_key']
 _ADD_HOST_REQ.oneofs_by_name['_psk_encrypted'].fields.append(
-    _ADD_HOST_REQ.fields_by_name['psk_encrypted'])
+  _ADD_HOST_REQ.fields_by_name['psk_encrypted'])
 _ADD_HOST_REQ.fields_by_name['psk_encrypted'].containing_oneof = _ADD_HOST_REQ.oneofs_by_name['_psk_encrypted']
 _ADD_HOST_REQ.oneofs_by_name['_key_encrypted'].fields.append(
-    _ADD_HOST_REQ.fields_by_name['key_encrypted'])
+  _ADD_HOST_REQ.fields_by_name['key_encrypted'])
 _ADD_HOST_REQ.fields_by_name['key_encrypted'].containing_oneof = _ADD_HOST_REQ.oneofs_by_name['_key_encrypted']
+_ADD_HOST_REQ.oneofs_by_name['_dhchap_ctrlr_key'].fields.append(
+  _ADD_HOST_REQ.fields_by_name['dhchap_ctrlr_key'])
+_ADD_HOST_REQ.fields_by_name['dhchap_ctrlr_key'].containing_oneof = _ADD_HOST_REQ.oneofs_by_name['_dhchap_ctrlr_key']
+_ADD_HOST_REQ.oneofs_by_name['_ctrlr_key_encrypted'].fields.append(
+  _ADD_HOST_REQ.fields_by_name['ctrlr_key_encrypted'])
+_ADD_HOST_REQ.fields_by_name['ctrlr_key_encrypted'].containing_oneof = _ADD_HOST_REQ.oneofs_by_name['_ctrlr_key_encrypted']
 _CHANGE_HOST_KEY_REQ.oneofs_by_name['_dhchap_key'].fields.append(
-    _CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_key'])
+  _CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_key'])
 _CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_key'].containing_oneof = _CHANGE_HOST_KEY_REQ.oneofs_by_name['_dhchap_key']
+_CHANGE_HOST_KEY_REQ.oneofs_by_name['_dhchap_ctrlr_key'].fields.append(
+  _CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_ctrlr_key'])
+_CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_ctrlr_key'].containing_oneof = _CHANGE_HOST_KEY_REQ.oneofs_by_name['_dhchap_ctrlr_key']
 _LIST_HOSTS_REQ.oneofs_by_name['_clear_alerts'].fields.append(
-    _LIST_HOSTS_REQ.fields_by_name['clear_alerts'])
+  _LIST_HOSTS_REQ.fields_by_name['clear_alerts'])
 _LIST_HOSTS_REQ.fields_by_name['clear_alerts'].containing_oneof = _LIST_HOSTS_REQ.oneofs_by_name['_clear_alerts']
+_LIST_CONNECTIONS_REQ.oneofs_by_name['_clear_alerts'].fields.append(
+  _LIST_CONNECTIONS_REQ.fields_by_name['clear_alerts'])
+_LIST_CONNECTIONS_REQ.fields_by_name['clear_alerts'].containing_oneof = _LIST_CONNECTIONS_REQ.oneofs_by_name['_clear_alerts']
 _CREATE_LISTENER_REQ.fields_by_name['adrfam'].enum_type = _ADDRESSFAMILY
 _CREATE_LISTENER_REQ.oneofs_by_name['_adrfam'].fields.append(
-    _CREATE_LISTENER_REQ.fields_by_name['adrfam'])
+  _CREATE_LISTENER_REQ.fields_by_name['adrfam'])
 _CREATE_LISTENER_REQ.fields_by_name['adrfam'].containing_oneof = _CREATE_LISTENER_REQ.oneofs_by_name['_adrfam']
 _CREATE_LISTENER_REQ.oneofs_by_name['_trsvcid'].fields.append(
-    _CREATE_LISTENER_REQ.fields_by_name['trsvcid'])
+  _CREATE_LISTENER_REQ.fields_by_name['trsvcid'])
 _CREATE_LISTENER_REQ.fields_by_name['trsvcid'].containing_oneof = _CREATE_LISTENER_REQ.oneofs_by_name['_trsvcid']
 _CREATE_LISTENER_REQ.oneofs_by_name['_secure'].fields.append(
-    _CREATE_LISTENER_REQ.fields_by_name['secure'])
+  _CREATE_LISTENER_REQ.fields_by_name['secure'])
 _CREATE_LISTENER_REQ.fields_by_name['secure'].containing_oneof = _CREATE_LISTENER_REQ.oneofs_by_name['_secure']
 _CREATE_LISTENER_REQ.oneofs_by_name['_verify_host_name'].fields.append(
-    _CREATE_LISTENER_REQ.fields_by_name['verify_host_name'])
+  _CREATE_LISTENER_REQ.fields_by_name['verify_host_name'])
 _CREATE_LISTENER_REQ.fields_by_name['verify_host_name'].containing_oneof = _CREATE_LISTENER_REQ.oneofs_by_name['_verify_host_name']
 _DELETE_LISTENER_REQ.fields_by_name['adrfam'].enum_type = _ADDRESSFAMILY
 _DELETE_LISTENER_REQ.oneofs_by_name['_adrfam'].fields.append(
-    _DELETE_LISTENER_REQ.fields_by_name['adrfam'])
+  _DELETE_LISTENER_REQ.fields_by_name['adrfam'])
 _DELETE_LISTENER_REQ.fields_by_name['adrfam'].containing_oneof = _DELETE_LISTENER_REQ.oneofs_by_name['_adrfam']
 _DELETE_LISTENER_REQ.oneofs_by_name['_trsvcid'].fields.append(
-    _DELETE_LISTENER_REQ.fields_by_name['trsvcid'])
+  _DELETE_LISTENER_REQ.fields_by_name['trsvcid'])
 _DELETE_LISTENER_REQ.fields_by_name['trsvcid'].containing_oneof = _DELETE_LISTENER_REQ.oneofs_by_name['_trsvcid']
 _DELETE_LISTENER_REQ.oneofs_by_name['_force'].fields.append(
-    _DELETE_LISTENER_REQ.fields_by_name['force'])
+  _DELETE_LISTENER_REQ.fields_by_name['force'])
 _DELETE_LISTENER_REQ.fields_by_name['force'].containing_oneof = _DELETE_LISTENER_REQ.oneofs_by_name['_force']
 _LIST_SUBSYSTEMS_REQ.oneofs_by_name['_subsystem_nqn'].fields.append(
-    _LIST_SUBSYSTEMS_REQ.fields_by_name['subsystem_nqn'])
+  _LIST_SUBSYSTEMS_REQ.fields_by_name['subsystem_nqn'])
 _LIST_SUBSYSTEMS_REQ.fields_by_name['subsystem_nqn'].containing_oneof = _LIST_SUBSYSTEMS_REQ.oneofs_by_name['_subsystem_nqn']
 _LIST_SUBSYSTEMS_REQ.oneofs_by_name['_serial_number'].fields.append(
-    _LIST_SUBSYSTEMS_REQ.fields_by_name['serial_number'])
+  _LIST_SUBSYSTEMS_REQ.fields_by_name['serial_number'])
 _LIST_SUBSYSTEMS_REQ.fields_by_name['serial_number'].containing_oneof = _LIST_SUBSYSTEMS_REQ.oneofs_by_name['_serial_number']
 _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ.oneofs_by_name['_all_log_flags'].fields.append(
-    _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ.fields_by_name['all_log_flags'])
-_GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ.fields_by_name[
-    'all_log_flags'].containing_oneof = _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ.oneofs_by_name['_all_log_flags']
+  _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ.fields_by_name['all_log_flags'])
+_GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ.fields_by_name['all_log_flags'].containing_oneof = _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ.oneofs_by_name['_all_log_flags']
 _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['log_level'].enum_type = _LOGLEVEL
 _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['print_level'].enum_type = _LOGLEVEL
 _SET_SPDK_NVMF_LOGS_REQ.oneofs_by_name['_log_level'].fields.append(
-    _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['log_level'])
+  _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['log_level'])
 _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['log_level'].containing_oneof = _SET_SPDK_NVMF_LOGS_REQ.oneofs_by_name['_log_level']
 _SET_SPDK_NVMF_LOGS_REQ.oneofs_by_name['_print_level'].fields.append(
-    _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['print_level'])
+  _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['print_level'])
 _SET_SPDK_NVMF_LOGS_REQ.fields_by_name['print_level'].containing_oneof = _SET_SPDK_NVMF_LOGS_REQ.oneofs_by_name['_print_level']
 _GET_GATEWAY_INFO_REQ.oneofs_by_name['_cli_version'].fields.append(
-    _GET_GATEWAY_INFO_REQ.fields_by_name['cli_version'])
+  _GET_GATEWAY_INFO_REQ.fields_by_name['cli_version'])
 _GET_GATEWAY_INFO_REQ.fields_by_name['cli_version'].containing_oneof = _GET_GATEWAY_INFO_REQ.oneofs_by_name['_cli_version']
 _SET_GATEWAY_LOG_LEVEL_REQ.fields_by_name['log_level'].enum_type = _GWLOGLEVEL
 _ANA_GROUP_STATE.fields_by_name['state'].enum_type = _ANA_STATE
@@ -4595,140 +5067,156 @@ _SUBSYSTEM.fields_by_name['listen_addresses'].message_type = _LISTEN_ADDRESS
 _SUBSYSTEM.fields_by_name['hosts'].message_type = _HOST
 _SUBSYSTEM.fields_by_name['namespaces'].message_type = _NAMESPACE
 _SUBSYSTEM.oneofs_by_name['_serial_number'].fields.append(
-    _SUBSYSTEM.fields_by_name['serial_number'])
+  _SUBSYSTEM.fields_by_name['serial_number'])
 _SUBSYSTEM.fields_by_name['serial_number'].containing_oneof = _SUBSYSTEM.oneofs_by_name['_serial_number']
 _SUBSYSTEM.oneofs_by_name['_model_number'].fields.append(
-    _SUBSYSTEM.fields_by_name['model_number'])
+  _SUBSYSTEM.fields_by_name['model_number'])
 _SUBSYSTEM.fields_by_name['model_number'].containing_oneof = _SUBSYSTEM.oneofs_by_name['_model_number']
 _SUBSYSTEM.oneofs_by_name['_max_namespaces'].fields.append(
-    _SUBSYSTEM.fields_by_name['max_namespaces'])
+  _SUBSYSTEM.fields_by_name['max_namespaces'])
 _SUBSYSTEM.fields_by_name['max_namespaces'].containing_oneof = _SUBSYSTEM.oneofs_by_name['_max_namespaces']
 _SUBSYSTEM.oneofs_by_name['_min_cntlid'].fields.append(
-    _SUBSYSTEM.fields_by_name['min_cntlid'])
+  _SUBSYSTEM.fields_by_name['min_cntlid'])
 _SUBSYSTEM.fields_by_name['min_cntlid'].containing_oneof = _SUBSYSTEM.oneofs_by_name['_min_cntlid']
 _SUBSYSTEM.oneofs_by_name['_max_cntlid'].fields.append(
-    _SUBSYSTEM.fields_by_name['max_cntlid'])
+  _SUBSYSTEM.fields_by_name['max_cntlid'])
 _SUBSYSTEM.fields_by_name['max_cntlid'].containing_oneof = _SUBSYSTEM.oneofs_by_name['_max_cntlid']
 _SUBSYSTEM.oneofs_by_name['_has_dhchap_key'].fields.append(
-    _SUBSYSTEM.fields_by_name['has_dhchap_key'])
+  _SUBSYSTEM.fields_by_name['has_dhchap_key'])
 _SUBSYSTEM.fields_by_name['has_dhchap_key'].containing_oneof = _SUBSYSTEM.oneofs_by_name['_has_dhchap_key']
 _LISTEN_ADDRESS.oneofs_by_name['_transport'].fields.append(
-    _LISTEN_ADDRESS.fields_by_name['transport'])
+  _LISTEN_ADDRESS.fields_by_name['transport'])
 _LISTEN_ADDRESS.fields_by_name['transport'].containing_oneof = _LISTEN_ADDRESS.oneofs_by_name['_transport']
 _LISTEN_ADDRESS.oneofs_by_name['_secure'].fields.append(
-    _LISTEN_ADDRESS.fields_by_name['secure'])
+  _LISTEN_ADDRESS.fields_by_name['secure'])
 _LISTEN_ADDRESS.fields_by_name['secure'].containing_oneof = _LISTEN_ADDRESS.oneofs_by_name['_secure']
 _NAMESPACE.oneofs_by_name['_bdev_name'].fields.append(
-    _NAMESPACE.fields_by_name['bdev_name'])
+  _NAMESPACE.fields_by_name['bdev_name'])
 _NAMESPACE.fields_by_name['bdev_name'].containing_oneof = _NAMESPACE.oneofs_by_name['_bdev_name']
 _NAMESPACE.oneofs_by_name['_nguid'].fields.append(
-    _NAMESPACE.fields_by_name['nguid'])
+  _NAMESPACE.fields_by_name['nguid'])
 _NAMESPACE.fields_by_name['nguid'].containing_oneof = _NAMESPACE.oneofs_by_name['_nguid']
 _NAMESPACE.oneofs_by_name['_uuid'].fields.append(
-    _NAMESPACE.fields_by_name['uuid'])
+  _NAMESPACE.fields_by_name['uuid'])
 _NAMESPACE.fields_by_name['uuid'].containing_oneof = _NAMESPACE.oneofs_by_name['_uuid']
 _NAMESPACE.oneofs_by_name['_anagrpid'].fields.append(
-    _NAMESPACE.fields_by_name['anagrpid'])
+  _NAMESPACE.fields_by_name['anagrpid'])
 _NAMESPACE.fields_by_name['anagrpid'].containing_oneof = _NAMESPACE.oneofs_by_name['_anagrpid']
 _NAMESPACE.oneofs_by_name['_nonce'].fields.append(
-    _NAMESPACE.fields_by_name['nonce'])
+  _NAMESPACE.fields_by_name['nonce'])
 _NAMESPACE.fields_by_name['nonce'].containing_oneof = _NAMESPACE.oneofs_by_name['_nonce']
 _NAMESPACE.oneofs_by_name['_auto_visible'].fields.append(
-    _NAMESPACE.fields_by_name['auto_visible'])
+  _NAMESPACE.fields_by_name['auto_visible'])
 _NAMESPACE.fields_by_name['auto_visible'].containing_oneof = _NAMESPACE.oneofs_by_name['_auto_visible']
 _SUBSYSTEMS_INFO_CLI.fields_by_name['subsystems'].message_type = _SUBSYSTEM_CLI
 _SUBSYSTEM_CLI.oneofs_by_name['_has_dhchap_key'].fields.append(
-    _SUBSYSTEM_CLI.fields_by_name['has_dhchap_key'])
+  _SUBSYSTEM_CLI.fields_by_name['has_dhchap_key'])
 _SUBSYSTEM_CLI.fields_by_name['has_dhchap_key'].containing_oneof = _SUBSYSTEM_CLI.oneofs_by_name['_has_dhchap_key']
 _SUBSYSTEM_CLI.oneofs_by_name['_allow_any_host'].fields.append(
-    _SUBSYSTEM_CLI.fields_by_name['allow_any_host'])
+  _SUBSYSTEM_CLI.fields_by_name['allow_any_host'])
 _SUBSYSTEM_CLI.fields_by_name['allow_any_host'].containing_oneof = _SUBSYSTEM_CLI.oneofs_by_name['_allow_any_host']
 _SUBSYSTEM_CLI.oneofs_by_name['_created_without_key'].fields.append(
-    _SUBSYSTEM_CLI.fields_by_name['created_without_key'])
+  _SUBSYSTEM_CLI.fields_by_name['created_without_key'])
 _SUBSYSTEM_CLI.fields_by_name['created_without_key'].containing_oneof = _SUBSYSTEM_CLI.oneofs_by_name['_created_without_key']
 _GATEWAY_INFO.oneofs_by_name['_spdk_version'].fields.append(
-    _GATEWAY_INFO.fields_by_name['spdk_version'])
+  _GATEWAY_INFO.fields_by_name['spdk_version'])
 _GATEWAY_INFO.fields_by_name['spdk_version'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_spdk_version']
 _GATEWAY_INFO.oneofs_by_name['_max_subsystems'].fields.append(
-    _GATEWAY_INFO.fields_by_name['max_subsystems'])
+  _GATEWAY_INFO.fields_by_name['max_subsystems'])
 _GATEWAY_INFO.fields_by_name['max_subsystems'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_max_subsystems']
 _GATEWAY_INFO.oneofs_by_name['_max_namespaces'].fields.append(
-    _GATEWAY_INFO.fields_by_name['max_namespaces'])
+  _GATEWAY_INFO.fields_by_name['max_namespaces'])
 _GATEWAY_INFO.fields_by_name['max_namespaces'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_max_namespaces']
 _GATEWAY_INFO.oneofs_by_name['_max_hosts_per_subsystem'].fields.append(
-    _GATEWAY_INFO.fields_by_name['max_hosts_per_subsystem'])
+  _GATEWAY_INFO.fields_by_name['max_hosts_per_subsystem'])
 _GATEWAY_INFO.fields_by_name['max_hosts_per_subsystem'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_max_hosts_per_subsystem']
 _GATEWAY_INFO.oneofs_by_name['_max_namespaces_per_subsystem'].fields.append(
-    _GATEWAY_INFO.fields_by_name['max_namespaces_per_subsystem'])
+  _GATEWAY_INFO.fields_by_name['max_namespaces_per_subsystem'])
 _GATEWAY_INFO.fields_by_name['max_namespaces_per_subsystem'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_max_namespaces_per_subsystem']
 _GATEWAY_INFO.oneofs_by_name['_max_hosts'].fields.append(
-    _GATEWAY_INFO.fields_by_name['max_hosts'])
+  _GATEWAY_INFO.fields_by_name['max_hosts'])
 _GATEWAY_INFO.fields_by_name['max_hosts'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_max_hosts']
+_GATEWAY_INFO.oneofs_by_name['_gateway_initialization_over'].fields.append(
+  _GATEWAY_INFO.fields_by_name['gateway_initialization_over'])
+_GATEWAY_INFO.fields_by_name['gateway_initialization_over'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_gateway_initialization_over']
 _POLL_GROUP_INFO.fields_by_name['transports'].message_type = _POLL_GROUP_TRANSPORT_INFO
 _GATEWAY_STATS_INFO.fields_by_name['poll_groups'].message_type = _POLL_GROUP_INFO
+_THREAD_STATS_INFO.fields_by_name['threads'].message_type = _SPDK_THREAD_INFO
 _LISTENER_INFO.fields_by_name['adrfam'].enum_type = _ADDRESSFAMILY
 _LISTENER_INFO.oneofs_by_name['_secure'].fields.append(
-    _LISTENER_INFO.fields_by_name['secure'])
+  _LISTENER_INFO.fields_by_name['secure'])
 _LISTENER_INFO.fields_by_name['secure'].containing_oneof = _LISTENER_INFO.oneofs_by_name['_secure']
 _LISTENER_INFO.oneofs_by_name['_active'].fields.append(
-    _LISTENER_INFO.fields_by_name['active'])
+  _LISTENER_INFO.fields_by_name['active'])
 _LISTENER_INFO.fields_by_name['active'].containing_oneof = _LISTENER_INFO.oneofs_by_name['_active']
+_LISTENER_INFO.oneofs_by_name['_manual'].fields.append(
+  _LISTENER_INFO.fields_by_name['manual'])
+_LISTENER_INFO.fields_by_name['manual'].containing_oneof = _LISTENER_INFO.oneofs_by_name['_manual']
 _LISTENERS_INFO.fields_by_name['listeners'].message_type = _LISTENER_INFO
 _GATEWAY_LISTENER_INFO.fields_by_name['listener'].message_type = _LISTENER_INFO
 _GATEWAY_LISTENER_INFO.fields_by_name['lb_states'].message_type = _ANA_GROUP_STATE
 _GATEWAY_LISTENERS_INFO.fields_by_name['gw_listeners'].message_type = _GATEWAY_LISTENER_INFO
 _HOST.oneofs_by_name['_use_psk'].fields.append(
-    _HOST.fields_by_name['use_psk'])
+  _HOST.fields_by_name['use_psk'])
 _HOST.fields_by_name['use_psk'].containing_oneof = _HOST.oneofs_by_name['_use_psk']
 _HOST.oneofs_by_name['_use_dhchap'].fields.append(
-    _HOST.fields_by_name['use_dhchap'])
+  _HOST.fields_by_name['use_dhchap'])
 _HOST.fields_by_name['use_dhchap'].containing_oneof = _HOST.oneofs_by_name['_use_dhchap']
 _HOST.oneofs_by_name['_disconnected_due_to_keepalive_timeout'].fields.append(
-    _HOST.fields_by_name['disconnected_due_to_keepalive_timeout'])
+  _HOST.fields_by_name['disconnected_due_to_keepalive_timeout'])
 _HOST.fields_by_name['disconnected_due_to_keepalive_timeout'].containing_oneof = _HOST.oneofs_by_name['_disconnected_due_to_keepalive_timeout']
 _HOSTS_INFO.fields_by_name['hosts'].message_type = _HOST
 _CONNECTION.fields_by_name['adrfam'].enum_type = _ADDRESSFAMILY
 _CONNECTION.oneofs_by_name['_secure'].fields.append(
-    _CONNECTION.fields_by_name['secure'])
+  _CONNECTION.fields_by_name['secure'])
 _CONNECTION.fields_by_name['secure'].containing_oneof = _CONNECTION.oneofs_by_name['_secure']
 _CONNECTION.oneofs_by_name['_use_psk'].fields.append(
-    _CONNECTION.fields_by_name['use_psk'])
+  _CONNECTION.fields_by_name['use_psk'])
 _CONNECTION.fields_by_name['use_psk'].containing_oneof = _CONNECTION.oneofs_by_name['_use_psk']
 _CONNECTION.oneofs_by_name['_use_dhchap'].fields.append(
-    _CONNECTION.fields_by_name['use_dhchap'])
+  _CONNECTION.fields_by_name['use_dhchap'])
 _CONNECTION.fields_by_name['use_dhchap'].containing_oneof = _CONNECTION.oneofs_by_name['_use_dhchap']
 _CONNECTION.oneofs_by_name['_subsystem'].fields.append(
-    _CONNECTION.fields_by_name['subsystem'])
+  _CONNECTION.fields_by_name['subsystem'])
 _CONNECTION.fields_by_name['subsystem'].containing_oneof = _CONNECTION.oneofs_by_name['_subsystem']
 _CONNECTION.oneofs_by_name['_disconnected_due_to_keepalive_timeout'].fields.append(
-    _CONNECTION.fields_by_name['disconnected_due_to_keepalive_timeout'])
+  _CONNECTION.fields_by_name['disconnected_due_to_keepalive_timeout'])
 _CONNECTION.fields_by_name['disconnected_due_to_keepalive_timeout'].containing_oneof = _CONNECTION.oneofs_by_name['_disconnected_due_to_keepalive_timeout']
 _CONNECTIONS_INFO.fields_by_name['connections'].message_type = _CONNECTION
 _NAMESPACE_CLI.oneofs_by_name['_ns_subsystem_nqn'].fields.append(
-    _NAMESPACE_CLI.fields_by_name['ns_subsystem_nqn'])
+  _NAMESPACE_CLI.fields_by_name['ns_subsystem_nqn'])
 _NAMESPACE_CLI.fields_by_name['ns_subsystem_nqn'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_ns_subsystem_nqn']
 _NAMESPACE_CLI.oneofs_by_name['_trash_image'].fields.append(
-    _NAMESPACE_CLI.fields_by_name['trash_image'])
+  _NAMESPACE_CLI.fields_by_name['trash_image'])
 _NAMESPACE_CLI.fields_by_name['trash_image'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_trash_image']
 _NAMESPACE_CLI.oneofs_by_name['_disable_auto_resize'].fields.append(
-    _NAMESPACE_CLI.fields_by_name['disable_auto_resize'])
+  _NAMESPACE_CLI.fields_by_name['disable_auto_resize'])
 _NAMESPACE_CLI.fields_by_name['disable_auto_resize'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_disable_auto_resize']
 _NAMESPACE_CLI.oneofs_by_name['_read_only'].fields.append(
-    _NAMESPACE_CLI.fields_by_name['read_only'])
+  _NAMESPACE_CLI.fields_by_name['read_only'])
 _NAMESPACE_CLI.fields_by_name['read_only'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_read_only']
 _NAMESPACE_CLI.oneofs_by_name['_cluster_name'].fields.append(
-    _NAMESPACE_CLI.fields_by_name['cluster_name'])
+  _NAMESPACE_CLI.fields_by_name['cluster_name'])
 _NAMESPACE_CLI.fields_by_name['cluster_name'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_cluster_name']
 _NAMESPACE_CLI.oneofs_by_name['_configured_load_balancing_group'].fields.append(
-    _NAMESPACE_CLI.fields_by_name['configured_load_balancing_group'])
+  _NAMESPACE_CLI.fields_by_name['configured_load_balancing_group'])
 _NAMESPACE_CLI.fields_by_name['configured_load_balancing_group'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_configured_load_balancing_group']
 _NAMESPACE_CLI.oneofs_by_name['_image_was_shrunk'].fields.append(
-    _NAMESPACE_CLI.fields_by_name['image_was_shrunk'])
+  _NAMESPACE_CLI.fields_by_name['image_was_shrunk'])
 _NAMESPACE_CLI.fields_by_name['image_was_shrunk'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_image_was_shrunk']
+_NAMESPACE_CLI.oneofs_by_name['_rbd_data_pool_name'].fields.append(
+  _NAMESPACE_CLI.fields_by_name['rbd_data_pool_name'])
+_NAMESPACE_CLI.fields_by_name['rbd_data_pool_name'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_rbd_data_pool_name']
+_NAMESPACE_CLI.oneofs_by_name['_location'].fields.append(
+  _NAMESPACE_CLI.fields_by_name['location'])
+_NAMESPACE_CLI.fields_by_name['location'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_location']
+_NAMESPACE_CLI.oneofs_by_name['_rados_namespace_name'].fields.append(
+  _NAMESPACE_CLI.fields_by_name['rados_namespace_name'])
+_NAMESPACE_CLI.fields_by_name['rados_namespace_name'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_rados_namespace_name']
 _NAMESPACES_INFO.fields_by_name['namespaces'].message_type = _NAMESPACE_CLI
 _NAMESPACE_IO_STATS_INFO.fields_by_name['io_error'].message_type = _NAMESPACE_IO_ERROR
 _NAMESPACE_IO_STATS_INFO.oneofs_by_name['_uuid'].fields.append(
-    _NAMESPACE_IO_STATS_INFO.fields_by_name['uuid'])
+  _NAMESPACE_IO_STATS_INFO.fields_by_name['uuid'])
 _NAMESPACE_IO_STATS_INFO.fields_by_name['uuid'].containing_oneof = _NAMESPACE_IO_STATS_INFO.oneofs_by_name['_uuid']
 _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO.fields_by_name['nvmf_log_flags'].message_type = _SPDK_LOG_FLAG_INFO
 _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO.fields_by_name['log_level'].enum_type = _LOGLEVEL
@@ -4740,6 +5228,7 @@ DESCRIPTOR.message_types_by_name['namespace_get_io_stats_req'] = _NAMESPACE_GET_
 DESCRIPTOR.message_types_by_name['namespace_set_qos_req'] = _NAMESPACE_SET_QOS_REQ
 DESCRIPTOR.message_types_by_name['namespace_change_load_balancing_group_req'] = _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ
 DESCRIPTOR.message_types_by_name['namespace_change_visibility_req'] = _NAMESPACE_CHANGE_VISIBILITY_REQ
+DESCRIPTOR.message_types_by_name['namespace_change_location_req'] = _NAMESPACE_CHANGE_LOCATION_REQ
 DESCRIPTOR.message_types_by_name['namespace_set_rbd_trash_image_req'] = _NAMESPACE_SET_RBD_TRASH_IMAGE_REQ
 DESCRIPTOR.message_types_by_name['namespace_set_auto_resize_req'] = _NAMESPACE_SET_AUTO_RESIZE_REQ
 DESCRIPTOR.message_types_by_name['namespace_delete_req'] = _NAMESPACE_DELETE_REQ
@@ -4748,6 +5237,8 @@ DESCRIPTOR.message_types_by_name['namespace_delete_host_req'] = _NAMESPACE_DELET
 DESCRIPTOR.message_types_by_name['create_subsystem_req'] = _CREATE_SUBSYSTEM_REQ
 DESCRIPTOR.message_types_by_name['delete_subsystem_req'] = _DELETE_SUBSYSTEM_REQ
 DESCRIPTOR.message_types_by_name['change_subsystem_key_req'] = _CHANGE_SUBSYSTEM_KEY_REQ
+DESCRIPTOR.message_types_by_name['add_subsystem_network_req'] = _ADD_SUBSYSTEM_NETWORK_REQ
+DESCRIPTOR.message_types_by_name['del_subsystem_network_req'] = _DEL_SUBSYSTEM_NETWORK_REQ
 DESCRIPTOR.message_types_by_name['list_namespaces_req'] = _LIST_NAMESPACES_REQ
 DESCRIPTOR.message_types_by_name['add_host_req'] = _ADD_HOST_REQ
 DESCRIPTOR.message_types_by_name['change_host_key_req'] = _CHANGE_HOST_KEY_REQ
@@ -4767,6 +5258,7 @@ DESCRIPTOR.message_types_by_name['get_gateway_log_level_req'] = _GET_GATEWAY_LOG
 DESCRIPTOR.message_types_by_name['set_gateway_log_level_req'] = _SET_GATEWAY_LOG_LEVEL_REQ
 DESCRIPTOR.message_types_by_name['show_gateway_listeners_info_req'] = _SHOW_GATEWAY_LISTENERS_INFO_REQ
 DESCRIPTOR.message_types_by_name['get_gateway_stats_req'] = _GET_GATEWAY_STATS_REQ
+DESCRIPTOR.message_types_by_name['get_thread_stats_req'] = _GET_THREAD_STATS_REQ
 DESCRIPTOR.message_types_by_name['ana_group_state'] = _ANA_GROUP_STATE
 DESCRIPTOR.message_types_by_name['nqn_ana_states'] = _NQN_ANA_STATES
 DESCRIPTOR.message_types_by_name['ana_info'] = _ANA_INFO
@@ -4785,6 +5277,8 @@ DESCRIPTOR.message_types_by_name['gw_version'] = _GW_VERSION
 DESCRIPTOR.message_types_by_name['poll_group_transport_info'] = _POLL_GROUP_TRANSPORT_INFO
 DESCRIPTOR.message_types_by_name['poll_group_info'] = _POLL_GROUP_INFO
 DESCRIPTOR.message_types_by_name['gateway_stats_info'] = _GATEWAY_STATS_INFO
+DESCRIPTOR.message_types_by_name['thread_stats_info'] = _THREAD_STATS_INFO
+DESCRIPTOR.message_types_by_name['spdk_thread_info'] = _SPDK_THREAD_INFO
 DESCRIPTOR.message_types_by_name['listener_info'] = _LISTENER_INFO
 DESCRIPTOR.message_types_by_name['listeners_info'] = _LISTENERS_INFO
 DESCRIPTOR.message_types_by_name['gateway_listener_info'] = _GATEWAY_LISTENER_INFO
@@ -4807,819 +5301,903 @@ DESCRIPTOR.enum_types_by_name['ana_state'] = _ANA_STATE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 namespace_add_req = _reflection.GeneratedProtocolMessageType('namespace_add_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_ADD_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_add_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_ADD_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_add_req)
+  })
 _sym_db.RegisterMessage(namespace_add_req)
 
 namespace_resize_req = _reflection.GeneratedProtocolMessageType('namespace_resize_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_RESIZE_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_resize_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_RESIZE_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_resize_req)
+  })
 _sym_db.RegisterMessage(namespace_resize_req)
 
 namespace_get_io_stats_req = _reflection.GeneratedProtocolMessageType('namespace_get_io_stats_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_GET_IO_STATS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_get_io_stats_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_GET_IO_STATS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_get_io_stats_req)
+  })
 _sym_db.RegisterMessage(namespace_get_io_stats_req)
 
 namespace_set_qos_req = _reflection.GeneratedProtocolMessageType('namespace_set_qos_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_SET_QOS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_set_qos_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_SET_QOS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_set_qos_req)
+  })
 _sym_db.RegisterMessage(namespace_set_qos_req)
 
 namespace_change_load_balancing_group_req = _reflection.GeneratedProtocolMessageType('namespace_change_load_balancing_group_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_change_load_balancing_group_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_change_load_balancing_group_req)
+  })
 _sym_db.RegisterMessage(namespace_change_load_balancing_group_req)
 
 namespace_change_visibility_req = _reflection.GeneratedProtocolMessageType('namespace_change_visibility_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_CHANGE_VISIBILITY_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_change_visibility_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_CHANGE_VISIBILITY_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_change_visibility_req)
+  })
 _sym_db.RegisterMessage(namespace_change_visibility_req)
 
+namespace_change_location_req = _reflection.GeneratedProtocolMessageType('namespace_change_location_req', (_message.Message,), {
+  'DESCRIPTOR' : _NAMESPACE_CHANGE_LOCATION_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_change_location_req)
+  })
+_sym_db.RegisterMessage(namespace_change_location_req)
+
 namespace_set_rbd_trash_image_req = _reflection.GeneratedProtocolMessageType('namespace_set_rbd_trash_image_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_SET_RBD_TRASH_IMAGE_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_set_rbd_trash_image_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_SET_RBD_TRASH_IMAGE_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_set_rbd_trash_image_req)
+  })
 _sym_db.RegisterMessage(namespace_set_rbd_trash_image_req)
 
 namespace_set_auto_resize_req = _reflection.GeneratedProtocolMessageType('namespace_set_auto_resize_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_SET_AUTO_RESIZE_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_set_auto_resize_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_SET_AUTO_RESIZE_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_set_auto_resize_req)
+  })
 _sym_db.RegisterMessage(namespace_set_auto_resize_req)
 
 namespace_delete_req = _reflection.GeneratedProtocolMessageType('namespace_delete_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_DELETE_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_delete_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_DELETE_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_delete_req)
+  })
 _sym_db.RegisterMessage(namespace_delete_req)
 
 namespace_add_host_req = _reflection.GeneratedProtocolMessageType('namespace_add_host_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_ADD_HOST_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_add_host_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_ADD_HOST_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_add_host_req)
+  })
 _sym_db.RegisterMessage(namespace_add_host_req)
 
 namespace_delete_host_req = _reflection.GeneratedProtocolMessageType('namespace_delete_host_req', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_DELETE_HOST_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_delete_host_req)
-})
+  'DESCRIPTOR' : _NAMESPACE_DELETE_HOST_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_delete_host_req)
+  })
 _sym_db.RegisterMessage(namespace_delete_host_req)
 
 create_subsystem_req = _reflection.GeneratedProtocolMessageType('create_subsystem_req', (_message.Message,), {
-    'DESCRIPTOR': _CREATE_SUBSYSTEM_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:create_subsystem_req)
-})
+  'DESCRIPTOR' : _CREATE_SUBSYSTEM_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:create_subsystem_req)
+  })
 _sym_db.RegisterMessage(create_subsystem_req)
 
 delete_subsystem_req = _reflection.GeneratedProtocolMessageType('delete_subsystem_req', (_message.Message,), {
-    'DESCRIPTOR': _DELETE_SUBSYSTEM_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:delete_subsystem_req)
-})
+  'DESCRIPTOR' : _DELETE_SUBSYSTEM_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:delete_subsystem_req)
+  })
 _sym_db.RegisterMessage(delete_subsystem_req)
 
 change_subsystem_key_req = _reflection.GeneratedProtocolMessageType('change_subsystem_key_req', (_message.Message,), {
-    'DESCRIPTOR': _CHANGE_SUBSYSTEM_KEY_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:change_subsystem_key_req)
-})
+  'DESCRIPTOR' : _CHANGE_SUBSYSTEM_KEY_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:change_subsystem_key_req)
+  })
 _sym_db.RegisterMessage(change_subsystem_key_req)
 
+add_subsystem_network_req = _reflection.GeneratedProtocolMessageType('add_subsystem_network_req', (_message.Message,), {
+  'DESCRIPTOR' : _ADD_SUBSYSTEM_NETWORK_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:add_subsystem_network_req)
+  })
+_sym_db.RegisterMessage(add_subsystem_network_req)
+
+del_subsystem_network_req = _reflection.GeneratedProtocolMessageType('del_subsystem_network_req', (_message.Message,), {
+  'DESCRIPTOR' : _DEL_SUBSYSTEM_NETWORK_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:del_subsystem_network_req)
+  })
+_sym_db.RegisterMessage(del_subsystem_network_req)
+
 list_namespaces_req = _reflection.GeneratedProtocolMessageType('list_namespaces_req', (_message.Message,), {
-    'DESCRIPTOR': _LIST_NAMESPACES_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:list_namespaces_req)
-})
+  'DESCRIPTOR' : _LIST_NAMESPACES_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_namespaces_req)
+  })
 _sym_db.RegisterMessage(list_namespaces_req)
 
 add_host_req = _reflection.GeneratedProtocolMessageType('add_host_req', (_message.Message,), {
-    'DESCRIPTOR': _ADD_HOST_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:add_host_req)
-})
+  'DESCRIPTOR' : _ADD_HOST_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:add_host_req)
+  })
 _sym_db.RegisterMessage(add_host_req)
 
 change_host_key_req = _reflection.GeneratedProtocolMessageType('change_host_key_req', (_message.Message,), {
-    'DESCRIPTOR': _CHANGE_HOST_KEY_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:change_host_key_req)
-})
+  'DESCRIPTOR' : _CHANGE_HOST_KEY_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:change_host_key_req)
+  })
 _sym_db.RegisterMessage(change_host_key_req)
 
 remove_host_req = _reflection.GeneratedProtocolMessageType('remove_host_req', (_message.Message,), {
-    'DESCRIPTOR': _REMOVE_HOST_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:remove_host_req)
-})
+  'DESCRIPTOR' : _REMOVE_HOST_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:remove_host_req)
+  })
 _sym_db.RegisterMessage(remove_host_req)
 
 list_hosts_req = _reflection.GeneratedProtocolMessageType('list_hosts_req', (_message.Message,), {
-    'DESCRIPTOR': _LIST_HOSTS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:list_hosts_req)
-})
+  'DESCRIPTOR' : _LIST_HOSTS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_hosts_req)
+  })
 _sym_db.RegisterMessage(list_hosts_req)
 
 list_connections_req = _reflection.GeneratedProtocolMessageType('list_connections_req', (_message.Message,), {
-    'DESCRIPTOR': _LIST_CONNECTIONS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:list_connections_req)
-})
+  'DESCRIPTOR' : _LIST_CONNECTIONS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_connections_req)
+  })
 _sym_db.RegisterMessage(list_connections_req)
 
 create_listener_req = _reflection.GeneratedProtocolMessageType('create_listener_req', (_message.Message,), {
-    'DESCRIPTOR': _CREATE_LISTENER_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:create_listener_req)
-})
+  'DESCRIPTOR' : _CREATE_LISTENER_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:create_listener_req)
+  })
 _sym_db.RegisterMessage(create_listener_req)
 
 delete_listener_req = _reflection.GeneratedProtocolMessageType('delete_listener_req', (_message.Message,), {
-    'DESCRIPTOR': _DELETE_LISTENER_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:delete_listener_req)
-})
+  'DESCRIPTOR' : _DELETE_LISTENER_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:delete_listener_req)
+  })
 _sym_db.RegisterMessage(delete_listener_req)
 
 list_listeners_req = _reflection.GeneratedProtocolMessageType('list_listeners_req', (_message.Message,), {
-    'DESCRIPTOR': _LIST_LISTENERS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:list_listeners_req)
-})
+  'DESCRIPTOR' : _LIST_LISTENERS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_listeners_req)
+  })
 _sym_db.RegisterMessage(list_listeners_req)
 
 list_subsystems_req = _reflection.GeneratedProtocolMessageType('list_subsystems_req', (_message.Message,), {
-    'DESCRIPTOR': _LIST_SUBSYSTEMS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:list_subsystems_req)
-})
+  'DESCRIPTOR' : _LIST_SUBSYSTEMS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_subsystems_req)
+  })
 _sym_db.RegisterMessage(list_subsystems_req)
 
 get_subsystems_req = _reflection.GeneratedProtocolMessageType('get_subsystems_req', (_message.Message,), {
-    'DESCRIPTOR': _GET_SUBSYSTEMS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:get_subsystems_req)
-})
+  'DESCRIPTOR' : _GET_SUBSYSTEMS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:get_subsystems_req)
+  })
 _sym_db.RegisterMessage(get_subsystems_req)
 
 get_spdk_nvmf_log_flags_and_level_req = _reflection.GeneratedProtocolMessageType('get_spdk_nvmf_log_flags_and_level_req', (_message.Message,), {
-    'DESCRIPTOR': _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:get_spdk_nvmf_log_flags_and_level_req)
-})
+  'DESCRIPTOR' : _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:get_spdk_nvmf_log_flags_and_level_req)
+  })
 _sym_db.RegisterMessage(get_spdk_nvmf_log_flags_and_level_req)
 
 disable_spdk_nvmf_logs_req = _reflection.GeneratedProtocolMessageType('disable_spdk_nvmf_logs_req', (_message.Message,), {
-    'DESCRIPTOR': _DISABLE_SPDK_NVMF_LOGS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:disable_spdk_nvmf_logs_req)
-})
+  'DESCRIPTOR' : _DISABLE_SPDK_NVMF_LOGS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:disable_spdk_nvmf_logs_req)
+  })
 _sym_db.RegisterMessage(disable_spdk_nvmf_logs_req)
 
 set_spdk_nvmf_logs_req = _reflection.GeneratedProtocolMessageType('set_spdk_nvmf_logs_req', (_message.Message,), {
-    'DESCRIPTOR': _SET_SPDK_NVMF_LOGS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:set_spdk_nvmf_logs_req)
-})
+  'DESCRIPTOR' : _SET_SPDK_NVMF_LOGS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:set_spdk_nvmf_logs_req)
+  })
 _sym_db.RegisterMessage(set_spdk_nvmf_logs_req)
 
 get_gateway_info_req = _reflection.GeneratedProtocolMessageType('get_gateway_info_req', (_message.Message,), {
-    'DESCRIPTOR': _GET_GATEWAY_INFO_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:get_gateway_info_req)
-})
+  'DESCRIPTOR' : _GET_GATEWAY_INFO_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:get_gateway_info_req)
+  })
 _sym_db.RegisterMessage(get_gateway_info_req)
 
 get_gateway_log_level_req = _reflection.GeneratedProtocolMessageType('get_gateway_log_level_req', (_message.Message,), {
-    'DESCRIPTOR': _GET_GATEWAY_LOG_LEVEL_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:get_gateway_log_level_req)
-})
+  'DESCRIPTOR' : _GET_GATEWAY_LOG_LEVEL_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:get_gateway_log_level_req)
+  })
 _sym_db.RegisterMessage(get_gateway_log_level_req)
 
 set_gateway_log_level_req = _reflection.GeneratedProtocolMessageType('set_gateway_log_level_req', (_message.Message,), {
-    'DESCRIPTOR': _SET_GATEWAY_LOG_LEVEL_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:set_gateway_log_level_req)
-})
+  'DESCRIPTOR' : _SET_GATEWAY_LOG_LEVEL_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:set_gateway_log_level_req)
+  })
 _sym_db.RegisterMessage(set_gateway_log_level_req)
 
 show_gateway_listeners_info_req = _reflection.GeneratedProtocolMessageType('show_gateway_listeners_info_req', (_message.Message,), {
-    'DESCRIPTOR': _SHOW_GATEWAY_LISTENERS_INFO_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:show_gateway_listeners_info_req)
-})
+  'DESCRIPTOR' : _SHOW_GATEWAY_LISTENERS_INFO_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:show_gateway_listeners_info_req)
+  })
 _sym_db.RegisterMessage(show_gateway_listeners_info_req)
 
 get_gateway_stats_req = _reflection.GeneratedProtocolMessageType('get_gateway_stats_req', (_message.Message,), {
-    'DESCRIPTOR': _GET_GATEWAY_STATS_REQ,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:get_gateway_stats_req)
-})
+  'DESCRIPTOR' : _GET_GATEWAY_STATS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:get_gateway_stats_req)
+  })
 _sym_db.RegisterMessage(get_gateway_stats_req)
 
+get_thread_stats_req = _reflection.GeneratedProtocolMessageType('get_thread_stats_req', (_message.Message,), {
+  'DESCRIPTOR' : _GET_THREAD_STATS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:get_thread_stats_req)
+  })
+_sym_db.RegisterMessage(get_thread_stats_req)
+
 ana_group_state = _reflection.GeneratedProtocolMessageType('ana_group_state', (_message.Message,), {
-    'DESCRIPTOR': _ANA_GROUP_STATE,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:ana_group_state)
-})
+  'DESCRIPTOR' : _ANA_GROUP_STATE,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:ana_group_state)
+  })
 _sym_db.RegisterMessage(ana_group_state)
 
 nqn_ana_states = _reflection.GeneratedProtocolMessageType('nqn_ana_states', (_message.Message,), {
-    'DESCRIPTOR': _NQN_ANA_STATES,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:nqn_ana_states)
-})
+  'DESCRIPTOR' : _NQN_ANA_STATES,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:nqn_ana_states)
+  })
 _sym_db.RegisterMessage(nqn_ana_states)
 
 ana_info = _reflection.GeneratedProtocolMessageType('ana_info', (_message.Message,), {
-    'DESCRIPTOR': _ANA_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:ana_info)
-})
+  'DESCRIPTOR' : _ANA_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:ana_info)
+  })
 _sym_db.RegisterMessage(ana_info)
 
 req_status = _reflection.GeneratedProtocolMessageType('req_status', (_message.Message,), {
-    'DESCRIPTOR': _REQ_STATUS,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:req_status)
-})
+  'DESCRIPTOR' : _REQ_STATUS,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:req_status)
+  })
 _sym_db.RegisterMessage(req_status)
 
 subsys_status = _reflection.GeneratedProtocolMessageType('subsys_status', (_message.Message,), {
-    'DESCRIPTOR': _SUBSYS_STATUS,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:subsys_status)
-})
+  'DESCRIPTOR' : _SUBSYS_STATUS,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:subsys_status)
+  })
 _sym_db.RegisterMessage(subsys_status)
 
 nsid_status = _reflection.GeneratedProtocolMessageType('nsid_status', (_message.Message,), {
-    'DESCRIPTOR': _NSID_STATUS,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:nsid_status)
-})
+  'DESCRIPTOR' : _NSID_STATUS,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:nsid_status)
+  })
 _sym_db.RegisterMessage(nsid_status)
 
 subsystems_info = _reflection.GeneratedProtocolMessageType('subsystems_info', (_message.Message,), {
-    'DESCRIPTOR': _SUBSYSTEMS_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:subsystems_info)
-})
+  'DESCRIPTOR' : _SUBSYSTEMS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:subsystems_info)
+  })
 _sym_db.RegisterMessage(subsystems_info)
 
 subsystem = _reflection.GeneratedProtocolMessageType('subsystem', (_message.Message,), {
-    'DESCRIPTOR': _SUBSYSTEM,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:subsystem)
-})
+  'DESCRIPTOR' : _SUBSYSTEM,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:subsystem)
+  })
 _sym_db.RegisterMessage(subsystem)
 
 listen_address = _reflection.GeneratedProtocolMessageType('listen_address', (_message.Message,), {
-    'DESCRIPTOR': _LISTEN_ADDRESS,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:listen_address)
-})
+  'DESCRIPTOR' : _LISTEN_ADDRESS,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:listen_address)
+  })
 _sym_db.RegisterMessage(listen_address)
 
 namespace = _reflection.GeneratedProtocolMessageType('namespace', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace)
-})
+  'DESCRIPTOR' : _NAMESPACE,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace)
+  })
 _sym_db.RegisterMessage(namespace)
 
 subsystems_info_cli = _reflection.GeneratedProtocolMessageType('subsystems_info_cli', (_message.Message,), {
-    'DESCRIPTOR': _SUBSYSTEMS_INFO_CLI,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:subsystems_info_cli)
-})
+  'DESCRIPTOR' : _SUBSYSTEMS_INFO_CLI,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:subsystems_info_cli)
+  })
 _sym_db.RegisterMessage(subsystems_info_cli)
 
 subsystem_cli = _reflection.GeneratedProtocolMessageType('subsystem_cli', (_message.Message,), {
-    'DESCRIPTOR': _SUBSYSTEM_CLI,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:subsystem_cli)
-})
+  'DESCRIPTOR' : _SUBSYSTEM_CLI,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:subsystem_cli)
+  })
 _sym_db.RegisterMessage(subsystem_cli)
 
 gateway_info = _reflection.GeneratedProtocolMessageType('gateway_info', (_message.Message,), {
-    'DESCRIPTOR': _GATEWAY_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:gateway_info)
-})
+  'DESCRIPTOR' : _GATEWAY_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:gateway_info)
+  })
 _sym_db.RegisterMessage(gateway_info)
 
 cli_version = _reflection.GeneratedProtocolMessageType('cli_version', (_message.Message,), {
-    'DESCRIPTOR': _CLI_VERSION,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:cli_version)
-})
+  'DESCRIPTOR' : _CLI_VERSION,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:cli_version)
+  })
 _sym_db.RegisterMessage(cli_version)
 
 gw_version = _reflection.GeneratedProtocolMessageType('gw_version', (_message.Message,), {
-    'DESCRIPTOR': _GW_VERSION,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:gw_version)
-})
+  'DESCRIPTOR' : _GW_VERSION,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:gw_version)
+  })
 _sym_db.RegisterMessage(gw_version)
 
 poll_group_transport_info = _reflection.GeneratedProtocolMessageType('poll_group_transport_info', (_message.Message,), {
-    'DESCRIPTOR': _POLL_GROUP_TRANSPORT_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:poll_group_transport_info)
-})
+  'DESCRIPTOR' : _POLL_GROUP_TRANSPORT_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:poll_group_transport_info)
+  })
 _sym_db.RegisterMessage(poll_group_transport_info)
 
 poll_group_info = _reflection.GeneratedProtocolMessageType('poll_group_info', (_message.Message,), {
-    'DESCRIPTOR': _POLL_GROUP_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:poll_group_info)
-})
+  'DESCRIPTOR' : _POLL_GROUP_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:poll_group_info)
+  })
 _sym_db.RegisterMessage(poll_group_info)
 
 gateway_stats_info = _reflection.GeneratedProtocolMessageType('gateway_stats_info', (_message.Message,), {
-    'DESCRIPTOR': _GATEWAY_STATS_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:gateway_stats_info)
-})
+  'DESCRIPTOR' : _GATEWAY_STATS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:gateway_stats_info)
+  })
 _sym_db.RegisterMessage(gateway_stats_info)
 
+thread_stats_info = _reflection.GeneratedProtocolMessageType('thread_stats_info', (_message.Message,), {
+  'DESCRIPTOR' : _THREAD_STATS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:thread_stats_info)
+  })
+_sym_db.RegisterMessage(thread_stats_info)
+
+spdk_thread_info = _reflection.GeneratedProtocolMessageType('spdk_thread_info', (_message.Message,), {
+  'DESCRIPTOR' : _SPDK_THREAD_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:spdk_thread_info)
+  })
+_sym_db.RegisterMessage(spdk_thread_info)
+
 listener_info = _reflection.GeneratedProtocolMessageType('listener_info', (_message.Message,), {
-    'DESCRIPTOR': _LISTENER_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:listener_info)
-})
+  'DESCRIPTOR' : _LISTENER_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:listener_info)
+  })
 _sym_db.RegisterMessage(listener_info)
 
 listeners_info = _reflection.GeneratedProtocolMessageType('listeners_info', (_message.Message,), {
-    'DESCRIPTOR': _LISTENERS_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:listeners_info)
-})
+  'DESCRIPTOR' : _LISTENERS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:listeners_info)
+  })
 _sym_db.RegisterMessage(listeners_info)
 
 gateway_listener_info = _reflection.GeneratedProtocolMessageType('gateway_listener_info', (_message.Message,), {
-    'DESCRIPTOR': _GATEWAY_LISTENER_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:gateway_listener_info)
-})
+  'DESCRIPTOR' : _GATEWAY_LISTENER_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:gateway_listener_info)
+  })
 _sym_db.RegisterMessage(gateway_listener_info)
 
 gateway_listeners_info = _reflection.GeneratedProtocolMessageType('gateway_listeners_info', (_message.Message,), {
-    'DESCRIPTOR': _GATEWAY_LISTENERS_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:gateway_listeners_info)
-})
+  'DESCRIPTOR' : _GATEWAY_LISTENERS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:gateway_listeners_info)
+  })
 _sym_db.RegisterMessage(gateway_listeners_info)
 
 host = _reflection.GeneratedProtocolMessageType('host', (_message.Message,), {
-    'DESCRIPTOR': _HOST,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:host)
-})
+  'DESCRIPTOR' : _HOST,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:host)
+  })
 _sym_db.RegisterMessage(host)
 
 hosts_info = _reflection.GeneratedProtocolMessageType('hosts_info', (_message.Message,), {
-    'DESCRIPTOR': _HOSTS_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:hosts_info)
-})
+  'DESCRIPTOR' : _HOSTS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:hosts_info)
+  })
 _sym_db.RegisterMessage(hosts_info)
 
 connection = _reflection.GeneratedProtocolMessageType('connection', (_message.Message,), {
-    'DESCRIPTOR': _CONNECTION,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:connection)
-})
+  'DESCRIPTOR' : _CONNECTION,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:connection)
+  })
 _sym_db.RegisterMessage(connection)
 
 connections_info = _reflection.GeneratedProtocolMessageType('connections_info', (_message.Message,), {
-    'DESCRIPTOR': _CONNECTIONS_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:connections_info)
-})
+  'DESCRIPTOR' : _CONNECTIONS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:connections_info)
+  })
 _sym_db.RegisterMessage(connections_info)
 
 namespace_cli = _reflection.GeneratedProtocolMessageType('namespace_cli', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_CLI,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_cli)
-})
+  'DESCRIPTOR' : _NAMESPACE_CLI,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_cli)
+  })
 _sym_db.RegisterMessage(namespace_cli)
 
 namespaces_info = _reflection.GeneratedProtocolMessageType('namespaces_info', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACES_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespaces_info)
-})
+  'DESCRIPTOR' : _NAMESPACES_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespaces_info)
+  })
 _sym_db.RegisterMessage(namespaces_info)
 
 namespace_io_error = _reflection.GeneratedProtocolMessageType('namespace_io_error', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_IO_ERROR,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_io_error)
-})
+  'DESCRIPTOR' : _NAMESPACE_IO_ERROR,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_io_error)
+  })
 _sym_db.RegisterMessage(namespace_io_error)
 
 namespace_io_stats_info = _reflection.GeneratedProtocolMessageType('namespace_io_stats_info', (_message.Message,), {
-    'DESCRIPTOR': _NAMESPACE_IO_STATS_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:namespace_io_stats_info)
-})
+  'DESCRIPTOR' : _NAMESPACE_IO_STATS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:namespace_io_stats_info)
+  })
 _sym_db.RegisterMessage(namespace_io_stats_info)
 
 spdk_log_flag_info = _reflection.GeneratedProtocolMessageType('spdk_log_flag_info', (_message.Message,), {
-    'DESCRIPTOR': _SPDK_LOG_FLAG_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:spdk_log_flag_info)
-})
+  'DESCRIPTOR' : _SPDK_LOG_FLAG_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:spdk_log_flag_info)
+  })
 _sym_db.RegisterMessage(spdk_log_flag_info)
 
 spdk_nvmf_log_flags_and_level_info = _reflection.GeneratedProtocolMessageType('spdk_nvmf_log_flags_and_level_info', (_message.Message,), {
-    'DESCRIPTOR': _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:spdk_nvmf_log_flags_and_level_info)
-})
+  'DESCRIPTOR' : _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:spdk_nvmf_log_flags_and_level_info)
+  })
 _sym_db.RegisterMessage(spdk_nvmf_log_flags_and_level_info)
 
 gateway_log_level_info = _reflection.GeneratedProtocolMessageType('gateway_log_level_info', (_message.Message,), {
-    'DESCRIPTOR': _GATEWAY_LOG_LEVEL_INFO,
-    '__module__': 'dashboard.services.proto.gateway_pb2'
-    # @@protoc_insertion_point(class_scope:gateway_log_level_info)
-})
+  'DESCRIPTOR' : _GATEWAY_LOG_LEVEL_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:gateway_log_level_info)
+  })
 _sym_db.RegisterMessage(gateway_log_level_info)
 
 
+DESCRIPTOR._options = None
+
 _GATEWAY = _descriptor.ServiceDescriptor(
-    name='Gateway',
-    full_name='Gateway',
-    file=DESCRIPTOR,
+  name='Gateway',
+  full_name='Gateway',
+  file=DESCRIPTOR,
+  index=0,
+  serialized_options=None,
+  create_key=_descriptor._internal_create_key,
+  serialized_start=11719,
+  serialized_end=14249,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='namespace_add',
+    full_name='Gateway.namespace_add',
     index=0,
+    containing_service=None,
+    input_type=_NAMESPACE_ADD_REQ,
+    output_type=_NSID_STATUS,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_start=10491,
-    serialized_end=12744,
-    methods=[
-        _descriptor.MethodDescriptor(
-            name='namespace_add',
-            full_name='Gateway.namespace_add',
-            index=0,
-            containing_service=None,
-            input_type=_NAMESPACE_ADD_REQ,
-            output_type=_NSID_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='create_subsystem',
-            full_name='Gateway.create_subsystem',
-            index=1,
-            containing_service=None,
-            input_type=_CREATE_SUBSYSTEM_REQ,
-            output_type=_SUBSYS_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='delete_subsystem',
-            full_name='Gateway.delete_subsystem',
-            index=2,
-            containing_service=None,
-            input_type=_DELETE_SUBSYSTEM_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='change_subsystem_key',
-            full_name='Gateway.change_subsystem_key',
-            index=3,
-            containing_service=None,
-            input_type=_CHANGE_SUBSYSTEM_KEY_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='list_namespaces',
-            full_name='Gateway.list_namespaces',
-            index=4,
-            containing_service=None,
-            input_type=_LIST_NAMESPACES_REQ,
-            output_type=_NAMESPACES_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_resize',
-            full_name='Gateway.namespace_resize',
-            index=5,
-            containing_service=None,
-            input_type=_NAMESPACE_RESIZE_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_get_io_stats',
-            full_name='Gateway.namespace_get_io_stats',
-            index=6,
-            containing_service=None,
-            input_type=_NAMESPACE_GET_IO_STATS_REQ,
-            output_type=_NAMESPACE_IO_STATS_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_set_qos_limits',
-            full_name='Gateway.namespace_set_qos_limits',
-            index=7,
-            containing_service=None,
-            input_type=_NAMESPACE_SET_QOS_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_change_load_balancing_group',
-            full_name='Gateway.namespace_change_load_balancing_group',
-            index=8,
-            containing_service=None,
-            input_type=_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_change_visibility',
-            full_name='Gateway.namespace_change_visibility',
-            index=9,
-            containing_service=None,
-            input_type=_NAMESPACE_CHANGE_VISIBILITY_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_set_rbd_trash_image',
-            full_name='Gateway.namespace_set_rbd_trash_image',
-            index=10,
-            containing_service=None,
-            input_type=_NAMESPACE_SET_RBD_TRASH_IMAGE_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_set_auto_resize',
-            full_name='Gateway.namespace_set_auto_resize',
-            index=11,
-            containing_service=None,
-            input_type=_NAMESPACE_SET_AUTO_RESIZE_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_delete',
-            full_name='Gateway.namespace_delete',
-            index=12,
-            containing_service=None,
-            input_type=_NAMESPACE_DELETE_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_add_host',
-            full_name='Gateway.namespace_add_host',
-            index=13,
-            containing_service=None,
-            input_type=_NAMESPACE_ADD_HOST_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='namespace_delete_host',
-            full_name='Gateway.namespace_delete_host',
-            index=14,
-            containing_service=None,
-            input_type=_NAMESPACE_DELETE_HOST_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='add_host',
-            full_name='Gateway.add_host',
-            index=15,
-            containing_service=None,
-            input_type=_ADD_HOST_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='remove_host',
-            full_name='Gateway.remove_host',
-            index=16,
-            containing_service=None,
-            input_type=_REMOVE_HOST_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='change_host_key',
-            full_name='Gateway.change_host_key',
-            index=17,
-            containing_service=None,
-            input_type=_CHANGE_HOST_KEY_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='list_hosts',
-            full_name='Gateway.list_hosts',
-            index=18,
-            containing_service=None,
-            input_type=_LIST_HOSTS_REQ,
-            output_type=_HOSTS_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='list_connections',
-            full_name='Gateway.list_connections',
-            index=19,
-            containing_service=None,
-            input_type=_LIST_CONNECTIONS_REQ,
-            output_type=_CONNECTIONS_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='create_listener',
-            full_name='Gateway.create_listener',
-            index=20,
-            containing_service=None,
-            input_type=_CREATE_LISTENER_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='delete_listener',
-            full_name='Gateway.delete_listener',
-            index=21,
-            containing_service=None,
-            input_type=_DELETE_LISTENER_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='list_listeners',
-            full_name='Gateway.list_listeners',
-            index=22,
-            containing_service=None,
-            input_type=_LIST_LISTENERS_REQ,
-            output_type=_LISTENERS_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='list_subsystems',
-            full_name='Gateway.list_subsystems',
-            index=23,
-            containing_service=None,
-            input_type=_LIST_SUBSYSTEMS_REQ,
-            output_type=_SUBSYSTEMS_INFO_CLI,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='get_subsystems',
-            full_name='Gateway.get_subsystems',
-            index=24,
-            containing_service=None,
-            input_type=_GET_SUBSYSTEMS_REQ,
-            output_type=_SUBSYSTEMS_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='set_ana_state',
-            full_name='Gateway.set_ana_state',
-            index=25,
-            containing_service=None,
-            input_type=_ANA_INFO,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='get_spdk_nvmf_log_flags_and_level',
-            full_name='Gateway.get_spdk_nvmf_log_flags_and_level',
-            index=26,
-            containing_service=None,
-            input_type=_GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ,
-            output_type=_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='disable_spdk_nvmf_logs',
-            full_name='Gateway.disable_spdk_nvmf_logs',
-            index=27,
-            containing_service=None,
-            input_type=_DISABLE_SPDK_NVMF_LOGS_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='set_spdk_nvmf_logs',
-            full_name='Gateway.set_spdk_nvmf_logs',
-            index=28,
-            containing_service=None,
-            input_type=_SET_SPDK_NVMF_LOGS_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='get_gateway_info',
-            full_name='Gateway.get_gateway_info',
-            index=29,
-            containing_service=None,
-            input_type=_GET_GATEWAY_INFO_REQ,
-            output_type=_GATEWAY_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='get_gateway_log_level',
-            full_name='Gateway.get_gateway_log_level',
-            index=30,
-            containing_service=None,
-            input_type=_GET_GATEWAY_LOG_LEVEL_REQ,
-            output_type=_GATEWAY_LOG_LEVEL_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='set_gateway_log_level',
-            full_name='Gateway.set_gateway_log_level',
-            index=31,
-            containing_service=None,
-            input_type=_SET_GATEWAY_LOG_LEVEL_REQ,
-            output_type=_REQ_STATUS,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='show_gateway_listeners_info',
-            full_name='Gateway.show_gateway_listeners_info',
-            index=32,
-            containing_service=None,
-            input_type=_SHOW_GATEWAY_LISTENERS_INFO_REQ,
-            output_type=_GATEWAY_LISTENERS_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.MethodDescriptor(
-            name='get_gateway_stats',
-            full_name='Gateway.get_gateway_stats',
-            index=33,
-            containing_service=None,
-            input_type=_GET_GATEWAY_STATS_REQ,
-            output_type=_GATEWAY_STATS_INFO,
-            serialized_options=None,
-            create_key=_descriptor._internal_create_key,
-        ),
-    ])
+  ),
+  _descriptor.MethodDescriptor(
+    name='create_subsystem',
+    full_name='Gateway.create_subsystem',
+    index=1,
+    containing_service=None,
+    input_type=_CREATE_SUBSYSTEM_REQ,
+    output_type=_SUBSYS_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='delete_subsystem',
+    full_name='Gateway.delete_subsystem',
+    index=2,
+    containing_service=None,
+    input_type=_DELETE_SUBSYSTEM_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='change_subsystem_key',
+    full_name='Gateway.change_subsystem_key',
+    index=3,
+    containing_service=None,
+    input_type=_CHANGE_SUBSYSTEM_KEY_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='add_subsystem_network',
+    full_name='Gateway.add_subsystem_network',
+    index=4,
+    containing_service=None,
+    input_type=_ADD_SUBSYSTEM_NETWORK_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='del_subsystem_network',
+    full_name='Gateway.del_subsystem_network',
+    index=5,
+    containing_service=None,
+    input_type=_DEL_SUBSYSTEM_NETWORK_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='list_namespaces',
+    full_name='Gateway.list_namespaces',
+    index=6,
+    containing_service=None,
+    input_type=_LIST_NAMESPACES_REQ,
+    output_type=_NAMESPACES_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_resize',
+    full_name='Gateway.namespace_resize',
+    index=7,
+    containing_service=None,
+    input_type=_NAMESPACE_RESIZE_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_get_io_stats',
+    full_name='Gateway.namespace_get_io_stats',
+    index=8,
+    containing_service=None,
+    input_type=_NAMESPACE_GET_IO_STATS_REQ,
+    output_type=_NAMESPACE_IO_STATS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_set_qos_limits',
+    full_name='Gateway.namespace_set_qos_limits',
+    index=9,
+    containing_service=None,
+    input_type=_NAMESPACE_SET_QOS_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_change_load_balancing_group',
+    full_name='Gateway.namespace_change_load_balancing_group',
+    index=10,
+    containing_service=None,
+    input_type=_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_change_visibility',
+    full_name='Gateway.namespace_change_visibility',
+    index=11,
+    containing_service=None,
+    input_type=_NAMESPACE_CHANGE_VISIBILITY_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_change_location',
+    full_name='Gateway.namespace_change_location',
+    index=12,
+    containing_service=None,
+    input_type=_NAMESPACE_CHANGE_LOCATION_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_set_rbd_trash_image',
+    full_name='Gateway.namespace_set_rbd_trash_image',
+    index=13,
+    containing_service=None,
+    input_type=_NAMESPACE_SET_RBD_TRASH_IMAGE_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_set_auto_resize',
+    full_name='Gateway.namespace_set_auto_resize',
+    index=14,
+    containing_service=None,
+    input_type=_NAMESPACE_SET_AUTO_RESIZE_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_delete',
+    full_name='Gateway.namespace_delete',
+    index=15,
+    containing_service=None,
+    input_type=_NAMESPACE_DELETE_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_add_host',
+    full_name='Gateway.namespace_add_host',
+    index=16,
+    containing_service=None,
+    input_type=_NAMESPACE_ADD_HOST_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='namespace_delete_host',
+    full_name='Gateway.namespace_delete_host',
+    index=17,
+    containing_service=None,
+    input_type=_NAMESPACE_DELETE_HOST_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='add_host',
+    full_name='Gateway.add_host',
+    index=18,
+    containing_service=None,
+    input_type=_ADD_HOST_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='remove_host',
+    full_name='Gateway.remove_host',
+    index=19,
+    containing_service=None,
+    input_type=_REMOVE_HOST_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='change_host_key',
+    full_name='Gateway.change_host_key',
+    index=20,
+    containing_service=None,
+    input_type=_CHANGE_HOST_KEY_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='list_hosts',
+    full_name='Gateway.list_hosts',
+    index=21,
+    containing_service=None,
+    input_type=_LIST_HOSTS_REQ,
+    output_type=_HOSTS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='list_connections',
+    full_name='Gateway.list_connections',
+    index=22,
+    containing_service=None,
+    input_type=_LIST_CONNECTIONS_REQ,
+    output_type=_CONNECTIONS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='create_listener',
+    full_name='Gateway.create_listener',
+    index=23,
+    containing_service=None,
+    input_type=_CREATE_LISTENER_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='delete_listener',
+    full_name='Gateway.delete_listener',
+    index=24,
+    containing_service=None,
+    input_type=_DELETE_LISTENER_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='list_listeners',
+    full_name='Gateway.list_listeners',
+    index=25,
+    containing_service=None,
+    input_type=_LIST_LISTENERS_REQ,
+    output_type=_LISTENERS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='list_subsystems',
+    full_name='Gateway.list_subsystems',
+    index=26,
+    containing_service=None,
+    input_type=_LIST_SUBSYSTEMS_REQ,
+    output_type=_SUBSYSTEMS_INFO_CLI,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_subsystems',
+    full_name='Gateway.get_subsystems',
+    index=27,
+    containing_service=None,
+    input_type=_GET_SUBSYSTEMS_REQ,
+    output_type=_SUBSYSTEMS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='set_ana_state',
+    full_name='Gateway.set_ana_state',
+    index=28,
+    containing_service=None,
+    input_type=_ANA_INFO,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_spdk_nvmf_log_flags_and_level',
+    full_name='Gateway.get_spdk_nvmf_log_flags_and_level',
+    index=29,
+    containing_service=None,
+    input_type=_GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ,
+    output_type=_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='disable_spdk_nvmf_logs',
+    full_name='Gateway.disable_spdk_nvmf_logs',
+    index=30,
+    containing_service=None,
+    input_type=_DISABLE_SPDK_NVMF_LOGS_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='set_spdk_nvmf_logs',
+    full_name='Gateway.set_spdk_nvmf_logs',
+    index=31,
+    containing_service=None,
+    input_type=_SET_SPDK_NVMF_LOGS_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_gateway_info',
+    full_name='Gateway.get_gateway_info',
+    index=32,
+    containing_service=None,
+    input_type=_GET_GATEWAY_INFO_REQ,
+    output_type=_GATEWAY_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_gateway_log_level',
+    full_name='Gateway.get_gateway_log_level',
+    index=33,
+    containing_service=None,
+    input_type=_GET_GATEWAY_LOG_LEVEL_REQ,
+    output_type=_GATEWAY_LOG_LEVEL_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='set_gateway_log_level',
+    full_name='Gateway.set_gateway_log_level',
+    index=34,
+    containing_service=None,
+    input_type=_SET_GATEWAY_LOG_LEVEL_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='show_gateway_listeners_info',
+    full_name='Gateway.show_gateway_listeners_info',
+    index=35,
+    containing_service=None,
+    input_type=_SHOW_GATEWAY_LISTENERS_INFO_REQ,
+    output_type=_GATEWAY_LISTENERS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_gateway_stats',
+    full_name='Gateway.get_gateway_stats',
+    index=36,
+    containing_service=None,
+    input_type=_GET_GATEWAY_STATS_REQ,
+    output_type=_GATEWAY_STATS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_thread_stats',
+    full_name='Gateway.get_thread_stats',
+    index=37,
+    containing_service=None,
+    input_type=_GET_THREAD_STATS_REQ,
+    output_type=_THREAD_STATS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+])
 _sym_db.RegisterServiceDescriptor(_GATEWAY)
 
 DESCRIPTOR.services_by_name['Gateway'] = _GATEWAY

--- a/src/pybind/mgr/dashboard/services/proto/gateway_pb2.py
+++ b/src/pybind/mgr/dashboard/services/proto/gateway_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeof',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n&dashboard/services/proto/gateway.proto\"\x83\x05\n\x11namespace_add_req\x12\x15\n\rrbd_pool_name\x18\x01 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x11\n\x04nsid\x18\x04 \x01(\rH\x00\x88\x01\x01\x12\x12\n\nblock_size\x18\x05 \x01(\r\x12\x11\n\x04uuid\x18\x06 \x01(\tH\x01\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x07 \x01(\x05H\x02\x88\x01\x01\x12\x19\n\x0c\x63reate_image\x18\x08 \x01(\x08H\x03\x88\x01\x01\x12\x11\n\x04size\x18\t \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\n \x01(\x08H\x05\x88\x01\x01\x12\x1c\n\x0fno_auto_visible\x18\x0b \x01(\x08H\x06\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x0c \x01(\x08H\x07\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\r \x01(\x08H\x08\x88\x01\x01\x12\x16\n\tread_only\x18\x0e \x01(\x08H\t\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x0f \x01(\tH\n\x88\x01\x01\x12\x15\n\x08location\x18\x10 \x01(\tH\x0b\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x11 \x01(\tH\x0c\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x0f\n\r_create_imageB\x07\n\x05_sizeB\x08\n\x06_forceB\x12\n\x10_no_auto_visibleB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_name\"{\n\x14namespace_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08new_size\x18\x04 \x01(\x04\x42\x10\n\x0e_OBSOLETE_uuid\"o\n\x1anamespace_get_io_stats_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuid\"\xee\x02\n\x15namespace_set_qos_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1e\n\x11rw_ios_per_second\x18\x04 \x01(\x04H\x01\x88\x01\x01\x12!\n\x14rw_mbytes_per_second\x18\x05 \x01(\x04H\x02\x88\x01\x01\x12 \n\x13r_mbytes_per_second\x18\x06 \x01(\x04H\x03\x88\x01\x01\x12 \n\x13w_mbytes_per_second\x18\x07 \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x14\n\x12_rw_ios_per_secondB\x17\n\x15_rw_mbytes_per_secondB\x16\n\x14_r_mbytes_per_secondB\x16\n\x14_w_mbytes_per_secondB\x08\n\x06_force\"\xbe\x01\n)namespace_change_load_balancing_group_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61nagrpid\x18\x04 \x01(\x05\x12\x1a\n\rauto_lb_logic\x18\x05 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x10\n\x0e_auto_lb_logic\"z\n\x1fnamespace_change_visibility_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x14\n\x0c\x61uto_visible\x18\x03 \x01(\x08\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"h\n\x1dnamespace_change_location_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x15\n\x08location\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x0b\n\t_location\"]\n!namespace_set_rbd_trash_image_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0btrash_image\x18\x03 \x01(\x08\"Y\n\x1dnamespace_set_auto_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0b\x61uto_resize\x18\x03 \x01(\x08\"\x8f\x01\n\x14namespace_delete_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x04 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x0c\n\n_i_am_sure\"m\n\x16namespace_add_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"R\n\x19namespace_delete_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\"\xd9\x02\n\x14\x63reate_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x15\n\rserial_number\x18\x02 \x01(\t\x12\x1b\n\x0emax_namespaces\x18\x03 \x01(\rH\x00\x88\x01\x01\x12\x11\n\tenable_ha\x18\x04 \x01(\x08\x12\x1c\n\x0fno_group_append\x18\x05 \x01(\x08H\x01\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x06 \x01(\tH\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x07 \x01(\x08H\x03\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\x08 \x03(\t\x12\x1d\n\x10secure_listeners\x18\t \x01(\x08H\x04\x88\x01\x01\x42\x11\n\x0f_max_namespacesB\x12\n\x10_no_group_appendB\r\n\x0b_dhchap_keyB\x10\n\x0e_key_encryptedB\x13\n\x11_secure_listeners\"q\n\x14\x64\x65lete_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x12\n\x05\x66orce\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x03 \x01(\x08H\x01\x88\x01\x01\x42\x08\n\x06_forceB\x0c\n\n_i_am_sure\"Y\n\x18\x63hange_subsystem_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x17\n\ndhchap_key\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\r\n\x0b_dhchap_key\"H\n\x19\x61\x64\x64_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"H\n\x19\x64\x65l_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"`\n\x13list_namespaces_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x00\x88\x01\x01\x12\x11\n\x04uuid\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuid\"\xc3\x02\n\x0c\x61\x64\x64_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x10\n\x03psk\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rpsk_encrypted\x18\x05 \x01(\x08H\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x06 \x01(\x08H\x03\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x07 \x01(\tH\x04\x88\x01\x01\x12 \n\x13\x63trlr_key_encrypted\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x06\n\x04_pskB\r\n\x0b_dhchap_keyB\x10\n\x0e_psk_encryptedB\x10\n\x0e_key_encryptedB\x13\n\x11_dhchap_ctrlr_keyB\x16\n\x14_ctrlr_key_encrypted\"\x9a\x01\n\x13\x63hange_host_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x17\n\ndhchap_key\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_dhchap_keyB\x13\n\x11_dhchap_ctrlr_key\":\n\x0fremove_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\"O\n\x0elist_hosts_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"U\n\x14list_connections_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"\xeb\x01\n\x13\x63reate_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x13\n\x06secure\x18\x07 \x01(\x08H\x02\x88\x01\x01\x12\x1d\n\x10verify_host_name\x18\x08 \x01(\x08H\x03\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\t\n\x07_secureB\x13\n\x11_verify_host_name\"\xb5\x01\n\x13\x64\x65lete_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x07 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\x08\n\x06_force\"\'\n\x12list_listeners_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\"q\n\x13list_subsystems_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1a\n\rserial_number\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x10\n\x0e_serial_number\"\x14\n\x12get_subsystems_req\"U\n%get_spdk_nvmf_log_flags_and_level_req\x12\x1a\n\rall_log_flags\x18\x01 \x01(\x08H\x00\x88\x01\x01\x42\x10\n\x0e_all_log_flags\"5\n\x1a\x64isable_spdk_nvmf_logs_req\x12\x17\n\x0f\x65xtra_log_flags\x18\x01 \x03(\t\"\x97\x01\n\x16set_spdk_nvmf_logs_req\x12!\n\tlog_level\x18\x01 \x01(\x0e\x32\t.LogLevelH\x00\x88\x01\x01\x12#\n\x0bprint_level\x18\x02 \x01(\x0e\x32\t.LogLevelH\x01\x88\x01\x01\x12\x17\n\x0f\x65xtra_log_flags\x18\x03 \x03(\tB\x0c\n\n_log_levelB\x0e\n\x0c_print_level\"@\n\x14get_gateway_info_req\x12\x18\n\x0b\x63li_version\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_cli_version\"\x1b\n\x19get_gateway_log_level_req\";\n\x19set_gateway_log_level_req\x12\x1e\n\tlog_level\x18\x01 \x01(\x0e\x32\x0b.GwLogLevel\"8\n\x1fshow_gateway_listeners_info_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\"\x17\n\x15get_gateway_stats_req\"\x16\n\x14get_thread_stats_req\"<\n\x0f\x61na_group_state\x12\x0e\n\x06grp_id\x18\x01 \x01(\r\x12\x19\n\x05state\x18\x02 \x01(\x0e\x32\n.ana_state\"?\n\x0enqn_ana_states\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12 \n\x06states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"+\n\x08\x61na_info\x12\x1f\n\x06states\x18\x01 \x03(\x0b\x32\x0f.nqn_ana_states\"3\n\nreq_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\"C\n\rsubsys_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0b\n\x03nqn\x18\x03 \x01(\t\"B\n\x0bnsid_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0c\n\x04nsid\x18\x03 \x01(\r\"1\n\x0fsubsystems_info\x12\x1e\n\nsubsystems\x18\x01 \x03(\x0b\x32\n.subsystem\"\xc2\x03\n\tsubsystem\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0f\n\x07subtype\x18\x02 \x01(\t\x12)\n\x10listen_addresses\x18\x03 \x03(\x0b\x32\x0f.listen_address\x12\x14\n\x05hosts\x18\x04 \x03(\x0b\x32\x05.host\x12\x16\n\x0e\x61llow_any_host\x18\x05 \x01(\x08\x12\x1a\n\rserial_number\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0cmodel_number\x18\x07 \x01(\tH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x08 \x01(\rH\x02\x88\x01\x01\x12\x17\n\nmin_cntlid\x18\t \x01(\rH\x03\x88\x01\x01\x12\x17\n\nmax_cntlid\x18\n \x01(\rH\x04\x88\x01\x01\x12\x1e\n\nnamespaces\x18\x0b \x03(\x0b\x32\n.namespace\x12\x1b\n\x0ehas_dhchap_key\x18\x0c \x01(\x08H\x05\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x10\n\x0e_serial_numberB\x0f\n\r_model_numberB\x11\n\x0f_max_namespacesB\r\n\x0b_min_cntlidB\r\n\x0b_max_cntlidB\x11\n\x0f_has_dhchap_key\"\x97\x01\n\x0elisten_address\x12\x0e\n\x06trtype\x18\x01 \x01(\t\x12\x0e\n\x06\x61\x64rfam\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12\x0f\n\x07trsvcid\x18\x04 \x01(\t\x12\x16\n\ttransport\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x01\x88\x01\x01\x42\x0c\n\n_transportB\t\n\x07_secure\"\x84\x02\n\tnamespace\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x16\n\tbdev_name\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05nguid\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x02\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x12\n\x05nonce\x18\x07 \x01(\tH\x04\x88\x01\x01\x12\x19\n\x0c\x61uto_visible\x18\x08 \x01(\x08H\x05\x88\x01\x01\x12\r\n\x05hosts\x18\t \x03(\tB\x0c\n\n_bdev_nameB\x08\n\x06_nguidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x08\n\x06_nonceB\x0f\n\r_auto_visible\"`\n\x13subsystems_info_cli\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\nsubsystems\x18\x03 \x03(\x0b\x32\x0e.subsystem_cli\"\xf6\x02\n\rsubsystem_cli\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\tenable_ha\x18\x02 \x01(\x08\x12\x15\n\rserial_number\x18\x03 \x01(\t\x12\x14\n\x0cmodel_number\x18\x04 \x01(\t\x12\x12\n\nmin_cntlid\x18\x05 \x01(\r\x12\x12\n\nmax_cntlid\x18\x06 \x01(\r\x12\x17\n\x0fnamespace_count\x18\x07 \x01(\r\x12\x0f\n\x07subtype\x18\x08 \x01(\t\x12\x16\n\x0emax_namespaces\x18\t \x01(\r\x12\x1b\n\x0ehas_dhchap_key\x18\n \x01(\x08H\x00\x88\x01\x01\x12\x1b\n\x0e\x61llow_any_host\x18\x0b \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x63reated_without_key\x18\x0c \x01(\x08H\x02\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x11\n\x0f_has_dhchap_keyB\x11\n\x0f_allow_any_hostB\x16\n\x14_created_without_key\"\xe3\x04\n\x0cgateway_info\x12\x13\n\x0b\x63li_version\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05group\x18\x04 \x01(\t\x12\x0c\n\x04\x61\x64\x64r\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\t\x12\x13\n\x0b\x62ool_status\x18\x07 \x01(\x08\x12\x0e\n\x06status\x18\x08 \x01(\x05\x12\x15\n\rerror_message\x18\t \x01(\t\x12\x19\n\x0cspdk_version\x18\n \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x14load_balancing_group\x18\x0b \x01(\r\x12\x10\n\x08hostname\x18\x0c \x01(\t\x12\x1b\n\x0emax_subsystems\x18\r \x01(\rH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x0e \x01(\rH\x02\x88\x01\x01\x12$\n\x17max_hosts_per_subsystem\x18\x0f \x01(\rH\x03\x88\x01\x01\x12)\n\x1cmax_namespaces_per_subsystem\x18\x10 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tmax_hosts\x18\x11 \x01(\rH\x05\x88\x01\x01\x12(\n\x1bgateway_initialization_over\x18\x12 \x01(\x08H\x06\x88\x01\x01\x42\x0f\n\r_spdk_versionB\x11\n\x0f_max_subsystemsB\x11\n\x0f_max_namespacesB\x1a\n\x18_max_hosts_per_subsystemB\x1f\n\x1d_max_namespaces_per_subsystemB\x0c\n\n_max_hostsB\x1e\n\x1c_gateway_initialization_over\"E\n\x0b\x63li_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"D\n\ngw_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"+\n\x19poll_group_transport_info\x12\x0e\n\x06trtype\x18\x01 \x01(\t\"\xe5\x01\n\x0fpoll_group_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x61\x64min_qpairs\x18\x02 \x01(\r\x12\x11\n\tio_qpairs\x18\x03 \x01(\r\x12\x1c\n\x14\x63urrent_admin_qpairs\x18\x04 \x01(\r\x12\x19\n\x11\x63urrent_io_qpairs\x18\x05 \x01(\r\x12\x17\n\x0fpending_bdev_io\x18\x06 \x01(\x04\x12\x19\n\x11\x63ompleted_nvme_io\x18\x07 \x01(\x04\x12.\n\ntransports\x18\x08 \x03(\x0b\x32\x1a.poll_group_transport_info\"u\n\x12gateway_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12%\n\x0bpoll_groups\x18\x04 \x03(\x0b\x32\x10.poll_group_info\"q\n\x11thread_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\x07threads\x18\x03 \x03(\x0b\x32\x11.spdk_thread_info\x12\x11\n\ttick_rate\x18\x04 \x01(\x04\"<\n\x10spdk_thread_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62usy\x18\x02 \x01(\x04\x12\x0c\n\x04idle\x18\x03 \x01(\x04\"\xd3\x01\n\rlistener_info\x12\x11\n\thost_name\x18\x01 \x01(\t\x12\x0e\n\x06trtype\x18\x02 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x03 \x01(\x0e\x32\x0e.AddressFamily\x12\x0e\n\x06traddr\x18\x04 \x01(\t\x12\x0f\n\x07trsvcid\x18\x05 \x01(\r\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x00\x88\x01\x01\x12\x13\n\x06\x61\x63tive\x18\x07 \x01(\x08H\x01\x88\x01\x01\x12\x13\n\x06manual\x18\x08 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_secureB\t\n\x07_activeB\t\n\x07_manual\"Z\n\x0elisteners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12!\n\tlisteners\x18\x03 \x03(\x0b\x32\x0e.listener_info\"^\n\x15gateway_listener_info\x12 \n\x08listener\x18\x01 \x01(\x0b\x32\x0e.listener_info\x12#\n\tlb_states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"m\n\x16gateway_listeners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12,\n\x0cgw_listeners\x18\x03 \x03(\x0b\x32\x16.gateway_listener_info\"\xbb\x01\n\x04host\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x14\n\x07use_psk\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x03 \x01(\x08H\x01\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\x04 \x01(\x08H\x02\x88\x01\x01\x42\n\n\x08_use_pskB\r\n\x0b_use_dhchapB(\n&_disconnected_due_to_keepalive_timeout\"x\n\nhosts_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x16\n\x0e\x61llow_any_host\x18\x03 \x01(\x08\x12\x15\n\rsubsystem_nqn\x18\x04 \x01(\t\x12\x14\n\x05hosts\x18\x05 \x03(\x0b\x32\x05.host\"\x98\x03\n\nconnection\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0e\n\x06traddr\x18\x02 \x01(\t\x12\x0f\n\x07trsvcid\x18\x03 \x01(\r\x12\x0e\n\x06trtype\x18\x04 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamily\x12\x11\n\tconnected\x18\x06 \x01(\x08\x12\x14\n\x0cqpairs_count\x18\x07 \x01(\x05\x12\x15\n\rcontroller_id\x18\x08 \x01(\x05\x12\x13\n\x06secure\x18\t \x01(\x08H\x00\x88\x01\x01\x12\x14\n\x07use_psk\x18\n \x01(\x08H\x01\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x0b \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tsubsystem\x18\x0c \x01(\tH\x03\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\r \x01(\x08H\x04\x88\x01\x01\x42\t\n\x07_secureB\n\n\x08_use_pskB\r\n\x0b_use_dhchapB\x0c\n\n_subsystemB(\n&_disconnected_due_to_keepalive_timeout\"r\n\x10\x63onnections_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12 \n\x0b\x63onnections\x18\x04 \x03(\x0b\x32\x0b.connection\"\xd7\x06\n\rnamespace_cli\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x11\n\tbdev_name\x18\x02 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x03 \x01(\t\x12\x15\n\rrbd_pool_name\x18\x04 \x01(\t\x12\x1c\n\x14load_balancing_group\x18\x05 \x01(\r\x12\x12\n\nblock_size\x18\x06 \x01(\r\x12\x16\n\x0erbd_image_size\x18\x07 \x01(\x04\x12\x0c\n\x04uuid\x18\x08 \x01(\t\x12\x19\n\x11rw_ios_per_second\x18\t \x01(\x04\x12\x1c\n\x14rw_mbytes_per_second\x18\n \x01(\x04\x12\x1b\n\x13r_mbytes_per_second\x18\x0b \x01(\x04\x12\x1b\n\x13w_mbytes_per_second\x18\x0c \x01(\x04\x12\x14\n\x0c\x61uto_visible\x18\r \x01(\x08\x12\r\n\x05hosts\x18\x0e \x03(\t\x12\x1d\n\x10ns_subsystem_nqn\x18\x0f \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x10 \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\x11 \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tread_only\x18\x12 \x01(\x08H\x03\x88\x01\x01\x12\x19\n\x0c\x63luster_name\x18\x13 \x01(\tH\x04\x88\x01\x01\x12,\n\x1f\x63onfigured_load_balancing_group\x18\x14 \x01(\rH\x05\x88\x01\x01\x12\x1d\n\x10image_was_shrunk\x18\x15 \x01(\x08H\x06\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x16 \x01(\tH\x07\x88\x01\x01\x12\x15\n\x08location\x18\x17 \x01(\tH\x08\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x18 \x01(\tH\t\x88\x01\x01\x42\x13\n\x11_ns_subsystem_nqnB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x0f\n\r_cluster_nameB\"\n _configured_load_balancing_groupB\x13\n\x11_image_was_shrunkB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_name\"s\n\x0fnamespaces_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\"\n\nnamespaces\x18\x04 \x03(\x0b\x32\x0e.namespace_cli\"1\n\x12namespace_io_error\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r\"\xda\x05\n\x17namespace_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x0c\n\x04nsid\x18\x04 \x01(\r\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tbdev_name\x18\x06 \x01(\t\x12\x11\n\ttick_rate\x18\x07 \x01(\x04\x12\r\n\x05ticks\x18\x08 \x01(\x04\x12\x12\n\nbytes_read\x18\t \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\n \x01(\x04\x12\x15\n\rbytes_written\x18\x0b \x01(\x04\x12\x15\n\rnum_write_ops\x18\x0c \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\r \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x0e \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\x0f \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x10 \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x11 \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\x12 \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x13 \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x14 \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x15 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x16 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x17 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x18 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x19 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x1a \x01(\x04\x12%\n\x08io_error\x18\x1b \x03(\x0b\x32\x13.namespace_io_errorB\x07\n\x05_uuid\"3\n\x12spdk_log_flag_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"\xba\x01\n\"spdk_nvmf_log_flags_and_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12+\n\x0envmf_log_flags\x18\x03 \x03(\x0b\x32\x13.spdk_log_flag_info\x12\x1c\n\tlog_level\x18\x04 \x01(\x0e\x32\t.LogLevel\x12\"\n\x0flog_print_level\x18\x05 \x01(\x0e\x32\t.LogLevel\"_\n\x16gateway_log_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x1e\n\tlog_level\x18\x03 \x01(\x0e\x32\x0b.GwLogLevel*#\n\rAddressFamily\x12\x08\n\x04ipv4\x10\x00\x12\x08\n\x04ipv6\x10\x01*C\n\x08LogLevel\x12\t\n\x05\x45RROR\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\n\n\x06NOTICE\x10\x02\x12\x08\n\x04INFO\x10\x03\x12\t\n\x05\x44\x45\x42UG\x10\x04*S\n\nGwLogLevel\x12\n\n\x06notset\x10\x00\x12\t\n\x05\x64\x65\x62ug\x10\n\x12\x08\n\x04info\x10\x14\x12\x0b\n\x07warning\x10\x1e\x12\t\n\x05\x65rror\x10(\x12\x0c\n\x08\x63ritical\x10\x32*J\n\tana_state\x12\t\n\x05UNSET\x10\x00\x12\r\n\tOPTIMIZED\x10\x01\x12\x11\n\rNON_OPTIMIZED\x10\x02\x12\x10\n\x0cINACCESSIBLE\x10\x03\x32\xe2\x13\n\x07Gateway\x12\x33\n\rnamespace_add\x12\x12.namespace_add_req\x1a\x0c.nsid_status\"\x00\x12;\n\x10\x63reate_subsystem\x12\x15.create_subsystem_req\x1a\x0e.subsys_status\"\x00\x12\x38\n\x10\x64\x65lete_subsystem\x12\x15.delete_subsystem_req\x1a\x0b.req_status\"\x00\x12@\n\x14\x63hange_subsystem_key\x12\x19.change_subsystem_key_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x61\x64\x64_subsystem_network\x12\x1a.add_subsystem_network_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x64\x65l_subsystem_network\x12\x1a.del_subsystem_network_req\x1a\x0b.req_status\"\x00\x12;\n\x0flist_namespaces\x12\x14.list_namespaces_req\x1a\x10.namespaces_info\"\x00\x12\x38\n\x10namespace_resize\x12\x15.namespace_resize_req\x1a\x0b.req_status\"\x00\x12Q\n\x16namespace_get_io_stats\x12\x1b.namespace_get_io_stats_req\x1a\x18.namespace_io_stats_info\"\x00\x12\x41\n\x18namespace_set_qos_limits\x12\x16.namespace_set_qos_req\x1a\x0b.req_status\"\x00\x12\x62\n%namespace_change_load_balancing_group\x12*.namespace_change_load_balancing_group_req\x1a\x0b.req_status\"\x00\x12N\n\x1bnamespace_change_visibility\x12 .namespace_change_visibility_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_change_location\x12\x1e.namespace_change_location_req\x1a\x0b.req_status\"\x00\x12R\n\x1dnamespace_set_rbd_trash_image\x12\".namespace_set_rbd_trash_image_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_set_auto_resize\x12\x1e.namespace_set_auto_resize_req\x1a\x0b.req_status\"\x00\x12\x38\n\x10namespace_delete\x12\x15.namespace_delete_req\x1a\x0b.req_status\"\x00\x12<\n\x12namespace_add_host\x12\x17.namespace_add_host_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15namespace_delete_host\x12\x1a.namespace_delete_host_req\x1a\x0b.req_status\"\x00\x12(\n\x08\x61\x64\x64_host\x12\r.add_host_req\x1a\x0b.req_status\"\x00\x12.\n\x0bremove_host\x12\x10.remove_host_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x63hange_host_key\x12\x14.change_host_key_req\x1a\x0b.req_status\"\x00\x12,\n\nlist_hosts\x12\x0f.list_hosts_req\x1a\x0b.hosts_info\"\x00\x12>\n\x10list_connections\x12\x15.list_connections_req\x1a\x11.connections_info\"\x00\x12\x36\n\x0f\x63reate_listener\x12\x14.create_listener_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x64\x65lete_listener\x12\x14.delete_listener_req\x1a\x0b.req_status\"\x00\x12\x38\n\x0elist_listeners\x12\x13.list_listeners_req\x1a\x0f.listeners_info\"\x00\x12?\n\x0flist_subsystems\x12\x14.list_subsystems_req\x1a\x14.subsystems_info_cli\"\x00\x12\x39\n\x0eget_subsystems\x12\x13.get_subsystems_req\x1a\x10.subsystems_info\"\x00\x12)\n\rset_ana_state\x12\t.ana_info\x1a\x0b.req_status\"\x00\x12r\n!get_spdk_nvmf_log_flags_and_level\x12&.get_spdk_nvmf_log_flags_and_level_req\x1a#.spdk_nvmf_log_flags_and_level_info\"\x00\x12\x44\n\x16\x64isable_spdk_nvmf_logs\x12\x1b.disable_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12<\n\x12set_spdk_nvmf_logs\x12\x17.set_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12:\n\x10get_gateway_info\x12\x15.get_gateway_info_req\x1a\r.gateway_info\"\x00\x12N\n\x15get_gateway_log_level\x12\x1a.get_gateway_log_level_req\x1a\x17.gateway_log_level_info\"\x00\x12\x42\n\x15set_gateway_log_level\x12\x1a.set_gateway_log_level_req\x1a\x0b.req_status\"\x00\x12Z\n\x1bshow_gateway_listeners_info\x12 .show_gateway_listeners_info_req\x1a\x17.gateway_listeners_info\"\x00\x12\x42\n\x11get_gateway_stats\x12\x16.get_gateway_stats_req\x1a\x13.gateway_stats_info\"\x00\x12?\n\x10get_thread_stats\x12\x15.get_thread_stats_req\x1a\x12.thread_stats_info\"\x00\x42+Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeofb\x06proto3'
+  serialized_pb=b'\n&dashboard/services/proto/gateway.proto\"\x84\x06\n\x11namespace_add_req\x12\x15\n\rrbd_pool_name\x18\x01 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x11\n\x04nsid\x18\x04 \x01(\rH\x00\x88\x01\x01\x12\x12\n\nblock_size\x18\x05 \x01(\r\x12\x11\n\x04uuid\x18\x06 \x01(\tH\x01\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x07 \x01(\x05H\x02\x88\x01\x01\x12\x19\n\x0c\x63reate_image\x18\x08 \x01(\x08H\x03\x88\x01\x01\x12\x11\n\x04size\x18\t \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\n \x01(\x08H\x05\x88\x01\x01\x12\x1c\n\x0fno_auto_visible\x18\x0b \x01(\x08H\x06\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x0c \x01(\x08H\x07\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\r \x01(\x08H\x08\x88\x01\x01\x12\x16\n\tread_only\x18\x0e \x01(\x08H\t\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x0f \x01(\tH\n\x88\x01\x01\x12\x15\n\x08location\x18\x10 \x01(\tH\x0b\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x11 \x01(\tH\x0c\x88\x01\x01\x12-\n\x12\x65ncryption_entries\x18\x12 \x03(\x0b\x32\x11.encryption_entry\x12\x37\n\x14\x65ncryption_algorithm\x18\x13 \x01(\x0e\x32\x14.EncryptionAlgorithmH\r\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x0f\n\r_create_imageB\x07\n\x05_sizeB\x08\n\x06_forceB\x12\n\x10_no_auto_visibleB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_nameB\x17\n\x15_encryption_algorithm\"{\n\x14namespace_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08new_size\x18\x04 \x01(\x04\x42\x10\n\x0e_OBSOLETE_uuid\"o\n\x1anamespace_get_io_stats_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuid\"h\n\x1clist_namespaces_io_stats_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x07\n\x05_nsid\"\xee\x02\n\x15namespace_set_qos_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1e\n\x11rw_ios_per_second\x18\x04 \x01(\x04H\x01\x88\x01\x01\x12!\n\x14rw_mbytes_per_second\x18\x05 \x01(\x04H\x02\x88\x01\x01\x12 \n\x13r_mbytes_per_second\x18\x06 \x01(\x04H\x03\x88\x01\x01\x12 \n\x13w_mbytes_per_second\x18\x07 \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x14\n\x12_rw_ios_per_secondB\x17\n\x15_rw_mbytes_per_secondB\x16\n\x14_r_mbytes_per_secondB\x16\n\x14_w_mbytes_per_secondB\x08\n\x06_force\"\xbe\x01\n)namespace_change_load_balancing_group_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61nagrpid\x18\x04 \x01(\x05\x12\x1a\n\rauto_lb_logic\x18\x05 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x10\n\x0e_auto_lb_logic\"z\n\x1fnamespace_change_visibility_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x14\n\x0c\x61uto_visible\x18\x03 \x01(\x08\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"h\n\x1dnamespace_change_location_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x15\n\x08location\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x0b\n\t_location\"]\n!namespace_set_rbd_trash_image_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0btrash_image\x18\x03 \x01(\x08\"Y\n\x1dnamespace_set_auto_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0b\x61uto_resize\x18\x03 \x01(\x08\"\x8f\x01\n\x14namespace_delete_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x04 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x0c\n\n_i_am_sure\"m\n\x16namespace_add_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"R\n\x19namespace_delete_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\"\xd9\x02\n\x14\x63reate_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x15\n\rserial_number\x18\x02 \x01(\t\x12\x1b\n\x0emax_namespaces\x18\x03 \x01(\rH\x00\x88\x01\x01\x12\x11\n\tenable_ha\x18\x04 \x01(\x08\x12\x1c\n\x0fno_group_append\x18\x05 \x01(\x08H\x01\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x06 \x01(\tH\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x07 \x01(\x08H\x03\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\x08 \x03(\t\x12\x1d\n\x10secure_listeners\x18\t \x01(\x08H\x04\x88\x01\x01\x42\x11\n\x0f_max_namespacesB\x12\n\x10_no_group_appendB\r\n\x0b_dhchap_keyB\x10\n\x0e_key_encryptedB\x13\n\x11_secure_listeners\"q\n\x14\x64\x65lete_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x12\n\x05\x66orce\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x03 \x01(\x08H\x01\x88\x01\x01\x42\x08\n\x06_forceB\x0c\n\n_i_am_sure\"Y\n\x18\x63hange_subsystem_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x17\n\ndhchap_key\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\r\n\x0b_dhchap_key\"H\n\x19\x61\x64\x64_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"H\n\x19\x64\x65l_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"`\n\x13list_namespaces_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x00\x88\x01\x01\x12\x11\n\x04uuid\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuid\"\xc3\x02\n\x0c\x61\x64\x64_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x10\n\x03psk\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rpsk_encrypted\x18\x05 \x01(\x08H\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x06 \x01(\x08H\x03\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x07 \x01(\tH\x04\x88\x01\x01\x12 \n\x13\x63trlr_key_encrypted\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x06\n\x04_pskB\r\n\x0b_dhchap_keyB\x10\n\x0e_psk_encryptedB\x10\n\x0e_key_encryptedB\x13\n\x11_dhchap_ctrlr_keyB\x16\n\x14_ctrlr_key_encrypted\"\x9a\x01\n\x13\x63hange_host_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x17\n\ndhchap_key\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_dhchap_keyB\x13\n\x11_dhchap_ctrlr_key\"i\n get_connection_io_statistics_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x12\n\x05reset\x18\x03 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_reset\"X\n\x0fremove_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x12\n\x05\x66orce\x18\x03 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"O\n\x0elist_hosts_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"U\n\x14list_connections_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"\xeb\x01\n\x13\x63reate_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x13\n\x06secure\x18\x07 \x01(\x08H\x02\x88\x01\x01\x12\x1d\n\x10verify_host_name\x18\x08 \x01(\x08H\x03\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\t\n\x07_secureB\x13\n\x11_verify_host_name\"\xb5\x01\n\x13\x64\x65lete_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x07 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\x08\n\x06_force\"\'\n\x12list_listeners_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\"q\n\x13list_subsystems_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1a\n\rserial_number\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x10\n\x0e_serial_number\"\x14\n\x12get_subsystems_req\"U\n%get_spdk_nvmf_log_flags_and_level_req\x12\x1a\n\rall_log_flags\x18\x01 \x01(\x08H\x00\x88\x01\x01\x42\x10\n\x0e_all_log_flags\"5\n\x1a\x64isable_spdk_nvmf_logs_req\x12\x17\n\x0f\x65xtra_log_flags\x18\x01 \x03(\t\"\x97\x01\n\x16set_spdk_nvmf_logs_req\x12!\n\tlog_level\x18\x01 \x01(\x0e\x32\t.LogLevelH\x00\x88\x01\x01\x12#\n\x0bprint_level\x18\x02 \x01(\x0e\x32\t.LogLevelH\x01\x88\x01\x01\x12\x17\n\x0f\x65xtra_log_flags\x18\x03 \x03(\tB\x0c\n\n_log_levelB\x0e\n\x0c_print_level\"@\n\x14get_gateway_info_req\x12\x18\n\x0b\x63li_version\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_cli_version\"\x1b\n\x19get_gateway_log_level_req\";\n\x19set_gateway_log_level_req\x12\x1e\n\tlog_level\x18\x01 \x01(\x0e\x32\x0b.GwLogLevel\"8\n\x1fshow_gateway_listeners_info_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\"\x17\n\x15get_gateway_stats_req\"\x16\n\x14get_thread_stats_req\"0\n\x1dset_gateway_io_stats_mode_req\x12\x0f\n\x07\x65nabled\x18\x01 \x01(\x08\"<\n\x0f\x61na_group_state\x12\x0e\n\x06grp_id\x18\x01 \x01(\r\x12\x19\n\x05state\x18\x02 \x01(\x0e\x32\n.ana_state\"?\n\x0enqn_ana_states\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12 \n\x06states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"+\n\x08\x61na_info\x12\x1f\n\x06states\x18\x01 \x03(\x0b\x32\x0f.nqn_ana_states\"3\n\nreq_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\"C\n\rsubsys_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0b\n\x03nqn\x18\x03 \x01(\t\"B\n\x0bnsid_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0c\n\x04nsid\x18\x03 \x01(\r\"1\n\x0fsubsystems_info\x12\x1e\n\nsubsystems\x18\x01 \x03(\x0b\x32\n.subsystem\"\xc2\x03\n\tsubsystem\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0f\n\x07subtype\x18\x02 \x01(\t\x12)\n\x10listen_addresses\x18\x03 \x03(\x0b\x32\x0f.listen_address\x12\x14\n\x05hosts\x18\x04 \x03(\x0b\x32\x05.host\x12\x16\n\x0e\x61llow_any_host\x18\x05 \x01(\x08\x12\x1a\n\rserial_number\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0cmodel_number\x18\x07 \x01(\tH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x08 \x01(\rH\x02\x88\x01\x01\x12\x17\n\nmin_cntlid\x18\t \x01(\rH\x03\x88\x01\x01\x12\x17\n\nmax_cntlid\x18\n \x01(\rH\x04\x88\x01\x01\x12\x1e\n\nnamespaces\x18\x0b \x03(\x0b\x32\n.namespace\x12\x1b\n\x0ehas_dhchap_key\x18\x0c \x01(\x08H\x05\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x10\n\x0e_serial_numberB\x0f\n\r_model_numberB\x11\n\x0f_max_namespacesB\r\n\x0b_min_cntlidB\r\n\x0b_max_cntlidB\x11\n\x0f_has_dhchap_key\"\x97\x01\n\x0elisten_address\x12\x0e\n\x06trtype\x18\x01 \x01(\t\x12\x0e\n\x06\x61\x64rfam\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12\x0f\n\x07trsvcid\x18\x04 \x01(\t\x12\x16\n\ttransport\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x01\x88\x01\x01\x42\x0c\n\n_transportB\t\n\x07_secure\"\x84\x02\n\tnamespace\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x16\n\tbdev_name\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05nguid\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x02\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x12\n\x05nonce\x18\x07 \x01(\tH\x04\x88\x01\x01\x12\x19\n\x0c\x61uto_visible\x18\x08 \x01(\x08H\x05\x88\x01\x01\x12\r\n\x05hosts\x18\t \x03(\tB\x0c\n\n_bdev_nameB\x08\n\x06_nguidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x08\n\x06_nonceB\x0f\n\r_auto_visible\"`\n\x13subsystems_info_cli\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\nsubsystems\x18\x03 \x03(\x0b\x32\x0e.subsystem_cli\"\xf6\x02\n\rsubsystem_cli\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\tenable_ha\x18\x02 \x01(\x08\x12\x15\n\rserial_number\x18\x03 \x01(\t\x12\x14\n\x0cmodel_number\x18\x04 \x01(\t\x12\x12\n\nmin_cntlid\x18\x05 \x01(\r\x12\x12\n\nmax_cntlid\x18\x06 \x01(\r\x12\x17\n\x0fnamespace_count\x18\x07 \x01(\r\x12\x0f\n\x07subtype\x18\x08 \x01(\t\x12\x16\n\x0emax_namespaces\x18\t \x01(\r\x12\x1b\n\x0ehas_dhchap_key\x18\n \x01(\x08H\x00\x88\x01\x01\x12\x1b\n\x0e\x61llow_any_host\x18\x0b \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x63reated_without_key\x18\x0c \x01(\x08H\x02\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x11\n\x0f_has_dhchap_keyB\x11\n\x0f_allow_any_hostB\x16\n\x14_created_without_key\"\x97\x05\n\x0cgateway_info\x12\x13\n\x0b\x63li_version\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05group\x18\x04 \x01(\t\x12\x0c\n\x04\x61\x64\x64r\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\t\x12\x13\n\x0b\x62ool_status\x18\x07 \x01(\x08\x12\x0e\n\x06status\x18\x08 \x01(\x05\x12\x15\n\rerror_message\x18\t \x01(\t\x12\x19\n\x0cspdk_version\x18\n \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x14load_balancing_group\x18\x0b \x01(\r\x12\x10\n\x08hostname\x18\x0c \x01(\t\x12\x1b\n\x0emax_subsystems\x18\r \x01(\rH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x0e \x01(\rH\x02\x88\x01\x01\x12$\n\x17max_hosts_per_subsystem\x18\x0f \x01(\rH\x03\x88\x01\x01\x12)\n\x1cmax_namespaces_per_subsystem\x18\x10 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tmax_hosts\x18\x11 \x01(\rH\x05\x88\x01\x01\x12(\n\x1bgateway_initialization_over\x18\x12 \x01(\x08H\x06\x88\x01\x01\x12\x1d\n\x10io_stats_enabled\x18\x13 \x01(\x08H\x07\x88\x01\x01\x42\x0f\n\r_spdk_versionB\x11\n\x0f_max_subsystemsB\x11\n\x0f_max_namespacesB\x1a\n\x18_max_hosts_per_subsystemB\x1f\n\x1d_max_namespaces_per_subsystemB\x0c\n\n_max_hostsB\x1e\n\x1c_gateway_initialization_overB\x13\n\x11_io_stats_enabled\"E\n\x0b\x63li_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"D\n\ngw_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"+\n\x19poll_group_transport_info\x12\x0e\n\x06trtype\x18\x01 \x01(\t\"\xe5\x01\n\x0fpoll_group_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x61\x64min_qpairs\x18\x02 \x01(\r\x12\x11\n\tio_qpairs\x18\x03 \x01(\r\x12\x1c\n\x14\x63urrent_admin_qpairs\x18\x04 \x01(\r\x12\x19\n\x11\x63urrent_io_qpairs\x18\x05 \x01(\r\x12\x17\n\x0fpending_bdev_io\x18\x06 \x01(\x04\x12\x19\n\x11\x63ompleted_nvme_io\x18\x07 \x01(\x04\x12.\n\ntransports\x18\x08 \x03(\x0b\x32\x1a.poll_group_transport_info\"u\n\x12gateway_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12%\n\x0bpoll_groups\x18\x04 \x03(\x0b\x32\x10.poll_group_info\"q\n\x11thread_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\x07threads\x18\x03 \x03(\x0b\x32\x11.spdk_thread_info\x12\x11\n\ttick_rate\x18\x04 \x01(\x04\"<\n\x10spdk_thread_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62usy\x18\x02 \x01(\x04\x12\x0c\n\x04idle\x18\x03 \x01(\x04\"\xd3\x01\n\rlistener_info\x12\x11\n\thost_name\x18\x01 \x01(\t\x12\x0e\n\x06trtype\x18\x02 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x03 \x01(\x0e\x32\x0e.AddressFamily\x12\x0e\n\x06traddr\x18\x04 \x01(\t\x12\x0f\n\x07trsvcid\x18\x05 \x01(\r\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x00\x88\x01\x01\x12\x13\n\x06\x61\x63tive\x18\x07 \x01(\x08H\x01\x88\x01\x01\x12\x13\n\x06manual\x18\x08 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_secureB\t\n\x07_activeB\t\n\x07_manual\"Z\n\x0elisteners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12!\n\tlisteners\x18\x03 \x03(\x0b\x32\x0e.listener_info\"^\n\x15gateway_listener_info\x12 \n\x08listener\x18\x01 \x01(\x0b\x32\x0e.listener_info\x12#\n\tlb_states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"m\n\x16gateway_listeners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12,\n\x0cgw_listeners\x18\x03 \x03(\x0b\x32\x16.gateway_listener_info\"\x9b\x02\n\x04host\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x14\n\x07use_psk\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x03 \x01(\x08H\x01\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\x04 \x01(\x08H\x02\x88\x01\x01\x12\x41\n\x18\x64hchap_controller_origin\x18\x05 \x01(\x0e\x32\x1a.DHCHAPControllerKeyOriginH\x03\x88\x01\x01\x42\n\n\x08_use_pskB\r\n\x0b_use_dhchapB(\n&_disconnected_due_to_keepalive_timeoutB\x1b\n\x19_dhchap_controller_origin\"7\n\rlatency_stats\x12\x0b\n\x03min\x18\x01 \x01(\x04\x12\x0b\n\x03max\x18\x02 \x01(\x04\x12\x0c\n\x04mean\x18\x03 \x01(\x04\"\x98\x01\n\rlatency_group\x12\x10\n\x08io_count\x18\x01 \x01(\x04\x12\x1d\n\x05total\x18\x02 \x01(\x0b\x32\x0e.latency_stats\x12\x1c\n\x04\x62\x64\x65v\x18\x03 \x01(\x0b\x32\x0e.latency_stats\x12\x1b\n\x03net\x18\x04 \x01(\x0b\x32\x0e.latency_stats\x12\x1b\n\x03qos\x18\x05 \x01(\x0b\x32\x0e.latency_stats\"X\n\x0b\x62ucket_info\x12\x0c\n\x04size\x18\x01 \x01(\r\x12\x1c\n\x04read\x18\x02 \x01(\x0b\x32\x0e.latency_group\x12\x1d\n\x05write\x18\x03 \x01(\x0b\x32\x0e.latency_group\"\xb7\x01\n\x18\x63onnection_io_statistics\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x10\n\x08host_nqn\x18\x04 \x01(\t\x12\x1a\n\rtotal_num_ios\x18\x05 \x01(\x04H\x00\x88\x01\x01\x12\x1d\n\x07\x62uckets\x18\x06 \x03(\x0b\x32\x0c.bucket_infoB\x10\n\x0e_total_num_ios\"x\n\nhosts_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x16\n\x0e\x61llow_any_host\x18\x03 \x01(\x08\x12\x15\n\rsubsystem_nqn\x18\x04 \x01(\t\x12\x14\n\x05hosts\x18\x05 \x03(\x0b\x32\x05.host\"\xf8\x03\n\nconnection\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0e\n\x06traddr\x18\x02 \x01(\t\x12\x0f\n\x07trsvcid\x18\x03 \x01(\r\x12\x0e\n\x06trtype\x18\x04 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamily\x12\x11\n\tconnected\x18\x06 \x01(\x08\x12\x14\n\x0cqpairs_count\x18\x07 \x01(\x05\x12\x15\n\rcontroller_id\x18\x08 \x01(\x05\x12\x13\n\x06secure\x18\t \x01(\x08H\x00\x88\x01\x01\x12\x14\n\x07use_psk\x18\n \x01(\x08H\x01\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x0b \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tsubsystem\x18\x0c \x01(\tH\x03\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\r \x01(\x08H\x04\x88\x01\x01\x12\x41\n\x18\x64hchap_controller_origin\x18\x0e \x01(\x0e\x32\x1a.DHCHAPControllerKeyOriginH\x05\x88\x01\x01\x42\t\n\x07_secureB\n\n\x08_use_pskB\r\n\x0b_use_dhchapB\x0c\n\n_subsystemB(\n&_disconnected_due_to_keepalive_timeoutB\x1b\n\x19_dhchap_controller_origin\"r\n\x10\x63onnections_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12 \n\x0b\x63onnections\x18\x04 \x03(\x0b\x32\x0b.connection\"\xd8\x07\n\rnamespace_cli\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x11\n\tbdev_name\x18\x02 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x03 \x01(\t\x12\x15\n\rrbd_pool_name\x18\x04 \x01(\t\x12\x1c\n\x14load_balancing_group\x18\x05 \x01(\r\x12\x12\n\nblock_size\x18\x06 \x01(\r\x12\x16\n\x0erbd_image_size\x18\x07 \x01(\x04\x12\x0c\n\x04uuid\x18\x08 \x01(\t\x12\x19\n\x11rw_ios_per_second\x18\t \x01(\x04\x12\x1c\n\x14rw_mbytes_per_second\x18\n \x01(\x04\x12\x1b\n\x13r_mbytes_per_second\x18\x0b \x01(\x04\x12\x1b\n\x13w_mbytes_per_second\x18\x0c \x01(\x04\x12\x14\n\x0c\x61uto_visible\x18\r \x01(\x08\x12\r\n\x05hosts\x18\x0e \x03(\t\x12\x1d\n\x10ns_subsystem_nqn\x18\x0f \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x10 \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\x11 \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tread_only\x18\x12 \x01(\x08H\x03\x88\x01\x01\x12\x19\n\x0c\x63luster_name\x18\x13 \x01(\tH\x04\x88\x01\x01\x12,\n\x1f\x63onfigured_load_balancing_group\x18\x14 \x01(\rH\x05\x88\x01\x01\x12\x1d\n\x10image_was_shrunk\x18\x15 \x01(\x08H\x06\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x16 \x01(\tH\x07\x88\x01\x01\x12\x15\n\x08location\x18\x17 \x01(\tH\x08\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x18 \x01(\tH\t\x88\x01\x01\x12\x37\n\x14\x65ncryption_algorithm\x18\x19 \x01(\x0e\x32\x14.EncryptionAlgorithmH\n\x88\x01\x01\x12-\n\x12\x65ncryption_entries\x18\x1a \x03(\x0b\x32\x11.encryption_entryB\x13\n\x11_ns_subsystem_nqnB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x0f\n\r_cluster_nameB\"\n _configured_load_balancing_groupB\x13\n\x11_image_was_shrunkB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_nameB\x17\n\x15_encryption_algorithm\"s\n\x0fnamespaces_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\"\n\nnamespaces\x18\x04 \x03(\x0b\x32\x0e.namespace_cli\"1\n\x12namespace_io_error\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r\"\x91\x01\n\x1dlist_namespaces_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12\r\n\x05ticks\x18\x04 \x01(\x04\x12\'\n\nnamespaces\x18\x05 \x03(\x0b\x32\x13.bdev_io_stats_info\"\xf7\x04\n\x12\x62\x64\x65v_io_stats_info\x12\x11\n\tbdev_name\x18\x01 \x01(\t\x12\x12\n\nbytes_read\x18\x02 \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\x03 \x01(\x04\x12\x15\n\rbytes_written\x18\x04 \x01(\x04\x12\x15\n\rnum_write_ops\x18\x05 \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\x06 \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x07 \x01(\x04\x12\x14\n\x0c\x62ytes_copied\x18\x08 \x01(\x04\x12\x14\n\x0cnum_copy_ops\x18\t \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\n \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x0b \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x0c \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\r \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x0e \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x0f \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x10 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x11 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x12 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x13 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x14 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x15 \x01(\x04\x12%\n\x08io_error\x18\x16 \x03(\x0b\x32\x13.namespace_io_error\"\xda\x05\n\x17namespace_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x0c\n\x04nsid\x18\x04 \x01(\r\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tbdev_name\x18\x06 \x01(\t\x12\x11\n\ttick_rate\x18\x07 \x01(\x04\x12\r\n\x05ticks\x18\x08 \x01(\x04\x12\x12\n\nbytes_read\x18\t \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\n \x01(\x04\x12\x15\n\rbytes_written\x18\x0b \x01(\x04\x12\x15\n\rnum_write_ops\x18\x0c \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\r \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x0e \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\x0f \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x10 \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x11 \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\x12 \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x13 \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x14 \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x15 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x16 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x17 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x18 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x19 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x1a \x01(\x04\x12%\n\x08io_error\x18\x1b \x03(\x0b\x32\x13.namespace_io_errorB\x07\n\x05_uuid\"3\n\x12spdk_log_flag_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"\xba\x01\n\"spdk_nvmf_log_flags_and_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12+\n\x0envmf_log_flags\x18\x03 \x03(\x0b\x32\x13.spdk_log_flag_info\x12\x1c\n\tlog_level\x18\x04 \x01(\x0e\x32\t.LogLevel\x12\"\n\x0flog_print_level\x18\x05 \x01(\x0e\x32\t.LogLevel\"_\n\x16gateway_log_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x1e\n\tlog_level\x18\x03 \x01(\x0e\x32\x0b.GwLogLevel\"E\n\x10\x65ncryption_entry\x12!\n\x06\x66ormat\x18\x01 \x01(\x0e\x32\x11.EncryptionFormat\x12\x0e\n\x06key_id\x18\x02 \x01(\t*#\n\rAddressFamily\x12\x08\n\x04ipv4\x10\x00\x12\x08\n\x04ipv6\x10\x01*C\n\x08LogLevel\x12\t\n\x05\x45RROR\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\n\n\x06NOTICE\x10\x02\x12\x08\n\x04INFO\x10\x03\x12\t\n\x05\x44\x45\x42UG\x10\x04*S\n\nGwLogLevel\x12\n\n\x06notset\x10\x00\x12\t\n\x05\x64\x65\x62ug\x10\n\x12\x08\n\x04info\x10\x14\x12\x0b\n\x07warning\x10\x1e\x12\t\n\x05\x65rror\x10(\x12\x0c\n\x08\x63ritical\x10\x32*2\n\x10\x45ncryptionFormat\x12\x08\n\x04none\x10\x00\x12\t\n\x05luks1\x10\x01\x12\t\n\x05luks2\x10\x02*?\n\x13\x45ncryptionAlgorithm\x12\x10\n\x0cno_algorithm\x10\x00\x12\n\n\x06\x61\x65s128\x10\x01\x12\n\n\x06\x61\x65s256\x10\x02*R\n\x19\x44HCHAPControllerKeyOrigin\x12\n\n\x06no_key\x10\x00\x12\x11\n\rhost_specific\x10\x01\x12\x16\n\x12subsystem_implicit\x10\x02*J\n\tana_state\x12\t\n\x05UNSET\x10\x00\x12\r\n\tOPTIMIZED\x10\x01\x12\x11\n\rNON_OPTIMIZED\x10\x02\x12\x10\n\x0cINACCESSIBLE\x10\x03\x32\xeb\x15\n\x07Gateway\x12\x33\n\rnamespace_add\x12\x12.namespace_add_req\x1a\x0c.nsid_status\"\x00\x12;\n\x10\x63reate_subsystem\x12\x15.create_subsystem_req\x1a\x0e.subsys_status\"\x00\x12\x38\n\x10\x64\x65lete_subsystem\x12\x15.delete_subsystem_req\x1a\x0b.req_status\"\x00\x12@\n\x14\x63hange_subsystem_key\x12\x19.change_subsystem_key_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x61\x64\x64_subsystem_network\x12\x1a.add_subsystem_network_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x64\x65l_subsystem_network\x12\x1a.del_subsystem_network_req\x1a\x0b.req_status\"\x00\x12;\n\x0flist_namespaces\x12\x14.list_namespaces_req\x1a\x10.namespaces_info\"\x00\x12\x38\n\x10namespace_resize\x12\x15.namespace_resize_req\x1a\x0b.req_status\"\x00\x12Q\n\x16namespace_get_io_stats\x12\x1b.namespace_get_io_stats_req\x1a\x18.namespace_io_stats_info\"\x00\x12[\n\x18list_namespaces_io_stats\x12\x1d.list_namespaces_io_stats_req\x1a\x1e.list_namespaces_io_stats_info\"\x00\x12\x41\n\x18namespace_set_qos_limits\x12\x16.namespace_set_qos_req\x1a\x0b.req_status\"\x00\x12\x62\n%namespace_change_load_balancing_group\x12*.namespace_change_load_balancing_group_req\x1a\x0b.req_status\"\x00\x12N\n\x1bnamespace_change_visibility\x12 .namespace_change_visibility_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_change_location\x12\x1e.namespace_change_location_req\x1a\x0b.req_status\"\x00\x12R\n\x1dnamespace_set_rbd_trash_image\x12\".namespace_set_rbd_trash_image_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_set_auto_resize\x12\x1e.namespace_set_auto_resize_req\x1a\x0b.req_status\"\x00\x12\x38\n\x10namespace_delete\x12\x15.namespace_delete_req\x1a\x0b.req_status\"\x00\x12<\n\x12namespace_add_host\x12\x17.namespace_add_host_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15namespace_delete_host\x12\x1a.namespace_delete_host_req\x1a\x0b.req_status\"\x00\x12(\n\x08\x61\x64\x64_host\x12\r.add_host_req\x1a\x0b.req_status\"\x00\x12.\n\x0bremove_host\x12\x10.remove_host_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x63hange_host_key\x12\x14.change_host_key_req\x1a\x0b.req_status\"\x00\x12,\n\nlist_hosts\x12\x0f.list_hosts_req\x1a\x0b.hosts_info\"\x00\x12>\n\x10list_connections\x12\x15.list_connections_req\x1a\x11.connections_info\"\x00\x12^\n\x1cget_connection_io_statistics\x12!.get_connection_io_statistics_req\x1a\x19.connection_io_statistics\"\x00\x12\x36\n\x0f\x63reate_listener\x12\x14.create_listener_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x64\x65lete_listener\x12\x14.delete_listener_req\x1a\x0b.req_status\"\x00\x12\x38\n\x0elist_listeners\x12\x13.list_listeners_req\x1a\x0f.listeners_info\"\x00\x12?\n\x0flist_subsystems\x12\x14.list_subsystems_req\x1a\x14.subsystems_info_cli\"\x00\x12\x39\n\x0eget_subsystems\x12\x13.get_subsystems_req\x1a\x10.subsystems_info\"\x00\x12)\n\rset_ana_state\x12\t.ana_info\x1a\x0b.req_status\"\x00\x12r\n!get_spdk_nvmf_log_flags_and_level\x12&.get_spdk_nvmf_log_flags_and_level_req\x1a#.spdk_nvmf_log_flags_and_level_info\"\x00\x12\x44\n\x16\x64isable_spdk_nvmf_logs\x12\x1b.disable_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12<\n\x12set_spdk_nvmf_logs\x12\x17.set_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12:\n\x10get_gateway_info\x12\x15.get_gateway_info_req\x1a\r.gateway_info\"\x00\x12N\n\x15get_gateway_log_level\x12\x1a.get_gateway_log_level_req\x1a\x17.gateway_log_level_info\"\x00\x12\x42\n\x15set_gateway_log_level\x12\x1a.set_gateway_log_level_req\x1a\x0b.req_status\"\x00\x12Z\n\x1bshow_gateway_listeners_info\x12 .show_gateway_listeners_info_req\x1a\x17.gateway_listeners_info\"\x00\x12\x42\n\x11get_gateway_stats\x12\x16.get_gateway_stats_req\x1a\x13.gateway_stats_info\"\x00\x12?\n\x10get_thread_stats\x12\x15.get_thread_stats_req\x1a\x12.thread_stats_info\"\x00\x12J\n\x19set_gateway_io_stats_mode\x12\x1e.set_gateway_io_stats_mode_req\x1a\x0b.req_status\"\x00\x42+Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeofb\x06proto3'
 )
 
 _ADDRESSFAMILY = _descriptor.EnumDescriptor(
@@ -43,8 +43,8 @@ _ADDRESSFAMILY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11451,
-  serialized_end=11486,
+  serialized_start=13587,
+  serialized_end=13622,
 )
 _sym_db.RegisterEnumDescriptor(_ADDRESSFAMILY)
 
@@ -84,8 +84,8 @@ _LOGLEVEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11488,
-  serialized_end=11555,
+  serialized_start=13624,
+  serialized_end=13691,
 )
 _sym_db.RegisterEnumDescriptor(_LOGLEVEL)
 
@@ -130,12 +130,105 @@ _GWLOGLEVEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11557,
-  serialized_end=11640,
+  serialized_start=13693,
+  serialized_end=13776,
 )
 _sym_db.RegisterEnumDescriptor(_GWLOGLEVEL)
 
 GwLogLevel = enum_type_wrapper.EnumTypeWrapper(_GWLOGLEVEL)
+_ENCRYPTIONFORMAT = _descriptor.EnumDescriptor(
+  name='EncryptionFormat',
+  full_name='EncryptionFormat',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='none', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='luks1', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='luks2', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=13778,
+  serialized_end=13828,
+)
+_sym_db.RegisterEnumDescriptor(_ENCRYPTIONFORMAT)
+
+EncryptionFormat = enum_type_wrapper.EnumTypeWrapper(_ENCRYPTIONFORMAT)
+_ENCRYPTIONALGORITHM = _descriptor.EnumDescriptor(
+  name='EncryptionAlgorithm',
+  full_name='EncryptionAlgorithm',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='no_algorithm', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='aes128', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='aes256', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=13830,
+  serialized_end=13893,
+)
+_sym_db.RegisterEnumDescriptor(_ENCRYPTIONALGORITHM)
+
+EncryptionAlgorithm = enum_type_wrapper.EnumTypeWrapper(_ENCRYPTIONALGORITHM)
+_DHCHAPCONTROLLERKEYORIGIN = _descriptor.EnumDescriptor(
+  name='DHCHAPControllerKeyOrigin',
+  full_name='DHCHAPControllerKeyOrigin',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='no_key', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='host_specific', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='subsystem_implicit', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=13895,
+  serialized_end=13977,
+)
+_sym_db.RegisterEnumDescriptor(_DHCHAPCONTROLLERKEYORIGIN)
+
+DHCHAPControllerKeyOrigin = enum_type_wrapper.EnumTypeWrapper(_DHCHAPCONTROLLERKEYORIGIN)
 _ANA_STATE = _descriptor.EnumDescriptor(
   name='ana_state',
   full_name='ana_state',
@@ -166,8 +259,8 @@ _ANA_STATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11642,
-  serialized_end=11716,
+  serialized_start=13979,
+  serialized_end=14053,
 )
 _sym_db.RegisterEnumDescriptor(_ANA_STATE)
 
@@ -185,6 +278,15 @@ info = 20
 warning = 30
 error = 40
 critical = 50
+none = 0
+luks1 = 1
+luks2 = 2
+no_algorithm = 0
+aes128 = 1
+aes256 = 2
+no_key = 0
+host_specific = 1
+subsystem_implicit = 2
 UNSET = 0
 OPTIMIZED = 1
 NON_OPTIMIZED = 2
@@ -319,6 +421,20 @@ _NAMESPACE_ADD_REQ = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='encryption_entries', full_name='namespace_add_req.encryption_entries', index=17,
+      number=18, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='encryption_algorithm', full_name='namespace_add_req.encryption_algorithm', index=18,
+      number=19, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -395,9 +511,14 @@ _NAMESPACE_ADD_REQ = _descriptor.Descriptor(
       index=12, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_encryption_algorithm', full_name='namespace_add_req._encryption_algorithm',
+      index=13, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
   serialized_start=43,
-  serialized_end=686,
+  serialized_end=815,
 )
 
 
@@ -454,8 +575,8 @@ _NAMESPACE_RESIZE_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=688,
-  serialized_end=811,
+  serialized_start=817,
+  serialized_end=940,
 )
 
 
@@ -505,8 +626,57 @@ _NAMESPACE_GET_IO_STATS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=813,
-  serialized_end=924,
+  serialized_start=942,
+  serialized_end=1053,
+)
+
+
+_LIST_NAMESPACES_IO_STATS_REQ = _descriptor.Descriptor(
+  name='list_namespaces_io_stats_req',
+  full_name='list_namespaces_io_stats_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='list_namespaces_io_stats_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nsid', full_name='list_namespaces_io_stats_req.nsid', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_subsystem_nqn', full_name='list_namespaces_io_stats_req._subsystem_nqn',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_nsid', full_name='list_namespaces_io_stats_req._nsid',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=1055,
+  serialized_end=1159,
 )
 
 
@@ -616,8 +786,8 @@ _NAMESPACE_SET_QOS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=927,
-  serialized_end=1293,
+  serialized_start=1162,
+  serialized_end=1528,
 )
 
 
@@ -686,8 +856,8 @@ _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1296,
-  serialized_end=1486,
+  serialized_start=1531,
+  serialized_end=1721,
 )
 
 
@@ -744,8 +914,8 @@ _NAMESPACE_CHANGE_VISIBILITY_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1488,
-  serialized_end=1610,
+  serialized_start=1723,
+  serialized_end=1845,
 )
 
 
@@ -795,8 +965,8 @@ _NAMESPACE_CHANGE_LOCATION_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1612,
-  serialized_end=1716,
+  serialized_start=1847,
+  serialized_end=1951,
 )
 
 
@@ -841,8 +1011,8 @@ _NAMESPACE_SET_RBD_TRASH_IMAGE_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1718,
-  serialized_end=1811,
+  serialized_start=1953,
+  serialized_end=2046,
 )
 
 
@@ -887,8 +1057,8 @@ _NAMESPACE_SET_AUTO_RESIZE_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1813,
-  serialized_end=1902,
+  serialized_start=2048,
+  serialized_end=2137,
 )
 
 
@@ -950,8 +1120,8 @@ _NAMESPACE_DELETE_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1905,
-  serialized_end=2048,
+  serialized_start=2140,
+  serialized_end=2283,
 )
 
 
@@ -1008,8 +1178,8 @@ _NAMESPACE_ADD_HOST_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2050,
-  serialized_end=2159,
+  serialized_start=2285,
+  serialized_end=2394,
 )
 
 
@@ -1054,8 +1224,8 @@ _NAMESPACE_DELETE_HOST_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2161,
-  serialized_end=2243,
+  serialized_start=2396,
+  serialized_end=2478,
 )
 
 
@@ -1167,8 +1337,8 @@ _CREATE_SUBSYSTEM_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2246,
-  serialized_end=2591,
+  serialized_start=2481,
+  serialized_end=2826,
 )
 
 
@@ -1223,8 +1393,8 @@ _DELETE_SUBSYSTEM_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2593,
-  serialized_end=2706,
+  serialized_start=2828,
+  serialized_end=2941,
 )
 
 
@@ -1267,8 +1437,8 @@ _CHANGE_SUBSYSTEM_KEY_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2708,
-  serialized_end=2797,
+  serialized_start=2943,
+  serialized_end=3032,
 )
 
 
@@ -1306,8 +1476,8 @@ _ADD_SUBSYSTEM_NETWORK_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2799,
-  serialized_end=2871,
+  serialized_start=3034,
+  serialized_end=3106,
 )
 
 
@@ -1345,8 +1515,8 @@ _DEL_SUBSYSTEM_NETWORK_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2873,
-  serialized_end=2945,
+  serialized_start=3108,
+  serialized_end=3180,
 )
 
 
@@ -1401,8 +1571,8 @@ _LIST_NAMESPACES_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2947,
-  serialized_end=3043,
+  serialized_start=3182,
+  serialized_end=3278,
 )
 
 
@@ -1512,8 +1682,8 @@ _ADD_HOST_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3046,
-  serialized_end=3369,
+  serialized_start=3281,
+  serialized_end=3604,
 )
 
 
@@ -1575,8 +1745,59 @@ _CHANGE_HOST_KEY_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3372,
-  serialized_end=3526,
+  serialized_start=3607,
+  serialized_end=3761,
+)
+
+
+_GET_CONNECTION_IO_STATISTICS_REQ = _descriptor.Descriptor(
+  name='get_connection_io_statistics_req',
+  full_name='get_connection_io_statistics_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='get_connection_io_statistics_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_nqn', full_name='get_connection_io_statistics_req.host_nqn', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='reset', full_name='get_connection_io_statistics_req.reset', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_reset', full_name='get_connection_io_statistics_req._reset',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3763,
+  serialized_end=3868,
 )
 
 
@@ -1602,6 +1823,13 @@ _REMOVE_HOST_REQ = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='remove_host_req.force', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -1613,9 +1841,14 @@ _REMOVE_HOST_REQ = _descriptor.Descriptor(
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='remove_host_req._force',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
-  serialized_start=3528,
-  serialized_end=3586,
+  serialized_start=3870,
+  serialized_end=3958,
 )
 
 
@@ -1658,8 +1891,8 @@ _LIST_HOSTS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3588,
-  serialized_end=3667,
+  serialized_start=3960,
+  serialized_end=4039,
 )
 
 
@@ -1702,8 +1935,8 @@ _LIST_CONNECTIONS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3669,
-  serialized_end=3754,
+  serialized_start=4041,
+  serialized_end=4126,
 )
 
 
@@ -1796,8 +2029,8 @@ _CREATE_LISTENER_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3757,
-  serialized_end=3992,
+  serialized_start=4129,
+  serialized_end=4364,
 )
 
 
@@ -1878,8 +2111,8 @@ _DELETE_LISTENER_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3995,
-  serialized_end=4176,
+  serialized_start=4367,
+  serialized_end=4548,
 )
 
 
@@ -1910,8 +2143,8 @@ _LIST_LISTENERS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4178,
-  serialized_end=4217,
+  serialized_start=4550,
+  serialized_end=4589,
 )
 
 
@@ -1959,8 +2192,8 @@ _LIST_SUBSYSTEMS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4219,
-  serialized_end=4332,
+  serialized_start=4591,
+  serialized_end=4704,
 )
 
 
@@ -1984,8 +2217,8 @@ _GET_SUBSYSTEMS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4334,
-  serialized_end=4354,
+  serialized_start=4706,
+  serialized_end=4726,
 )
 
 
@@ -2021,8 +2254,8 @@ _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4356,
-  serialized_end=4441,
+  serialized_start=4728,
+  serialized_end=4813,
 )
 
 
@@ -2053,8 +2286,8 @@ _DISABLE_SPDK_NVMF_LOGS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4443,
-  serialized_end=4496,
+  serialized_start=4815,
+  serialized_end=4868,
 )
 
 
@@ -2109,8 +2342,8 @@ _SET_SPDK_NVMF_LOGS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4499,
-  serialized_end=4650,
+  serialized_start=4871,
+  serialized_end=5022,
 )
 
 
@@ -2146,8 +2379,8 @@ _GET_GATEWAY_INFO_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4652,
-  serialized_end=4716,
+  serialized_start=5024,
+  serialized_end=5088,
 )
 
 
@@ -2171,8 +2404,8 @@ _GET_GATEWAY_LOG_LEVEL_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4718,
-  serialized_end=4745,
+  serialized_start=5090,
+  serialized_end=5117,
 )
 
 
@@ -2203,8 +2436,8 @@ _SET_GATEWAY_LOG_LEVEL_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4747,
-  serialized_end=4806,
+  serialized_start=5119,
+  serialized_end=5178,
 )
 
 
@@ -2235,8 +2468,8 @@ _SHOW_GATEWAY_LISTENERS_INFO_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4808,
-  serialized_end=4864,
+  serialized_start=5180,
+  serialized_end=5236,
 )
 
 
@@ -2260,8 +2493,8 @@ _GET_GATEWAY_STATS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4866,
-  serialized_end=4889,
+  serialized_start=5238,
+  serialized_end=5261,
 )
 
 
@@ -2285,8 +2518,40 @@ _GET_THREAD_STATS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4891,
-  serialized_end=4913,
+  serialized_start=5263,
+  serialized_end=5285,
+)
+
+
+_SET_GATEWAY_IO_STATS_MODE_REQ = _descriptor.Descriptor(
+  name='set_gateway_io_stats_mode_req',
+  full_name='set_gateway_io_stats_mode_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='enabled', full_name='set_gateway_io_stats_mode_req.enabled', index=0,
+      number=1, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5287,
+  serialized_end=5335,
 )
 
 
@@ -2324,8 +2589,8 @@ _ANA_GROUP_STATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4915,
-  serialized_end=4975,
+  serialized_start=5337,
+  serialized_end=5397,
 )
 
 
@@ -2363,8 +2628,8 @@ _NQN_ANA_STATES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4977,
-  serialized_end=5040,
+  serialized_start=5399,
+  serialized_end=5462,
 )
 
 
@@ -2395,8 +2660,8 @@ _ANA_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5042,
-  serialized_end=5085,
+  serialized_start=5464,
+  serialized_end=5507,
 )
 
 
@@ -2434,8 +2699,8 @@ _REQ_STATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5087,
-  serialized_end=5138,
+  serialized_start=5509,
+  serialized_end=5560,
 )
 
 
@@ -2480,8 +2745,8 @@ _SUBSYS_STATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5140,
-  serialized_end=5207,
+  serialized_start=5562,
+  serialized_end=5629,
 )
 
 
@@ -2526,8 +2791,8 @@ _NSID_STATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5209,
-  serialized_end=5275,
+  serialized_start=5631,
+  serialized_end=5697,
 )
 
 
@@ -2558,8 +2823,8 @@ _SUBSYSTEMS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5277,
-  serialized_end=5326,
+  serialized_start=5699,
+  serialized_end=5748,
 )
 
 
@@ -2704,8 +2969,8 @@ _SUBSYSTEM = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=5329,
-  serialized_end=5779,
+  serialized_start=5751,
+  serialized_end=6201,
 )
 
 
@@ -2781,8 +3046,8 @@ _LISTEN_ADDRESS = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=5782,
-  serialized_end=5933,
+  serialized_start=6204,
+  serialized_end=6355,
 )
 
 
@@ -2899,8 +3164,8 @@ _NAMESPACE = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=5936,
-  serialized_end=6196,
+  serialized_start=6358,
+  serialized_end=6618,
 )
 
 
@@ -2945,8 +3210,8 @@ _SUBSYSTEMS_INFO_CLI = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6198,
-  serialized_end=6294,
+  serialized_start=6620,
+  serialized_end=6716,
 )
 
 
@@ -3076,8 +3341,8 @@ _SUBSYSTEM_CLI = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=6297,
-  serialized_end=6671,
+  serialized_start=6719,
+  serialized_end=7093,
 )
 
 
@@ -3215,6 +3480,13 @@ _GATEWAY_INFO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='io_stats_enabled', full_name='gateway_info.io_stats_enabled', index=18,
+      number=19, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -3261,9 +3533,14 @@ _GATEWAY_INFO = _descriptor.Descriptor(
       index=6, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_io_stats_enabled', full_name='gateway_info._io_stats_enabled',
+      index=7, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
-  serialized_start=6674,
-  serialized_end=7285,
+  serialized_start=7096,
+  serialized_end=7759,
 )
 
 
@@ -3308,8 +3585,8 @@ _CLI_VERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7287,
-  serialized_end=7356,
+  serialized_start=7761,
+  serialized_end=7830,
 )
 
 
@@ -3354,8 +3631,8 @@ _GW_VERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7358,
-  serialized_end=7426,
+  serialized_start=7832,
+  serialized_end=7900,
 )
 
 
@@ -3386,8 +3663,8 @@ _POLL_GROUP_TRANSPORT_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7428,
-  serialized_end=7471,
+  serialized_start=7902,
+  serialized_end=7945,
 )
 
 
@@ -3467,8 +3744,8 @@ _POLL_GROUP_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7474,
-  serialized_end=7703,
+  serialized_start=7948,
+  serialized_end=8177,
 )
 
 
@@ -3520,8 +3797,8 @@ _GATEWAY_STATS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7705,
-  serialized_end=7822,
+  serialized_start=8179,
+  serialized_end=8296,
 )
 
 
@@ -3573,8 +3850,8 @@ _THREAD_STATS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7824,
-  serialized_end=7937,
+  serialized_start=8298,
+  serialized_end=8411,
 )
 
 
@@ -3619,8 +3896,8 @@ _SPDK_THREAD_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7939,
-  serialized_end=7999,
+  serialized_start=8413,
+  serialized_end=8473,
 )
 
 
@@ -3715,8 +3992,8 @@ _LISTENER_INFO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=8002,
-  serialized_end=8213,
+  serialized_start=8476,
+  serialized_end=8687,
 )
 
 
@@ -3761,8 +4038,8 @@ _LISTENERS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8215,
-  serialized_end=8305,
+  serialized_start=8689,
+  serialized_end=8779,
 )
 
 
@@ -3800,8 +4077,8 @@ _GATEWAY_LISTENER_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8307,
-  serialized_end=8401,
+  serialized_start=8781,
+  serialized_end=8875,
 )
 
 
@@ -3846,8 +4123,8 @@ _GATEWAY_LISTENERS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8403,
-  serialized_end=8512,
+  serialized_start=8877,
+  serialized_end=8986,
 )
 
 
@@ -3887,6 +4164,13 @@ _HOST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_controller_origin', full_name='host.dhchap_controller_origin', index=4,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -3913,9 +4197,238 @@ _HOST = _descriptor.Descriptor(
       index=2, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_dhchap_controller_origin', full_name='host._dhchap_controller_origin',
+      index=3, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
-  serialized_start=8515,
-  serialized_end=8702,
+  serialized_start=8989,
+  serialized_end=9272,
+)
+
+
+_LATENCY_STATS = _descriptor.Descriptor(
+  name='latency_stats',
+  full_name='latency_stats',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='min', full_name='latency_stats.min', index=0,
+      number=1, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max', full_name='latency_stats.max', index=1,
+      number=2, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='mean', full_name='latency_stats.mean', index=2,
+      number=3, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=9274,
+  serialized_end=9329,
+)
+
+
+_LATENCY_GROUP = _descriptor.Descriptor(
+  name='latency_group',
+  full_name='latency_group',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='io_count', full_name='latency_group.io_count', index=0,
+      number=1, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='total', full_name='latency_group.total', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bdev', full_name='latency_group.bdev', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='net', full_name='latency_group.net', index=3,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='qos', full_name='latency_group.qos', index=4,
+      number=5, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=9332,
+  serialized_end=9484,
+)
+
+
+_BUCKET_INFO = _descriptor.Descriptor(
+  name='bucket_info',
+  full_name='bucket_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='size', full_name='bucket_info.size', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='read', full_name='bucket_info.read', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='write', full_name='bucket_info.write', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=9486,
+  serialized_end=9574,
+)
+
+
+_CONNECTION_IO_STATISTICS = _descriptor.Descriptor(
+  name='connection_io_statistics',
+  full_name='connection_io_statistics',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='connection_io_statistics.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='connection_io_statistics.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='connection_io_statistics.subsystem_nqn', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='host_nqn', full_name='connection_io_statistics.host_nqn', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='total_num_ios', full_name='connection_io_statistics.total_num_ios', index=4,
+      number=5, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='buckets', full_name='connection_io_statistics.buckets', index=5,
+      number=6, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_total_num_ios', full_name='connection_io_statistics._total_num_ios',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=9577,
+  serialized_end=9760,
 )
 
 
@@ -3974,8 +4487,8 @@ _HOSTS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8704,
-  serialized_end=8824,
+  serialized_start=9762,
+  serialized_end=9882,
 )
 
 
@@ -4078,6 +4591,13 @@ _CONNECTION = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dhchap_controller_origin', full_name='connection.dhchap_controller_origin', index=13,
+      number=14, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -4114,9 +4634,14 @@ _CONNECTION = _descriptor.Descriptor(
       index=4, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_dhchap_controller_origin', full_name='connection._dhchap_controller_origin',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
-  serialized_start=8827,
-  serialized_end=9235,
+  serialized_start=9885,
+  serialized_end=10389,
 )
 
 
@@ -4168,8 +4693,8 @@ _CONNECTIONS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9237,
-  serialized_end=9351,
+  serialized_start=10391,
+  serialized_end=10505,
 )
 
 
@@ -4349,6 +4874,20 @@ _NAMESPACE_CLI = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='encryption_algorithm', full_name='namespace_cli.encryption_algorithm', index=24,
+      number=25, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='encryption_entries', full_name='namespace_cli.encryption_entries', index=25,
+      number=26, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -4410,9 +4949,14 @@ _NAMESPACE_CLI = _descriptor.Descriptor(
       index=9, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_encryption_algorithm', full_name='namespace_cli._encryption_algorithm',
+      index=10, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
-  serialized_start=9354,
-  serialized_end=10209,
+  serialized_start=10508,
+  serialized_end=11492,
 )
 
 
@@ -4464,8 +5008,8 @@ _NAMESPACES_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10211,
-  serialized_end=10326,
+  serialized_start=11494,
+  serialized_end=11609,
 )
 
 
@@ -4503,8 +5047,247 @@ _NAMESPACE_IO_ERROR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10328,
-  serialized_end=10377,
+  serialized_start=11611,
+  serialized_end=11660,
+)
+
+
+_LIST_NAMESPACES_IO_STATS_INFO = _descriptor.Descriptor(
+  name='list_namespaces_io_stats_info',
+  full_name='list_namespaces_io_stats_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='list_namespaces_io_stats_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='list_namespaces_io_stats_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='tick_rate', full_name='list_namespaces_io_stats_info.tick_rate', index=2,
+      number=3, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='ticks', full_name='list_namespaces_io_stats_info.ticks', index=3,
+      number=4, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='namespaces', full_name='list_namespaces_io_stats_info.namespaces', index=4,
+      number=5, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11663,
+  serialized_end=11808,
+)
+
+
+_BDEV_IO_STATS_INFO = _descriptor.Descriptor(
+  name='bdev_io_stats_info',
+  full_name='bdev_io_stats_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='bdev_name', full_name='bdev_io_stats_info.bdev_name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bytes_read', full_name='bdev_io_stats_info.bytes_read', index=1,
+      number=2, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='num_read_ops', full_name='bdev_io_stats_info.num_read_ops', index=2,
+      number=3, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bytes_written', full_name='bdev_io_stats_info.bytes_written', index=3,
+      number=4, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='num_write_ops', full_name='bdev_io_stats_info.num_write_ops', index=4,
+      number=5, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bytes_unmapped', full_name='bdev_io_stats_info.bytes_unmapped', index=5,
+      number=6, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='num_unmap_ops', full_name='bdev_io_stats_info.num_unmap_ops', index=6,
+      number=7, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='bytes_copied', full_name='bdev_io_stats_info.bytes_copied', index=7,
+      number=8, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='num_copy_ops', full_name='bdev_io_stats_info.num_copy_ops', index=8,
+      number=9, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='read_latency_ticks', full_name='bdev_io_stats_info.read_latency_ticks', index=9,
+      number=10, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_read_latency_ticks', full_name='bdev_io_stats_info.max_read_latency_ticks', index=10,
+      number=11, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_read_latency_ticks', full_name='bdev_io_stats_info.min_read_latency_ticks', index=11,
+      number=12, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='write_latency_ticks', full_name='bdev_io_stats_info.write_latency_ticks', index=12,
+      number=13, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_write_latency_ticks', full_name='bdev_io_stats_info.max_write_latency_ticks', index=13,
+      number=14, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_write_latency_ticks', full_name='bdev_io_stats_info.min_write_latency_ticks', index=14,
+      number=15, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='unmap_latency_ticks', full_name='bdev_io_stats_info.unmap_latency_ticks', index=15,
+      number=16, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_unmap_latency_ticks', full_name='bdev_io_stats_info.max_unmap_latency_ticks', index=16,
+      number=17, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_unmap_latency_ticks', full_name='bdev_io_stats_info.min_unmap_latency_ticks', index=17,
+      number=18, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='copy_latency_ticks', full_name='bdev_io_stats_info.copy_latency_ticks', index=18,
+      number=19, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='max_copy_latency_ticks', full_name='bdev_io_stats_info.max_copy_latency_ticks', index=19,
+      number=20, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='min_copy_latency_ticks', full_name='bdev_io_stats_info.min_copy_latency_ticks', index=20,
+      number=21, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='io_error', full_name='bdev_io_stats_info.io_error', index=21,
+      number=22, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11811,
+  serialized_end=12442,
 )
 
 
@@ -4722,8 +5505,8 @@ _NAMESPACE_IO_STATS_INFO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=10380,
-  serialized_end=11110,
+  serialized_start=12445,
+  serialized_end=13175,
 )
 
 
@@ -4761,8 +5544,8 @@ _SPDK_LOG_FLAG_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11112,
-  serialized_end=11163,
+  serialized_start=13177,
+  serialized_end=13228,
 )
 
 
@@ -4821,8 +5604,8 @@ _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11166,
-  serialized_end=11352,
+  serialized_start=13231,
+  serialized_end=13417,
 )
 
 
@@ -4867,10 +5650,51 @@ _GATEWAY_LOG_LEVEL_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11354,
-  serialized_end=11449,
+  serialized_start=13419,
+  serialized_end=13514,
 )
 
+
+_ENCRYPTION_ENTRY = _descriptor.Descriptor(
+  name='encryption_entry',
+  full_name='encryption_entry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='format', full_name='encryption_entry.format', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='key_id', full_name='encryption_entry.key_id', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=13516,
+  serialized_end=13585,
+)
+
+_NAMESPACE_ADD_REQ.fields_by_name['encryption_entries'].message_type = _ENCRYPTION_ENTRY
+_NAMESPACE_ADD_REQ.fields_by_name['encryption_algorithm'].enum_type = _ENCRYPTIONALGORITHM
 _NAMESPACE_ADD_REQ.oneofs_by_name['_nsid'].fields.append(
   _NAMESPACE_ADD_REQ.fields_by_name['nsid'])
 _NAMESPACE_ADD_REQ.fields_by_name['nsid'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_nsid']
@@ -4910,12 +5734,21 @@ _NAMESPACE_ADD_REQ.fields_by_name['location'].containing_oneof = _NAMESPACE_ADD_
 _NAMESPACE_ADD_REQ.oneofs_by_name['_rados_namespace_name'].fields.append(
   _NAMESPACE_ADD_REQ.fields_by_name['rados_namespace_name'])
 _NAMESPACE_ADD_REQ.fields_by_name['rados_namespace_name'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_rados_namespace_name']
+_NAMESPACE_ADD_REQ.oneofs_by_name['_encryption_algorithm'].fields.append(
+  _NAMESPACE_ADD_REQ.fields_by_name['encryption_algorithm'])
+_NAMESPACE_ADD_REQ.fields_by_name['encryption_algorithm'].containing_oneof = _NAMESPACE_ADD_REQ.oneofs_by_name['_encryption_algorithm']
 _NAMESPACE_RESIZE_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
   _NAMESPACE_RESIZE_REQ.fields_by_name['OBSOLETE_uuid'])
 _NAMESPACE_RESIZE_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_RESIZE_REQ.oneofs_by_name['_OBSOLETE_uuid']
 _NAMESPACE_GET_IO_STATS_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
   _NAMESPACE_GET_IO_STATS_REQ.fields_by_name['OBSOLETE_uuid'])
 _NAMESPACE_GET_IO_STATS_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_GET_IO_STATS_REQ.oneofs_by_name['_OBSOLETE_uuid']
+_LIST_NAMESPACES_IO_STATS_REQ.oneofs_by_name['_subsystem_nqn'].fields.append(
+  _LIST_NAMESPACES_IO_STATS_REQ.fields_by_name['subsystem_nqn'])
+_LIST_NAMESPACES_IO_STATS_REQ.fields_by_name['subsystem_nqn'].containing_oneof = _LIST_NAMESPACES_IO_STATS_REQ.oneofs_by_name['_subsystem_nqn']
+_LIST_NAMESPACES_IO_STATS_REQ.oneofs_by_name['_nsid'].fields.append(
+  _LIST_NAMESPACES_IO_STATS_REQ.fields_by_name['nsid'])
+_LIST_NAMESPACES_IO_STATS_REQ.fields_by_name['nsid'].containing_oneof = _LIST_NAMESPACES_IO_STATS_REQ.oneofs_by_name['_nsid']
 _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_OBSOLETE_uuid'].fields.append(
   _NAMESPACE_SET_QOS_REQ.fields_by_name['OBSOLETE_uuid'])
 _NAMESPACE_SET_QOS_REQ.fields_by_name['OBSOLETE_uuid'].containing_oneof = _NAMESPACE_SET_QOS_REQ.oneofs_by_name['_OBSOLETE_uuid']
@@ -5009,6 +5842,12 @@ _CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_key'].containing_oneof = _CHANGE_HOS
 _CHANGE_HOST_KEY_REQ.oneofs_by_name['_dhchap_ctrlr_key'].fields.append(
   _CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_ctrlr_key'])
 _CHANGE_HOST_KEY_REQ.fields_by_name['dhchap_ctrlr_key'].containing_oneof = _CHANGE_HOST_KEY_REQ.oneofs_by_name['_dhchap_ctrlr_key']
+_GET_CONNECTION_IO_STATISTICS_REQ.oneofs_by_name['_reset'].fields.append(
+  _GET_CONNECTION_IO_STATISTICS_REQ.fields_by_name['reset'])
+_GET_CONNECTION_IO_STATISTICS_REQ.fields_by_name['reset'].containing_oneof = _GET_CONNECTION_IO_STATISTICS_REQ.oneofs_by_name['_reset']
+_REMOVE_HOST_REQ.oneofs_by_name['_force'].fields.append(
+  _REMOVE_HOST_REQ.fields_by_name['force'])
+_REMOVE_HOST_REQ.fields_by_name['force'].containing_oneof = _REMOVE_HOST_REQ.oneofs_by_name['_force']
 _LIST_HOSTS_REQ.oneofs_by_name['_clear_alerts'].fields.append(
   _LIST_HOSTS_REQ.fields_by_name['clear_alerts'])
 _LIST_HOSTS_REQ.fields_by_name['clear_alerts'].containing_oneof = _LIST_HOSTS_REQ.oneofs_by_name['_clear_alerts']
@@ -5139,6 +5978,9 @@ _GATEWAY_INFO.fields_by_name['max_hosts'].containing_oneof = _GATEWAY_INFO.oneof
 _GATEWAY_INFO.oneofs_by_name['_gateway_initialization_over'].fields.append(
   _GATEWAY_INFO.fields_by_name['gateway_initialization_over'])
 _GATEWAY_INFO.fields_by_name['gateway_initialization_over'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_gateway_initialization_over']
+_GATEWAY_INFO.oneofs_by_name['_io_stats_enabled'].fields.append(
+  _GATEWAY_INFO.fields_by_name['io_stats_enabled'])
+_GATEWAY_INFO.fields_by_name['io_stats_enabled'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_io_stats_enabled']
 _POLL_GROUP_INFO.fields_by_name['transports'].message_type = _POLL_GROUP_TRANSPORT_INFO
 _GATEWAY_STATS_INFO.fields_by_name['poll_groups'].message_type = _POLL_GROUP_INFO
 _THREAD_STATS_INFO.fields_by_name['threads'].message_type = _SPDK_THREAD_INFO
@@ -5156,6 +5998,7 @@ _LISTENERS_INFO.fields_by_name['listeners'].message_type = _LISTENER_INFO
 _GATEWAY_LISTENER_INFO.fields_by_name['listener'].message_type = _LISTENER_INFO
 _GATEWAY_LISTENER_INFO.fields_by_name['lb_states'].message_type = _ANA_GROUP_STATE
 _GATEWAY_LISTENERS_INFO.fields_by_name['gw_listeners'].message_type = _GATEWAY_LISTENER_INFO
+_HOST.fields_by_name['dhchap_controller_origin'].enum_type = _DHCHAPCONTROLLERKEYORIGIN
 _HOST.oneofs_by_name['_use_psk'].fields.append(
   _HOST.fields_by_name['use_psk'])
 _HOST.fields_by_name['use_psk'].containing_oneof = _HOST.oneofs_by_name['_use_psk']
@@ -5165,8 +6008,22 @@ _HOST.fields_by_name['use_dhchap'].containing_oneof = _HOST.oneofs_by_name['_use
 _HOST.oneofs_by_name['_disconnected_due_to_keepalive_timeout'].fields.append(
   _HOST.fields_by_name['disconnected_due_to_keepalive_timeout'])
 _HOST.fields_by_name['disconnected_due_to_keepalive_timeout'].containing_oneof = _HOST.oneofs_by_name['_disconnected_due_to_keepalive_timeout']
+_HOST.oneofs_by_name['_dhchap_controller_origin'].fields.append(
+  _HOST.fields_by_name['dhchap_controller_origin'])
+_HOST.fields_by_name['dhchap_controller_origin'].containing_oneof = _HOST.oneofs_by_name['_dhchap_controller_origin']
+_LATENCY_GROUP.fields_by_name['total'].message_type = _LATENCY_STATS
+_LATENCY_GROUP.fields_by_name['bdev'].message_type = _LATENCY_STATS
+_LATENCY_GROUP.fields_by_name['net'].message_type = _LATENCY_STATS
+_LATENCY_GROUP.fields_by_name['qos'].message_type = _LATENCY_STATS
+_BUCKET_INFO.fields_by_name['read'].message_type = _LATENCY_GROUP
+_BUCKET_INFO.fields_by_name['write'].message_type = _LATENCY_GROUP
+_CONNECTION_IO_STATISTICS.fields_by_name['buckets'].message_type = _BUCKET_INFO
+_CONNECTION_IO_STATISTICS.oneofs_by_name['_total_num_ios'].fields.append(
+  _CONNECTION_IO_STATISTICS.fields_by_name['total_num_ios'])
+_CONNECTION_IO_STATISTICS.fields_by_name['total_num_ios'].containing_oneof = _CONNECTION_IO_STATISTICS.oneofs_by_name['_total_num_ios']
 _HOSTS_INFO.fields_by_name['hosts'].message_type = _HOST
 _CONNECTION.fields_by_name['adrfam'].enum_type = _ADDRESSFAMILY
+_CONNECTION.fields_by_name['dhchap_controller_origin'].enum_type = _DHCHAPCONTROLLERKEYORIGIN
 _CONNECTION.oneofs_by_name['_secure'].fields.append(
   _CONNECTION.fields_by_name['secure'])
 _CONNECTION.fields_by_name['secure'].containing_oneof = _CONNECTION.oneofs_by_name['_secure']
@@ -5182,7 +6039,12 @@ _CONNECTION.fields_by_name['subsystem'].containing_oneof = _CONNECTION.oneofs_by
 _CONNECTION.oneofs_by_name['_disconnected_due_to_keepalive_timeout'].fields.append(
   _CONNECTION.fields_by_name['disconnected_due_to_keepalive_timeout'])
 _CONNECTION.fields_by_name['disconnected_due_to_keepalive_timeout'].containing_oneof = _CONNECTION.oneofs_by_name['_disconnected_due_to_keepalive_timeout']
+_CONNECTION.oneofs_by_name['_dhchap_controller_origin'].fields.append(
+  _CONNECTION.fields_by_name['dhchap_controller_origin'])
+_CONNECTION.fields_by_name['dhchap_controller_origin'].containing_oneof = _CONNECTION.oneofs_by_name['_dhchap_controller_origin']
 _CONNECTIONS_INFO.fields_by_name['connections'].message_type = _CONNECTION
+_NAMESPACE_CLI.fields_by_name['encryption_algorithm'].enum_type = _ENCRYPTIONALGORITHM
+_NAMESPACE_CLI.fields_by_name['encryption_entries'].message_type = _ENCRYPTION_ENTRY
 _NAMESPACE_CLI.oneofs_by_name['_ns_subsystem_nqn'].fields.append(
   _NAMESPACE_CLI.fields_by_name['ns_subsystem_nqn'])
 _NAMESPACE_CLI.fields_by_name['ns_subsystem_nqn'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_ns_subsystem_nqn']
@@ -5213,7 +6075,12 @@ _NAMESPACE_CLI.fields_by_name['location'].containing_oneof = _NAMESPACE_CLI.oneo
 _NAMESPACE_CLI.oneofs_by_name['_rados_namespace_name'].fields.append(
   _NAMESPACE_CLI.fields_by_name['rados_namespace_name'])
 _NAMESPACE_CLI.fields_by_name['rados_namespace_name'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_rados_namespace_name']
+_NAMESPACE_CLI.oneofs_by_name['_encryption_algorithm'].fields.append(
+  _NAMESPACE_CLI.fields_by_name['encryption_algorithm'])
+_NAMESPACE_CLI.fields_by_name['encryption_algorithm'].containing_oneof = _NAMESPACE_CLI.oneofs_by_name['_encryption_algorithm']
 _NAMESPACES_INFO.fields_by_name['namespaces'].message_type = _NAMESPACE_CLI
+_LIST_NAMESPACES_IO_STATS_INFO.fields_by_name['namespaces'].message_type = _BDEV_IO_STATS_INFO
+_BDEV_IO_STATS_INFO.fields_by_name['io_error'].message_type = _NAMESPACE_IO_ERROR
 _NAMESPACE_IO_STATS_INFO.fields_by_name['io_error'].message_type = _NAMESPACE_IO_ERROR
 _NAMESPACE_IO_STATS_INFO.oneofs_by_name['_uuid'].fields.append(
   _NAMESPACE_IO_STATS_INFO.fields_by_name['uuid'])
@@ -5222,9 +6089,11 @@ _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO.fields_by_name['nvmf_log_flags'].message_typ
 _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO.fields_by_name['log_level'].enum_type = _LOGLEVEL
 _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO.fields_by_name['log_print_level'].enum_type = _LOGLEVEL
 _GATEWAY_LOG_LEVEL_INFO.fields_by_name['log_level'].enum_type = _GWLOGLEVEL
+_ENCRYPTION_ENTRY.fields_by_name['format'].enum_type = _ENCRYPTIONFORMAT
 DESCRIPTOR.message_types_by_name['namespace_add_req'] = _NAMESPACE_ADD_REQ
 DESCRIPTOR.message_types_by_name['namespace_resize_req'] = _NAMESPACE_RESIZE_REQ
 DESCRIPTOR.message_types_by_name['namespace_get_io_stats_req'] = _NAMESPACE_GET_IO_STATS_REQ
+DESCRIPTOR.message_types_by_name['list_namespaces_io_stats_req'] = _LIST_NAMESPACES_IO_STATS_REQ
 DESCRIPTOR.message_types_by_name['namespace_set_qos_req'] = _NAMESPACE_SET_QOS_REQ
 DESCRIPTOR.message_types_by_name['namespace_change_load_balancing_group_req'] = _NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ
 DESCRIPTOR.message_types_by_name['namespace_change_visibility_req'] = _NAMESPACE_CHANGE_VISIBILITY_REQ
@@ -5242,6 +6111,7 @@ DESCRIPTOR.message_types_by_name['del_subsystem_network_req'] = _DEL_SUBSYSTEM_N
 DESCRIPTOR.message_types_by_name['list_namespaces_req'] = _LIST_NAMESPACES_REQ
 DESCRIPTOR.message_types_by_name['add_host_req'] = _ADD_HOST_REQ
 DESCRIPTOR.message_types_by_name['change_host_key_req'] = _CHANGE_HOST_KEY_REQ
+DESCRIPTOR.message_types_by_name['get_connection_io_statistics_req'] = _GET_CONNECTION_IO_STATISTICS_REQ
 DESCRIPTOR.message_types_by_name['remove_host_req'] = _REMOVE_HOST_REQ
 DESCRIPTOR.message_types_by_name['list_hosts_req'] = _LIST_HOSTS_REQ
 DESCRIPTOR.message_types_by_name['list_connections_req'] = _LIST_CONNECTIONS_REQ
@@ -5259,6 +6129,7 @@ DESCRIPTOR.message_types_by_name['set_gateway_log_level_req'] = _SET_GATEWAY_LOG
 DESCRIPTOR.message_types_by_name['show_gateway_listeners_info_req'] = _SHOW_GATEWAY_LISTENERS_INFO_REQ
 DESCRIPTOR.message_types_by_name['get_gateway_stats_req'] = _GET_GATEWAY_STATS_REQ
 DESCRIPTOR.message_types_by_name['get_thread_stats_req'] = _GET_THREAD_STATS_REQ
+DESCRIPTOR.message_types_by_name['set_gateway_io_stats_mode_req'] = _SET_GATEWAY_IO_STATS_MODE_REQ
 DESCRIPTOR.message_types_by_name['ana_group_state'] = _ANA_GROUP_STATE
 DESCRIPTOR.message_types_by_name['nqn_ana_states'] = _NQN_ANA_STATES
 DESCRIPTOR.message_types_by_name['ana_info'] = _ANA_INFO
@@ -5284,19 +6155,29 @@ DESCRIPTOR.message_types_by_name['listeners_info'] = _LISTENERS_INFO
 DESCRIPTOR.message_types_by_name['gateway_listener_info'] = _GATEWAY_LISTENER_INFO
 DESCRIPTOR.message_types_by_name['gateway_listeners_info'] = _GATEWAY_LISTENERS_INFO
 DESCRIPTOR.message_types_by_name['host'] = _HOST
+DESCRIPTOR.message_types_by_name['latency_stats'] = _LATENCY_STATS
+DESCRIPTOR.message_types_by_name['latency_group'] = _LATENCY_GROUP
+DESCRIPTOR.message_types_by_name['bucket_info'] = _BUCKET_INFO
+DESCRIPTOR.message_types_by_name['connection_io_statistics'] = _CONNECTION_IO_STATISTICS
 DESCRIPTOR.message_types_by_name['hosts_info'] = _HOSTS_INFO
 DESCRIPTOR.message_types_by_name['connection'] = _CONNECTION
 DESCRIPTOR.message_types_by_name['connections_info'] = _CONNECTIONS_INFO
 DESCRIPTOR.message_types_by_name['namespace_cli'] = _NAMESPACE_CLI
 DESCRIPTOR.message_types_by_name['namespaces_info'] = _NAMESPACES_INFO
 DESCRIPTOR.message_types_by_name['namespace_io_error'] = _NAMESPACE_IO_ERROR
+DESCRIPTOR.message_types_by_name['list_namespaces_io_stats_info'] = _LIST_NAMESPACES_IO_STATS_INFO
+DESCRIPTOR.message_types_by_name['bdev_io_stats_info'] = _BDEV_IO_STATS_INFO
 DESCRIPTOR.message_types_by_name['namespace_io_stats_info'] = _NAMESPACE_IO_STATS_INFO
 DESCRIPTOR.message_types_by_name['spdk_log_flag_info'] = _SPDK_LOG_FLAG_INFO
 DESCRIPTOR.message_types_by_name['spdk_nvmf_log_flags_and_level_info'] = _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO
 DESCRIPTOR.message_types_by_name['gateway_log_level_info'] = _GATEWAY_LOG_LEVEL_INFO
+DESCRIPTOR.message_types_by_name['encryption_entry'] = _ENCRYPTION_ENTRY
 DESCRIPTOR.enum_types_by_name['AddressFamily'] = _ADDRESSFAMILY
 DESCRIPTOR.enum_types_by_name['LogLevel'] = _LOGLEVEL
 DESCRIPTOR.enum_types_by_name['GwLogLevel'] = _GWLOGLEVEL
+DESCRIPTOR.enum_types_by_name['EncryptionFormat'] = _ENCRYPTIONFORMAT
+DESCRIPTOR.enum_types_by_name['EncryptionAlgorithm'] = _ENCRYPTIONALGORITHM
+DESCRIPTOR.enum_types_by_name['DHCHAPControllerKeyOrigin'] = _DHCHAPCONTROLLERKEYORIGIN
 DESCRIPTOR.enum_types_by_name['ana_state'] = _ANA_STATE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -5320,6 +6201,13 @@ namespace_get_io_stats_req = _reflection.GeneratedProtocolMessageType('namespace
   # @@protoc_insertion_point(class_scope:namespace_get_io_stats_req)
   })
 _sym_db.RegisterMessage(namespace_get_io_stats_req)
+
+list_namespaces_io_stats_req = _reflection.GeneratedProtocolMessageType('list_namespaces_io_stats_req', (_message.Message,), {
+  'DESCRIPTOR' : _LIST_NAMESPACES_IO_STATS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_namespaces_io_stats_req)
+  })
+_sym_db.RegisterMessage(list_namespaces_io_stats_req)
 
 namespace_set_qos_req = _reflection.GeneratedProtocolMessageType('namespace_set_qos_req', (_message.Message,), {
   'DESCRIPTOR' : _NAMESPACE_SET_QOS_REQ,
@@ -5440,6 +6328,13 @@ change_host_key_req = _reflection.GeneratedProtocolMessageType('change_host_key_
   })
 _sym_db.RegisterMessage(change_host_key_req)
 
+get_connection_io_statistics_req = _reflection.GeneratedProtocolMessageType('get_connection_io_statistics_req', (_message.Message,), {
+  'DESCRIPTOR' : _GET_CONNECTION_IO_STATISTICS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:get_connection_io_statistics_req)
+  })
+_sym_db.RegisterMessage(get_connection_io_statistics_req)
+
 remove_host_req = _reflection.GeneratedProtocolMessageType('remove_host_req', (_message.Message,), {
   'DESCRIPTOR' : _REMOVE_HOST_REQ,
   '__module__' : 'dashboard.services.proto.gateway_pb2'
@@ -5558,6 +6453,13 @@ get_thread_stats_req = _reflection.GeneratedProtocolMessageType('get_thread_stat
   # @@protoc_insertion_point(class_scope:get_thread_stats_req)
   })
 _sym_db.RegisterMessage(get_thread_stats_req)
+
+set_gateway_io_stats_mode_req = _reflection.GeneratedProtocolMessageType('set_gateway_io_stats_mode_req', (_message.Message,), {
+  'DESCRIPTOR' : _SET_GATEWAY_IO_STATS_MODE_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:set_gateway_io_stats_mode_req)
+  })
+_sym_db.RegisterMessage(set_gateway_io_stats_mode_req)
 
 ana_group_state = _reflection.GeneratedProtocolMessageType('ana_group_state', (_message.Message,), {
   'DESCRIPTOR' : _ANA_GROUP_STATE,
@@ -5734,6 +6636,34 @@ host = _reflection.GeneratedProtocolMessageType('host', (_message.Message,), {
   })
 _sym_db.RegisterMessage(host)
 
+latency_stats = _reflection.GeneratedProtocolMessageType('latency_stats', (_message.Message,), {
+  'DESCRIPTOR' : _LATENCY_STATS,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:latency_stats)
+  })
+_sym_db.RegisterMessage(latency_stats)
+
+latency_group = _reflection.GeneratedProtocolMessageType('latency_group', (_message.Message,), {
+  'DESCRIPTOR' : _LATENCY_GROUP,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:latency_group)
+  })
+_sym_db.RegisterMessage(latency_group)
+
+bucket_info = _reflection.GeneratedProtocolMessageType('bucket_info', (_message.Message,), {
+  'DESCRIPTOR' : _BUCKET_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:bucket_info)
+  })
+_sym_db.RegisterMessage(bucket_info)
+
+connection_io_statistics = _reflection.GeneratedProtocolMessageType('connection_io_statistics', (_message.Message,), {
+  'DESCRIPTOR' : _CONNECTION_IO_STATISTICS,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:connection_io_statistics)
+  })
+_sym_db.RegisterMessage(connection_io_statistics)
+
 hosts_info = _reflection.GeneratedProtocolMessageType('hosts_info', (_message.Message,), {
   'DESCRIPTOR' : _HOSTS_INFO,
   '__module__' : 'dashboard.services.proto.gateway_pb2'
@@ -5776,6 +6706,20 @@ namespace_io_error = _reflection.GeneratedProtocolMessageType('namespace_io_erro
   })
 _sym_db.RegisterMessage(namespace_io_error)
 
+list_namespaces_io_stats_info = _reflection.GeneratedProtocolMessageType('list_namespaces_io_stats_info', (_message.Message,), {
+  'DESCRIPTOR' : _LIST_NAMESPACES_IO_STATS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_namespaces_io_stats_info)
+  })
+_sym_db.RegisterMessage(list_namespaces_io_stats_info)
+
+bdev_io_stats_info = _reflection.GeneratedProtocolMessageType('bdev_io_stats_info', (_message.Message,), {
+  'DESCRIPTOR' : _BDEV_IO_STATS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:bdev_io_stats_info)
+  })
+_sym_db.RegisterMessage(bdev_io_stats_info)
+
 namespace_io_stats_info = _reflection.GeneratedProtocolMessageType('namespace_io_stats_info', (_message.Message,), {
   'DESCRIPTOR' : _NAMESPACE_IO_STATS_INFO,
   '__module__' : 'dashboard.services.proto.gateway_pb2'
@@ -5804,6 +6748,13 @@ gateway_log_level_info = _reflection.GeneratedProtocolMessageType('gateway_log_l
   })
 _sym_db.RegisterMessage(gateway_log_level_info)
 
+encryption_entry = _reflection.GeneratedProtocolMessageType('encryption_entry', (_message.Message,), {
+  'DESCRIPTOR' : _ENCRYPTION_ENTRY,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:encryption_entry)
+  })
+_sym_db.RegisterMessage(encryption_entry)
+
 
 DESCRIPTOR._options = None
 
@@ -5814,8 +6765,8 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=11719,
-  serialized_end=14249,
+  serialized_start=14056,
+  serialized_end=16851,
   methods=[
   _descriptor.MethodDescriptor(
     name='namespace_add',
@@ -5908,9 +6859,19 @@ _GATEWAY = _descriptor.ServiceDescriptor(
     create_key=_descriptor._internal_create_key,
   ),
   _descriptor.MethodDescriptor(
+    name='list_namespaces_io_stats',
+    full_name='Gateway.list_namespaces_io_stats',
+    index=9,
+    containing_service=None,
+    input_type=_LIST_NAMESPACES_IO_STATS_REQ,
+    output_type=_LIST_NAMESPACES_IO_STATS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
     name='namespace_set_qos_limits',
     full_name='Gateway.namespace_set_qos_limits',
-    index=9,
+    index=10,
     containing_service=None,
     input_type=_NAMESPACE_SET_QOS_REQ,
     output_type=_REQ_STATUS,
@@ -5920,7 +6881,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_change_load_balancing_group',
     full_name='Gateway.namespace_change_load_balancing_group',
-    index=10,
+    index=11,
     containing_service=None,
     input_type=_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ,
     output_type=_REQ_STATUS,
@@ -5930,7 +6891,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_change_visibility',
     full_name='Gateway.namespace_change_visibility',
-    index=11,
+    index=12,
     containing_service=None,
     input_type=_NAMESPACE_CHANGE_VISIBILITY_REQ,
     output_type=_REQ_STATUS,
@@ -5940,7 +6901,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_change_location',
     full_name='Gateway.namespace_change_location',
-    index=12,
+    index=13,
     containing_service=None,
     input_type=_NAMESPACE_CHANGE_LOCATION_REQ,
     output_type=_REQ_STATUS,
@@ -5950,7 +6911,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_set_rbd_trash_image',
     full_name='Gateway.namespace_set_rbd_trash_image',
-    index=13,
+    index=14,
     containing_service=None,
     input_type=_NAMESPACE_SET_RBD_TRASH_IMAGE_REQ,
     output_type=_REQ_STATUS,
@@ -5960,7 +6921,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_set_auto_resize',
     full_name='Gateway.namespace_set_auto_resize',
-    index=14,
+    index=15,
     containing_service=None,
     input_type=_NAMESPACE_SET_AUTO_RESIZE_REQ,
     output_type=_REQ_STATUS,
@@ -5970,7 +6931,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_delete',
     full_name='Gateway.namespace_delete',
-    index=15,
+    index=16,
     containing_service=None,
     input_type=_NAMESPACE_DELETE_REQ,
     output_type=_REQ_STATUS,
@@ -5980,7 +6941,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_add_host',
     full_name='Gateway.namespace_add_host',
-    index=16,
+    index=17,
     containing_service=None,
     input_type=_NAMESPACE_ADD_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -5990,7 +6951,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_delete_host',
     full_name='Gateway.namespace_delete_host',
-    index=17,
+    index=18,
     containing_service=None,
     input_type=_NAMESPACE_DELETE_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -6000,7 +6961,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='add_host',
     full_name='Gateway.add_host',
-    index=18,
+    index=19,
     containing_service=None,
     input_type=_ADD_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -6010,7 +6971,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='remove_host',
     full_name='Gateway.remove_host',
-    index=19,
+    index=20,
     containing_service=None,
     input_type=_REMOVE_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -6020,7 +6981,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='change_host_key',
     full_name='Gateway.change_host_key',
-    index=20,
+    index=21,
     containing_service=None,
     input_type=_CHANGE_HOST_KEY_REQ,
     output_type=_REQ_STATUS,
@@ -6030,7 +6991,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_hosts',
     full_name='Gateway.list_hosts',
-    index=21,
+    index=22,
     containing_service=None,
     input_type=_LIST_HOSTS_REQ,
     output_type=_HOSTS_INFO,
@@ -6040,7 +7001,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_connections',
     full_name='Gateway.list_connections',
-    index=22,
+    index=23,
     containing_service=None,
     input_type=_LIST_CONNECTIONS_REQ,
     output_type=_CONNECTIONS_INFO,
@@ -6048,9 +7009,19 @@ _GATEWAY = _descriptor.ServiceDescriptor(
     create_key=_descriptor._internal_create_key,
   ),
   _descriptor.MethodDescriptor(
+    name='get_connection_io_statistics',
+    full_name='Gateway.get_connection_io_statistics',
+    index=24,
+    containing_service=None,
+    input_type=_GET_CONNECTION_IO_STATISTICS_REQ,
+    output_type=_CONNECTION_IO_STATISTICS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
     name='create_listener',
     full_name='Gateway.create_listener',
-    index=23,
+    index=25,
     containing_service=None,
     input_type=_CREATE_LISTENER_REQ,
     output_type=_REQ_STATUS,
@@ -6060,7 +7031,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='delete_listener',
     full_name='Gateway.delete_listener',
-    index=24,
+    index=26,
     containing_service=None,
     input_type=_DELETE_LISTENER_REQ,
     output_type=_REQ_STATUS,
@@ -6070,7 +7041,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_listeners',
     full_name='Gateway.list_listeners',
-    index=25,
+    index=27,
     containing_service=None,
     input_type=_LIST_LISTENERS_REQ,
     output_type=_LISTENERS_INFO,
@@ -6080,7 +7051,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_subsystems',
     full_name='Gateway.list_subsystems',
-    index=26,
+    index=28,
     containing_service=None,
     input_type=_LIST_SUBSYSTEMS_REQ,
     output_type=_SUBSYSTEMS_INFO_CLI,
@@ -6090,7 +7061,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_subsystems',
     full_name='Gateway.get_subsystems',
-    index=27,
+    index=29,
     containing_service=None,
     input_type=_GET_SUBSYSTEMS_REQ,
     output_type=_SUBSYSTEMS_INFO,
@@ -6100,7 +7071,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='set_ana_state',
     full_name='Gateway.set_ana_state',
-    index=28,
+    index=30,
     containing_service=None,
     input_type=_ANA_INFO,
     output_type=_REQ_STATUS,
@@ -6110,7 +7081,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_spdk_nvmf_log_flags_and_level',
     full_name='Gateway.get_spdk_nvmf_log_flags_and_level',
-    index=29,
+    index=31,
     containing_service=None,
     input_type=_GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ,
     output_type=_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO,
@@ -6120,7 +7091,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='disable_spdk_nvmf_logs',
     full_name='Gateway.disable_spdk_nvmf_logs',
-    index=30,
+    index=32,
     containing_service=None,
     input_type=_DISABLE_SPDK_NVMF_LOGS_REQ,
     output_type=_REQ_STATUS,
@@ -6130,7 +7101,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='set_spdk_nvmf_logs',
     full_name='Gateway.set_spdk_nvmf_logs',
-    index=31,
+    index=33,
     containing_service=None,
     input_type=_SET_SPDK_NVMF_LOGS_REQ,
     output_type=_REQ_STATUS,
@@ -6140,7 +7111,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_gateway_info',
     full_name='Gateway.get_gateway_info',
-    index=32,
+    index=34,
     containing_service=None,
     input_type=_GET_GATEWAY_INFO_REQ,
     output_type=_GATEWAY_INFO,
@@ -6150,7 +7121,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_gateway_log_level',
     full_name='Gateway.get_gateway_log_level',
-    index=33,
+    index=35,
     containing_service=None,
     input_type=_GET_GATEWAY_LOG_LEVEL_REQ,
     output_type=_GATEWAY_LOG_LEVEL_INFO,
@@ -6160,7 +7131,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='set_gateway_log_level',
     full_name='Gateway.set_gateway_log_level',
-    index=34,
+    index=36,
     containing_service=None,
     input_type=_SET_GATEWAY_LOG_LEVEL_REQ,
     output_type=_REQ_STATUS,
@@ -6170,7 +7141,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='show_gateway_listeners_info',
     full_name='Gateway.show_gateway_listeners_info',
-    index=35,
+    index=37,
     containing_service=None,
     input_type=_SHOW_GATEWAY_LISTENERS_INFO_REQ,
     output_type=_GATEWAY_LISTENERS_INFO,
@@ -6180,7 +7151,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_gateway_stats',
     full_name='Gateway.get_gateway_stats',
-    index=36,
+    index=38,
     containing_service=None,
     input_type=_GET_GATEWAY_STATS_REQ,
     output_type=_GATEWAY_STATS_INFO,
@@ -6190,10 +7161,20 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_thread_stats',
     full_name='Gateway.get_thread_stats',
-    index=37,
+    index=39,
     containing_service=None,
     input_type=_GET_THREAD_STATS_REQ,
     output_type=_THREAD_STATS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='set_gateway_io_stats_mode',
+    full_name='Gateway.set_gateway_io_stats_mode',
+    index=40,
+    containing_service=None,
+    input_type=_SET_GATEWAY_IO_STATS_MODE_REQ,
+    output_type=_REQ_STATUS,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
   ),

--- a/src/pybind/mgr/dashboard/services/proto/gateway_pb2.py
+++ b/src/pybind/mgr/dashboard/services/proto/gateway_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeof',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n&dashboard/services/proto/gateway.proto\"\x84\x06\n\x11namespace_add_req\x12\x15\n\rrbd_pool_name\x18\x01 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x11\n\x04nsid\x18\x04 \x01(\rH\x00\x88\x01\x01\x12\x12\n\nblock_size\x18\x05 \x01(\r\x12\x11\n\x04uuid\x18\x06 \x01(\tH\x01\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x07 \x01(\x05H\x02\x88\x01\x01\x12\x19\n\x0c\x63reate_image\x18\x08 \x01(\x08H\x03\x88\x01\x01\x12\x11\n\x04size\x18\t \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\n \x01(\x08H\x05\x88\x01\x01\x12\x1c\n\x0fno_auto_visible\x18\x0b \x01(\x08H\x06\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x0c \x01(\x08H\x07\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\r \x01(\x08H\x08\x88\x01\x01\x12\x16\n\tread_only\x18\x0e \x01(\x08H\t\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x0f \x01(\tH\n\x88\x01\x01\x12\x15\n\x08location\x18\x10 \x01(\tH\x0b\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x11 \x01(\tH\x0c\x88\x01\x01\x12-\n\x12\x65ncryption_entries\x18\x12 \x03(\x0b\x32\x11.encryption_entry\x12\x37\n\x14\x65ncryption_algorithm\x18\x13 \x01(\x0e\x32\x14.EncryptionAlgorithmH\r\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x0f\n\r_create_imageB\x07\n\x05_sizeB\x08\n\x06_forceB\x12\n\x10_no_auto_visibleB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_nameB\x17\n\x15_encryption_algorithm\"{\n\x14namespace_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08new_size\x18\x04 \x01(\x04\x42\x10\n\x0e_OBSOLETE_uuid\"o\n\x1anamespace_get_io_stats_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuid\"h\n\x1clist_namespaces_io_stats_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x07\n\x05_nsid\"\xee\x02\n\x15namespace_set_qos_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1e\n\x11rw_ios_per_second\x18\x04 \x01(\x04H\x01\x88\x01\x01\x12!\n\x14rw_mbytes_per_second\x18\x05 \x01(\x04H\x02\x88\x01\x01\x12 \n\x13r_mbytes_per_second\x18\x06 \x01(\x04H\x03\x88\x01\x01\x12 \n\x13w_mbytes_per_second\x18\x07 \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x14\n\x12_rw_ios_per_secondB\x17\n\x15_rw_mbytes_per_secondB\x16\n\x14_r_mbytes_per_secondB\x16\n\x14_w_mbytes_per_secondB\x08\n\x06_force\"\xbe\x01\n)namespace_change_load_balancing_group_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61nagrpid\x18\x04 \x01(\x05\x12\x1a\n\rauto_lb_logic\x18\x05 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x10\n\x0e_auto_lb_logic\"z\n\x1fnamespace_change_visibility_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x14\n\x0c\x61uto_visible\x18\x03 \x01(\x08\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"h\n\x1dnamespace_change_location_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x15\n\x08location\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x0b\n\t_location\"]\n!namespace_set_rbd_trash_image_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0btrash_image\x18\x03 \x01(\x08\"Y\n\x1dnamespace_set_auto_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0b\x61uto_resize\x18\x03 \x01(\x08\"\x8f\x01\n\x14namespace_delete_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x04 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x0c\n\n_i_am_sure\"m\n\x16namespace_add_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"R\n\x19namespace_delete_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\"\xd9\x02\n\x14\x63reate_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x15\n\rserial_number\x18\x02 \x01(\t\x12\x1b\n\x0emax_namespaces\x18\x03 \x01(\rH\x00\x88\x01\x01\x12\x11\n\tenable_ha\x18\x04 \x01(\x08\x12\x1c\n\x0fno_group_append\x18\x05 \x01(\x08H\x01\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x06 \x01(\tH\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x07 \x01(\x08H\x03\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\x08 \x03(\t\x12\x1d\n\x10secure_listeners\x18\t \x01(\x08H\x04\x88\x01\x01\x42\x11\n\x0f_max_namespacesB\x12\n\x10_no_group_appendB\r\n\x0b_dhchap_keyB\x10\n\x0e_key_encryptedB\x13\n\x11_secure_listeners\"q\n\x14\x64\x65lete_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x12\n\x05\x66orce\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x03 \x01(\x08H\x01\x88\x01\x01\x42\x08\n\x06_forceB\x0c\n\n_i_am_sure\"Y\n\x18\x63hange_subsystem_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x17\n\ndhchap_key\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\r\n\x0b_dhchap_key\"H\n\x19\x61\x64\x64_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"H\n\x19\x64\x65l_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"`\n\x13list_namespaces_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x00\x88\x01\x01\x12\x11\n\x04uuid\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuid\"\xc3\x02\n\x0c\x61\x64\x64_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x10\n\x03psk\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rpsk_encrypted\x18\x05 \x01(\x08H\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x06 \x01(\x08H\x03\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x07 \x01(\tH\x04\x88\x01\x01\x12 \n\x13\x63trlr_key_encrypted\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x06\n\x04_pskB\r\n\x0b_dhchap_keyB\x10\n\x0e_psk_encryptedB\x10\n\x0e_key_encryptedB\x13\n\x11_dhchap_ctrlr_keyB\x16\n\x14_ctrlr_key_encrypted\"\x9a\x01\n\x13\x63hange_host_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x17\n\ndhchap_key\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_dhchap_keyB\x13\n\x11_dhchap_ctrlr_key\"i\n get_connection_io_statistics_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x12\n\x05reset\x18\x03 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_reset\"X\n\x0fremove_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x12\n\x05\x66orce\x18\x03 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"O\n\x0elist_hosts_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"U\n\x14list_connections_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"\xeb\x01\n\x13\x63reate_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x13\n\x06secure\x18\x07 \x01(\x08H\x02\x88\x01\x01\x12\x1d\n\x10verify_host_name\x18\x08 \x01(\x08H\x03\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\t\n\x07_secureB\x13\n\x11_verify_host_name\"\xb5\x01\n\x13\x64\x65lete_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x07 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\x08\n\x06_force\"\'\n\x12list_listeners_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\"q\n\x13list_subsystems_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1a\n\rserial_number\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x10\n\x0e_serial_number\"\x14\n\x12get_subsystems_req\"U\n%get_spdk_nvmf_log_flags_and_level_req\x12\x1a\n\rall_log_flags\x18\x01 \x01(\x08H\x00\x88\x01\x01\x42\x10\n\x0e_all_log_flags\"5\n\x1a\x64isable_spdk_nvmf_logs_req\x12\x17\n\x0f\x65xtra_log_flags\x18\x01 \x03(\t\"\x97\x01\n\x16set_spdk_nvmf_logs_req\x12!\n\tlog_level\x18\x01 \x01(\x0e\x32\t.LogLevelH\x00\x88\x01\x01\x12#\n\x0bprint_level\x18\x02 \x01(\x0e\x32\t.LogLevelH\x01\x88\x01\x01\x12\x17\n\x0f\x65xtra_log_flags\x18\x03 \x03(\tB\x0c\n\n_log_levelB\x0e\n\x0c_print_level\"@\n\x14get_gateway_info_req\x12\x18\n\x0b\x63li_version\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_cli_version\"\x1b\n\x19get_gateway_log_level_req\";\n\x19set_gateway_log_level_req\x12\x1e\n\tlog_level\x18\x01 \x01(\x0e\x32\x0b.GwLogLevel\"8\n\x1fshow_gateway_listeners_info_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\"\x17\n\x15get_gateway_stats_req\"\x16\n\x14get_thread_stats_req\"0\n\x1dset_gateway_io_stats_mode_req\x12\x0f\n\x07\x65nabled\x18\x01 \x01(\x08\"<\n\x0f\x61na_group_state\x12\x0e\n\x06grp_id\x18\x01 \x01(\r\x12\x19\n\x05state\x18\x02 \x01(\x0e\x32\n.ana_state\"?\n\x0enqn_ana_states\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12 \n\x06states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"+\n\x08\x61na_info\x12\x1f\n\x06states\x18\x01 \x03(\x0b\x32\x0f.nqn_ana_states\"3\n\nreq_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\"C\n\rsubsys_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0b\n\x03nqn\x18\x03 \x01(\t\"B\n\x0bnsid_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0c\n\x04nsid\x18\x03 \x01(\r\"1\n\x0fsubsystems_info\x12\x1e\n\nsubsystems\x18\x01 \x03(\x0b\x32\n.subsystem\"\xc2\x03\n\tsubsystem\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0f\n\x07subtype\x18\x02 \x01(\t\x12)\n\x10listen_addresses\x18\x03 \x03(\x0b\x32\x0f.listen_address\x12\x14\n\x05hosts\x18\x04 \x03(\x0b\x32\x05.host\x12\x16\n\x0e\x61llow_any_host\x18\x05 \x01(\x08\x12\x1a\n\rserial_number\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0cmodel_number\x18\x07 \x01(\tH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x08 \x01(\rH\x02\x88\x01\x01\x12\x17\n\nmin_cntlid\x18\t \x01(\rH\x03\x88\x01\x01\x12\x17\n\nmax_cntlid\x18\n \x01(\rH\x04\x88\x01\x01\x12\x1e\n\nnamespaces\x18\x0b \x03(\x0b\x32\n.namespace\x12\x1b\n\x0ehas_dhchap_key\x18\x0c \x01(\x08H\x05\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x10\n\x0e_serial_numberB\x0f\n\r_model_numberB\x11\n\x0f_max_namespacesB\r\n\x0b_min_cntlidB\r\n\x0b_max_cntlidB\x11\n\x0f_has_dhchap_key\"\x97\x01\n\x0elisten_address\x12\x0e\n\x06trtype\x18\x01 \x01(\t\x12\x0e\n\x06\x61\x64rfam\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12\x0f\n\x07trsvcid\x18\x04 \x01(\t\x12\x16\n\ttransport\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x01\x88\x01\x01\x42\x0c\n\n_transportB\t\n\x07_secure\"\x84\x02\n\tnamespace\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x16\n\tbdev_name\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05nguid\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x02\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x12\n\x05nonce\x18\x07 \x01(\tH\x04\x88\x01\x01\x12\x19\n\x0c\x61uto_visible\x18\x08 \x01(\x08H\x05\x88\x01\x01\x12\r\n\x05hosts\x18\t \x03(\tB\x0c\n\n_bdev_nameB\x08\n\x06_nguidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x08\n\x06_nonceB\x0f\n\r_auto_visible\"`\n\x13subsystems_info_cli\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\nsubsystems\x18\x03 \x03(\x0b\x32\x0e.subsystem_cli\"\xf6\x02\n\rsubsystem_cli\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\tenable_ha\x18\x02 \x01(\x08\x12\x15\n\rserial_number\x18\x03 \x01(\t\x12\x14\n\x0cmodel_number\x18\x04 \x01(\t\x12\x12\n\nmin_cntlid\x18\x05 \x01(\r\x12\x12\n\nmax_cntlid\x18\x06 \x01(\r\x12\x17\n\x0fnamespace_count\x18\x07 \x01(\r\x12\x0f\n\x07subtype\x18\x08 \x01(\t\x12\x16\n\x0emax_namespaces\x18\t \x01(\r\x12\x1b\n\x0ehas_dhchap_key\x18\n \x01(\x08H\x00\x88\x01\x01\x12\x1b\n\x0e\x61llow_any_host\x18\x0b \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x63reated_without_key\x18\x0c \x01(\x08H\x02\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x11\n\x0f_has_dhchap_keyB\x11\n\x0f_allow_any_hostB\x16\n\x14_created_without_key\"\x97\x05\n\x0cgateway_info\x12\x13\n\x0b\x63li_version\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05group\x18\x04 \x01(\t\x12\x0c\n\x04\x61\x64\x64r\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\t\x12\x13\n\x0b\x62ool_status\x18\x07 \x01(\x08\x12\x0e\n\x06status\x18\x08 \x01(\x05\x12\x15\n\rerror_message\x18\t \x01(\t\x12\x19\n\x0cspdk_version\x18\n \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x14load_balancing_group\x18\x0b \x01(\r\x12\x10\n\x08hostname\x18\x0c \x01(\t\x12\x1b\n\x0emax_subsystems\x18\r \x01(\rH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x0e \x01(\rH\x02\x88\x01\x01\x12$\n\x17max_hosts_per_subsystem\x18\x0f \x01(\rH\x03\x88\x01\x01\x12)\n\x1cmax_namespaces_per_subsystem\x18\x10 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tmax_hosts\x18\x11 \x01(\rH\x05\x88\x01\x01\x12(\n\x1bgateway_initialization_over\x18\x12 \x01(\x08H\x06\x88\x01\x01\x12\x1d\n\x10io_stats_enabled\x18\x13 \x01(\x08H\x07\x88\x01\x01\x42\x0f\n\r_spdk_versionB\x11\n\x0f_max_subsystemsB\x11\n\x0f_max_namespacesB\x1a\n\x18_max_hosts_per_subsystemB\x1f\n\x1d_max_namespaces_per_subsystemB\x0c\n\n_max_hostsB\x1e\n\x1c_gateway_initialization_overB\x13\n\x11_io_stats_enabled\"E\n\x0b\x63li_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"D\n\ngw_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"+\n\x19poll_group_transport_info\x12\x0e\n\x06trtype\x18\x01 \x01(\t\"\xe5\x01\n\x0fpoll_group_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x61\x64min_qpairs\x18\x02 \x01(\r\x12\x11\n\tio_qpairs\x18\x03 \x01(\r\x12\x1c\n\x14\x63urrent_admin_qpairs\x18\x04 \x01(\r\x12\x19\n\x11\x63urrent_io_qpairs\x18\x05 \x01(\r\x12\x17\n\x0fpending_bdev_io\x18\x06 \x01(\x04\x12\x19\n\x11\x63ompleted_nvme_io\x18\x07 \x01(\x04\x12.\n\ntransports\x18\x08 \x03(\x0b\x32\x1a.poll_group_transport_info\"u\n\x12gateway_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12%\n\x0bpoll_groups\x18\x04 \x03(\x0b\x32\x10.poll_group_info\"q\n\x11thread_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\x07threads\x18\x03 \x03(\x0b\x32\x11.spdk_thread_info\x12\x11\n\ttick_rate\x18\x04 \x01(\x04\"<\n\x10spdk_thread_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62usy\x18\x02 \x01(\x04\x12\x0c\n\x04idle\x18\x03 \x01(\x04\"\xd3\x01\n\rlistener_info\x12\x11\n\thost_name\x18\x01 \x01(\t\x12\x0e\n\x06trtype\x18\x02 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x03 \x01(\x0e\x32\x0e.AddressFamily\x12\x0e\n\x06traddr\x18\x04 \x01(\t\x12\x0f\n\x07trsvcid\x18\x05 \x01(\r\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x00\x88\x01\x01\x12\x13\n\x06\x61\x63tive\x18\x07 \x01(\x08H\x01\x88\x01\x01\x12\x13\n\x06manual\x18\x08 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_secureB\t\n\x07_activeB\t\n\x07_manual\"Z\n\x0elisteners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12!\n\tlisteners\x18\x03 \x03(\x0b\x32\x0e.listener_info\"^\n\x15gateway_listener_info\x12 \n\x08listener\x18\x01 \x01(\x0b\x32\x0e.listener_info\x12#\n\tlb_states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"m\n\x16gateway_listeners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12,\n\x0cgw_listeners\x18\x03 \x03(\x0b\x32\x16.gateway_listener_info\"\x9b\x02\n\x04host\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x14\n\x07use_psk\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x03 \x01(\x08H\x01\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\x04 \x01(\x08H\x02\x88\x01\x01\x12\x41\n\x18\x64hchap_controller_origin\x18\x05 \x01(\x0e\x32\x1a.DHCHAPControllerKeyOriginH\x03\x88\x01\x01\x42\n\n\x08_use_pskB\r\n\x0b_use_dhchapB(\n&_disconnected_due_to_keepalive_timeoutB\x1b\n\x19_dhchap_controller_origin\"7\n\rlatency_stats\x12\x0b\n\x03min\x18\x01 \x01(\x04\x12\x0b\n\x03max\x18\x02 \x01(\x04\x12\x0c\n\x04mean\x18\x03 \x01(\x04\"\x98\x01\n\rlatency_group\x12\x10\n\x08io_count\x18\x01 \x01(\x04\x12\x1d\n\x05total\x18\x02 \x01(\x0b\x32\x0e.latency_stats\x12\x1c\n\x04\x62\x64\x65v\x18\x03 \x01(\x0b\x32\x0e.latency_stats\x12\x1b\n\x03net\x18\x04 \x01(\x0b\x32\x0e.latency_stats\x12\x1b\n\x03qos\x18\x05 \x01(\x0b\x32\x0e.latency_stats\"X\n\x0b\x62ucket_info\x12\x0c\n\x04size\x18\x01 \x01(\r\x12\x1c\n\x04read\x18\x02 \x01(\x0b\x32\x0e.latency_group\x12\x1d\n\x05write\x18\x03 \x01(\x0b\x32\x0e.latency_group\"\xb7\x01\n\x18\x63onnection_io_statistics\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x10\n\x08host_nqn\x18\x04 \x01(\t\x12\x1a\n\rtotal_num_ios\x18\x05 \x01(\x04H\x00\x88\x01\x01\x12\x1d\n\x07\x62uckets\x18\x06 \x03(\x0b\x32\x0c.bucket_infoB\x10\n\x0e_total_num_ios\"x\n\nhosts_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x16\n\x0e\x61llow_any_host\x18\x03 \x01(\x08\x12\x15\n\rsubsystem_nqn\x18\x04 \x01(\t\x12\x14\n\x05hosts\x18\x05 \x03(\x0b\x32\x05.host\"\xf8\x03\n\nconnection\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0e\n\x06traddr\x18\x02 \x01(\t\x12\x0f\n\x07trsvcid\x18\x03 \x01(\r\x12\x0e\n\x06trtype\x18\x04 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamily\x12\x11\n\tconnected\x18\x06 \x01(\x08\x12\x14\n\x0cqpairs_count\x18\x07 \x01(\x05\x12\x15\n\rcontroller_id\x18\x08 \x01(\x05\x12\x13\n\x06secure\x18\t \x01(\x08H\x00\x88\x01\x01\x12\x14\n\x07use_psk\x18\n \x01(\x08H\x01\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x0b \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tsubsystem\x18\x0c \x01(\tH\x03\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\r \x01(\x08H\x04\x88\x01\x01\x12\x41\n\x18\x64hchap_controller_origin\x18\x0e \x01(\x0e\x32\x1a.DHCHAPControllerKeyOriginH\x05\x88\x01\x01\x42\t\n\x07_secureB\n\n\x08_use_pskB\r\n\x0b_use_dhchapB\x0c\n\n_subsystemB(\n&_disconnected_due_to_keepalive_timeoutB\x1b\n\x19_dhchap_controller_origin\"r\n\x10\x63onnections_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12 \n\x0b\x63onnections\x18\x04 \x03(\x0b\x32\x0b.connection\"\xd8\x07\n\rnamespace_cli\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x11\n\tbdev_name\x18\x02 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x03 \x01(\t\x12\x15\n\rrbd_pool_name\x18\x04 \x01(\t\x12\x1c\n\x14load_balancing_group\x18\x05 \x01(\r\x12\x12\n\nblock_size\x18\x06 \x01(\r\x12\x16\n\x0erbd_image_size\x18\x07 \x01(\x04\x12\x0c\n\x04uuid\x18\x08 \x01(\t\x12\x19\n\x11rw_ios_per_second\x18\t \x01(\x04\x12\x1c\n\x14rw_mbytes_per_second\x18\n \x01(\x04\x12\x1b\n\x13r_mbytes_per_second\x18\x0b \x01(\x04\x12\x1b\n\x13w_mbytes_per_second\x18\x0c \x01(\x04\x12\x14\n\x0c\x61uto_visible\x18\r \x01(\x08\x12\r\n\x05hosts\x18\x0e \x03(\t\x12\x1d\n\x10ns_subsystem_nqn\x18\x0f \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x10 \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\x11 \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tread_only\x18\x12 \x01(\x08H\x03\x88\x01\x01\x12\x19\n\x0c\x63luster_name\x18\x13 \x01(\tH\x04\x88\x01\x01\x12,\n\x1f\x63onfigured_load_balancing_group\x18\x14 \x01(\rH\x05\x88\x01\x01\x12\x1d\n\x10image_was_shrunk\x18\x15 \x01(\x08H\x06\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x16 \x01(\tH\x07\x88\x01\x01\x12\x15\n\x08location\x18\x17 \x01(\tH\x08\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x18 \x01(\tH\t\x88\x01\x01\x12\x37\n\x14\x65ncryption_algorithm\x18\x19 \x01(\x0e\x32\x14.EncryptionAlgorithmH\n\x88\x01\x01\x12-\n\x12\x65ncryption_entries\x18\x1a \x03(\x0b\x32\x11.encryption_entryB\x13\n\x11_ns_subsystem_nqnB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x0f\n\r_cluster_nameB\"\n _configured_load_balancing_groupB\x13\n\x11_image_was_shrunkB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_nameB\x17\n\x15_encryption_algorithm\"s\n\x0fnamespaces_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\"\n\nnamespaces\x18\x04 \x03(\x0b\x32\x0e.namespace_cli\"1\n\x12namespace_io_error\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r\"\x91\x01\n\x1dlist_namespaces_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12\r\n\x05ticks\x18\x04 \x01(\x04\x12\'\n\nnamespaces\x18\x05 \x03(\x0b\x32\x13.bdev_io_stats_info\"\xf7\x04\n\x12\x62\x64\x65v_io_stats_info\x12\x11\n\tbdev_name\x18\x01 \x01(\t\x12\x12\n\nbytes_read\x18\x02 \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\x03 \x01(\x04\x12\x15\n\rbytes_written\x18\x04 \x01(\x04\x12\x15\n\rnum_write_ops\x18\x05 \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\x06 \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x07 \x01(\x04\x12\x14\n\x0c\x62ytes_copied\x18\x08 \x01(\x04\x12\x14\n\x0cnum_copy_ops\x18\t \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\n \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x0b \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x0c \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\r \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x0e \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x0f \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x10 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x11 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x12 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x13 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x14 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x15 \x01(\x04\x12%\n\x08io_error\x18\x16 \x03(\x0b\x32\x13.namespace_io_error\"\xda\x05\n\x17namespace_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x0c\n\x04nsid\x18\x04 \x01(\r\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tbdev_name\x18\x06 \x01(\t\x12\x11\n\ttick_rate\x18\x07 \x01(\x04\x12\r\n\x05ticks\x18\x08 \x01(\x04\x12\x12\n\nbytes_read\x18\t \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\n \x01(\x04\x12\x15\n\rbytes_written\x18\x0b \x01(\x04\x12\x15\n\rnum_write_ops\x18\x0c \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\r \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x0e \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\x0f \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x10 \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x11 \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\x12 \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x13 \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x14 \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x15 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x16 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x17 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x18 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x19 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x1a \x01(\x04\x12%\n\x08io_error\x18\x1b \x03(\x0b\x32\x13.namespace_io_errorB\x07\n\x05_uuid\"3\n\x12spdk_log_flag_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"\xba\x01\n\"spdk_nvmf_log_flags_and_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12+\n\x0envmf_log_flags\x18\x03 \x03(\x0b\x32\x13.spdk_log_flag_info\x12\x1c\n\tlog_level\x18\x04 \x01(\x0e\x32\t.LogLevel\x12\"\n\x0flog_print_level\x18\x05 \x01(\x0e\x32\t.LogLevel\"_\n\x16gateway_log_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x1e\n\tlog_level\x18\x03 \x01(\x0e\x32\x0b.GwLogLevel\"E\n\x10\x65ncryption_entry\x12!\n\x06\x66ormat\x18\x01 \x01(\x0e\x32\x11.EncryptionFormat\x12\x0e\n\x06key_id\x18\x02 \x01(\t*#\n\rAddressFamily\x12\x08\n\x04ipv4\x10\x00\x12\x08\n\x04ipv6\x10\x01*C\n\x08LogLevel\x12\t\n\x05\x45RROR\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\n\n\x06NOTICE\x10\x02\x12\x08\n\x04INFO\x10\x03\x12\t\n\x05\x44\x45\x42UG\x10\x04*S\n\nGwLogLevel\x12\n\n\x06notset\x10\x00\x12\t\n\x05\x64\x65\x62ug\x10\n\x12\x08\n\x04info\x10\x14\x12\x0b\n\x07warning\x10\x1e\x12\t\n\x05\x65rror\x10(\x12\x0c\n\x08\x63ritical\x10\x32*2\n\x10\x45ncryptionFormat\x12\x08\n\x04none\x10\x00\x12\t\n\x05luks1\x10\x01\x12\t\n\x05luks2\x10\x02*?\n\x13\x45ncryptionAlgorithm\x12\x10\n\x0cno_algorithm\x10\x00\x12\n\n\x06\x61\x65s128\x10\x01\x12\n\n\x06\x61\x65s256\x10\x02*R\n\x19\x44HCHAPControllerKeyOrigin\x12\n\n\x06no_key\x10\x00\x12\x11\n\rhost_specific\x10\x01\x12\x16\n\x12subsystem_implicit\x10\x02*J\n\tana_state\x12\t\n\x05UNSET\x10\x00\x12\r\n\tOPTIMIZED\x10\x01\x12\x11\n\rNON_OPTIMIZED\x10\x02\x12\x10\n\x0cINACCESSIBLE\x10\x03\x32\xeb\x15\n\x07Gateway\x12\x33\n\rnamespace_add\x12\x12.namespace_add_req\x1a\x0c.nsid_status\"\x00\x12;\n\x10\x63reate_subsystem\x12\x15.create_subsystem_req\x1a\x0e.subsys_status\"\x00\x12\x38\n\x10\x64\x65lete_subsystem\x12\x15.delete_subsystem_req\x1a\x0b.req_status\"\x00\x12@\n\x14\x63hange_subsystem_key\x12\x19.change_subsystem_key_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x61\x64\x64_subsystem_network\x12\x1a.add_subsystem_network_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x64\x65l_subsystem_network\x12\x1a.del_subsystem_network_req\x1a\x0b.req_status\"\x00\x12;\n\x0flist_namespaces\x12\x14.list_namespaces_req\x1a\x10.namespaces_info\"\x00\x12\x38\n\x10namespace_resize\x12\x15.namespace_resize_req\x1a\x0b.req_status\"\x00\x12Q\n\x16namespace_get_io_stats\x12\x1b.namespace_get_io_stats_req\x1a\x18.namespace_io_stats_info\"\x00\x12[\n\x18list_namespaces_io_stats\x12\x1d.list_namespaces_io_stats_req\x1a\x1e.list_namespaces_io_stats_info\"\x00\x12\x41\n\x18namespace_set_qos_limits\x12\x16.namespace_set_qos_req\x1a\x0b.req_status\"\x00\x12\x62\n%namespace_change_load_balancing_group\x12*.namespace_change_load_balancing_group_req\x1a\x0b.req_status\"\x00\x12N\n\x1bnamespace_change_visibility\x12 .namespace_change_visibility_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_change_location\x12\x1e.namespace_change_location_req\x1a\x0b.req_status\"\x00\x12R\n\x1dnamespace_set_rbd_trash_image\x12\".namespace_set_rbd_trash_image_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_set_auto_resize\x12\x1e.namespace_set_auto_resize_req\x1a\x0b.req_status\"\x00\x12\x38\n\x10namespace_delete\x12\x15.namespace_delete_req\x1a\x0b.req_status\"\x00\x12<\n\x12namespace_add_host\x12\x17.namespace_add_host_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15namespace_delete_host\x12\x1a.namespace_delete_host_req\x1a\x0b.req_status\"\x00\x12(\n\x08\x61\x64\x64_host\x12\r.add_host_req\x1a\x0b.req_status\"\x00\x12.\n\x0bremove_host\x12\x10.remove_host_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x63hange_host_key\x12\x14.change_host_key_req\x1a\x0b.req_status\"\x00\x12,\n\nlist_hosts\x12\x0f.list_hosts_req\x1a\x0b.hosts_info\"\x00\x12>\n\x10list_connections\x12\x15.list_connections_req\x1a\x11.connections_info\"\x00\x12^\n\x1cget_connection_io_statistics\x12!.get_connection_io_statistics_req\x1a\x19.connection_io_statistics\"\x00\x12\x36\n\x0f\x63reate_listener\x12\x14.create_listener_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x64\x65lete_listener\x12\x14.delete_listener_req\x1a\x0b.req_status\"\x00\x12\x38\n\x0elist_listeners\x12\x13.list_listeners_req\x1a\x0f.listeners_info\"\x00\x12?\n\x0flist_subsystems\x12\x14.list_subsystems_req\x1a\x14.subsystems_info_cli\"\x00\x12\x39\n\x0eget_subsystems\x12\x13.get_subsystems_req\x1a\x10.subsystems_info\"\x00\x12)\n\rset_ana_state\x12\t.ana_info\x1a\x0b.req_status\"\x00\x12r\n!get_spdk_nvmf_log_flags_and_level\x12&.get_spdk_nvmf_log_flags_and_level_req\x1a#.spdk_nvmf_log_flags_and_level_info\"\x00\x12\x44\n\x16\x64isable_spdk_nvmf_logs\x12\x1b.disable_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12<\n\x12set_spdk_nvmf_logs\x12\x17.set_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12:\n\x10get_gateway_info\x12\x15.get_gateway_info_req\x1a\r.gateway_info\"\x00\x12N\n\x15get_gateway_log_level\x12\x1a.get_gateway_log_level_req\x1a\x17.gateway_log_level_info\"\x00\x12\x42\n\x15set_gateway_log_level\x12\x1a.set_gateway_log_level_req\x1a\x0b.req_status\"\x00\x12Z\n\x1bshow_gateway_listeners_info\x12 .show_gateway_listeners_info_req\x1a\x17.gateway_listeners_info\"\x00\x12\x42\n\x11get_gateway_stats\x12\x16.get_gateway_stats_req\x1a\x13.gateway_stats_info\"\x00\x12?\n\x10get_thread_stats\x12\x15.get_thread_stats_req\x1a\x12.thread_stats_info\"\x00\x12J\n\x19set_gateway_io_stats_mode\x12\x1e.set_gateway_io_stats_mode_req\x1a\x0b.req_status\"\x00\x42+Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeofb\x06proto3'
+  serialized_pb=b'\n&dashboard/services/proto/gateway.proto\"\x84\x06\n\x11namespace_add_req\x12\x15\n\rrbd_pool_name\x18\x01 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x11\n\x04nsid\x18\x04 \x01(\rH\x00\x88\x01\x01\x12\x12\n\nblock_size\x18\x05 \x01(\r\x12\x11\n\x04uuid\x18\x06 \x01(\tH\x01\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x07 \x01(\x05H\x02\x88\x01\x01\x12\x19\n\x0c\x63reate_image\x18\x08 \x01(\x08H\x03\x88\x01\x01\x12\x11\n\x04size\x18\t \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\n \x01(\x08H\x05\x88\x01\x01\x12\x1c\n\x0fno_auto_visible\x18\x0b \x01(\x08H\x06\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x0c \x01(\x08H\x07\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\r \x01(\x08H\x08\x88\x01\x01\x12\x16\n\tread_only\x18\x0e \x01(\x08H\t\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x0f \x01(\tH\n\x88\x01\x01\x12\x15\n\x08location\x18\x10 \x01(\tH\x0b\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x11 \x01(\tH\x0c\x88\x01\x01\x12-\n\x12\x65ncryption_entries\x18\x12 \x03(\x0b\x32\x11.encryption_entry\x12\x37\n\x14\x65ncryption_algorithm\x18\x13 \x01(\x0e\x32\x14.EncryptionAlgorithmH\r\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x0f\n\r_create_imageB\x07\n\x05_sizeB\x08\n\x06_forceB\x12\n\x10_no_auto_visibleB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_nameB\x17\n\x15_encryption_algorithm\"{\n\x14namespace_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08new_size\x18\x04 \x01(\x04\x42\x10\n\x0e_OBSOLETE_uuid\"o\n\x1anamespace_get_io_stats_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuid\"h\n\x1clist_namespaces_io_stats_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x07\n\x05_nsid\"\xee\x02\n\x15namespace_set_qos_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1e\n\x11rw_ios_per_second\x18\x04 \x01(\x04H\x01\x88\x01\x01\x12!\n\x14rw_mbytes_per_second\x18\x05 \x01(\x04H\x02\x88\x01\x01\x12 \n\x13r_mbytes_per_second\x18\x06 \x01(\x04H\x03\x88\x01\x01\x12 \n\x13w_mbytes_per_second\x18\x07 \x01(\x04H\x04\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x14\n\x12_rw_ios_per_secondB\x17\n\x15_rw_mbytes_per_secondB\x16\n\x14_r_mbytes_per_secondB\x16\n\x14_w_mbytes_per_secondB\x08\n\x06_force\"\xbe\x01\n)namespace_change_load_balancing_group_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61nagrpid\x18\x04 \x01(\x05\x12\x1a\n\rauto_lb_logic\x18\x05 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x10\n\x0e_auto_lb_logic\"z\n\x1fnamespace_change_visibility_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x14\n\x0c\x61uto_visible\x18\x03 \x01(\x08\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"h\n\x1dnamespace_change_location_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x15\n\x08location\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x0b\n\t_location\"]\n!namespace_set_rbd_trash_image_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0btrash_image\x18\x03 \x01(\x08\"Y\n\x1dnamespace_set_auto_resize_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x13\n\x0b\x61uto_resize\x18\x03 \x01(\x08\"\x8f\x01\n\x14namespace_delete_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x1a\n\rOBSOLETE_uuid\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x04 \x01(\x08H\x01\x88\x01\x01\x42\x10\n\x0e_OBSOLETE_uuidB\x0c\n\n_i_am_sure\"m\n\x16namespace_add_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\x12\x12\n\x05\x66orce\x18\x04 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"R\n\x19namespace_delete_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x0c\n\x04nsid\x18\x02 \x01(\r\x12\x10\n\x08host_nqn\x18\x03 \x01(\t\"\xf5\x02\n\x14\x63reate_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x15\n\rserial_number\x18\x02 \x01(\t\x12\x1b\n\x0emax_namespaces\x18\x03 \x01(\rH\x00\x88\x01\x01\x12\x11\n\tenable_ha\x18\x04 \x01(\x08\x12\x1c\n\x0fno_group_append\x18\x05 \x01(\x08H\x01\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x06 \x01(\tH\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x07 \x01(\x08H\x03\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\x08 \x03(\t\x12\x1d\n\x10secure_listeners\x18\t \x01(\x08H\x04\x88\x01\x01\x12\x11\n\x04port\x18\n \x01(\rH\x05\x88\x01\x01\x42\x11\n\x0f_max_namespacesB\x12\n\x10_no_group_appendB\r\n\x0b_dhchap_keyB\x10\n\x0e_key_encryptedB\x13\n\x11_secure_listenersB\x07\n\x05_port\"q\n\x14\x64\x65lete_subsystem_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x12\n\x05\x66orce\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x16\n\ti_am_sure\x18\x03 \x01(\x08H\x01\x88\x01\x01\x42\x08\n\x06_forceB\x0c\n\n_i_am_sure\"Y\n\x18\x63hange_subsystem_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x17\n\ndhchap_key\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\r\n\x0b_dhchap_key\"H\n\x19\x61\x64\x64_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"H\n\x19\x64\x65l_subsystem_network_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_mask\x18\x02 \x01(\t\"C\n\x14kmip_server_endpoint\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x11\n\x04port\x18\x02 \x01(\rH\x00\x88\x01\x01\x42\x07\n\x05_port\"e\n\x18kmip_server_endpoint_cli\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x13\n\x0bserver_name\x18\x02 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x03 \x01(\t\x12\x0c\n\x04port\x18\x04 \x01(\r\"u\n\x1d\x61\x64\x64_kmip_server_endpoints_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x13\n\x0bserver_name\x18\x02 \x01(\t\x12(\n\tendpoints\x18\x03 \x03(\x0b\x32\x15.kmip_server_endpoint\"u\n\x1d\x64\x65l_kmip_server_endpoints_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x13\n\x0bserver_name\x18\x02 \x01(\t\x12(\n\tendpoints\x18\x03 \x03(\x0b\x32\x15.kmip_server_endpoint\"x\n\x1elist_kmip_server_endpoints_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0bserver_name\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x0e\n\x0c_server_name\"q\n\x1akmip_server_endpoints_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12,\n\tendpoints\x18\x03 \x03(\x0b\x32\x19.kmip_server_endpoint_cli\"`\n\x13list_namespaces_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x11\n\x04nsid\x18\x02 \x01(\rH\x00\x88\x01\x01\x12\x11\n\x04uuid\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x07\n\x05_nsidB\x07\n\x05_uuid\"\xc3\x02\n\x0c\x61\x64\x64_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x10\n\x03psk\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ndhchap_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rpsk_encrypted\x18\x05 \x01(\x08H\x02\x88\x01\x01\x12\x1a\n\rkey_encrypted\x18\x06 \x01(\x08H\x03\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x07 \x01(\tH\x04\x88\x01\x01\x12 \n\x13\x63trlr_key_encrypted\x18\x08 \x01(\x08H\x05\x88\x01\x01\x42\x06\n\x04_pskB\r\n\x0b_dhchap_keyB\x10\n\x0e_psk_encryptedB\x10\n\x0e_key_encryptedB\x13\n\x11_dhchap_ctrlr_keyB\x16\n\x14_ctrlr_key_encrypted\"\x9a\x01\n\x13\x63hange_host_key_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x17\n\ndhchap_key\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1d\n\x10\x64hchap_ctrlr_key\x18\x04 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_dhchap_keyB\x13\n\x11_dhchap_ctrlr_key\"i\n get_connection_io_statistics_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x12\n\x05reset\x18\x03 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_reset\"X\n\x0fremove_host_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\x12\x10\n\x08host_nqn\x18\x02 \x01(\t\x12\x12\n\x05\x66orce\x18\x03 \x01(\x08H\x00\x88\x01\x01\x42\x08\n\x06_force\"O\n\x0elist_hosts_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"U\n\x14list_connections_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\x12\x19\n\x0c\x63lear_alerts\x18\x02 \x01(\x08H\x00\x88\x01\x01\x42\x0f\n\r_clear_alerts\"\x89\x02\n\x13\x63reate_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x13\n\x06secure\x18\x07 \x01(\x08H\x02\x88\x01\x01\x12\x1d\n\x10verify_host_name\x18\x08 \x01(\x08H\x03\x88\x01\x01\x12\x12\n\x05\x66orce\x18\t \x01(\x08H\x04\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\t\n\x07_secureB\x13\n\x11_verify_host_nameB\x08\n\x06_force\"\xb5\x01\n\x13\x64\x65lete_listener_req\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\thost_name\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12#\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamilyH\x00\x88\x01\x01\x12\x14\n\x07trsvcid\x18\x06 \x01(\rH\x01\x88\x01\x01\x12\x12\n\x05\x66orce\x18\x07 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_adrfamB\n\n\x08_trsvcidB\x08\n\x06_force\"\'\n\x12list_listeners_req\x12\x11\n\tsubsystem\x18\x01 \x01(\t\"q\n\x13list_subsystems_req\x12\x1a\n\rsubsystem_nqn\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1a\n\rserial_number\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x10\n\x0e_subsystem_nqnB\x10\n\x0e_serial_number\"\x14\n\x12get_subsystems_req\"U\n%get_spdk_nvmf_log_flags_and_level_req\x12\x1a\n\rall_log_flags\x18\x01 \x01(\x08H\x00\x88\x01\x01\x42\x10\n\x0e_all_log_flags\"5\n\x1a\x64isable_spdk_nvmf_logs_req\x12\x17\n\x0f\x65xtra_log_flags\x18\x01 \x03(\t\"\x97\x01\n\x16set_spdk_nvmf_logs_req\x12!\n\tlog_level\x18\x01 \x01(\x0e\x32\t.LogLevelH\x00\x88\x01\x01\x12#\n\x0bprint_level\x18\x02 \x01(\x0e\x32\t.LogLevelH\x01\x88\x01\x01\x12\x17\n\x0f\x65xtra_log_flags\x18\x03 \x03(\tB\x0c\n\n_log_levelB\x0e\n\x0c_print_level\"@\n\x14get_gateway_info_req\x12\x18\n\x0b\x63li_version\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_cli_version\"\x1b\n\x19get_gateway_log_level_req\";\n\x19set_gateway_log_level_req\x12\x1e\n\tlog_level\x18\x01 \x01(\x0e\x32\x0b.GwLogLevel\"8\n\x1fshow_gateway_listeners_info_req\x12\x15\n\rsubsystem_nqn\x18\x01 \x01(\t\"\x17\n\x15get_gateway_stats_req\"\x16\n\x14get_thread_stats_req\"0\n\x1dset_gateway_io_stats_mode_req\x12\x0f\n\x07\x65nabled\x18\x01 \x01(\x08\"<\n\x0f\x61na_group_state\x12\x0e\n\x06grp_id\x18\x01 \x01(\r\x12\x19\n\x05state\x18\x02 \x01(\x0e\x32\n.ana_state\"?\n\x0enqn_ana_states\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12 \n\x06states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"+\n\x08\x61na_info\x12\x1f\n\x06states\x18\x01 \x03(\x0b\x32\x0f.nqn_ana_states\"3\n\nreq_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\"C\n\rsubsys_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0b\n\x03nqn\x18\x03 \x01(\t\"B\n\x0bnsid_status\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0c\n\x04nsid\x18\x03 \x01(\r\"1\n\x0fsubsystems_info\x12\x1e\n\nsubsystems\x18\x01 \x03(\x0b\x32\n.subsystem\"\xc2\x03\n\tsubsystem\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0f\n\x07subtype\x18\x02 \x01(\t\x12)\n\x10listen_addresses\x18\x03 \x03(\x0b\x32\x0f.listen_address\x12\x14\n\x05hosts\x18\x04 \x03(\x0b\x32\x05.host\x12\x16\n\x0e\x61llow_any_host\x18\x05 \x01(\x08\x12\x1a\n\rserial_number\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0cmodel_number\x18\x07 \x01(\tH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x08 \x01(\rH\x02\x88\x01\x01\x12\x17\n\nmin_cntlid\x18\t \x01(\rH\x03\x88\x01\x01\x12\x17\n\nmax_cntlid\x18\n \x01(\rH\x04\x88\x01\x01\x12\x1e\n\nnamespaces\x18\x0b \x03(\x0b\x32\n.namespace\x12\x1b\n\x0ehas_dhchap_key\x18\x0c \x01(\x08H\x05\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x10\n\x0e_serial_numberB\x0f\n\r_model_numberB\x11\n\x0f_max_namespacesB\r\n\x0b_min_cntlidB\r\n\x0b_max_cntlidB\x11\n\x0f_has_dhchap_key\"\x97\x01\n\x0elisten_address\x12\x0e\n\x06trtype\x18\x01 \x01(\t\x12\x0e\n\x06\x61\x64rfam\x18\x02 \x01(\t\x12\x0e\n\x06traddr\x18\x03 \x01(\t\x12\x0f\n\x07trsvcid\x18\x04 \x01(\t\x12\x16\n\ttransport\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x01\x88\x01\x01\x42\x0c\n\n_transportB\t\n\x07_secure\"\x84\x02\n\tnamespace\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x16\n\tbdev_name\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05nguid\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x02\x88\x01\x01\x12\x15\n\x08\x61nagrpid\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x12\n\x05nonce\x18\x07 \x01(\tH\x04\x88\x01\x01\x12\x19\n\x0c\x61uto_visible\x18\x08 \x01(\x08H\x05\x88\x01\x01\x12\r\n\x05hosts\x18\t \x03(\tB\x0c\n\n_bdev_nameB\x08\n\x06_nguidB\x07\n\x05_uuidB\x0b\n\t_anagrpidB\x08\n\x06_nonceB\x0f\n\r_auto_visible\"`\n\x13subsystems_info_cli\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\nsubsystems\x18\x03 \x03(\x0b\x32\x0e.subsystem_cli\"\xf6\x02\n\rsubsystem_cli\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x11\n\tenable_ha\x18\x02 \x01(\x08\x12\x15\n\rserial_number\x18\x03 \x01(\t\x12\x14\n\x0cmodel_number\x18\x04 \x01(\t\x12\x12\n\nmin_cntlid\x18\x05 \x01(\r\x12\x12\n\nmax_cntlid\x18\x06 \x01(\r\x12\x17\n\x0fnamespace_count\x18\x07 \x01(\r\x12\x0f\n\x07subtype\x18\x08 \x01(\t\x12\x16\n\x0emax_namespaces\x18\t \x01(\r\x12\x1b\n\x0ehas_dhchap_key\x18\n \x01(\x08H\x00\x88\x01\x01\x12\x1b\n\x0e\x61llow_any_host\x18\x0b \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x63reated_without_key\x18\x0c \x01(\x08H\x02\x88\x01\x01\x12\x14\n\x0cnetwork_mask\x18\r \x03(\tB\x11\n\x0f_has_dhchap_keyB\x11\n\x0f_allow_any_hostB\x16\n\x14_created_without_key\"\xbb\x05\n\x0cgateway_info\x12\x13\n\x0b\x63li_version\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05group\x18\x04 \x01(\t\x12\x0c\n\x04\x61\x64\x64r\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\t\x12\x13\n\x0b\x62ool_status\x18\x07 \x01(\x08\x12\x0e\n\x06status\x18\x08 \x01(\x05\x12\x15\n\rerror_message\x18\t \x01(\t\x12\x19\n\x0cspdk_version\x18\n \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x14load_balancing_group\x18\x0b \x01(\r\x12\x10\n\x08hostname\x18\x0c \x01(\t\x12\x1b\n\x0emax_subsystems\x18\r \x01(\rH\x01\x88\x01\x01\x12\x1b\n\x0emax_namespaces\x18\x0e \x01(\rH\x02\x88\x01\x01\x12$\n\x17max_hosts_per_subsystem\x18\x0f \x01(\rH\x03\x88\x01\x01\x12)\n\x1cmax_namespaces_per_subsystem\x18\x10 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tmax_hosts\x18\x11 \x01(\rH\x05\x88\x01\x01\x12(\n\x1bgateway_initialization_over\x18\x12 \x01(\x08H\x06\x88\x01\x01\x12\x1d\n\x10io_stats_enabled\x18\x13 \x01(\x08H\x07\x88\x01\x01\x12\x15\n\x08location\x18\x14 \x01(\tH\x08\x88\x01\x01\x42\x0f\n\r_spdk_versionB\x11\n\x0f_max_subsystemsB\x11\n\x0f_max_namespacesB\x1a\n\x18_max_hosts_per_subsystemB\x1f\n\x1d_max_namespaces_per_subsystemB\x0c\n\n_max_hostsB\x1e\n\x1c_gateway_initialization_overB\x13\n\x11_io_stats_enabledB\x0b\n\t_location\"E\n\x0b\x63li_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"D\n\ngw_version\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"+\n\x19poll_group_transport_info\x12\x0e\n\x06trtype\x18\x01 \x01(\t\"\xe5\x01\n\x0fpoll_group_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x61\x64min_qpairs\x18\x02 \x01(\r\x12\x11\n\tio_qpairs\x18\x03 \x01(\r\x12\x1c\n\x14\x63urrent_admin_qpairs\x18\x04 \x01(\r\x12\x19\n\x11\x63urrent_io_qpairs\x18\x05 \x01(\r\x12\x17\n\x0fpending_bdev_io\x18\x06 \x01(\x04\x12\x19\n\x11\x63ompleted_nvme_io\x18\x07 \x01(\x04\x12.\n\ntransports\x18\x08 \x03(\x0b\x32\x1a.poll_group_transport_info\"u\n\x12gateway_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12%\n\x0bpoll_groups\x18\x04 \x03(\x0b\x32\x10.poll_group_info\"q\n\x11thread_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\"\n\x07threads\x18\x03 \x03(\x0b\x32\x11.spdk_thread_info\x12\x11\n\ttick_rate\x18\x04 \x01(\x04\"<\n\x10spdk_thread_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62usy\x18\x02 \x01(\x04\x12\x0c\n\x04idle\x18\x03 \x01(\x04\"\xd3\x01\n\rlistener_info\x12\x11\n\thost_name\x18\x01 \x01(\t\x12\x0e\n\x06trtype\x18\x02 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x03 \x01(\x0e\x32\x0e.AddressFamily\x12\x0e\n\x06traddr\x18\x04 \x01(\t\x12\x0f\n\x07trsvcid\x18\x05 \x01(\r\x12\x13\n\x06secure\x18\x06 \x01(\x08H\x00\x88\x01\x01\x12\x13\n\x06\x61\x63tive\x18\x07 \x01(\x08H\x01\x88\x01\x01\x12\x13\n\x06manual\x18\x08 \x01(\x08H\x02\x88\x01\x01\x42\t\n\x07_secureB\t\n\x07_activeB\t\n\x07_manual\"Z\n\x0elisteners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12!\n\tlisteners\x18\x03 \x03(\x0b\x32\x0e.listener_info\"^\n\x15gateway_listener_info\x12 \n\x08listener\x18\x01 \x01(\x0b\x32\x0e.listener_info\x12#\n\tlb_states\x18\x02 \x03(\x0b\x32\x10.ana_group_state\"m\n\x16gateway_listeners_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12,\n\x0cgw_listeners\x18\x03 \x03(\x0b\x32\x16.gateway_listener_info\"\x9b\x02\n\x04host\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x14\n\x07use_psk\x18\x02 \x01(\x08H\x00\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x03 \x01(\x08H\x01\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\x04 \x01(\x08H\x02\x88\x01\x01\x12\x41\n\x18\x64hchap_controller_origin\x18\x05 \x01(\x0e\x32\x1a.DHCHAPControllerKeyOriginH\x03\x88\x01\x01\x42\n\n\x08_use_pskB\r\n\x0b_use_dhchapB(\n&_disconnected_due_to_keepalive_timeoutB\x1b\n\x19_dhchap_controller_origin\"7\n\rlatency_stats\x12\x0b\n\x03min\x18\x01 \x01(\x04\x12\x0b\n\x03max\x18\x02 \x01(\x04\x12\x0c\n\x04mean\x18\x03 \x01(\x04\"\x98\x01\n\rlatency_group\x12\x10\n\x08io_count\x18\x01 \x01(\x04\x12\x1d\n\x05total\x18\x02 \x01(\x0b\x32\x0e.latency_stats\x12\x1c\n\x04\x62\x64\x65v\x18\x03 \x01(\x0b\x32\x0e.latency_stats\x12\x1b\n\x03net\x18\x04 \x01(\x0b\x32\x0e.latency_stats\x12\x1b\n\x03qos\x18\x05 \x01(\x0b\x32\x0e.latency_stats\"X\n\x0b\x62ucket_info\x12\x0c\n\x04size\x18\x01 \x01(\r\x12\x1c\n\x04read\x18\x02 \x01(\x0b\x32\x0e.latency_group\x12\x1d\n\x05write\x18\x03 \x01(\x0b\x32\x0e.latency_group\"\xb7\x01\n\x18\x63onnection_io_statistics\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x10\n\x08host_nqn\x18\x04 \x01(\t\x12\x1a\n\rtotal_num_ios\x18\x05 \x01(\x04H\x00\x88\x01\x01\x12\x1d\n\x07\x62uckets\x18\x06 \x03(\x0b\x32\x0c.bucket_infoB\x10\n\x0e_total_num_ios\"x\n\nhosts_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x16\n\x0e\x61llow_any_host\x18\x03 \x01(\x08\x12\x15\n\rsubsystem_nqn\x18\x04 \x01(\t\x12\x14\n\x05hosts\x18\x05 \x03(\x0b\x32\x05.host\"\xf8\x03\n\nconnection\x12\x0b\n\x03nqn\x18\x01 \x01(\t\x12\x0e\n\x06traddr\x18\x02 \x01(\t\x12\x0f\n\x07trsvcid\x18\x03 \x01(\r\x12\x0e\n\x06trtype\x18\x04 \x01(\t\x12\x1e\n\x06\x61\x64rfam\x18\x05 \x01(\x0e\x32\x0e.AddressFamily\x12\x11\n\tconnected\x18\x06 \x01(\x08\x12\x14\n\x0cqpairs_count\x18\x07 \x01(\x05\x12\x15\n\rcontroller_id\x18\x08 \x01(\x05\x12\x13\n\x06secure\x18\t \x01(\x08H\x00\x88\x01\x01\x12\x14\n\x07use_psk\x18\n \x01(\x08H\x01\x88\x01\x01\x12\x17\n\nuse_dhchap\x18\x0b \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tsubsystem\x18\x0c \x01(\tH\x03\x88\x01\x01\x12\x32\n%disconnected_due_to_keepalive_timeout\x18\r \x01(\x08H\x04\x88\x01\x01\x12\x41\n\x18\x64hchap_controller_origin\x18\x0e \x01(\x0e\x32\x1a.DHCHAPControllerKeyOriginH\x05\x88\x01\x01\x42\t\n\x07_secureB\n\n\x08_use_pskB\r\n\x0b_use_dhchapB\x0c\n\n_subsystemB(\n&_disconnected_due_to_keepalive_timeoutB\x1b\n\x19_dhchap_controller_origin\"r\n\x10\x63onnections_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12 \n\x0b\x63onnections\x18\x04 \x03(\x0b\x32\x0b.connection\"\xd8\x07\n\rnamespace_cli\x12\x0c\n\x04nsid\x18\x01 \x01(\r\x12\x11\n\tbdev_name\x18\x02 \x01(\t\x12\x16\n\x0erbd_image_name\x18\x03 \x01(\t\x12\x15\n\rrbd_pool_name\x18\x04 \x01(\t\x12\x1c\n\x14load_balancing_group\x18\x05 \x01(\r\x12\x12\n\nblock_size\x18\x06 \x01(\r\x12\x16\n\x0erbd_image_size\x18\x07 \x01(\x04\x12\x0c\n\x04uuid\x18\x08 \x01(\t\x12\x19\n\x11rw_ios_per_second\x18\t \x01(\x04\x12\x1c\n\x14rw_mbytes_per_second\x18\n \x01(\x04\x12\x1b\n\x13r_mbytes_per_second\x18\x0b \x01(\x04\x12\x1b\n\x13w_mbytes_per_second\x18\x0c \x01(\x04\x12\x14\n\x0c\x61uto_visible\x18\r \x01(\x08\x12\r\n\x05hosts\x18\x0e \x03(\t\x12\x1d\n\x10ns_subsystem_nqn\x18\x0f \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0btrash_image\x18\x10 \x01(\x08H\x01\x88\x01\x01\x12 \n\x13\x64isable_auto_resize\x18\x11 \x01(\x08H\x02\x88\x01\x01\x12\x16\n\tread_only\x18\x12 \x01(\x08H\x03\x88\x01\x01\x12\x19\n\x0c\x63luster_name\x18\x13 \x01(\tH\x04\x88\x01\x01\x12,\n\x1f\x63onfigured_load_balancing_group\x18\x14 \x01(\rH\x05\x88\x01\x01\x12\x1d\n\x10image_was_shrunk\x18\x15 \x01(\x08H\x06\x88\x01\x01\x12\x1f\n\x12rbd_data_pool_name\x18\x16 \x01(\tH\x07\x88\x01\x01\x12\x15\n\x08location\x18\x17 \x01(\tH\x08\x88\x01\x01\x12!\n\x14rados_namespace_name\x18\x18 \x01(\tH\t\x88\x01\x01\x12\x37\n\x14\x65ncryption_algorithm\x18\x19 \x01(\x0e\x32\x14.EncryptionAlgorithmH\n\x88\x01\x01\x12-\n\x12\x65ncryption_entries\x18\x1a \x03(\x0b\x32\x11.encryption_entryB\x13\n\x11_ns_subsystem_nqnB\x0e\n\x0c_trash_imageB\x16\n\x14_disable_auto_resizeB\x0c\n\n_read_onlyB\x0f\n\r_cluster_nameB\"\n _configured_load_balancing_groupB\x13\n\x11_image_was_shrunkB\x15\n\x13_rbd_data_pool_nameB\x0b\n\t_locationB\x17\n\x15_rados_namespace_nameB\x17\n\x15_encryption_algorithm\"s\n\x0fnamespaces_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\"\n\nnamespaces\x18\x04 \x03(\x0b\x32\x0e.namespace_cli\"1\n\x12namespace_io_error\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r\"\x91\x01\n\x1dlist_namespaces_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x11\n\ttick_rate\x18\x03 \x01(\x04\x12\r\n\x05ticks\x18\x04 \x01(\x04\x12\'\n\nnamespaces\x18\x05 \x03(\x0b\x32\x13.bdev_io_stats_info\"\xf7\x04\n\x12\x62\x64\x65v_io_stats_info\x12\x11\n\tbdev_name\x18\x01 \x01(\t\x12\x12\n\nbytes_read\x18\x02 \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\x03 \x01(\x04\x12\x15\n\rbytes_written\x18\x04 \x01(\x04\x12\x15\n\rnum_write_ops\x18\x05 \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\x06 \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x07 \x01(\x04\x12\x14\n\x0c\x62ytes_copied\x18\x08 \x01(\x04\x12\x14\n\x0cnum_copy_ops\x18\t \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\n \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x0b \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x0c \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\r \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x0e \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x0f \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x10 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x11 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x12 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x13 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x14 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x15 \x01(\x04\x12%\n\x08io_error\x18\x16 \x03(\x0b\x32\x13.namespace_io_error\"\xda\x05\n\x17namespace_io_stats_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x15\n\rsubsystem_nqn\x18\x03 \x01(\t\x12\x0c\n\x04nsid\x18\x04 \x01(\r\x12\x11\n\x04uuid\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tbdev_name\x18\x06 \x01(\t\x12\x11\n\ttick_rate\x18\x07 \x01(\x04\x12\r\n\x05ticks\x18\x08 \x01(\x04\x12\x12\n\nbytes_read\x18\t \x01(\x04\x12\x14\n\x0cnum_read_ops\x18\n \x01(\x04\x12\x15\n\rbytes_written\x18\x0b \x01(\x04\x12\x15\n\rnum_write_ops\x18\x0c \x01(\x04\x12\x16\n\x0e\x62ytes_unmapped\x18\r \x01(\x04\x12\x15\n\rnum_unmap_ops\x18\x0e \x01(\x04\x12\x1a\n\x12read_latency_ticks\x18\x0f \x01(\x04\x12\x1e\n\x16max_read_latency_ticks\x18\x10 \x01(\x04\x12\x1e\n\x16min_read_latency_ticks\x18\x11 \x01(\x04\x12\x1b\n\x13write_latency_ticks\x18\x12 \x01(\x04\x12\x1f\n\x17max_write_latency_ticks\x18\x13 \x01(\x04\x12\x1f\n\x17min_write_latency_ticks\x18\x14 \x01(\x04\x12\x1b\n\x13unmap_latency_ticks\x18\x15 \x01(\x04\x12\x1f\n\x17max_unmap_latency_ticks\x18\x16 \x01(\x04\x12\x1f\n\x17min_unmap_latency_ticks\x18\x17 \x01(\x04\x12\x1a\n\x12\x63opy_latency_ticks\x18\x18 \x01(\x04\x12\x1e\n\x16max_copy_latency_ticks\x18\x19 \x01(\x04\x12\x1e\n\x16min_copy_latency_ticks\x18\x1a \x01(\x04\x12%\n\x08io_error\x18\x1b \x03(\x0b\x32\x13.namespace_io_errorB\x07\n\x05_uuid\"3\n\x12spdk_log_flag_info\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"\xba\x01\n\"spdk_nvmf_log_flags_and_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12+\n\x0envmf_log_flags\x18\x03 \x03(\x0b\x32\x13.spdk_log_flag_info\x12\x1c\n\tlog_level\x18\x04 \x01(\x0e\x32\t.LogLevel\x12\"\n\x0flog_print_level\x18\x05 \x01(\x0e\x32\t.LogLevel\"_\n\x16gateway_log_level_info\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x1e\n\tlog_level\x18\x03 \x01(\x0e\x32\x0b.GwLogLevel\"E\n\x10\x65ncryption_entry\x12!\n\x06\x66ormat\x18\x01 \x01(\x0e\x32\x11.EncryptionFormat\x12\x0e\n\x06key_id\x18\x02 \x01(\t*#\n\rAddressFamily\x12\x08\n\x04ipv4\x10\x00\x12\x08\n\x04ipv6\x10\x01*C\n\x08LogLevel\x12\t\n\x05\x45RROR\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\n\n\x06NOTICE\x10\x02\x12\x08\n\x04INFO\x10\x03\x12\t\n\x05\x44\x45\x42UG\x10\x04*S\n\nGwLogLevel\x12\n\n\x06notset\x10\x00\x12\t\n\x05\x64\x65\x62ug\x10\n\x12\x08\n\x04info\x10\x14\x12\x0b\n\x07warning\x10\x1e\x12\t\n\x05\x65rror\x10(\x12\x0c\n\x08\x63ritical\x10\x32*2\n\x10\x45ncryptionFormat\x12\x08\n\x04none\x10\x00\x12\t\n\x05luks1\x10\x01\x12\t\n\x05luks2\x10\x02*?\n\x13\x45ncryptionAlgorithm\x12\x10\n\x0cno_algorithm\x10\x00\x12\n\n\x06\x61\x65s128\x10\x01\x12\n\n\x06\x61\x65s256\x10\x02*R\n\x19\x44HCHAPControllerKeyOrigin\x12\n\n\x06no_key\x10\x00\x12\x11\n\rhost_specific\x10\x01\x12\x16\n\x12subsystem_implicit\x10\x02*J\n\tana_state\x12\t\n\x05UNSET\x10\x00\x12\r\n\tOPTIMIZED\x10\x01\x12\x11\n\rNON_OPTIMIZED\x10\x02\x12\x10\n\x0cINACCESSIBLE\x10\x03\x32\xe1\x17\n\x07Gateway\x12\x33\n\rnamespace_add\x12\x12.namespace_add_req\x1a\x0c.nsid_status\"\x00\x12;\n\x10\x63reate_subsystem\x12\x15.create_subsystem_req\x1a\x0e.subsys_status\"\x00\x12\x38\n\x10\x64\x65lete_subsystem\x12\x15.delete_subsystem_req\x1a\x0b.req_status\"\x00\x12@\n\x14\x63hange_subsystem_key\x12\x19.change_subsystem_key_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x61\x64\x64_subsystem_network\x12\x1a.add_subsystem_network_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15\x64\x65l_subsystem_network\x12\x1a.del_subsystem_network_req\x1a\x0b.req_status\"\x00\x12J\n\x19\x61\x64\x64_kmip_server_endpoints\x12\x1e.add_kmip_server_endpoints_req\x1a\x0b.req_status\"\x00\x12J\n\x19\x64\x65l_kmip_server_endpoints\x12\x1e.del_kmip_server_endpoints_req\x1a\x0b.req_status\"\x00\x12\\\n\x1alist_kmip_server_endpoints\x12\x1f.list_kmip_server_endpoints_req\x1a\x1b.kmip_server_endpoints_info\"\x00\x12;\n\x0flist_namespaces\x12\x14.list_namespaces_req\x1a\x10.namespaces_info\"\x00\x12\x38\n\x10namespace_resize\x12\x15.namespace_resize_req\x1a\x0b.req_status\"\x00\x12Q\n\x16namespace_get_io_stats\x12\x1b.namespace_get_io_stats_req\x1a\x18.namespace_io_stats_info\"\x00\x12[\n\x18list_namespaces_io_stats\x12\x1d.list_namespaces_io_stats_req\x1a\x1e.list_namespaces_io_stats_info\"\x00\x12\x41\n\x18namespace_set_qos_limits\x12\x16.namespace_set_qos_req\x1a\x0b.req_status\"\x00\x12\x62\n%namespace_change_load_balancing_group\x12*.namespace_change_load_balancing_group_req\x1a\x0b.req_status\"\x00\x12N\n\x1bnamespace_change_visibility\x12 .namespace_change_visibility_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_change_location\x12\x1e.namespace_change_location_req\x1a\x0b.req_status\"\x00\x12R\n\x1dnamespace_set_rbd_trash_image\x12\".namespace_set_rbd_trash_image_req\x1a\x0b.req_status\"\x00\x12J\n\x19namespace_set_auto_resize\x12\x1e.namespace_set_auto_resize_req\x1a\x0b.req_status\"\x00\x12\x38\n\x10namespace_delete\x12\x15.namespace_delete_req\x1a\x0b.req_status\"\x00\x12<\n\x12namespace_add_host\x12\x17.namespace_add_host_req\x1a\x0b.req_status\"\x00\x12\x42\n\x15namespace_delete_host\x12\x1a.namespace_delete_host_req\x1a\x0b.req_status\"\x00\x12(\n\x08\x61\x64\x64_host\x12\r.add_host_req\x1a\x0b.req_status\"\x00\x12.\n\x0bremove_host\x12\x10.remove_host_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x63hange_host_key\x12\x14.change_host_key_req\x1a\x0b.req_status\"\x00\x12,\n\nlist_hosts\x12\x0f.list_hosts_req\x1a\x0b.hosts_info\"\x00\x12>\n\x10list_connections\x12\x15.list_connections_req\x1a\x11.connections_info\"\x00\x12^\n\x1cget_connection_io_statistics\x12!.get_connection_io_statistics_req\x1a\x19.connection_io_statistics\"\x00\x12\x36\n\x0f\x63reate_listener\x12\x14.create_listener_req\x1a\x0b.req_status\"\x00\x12\x36\n\x0f\x64\x65lete_listener\x12\x14.delete_listener_req\x1a\x0b.req_status\"\x00\x12\x38\n\x0elist_listeners\x12\x13.list_listeners_req\x1a\x0f.listeners_info\"\x00\x12?\n\x0flist_subsystems\x12\x14.list_subsystems_req\x1a\x14.subsystems_info_cli\"\x00\x12\x39\n\x0eget_subsystems\x12\x13.get_subsystems_req\x1a\x10.subsystems_info\"\x00\x12)\n\rset_ana_state\x12\t.ana_info\x1a\x0b.req_status\"\x00\x12r\n!get_spdk_nvmf_log_flags_and_level\x12&.get_spdk_nvmf_log_flags_and_level_req\x1a#.spdk_nvmf_log_flags_and_level_info\"\x00\x12\x44\n\x16\x64isable_spdk_nvmf_logs\x12\x1b.disable_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12<\n\x12set_spdk_nvmf_logs\x12\x17.set_spdk_nvmf_logs_req\x1a\x0b.req_status\"\x00\x12:\n\x10get_gateway_info\x12\x15.get_gateway_info_req\x1a\r.gateway_info\"\x00\x12N\n\x15get_gateway_log_level\x12\x1a.get_gateway_log_level_req\x1a\x17.gateway_log_level_info\"\x00\x12\x42\n\x15set_gateway_log_level\x12\x1a.set_gateway_log_level_req\x1a\x0b.req_status\"\x00\x12Z\n\x1bshow_gateway_listeners_info\x12 .show_gateway_listeners_info_req\x1a\x17.gateway_listeners_info\"\x00\x12\x42\n\x11get_gateway_stats\x12\x16.get_gateway_stats_req\x1a\x13.gateway_stats_info\"\x00\x12?\n\x10get_thread_stats\x12\x15.get_thread_stats_req\x1a\x12.thread_stats_info\"\x00\x12J\n\x19set_gateway_io_stats_mode\x12\x1e.set_gateway_io_stats_mode_req\x1a\x0b.req_status\"\x00\x42+Z)github.com/ceph/ceph-nvmeof/lib/go/nvmeofb\x06proto3'
 )
 
 _ADDRESSFAMILY = _descriptor.EnumDescriptor(
@@ -43,8 +43,8 @@ _ADDRESSFAMILY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=13587,
-  serialized_end=13622,
+  serialized_start=14328,
+  serialized_end=14363,
 )
 _sym_db.RegisterEnumDescriptor(_ADDRESSFAMILY)
 
@@ -84,8 +84,8 @@ _LOGLEVEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=13624,
-  serialized_end=13691,
+  serialized_start=14365,
+  serialized_end=14432,
 )
 _sym_db.RegisterEnumDescriptor(_LOGLEVEL)
 
@@ -130,8 +130,8 @@ _GWLOGLEVEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=13693,
-  serialized_end=13776,
+  serialized_start=14434,
+  serialized_end=14517,
 )
 _sym_db.RegisterEnumDescriptor(_GWLOGLEVEL)
 
@@ -161,8 +161,8 @@ _ENCRYPTIONFORMAT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=13778,
-  serialized_end=13828,
+  serialized_start=14519,
+  serialized_end=14569,
 )
 _sym_db.RegisterEnumDescriptor(_ENCRYPTIONFORMAT)
 
@@ -192,8 +192,8 @@ _ENCRYPTIONALGORITHM = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=13830,
-  serialized_end=13893,
+  serialized_start=14571,
+  serialized_end=14634,
 )
 _sym_db.RegisterEnumDescriptor(_ENCRYPTIONALGORITHM)
 
@@ -223,8 +223,8 @@ _DHCHAPCONTROLLERKEYORIGIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=13895,
-  serialized_end=13977,
+  serialized_start=14636,
+  serialized_end=14718,
 )
 _sym_db.RegisterEnumDescriptor(_DHCHAPCONTROLLERKEYORIGIN)
 
@@ -259,8 +259,8 @@ _ANA_STATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=13979,
-  serialized_end=14053,
+  serialized_start=14720,
+  serialized_end=14794,
 )
 _sym_db.RegisterEnumDescriptor(_ANA_STATE)
 
@@ -1300,6 +1300,13 @@ _CREATE_SUBSYSTEM_REQ = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='port', full_name='create_subsystem_req.port', index=9,
+      number=10, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -1336,9 +1343,14 @@ _CREATE_SUBSYSTEM_REQ = _descriptor.Descriptor(
       index=4, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_port', full_name='create_subsystem_req._port',
+      index=5, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
   serialized_start=2481,
-  serialized_end=2826,
+  serialized_end=2854,
 )
 
 
@@ -1393,8 +1405,8 @@ _DELETE_SUBSYSTEM_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2828,
-  serialized_end=2941,
+  serialized_start=2856,
+  serialized_end=2969,
 )
 
 
@@ -1437,8 +1449,8 @@ _CHANGE_SUBSYSTEM_KEY_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2943,
-  serialized_end=3032,
+  serialized_start=2971,
+  serialized_end=3060,
 )
 
 
@@ -1476,8 +1488,8 @@ _ADD_SUBSYSTEM_NETWORK_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3034,
-  serialized_end=3106,
+  serialized_start=3062,
+  serialized_end=3134,
 )
 
 
@@ -1515,8 +1527,292 @@ _DEL_SUBSYSTEM_NETWORK_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3108,
-  serialized_end=3180,
+  serialized_start=3136,
+  serialized_end=3208,
+)
+
+
+_KMIP_SERVER_ENDPOINT = _descriptor.Descriptor(
+  name='kmip_server_endpoint',
+  full_name='kmip_server_endpoint',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='address', full_name='kmip_server_endpoint.address', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='port', full_name='kmip_server_endpoint.port', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_port', full_name='kmip_server_endpoint._port',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3210,
+  serialized_end=3277,
+)
+
+
+_KMIP_SERVER_ENDPOINT_CLI = _descriptor.Descriptor(
+  name='kmip_server_endpoint_cli',
+  full_name='kmip_server_endpoint_cli',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='kmip_server_endpoint_cli.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='server_name', full_name='kmip_server_endpoint_cli.server_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='address', full_name='kmip_server_endpoint_cli.address', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='port', full_name='kmip_server_endpoint_cli.port', index=3,
+      number=4, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3279,
+  serialized_end=3380,
+)
+
+
+_ADD_KMIP_SERVER_ENDPOINTS_REQ = _descriptor.Descriptor(
+  name='add_kmip_server_endpoints_req',
+  full_name='add_kmip_server_endpoints_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='add_kmip_server_endpoints_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='server_name', full_name='add_kmip_server_endpoints_req.server_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='endpoints', full_name='add_kmip_server_endpoints_req.endpoints', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3382,
+  serialized_end=3499,
+)
+
+
+_DEL_KMIP_SERVER_ENDPOINTS_REQ = _descriptor.Descriptor(
+  name='del_kmip_server_endpoints_req',
+  full_name='del_kmip_server_endpoints_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='del_kmip_server_endpoints_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='server_name', full_name='del_kmip_server_endpoints_req.server_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='endpoints', full_name='del_kmip_server_endpoints_req.endpoints', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3501,
+  serialized_end=3618,
+)
+
+
+_LIST_KMIP_SERVER_ENDPOINTS_REQ = _descriptor.Descriptor(
+  name='list_kmip_server_endpoints_req',
+  full_name='list_kmip_server_endpoints_req',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='subsystem_nqn', full_name='list_kmip_server_endpoints_req.subsystem_nqn', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='server_name', full_name='list_kmip_server_endpoints_req.server_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='_subsystem_nqn', full_name='list_kmip_server_endpoints_req._subsystem_nqn',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_server_name', full_name='list_kmip_server_endpoints_req._server_name',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=3620,
+  serialized_end=3740,
+)
+
+
+_KMIP_SERVER_ENDPOINTS_INFO = _descriptor.Descriptor(
+  name='kmip_server_endpoints_info',
+  full_name='kmip_server_endpoints_info',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='kmip_server_endpoints_info.status', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='error_message', full_name='kmip_server_endpoints_info.error_message', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='endpoints', full_name='kmip_server_endpoints_info.endpoints', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3742,
+  serialized_end=3855,
 )
 
 
@@ -1571,8 +1867,8 @@ _LIST_NAMESPACES_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3182,
-  serialized_end=3278,
+  serialized_start=3857,
+  serialized_end=3953,
 )
 
 
@@ -1682,8 +1978,8 @@ _ADD_HOST_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3281,
-  serialized_end=3604,
+  serialized_start=3956,
+  serialized_end=4279,
 )
 
 
@@ -1745,8 +2041,8 @@ _CHANGE_HOST_KEY_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3607,
-  serialized_end=3761,
+  serialized_start=4282,
+  serialized_end=4436,
 )
 
 
@@ -1796,8 +2092,8 @@ _GET_CONNECTION_IO_STATISTICS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3763,
-  serialized_end=3868,
+  serialized_start=4438,
+  serialized_end=4543,
 )
 
 
@@ -1847,8 +2143,8 @@ _REMOVE_HOST_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3870,
-  serialized_end=3958,
+  serialized_start=4545,
+  serialized_end=4633,
 )
 
 
@@ -1891,8 +2187,8 @@ _LIST_HOSTS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3960,
-  serialized_end=4039,
+  serialized_start=4635,
+  serialized_end=4714,
 )
 
 
@@ -1935,8 +2231,8 @@ _LIST_CONNECTIONS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4041,
-  serialized_end=4126,
+  serialized_start=4716,
+  serialized_end=4801,
 )
 
 
@@ -1997,6 +2293,13 @@ _CREATE_LISTENER_REQ = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='force', full_name='create_listener_req.force', index=7,
+      number=9, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -2028,9 +2331,14 @@ _CREATE_LISTENER_REQ = _descriptor.Descriptor(
       index=3, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_force', full_name='create_listener_req._force',
+      index=4, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
-  serialized_start=4129,
-  serialized_end=4364,
+  serialized_start=4804,
+  serialized_end=5069,
 )
 
 
@@ -2111,8 +2419,8 @@ _DELETE_LISTENER_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4367,
-  serialized_end=4548,
+  serialized_start=5072,
+  serialized_end=5253,
 )
 
 
@@ -2143,8 +2451,8 @@ _LIST_LISTENERS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4550,
-  serialized_end=4589,
+  serialized_start=5255,
+  serialized_end=5294,
 )
 
 
@@ -2192,8 +2500,8 @@ _LIST_SUBSYSTEMS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4591,
-  serialized_end=4704,
+  serialized_start=5296,
+  serialized_end=5409,
 )
 
 
@@ -2217,8 +2525,8 @@ _GET_SUBSYSTEMS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4706,
-  serialized_end=4726,
+  serialized_start=5411,
+  serialized_end=5431,
 )
 
 
@@ -2254,8 +2562,8 @@ _GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4728,
-  serialized_end=4813,
+  serialized_start=5433,
+  serialized_end=5518,
 )
 
 
@@ -2286,8 +2594,8 @@ _DISABLE_SPDK_NVMF_LOGS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4815,
-  serialized_end=4868,
+  serialized_start=5520,
+  serialized_end=5573,
 )
 
 
@@ -2342,8 +2650,8 @@ _SET_SPDK_NVMF_LOGS_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4871,
-  serialized_end=5022,
+  serialized_start=5576,
+  serialized_end=5727,
 )
 
 
@@ -2379,8 +2687,8 @@ _GET_GATEWAY_INFO_REQ = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=5024,
-  serialized_end=5088,
+  serialized_start=5729,
+  serialized_end=5793,
 )
 
 
@@ -2404,8 +2712,8 @@ _GET_GATEWAY_LOG_LEVEL_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5090,
-  serialized_end=5117,
+  serialized_start=5795,
+  serialized_end=5822,
 )
 
 
@@ -2436,8 +2744,8 @@ _SET_GATEWAY_LOG_LEVEL_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5119,
-  serialized_end=5178,
+  serialized_start=5824,
+  serialized_end=5883,
 )
 
 
@@ -2468,8 +2776,8 @@ _SHOW_GATEWAY_LISTENERS_INFO_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5180,
-  serialized_end=5236,
+  serialized_start=5885,
+  serialized_end=5941,
 )
 
 
@@ -2493,8 +2801,8 @@ _GET_GATEWAY_STATS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5238,
-  serialized_end=5261,
+  serialized_start=5943,
+  serialized_end=5966,
 )
 
 
@@ -2518,8 +2826,8 @@ _GET_THREAD_STATS_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5263,
-  serialized_end=5285,
+  serialized_start=5968,
+  serialized_end=5990,
 )
 
 
@@ -2550,8 +2858,8 @@ _SET_GATEWAY_IO_STATS_MODE_REQ = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5287,
-  serialized_end=5335,
+  serialized_start=5992,
+  serialized_end=6040,
 )
 
 
@@ -2589,8 +2897,8 @@ _ANA_GROUP_STATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5337,
-  serialized_end=5397,
+  serialized_start=6042,
+  serialized_end=6102,
 )
 
 
@@ -2628,8 +2936,8 @@ _NQN_ANA_STATES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5399,
-  serialized_end=5462,
+  serialized_start=6104,
+  serialized_end=6167,
 )
 
 
@@ -2660,8 +2968,8 @@ _ANA_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5464,
-  serialized_end=5507,
+  serialized_start=6169,
+  serialized_end=6212,
 )
 
 
@@ -2699,8 +3007,8 @@ _REQ_STATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5509,
-  serialized_end=5560,
+  serialized_start=6214,
+  serialized_end=6265,
 )
 
 
@@ -2745,8 +3053,8 @@ _SUBSYS_STATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5562,
-  serialized_end=5629,
+  serialized_start=6267,
+  serialized_end=6334,
 )
 
 
@@ -2791,8 +3099,8 @@ _NSID_STATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5631,
-  serialized_end=5697,
+  serialized_start=6336,
+  serialized_end=6402,
 )
 
 
@@ -2823,8 +3131,8 @@ _SUBSYSTEMS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5699,
-  serialized_end=5748,
+  serialized_start=6404,
+  serialized_end=6453,
 )
 
 
@@ -2969,8 +3277,8 @@ _SUBSYSTEM = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=5751,
-  serialized_end=6201,
+  serialized_start=6456,
+  serialized_end=6906,
 )
 
 
@@ -3046,8 +3354,8 @@ _LISTEN_ADDRESS = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=6204,
-  serialized_end=6355,
+  serialized_start=6909,
+  serialized_end=7060,
 )
 
 
@@ -3164,8 +3472,8 @@ _NAMESPACE = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=6358,
-  serialized_end=6618,
+  serialized_start=7063,
+  serialized_end=7323,
 )
 
 
@@ -3210,8 +3518,8 @@ _SUBSYSTEMS_INFO_CLI = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6620,
-  serialized_end=6716,
+  serialized_start=7325,
+  serialized_end=7421,
 )
 
 
@@ -3341,8 +3649,8 @@ _SUBSYSTEM_CLI = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=6719,
-  serialized_end=7093,
+  serialized_start=7424,
+  serialized_end=7798,
 )
 
 
@@ -3487,6 +3795,13 @@ _GATEWAY_INFO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='location', full_name='gateway_info.location', index=19,
+      number=20, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -3538,9 +3853,14 @@ _GATEWAY_INFO = _descriptor.Descriptor(
       index=7, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_location', full_name='gateway_info._location',
+      index=8, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
-  serialized_start=7096,
-  serialized_end=7759,
+  serialized_start=7801,
+  serialized_end=8500,
 )
 
 
@@ -3585,8 +3905,8 @@ _CLI_VERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7761,
-  serialized_end=7830,
+  serialized_start=8502,
+  serialized_end=8571,
 )
 
 
@@ -3631,8 +3951,8 @@ _GW_VERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7832,
-  serialized_end=7900,
+  serialized_start=8573,
+  serialized_end=8641,
 )
 
 
@@ -3663,8 +3983,8 @@ _POLL_GROUP_TRANSPORT_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7902,
-  serialized_end=7945,
+  serialized_start=8643,
+  serialized_end=8686,
 )
 
 
@@ -3744,8 +4064,8 @@ _POLL_GROUP_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7948,
-  serialized_end=8177,
+  serialized_start=8689,
+  serialized_end=8918,
 )
 
 
@@ -3797,8 +4117,8 @@ _GATEWAY_STATS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8179,
-  serialized_end=8296,
+  serialized_start=8920,
+  serialized_end=9037,
 )
 
 
@@ -3850,8 +4170,8 @@ _THREAD_STATS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8298,
-  serialized_end=8411,
+  serialized_start=9039,
+  serialized_end=9152,
 )
 
 
@@ -3896,8 +4216,8 @@ _SPDK_THREAD_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8413,
-  serialized_end=8473,
+  serialized_start=9154,
+  serialized_end=9214,
 )
 
 
@@ -3992,8 +4312,8 @@ _LISTENER_INFO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=8476,
-  serialized_end=8687,
+  serialized_start=9217,
+  serialized_end=9428,
 )
 
 
@@ -4038,8 +4358,8 @@ _LISTENERS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8689,
-  serialized_end=8779,
+  serialized_start=9430,
+  serialized_end=9520,
 )
 
 
@@ -4077,8 +4397,8 @@ _GATEWAY_LISTENER_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8781,
-  serialized_end=8875,
+  serialized_start=9522,
+  serialized_end=9616,
 )
 
 
@@ -4123,8 +4443,8 @@ _GATEWAY_LISTENERS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8877,
-  serialized_end=8986,
+  serialized_start=9618,
+  serialized_end=9727,
 )
 
 
@@ -4203,8 +4523,8 @@ _HOST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=8989,
-  serialized_end=9272,
+  serialized_start=9730,
+  serialized_end=10013,
 )
 
 
@@ -4249,8 +4569,8 @@ _LATENCY_STATS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9274,
-  serialized_end=9329,
+  serialized_start=10015,
+  serialized_end=10070,
 )
 
 
@@ -4309,8 +4629,8 @@ _LATENCY_GROUP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9332,
-  serialized_end=9484,
+  serialized_start=10073,
+  serialized_end=10225,
 )
 
 
@@ -4355,8 +4675,8 @@ _BUCKET_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9486,
-  serialized_end=9574,
+  serialized_start=10227,
+  serialized_end=10315,
 )
 
 
@@ -4427,8 +4747,8 @@ _CONNECTION_IO_STATISTICS = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=9577,
-  serialized_end=9760,
+  serialized_start=10318,
+  serialized_end=10501,
 )
 
 
@@ -4487,8 +4807,8 @@ _HOSTS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9762,
-  serialized_end=9882,
+  serialized_start=10503,
+  serialized_end=10623,
 )
 
 
@@ -4640,8 +4960,8 @@ _CONNECTION = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=9885,
-  serialized_end=10389,
+  serialized_start=10626,
+  serialized_end=11130,
 )
 
 
@@ -4693,8 +5013,8 @@ _CONNECTIONS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10391,
-  serialized_end=10505,
+  serialized_start=11132,
+  serialized_end=11246,
 )
 
 
@@ -4955,8 +5275,8 @@ _NAMESPACE_CLI = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=10508,
-  serialized_end=11492,
+  serialized_start=11249,
+  serialized_end=12233,
 )
 
 
@@ -5008,8 +5328,8 @@ _NAMESPACES_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11494,
-  serialized_end=11609,
+  serialized_start=12235,
+  serialized_end=12350,
 )
 
 
@@ -5047,8 +5367,8 @@ _NAMESPACE_IO_ERROR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11611,
-  serialized_end=11660,
+  serialized_start=12352,
+  serialized_end=12401,
 )
 
 
@@ -5107,8 +5427,8 @@ _LIST_NAMESPACES_IO_STATS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11663,
-  serialized_end=11808,
+  serialized_start=12404,
+  serialized_end=12549,
 )
 
 
@@ -5286,8 +5606,8 @@ _BDEV_IO_STATS_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11811,
-  serialized_end=12442,
+  serialized_start=12552,
+  serialized_end=13183,
 )
 
 
@@ -5505,8 +5825,8 @@ _NAMESPACE_IO_STATS_INFO = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=12445,
-  serialized_end=13175,
+  serialized_start=13186,
+  serialized_end=13916,
 )
 
 
@@ -5544,8 +5864,8 @@ _SPDK_LOG_FLAG_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13177,
-  serialized_end=13228,
+  serialized_start=13918,
+  serialized_end=13969,
 )
 
 
@@ -5604,8 +5924,8 @@ _SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13231,
-  serialized_end=13417,
+  serialized_start=13972,
+  serialized_end=14158,
 )
 
 
@@ -5650,8 +5970,8 @@ _GATEWAY_LOG_LEVEL_INFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13419,
-  serialized_end=13514,
+  serialized_start=14160,
+  serialized_end=14255,
 )
 
 
@@ -5689,8 +6009,8 @@ _ENCRYPTION_ENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=13516,
-  serialized_end=13585,
+  serialized_start=14257,
+  serialized_end=14326,
 )
 
 _NAMESPACE_ADD_REQ.fields_by_name['encryption_entries'].message_type = _ENCRYPTION_ENTRY
@@ -5803,6 +6123,9 @@ _CREATE_SUBSYSTEM_REQ.fields_by_name['key_encrypted'].containing_oneof = _CREATE
 _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_secure_listeners'].fields.append(
   _CREATE_SUBSYSTEM_REQ.fields_by_name['secure_listeners'])
 _CREATE_SUBSYSTEM_REQ.fields_by_name['secure_listeners'].containing_oneof = _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_secure_listeners']
+_CREATE_SUBSYSTEM_REQ.oneofs_by_name['_port'].fields.append(
+  _CREATE_SUBSYSTEM_REQ.fields_by_name['port'])
+_CREATE_SUBSYSTEM_REQ.fields_by_name['port'].containing_oneof = _CREATE_SUBSYSTEM_REQ.oneofs_by_name['_port']
 _DELETE_SUBSYSTEM_REQ.oneofs_by_name['_force'].fields.append(
   _DELETE_SUBSYSTEM_REQ.fields_by_name['force'])
 _DELETE_SUBSYSTEM_REQ.fields_by_name['force'].containing_oneof = _DELETE_SUBSYSTEM_REQ.oneofs_by_name['_force']
@@ -5812,6 +6135,18 @@ _DELETE_SUBSYSTEM_REQ.fields_by_name['i_am_sure'].containing_oneof = _DELETE_SUB
 _CHANGE_SUBSYSTEM_KEY_REQ.oneofs_by_name['_dhchap_key'].fields.append(
   _CHANGE_SUBSYSTEM_KEY_REQ.fields_by_name['dhchap_key'])
 _CHANGE_SUBSYSTEM_KEY_REQ.fields_by_name['dhchap_key'].containing_oneof = _CHANGE_SUBSYSTEM_KEY_REQ.oneofs_by_name['_dhchap_key']
+_KMIP_SERVER_ENDPOINT.oneofs_by_name['_port'].fields.append(
+  _KMIP_SERVER_ENDPOINT.fields_by_name['port'])
+_KMIP_SERVER_ENDPOINT.fields_by_name['port'].containing_oneof = _KMIP_SERVER_ENDPOINT.oneofs_by_name['_port']
+_ADD_KMIP_SERVER_ENDPOINTS_REQ.fields_by_name['endpoints'].message_type = _KMIP_SERVER_ENDPOINT
+_DEL_KMIP_SERVER_ENDPOINTS_REQ.fields_by_name['endpoints'].message_type = _KMIP_SERVER_ENDPOINT
+_LIST_KMIP_SERVER_ENDPOINTS_REQ.oneofs_by_name['_subsystem_nqn'].fields.append(
+  _LIST_KMIP_SERVER_ENDPOINTS_REQ.fields_by_name['subsystem_nqn'])
+_LIST_KMIP_SERVER_ENDPOINTS_REQ.fields_by_name['subsystem_nqn'].containing_oneof = _LIST_KMIP_SERVER_ENDPOINTS_REQ.oneofs_by_name['_subsystem_nqn']
+_LIST_KMIP_SERVER_ENDPOINTS_REQ.oneofs_by_name['_server_name'].fields.append(
+  _LIST_KMIP_SERVER_ENDPOINTS_REQ.fields_by_name['server_name'])
+_LIST_KMIP_SERVER_ENDPOINTS_REQ.fields_by_name['server_name'].containing_oneof = _LIST_KMIP_SERVER_ENDPOINTS_REQ.oneofs_by_name['_server_name']
+_KMIP_SERVER_ENDPOINTS_INFO.fields_by_name['endpoints'].message_type = _KMIP_SERVER_ENDPOINT_CLI
 _LIST_NAMESPACES_REQ.oneofs_by_name['_nsid'].fields.append(
   _LIST_NAMESPACES_REQ.fields_by_name['nsid'])
 _LIST_NAMESPACES_REQ.fields_by_name['nsid'].containing_oneof = _LIST_NAMESPACES_REQ.oneofs_by_name['_nsid']
@@ -5867,6 +6202,9 @@ _CREATE_LISTENER_REQ.fields_by_name['secure'].containing_oneof = _CREATE_LISTENE
 _CREATE_LISTENER_REQ.oneofs_by_name['_verify_host_name'].fields.append(
   _CREATE_LISTENER_REQ.fields_by_name['verify_host_name'])
 _CREATE_LISTENER_REQ.fields_by_name['verify_host_name'].containing_oneof = _CREATE_LISTENER_REQ.oneofs_by_name['_verify_host_name']
+_CREATE_LISTENER_REQ.oneofs_by_name['_force'].fields.append(
+  _CREATE_LISTENER_REQ.fields_by_name['force'])
+_CREATE_LISTENER_REQ.fields_by_name['force'].containing_oneof = _CREATE_LISTENER_REQ.oneofs_by_name['_force']
 _DELETE_LISTENER_REQ.fields_by_name['adrfam'].enum_type = _ADDRESSFAMILY
 _DELETE_LISTENER_REQ.oneofs_by_name['_adrfam'].fields.append(
   _DELETE_LISTENER_REQ.fields_by_name['adrfam'])
@@ -5981,6 +6319,9 @@ _GATEWAY_INFO.fields_by_name['gateway_initialization_over'].containing_oneof = _
 _GATEWAY_INFO.oneofs_by_name['_io_stats_enabled'].fields.append(
   _GATEWAY_INFO.fields_by_name['io_stats_enabled'])
 _GATEWAY_INFO.fields_by_name['io_stats_enabled'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_io_stats_enabled']
+_GATEWAY_INFO.oneofs_by_name['_location'].fields.append(
+  _GATEWAY_INFO.fields_by_name['location'])
+_GATEWAY_INFO.fields_by_name['location'].containing_oneof = _GATEWAY_INFO.oneofs_by_name['_location']
 _POLL_GROUP_INFO.fields_by_name['transports'].message_type = _POLL_GROUP_TRANSPORT_INFO
 _GATEWAY_STATS_INFO.fields_by_name['poll_groups'].message_type = _POLL_GROUP_INFO
 _THREAD_STATS_INFO.fields_by_name['threads'].message_type = _SPDK_THREAD_INFO
@@ -6108,6 +6449,12 @@ DESCRIPTOR.message_types_by_name['delete_subsystem_req'] = _DELETE_SUBSYSTEM_REQ
 DESCRIPTOR.message_types_by_name['change_subsystem_key_req'] = _CHANGE_SUBSYSTEM_KEY_REQ
 DESCRIPTOR.message_types_by_name['add_subsystem_network_req'] = _ADD_SUBSYSTEM_NETWORK_REQ
 DESCRIPTOR.message_types_by_name['del_subsystem_network_req'] = _DEL_SUBSYSTEM_NETWORK_REQ
+DESCRIPTOR.message_types_by_name['kmip_server_endpoint'] = _KMIP_SERVER_ENDPOINT
+DESCRIPTOR.message_types_by_name['kmip_server_endpoint_cli'] = _KMIP_SERVER_ENDPOINT_CLI
+DESCRIPTOR.message_types_by_name['add_kmip_server_endpoints_req'] = _ADD_KMIP_SERVER_ENDPOINTS_REQ
+DESCRIPTOR.message_types_by_name['del_kmip_server_endpoints_req'] = _DEL_KMIP_SERVER_ENDPOINTS_REQ
+DESCRIPTOR.message_types_by_name['list_kmip_server_endpoints_req'] = _LIST_KMIP_SERVER_ENDPOINTS_REQ
+DESCRIPTOR.message_types_by_name['kmip_server_endpoints_info'] = _KMIP_SERVER_ENDPOINTS_INFO
 DESCRIPTOR.message_types_by_name['list_namespaces_req'] = _LIST_NAMESPACES_REQ
 DESCRIPTOR.message_types_by_name['add_host_req'] = _ADD_HOST_REQ
 DESCRIPTOR.message_types_by_name['change_host_key_req'] = _CHANGE_HOST_KEY_REQ
@@ -6306,6 +6653,48 @@ del_subsystem_network_req = _reflection.GeneratedProtocolMessageType('del_subsys
   # @@protoc_insertion_point(class_scope:del_subsystem_network_req)
   })
 _sym_db.RegisterMessage(del_subsystem_network_req)
+
+kmip_server_endpoint = _reflection.GeneratedProtocolMessageType('kmip_server_endpoint', (_message.Message,), {
+  'DESCRIPTOR' : _KMIP_SERVER_ENDPOINT,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:kmip_server_endpoint)
+  })
+_sym_db.RegisterMessage(kmip_server_endpoint)
+
+kmip_server_endpoint_cli = _reflection.GeneratedProtocolMessageType('kmip_server_endpoint_cli', (_message.Message,), {
+  'DESCRIPTOR' : _KMIP_SERVER_ENDPOINT_CLI,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:kmip_server_endpoint_cli)
+  })
+_sym_db.RegisterMessage(kmip_server_endpoint_cli)
+
+add_kmip_server_endpoints_req = _reflection.GeneratedProtocolMessageType('add_kmip_server_endpoints_req', (_message.Message,), {
+  'DESCRIPTOR' : _ADD_KMIP_SERVER_ENDPOINTS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:add_kmip_server_endpoints_req)
+  })
+_sym_db.RegisterMessage(add_kmip_server_endpoints_req)
+
+del_kmip_server_endpoints_req = _reflection.GeneratedProtocolMessageType('del_kmip_server_endpoints_req', (_message.Message,), {
+  'DESCRIPTOR' : _DEL_KMIP_SERVER_ENDPOINTS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:del_kmip_server_endpoints_req)
+  })
+_sym_db.RegisterMessage(del_kmip_server_endpoints_req)
+
+list_kmip_server_endpoints_req = _reflection.GeneratedProtocolMessageType('list_kmip_server_endpoints_req', (_message.Message,), {
+  'DESCRIPTOR' : _LIST_KMIP_SERVER_ENDPOINTS_REQ,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:list_kmip_server_endpoints_req)
+  })
+_sym_db.RegisterMessage(list_kmip_server_endpoints_req)
+
+kmip_server_endpoints_info = _reflection.GeneratedProtocolMessageType('kmip_server_endpoints_info', (_message.Message,), {
+  'DESCRIPTOR' : _KMIP_SERVER_ENDPOINTS_INFO,
+  '__module__' : 'dashboard.services.proto.gateway_pb2'
+  # @@protoc_insertion_point(class_scope:kmip_server_endpoints_info)
+  })
+_sym_db.RegisterMessage(kmip_server_endpoints_info)
 
 list_namespaces_req = _reflection.GeneratedProtocolMessageType('list_namespaces_req', (_message.Message,), {
   'DESCRIPTOR' : _LIST_NAMESPACES_REQ,
@@ -6765,8 +7154,8 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=14056,
-  serialized_end=16851,
+  serialized_start=14797,
+  serialized_end=17838,
   methods=[
   _descriptor.MethodDescriptor(
     name='namespace_add',
@@ -6829,9 +7218,39 @@ _GATEWAY = _descriptor.ServiceDescriptor(
     create_key=_descriptor._internal_create_key,
   ),
   _descriptor.MethodDescriptor(
+    name='add_kmip_server_endpoints',
+    full_name='Gateway.add_kmip_server_endpoints',
+    index=6,
+    containing_service=None,
+    input_type=_ADD_KMIP_SERVER_ENDPOINTS_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='del_kmip_server_endpoints',
+    full_name='Gateway.del_kmip_server_endpoints',
+    index=7,
+    containing_service=None,
+    input_type=_DEL_KMIP_SERVER_ENDPOINTS_REQ,
+    output_type=_REQ_STATUS,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='list_kmip_server_endpoints',
+    full_name='Gateway.list_kmip_server_endpoints',
+    index=8,
+    containing_service=None,
+    input_type=_LIST_KMIP_SERVER_ENDPOINTS_REQ,
+    output_type=_KMIP_SERVER_ENDPOINTS_INFO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
     name='list_namespaces',
     full_name='Gateway.list_namespaces',
-    index=6,
+    index=9,
     containing_service=None,
     input_type=_LIST_NAMESPACES_REQ,
     output_type=_NAMESPACES_INFO,
@@ -6841,7 +7260,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_resize',
     full_name='Gateway.namespace_resize',
-    index=7,
+    index=10,
     containing_service=None,
     input_type=_NAMESPACE_RESIZE_REQ,
     output_type=_REQ_STATUS,
@@ -6851,7 +7270,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_get_io_stats',
     full_name='Gateway.namespace_get_io_stats',
-    index=8,
+    index=11,
     containing_service=None,
     input_type=_NAMESPACE_GET_IO_STATS_REQ,
     output_type=_NAMESPACE_IO_STATS_INFO,
@@ -6861,7 +7280,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_namespaces_io_stats',
     full_name='Gateway.list_namespaces_io_stats',
-    index=9,
+    index=12,
     containing_service=None,
     input_type=_LIST_NAMESPACES_IO_STATS_REQ,
     output_type=_LIST_NAMESPACES_IO_STATS_INFO,
@@ -6871,7 +7290,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_set_qos_limits',
     full_name='Gateway.namespace_set_qos_limits',
-    index=10,
+    index=13,
     containing_service=None,
     input_type=_NAMESPACE_SET_QOS_REQ,
     output_type=_REQ_STATUS,
@@ -6881,7 +7300,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_change_load_balancing_group',
     full_name='Gateway.namespace_change_load_balancing_group',
-    index=11,
+    index=14,
     containing_service=None,
     input_type=_NAMESPACE_CHANGE_LOAD_BALANCING_GROUP_REQ,
     output_type=_REQ_STATUS,
@@ -6891,7 +7310,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_change_visibility',
     full_name='Gateway.namespace_change_visibility',
-    index=12,
+    index=15,
     containing_service=None,
     input_type=_NAMESPACE_CHANGE_VISIBILITY_REQ,
     output_type=_REQ_STATUS,
@@ -6901,7 +7320,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_change_location',
     full_name='Gateway.namespace_change_location',
-    index=13,
+    index=16,
     containing_service=None,
     input_type=_NAMESPACE_CHANGE_LOCATION_REQ,
     output_type=_REQ_STATUS,
@@ -6911,7 +7330,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_set_rbd_trash_image',
     full_name='Gateway.namespace_set_rbd_trash_image',
-    index=14,
+    index=17,
     containing_service=None,
     input_type=_NAMESPACE_SET_RBD_TRASH_IMAGE_REQ,
     output_type=_REQ_STATUS,
@@ -6921,7 +7340,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_set_auto_resize',
     full_name='Gateway.namespace_set_auto_resize',
-    index=15,
+    index=18,
     containing_service=None,
     input_type=_NAMESPACE_SET_AUTO_RESIZE_REQ,
     output_type=_REQ_STATUS,
@@ -6931,7 +7350,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_delete',
     full_name='Gateway.namespace_delete',
-    index=16,
+    index=19,
     containing_service=None,
     input_type=_NAMESPACE_DELETE_REQ,
     output_type=_REQ_STATUS,
@@ -6941,7 +7360,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_add_host',
     full_name='Gateway.namespace_add_host',
-    index=17,
+    index=20,
     containing_service=None,
     input_type=_NAMESPACE_ADD_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -6951,7 +7370,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='namespace_delete_host',
     full_name='Gateway.namespace_delete_host',
-    index=18,
+    index=21,
     containing_service=None,
     input_type=_NAMESPACE_DELETE_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -6961,7 +7380,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='add_host',
     full_name='Gateway.add_host',
-    index=19,
+    index=22,
     containing_service=None,
     input_type=_ADD_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -6971,7 +7390,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='remove_host',
     full_name='Gateway.remove_host',
-    index=20,
+    index=23,
     containing_service=None,
     input_type=_REMOVE_HOST_REQ,
     output_type=_REQ_STATUS,
@@ -6981,7 +7400,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='change_host_key',
     full_name='Gateway.change_host_key',
-    index=21,
+    index=24,
     containing_service=None,
     input_type=_CHANGE_HOST_KEY_REQ,
     output_type=_REQ_STATUS,
@@ -6991,7 +7410,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_hosts',
     full_name='Gateway.list_hosts',
-    index=22,
+    index=25,
     containing_service=None,
     input_type=_LIST_HOSTS_REQ,
     output_type=_HOSTS_INFO,
@@ -7001,7 +7420,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_connections',
     full_name='Gateway.list_connections',
-    index=23,
+    index=26,
     containing_service=None,
     input_type=_LIST_CONNECTIONS_REQ,
     output_type=_CONNECTIONS_INFO,
@@ -7011,7 +7430,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_connection_io_statistics',
     full_name='Gateway.get_connection_io_statistics',
-    index=24,
+    index=27,
     containing_service=None,
     input_type=_GET_CONNECTION_IO_STATISTICS_REQ,
     output_type=_CONNECTION_IO_STATISTICS,
@@ -7021,7 +7440,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='create_listener',
     full_name='Gateway.create_listener',
-    index=25,
+    index=28,
     containing_service=None,
     input_type=_CREATE_LISTENER_REQ,
     output_type=_REQ_STATUS,
@@ -7031,7 +7450,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='delete_listener',
     full_name='Gateway.delete_listener',
-    index=26,
+    index=29,
     containing_service=None,
     input_type=_DELETE_LISTENER_REQ,
     output_type=_REQ_STATUS,
@@ -7041,7 +7460,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_listeners',
     full_name='Gateway.list_listeners',
-    index=27,
+    index=30,
     containing_service=None,
     input_type=_LIST_LISTENERS_REQ,
     output_type=_LISTENERS_INFO,
@@ -7051,7 +7470,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='list_subsystems',
     full_name='Gateway.list_subsystems',
-    index=28,
+    index=31,
     containing_service=None,
     input_type=_LIST_SUBSYSTEMS_REQ,
     output_type=_SUBSYSTEMS_INFO_CLI,
@@ -7061,7 +7480,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_subsystems',
     full_name='Gateway.get_subsystems',
-    index=29,
+    index=32,
     containing_service=None,
     input_type=_GET_SUBSYSTEMS_REQ,
     output_type=_SUBSYSTEMS_INFO,
@@ -7071,7 +7490,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='set_ana_state',
     full_name='Gateway.set_ana_state',
-    index=30,
+    index=33,
     containing_service=None,
     input_type=_ANA_INFO,
     output_type=_REQ_STATUS,
@@ -7081,7 +7500,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_spdk_nvmf_log_flags_and_level',
     full_name='Gateway.get_spdk_nvmf_log_flags_and_level',
-    index=31,
+    index=34,
     containing_service=None,
     input_type=_GET_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_REQ,
     output_type=_SPDK_NVMF_LOG_FLAGS_AND_LEVEL_INFO,
@@ -7091,7 +7510,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='disable_spdk_nvmf_logs',
     full_name='Gateway.disable_spdk_nvmf_logs',
-    index=32,
+    index=35,
     containing_service=None,
     input_type=_DISABLE_SPDK_NVMF_LOGS_REQ,
     output_type=_REQ_STATUS,
@@ -7101,7 +7520,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='set_spdk_nvmf_logs',
     full_name='Gateway.set_spdk_nvmf_logs',
-    index=33,
+    index=36,
     containing_service=None,
     input_type=_SET_SPDK_NVMF_LOGS_REQ,
     output_type=_REQ_STATUS,
@@ -7111,7 +7530,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_gateway_info',
     full_name='Gateway.get_gateway_info',
-    index=34,
+    index=37,
     containing_service=None,
     input_type=_GET_GATEWAY_INFO_REQ,
     output_type=_GATEWAY_INFO,
@@ -7121,7 +7540,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_gateway_log_level',
     full_name='Gateway.get_gateway_log_level',
-    index=35,
+    index=38,
     containing_service=None,
     input_type=_GET_GATEWAY_LOG_LEVEL_REQ,
     output_type=_GATEWAY_LOG_LEVEL_INFO,
@@ -7131,7 +7550,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='set_gateway_log_level',
     full_name='Gateway.set_gateway_log_level',
-    index=36,
+    index=39,
     containing_service=None,
     input_type=_SET_GATEWAY_LOG_LEVEL_REQ,
     output_type=_REQ_STATUS,
@@ -7141,7 +7560,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='show_gateway_listeners_info',
     full_name='Gateway.show_gateway_listeners_info',
-    index=37,
+    index=40,
     containing_service=None,
     input_type=_SHOW_GATEWAY_LISTENERS_INFO_REQ,
     output_type=_GATEWAY_LISTENERS_INFO,
@@ -7151,7 +7570,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_gateway_stats',
     full_name='Gateway.get_gateway_stats',
-    index=38,
+    index=41,
     containing_service=None,
     input_type=_GET_GATEWAY_STATS_REQ,
     output_type=_GATEWAY_STATS_INFO,
@@ -7161,7 +7580,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='get_thread_stats',
     full_name='Gateway.get_thread_stats',
-    index=39,
+    index=42,
     containing_service=None,
     input_type=_GET_THREAD_STATS_REQ,
     output_type=_THREAD_STATS_INFO,
@@ -7171,7 +7590,7 @@ _GATEWAY = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='set_gateway_io_stats_mode',
     full_name='Gateway.set_gateway_io_stats_mode',
-    index=40,
+    index=43,
     containing_service=None,
     input_type=_SET_GATEWAY_IO_STATS_MODE_REQ,
     output_type=_REQ_STATUS,

--- a/src/pybind/mgr/dashboard/services/proto/gateway_pb2_grpc.py
+++ b/src/pybind/mgr/dashboard/services/proto/gateway_pb2_grpc.py
@@ -59,6 +59,11 @@ class GatewayStub(object):
                 request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.SerializeToString,
                 response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.FromString,
                 )
+        self.list_namespaces_io_stats = channel.unary_unary(
+                '/Gateway/list_namespaces_io_stats',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_io_stats_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_io_stats_info.FromString,
+                )
         self.namespace_set_qos_limits = channel.unary_unary(
                 '/Gateway/namespace_set_qos_limits',
                 request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_qos_req.SerializeToString,
@@ -128,6 +133,11 @@ class GatewayStub(object):
                 '/Gateway/list_connections',
                 request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.SerializeToString,
                 response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.FromString,
+                )
+        self.get_connection_io_statistics = channel.unary_unary(
+                '/Gateway/get_connection_io_statistics',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_connection_io_statistics_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connection_io_statistics.FromString,
                 )
         self.create_listener = channel.unary_unary(
                 '/Gateway/create_listener',
@@ -204,6 +214,11 @@ class GatewayStub(object):
                 request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_thread_stats_req.SerializeToString,
                 response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.thread_stats_info.FromString,
                 )
+        self.set_gateway_io_stats_mode = channel.unary_unary(
+                '/Gateway/set_gateway_io_stats_mode',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_io_stats_mode_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
 
 
 class GatewayServicer(object):
@@ -267,6 +282,13 @@ class GatewayServicer(object):
 
     def namespace_get_io_stats(self, request, context):
         """Gets namespace's IO stats
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def list_namespaces_io_stats(self, request, context):
+        """List namespaces IO stats
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -365,6 +387,13 @@ class GatewayServicer(object):
 
     def list_connections(self, request, context):
         """List connections
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def get_connection_io_statistics(self, request, context):
+        """Gets connection's IO statistics
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -475,6 +504,13 @@ class GatewayServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def set_gateway_io_stats_mode(self, request, context):
+        """Set gateway IO stats on or off
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_GatewayServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -522,6 +558,11 @@ def add_GatewayServicer_to_server(servicer, server):
                     servicer.namespace_get_io_stats,
                     request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.FromString,
                     response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.SerializeToString,
+            ),
+            'list_namespaces_io_stats': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_namespaces_io_stats,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_io_stats_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_io_stats_info.SerializeToString,
             ),
             'namespace_set_qos_limits': grpc.unary_unary_rpc_method_handler(
                     servicer.namespace_set_qos_limits,
@@ -592,6 +633,11 @@ def add_GatewayServicer_to_server(servicer, server):
                     servicer.list_connections,
                     request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.FromString,
                     response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.SerializeToString,
+            ),
+            'get_connection_io_statistics': grpc.unary_unary_rpc_method_handler(
+                    servicer.get_connection_io_statistics,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_connection_io_statistics_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connection_io_statistics.SerializeToString,
             ),
             'create_listener': grpc.unary_unary_rpc_method_handler(
                     servicer.create_listener,
@@ -667,6 +713,11 @@ def add_GatewayServicer_to_server(servicer, server):
                     servicer.get_thread_stats,
                     request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_thread_stats_req.FromString,
                     response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.thread_stats_info.SerializeToString,
+            ),
+            'set_gateway_io_stats_mode': grpc.unary_unary_rpc_method_handler(
+                    servicer.set_gateway_io_stats_mode,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_io_stats_mode_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -828,6 +879,23 @@ class Gateway(object):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_get_io_stats',
             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.SerializeToString,
             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def list_namespaces_io_stats(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/list_namespaces_io_stats',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_io_stats_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_io_stats_info.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -1066,6 +1134,23 @@ class Gateway(object):
         return grpc.experimental.unary_unary(request, target, '/Gateway/list_connections',
             dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.SerializeToString,
             dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def get_connection_io_statistics(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/get_connection_io_statistics',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.get_connection_io_statistics_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.connection_io_statistics.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -1321,5 +1406,22 @@ class Gateway(object):
         return grpc.experimental.unary_unary(request, target, '/Gateway/get_thread_stats',
             dashboard_dot_services_dot_proto_dot_gateway__pb2.get_thread_stats_req.SerializeToString,
             dashboard_dot_services_dot_proto_dot_gateway__pb2.thread_stats_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def set_gateway_io_stats_mode(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/set_gateway_io_stats_mode',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_io_stats_mode_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/src/pybind/mgr/dashboard/services/proto/gateway_pb2_grpc.py
+++ b/src/pybind/mgr/dashboard/services/proto/gateway_pb2_grpc.py
@@ -15,175 +15,195 @@ class GatewayStub(object):
             channel: A grpc.Channel.
         """
         self.namespace_add = channel.unary_unary(
-            '/Gateway/namespace_add',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.nsid_status.FromString,
-        )
+                '/Gateway/namespace_add',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.nsid_status.FromString,
+                )
         self.create_subsystem = channel.unary_unary(
-            '/Gateway/create_subsystem',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_subsystem_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsys_status.FromString,
-        )
+                '/Gateway/create_subsystem',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_subsystem_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsys_status.FromString,
+                )
         self.delete_subsystem = channel.unary_unary(
-            '/Gateway/delete_subsystem',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_subsystem_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/delete_subsystem',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_subsystem_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.change_subsystem_key = channel.unary_unary(
-            '/Gateway/change_subsystem_key',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_subsystem_key_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/change_subsystem_key',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_subsystem_key_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
+        self.add_subsystem_network = channel.unary_unary(
+                '/Gateway/add_subsystem_network',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_subsystem_network_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
+        self.del_subsystem_network = channel.unary_unary(
+                '/Gateway/del_subsystem_network',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.del_subsystem_network_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.list_namespaces = channel.unary_unary(
-            '/Gateway/list_namespaces',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespaces_info.FromString,
-        )
+                '/Gateway/list_namespaces',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespaces_info.FromString,
+                )
         self.namespace_resize = channel.unary_unary(
-            '/Gateway/namespace_resize',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_resize_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_resize',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_resize_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_get_io_stats = channel.unary_unary(
-            '/Gateway/namespace_get_io_stats',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.FromString,
-        )
+                '/Gateway/namespace_get_io_stats',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.FromString,
+                )
         self.namespace_set_qos_limits = channel.unary_unary(
-            '/Gateway/namespace_set_qos_limits',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_qos_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_set_qos_limits',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_qos_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_change_load_balancing_group = channel.unary_unary(
-            '/Gateway/namespace_change_load_balancing_group',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_load_balancing_group_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_change_load_balancing_group',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_load_balancing_group_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_change_visibility = channel.unary_unary(
-            '/Gateway/namespace_change_visibility',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_visibility_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_change_visibility',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_visibility_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
+        self.namespace_change_location = channel.unary_unary(
+                '/Gateway/namespace_change_location',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_location_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_set_rbd_trash_image = channel.unary_unary(
-            '/Gateway/namespace_set_rbd_trash_image',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_rbd_trash_image_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_set_rbd_trash_image',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_rbd_trash_image_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_set_auto_resize = channel.unary_unary(
-            '/Gateway/namespace_set_auto_resize',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_auto_resize_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_set_auto_resize',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_auto_resize_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_delete = channel.unary_unary(
-            '/Gateway/namespace_delete',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_delete',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_add_host = channel.unary_unary(
-            '/Gateway/namespace_add_host',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_host_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_add_host',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_host_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.namespace_delete_host = channel.unary_unary(
-            '/Gateway/namespace_delete_host',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_host_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/namespace_delete_host',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_host_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.add_host = channel.unary_unary(
-            '/Gateway/add_host',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_host_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/add_host',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_host_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.remove_host = channel.unary_unary(
-            '/Gateway/remove_host',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.remove_host_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/remove_host',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.remove_host_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.change_host_key = channel.unary_unary(
-            '/Gateway/change_host_key',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_host_key_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/change_host_key',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_host_key_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.list_hosts = channel.unary_unary(
-            '/Gateway/list_hosts',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_hosts_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.hosts_info.FromString,
-        )
+                '/Gateway/list_hosts',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_hosts_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.hosts_info.FromString,
+                )
         self.list_connections = channel.unary_unary(
-            '/Gateway/list_connections',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.FromString,
-        )
+                '/Gateway/list_connections',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.FromString,
+                )
         self.create_listener = channel.unary_unary(
-            '/Gateway/create_listener',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_listener_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/create_listener',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_listener_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.delete_listener = channel.unary_unary(
-            '/Gateway/delete_listener',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_listener_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/delete_listener',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_listener_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.list_listeners = channel.unary_unary(
-            '/Gateway/list_listeners',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_listeners_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.listeners_info.FromString,
-        )
+                '/Gateway/list_listeners',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_listeners_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.listeners_info.FromString,
+                )
         self.list_subsystems = channel.unary_unary(
-            '/Gateway/list_subsystems',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_subsystems_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info_cli.FromString,
-        )
+                '/Gateway/list_subsystems',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_subsystems_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info_cli.FromString,
+                )
         self.get_subsystems = channel.unary_unary(
-            '/Gateway/get_subsystems',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_subsystems_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info.FromString,
-        )
+                '/Gateway/get_subsystems',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_subsystems_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info.FromString,
+                )
         self.set_ana_state = channel.unary_unary(
-            '/Gateway/set_ana_state',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.ana_info.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/set_ana_state',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.ana_info.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.get_spdk_nvmf_log_flags_and_level = channel.unary_unary(
-            '/Gateway/get_spdk_nvmf_log_flags_and_level',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_spdk_nvmf_log_flags_and_level_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.spdk_nvmf_log_flags_and_level_info.FromString,
-        )
+                '/Gateway/get_spdk_nvmf_log_flags_and_level',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_spdk_nvmf_log_flags_and_level_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.spdk_nvmf_log_flags_and_level_info.FromString,
+                )
         self.disable_spdk_nvmf_logs = channel.unary_unary(
-            '/Gateway/disable_spdk_nvmf_logs',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.disable_spdk_nvmf_logs_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/disable_spdk_nvmf_logs',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.disable_spdk_nvmf_logs_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.set_spdk_nvmf_logs = channel.unary_unary(
-            '/Gateway/set_spdk_nvmf_logs',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_spdk_nvmf_logs_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/set_spdk_nvmf_logs',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_spdk_nvmf_logs_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.get_gateway_info = channel.unary_unary(
-            '/Gateway/get_gateway_info',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_info_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_info.FromString,
-        )
+                '/Gateway/get_gateway_info',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_info_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_info.FromString,
+                )
         self.get_gateway_log_level = channel.unary_unary(
-            '/Gateway/get_gateway_log_level',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_log_level_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_log_level_info.FromString,
-        )
+                '/Gateway/get_gateway_log_level',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_log_level_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_log_level_info.FromString,
+                )
         self.set_gateway_log_level = channel.unary_unary(
-            '/Gateway/set_gateway_log_level',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_log_level_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-        )
+                '/Gateway/set_gateway_log_level',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_log_level_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
         self.show_gateway_listeners_info = channel.unary_unary(
-            '/Gateway/show_gateway_listeners_info',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.show_gateway_listeners_info_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_listeners_info.FromString,
-        )
+                '/Gateway/show_gateway_listeners_info',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.show_gateway_listeners_info_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_listeners_info.FromString,
+                )
         self.get_gateway_stats = channel.unary_unary(
-            '/Gateway/get_gateway_stats',
-            request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_stats_req.SerializeToString,
-            response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_stats_info.FromString,
-        )
+                '/Gateway/get_gateway_stats',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_stats_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_stats_info.FromString,
+                )
+        self.get_thread_stats = channel.unary_unary(
+                '/Gateway/get_thread_stats',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_thread_stats_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.thread_stats_info.FromString,
+                )
 
 
 class GatewayServicer(object):
@@ -212,6 +232,20 @@ class GatewayServicer(object):
 
     def change_subsystem_key(self, request, context):
         """Changes subsystem key
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def add_subsystem_network(self, request, context):
+        """Add a subsystem network
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def del_subsystem_network(self, request, context):
+        """Delete a subsystem network
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -254,6 +288,13 @@ class GatewayServicer(object):
 
     def namespace_change_visibility(self, request, context):
         """Changes namespace's visibility
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def namespace_change_location(self, request, context):
+        """Changes namespace's location
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -427,764 +468,858 @@ class GatewayServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def get_thread_stats(self, request, context):
+        """Gets spdk thread stats
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_GatewayServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        'namespace_add': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_add,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.nsid_status.SerializeToString,
-        ),
-        'create_subsystem': grpc.unary_unary_rpc_method_handler(
-            servicer.create_subsystem,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_subsystem_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsys_status.SerializeToString,
-        ),
-        'delete_subsystem': grpc.unary_unary_rpc_method_handler(
-            servicer.delete_subsystem,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_subsystem_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'change_subsystem_key': grpc.unary_unary_rpc_method_handler(
-            servicer.change_subsystem_key,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_subsystem_key_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'list_namespaces': grpc.unary_unary_rpc_method_handler(
-            servicer.list_namespaces,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespaces_info.SerializeToString,
-        ),
-        'namespace_resize': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_resize,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_resize_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_get_io_stats': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_get_io_stats,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.SerializeToString,
-        ),
-        'namespace_set_qos_limits': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_set_qos_limits,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_qos_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_change_load_balancing_group': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_change_load_balancing_group,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_load_balancing_group_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_change_visibility': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_change_visibility,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_visibility_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_set_rbd_trash_image': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_set_rbd_trash_image,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_rbd_trash_image_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_set_auto_resize': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_set_auto_resize,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_auto_resize_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_delete': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_delete,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_add_host': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_add_host,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_host_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'namespace_delete_host': grpc.unary_unary_rpc_method_handler(
-            servicer.namespace_delete_host,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_host_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'add_host': grpc.unary_unary_rpc_method_handler(
-            servicer.add_host,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_host_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'remove_host': grpc.unary_unary_rpc_method_handler(
-            servicer.remove_host,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.remove_host_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'change_host_key': grpc.unary_unary_rpc_method_handler(
-            servicer.change_host_key,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_host_key_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'list_hosts': grpc.unary_unary_rpc_method_handler(
-            servicer.list_hosts,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_hosts_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.hosts_info.SerializeToString,
-        ),
-        'list_connections': grpc.unary_unary_rpc_method_handler(
-            servicer.list_connections,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.SerializeToString,
-        ),
-        'create_listener': grpc.unary_unary_rpc_method_handler(
-            servicer.create_listener,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_listener_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'delete_listener': grpc.unary_unary_rpc_method_handler(
-            servicer.delete_listener,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_listener_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'list_listeners': grpc.unary_unary_rpc_method_handler(
-            servicer.list_listeners,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_listeners_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.listeners_info.SerializeToString,
-        ),
-        'list_subsystems': grpc.unary_unary_rpc_method_handler(
-            servicer.list_subsystems,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_subsystems_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info_cli.SerializeToString,
-        ),
-        'get_subsystems': grpc.unary_unary_rpc_method_handler(
-            servicer.get_subsystems,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_subsystems_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info.SerializeToString,
-        ),
-        'set_ana_state': grpc.unary_unary_rpc_method_handler(
-            servicer.set_ana_state,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.ana_info.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'get_spdk_nvmf_log_flags_and_level': grpc.unary_unary_rpc_method_handler(
-            servicer.get_spdk_nvmf_log_flags_and_level,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_spdk_nvmf_log_flags_and_level_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.spdk_nvmf_log_flags_and_level_info.SerializeToString,
-        ),
-        'disable_spdk_nvmf_logs': grpc.unary_unary_rpc_method_handler(
-            servicer.disable_spdk_nvmf_logs,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.disable_spdk_nvmf_logs_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'set_spdk_nvmf_logs': grpc.unary_unary_rpc_method_handler(
-            servicer.set_spdk_nvmf_logs,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_spdk_nvmf_logs_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'get_gateway_info': grpc.unary_unary_rpc_method_handler(
-            servicer.get_gateway_info,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_info_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_info.SerializeToString,
-        ),
-        'get_gateway_log_level': grpc.unary_unary_rpc_method_handler(
-            servicer.get_gateway_log_level,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_log_level_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_log_level_info.SerializeToString,
-        ),
-        'set_gateway_log_level': grpc.unary_unary_rpc_method_handler(
-            servicer.set_gateway_log_level,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_log_level_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
-        ),
-        'show_gateway_listeners_info': grpc.unary_unary_rpc_method_handler(
-            servicer.show_gateway_listeners_info,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.show_gateway_listeners_info_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_listeners_info.SerializeToString,
-        ),
-        'get_gateway_stats': grpc.unary_unary_rpc_method_handler(
-            servicer.get_gateway_stats,
-            request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_stats_req.FromString,
-            response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_stats_info.SerializeToString,
-        ),
+            'namespace_add': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_add,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.nsid_status.SerializeToString,
+            ),
+            'create_subsystem': grpc.unary_unary_rpc_method_handler(
+                    servicer.create_subsystem,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_subsystem_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsys_status.SerializeToString,
+            ),
+            'delete_subsystem': grpc.unary_unary_rpc_method_handler(
+                    servicer.delete_subsystem,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_subsystem_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'change_subsystem_key': grpc.unary_unary_rpc_method_handler(
+                    servicer.change_subsystem_key,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_subsystem_key_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'add_subsystem_network': grpc.unary_unary_rpc_method_handler(
+                    servicer.add_subsystem_network,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_subsystem_network_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'del_subsystem_network': grpc.unary_unary_rpc_method_handler(
+                    servicer.del_subsystem_network,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.del_subsystem_network_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'list_namespaces': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_namespaces,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespaces_info.SerializeToString,
+            ),
+            'namespace_resize': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_resize,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_resize_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_get_io_stats': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_get_io_stats,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.SerializeToString,
+            ),
+            'namespace_set_qos_limits': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_set_qos_limits,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_qos_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_change_load_balancing_group': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_change_load_balancing_group,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_load_balancing_group_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_change_visibility': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_change_visibility,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_visibility_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_change_location': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_change_location,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_location_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_set_rbd_trash_image': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_set_rbd_trash_image,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_rbd_trash_image_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_set_auto_resize': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_set_auto_resize,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_auto_resize_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_delete': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_delete,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_add_host': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_add_host,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_host_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'namespace_delete_host': grpc.unary_unary_rpc_method_handler(
+                    servicer.namespace_delete_host,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_host_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'add_host': grpc.unary_unary_rpc_method_handler(
+                    servicer.add_host,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_host_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'remove_host': grpc.unary_unary_rpc_method_handler(
+                    servicer.remove_host,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.remove_host_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'change_host_key': grpc.unary_unary_rpc_method_handler(
+                    servicer.change_host_key,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.change_host_key_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'list_hosts': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_hosts,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_hosts_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.hosts_info.SerializeToString,
+            ),
+            'list_connections': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_connections,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.SerializeToString,
+            ),
+            'create_listener': grpc.unary_unary_rpc_method_handler(
+                    servicer.create_listener,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.create_listener_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'delete_listener': grpc.unary_unary_rpc_method_handler(
+                    servicer.delete_listener,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_listener_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'list_listeners': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_listeners,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_listeners_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.listeners_info.SerializeToString,
+            ),
+            'list_subsystems': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_subsystems,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_subsystems_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info_cli.SerializeToString,
+            ),
+            'get_subsystems': grpc.unary_unary_rpc_method_handler(
+                    servicer.get_subsystems,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_subsystems_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info.SerializeToString,
+            ),
+            'set_ana_state': grpc.unary_unary_rpc_method_handler(
+                    servicer.set_ana_state,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.ana_info.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'get_spdk_nvmf_log_flags_and_level': grpc.unary_unary_rpc_method_handler(
+                    servicer.get_spdk_nvmf_log_flags_and_level,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_spdk_nvmf_log_flags_and_level_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.spdk_nvmf_log_flags_and_level_info.SerializeToString,
+            ),
+            'disable_spdk_nvmf_logs': grpc.unary_unary_rpc_method_handler(
+                    servicer.disable_spdk_nvmf_logs,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.disable_spdk_nvmf_logs_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'set_spdk_nvmf_logs': grpc.unary_unary_rpc_method_handler(
+                    servicer.set_spdk_nvmf_logs,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_spdk_nvmf_logs_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'get_gateway_info': grpc.unary_unary_rpc_method_handler(
+                    servicer.get_gateway_info,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_info_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_info.SerializeToString,
+            ),
+            'get_gateway_log_level': grpc.unary_unary_rpc_method_handler(
+                    servicer.get_gateway_log_level,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_log_level_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_log_level_info.SerializeToString,
+            ),
+            'set_gateway_log_level': grpc.unary_unary_rpc_method_handler(
+                    servicer.set_gateway_log_level,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_log_level_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'show_gateway_listeners_info': grpc.unary_unary_rpc_method_handler(
+                    servicer.show_gateway_listeners_info,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.show_gateway_listeners_info_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_listeners_info.SerializeToString,
+            ),
+            'get_gateway_stats': grpc.unary_unary_rpc_method_handler(
+                    servicer.get_gateway_stats,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_stats_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_stats_info.SerializeToString,
+            ),
+            'get_thread_stats': grpc.unary_unary_rpc_method_handler(
+                    servicer.get_thread_stats,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.get_thread_stats_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.thread_stats_info.SerializeToString,
+            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-        'Gateway', rpc_method_handlers)
+            'Gateway', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
+
  # This class is part of an EXPERIMENTAL API.
-
-
 class Gateway(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
     def namespace_add(request,
-                      target,
-                      options=(),
-                      channel_credentials=None,
-                      call_credentials=None,
-                      insecure=False,
-                      compression=None,
-                      wait_for_ready=None,
-                      timeout=None,
-                      metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_add',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.nsid_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.nsid_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def create_subsystem(request,
-                         target,
-                         options=(),
-                         channel_credentials=None,
-                         call_credentials=None,
-                         insecure=False,
-                         compression=None,
-                         wait_for_ready=None,
-                         timeout=None,
-                         metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/create_subsystem',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.create_subsystem_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.subsys_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.create_subsystem_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.subsys_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def delete_subsystem(request,
-                         target,
-                         options=(),
-                         channel_credentials=None,
-                         call_credentials=None,
-                         insecure=False,
-                         compression=None,
-                         wait_for_ready=None,
-                         timeout=None,
-                         metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/delete_subsystem',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_subsystem_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_subsystem_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def change_subsystem_key(request,
-                             target,
-                             options=(),
-                             channel_credentials=None,
-                             call_credentials=None,
-                             insecure=False,
-                             compression=None,
-                             wait_for_ready=None,
-                             timeout=None,
-                             metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/change_subsystem_key',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.change_subsystem_key_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.change_subsystem_key_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def add_subsystem_network(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/add_subsystem_network',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.add_subsystem_network_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def del_subsystem_network(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/del_subsystem_network',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.del_subsystem_network_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def list_namespaces(request,
-                        target,
-                        options=(),
-                        channel_credentials=None,
-                        call_credentials=None,
-                        insecure=False,
-                        compression=None,
-                        wait_for_ready=None,
-                        timeout=None,
-                        metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/list_namespaces',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespaces_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespaces_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_resize(request,
-                         target,
-                         options=(),
-                         channel_credentials=None,
-                         call_credentials=None,
-                         insecure=False,
-                         compression=None,
-                         wait_for_ready=None,
-                         timeout=None,
-                         metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_resize',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_resize_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_resize_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_get_io_stats(request,
-                               target,
-                               options=(),
-                               channel_credentials=None,
-                               call_credentials=None,
-                               insecure=False,
-                               compression=None,
-                               wait_for_ready=None,
-                               timeout=None,
-                               metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_get_io_stats',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_get_io_stats_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_io_stats_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_set_qos_limits(request,
-                                 target,
-                                 options=(),
-                                 channel_credentials=None,
-                                 call_credentials=None,
-                                 insecure=False,
-                                 compression=None,
-                                 wait_for_ready=None,
-                                 timeout=None,
-                                 metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_set_qos_limits',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_qos_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_qos_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_change_load_balancing_group(request,
-                                              target,
-                                              options=(),
-                                              channel_credentials=None,
-                                              call_credentials=None,
-                                              insecure=False,
-                                              compression=None,
-                                              wait_for_ready=None,
-                                              timeout=None,
-                                              metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_change_load_balancing_group',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_load_balancing_group_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_load_balancing_group_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_change_visibility(request,
-                                    target,
-                                    options=(),
-                                    channel_credentials=None,
-                                    call_credentials=None,
-                                    insecure=False,
-                                    compression=None,
-                                    wait_for_ready=None,
-                                    timeout=None,
-                                    metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_change_visibility',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_visibility_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_visibility_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def namespace_change_location(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_change_location',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_change_location_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_set_rbd_trash_image(request,
-                                      target,
-                                      options=(),
-                                      channel_credentials=None,
-                                      call_credentials=None,
-                                      insecure=False,
-                                      compression=None,
-                                      wait_for_ready=None,
-                                      timeout=None,
-                                      metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_set_rbd_trash_image',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_rbd_trash_image_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_rbd_trash_image_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_set_auto_resize(request,
-                                  target,
-                                  options=(),
-                                  channel_credentials=None,
-                                  call_credentials=None,
-                                  insecure=False,
-                                  compression=None,
-                                  wait_for_ready=None,
-                                  timeout=None,
-                                  metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_set_auto_resize',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_auto_resize_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_set_auto_resize_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_delete(request,
-                         target,
-                         options=(),
-                         channel_credentials=None,
-                         call_credentials=None,
-                         insecure=False,
-                         compression=None,
-                         wait_for_ready=None,
-                         timeout=None,
-                         metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_delete',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_add_host(request,
-                           target,
-                           options=(),
-                           channel_credentials=None,
-                           call_credentials=None,
-                           insecure=False,
-                           compression=None,
-                           wait_for_ready=None,
-                           timeout=None,
-                           metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_add_host',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_host_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_add_host_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def namespace_delete_host(request,
-                              target,
-                              options=(),
-                              channel_credentials=None,
-                              call_credentials=None,
-                              insecure=False,
-                              compression=None,
-                              wait_for_ready=None,
-                              timeout=None,
-                              metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/namespace_delete_host',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_host_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.namespace_delete_host_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def add_host(request,
-                 target,
-                 options=(),
-                 channel_credentials=None,
-                 call_credentials=None,
-                 insecure=False,
-                 compression=None,
-                 wait_for_ready=None,
-                 timeout=None,
-                 metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/add_host',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.add_host_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.add_host_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def remove_host(request,
-                    target,
-                    options=(),
-                    channel_credentials=None,
-                    call_credentials=None,
-                    insecure=False,
-                    compression=None,
-                    wait_for_ready=None,
-                    timeout=None,
-                    metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/remove_host',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.remove_host_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.remove_host_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def change_host_key(request,
-                        target,
-                        options=(),
-                        channel_credentials=None,
-                        call_credentials=None,
-                        insecure=False,
-                        compression=None,
-                        wait_for_ready=None,
-                        timeout=None,
-                        metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/change_host_key',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.change_host_key_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.change_host_key_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def list_hosts(request,
-                   target,
-                   options=(),
-                   channel_credentials=None,
-                   call_credentials=None,
-                   insecure=False,
-                   compression=None,
-                   wait_for_ready=None,
-                   timeout=None,
-                   metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/list_hosts',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.list_hosts_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.hosts_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_hosts_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.hosts_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def list_connections(request,
-                         target,
-                         options=(),
-                         channel_credentials=None,
-                         call_credentials=None,
-                         insecure=False,
-                         compression=None,
-                         wait_for_ready=None,
-                         timeout=None,
-                         metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/list_connections',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_connections_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.connections_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def create_listener(request,
-                        target,
-                        options=(),
-                        channel_credentials=None,
-                        call_credentials=None,
-                        insecure=False,
-                        compression=None,
-                        wait_for_ready=None,
-                        timeout=None,
-                        metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/create_listener',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.create_listener_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.create_listener_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def delete_listener(request,
-                        target,
-                        options=(),
-                        channel_credentials=None,
-                        call_credentials=None,
-                        insecure=False,
-                        compression=None,
-                        wait_for_ready=None,
-                        timeout=None,
-                        metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/delete_listener',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_listener_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.delete_listener_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def list_listeners(request,
-                       target,
-                       options=(),
-                       channel_credentials=None,
-                       call_credentials=None,
-                       insecure=False,
-                       compression=None,
-                       wait_for_ready=None,
-                       timeout=None,
-                       metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/list_listeners',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.list_listeners_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.listeners_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_listeners_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.listeners_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def list_subsystems(request,
-                        target,
-                        options=(),
-                        channel_credentials=None,
-                        call_credentials=None,
-                        insecure=False,
-                        compression=None,
-                        wait_for_ready=None,
-                        timeout=None,
-                        metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/list_subsystems',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.list_subsystems_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info_cli.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_subsystems_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info_cli.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def get_subsystems(request,
-                       target,
-                       options=(),
-                       channel_credentials=None,
-                       call_credentials=None,
-                       insecure=False,
-                       compression=None,
-                       wait_for_ready=None,
-                       timeout=None,
-                       metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/get_subsystems',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.get_subsystems_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.get_subsystems_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.subsystems_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def set_ana_state(request,
-                      target,
-                      options=(),
-                      channel_credentials=None,
-                      call_credentials=None,
-                      insecure=False,
-                      compression=None,
-                      wait_for_ready=None,
-                      timeout=None,
-                      metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/set_ana_state',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.ana_info.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.ana_info.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def get_spdk_nvmf_log_flags_and_level(request,
-                                          target,
-                                          options=(),
-                                          channel_credentials=None,
-                                          call_credentials=None,
-                                          insecure=False,
-                                          compression=None,
-                                          wait_for_ready=None,
-                                          timeout=None,
-                                          metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/get_spdk_nvmf_log_flags_and_level',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.get_spdk_nvmf_log_flags_and_level_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.spdk_nvmf_log_flags_and_level_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.get_spdk_nvmf_log_flags_and_level_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.spdk_nvmf_log_flags_and_level_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def disable_spdk_nvmf_logs(request,
-                               target,
-                               options=(),
-                               channel_credentials=None,
-                               call_credentials=None,
-                               insecure=False,
-                               compression=None,
-                               wait_for_ready=None,
-                               timeout=None,
-                               metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/disable_spdk_nvmf_logs',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.disable_spdk_nvmf_logs_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.disable_spdk_nvmf_logs_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def set_spdk_nvmf_logs(request,
-                           target,
-                           options=(),
-                           channel_credentials=None,
-                           call_credentials=None,
-                           insecure=False,
-                           compression=None,
-                           wait_for_ready=None,
-                           timeout=None,
-                           metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/set_spdk_nvmf_logs',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.set_spdk_nvmf_logs_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.set_spdk_nvmf_logs_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def get_gateway_info(request,
-                         target,
-                         options=(),
-                         channel_credentials=None,
-                         call_credentials=None,
-                         insecure=False,
-                         compression=None,
-                         wait_for_ready=None,
-                         timeout=None,
-                         metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/get_gateway_info',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_info_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_info_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def get_gateway_log_level(request,
-                              target,
-                              options=(),
-                              channel_credentials=None,
-                              call_credentials=None,
-                              insecure=False,
-                              compression=None,
-                              wait_for_ready=None,
-                              timeout=None,
-                              metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/get_gateway_log_level',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_log_level_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_log_level_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_log_level_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_log_level_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def set_gateway_log_level(request,
-                              target,
-                              options=(),
-                              channel_credentials=None,
-                              call_credentials=None,
-                              insecure=False,
-                              compression=None,
-                              wait_for_ready=None,
-                              timeout=None,
-                              metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/set_gateway_log_level',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_log_level_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.set_gateway_log_level_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def show_gateway_listeners_info(request,
-                                    target,
-                                    options=(),
-                                    channel_credentials=None,
-                                    call_credentials=None,
-                                    insecure=False,
-                                    compression=None,
-                                    wait_for_ready=None,
-                                    timeout=None,
-                                    metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/show_gateway_listeners_info',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.show_gateway_listeners_info_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_listeners_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.show_gateway_listeners_info_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_listeners_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def get_gateway_stats(request,
-                          target,
-                          options=(),
-                          channel_credentials=None,
-                          call_credentials=None,
-                          insecure=False,
-                          compression=None,
-                          wait_for_ready=None,
-                          timeout=None,
-                          metadata=None):
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
         return grpc.experimental.unary_unary(request, target, '/Gateway/get_gateway_stats',
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_stats_req.SerializeToString,
-                                             dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_stats_info.FromString,
-                                             options, channel_credentials,
-                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.get_gateway_stats_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.gateway_stats_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def get_thread_stats(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/get_thread_stats',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.get_thread_stats_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.thread_stats_info.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/src/pybind/mgr/dashboard/services/proto/gateway_pb2_grpc.py
+++ b/src/pybind/mgr/dashboard/services/proto/gateway_pb2_grpc.py
@@ -44,6 +44,21 @@ class GatewayStub(object):
                 request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.del_subsystem_network_req.SerializeToString,
                 response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
                 )
+        self.add_kmip_server_endpoints = channel.unary_unary(
+                '/Gateway/add_kmip_server_endpoints',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_kmip_server_endpoints_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
+        self.del_kmip_server_endpoints = channel.unary_unary(
+                '/Gateway/del_kmip_server_endpoints',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.del_kmip_server_endpoints_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+                )
+        self.list_kmip_server_endpoints = channel.unary_unary(
+                '/Gateway/list_kmip_server_endpoints',
+                request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_kmip_server_endpoints_req.SerializeToString,
+                response_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.kmip_server_endpoints_info.FromString,
+                )
         self.list_namespaces = channel.unary_unary(
                 '/Gateway/list_namespaces',
                 request_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_namespaces_req.SerializeToString,
@@ -261,6 +276,27 @@ class GatewayServicer(object):
 
     def del_subsystem_network(self, request, context):
         """Delete a subsystem network
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def add_kmip_server_endpoints(self, request, context):
+        """Add KMIP server endpoints
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def del_kmip_server_endpoints(self, request, context):
+        """Delete KMIP server endpoints
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def list_kmip_server_endpoints(self, request, context):
+        """List KMIP server endpoints
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -543,6 +579,21 @@ def add_GatewayServicer_to_server(servicer, server):
                     servicer.del_subsystem_network,
                     request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.del_subsystem_network_req.FromString,
                     response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'add_kmip_server_endpoints': grpc.unary_unary_rpc_method_handler(
+                    servicer.add_kmip_server_endpoints,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.add_kmip_server_endpoints_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'del_kmip_server_endpoints': grpc.unary_unary_rpc_method_handler(
+                    servicer.del_kmip_server_endpoints,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.del_kmip_server_endpoints_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.SerializeToString,
+            ),
+            'list_kmip_server_endpoints': grpc.unary_unary_rpc_method_handler(
+                    servicer.list_kmip_server_endpoints,
+                    request_deserializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.list_kmip_server_endpoints_req.FromString,
+                    response_serializer=dashboard_dot_services_dot_proto_dot_gateway__pb2.kmip_server_endpoints_info.SerializeToString,
             ),
             'list_namespaces': grpc.unary_unary_rpc_method_handler(
                     servicer.list_namespaces,
@@ -828,6 +879,57 @@ class Gateway(object):
         return grpc.experimental.unary_unary(request, target, '/Gateway/del_subsystem_network',
             dashboard_dot_services_dot_proto_dot_gateway__pb2.del_subsystem_network_req.SerializeToString,
             dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def add_kmip_server_endpoints(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/add_kmip_server_endpoints',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.add_kmip_server_endpoints_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def del_kmip_server_endpoints(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/del_kmip_server_endpoints',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.del_kmip_server_endpoints_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.req_status.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def list_kmip_server_endpoints(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Gateway/list_kmip_server_endpoints',
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.list_kmip_server_endpoints_req.SerializeToString,
+            dashboard_dot_services_dot_proto_dot_gateway__pb2.kmip_server_endpoints_info.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 


### PR DESCRIPTION
This PR backports following main PRs:
1. https://github.com/ceph/ceph/pull/67044 (bump to 1.6.5)
2. https://github.com/ceph/ceph/pull/67410 (bump to 1.6.7)
3. https://github.com/ceph/ceph/pull/67992 (bump to 1.7.2)

backport tracker: https://tracker.ceph.com/issues/74898

---

backport of https://github.com/ceph/ceph/pull/67044
parent tracker: https://tracker.ceph.com/issues/74506

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh