### PR TITLE
tentacle: qa/tasks/thrashosds-health: fine tune ignorelist for degraded and undersized pgs

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -40,3 +40,5 @@ overrides:
       - Low space hindering backfill .*? backfill_toofull
       - OSD_HOST_DOWN
       - OSD_ROOT_DOWN
+      - pgs degraded
+      - pgs undersized


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72937

---

backport of https://github.com/ceph/ceph/pull/64844
parent tracker: https://tracker.ceph.com/issues/72312

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh