### PR TITLE
tentacle: osd/PrimaryLogPG: encode an empty data_bl for empty sparse reads

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5960,6 +5960,8 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
       dout(10) << " sparse read ended up empty for " << soid << dendl;
       map<uint64_t, uint64_t> extents;
       encode(extents, osd_op.outdata);
+      bufferlist data_bl;
+      encode(data_bl, osd_op.outdata);
     }
   } else {
     // read into a buffer


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74940

---

backport of https://github.com/ceph/ceph/pull/66912
parent tracker: https://tracker.ceph.com/issues/74394