### PR TITLE
cephadm: reapply hugepages for nvmeof at service start

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1057,6 +1057,17 @@ def deploy_daemon_units(
         post_stop_commands.append(
             CephIscsi.configfs_mount_umount(data_dir, mount=False)
         )
+    daemon = daemon_form_create(ctx, ident)
+    if ident.daemon_type == 'nvmeof':
+        hp = '4096'
+        files = getattr(daemon, 'files', None)
+        if isinstance(files, dict):
+            val = files.get('spdk_huge_pages')
+            if isinstance(val, int):
+                hp = str(val)
+            elif isinstance(val, str) and val.isdigit():
+                hp = val
+        pre_start_commands.append(f'/usr/sbin/sysctl -w vm.nr_hugepages={hp} || true\n')
 
     runscripts.write_service_scripts(
         ctx,
@@ -1071,7 +1082,7 @@ def deploy_daemon_units(
     )
 
     # sysctl
-    install_sysctl(ctx, ident.fsid, daemon_form_create(ctx, ident))
+    install_sysctl(ctx, ident.fsid, daemon)
 
     # systemd
     ic_ids = [


### PR DESCRIPTION
cephadm: reapply hugepages for nvmeof at service start

NVMeoF gateways (SPDK) require host hugepages (vm.nr_hugepages + /dev/hugepages). After a power-cycle some nodes boot with hugepages=0 (and/or the cephadm sysctl drop-in under /etc/sysctl.d is missing/not applied), causing SPDK to fail and the nvmeof container to crash-loop until the service is redeployed.

Cephadm previously applied hugepages only during deploy/reconfig via install_sysctl(). Normal boot/start uses the generated systemd unit which runs unit.run and does not re-apply sysctl settings.

Added a pre-start step for nvmeof to set vm.nr_hugepages to the configured value (from spdk_huge_pages, defaulting to 4096) before launching the container, so the service self-heals on reboot/service restart.

Testing:
```
[root@ceph-node-0 ~]# cd /etc/sysctl.d
[root@ceph-node-0 sysctl.d]# ls -l
total 12
-rw-r--r--. 1 root root 44 Feb 16 14:26 90-ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof.conf
-rw-r--r--. 1 root root 46 Feb 16 13:11 90-ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-osd.conf
lrwxrwxrwx. 1 root root 14 Mar  1  2024 99-sysctl.conf -> ../sysctl.conf
[root@ceph-node-0 sysctl.d]# rm -rf 90-ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof.conf 
[root@ceph-node-0 sysctl.d]# ls -l
total 8
-rw-r--r--. 1 root root 46 Feb 16 13:11 90-ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-osd.conf
lrwxrwxrwx. 1 root root 14 Mar  1  2024 99-sysctl.conf -> ../sysctl.conf
[root@ceph-node-0 sysctl.d]# sysctl vm.nr_hugepages
vm.nr_hugepages = 512
[root@ceph-node-0 sysctl.d]# sysctl -w vm.nr_hugepages=0
vm.nr_hugepages = 0

```

```
[root@ceph-node-0 sysctl.d]# systemctl list-units | grep nvme
  ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@nvmeof.gw.ceph-node-0.dxodxe.service                                   loaded active running   Ceph nvmeof.gw.ceph-node-0.dxodxe for e8f3cbf4-0b37-11f1-adfe-525400cf0382
[root@ceph-node-0 sysctl.d]# systemctl restart ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@nvmeof.gw.ceph-node-0.dxodxe.service
[root@ceph-node-0 sysctl.d]# systemctl status ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@nvmeof.gw.ceph-node-0.dxodxe.service --no-pager
● ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@nvmeof.gw.ceph-node-0.dxodxe.service - Ceph nvmeof.gw.ceph-node-0.dxodxe for e8f3cbf4-0b37-11f1-adfe-525400cf0382
     Loaded: loaded (/etc/systemd/system/ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: active (running) since Mon 2026-02-16 14:27:32 UTC; 12s ago
    Process: 39113 ExecStartPre=/bin/rm -f /run/ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@nvmeof.gw.ceph-node-0.dxodxe.service-pid /run/ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@nvmeof.gw.ceph-node-0.dxodxe.service-cid (code=exited, status=0/SUCCESS)
    Process: 39114 ExecStart=/bin/bash /var/lib/ceph/e8f3cbf4-0b37-11f1-adfe-525400cf0382/nvmeof.gw.ceph-node-0.dxodxe/unit.run (code=exited, status=0/SUCCESS)
   Main PID: 39149 (conmon)
      Tasks: 58 (limit: 7056)
     Memory: 79.1M (peak: 79.8M)
        CPU: 7.973s
     CGroup: /system.slice/system-ceph\x2de8f3cbf4\x2d0b37\x2d11f1\x2dadfe\x2d525400cf0382.slice/ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382@nvmeof.gw.ceph-node-0.dxodxe.service
             ├─libpod-payload-bd3169be2efaf0d81d0f66334b2cfe890a009729b80350e06d1efd4e6b271ef2
             │ ├─39152 /run/podman-init -- python3 -m control -c /src/ceph-nvmeof.conf
             │ ├─39154 python3 -m control -c /src/ceph-nvmeof.conf
             │ ├─39173 /usr/bin/ceph-nvmeof-monitor-client --gateway-name client.nvmeof.gw.ceph-node-0.dxodxe --gateway-address 192.168.100.100:5500 --gateway-pool test --gateway-group gw --monitor-group-addres…
             │ ├─39206 /usr/local/bin/nvmf_tgt --wait-for-rpc -u -r /var/tmp/spdk.sock --lcores "(0-0)"
             │ └─39208 python3 -m control -c /src/ceph-nvmeof.conf
             └─runtime
               └─39149 /usr/bin/conmon --api-version 1 -c bd3169be2efaf0d81d0f66334b2cfe890a009729b80350e06d1efd4e6b271ef2 -u bd3169be2efaf0d81d0f66334b2cfe890a009729b80350e06d1efd4e6b271ef2 -r /usr/bin/crun -b…

Feb 16 14:27:37 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: [16-Feb-2026 14:27:37] INFO state.py:2073 (2): Initialization is over (gateway-client.nvmeof.…0.dxodxe).
Feb 16 14:27:37 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: [16-Feb-2026 14:27:37] INFO cephutils.py:307 (2): Registered gw.ceph-node-0.dxodxe to service_map!
Feb 16 14:27:37 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: [16-Feb-2026 14:27:37] INFO server.py:278 (2): Prometheus exporter endpoint is enabled
Feb 16 14:27:37 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: [16-Feb-2026 14:27:37] INFO server.py:283 (2): Delaying Prometheus exporter startup by 240 seconds...
Feb 16 14:27:37 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: [16-Feb-2026 14:27:37] INFO server.py:290 (2): Prometheus exporter startup scheduled in background
Feb 16 14:27:37 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: [16-Feb-2026 14:27:37] INFO cephutils.py:155 (2): ana-location dict:  {1: ''}
Feb 16 14:27:38 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: 2026-02-16T14:27:38.892+0000 7f02fd000640  1 nvmeofgw void NVMeofGwMonitorClient::send_beacon…ap_epoch 7
Feb 16 14:27:40 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: 2026-02-16T14:27:40.891+0000 7f02fd000640  1 nvmeofgw void NVMeofGwMonitorClient::send_beacon…ap_epoch 8
Feb 16 14:27:42 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: 2026-02-16T14:27:42.891+0000 7f02fd000640  1 nvmeofgw void NVMeofGwMonitorClient::send_beacon…ap_epoch 8
Feb 16 14:27:44 ceph-node-0 ceph-e8f3cbf4-0b37-11f1-adfe-525400cf0382-nvmeof-gw-ceph-node-0-dxodxe[39149]: [16-Feb-2026 14:27:44] INFO cephutils.py:155 (2): ana-location dict:  {1: ''}

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
