### PR TITLE
logrotate: send SIGHUP to ceph-exporter on log rotation

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -4,7 +4,7 @@
     compress
     sharedscripts
     postrotate
-        killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror cephfs-mirror || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror|cephfs-mirror" || true
+        killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror cephfs-mirror ceph-exporter || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror|cephfs-mirror|ceph-exporter" || true
     endscript
     missingok
     notifempty


### PR DESCRIPTION
ceph-exporter registers a `SIGHUP` handler that reopens its log files, but it was missing from the `postrotate` killall/pkill list.  Without the signal, the daemon keeps an open fd to the already-rotated file and continues writing there, causing `/var/log/ceph` to fill up.