### PR TITLE
python-common: Improve profile name string validation

### DIFF
--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -41,7 +41,7 @@ from ceph.deployment.hostspec import (
 )
 from ceph.deployment.utils import unwrap_ipv6, valid_addr, verify_non_negative_int
 from ceph.deployment.utils import verify_positive_int, verify_non_negative_number
-from ceph.deployment.utils import verify_boolean, verify_enum, verify_int
+from ceph.deployment.utils import verify_boolean, verify_enum, verify_int, verify_non_empty_string
 from ceph.deployment.utils import parse_combined_pem_file, validate_port, validate_unique_ports
 from ceph.cephadm.d3n_types import D3NCacheSpec, D3NCacheError
 from ceph.utils import is_hex
@@ -50,11 +50,6 @@ from ceph.smb import network as smbnet
 
 ServiceSpecT = TypeVar('ServiceSpecT', bound='ServiceSpec')
 FuncT = TypeVar('FuncT', bound=Callable)
-
-
-def validate_non_empty_string(value: Optional[str], field_name: str) -> None:
-    if not isinstance(value, str) or not value.strip():
-        raise SpecValidationError(f"Invalid {field_name}: Must be a non-empty string.")
 
 
 class TLSBlock(TypedDict, total=False):
@@ -2827,15 +2822,16 @@ class OAuth2ProxySpec(ServiceSpec):
                 + ', '.join(missing_required_fields)
                 + '.'
             )
-        validate_non_empty_string(self.provider_display_name, "provider_display_name")
-        validate_non_empty_string(self.client_id, "client_id")
-        validate_non_empty_string(self.client_secret, "client_secret")
+        verify_non_empty_string(self.provider_display_name, "provider_display_name")
+        verify_non_empty_string(self.client_id, "client_id")
+        verify_non_empty_string(self.client_secret, "client_secret")
+
         self._validate_cookie_secret(self.cookie_secret)
         self._validate_url(self.oidc_issuer_url, "oidc_issuer_url")
         if self.redirect_url is not None:
             self._validate_url(self.redirect_url, "redirect_url")
         if self.scope is not None:
-            self._validate_non_empty_string(self.scope, "scope")
+            verify_non_empty_string(self.scope, "scope")
         if self.email_domains is not None:
             self._validate_domain_name(self.email_domains, "email_domains")
         if self.https_address is not None:
@@ -3657,7 +3653,7 @@ class TunedProfileSpec():
         if 'profile_name' not in spec:
             raise SpecValidationError('Tuned profile spec must include "profile_name" field')
         data['profile_name'] = spec['profile_name']
-        validate_non_empty_string(data['profile_name'], "profile_name")
+        verify_non_empty_string(data['profile_name'], "profile_name")
         if 'placement' in spec:
             data['placement'] = PlacementSpec.from_json(spec['placement'])
         if 'settings' in spec:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -52,6 +52,11 @@ ServiceSpecT = TypeVar('ServiceSpecT', bound='ServiceSpec')
 FuncT = TypeVar('FuncT', bound=Callable)
 
 
+def validate_non_empty_string(value: Optional[str], field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise SpecValidationError(f"Invalid {field_name}: Must be a non-empty string.")
+
+
 class TLSBlock(TypedDict, total=False):
     ssl: bool
     certificate_source: str
@@ -2805,6 +2810,7 @@ class OAuth2ProxySpec(ServiceSpec):
 
     def validate(self) -> None:
         super(OAuth2ProxySpec, self).validate()
+
         required_values = {
             'provider_display_name': self.provider_display_name,
             'oidc_issuer_url': self.oidc_issuer_url,
@@ -2821,9 +2827,9 @@ class OAuth2ProxySpec(ServiceSpec):
                 + ', '.join(missing_required_fields)
                 + '.'
             )
-        self._validate_non_empty_string(self.provider_display_name, "provider_display_name")
-        self._validate_non_empty_string(self.client_id, "client_id")
-        self._validate_non_empty_string(self.client_secret, "client_secret")
+        validate_non_empty_string(self.provider_display_name, "provider_display_name")
+        validate_non_empty_string(self.client_id, "client_id")
+        validate_non_empty_string(self.client_secret, "client_secret")
         self._validate_cookie_secret(self.cookie_secret)
         self._validate_url(self.oidc_issuer_url, "oidc_issuer_url")
         if self.redirect_url is not None:
@@ -2834,10 +2840,6 @@ class OAuth2ProxySpec(ServiceSpec):
             self._validate_domain_name(self.email_domains, "email_domains")
         if self.https_address is not None:
             self._validate_https_address(self.https_address)
-
-    def _validate_non_empty_string(self, value: Optional[str], field_name: str) -> None:
-        if not value or not isinstance(value, str) or not value.strip():
-            raise SpecValidationError(f"Invalid {field_name}: Must be a non-empty string.")
 
     def _validate_url(self, url: Optional[str], field_name: str) -> None:
         from urllib.parse import urlparse
@@ -3655,8 +3657,7 @@ class TunedProfileSpec():
         if 'profile_name' not in spec:
             raise SpecValidationError('Tuned profile spec must include "profile_name" field')
         data['profile_name'] = spec['profile_name']
-        if not isinstance(data['profile_name'], str):
-            raise SpecValidationError('"profile_name" field must be a string')
+        validate_non_empty_string(data['profile_name'], "profile_name")
         if 'placement' in spec:
             data['placement'] = PlacementSpec.from_json(spec['placement'])
         if 'settings' in spec:

--- a/src/python-common/ceph/deployment/utils.py
+++ b/src/python-common/ceph/deployment/utils.py
@@ -191,3 +191,9 @@ def validate_unique_ports(ports: List[int]) -> None:
         raise SpecValidationError(
             'Invalid port: Duplicate ports are not allowed'
         )
+
+
+def verify_non_empty_string(field: Any, field_name: str) -> None:
+    # isinstance first so we never call .strip() on None or non-str
+    if not isinstance(field, str) or not field.strip():
+        raise SpecValidationError(f"Invalid {field_name}: Must be a non-empty string.")

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -21,6 +21,7 @@ from ceph.deployment.service_spec import (
     RGWSpec,
     ServiceSpec,
     YamlLiteralString,
+    TunedProfileSpec,
 )
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.hostspec import SpecValidationError
@@ -1592,3 +1593,49 @@ spec:
 
     assert 'ssl_cert: |' in dumped
     assert 'ssl_key: |' in dumped
+
+# Tuned profile spec (e.g. ceph orch tuned-profile apply -i os-tune.spec)
+VALID_TUNED_PROFILE_SPEC = """
+profile_name: os-tune
+placement:
+  hosts:
+    - ceph-node-0
+    - ceph-node-1
+    - ceph-node-2
+"""
+
+EMPTY_PROFILE_NAME_SPEC = """
+profile_name: ''
+placement:
+  hosts:
+    - ceph-node-0
+    - ceph-node-1
+    - ceph-node-2
+"""
+
+MISSING_PROFILE_NAME_SPEC = """
+placement:
+  hosts:
+    - ceph-node-0
+    - ceph-node-1
+    - ceph-node-2
+"""
+
+
+@pytest.mark.parametrize("spec_yaml, expect_error, error_match", [
+    (EMPTY_PROFILE_NAME_SPEC, True, r'Invalid profile_name: Must be a non-empty string\.'),
+    (MISSING_PROFILE_NAME_SPEC, True, r'Tuned profile spec must include "profile_name" field'),
+    (VALID_TUNED_PROFILE_SPEC, False, None),
+])
+def test_tuned_profile_spec_profile_name_validation(spec_yaml, expect_error, error_match):
+    """Test TunedProfileSpec.from_json validation for profile_name (ceph orch tuned-profile apply -i <spec>)."""
+    data = yaml.safe_load(spec_yaml)
+    if expect_error:
+        with pytest.raises(SpecValidationError, match=error_match):
+            TunedProfileSpec.from_json(data)
+    else:
+        spec = TunedProfileSpec.from_json(data)
+        assert spec.profile_name == 'os-tune'
+        assert spec.placement is not None
+        # round-trip
+        assert TunedProfileSpec.from_json(spec.to_json()).profile_name == spec.profile_name


### PR DESCRIPTION
The fix improves the validation for profile_name string passed to `ceph orch tuned-profile apply -I <os_tune.spec>`

Before Fix: 

```
With empty ‘’ profile_name
[ceph: root@ceph-node-0 /]# ceph orch tuned-profile apply -i os.tune.spec                                                                                                                                                                                                                                                             
Saved tuned profile                                                                                                                                                
[ceph: root@ceph-node-0 /]#          
                                                                                             

With no profile_name                                                                                                                                                                   

[ceph: root@ceph-node-0 /]# ceph orch tuned-profile apply -i os.tune.spec                                                                                          
Error EINVAL: Tuned profile spec must include "profile_name" field                                                                                                 
[ceph: root@ceph-node-0 /]#
```


After Fix with empty profile name string:

```
[ceph: root@ceph-node-0 /]# ceph orch tuned-profile apply -i os.tune.spec
Error EINVAL: Invalid profile_name: Must be a non-empty string.
[ceph: root@ceph-node-0 /]# cat os.tune.spec
profile_name: ''                                                                                                                                                   
placement:                                                                                                                                                         
  hosts:                                                                                                                                                           
    - ceph-node-0                                                                                                                                                  
    - ceph-node-1                                                                                                                                                  
    - ceph-node-2                                                                                                                                                  
settings:                                                                                                                                                          
  fs.file-max: 100000 
[ceph: root@ceph-node-0 /]#
```

With no profile_name
```
[ceph: root@ceph-node-0 /]# vi os.tune.spec
[ceph: root@ceph-node-0 /]# ceph orch tuned-profile apply -i os.tune.spec
Error EINVAL: Tuned profile spec must include "profile_name" field
[ceph: root@ceph-node-0 /]#
Fixes: https://tracker.ceph.com/issues/74986
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>
```

Fixes: https://tracker.ceph.com/issues/74986
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
