### PR TITLE
Objecter fix and store caller id in objecter request

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -61,6 +61,10 @@ public:
   virtual std::ostream& gen_prefix(std::ostream& out) const = 0;
   virtual CephContext *get_cct() const = 0;
   virtual unsigned get_subsys() const = 0;
+
+  virtual std::string
+  get_trans_id() const { return ""; }
+
   virtual ~DoutPrefixProvider() {}
 };
 

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -377,6 +377,15 @@ inline namespace v14_2_0 {
       const std::map<std::string, std::pair<bufferlist, int> > &assertions,
       int *prval);
 
+    /**
+     * Set caller ID for request correlation (e.g., RGW trans_id)
+     * This ID will be included in objecter_requests admin socket output
+     * to allow tracing RADOS operations back to their originating request.
+     *
+     * @param caller_id [in] identifier string (e.g., S3 request trans_id)
+     */
+    void set_caller_id(std::string caller_id);
+
   protected:
     ObjectOperationImpl* impl;
     friend class IoCtx;

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1432,6 +1432,12 @@ inline namespace v14_2_0 {
     config_t cct();
     int connect();
     void shutdown();
+
+    /// Set the name suffix for the objecter admin socket command.
+    /// Call before connect(). If non-empty, the command will be
+    /// registered as "objecter_requests.<name>" instead of "objecter_requests".
+    void set_objecter_admin_socket_name(std::string name);
+
     int watch_flush();
     int aio_watch_flush(AioCompletion*);
     int conf_read_file(const char * const path) const;

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -268,7 +268,7 @@ int librados::RadosClient::connect()
   monclient.set_messenger(messenger);
   mgrclient.set_messenger(messenger);
 
-  objecter->init();
+  objecter->init(objecter_admin_socket_name);
   messenger->add_dispatcher_head(&mgrclient);
   messenger->add_dispatcher_tail(objecter);
   messenger->add_dispatcher_tail(this);

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -69,6 +69,11 @@ private:
 
   uint64_t instance_id{0};
 
+  // Optional name suffix for objecter admin socket command.
+  // If empty, registers as "objecter_requests".
+  // If non-empty, registers as "objecter_requests.<name>".
+  std::string objecter_admin_socket_name;
+
   bool _dispatch(Message *m);
   bool ms_dispatch(Message *m) override;
 
@@ -105,6 +110,13 @@ public:
   int ping_monitor(std::string mon_id, std::string *result);
   int connect();
   void shutdown();
+
+  /// Set the name suffix for the objecter admin socket command.
+  /// Call before connect(). If non-empty, the command will be
+  /// registered as "objecter_requests.<name>" instead of "objecter_requests".
+  void set_objecter_admin_socket_name(std::string name) {
+    objecter_admin_socket_name = std::move(name);
+  }
 
   int watch_flush();
   int async_watch_flush(AioCompletionImpl *c);

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2405,6 +2405,11 @@ int librados::Rados::connect()
   return client->connect();
 }
 
+void librados::Rados::set_objecter_admin_socket_name(std::string name)
+{
+  client->set_objecter_admin_socket_name(std::move(name));
+}
+
 librados::config_t librados::Rados::cct()
 {
   return (config_t)client->cct;

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -341,6 +341,13 @@ void librados::ObjectOperation::omap_cmp(
   o->omap_cmp(assertions, prval);
 }
 
+void librados::ObjectOperation::set_caller_id(std::string caller_id)
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->set_caller_id(std::move(caller_id));
+}
+
 void librados::ObjectReadOperation::list_watchers(
   list<obj_watch_t> *out_watchers,
   int *prval)

--- a/src/neorados/RADOSImpl.cc
+++ b/src/neorados/RADOSImpl.cc
@@ -46,7 +46,8 @@ RADOS::RADOS(boost::asio::io_context& ioctx,
   objecter->set_balanced_budget();
   monclient.set_messenger(messenger.get());
   mgrclient.set_messenger(messenger.get());
-  objecter->init();
+  // Use a distinct admin socket command name for the neorados client.
+  objecter->init("neorados");
   messenger->add_dispatcher_head(&mgrclient);
   messenger->add_dispatcher_tail(objecter.get());
   messenger->start();

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -267,7 +267,8 @@ void Objecter::update_crush_location()
 /*
  * initialize only internal data structures, don't initiate cluster interaction
  */
-void Objecter::init()
+void
+Objecter::init(std::string_view admin_socket_name)
 {
   ceph_assert(!initialized);
 
@@ -407,9 +408,16 @@ void Objecter::init()
 
   m_request_state_hook = new RequestStateHook(this);
   auto admin_socket = cct->get_admin_socket();
-  int ret = admin_socket->register_command("objecter_requests",
-					   m_request_state_hook,
-					   "show in-progress osd requests");
+
+  // Build the admin socket command name. If a name is provided, use
+  // "objecter_requests.<name>", otherwise use "objecter_requests".
+  std::string cmd_name = "objecter_requests";
+  if (!admin_socket_name.empty()) {
+    cmd_name += ".";
+    cmd_name += admin_socket_name;
+  }
+  int ret = admin_socket->register_command(
+      cmd_name, m_request_state_hook, "show in-progress osd requests");
 
   /* Don't warn on EEXIST, happens if multiple ceph clients
    * are instantiated from one process */

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2389,6 +2389,7 @@ void Objecter::_op_submit_with_budget(Op *op,
 {
   ceph_assert(initialized);
 
+
   ceph_assert(op->ops.size() == op->out_bl.size());
   ceph_assert(op->ops.size() == op->out_rval.size());
   ceph_assert(op->ops.size() == op->out_handler.size());
@@ -4866,6 +4867,10 @@ void Objecter::_dump_ops(const OSDSession *s, Formatter *fmt)
     auto age = std::chrono::duration<double>(ceph::coarse_mono_clock::now() - op->stamp);
     fmt->open_object_section("op");
     fmt->dump_unsigned("tid", op->tid);
+    // Dump caller_id if set (for RGW request correlation)
+    if (!op->caller_id.empty()) {
+      fmt->dump_string("caller_id", op->caller_id);
+    }
     op->target.dump(fmt);
     fmt->dump_stream("last_sent") << op->stamp;
     fmt->dump_float("age", age.count());

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2701,7 +2701,11 @@ private:
 	   boost::asio::io_context& service);
   ~Objecter() override;
 
-  void init();
+  /// Initialize the Objecter.
+  /// @param admin_socket_name Optional name for the admin socket command.
+  ///        If empty (default), registers as "objecter_requests".
+  ///        If non-empty, registers as "objecter_requests.<name>".
+  void init(std::string_view admin_socket_name = {});
   void start(const OSDMap *o = nullptr);
   void shutdown();
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -92,6 +92,8 @@ struct ObjectOperation {
   osdc_opvec ops;
   int flags = 0;
   int priority = 0;
+  std::string caller_id;
+  ///< Optional caller ID for debugging (e.g., RGW trans_id)
 
   boost::container::small_vector<ceph::buffer::list*, osdc_opvec_len> out_bl;
   boost::container::small_vector<
@@ -113,10 +115,23 @@ struct ObjectOperation {
     return ops.size();
   }
 
+  void
+  set_caller_id(std::string id)
+  {
+    caller_id = std::move(id);
+  }
+
+  const std::string&
+  get_caller_id() const
+  {
+    return caller_id;
+  }
+
   void clear() {
     ops.clear();
     flags = 0;
     priority = 0;
+    caller_id.clear();
     out_bl.clear();
     out_handler.clear();
     out_rval.clear();
@@ -1700,6 +1715,7 @@ public:
   using OpSignature = void(boost::system::error_code);
   using OpCompletion = boost::asio::any_completion_handler<OpSignature>;
 
+
   // config observer bits
   std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
@@ -2054,6 +2070,8 @@ public:
     ZTracer::Trace trace;
     std::uint64_t subsystem = 0;
     const jspan_context* otel_trace = nullptr;
+    std::string caller_id;
+    // Optional caller ID for request correlation (e.g., RGW trans_id)
 
     static bool has_completion(decltype(onfinish)& f) {
       return std::visit([](auto&& arg) { return bool(arg);}, f);
@@ -3077,6 +3095,10 @@ public:
     o->out_handler.swap(op.out_handler);
     o->out_ec.swap(op.out_ec);
     o->reqid = reqid;
+    // Copy caller_id from public ObjectOperation to internal Op
+    if (!op.get_caller_id().empty()) {
+      o->caller_id = op.get_caller_id();
+    }
     op.clear();
     return o;
   }
@@ -3134,6 +3156,10 @@ public:
     o->out_handler.swap(op.out_handler);
     o->out_rval.swap(op.out_rval);
     o->out_ec.swap(op.out_ec);
+    // Copy caller_id from public ObjectOperation to internal Op
+    if (!op.get_caller_id().empty()) {
+      o->caller_id = op.get_caller_id();
+    }
     op.clear();
     return o;
   }

--- a/src/rgw/driver/rados/config/realm_watcher.cc
+++ b/src/rgw/driver/rados/config/realm_watcher.cc
@@ -85,23 +85,9 @@ int RadosRealmWatcher::watch_start(const DoutPrefixProvider* dpp,
                                    librados::Rados& rados,
                                    const RGWRealm& realm)
 {
-  // initialize a Rados client
-  int r = rados.init_with_context(cct);
-  if (r < 0) {
-    ldpp_dout(dpp, -1) << "Rados client initialization failed with "
-        << cpp_strerror(-r) << dendl;
-    return r;
-  }
-  r = rados.connect();
-  if (r < 0) {
-    ldpp_dout(dpp, -1) << "Rados client connection failed with "
-        << cpp_strerror(-r) << dendl;
-    return r;
-  }
-
   // open an IoCtx for the realm's pool
   rgw_pool pool(realm.get_pool(cct));
-  r = rgw_init_ioctx(dpp, &rados, pool, pool_ctx);
+  int r = rgw_init_ioctx(dpp, &rados, pool, pool_ctx);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "Failed to open pool " << pool
         << " with " << cpp_strerror(-r) << dendl;

--- a/src/rgw/driver/rados/config/store.cc
+++ b/src/rgw/driver/rados/config/store.cc
@@ -39,6 +39,10 @@ auto create_config_store(const DoutPrefixProvider* dpp)
         << cpp_strerror(-r) << dendl;
     return nullptr;
   }
+  // Use a distinct admin socket command name for the config store client,
+  // so it doesn't conflict with the main RGWRados objecter_requests command.
+  impl->rados.set_objecter_admin_socket_name("config");
+
   r = impl->rados.connect();
   if (r < 0) {
     ldpp_dout(dpp, -1) << "Rados client connection failed with "

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -721,7 +721,7 @@ int RGWRadosBILogTrimCR::send_request(const DoutPrefixProvider *dpp)
   op.exec(RGW_CLASS, RGW_BI_LOG_TRIM, in);
 
   cn = stack->create_completion_notifier();
-  return bs.bucket_obj.aio_operate(cn->completion(), &op);
+  return bs.bucket_obj.aio_operate(dpp, cn->completion(), &op);
 }
 
 int RGWRadosBILogTrimCR::request_complete()

--- a/src/rgw/driver/rados/rgw_d3n_datacache.h
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.h
@@ -207,7 +207,9 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
     const uint64_t cost = len;
     const uint64_t id = obj_ofs; // use logical object offset for sorting replies
 
-    auto completed = d->aio->get(ref.obj, rgw::Aio::librados_op(ref.ioctx, std::move(op), d->yield), cost, id);
+    auto completed = d->aio->get(
+        ref.obj, rgw::Aio::librados_op(dpp, ref.ioctx, std::move(op), d->yield),
+        cost, id);
     return d->flush(std::move(completed));
   } else {
     ldpp_dout(dpp, 20) << "D3nDataCache::" << __func__ << "(): oid=" << read_obj.oid << ", is_head_obj=" << is_head_obj << ", obj-ofs=" << obj_ofs << ", read_ofs=" << read_ofs << ", len=" << len << dendl;
@@ -230,8 +232,11 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
     const bool is_encrypted = (astate->attrset.find(RGW_ATTR_CRYPT_MODE) != astate->attrset.end());
     if (read_ofs != 0 || astate->size != astate->accounted_size || is_compressed || is_encrypted) {
       d->d3n_bypass_cache_write = true;
-      lsubdout(g_ceph_context, rgw, 5) << "D3nDataCache: " << __func__ << "(): Note - bypassing datacache: oid=" << read_obj.oid << ", read_ofs!=0 = " << read_ofs << ", size=" << astate->size << " != accounted_size=" << astate->accounted_size << ", is_compressed=" << is_compressed << ", is_encrypted=" << is_encrypted  << dendl;
-      auto completed = d->aio->get(ref.obj, rgw::Aio::librados_op(ref.ioctx, std::move(op), d->yield), cost, id);
+      lsubdout(g_ceph_context, rgw, 5) << "D3nDataCache: " << __func__ << "(): Note - bypassing datacache: oid=" << read_obj.oid << ", read_ofs!=0 = " << read_ofs << ", size=" << astate->size << " != accounted_size=" << astate->accounted_size << ", is_compressed=" << is_compressed << ", is_encrypted=" << is_encrypted
+ << dendl;
+      auto completed = d->aio->get(
+          ref.obj,
+          rgw::Aio::librados_op(dpp, ref.ioctx, std::move(op), d->yield), cost, id);
       r = d->flush(std::move(completed));
       return r;
     }
@@ -247,8 +252,10 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
       return r;
     } else {
       // Write To Cache
-      ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): WRITE TO CACHE: oid=" << read_obj.oid << ", obj-ofs=" << obj_ofs << ", read_ofs=" << read_ofs << " len=" << len << dendl;
-      auto completed = d->aio->get(ref.obj, rgw::Aio::librados_op(ref.ioctx, std::move(op), d->yield), cost, id);
+      ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): WRITE TO CACHE: oid=" << read_obj.oid << ", obj-ofs=" << obj_ofs << ", read_ofs=" <<
+ read_ofs << " len=" << len << dendl;
+      auto completed = d->aio->get(
+          ref.obj, rgw::Aio::librados_op(dpp, ref.ioctx, std::move(op), d->yield), cost, id);
       return d->flush(std::move(completed));
     }
   }

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -587,7 +587,9 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 20) << __func__ << "::dec ref-count on tail object: " << raw_obj.oid << dendl;
       cls_refcount_put(op, ref_tag, true);
       rgw::AioResultList completed = aio->get(obj.obj,
-                                              rgw::Aio::librados_op(obj.ioctx, std::move(op), null_yield),
+                                              rgw::Aio::librados_op(
+                                                  dpp, obj.ioctx, std::move(op),
+                                                  null_yield),
                                               cost, id);
     }
     rgw::AioResultList completed = aio->drain();
@@ -621,10 +623,12 @@ namespace rgw::dedup {
       ObjectWriteOperation op;
       cls_refcount_get(op, ref_tag, true);
       d_ctl.metadata_access_throttle.acquire();
-      ldpp_dout(dpp, 20) << __func__ << "::inc ref-count on tail object: " << raw_obj.oid << dendl;
-      rgw::AioResultList completed = aio->get(obj.obj,
-                                              rgw::Aio::librados_op(obj.ioctx, std::move(op), null_yield),
-                                              cost, id);
+      ldpp_dout(dpp, 20) << __func__ << "::inc ref-count on tail object: " <<
+ raw_obj.oid << dendl;
+      rgw::AioResultList completed = aio->get(
+          obj.obj,
+          rgw::Aio::librados_op(dpp, obj.ioctx, std::move(op), null_yield),
+          cost, id);
       ret = rgw::check_for_errors(completed);
       all_results.splice(all_results.end(), completed);
       if (ret < 0) {
@@ -664,9 +668,10 @@ namespace rgw::dedup {
 
       ObjectWriteOperation op;
       cls_refcount_put(op, ref_tag, true);
-      rgw::AioResultList completed = aio->get(obj.obj,
-                                              rgw::Aio::librados_op(obj.ioctx, std::move(op), null_yield),
-                                              cost, id);
+      rgw::AioResultList completed = aio->get(
+          obj.obj,
+          rgw::Aio::librados_op(dpp, obj.ioctx, std::move(op), null_yield),
+          cost, id);
       ret2 = rgw::check_for_errors(completed);
       if (ret2 < 0) {
         ldpp_dout(dpp, 1) << __func__ << "::ERR: cleanup after error failed to drop reference on obj=" << aio_res.obj << dendl;

--- a/src/rgw/driver/rados/rgw_gc.h
+++ b/src/rgw/driver/rados/rgw_gc.h
@@ -15,6 +15,8 @@
 
 #include <atomic>
 
+static const std::string gc_trans_id_prefix = "GarbageCollection";
+
 class RGWGCIOManager;
 
 class RGWGC : public DoutPrefixProvider {
@@ -76,6 +78,11 @@ public:
 
   CephContext *get_cct() const override { return store->ctx(); }
   unsigned get_subsys() const;
+
+  std::string
+  get_trans_id() const override {
+    return gc_trans_id_prefix;
+  }
 
   std::ostream& gen_prefix(std::ostream& out) const;
 

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -180,9 +180,11 @@ int RadosWriter::process(bufferlist&& bl, uint64_t offset)
     op.write(offset, data);
   }
   constexpr uint64_t id = 0; // unused
-  auto c = aio->get(stripe_obj.obj, Aio::librados_op(stripe_obj.ioctx,
-						     std::move(op), y, &trace),
-		    cost, id);
+  auto c = aio->get(
+      stripe_obj.obj, Aio::librados_op(
+          dpp, stripe_obj.ioctx,
+          std::move(op), y, &trace),
+      cost, id);
   return process_completed(c, &written);
 }
 
@@ -196,8 +198,10 @@ int RadosWriter::write_exclusive(const bufferlist& data)
   op.write_full(data);
 
   constexpr uint64_t id = 0; // unused
-  auto c = aio->get(stripe_obj.obj, Aio::librados_op(stripe_obj.ioctx,
-						     std::move(op), y, &trace),
+  auto c = aio->get(
+      stripe_obj.obj, Aio::librados_op(
+          dpp, stripe_obj.ioctx,
+          std::move(op), y, &trace),
 		    cost, id);
   auto d = aio->drain();
   c.splice(c.end(), d);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5243,8 +5243,9 @@ int RGWRados::copy_obj(RGWObjectCtx& src_obj_ctx,
       static constexpr uint64_t cost = 1; // 1 throttle unit per request
       static constexpr uint64_t id = 0; // ids unused
       rgw::AioResultList completed =
-	aio->get(obj.obj, rgw::Aio::librados_op(obj.ioctx, std::move(op), y),
-		 cost, id);
+          aio->get(
+              obj.obj, rgw::Aio::librados_op(dpp, obj.ioctx, std::move(op), y),
+              cost, id);
       ret = rgw::check_for_errors(completed);
       all_results.splice(all_results.end(), completed);
       if (ret < 0) {
@@ -5324,8 +5325,9 @@ done_ret:
       static constexpr uint64_t cost = 1; // 1 throttle unit per request
       static constexpr uint64_t id = 0; // ids unused
       rgw::AioResultList completed =
-	aio->get(obj.obj, rgw::Aio::librados_op(obj.ioctx, std::move(op), y),
-		 cost, id);
+          aio->get(
+              obj.obj, rgw::Aio::librados_op(dpp, obj.ioctx, std::move(op), y),
+              cost, id);
       ret2 = rgw::check_for_errors(completed);
       if (ret2 < 0) {
         ldpp_dout(dpp, 0) << "ERROR: cleanup after error failed to drop reference on obj=" << r.obj << dendl;
@@ -6237,8 +6239,9 @@ void RGWRados::delete_objs_inline(const DoutPrefixProvider *dpp, cls_rgw_obj_cha
     raw.oid = std::move(obj->key.name);
     raw.loc = std::move(obj->loc);
 
-    auto completed = aio->get(std::move(raw), rgw::Aio::librados_op(
-            ioctx, std::move(op), y), cost, id);
+    auto completed = aio->get(
+        std::move(raw), rgw::Aio::librados_op(
+            dpp, ioctx, std::move(op), y), cost, id);
     std::ignore = rgw::check_for_errors(completed);
   }
 
@@ -8085,7 +8088,9 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
 
   bool add_log = log_op && store->svc.zone->need_to_log_data();
 
-  ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace, add_log);
+  ret = store->cls_obj_complete_add(
+      dpp, *bs, obj, optag, poolid, epoch, ent, category, remove_objs,
+      bilog_flags, zones_trace, add_log);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
 			    target->bucket_info, bs->shard_id, y);
@@ -8115,7 +8120,9 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
 
   bool add_log = log_op && store->svc.zone->need_to_log_data();
 
-  ret = store->cls_obj_complete_del(*bs, optag, poolid, epoch, obj, removed_mtime, remove_objs, bilog_flags, zones_trace, add_log);
+  ret = store->cls_obj_complete_del(
+      dpp, *bs, optag, poolid, epoch, obj, removed_mtime, remove_objs,
+      bilog_flags, zones_trace, add_log);
 
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
@@ -8140,8 +8147,9 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
   bool add_log = log_op && store->svc.zone->need_to_log_data();
 
   int ret = guard_reshard(dpp, obj, &bs, [&](BucketShard *bs) -> int {
-				 return store->cls_obj_complete_cancel(*bs, optag, obj, remove_objs, bilog_flags, zones_trace, add_log);
-			       }, y);
+      return store->cls_obj_complete_cancel(
+          dpp, *bs, optag, obj, remove_objs, bilog_flags, zones_trace, add_log);
+    }, y);
 
   if (add_log) {
     /*
@@ -8375,7 +8383,9 @@ int RGWRados::get_obj_iterate_cb(const DoutPrefixProvider *dpp,
   const uint64_t cost = len;
   const uint64_t id = obj_ofs; // use logical object offset for sorting replies
 
-  auto completed = d->aio->get(obj.obj, rgw::Aio::librados_op(obj.ioctx, std::move(op), d->yield), cost, id);
+  auto completed = d->aio->get(
+      obj.obj, rgw::Aio::librados_op(
+          dpp, obj.ioctx, std::move(op), d->yield), cost, id);
 
   return d->flush(std::move(completed));
 }
@@ -10503,11 +10513,21 @@ int RGWRados::cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs,
   return ret;
 }
 
-int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, string& tag,
-                                  int64_t pool, uint64_t epoch,
-                                  rgw_bucket_dir_entry& ent, RGWObjCategory category,
-                                  list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                                  rgw_zone_set *_zones_trace, bool log_op)
+int
+RGWRados::cls_obj_complete_op(
+    const DoutPrefixProvider* dpp,
+    BucketShard& bs,
+    const rgw_obj& obj,
+    RGWModifyOp op,
+    string& tag,
+    int64_t pool,
+    uint64_t epoch,
+    rgw_bucket_dir_entry& ent,
+    RGWObjCategory category,
+    list<rgw_obj_index_key>* remove_objs,
+    uint16_t bilog_flags,
+    rgw_zone_set* _zones_trace,
+    bool log_op)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
   ldout_bitx_c(bitx, cct, 10) << "ENTERING " << __func__ << ": bucket-shard=" << bs <<
@@ -10540,51 +10560,75 @@ int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModify
   index_completion_manager->create_completion(obj, op, tag, ver, key, dir_meta, remove_objs,
                                               log_op, bilog_flags, &zones_trace, &arg);
   librados::AioCompletion *completion = arg->rados_completion;
-  int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
+  int ret = bs.bucket_obj.aio_operate(dpp, arg->rados_completion, &o);
   completion->release(); /* can't reference arg here, as it might have already been released */
 
   ldout_bitx_c(bitx, cct, 10) << "EXITING " << __func__ << ": ret=" << ret << dendl_bitx;
   return ret;
 }
 
-int RGWRados::cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, string& tag,
-                                   int64_t pool, uint64_t epoch,
-                                   rgw_bucket_dir_entry& ent, RGWObjCategory category,
-                                   list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                                   rgw_zone_set *zones_trace, bool log_op)
+int
+RGWRados::cls_obj_complete_add(
+    const DoutPrefixProvider* dpp,
+    BucketShard& bs,
+    const rgw_obj& obj,
+    string& tag,
+    int64_t pool,
+    uint64_t epoch,
+    rgw_bucket_dir_entry& ent,
+    RGWObjCategory category,
+    list<rgw_obj_index_key>* remove_objs,
+    uint16_t bilog_flags,
+    rgw_zone_set* zones_trace,
+    bool log_op)
 {
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_ADD, tag, pool, epoch,
-                             ent, category, remove_objs, bilog_flags,
-                             zones_trace, log_op);
+  return cls_obj_complete_op(
+      dpp, bs, obj, CLS_RGW_OP_ADD, tag, pool, epoch,
+      ent, category, remove_objs, bilog_flags,
+      zones_trace, log_op);
 }
 
-int RGWRados::cls_obj_complete_del(BucketShard& bs, string& tag,
-                                   int64_t pool, uint64_t epoch,
-                                   rgw_obj& obj,
-                                   real_time& removed_mtime,
-                                   list<rgw_obj_index_key> *remove_objs,
-                                   uint16_t bilog_flags,
-                                   rgw_zone_set *zones_trace,
-                                   bool log_op)
+int
+RGWRados::cls_obj_complete_del(
+    const DoutPrefixProvider* dpp,
+    BucketShard& bs,
+    string& tag,
+    int64_t pool,
+    uint64_t epoch,
+    rgw_obj& obj,
+    real_time& removed_mtime,
+    list<rgw_obj_index_key>* remove_objs,
+    uint16_t bilog_flags,
+    rgw_zone_set* zones_trace,
+    bool log_op)
 {
   rgw_bucket_dir_entry ent;
   ent.meta.mtime = removed_mtime;
   obj.key.get_index_key(&ent.key);
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_DEL, tag, pool, epoch,
-			     ent, RGWObjCategory::None, remove_objs,
-			     bilog_flags, zones_trace, log_op);
+  return cls_obj_complete_op(
+      dpp, bs, obj, CLS_RGW_OP_DEL, tag, pool, epoch,
+      ent, RGWObjCategory::None, remove_objs,
+      bilog_flags, zones_trace, log_op);
 }
 
-int RGWRados::cls_obj_complete_cancel(BucketShard& bs, string& tag, rgw_obj& obj,
-                                      list<rgw_obj_index_key> *remove_objs,
-                                      uint16_t bilog_flags, rgw_zone_set *zones_trace, bool log_op)
+int
+RGWRados::cls_obj_complete_cancel(
+    const DoutPrefixProvider* dpp,
+    BucketShard& bs,
+    string& tag,
+    rgw_obj& obj,
+    list<rgw_obj_index_key>* remove_objs,
+    uint16_t bilog_flags,
+    rgw_zone_set* zones_trace,
+    bool log_op)
 {
   rgw_bucket_dir_entry ent;
   obj.key.get_index_key(&ent.key);
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_CANCEL, tag,
-			     -1 /* pool id */, 0, ent,
-			     RGWObjCategory::None, remove_objs, bilog_flags,
-			     zones_trace, log_op);
+  return cls_obj_complete_op(
+      dpp, bs, obj, CLS_RGW_OP_CANCEL, tag,
+      -1 /* pool id */, 0, ent,
+      RGWObjCategory::None, remove_objs, bilog_flags,
+      zones_trace, log_op);
 }
 
 

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1531,18 +1531,54 @@ public:
 
   int cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs, RGWModifyOp op, std::string& tag, rgw_obj& obj,
                          optional_yield y);
-  int cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, std::string& tag, int64_t pool, uint64_t epoch,
-                          rgw_bucket_dir_entry& ent, RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs,
-                          uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, std::string& tag, int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
-                           RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                           rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_del(BucketShard& bs, std::string& tag, int64_t pool, uint64_t epoch, rgw_obj& obj,
-                           ceph::real_time& removed_mtime, std::list<rgw_obj_index_key> *remove_objs,
-                           uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,
-                              std::list<rgw_obj_index_key> *remove_objs,
-                              uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
+  int cls_obj_complete_op(
+      const DoutPrefixProvider* dpp,
+      BucketShard& bs,
+      const rgw_obj& obj,
+      RGWModifyOp op,
+      std::string& tag,
+      int64_t pool,
+      uint64_t epoch,
+      rgw_bucket_dir_entry& ent,
+      RGWObjCategory category,
+      std::list<rgw_obj_index_key>* remove_objs,
+      uint16_t bilog_flags,
+      rgw_zone_set* zones_trace = nullptr,
+      bool log_op = true);
+  int cls_obj_complete_add(
+      const DoutPrefixProvider* dpp,
+      BucketShard& bs,
+      const rgw_obj& obj,
+      std::string& tag,
+      int64_t pool,
+      uint64_t epoch,
+      rgw_bucket_dir_entry& ent,
+      RGWObjCategory category,
+      std::list<rgw_obj_index_key>* remove_objs,
+      uint16_t bilog_flags,
+      rgw_zone_set* zones_trace = nullptr,
+      bool log_op = true);
+  int cls_obj_complete_del(
+      const DoutPrefixProvider* dpp,
+      BucketShard& bs,
+      std::string& tag,
+      int64_t pool,
+      uint64_t epoch,
+      rgw_obj& obj,
+      ceph::real_time& removed_mtime,
+      std::list<rgw_obj_index_key>* remove_objs,
+      uint16_t bilog_flags,
+      rgw_zone_set* zones_trace = nullptr,
+      bool log_op = true);
+  int cls_obj_complete_cancel(
+      const DoutPrefixProvider* dpp,
+      BucketShard& bs,
+      std::string& tag,
+      rgw_obj& obj,
+      std::list<rgw_obj_index_key>* remove_objs,
+      uint16_t bilog_flags,
+      rgw_zone_set* zones_trace = nullptr,
+      bool log_op = true);
 
   using ent_map_t =
     boost::container::flat_map<std::string, rgw_bucket_dir_entry>;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -256,7 +256,7 @@ public:
     if (ret < 0) {
       return ret;
     }
-    ret = bs.bucket_obj.aio_operate(c, &op);
+    ret = bs.bucket_obj.aio_operate(nullptr, c, &op);
     if (ret < 0) {
       derr << "ERROR: failed to store entries in target bucket shard (bs=" << bs.bucket << "/" << bs.shard_id << ") error=" << cpp_strerror(-ret) << dendl;
       return ret;

--- a/src/rgw/driver/rados/rgw_sync_error_repo.cc
+++ b/src/rgw/driver/rados/rgw_sync_error_repo.cc
@@ -144,7 +144,7 @@ class RGWErrorRepoWriteCR : public RGWSimpleCoroutine {
     }
 
     cn = stack->create_completion_notifier();
-    return ref.aio_operate(cn->completion(), &op);
+    return ref.aio_operate(dpp, cn->completion(), &op);
   }
 
   int request_complete() override {
@@ -189,7 +189,7 @@ class RGWErrorRepoRemoveCR : public RGWSimpleCoroutine {
     }
 
     cn = stack->create_completion_notifier();
-    return ref.aio_operate(cn->completion(), &op);
+    return ref.aio_operate(dpp, cn->completion(), &op);
   }
 
   int request_complete() override {

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -232,6 +232,14 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
                       optional_yield y, int flags, const jspan_context* trace_info,
                       version_t* pver)
 {
+  // Set caller_id from request context to enable correlation with S3 requests
+  if (dpp) {
+    auto trans_id = dpp->get_trans_id();
+    if (!trans_id.empty()) {
+      op.set_caller_id(std::move(trans_id));
+    }
+  }
+
   // given a yield_context, call async_operate() to yield the coroutine instead
   // of blocking
   if (y) {
@@ -260,6 +268,14 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
                       librados::ObjectWriteOperation&& op, optional_yield y,
 		      int flags, const jspan_context* trace_info, version_t* pver)
 {
+  // Set caller_id from request context to enable correlation with S3 requests
+  if (dpp) {
+    auto trans_id = dpp->get_trans_id();
+    if (!trans_id.empty()) {
+      op.set_caller_id(std::move(trans_id));
+    }
+  }
+
   if (y) {
     auto& yield = y.get_yield_context();
     auto ex = yield.get_executor();

--- a/src/rgw/driver/rados/rgw_tools.h
+++ b/src/rgw/driver/rados/rgw_tools.h
@@ -138,13 +138,36 @@ struct rgw_rados_ref {
     return rgw_rados_operate(dpp, ioctx, obj.oid, std::move(op), y, flags);
   }
 
-  int aio_operate(librados::AioCompletion* c,
-		  librados::ObjectWriteOperation* op) {
+  int
+  aio_operate(
+      const DoutPrefixProvider* dpp,
+      librados::AioCompletion* c,
+      librados::ObjectWriteOperation* op)
+  {
+    // Set caller_id from request context to enable correlation with S3 requests
+    if (dpp) {
+      auto trans_id = dpp->get_trans_id();
+      if (!trans_id.empty()) {
+        op->set_caller_id(std::move(trans_id));
+      }
+    }
     return ioctx.aio_operate(obj.oid, c, op);
   }
 
-  int aio_operate(librados::AioCompletion* c, librados::ObjectReadOperation* op,
-		  bufferlist *pbl) {
+  int
+  aio_operate(
+      const DoutPrefixProvider* dpp,
+      librados::AioCompletion* c,
+      librados::ObjectReadOperation* op,
+      bufferlist* pbl)
+  {
+    // Set caller_id from request context to enable correlation with S3 requests
+    if (dpp) {
+      auto trans_id = dpp->get_trans_id();
+      if (!trans_id.empty()) {
+        op->set_caller_id(std::move(trans_id));
+      }
+    }
     return ioctx.aio_operate(obj.oid, c, op, pbl);
   }
 

--- a/src/rgw/driver/rados/shard_io.h
+++ b/src/rgw/driver/rados/shard_io.h
@@ -60,7 +60,10 @@ class RevertibleWriter : public DoutPrefixPipe {
   executor_type get_executor() const { return ex; }
 
   RevertibleWriter(const DoutPrefixProvider& dpp, executor_type ex)
-    : DoutPrefixPipe(dpp), ex(std::move(ex)) {}
+    : DoutPrefixPipe(dpp), ex(std::move(ex)),
+      trans_id(dpp.get_trans_id())
+  {
+  }
 
   virtual ~RevertibleWriter() {}
 
@@ -84,6 +87,10 @@ class RevertibleWriter : public DoutPrefixPipe {
 
  private:
   executor_type ex;
+
+protected:
+  // Transaction ID captured at construction for caller_id correlation
+  std::string trans_id;
 };
 
 /// Interface for async_writes() that can initiate write operations.
@@ -95,7 +102,10 @@ class Writer : public DoutPrefixPipe {
   executor_type get_executor() const { return ex; }
 
   Writer(const DoutPrefixProvider& dpp, executor_type ex)
-    : DoutPrefixPipe(dpp), ex(std::move(ex)) {}
+    : DoutPrefixPipe(dpp), ex(std::move(ex)),
+      trans_id(dpp.get_trans_id())
+  {
+  }
 
   virtual ~Writer() {}
 
@@ -115,6 +125,10 @@ class Writer : public DoutPrefixPipe {
 
  private:
   executor_type ex;
+
+protected:
+  // Transaction ID captured at construction for caller_id correlation
+  std::string trans_id;
 };
 
 /// Interface for async_reads() that can initiate read operations.
@@ -126,7 +140,10 @@ class Reader : public DoutPrefixPipe {
   executor_type get_executor() const { return ex; }
 
   Reader(const DoutPrefixProvider& dpp, executor_type ex)
-    : DoutPrefixPipe(dpp), ex(std::move(ex)) {}
+    : DoutPrefixPipe(dpp), ex(std::move(ex)),
+      trans_id(dpp.get_trans_id())
+  {
+  }
 
   virtual ~Reader() {}
 
@@ -146,6 +163,10 @@ class Reader : public DoutPrefixPipe {
 
  private:
   executor_type ex;
+
+protected:
+  // Transaction ID captured at construction for caller_id correlation
+  std::string trans_id;
 };
 
 namespace detail {
@@ -658,6 +679,11 @@ class RadosRevertibleWriter : public RevertibleWriter {
     librados::ObjectWriteOperation op;
     prepare_write(shard, op);
 
+    // Set caller_id from trans_id captured at construction
+    if (!trans_id.empty()) {
+      op.set_caller_id(trans_id);
+    }
+
     constexpr int flags = 0;
     constexpr jspan_context* trace = nullptr;
     librados::async_operate(get_executor(), ioctx, object, std::move(op),
@@ -668,6 +694,11 @@ class RadosRevertibleWriter : public RevertibleWriter {
               detail::RevertHandler&& handler) final {
     librados::ObjectWriteOperation op;
     prepare_revert(shard, op);
+
+    // Set caller_id from trans_id captured at construction
+    if (!trans_id.empty()) {
+      op.set_caller_id(trans_id);
+    }
 
     constexpr int flags = 0;
     constexpr jspan_context* trace = nullptr;
@@ -696,6 +727,11 @@ class RadosWriter : public Writer {
     librados::ObjectWriteOperation op;
     prepare_write(shard, op);
 
+    // Set caller_id from trans_id captured at construction
+    if (!trans_id.empty()) {
+      op.set_caller_id(trans_id);
+    }
+
     constexpr int flags = 0;
     constexpr jspan_context* trace = nullptr;
     librados::async_operate(get_executor(), ioctx, object, std::move(op),
@@ -722,6 +758,11 @@ class RadosReader : public Reader {
             detail::ReadHandler&& handler) final {
     librados::ObjectReadOperation op;
     prepare_read(shard, op);
+
+    // Set caller_id from trans_id captured at construction
+    if (!trans_id.empty()) {
+      op.set_caller_id(trans_id);
+    }
 
     constexpr int flags = 0;
     constexpr jspan_context* trace = nullptr;

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -51,24 +51,40 @@ void cb(librados::completion_t, void* arg) {
 }
 
 template <typename Op>
-Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op, jspan_context* trace_ctx = nullptr) {
-  return [ctx = std::move(ctx), op = std::forward<Op>(op), trace_ctx] (Aio* aio, AioResult& r) mutable {
-      constexpr bool read = std::is_same_v<std::decay_t<Op>, librados::ObjectReadOperation>;
-      // use placement new to construct the rados state inside of user_data
-      auto s = new (&r.user_data) state(aio, ctx, r);
-      if constexpr (read) {
-        (void)trace_ctx; // suppress unused trace_ctx warning. until we will support the read op trace
-        r.result = ctx.aio_operate(r.obj.oid, s->c, &op, &r.data);
-      } else {
-        r.result = ctx.aio_operate(r.obj.oid, s->c, &op, 0, trace_ctx);
-      }
-      if (r.result < 0) {
-        // cb() won't be called, so release everything here
-        s->c->release();
-        aio->put(r);
-        s->~state();
-      }
-    };
+Aio::OpFunc
+aio_abstract(
+    librados::IoCtx ctx,
+    Op&& op,
+    std::string trans_id,
+    jspan_context* trace_ctx = nullptr)
+{
+  return [ctx = std::move(ctx), op = std::forward<Op>(op),
+        trans_id = std::move(trans_id), trace_ctx](
+      Aio* aio,
+      AioResult& r) mutable {
+    // Set caller_id from request context to enable correlation with S3 requests
+    if (!trans_id.empty()) {
+      op.set_caller_id(std::move(trans_id));
+    }
+
+    constexpr bool read = std::is_same_v<
+      std::decay_t<Op>, librados::ObjectReadOperation>;
+    // use placement new to construct the rados state inside of user_data
+    auto s = new(&r.user_data) state(aio, ctx, r);
+    if constexpr (read) {
+      (void)trace_ctx;
+      // suppress unused trace_ctx warning. until we will support the read op trace
+      r.result = ctx.aio_operate(r.obj.oid, s->c, &op, &r.data);
+    } else {
+      r.result = ctx.aio_operate(r.obj.oid, s->c, &op, 0, trace_ctx);
+    }
+    if (r.result < 0) {
+      // cb() won't be called, so release everything here
+      s->c->release();
+      aio->put(r);
+      s->~state();
+    }
+  };
 }
 
 struct Handler {
@@ -91,15 +107,26 @@ struct Handler {
 template <typename Op>
 Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op,
                          boost::asio::yield_context yield,
-                         jspan_context* trace_ctx) {
-  return [ctx = std::move(ctx), op = std::forward<Op>(op), yield, trace_ctx] (Aio* aio, AioResult& r) mutable {
-      // arrange for the completion Handler to run on the yield_context's strand
-      // executor so it can safely call back into Aio without locking
-      auto ex = yield.get_executor();
+                         std::string trans_id,
+                         jspan_context* trace_ctx)
+{
+  return [ctx = std::move(ctx), op = std::forward<Op>(op), yield,
+        trans_id = std::move(trans_id), trace_ctx](
+      Aio* aio,
+      AioResult& r) mutable {
+    // Set caller_id from request context to enable correlation with S3 requests
+    if (!trans_id.empty()) {
+      op.set_caller_id(std::move(trans_id));
+    }
 
-      librados::async_operate(ex, ctx, r.obj.oid, std::move(op), 0, trace_ctx,
-                              bind_executor(ex, Handler{aio, ctx, r}));
-    };
+    // arrange for the completion Handler to run on the yield_context's strand
+    // executor so it can safely call back into Aio without locking
+    auto ex = yield.get_executor();
+
+    librados::async_operate(
+        ex, ctx, r.obj.oid, std::move(op), 0, trace_ctx,
+        bind_executor(ex, Handler{aio, ctx, r}));
+  };
 }
 
 
@@ -115,32 +142,59 @@ Aio::OpFunc d3n_cache_aio_abstract(const DoutPrefixProvider *dpp, optional_yield
 
 
 template <typename Op>
-Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op, optional_yield y, jspan_context *trace_ctx = nullptr) {
+Aio::OpFunc
+aio_abstract(
+    librados::IoCtx ctx,
+    Op&& op,
+    optional_yield y,
+    std::string trans_id,
+    jspan_context* trace_ctx = nullptr)
+{
   static_assert(std::is_base_of_v<librados::ObjectOperation, std::decay_t<Op>>);
   static_assert(!std::is_lvalue_reference_v<Op>);
   static_assert(!std::is_const_v<Op>);
   if (y) {
     return aio_abstract(std::move(ctx), std::forward<Op>(op),
-                        y.get_yield_context(), trace_ctx);
+                        y.get_yield_context(), std::move(trans_id), trace_ctx);
   }
-  return aio_abstract(std::move(ctx), std::forward<Op>(op), trace_ctx);
+  return aio_abstract(
+      std::move(ctx), std::forward<Op>(op), std::move(trans_id), trace_ctx);
 }
 
 } // anonymous namespace
 
-Aio::OpFunc Aio::librados_op(librados::IoCtx ctx,
-                             librados::ObjectReadOperation&& op,
-                             optional_yield y) {
-  return aio_abstract(std::move(ctx), std::move(op), y);
-}
-Aio::OpFunc Aio::librados_op(librados::IoCtx ctx,
-                             librados::ObjectWriteOperation&& op,
-                             optional_yield y, jspan_context *trace_ctx) {
-  return aio_abstract(std::move(ctx), std::move(op), y, trace_ctx);
+Aio::OpFunc
+Aio::librados_op(
+    const DoutPrefixProvider* dpp,
+    librados::IoCtx ctx,
+    librados::ObjectReadOperation&& op,
+    optional_yield y)
+{
+  auto trans_id = dpp ? dpp->get_trans_id() : std::string{};
+  return aio_abstract(std::move(ctx), std::move(op), y, std::move(trans_id));
 }
 
-Aio::OpFunc Aio::d3n_cache_op(const DoutPrefixProvider *dpp, optional_yield y,
-                              off_t read_ofs, off_t read_len, std::string& cache_location) {
+Aio::OpFunc
+Aio::librados_op(
+    const DoutPrefixProvider* dpp,
+    librados::IoCtx ctx,
+    librados::ObjectWriteOperation&& op,
+    optional_yield y,
+    jspan_context* trace_ctx)
+{
+  auto trans_id = dpp ? dpp->get_trans_id() : std::string{};
+  return aio_abstract(
+      std::move(ctx), std::move(op), y, std::move(trans_id), trace_ctx);
+}
+
+Aio::OpFunc
+Aio::d3n_cache_op(
+    const DoutPrefixProvider* dpp,
+    optional_yield y,
+    off_t read_ofs,
+    off_t read_len,
+    std::string& cache_location)
+{
   return d3n_cache_aio_abstract(dpp, y, read_ofs, read_len, cache_location);
 }
 

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -98,12 +98,17 @@ class Aio {
   // wait for all outstanding completions and return their results
   virtual AioResultList drain() = 0;
 
-  static OpFunc librados_op(librados::IoCtx ctx,
-                            librados::ObjectReadOperation&& op,
-                            optional_yield y);
-  static OpFunc librados_op(librados::IoCtx ctx,
-                            librados::ObjectWriteOperation&& op,
-                            optional_yield y, jspan_context *trace_ctx = nullptr);
+  static OpFunc librados_op(
+      const DoutPrefixProvider* dpp,
+      librados::IoCtx ctx,
+      librados::ObjectReadOperation&& op,
+      optional_yield y);
+  static OpFunc librados_op(
+      const DoutPrefixProvider* dpp,
+      librados::IoCtx ctx,
+      librados::ObjectWriteOperation&& op,
+      optional_yield y,
+      jspan_context* trace_ctx = nullptr);
   static OpFunc d3n_cache_op(const DoutPrefixProvider *dpp, optional_yield y,
                              off_t read_ofs, off_t read_len, std::string& location);
 };

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1466,6 +1466,7 @@ struct req_state : DoutPrefixProvider {
   std::ostream& gen_prefix(std::ostream& out) const override;
   CephContext* get_cct() const override { return cct; }
   unsigned get_subsys() const override { return ceph_subsys_rgw; }
+  std::string get_trans_id() const override { return trans_id; }
 };
 
 void set_req_state_err(req_state*, int);

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -51,6 +51,8 @@ const char* LC_STATUS[] = {
       "COMPLETE"
 };
 
+thread_local std::string RGWLC::trans_id;
+
 using namespace librados;
 
 bool LCRule::valid() const
@@ -1598,6 +1600,8 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
 		       << " failed" << dendl;
     return ret;
   }
+// Set current bucket for transaction ID tracking
+  set_trans_id(bucket_name);
 
   // use a limited number of coroutines for concurrent processing
   size_t limit = cct->_conf.get_val<int64_t>("rgw_lc_max_wp_worker");
@@ -2067,8 +2071,11 @@ int RGWLC::process_bucket(int index, int max_lock_secs, LCWorker* worker,
 		     << " index: " << index << " worker ix: " << worker->ix
 		     << dendl;
 
+
   lock.unlock();
   ret = bucket_lc_process(entry.bucket, worker, thread_stop_at(), once);
+
+
   ldpp_dout(this, 5) << "RGWLC::process_bucket(): END entry 2: " << entry
     << " index: " << index << " worker ix: " << worker->ix << " ret: " << ret << dendl;
   bucket_lc_post(index, max_lock_secs, entry, ret, worker);

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -28,6 +28,7 @@
 #define MAX_ID_LEN 255
 static std::string lc_oid_prefix = "lc";
 static std::string lc_index_lock_name = "lc_process";
+static const std::string lc_trans_id_prefix = "Lifecycle";
 
 extern const char* LC_STATUS[];
 
@@ -669,13 +670,33 @@ public:
   unsigned get_subsys() const;
   std::ostream& gen_prefix(std::ostream& out) const;
 
-  private:
+  // Thread-local storage for current bucket being processed
+  static thread_local std::string trans_id;
 
+  static void set_trans_id(const std::string& bucket)
+  {
+    // Store as "Lifecycle:bucket_name" so get_trans_id() can return it directly
+    trans_id = lc_trans_id_prefix + ":" + bucket;
+  }
+
+  std::string
+  get_trans_id() const override
+  {
+    if (!trans_id.empty()) {
+      return trans_id;
+    }
+    return lc_trans_id_prefix;
+  }
+
+private:
   int handle_multipart_expiration(rgw::sal::Bucket* target,
-				  const std::multimap<std::string, lc_op>& prefix_map,
-				  ceph::async::spawn_throttle& workpool,
-				  boost::asio::yield_context yield,
-				  LCWorker* worker, time_t stop_at, bool once);
+                                  const std::multimap<std::string, lc_op>&
+                                  prefix_map,
+                                  ceph::async::spawn_throttle& workpool,
+                                  boost::asio::yield_context yield,
+                                  LCWorker* worker,
+                                  time_t stop_at,
+                                  bool once);
 };
 
 namespace rgw::lc {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -325,6 +325,9 @@ public:
   CephContext* get_cct() const override { return s->cct; }
   unsigned get_subsys() const override { return ceph_subsys_rgw; }
 
+  std::string
+  get_trans_id() const override { return s ? s->trans_id : ""; }
+
   virtual dmc::client_id dmclock_client() { return dmc::client_id::metadata; }
   virtual dmc::Cost dmclock_cost() { return 1; }
   virtual void write_ops_log_entry(rgw_log_entry& entry) const {};

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5658,8 +5658,15 @@ int RGWHandler_REST_S3::postauth_init(optional_yield y)
     return ret;
   }
 
-  ldpp_dout(s, 10) << "s->object=" << s->object
-           << " s->bucket=" << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name) << dendl;
+  ldpp_dout(s, 10) << "s->user=" << s->user->get_display_name()
+                   << " s->object=" << s->object
+                   << " s->bucket=" << rgw_make_bucket_entry_name(
+                      s->bucket_tenant, s->bucket_name)
+                   << " s->trans_id=" << s->trans_id
+                   << " s->op_type=" << (get_op()
+                                           ? get_op()->name()
+                                           : std::to_string(
+                                               s->op_type)) << dendl;
 
   ret = rgw_validate_tenant_name(s->bucket_tenant);
   if (ret)

--- a/src/rgw/services/svc_cls.cc
+++ b/src/rgw/services/svc_cls.cc
@@ -299,7 +299,7 @@ int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
   if (!completion) {
     r = obj.operate(dpp, std::move(op), y);
   } else {
-    r = obj.aio_operate(completion, &op);
+    r = obj.aio_operate(dpp, completion, &op);
   }
   return r;
 }
@@ -375,7 +375,7 @@ int RGWSI_Cls::TimeLog::info_async(const DoutPrefixProvider *dpp,
 
   cls_log_info(op, header);
 
-  int ret = obj.aio_operate(completion, &op, nullptr);
+  int ret = obj.aio_operate(dpp, completion, &op, nullptr);
   if (ret < 0)
     return ret;
 
@@ -404,7 +404,7 @@ int RGWSI_Cls::TimeLog::trim(const DoutPrefixProvider *dpp,
   if (!completion) {
     r = obj.operate(dpp, std::move(op), y);
   } else {
-    r = obj.aio_operate(completion, &op);
+    r = obj.aio_operate(dpp, completion, &op);
   }
   return r;
 }


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
