### PR TITLE
tentacle: test/encoding/readable: Add backward incompat checks

### DIFF
--- a/qa/workunits/dencoder/test-dencoder.sh
+++ b/qa/workunits/dencoder/test-dencoder.sh
@@ -7,6 +7,7 @@ ceph-dencoder version
 # clone the corpus repository on the host
 git clone -b master https://github.com/ceph/ceph-object-corpus.git $CEPH_MNT/client.0/tmp/ceph-object-corpus-master
 
-$mydir/test_readable.py $CEPH_MNT/client.0/tmp/ceph-object-corpus-master
+export CORPUS_PATH=$CEPH_MNT/client.0/tmp/ceph-object-corpus-master
+$mydir/../../../src/test/encoding/readable.sh
 
 echo $0 OK

--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-source $(dirname $0)/../detect-build-env-vars.sh
 
 [ -z "$CEPH_ROOT" ] && CEPH_ROOT=..
 
-dir=$CEPH_ROOT/ceph-object-corpus
+# check if CORPUS_PATH is set then use it for dir, if not use $CEPH_ROOT/ceph-object-corpus
+if [ -n "$CORPUS_PATH" ]; then
+    dir=$CORPUS_PATH
+else
+    source $(dirname $0)/../detect-build-env-vars.sh
+    dir=$CEPH_ROOT/ceph-object-corpus
+fi
 
 failed=0
 numtests=0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74999

---

backport of https://github.com/ceph/ceph/pull/66544
parent tracker: https://tracker.ceph.com/issues/74074

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh