### PR TITLE
rgw/multisite: fix data full sync timestamp

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2786,6 +2786,12 @@ options:
   - runtime
   see_also:
   - rgw_inject_delay_sec
+- name: rgw_data_sync_single_entry_inject_err_probability
+  type: float
+  level: dev
+  default: 0
+  services:
+  - rgw
   with_legacy: true
 - name: rgw_sync_trace_history_size
   type: size

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -646,6 +646,7 @@ public:
           RGWDataChangesLogInfo& info = shards_info[i];
           auto& marker = status->sync_markers[i];
           marker.next_step_marker = info.marker;
+          // timestamp from remote is epoch zero when datalog shards are empty.
           marker.timestamp = info.last_update;
           const auto& oid = RGWDataSyncStatusManager::shard_obj_name(sc->source_zone, i);
           auto& objv = objvs[i];
@@ -1438,6 +1439,8 @@ class RGWDataSyncSingleEntryCR : public RGWCoroutine {
 
   ceph::real_time progress;
   int sync_status = 0;
+  bool error_inject{false};
+
 public:
   RGWDataSyncSingleEntryCR(RGWDataSyncCtx *_sc, rgw::bucket_sync::Handle state,
                            rgw_data_sync_obligation _obligation,
@@ -1451,6 +1454,7 @@ public:
       lease_cr(std::move(lease_cr)) {
     set_description() << "data sync single entry (source_zone=" << sc->source_zone << ") " << obligation;
     tn = sync_env->sync_tracer->add_node(_tn_parent, "entry", to_string(obligation.bs, obligation.gen));
+    error_inject = (sync_env->cct->_conf->rgw_data_sync_single_entry_inject_err_probability > 0);
   }
 
   int operate(const DoutPrefixProvider *dpp) override {
@@ -1482,13 +1486,23 @@ public:
           obligation_counter = state->counter;
           progress = ceph::real_time{};
 
+          ldout(cct, 4) << "state obligation timestamp: " << state->obligation->timestamp << ' '
+              << "obligation timestamp: " << obligation.timestamp << dendl;
+
           ldout(cct, 4) << "starting sync on " << bucket_shard_str{state->key.first}
-              << ' ' << *state->obligation << " progress timestamp " << state->progress_timestamp
-              << " progress " << progress << dendl;
-          yield call(new RGWRunBucketSourcesSyncCR(sc, lease_cr,
-                                                   state->key.first, tn,
-                                                   state->obligation->gen,
-						   &progress));
+            << ' ' << *state->obligation << " progress timestamp " << state->progress_timestamp
+            << " progress " << progress << dendl;
+
+          if (error_inject &&
+              rand() % 10000 < cct->_conf->rgw_data_sync_single_entry_inject_err_probability * 10000.0) {
+             ldout(cct, 10) << " RGWDataSyncSingleEntryCR() injecting error "<< state->key.first << dendl;
+            retcode = -EIO;
+          } else {
+            yield call(new RGWRunBucketSourcesSyncCR(sc, lease_cr,
+                                                    state->key.first, tn,
+                                                    state->obligation->gen,
+                &progress));
+          }
           if (retcode < 0) {
             break;
           }
@@ -1497,6 +1511,8 @@ public:
         // any new obligations will process themselves
         complete = std::move(*state->obligation);
         state->obligation.reset();
+
+        tn->log(10, SSTR("complete timestamp: " <<  complete->timestamp));
 
         tn->log(10, SSTR("sync finished on " << bucket_shard_str{state->key.first}
                          << " progress=" << progress << ' ' << complete << " r=" << retcode));
@@ -1521,14 +1537,13 @@ public:
             tn->log(0, SSTR("ERROR: failed to log sync failure: retcode=" << retcode));
           }
         }
-        if (complete->timestamp != ceph::real_time{}) {
-          tn->log(10, SSTR("writing " << *complete << " to error repo for retry"));
-          yield call(rgw::error_repo::write_cr(sync_env->driver->getRados()->get_rados_handle(), error_repo,
-                                              rgw::error_repo::encode_key(complete->bs, complete->gen),
-                                              complete->timestamp));
-          if (retcode < 0) {
-            tn->log(0, SSTR("ERROR: failed to log sync failure in error repo: retcode=" << retcode));
-          }
+
+        tn->log(10, SSTR("writing " << *complete << " to error repo for retry"));
+        yield call(rgw::error_repo::write_cr(sync_env->driver->getRados()->get_rados_handle(), error_repo,
+                                            rgw::error_repo::encode_key(complete->bs, complete->gen),
+                                            complete->timestamp));
+        if (retcode < 0) {
+          tn->log(0, SSTR("ERROR: failed to log sync failure in error repo: retcode=" << retcode));
         }
       } else if (complete->retry) {
         yield call(rgw::error_repo::remove_cr(sync_env->driver->getRados()->get_rados_handle(), error_repo,

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2357,14 +2357,15 @@ class RGWDataSyncShardControlCR : public RGWBackoffControlCR {
 public:
   RGWDataSyncShardControlCR(RGWDataSyncCtx *_sc, const rgw_pool& _pool,
                            uint32_t _shard_id, rgw_data_sync_marker& _marker,
-                           const rgw_data_sync_status& sync_status,
+                           const rgw_data_sync_status& _sync_status,
                            RGWObjVersionTracker& objv,
                            RGWSyncTraceNodeRef& _tn_parent)
           : RGWBackoffControlCR(_sc->cct, false),
           sc(_sc), sync_env(_sc->env),
           pool(_pool),
           shard_id(_shard_id),
-          sync_marker(_marker), objv(objv) {
+          sync_marker(_marker),
+          sync_status(_sync_status), objv(objv) {
     tn = sync_env->sync_tracer->add_node(_tn_parent, "shard", std::to_string(shard_id));
   }
 


### PR DESCRIPTION

so that the full sync entries can be written to error repo upon failure

https://tracker.ceph.com/issues/75010
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
