### PR TITLE
mgr/dashboard : Delete certificate API

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/certificate.py
+++ b/src/pybind/mgr/dashboard/controllers/certificate.py
@@ -10,7 +10,7 @@ from ..services.certificate import CertificateService
 from ..services.exception import handle_orchestrator_error
 from ..services.orchestrator import OrchClient, OrchFeature
 from ..tools import str_to_bool
-from . import APIDoc, APIRouter, EndpointDoc, ReadPermission, RESTController
+from . import APIDoc, APIRouter, DeletePermission, EndpointDoc, ReadPermission, RESTController
 from .orchestrator import raise_if_no_orchestrator
 
 
@@ -145,6 +145,32 @@ class Certificate(RESTController):
             cert_details, cert_name or user_cert_name, cert_scope_str, target_key,
             include_target=True, include_details=True
         )
+
+    @EndpointDoc("Delete Certificate for Service",
+                 parameters={
+                     'service_name': (str, 'Service name (e.g., "rgw.myzone")')
+                 })
+    @raise_if_no_orchestrator([OrchFeature.SERVICE_LIST, OrchFeature.DAEMON_LIST])
+    @DeletePermission
+    @handle_orchestrator_error('certificate')
+    def delete(self, service_name: str) -> None:
+        """
+        Remove certificate and key for a service.
+
+        This endpoint removes all certificates associated with a service.
+        For HOST scope certificates (like cephadm-signed), it removes
+        certificates from all hosts where the service daemons run.
+
+        :param service_name: The service name, e.g. 'rgw.myzone'.
+        :return: None
+        """
+        orch = OrchClient.instance()
+
+        try:
+            CertificateService.delete_service_certificate(orch, service_name)
+        except LookupError as e:
+            raise DashboardException(msg=str(e), http_status_code=404,
+                                     component='certificate')
 
     @EndpointDoc("Get Root CA Certificate",
                  responses={

--- a/src/pybind/mgr/dashboard/model/certificate.py
+++ b/src/pybind/mgr/dashboard/model/certificate.py
@@ -4,9 +4,9 @@ Model definitions for certificate API responses.
 These classes centralize the enums and response shapes so callers avoid
 constructing ad-hoc dictionaries and can rely on consistent typing.
 """
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 
 class CertificateStatus(str, Enum):
@@ -82,6 +82,23 @@ class CertificateStatusResponse:
         for key in self.BOOL_FIELDS:
             if data.get(key) is None:
                 data[key] = False
+        return data
+
+
+@dataclass
+class CertificateDeleteResponse:
+    """Response for certificate deletion operation."""
+    service_name: str
+    cert_name: str
+    certificate_removed: Union[str, List[Dict[str, str]], None] = None
+    key_removed: Union[str, List[Dict[str, str]], None] = None
+    errors: Optional[List[str]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        # Convert None errors to empty list for consistent API response
+        if data.get('errors') is None:
+            data['errors'] = []
         return data
 
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -22545,6 +22545,53 @@ paths:
       tags:
       - Service
   /api/service/certificate/{service_name}:
+    delete:
+      description: "\n        Remove certificate and key for a service.\n\n      \
+        \  This endpoint removes all certificates associated with a service.\n   \
+        \     For HOST scope certificates (like cephadm-signed), it removes\n    \
+        \    certificates from all hosts where the service daemons run.\n\n      \
+        \  :param service_name: The service name, e.g. 'rgw.myzone'.\n        :return:\
+        \ None\n        "
+      parameters:
+      - description: Service name (e.g., "rgw.myzone")
+        in: path
+        name: service_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Operation is still executing. Please check the task queue.
+        '204':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Resource deleted.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Delete Certificate for Service
+      tags:
+      - Service
     get:
       description: "\n        Get detailed certificate information for a service.\n\
         \n        :param service_name: The service name, e.g. 'rgw.myzone'.\n    \

--- a/src/pybind/mgr/dashboard/services/certificate.py
+++ b/src/pybind/mgr/dashboard/services/certificate.py
@@ -6,11 +6,12 @@ This service provides certificate management functionality following the
 handling is contained here.
 """
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from .. import mgr
-from ..model.certificate import CEPHADM_SIGNED_CERT, CertificateListEntry, \
-    CertificateScope, CertificateStatus, CertificateStatusResponse
+from ..model.certificate import CEPHADM_SIGNED_CERT, \
+    CertificateDeleteResponse, CertificateListEntry, CertificateScope, \
+    CertificateStatus, CertificateStatusResponse
 from .orchestrator import OrchClient
 
 
@@ -550,3 +551,146 @@ class CertificateService:
         except NotImplementedError:
             # Orchestrator doesn't support certificate operations
             return {}
+
+    @staticmethod
+    def _remove_cert_and_key(orch: Any, cert_name: str,
+                             service_name: Optional[str] = None,
+                             hostname: Optional[str] = None) -> Dict[str, Any]:
+        """Remove a single certificate and its key."""
+        results: Dict[str, Any] = {'certificate': None, 'key': None, 'errors': []}
+        key_name = cert_name.replace('_cert', '_key')
+
+        results['certificate'] = orch.cert_store.rm_cert(cert_name, service_name, hostname)
+        results['key'] = orch.cert_store.rm_key(key_name, service_name, hostname)
+
+        return results
+
+    @staticmethod
+    def remove_certificate_for_service(
+        orch: Any, cert_name: str, cert_scope: str, service_name: str,
+        target_key: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Remove certificate and key for a service (single target)."""
+        scope_upper = cert_scope.upper()
+        rm_service = service_name if scope_upper == CertificateScope.SERVICE.value.upper() else None
+        rm_host = target_key if scope_upper == CertificateScope.HOST.value.upper() else None
+        return CertificateService._remove_cert_and_key(orch, cert_name, rm_service, rm_host)
+
+    @staticmethod
+    def remove_all_certificates_for_service(
+        orch: Any, cert_name: str, cert_scope: str, service_name: str,
+        daemon_hostnames: List[str], target_key: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Remove certificates for a service. For HOST scope, removes from all hosts.
+        """
+        is_host_scope = cert_scope.upper() == CertificateScope.HOST.value.upper()
+
+        if not is_host_scope or not daemon_hostnames:
+            result = CertificateService.remove_certificate_for_service(
+                orch, cert_name, cert_scope, service_name, target_key)
+            return CertificateDeleteResponse(
+                service_name=service_name,
+                cert_name=cert_name,
+                certificate_removed=result['certificate'],
+                key_removed=result['key'],
+                errors=result['errors'] or None
+            ).to_dict()
+
+        # HOST scope: remove from all hosts
+        certs_removed, keys_removed, errors = [], [], []
+        for hostname in daemon_hostnames:
+            result = CertificateService._remove_cert_and_key(orch, cert_name, None, hostname)
+            if result['certificate']:
+                certs_removed.append({'hostname': hostname, 'result': result['certificate']})
+            if result['key']:
+                keys_removed.append({'hostname': hostname, 'result': result['key']})
+            errors.extend([f"{hostname}: {e}" for e in result['errors']])
+
+        return CertificateDeleteResponse(
+            service_name=service_name,
+            cert_name=cert_name,
+            certificate_removed=certs_removed,
+            key_removed=keys_removed,
+            errors=errors or None
+        ).to_dict()
+
+    @staticmethod
+    def delete_service_certificate(orch: Any, service_name: str) -> Dict[str, Any]:
+        """
+        Delete certificate and key for a service.
+
+        This method handles the complete workflow of finding and removing
+        certificates for a service, including HOST scope certificates
+        that need to be removed from all daemon hosts.
+
+        It also handles orphaned certificates where the service no longer exists
+        but certificates remain in certmgr.
+
+        :param orch: Orchestrator client instance
+        :param service_name: Service name (e.g., 'rgw.myzone')
+        :return: Dictionary with deletion results
+        :raises: LookupError if no certificate found for service
+        """
+        from ceph.deployment.service_spec import ServiceSpec
+
+        services = orch.services.get(service_name)
+        daemon_hostnames: List[str] = []
+
+        if services:
+            service = services[0]
+            service_type = service.spec.service_type
+            service_name_full = service.spec.service_name()
+            daemon_hostnames, _ = CertificateService.get_daemon_hostnames(orch, service_name_full)
+        else:
+            service_type = service_name.split('.')[0]
+            service_name_full = service_name
+
+        cert_config: Dict[str, Any] = cast(
+            Dict[str, Any], ServiceSpec.REQUIRES_CERTIFICATES.get(service_type, {}))
+        cert_scope = CertificateScope(cert_config.get('scope', CertificateScope.SERVICE.value))
+
+        user_cert_name = f"{service_type.replace('-', '_')}_ssl_cert"
+        cephadm_cert_name = f"cephadm-signed_{service_type}_cert"
+
+        cert_ls_data = CertificateService.fetch_certificates_for_service(
+            orch, service_type, user_cert_name, cephadm_cert_name)
+
+        # for orphaned certificates, get hostnames from certificate data
+        if not daemon_hostnames:
+            daemon_hostnames = CertificateService._get_hostnames_from_cert_data(
+                cert_ls_data, user_cert_name, cephadm_cert_name, service_name_full)
+
+        cert_details, target_key, cert_name, cert_scope_str = \
+            CertificateService.find_certificate_for_service(
+                cert_ls_data, service_type, service_name_full, cert_scope, daemon_hostnames)
+
+        if not cert_details:
+            raise LookupError(f'No certificate found for service {service_name}')
+
+        return CertificateService.remove_all_certificates_for_service(
+            orch, cert_name, cert_scope_str, service_name_full, daemon_hostnames, target_key)
+
+    @staticmethod
+    def _get_hostnames_from_cert_data(cert_ls_data: Dict[str, Any], user_cert_name: str,
+                                      cephadm_cert_name: str, service_name: str) -> List[str]:
+        """
+        Extract hostnames from certificate data for orphaned certificates.
+
+        :param cert_ls_data: Certificate list data
+        :param user_cert_name: User-provided certificate name
+        :param cephadm_cert_name: Cephadm-signed certificate name
+        :param service_name: Service name
+        :return: List of hostnames found in certificate data
+        """
+        hostnames: List[str] = []
+        cephadm_cert_name_by_service = f"cephadm-signed_{service_name}_cert"
+
+        for cert_name in [user_cert_name, cephadm_cert_name, cephadm_cert_name_by_service]:
+            if cert_name in cert_ls_data:
+                cert_data = cert_ls_data[cert_name]
+                certificates = cert_data.get('certificates', {})
+                if isinstance(certificates, dict):
+                    hostnames.extend(certificates.keys())
+
+        return list(set(hostnames))

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -227,6 +227,16 @@ class CertStoreManager(ResourceManager):
                 include_cephadm_signed: bool = False) -> Dict[str, Any]:
         return self.api.cert_store_cert_ls(filter_by, show_details, include_cephadm_signed)
 
+    @wait_api_result
+    def rm_cert(self, cert_name: str, service_name: Optional[str] = None,
+                hostname: Optional[str] = None) -> str:
+        return self.api.cert_store_rm_cert(cert_name, service_name, hostname)
+
+    @wait_api_result
+    def rm_key(self, key_name: str, service_name: Optional[str] = None,
+               hostname: Optional[str] = None) -> str:
+        return self.api.cert_store_rm_key(key_name, service_name, hostname)
+
 
 class MonitoringManager(ResourceManager):
 

--- a/src/pybind/mgr/dashboard/tests/test_certificate.py
+++ b/src/pybind/mgr/dashboard/tests/test_certificate.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 from unittest.mock import patch
 
-from orchestrator import DaemonDescription
+from orchestrator import DaemonDescription, OrchestratorError
 
 from ..controllers._version import APIVersion
 from ..controllers.certificate import Certificate
@@ -535,6 +535,161 @@ class CertificateGetControllerTest(CertificateTestBase):
         result = self.json_body()
         self.assertEqual(result['scope'], 'HOST')
         self.assertEqual(result['target'], 'node0')
+
+
+class CertificateDeleteControllerTest(CertificateTestBase):
+    """Tests for the certificate delete() endpoint."""
+
+    @mock.patch('dashboard.controllers.certificate.OrchClient.instance')
+    def test_delete_certificate_success(self, instance):
+        """Test deleting certificate for a service successfully."""
+        fake_client = self._setup_fake_client(mock.Mock())
+        service = mock.Mock()
+        service.spec = mock.Mock()
+        service.spec.service_type = 'rgw'
+        service.spec.service_name = mock.Mock(return_value='rgw.test')
+        fake_client.services.get.return_value = [service]
+
+        cert_details = self._create_mock_cert_details()
+        cert_ls_data = self._create_mock_cert_ls_data(
+            cert_name='rgw_ssl_cert',
+            scope='SERVICE',
+            service_name='rgw.test',
+            cert_details=cert_details
+        )
+        fake_client.cert_store.cert_ls.return_value = cert_ls_data
+        fake_client.services.list_daemons.return_value = []
+        fake_client.cert_store.rm_cert.return_value = 'Certificate removed'
+        fake_client.cert_store.rm_key.return_value = 'Key removed'
+        instance.return_value = fake_client
+
+        self._delete('{}/rgw.test'.format(self.URL_CERTIFICATE))
+        self.assertStatus(204)
+
+    @mock.patch('dashboard.controllers.certificate.OrchClient.instance')
+    def test_delete_certificate_orphaned_service_with_cert(self, instance):
+        """Test deleting orphaned certificate when service no longer exists."""
+        fake_client = self._setup_fake_client(mock.Mock())
+        fake_client.services.get.return_value = []  # Service doesn't exist
+
+        cert_details = self._create_mock_cert_details()
+        cert_ls_data = self._create_mock_cert_ls_data(
+            cert_name='rgw_ssl_cert',
+            scope='SERVICE',
+            service_name='rgw.orphaned',
+            cert_details=cert_details
+        )
+        fake_client.cert_store.cert_ls.return_value = cert_ls_data
+        fake_client.cert_store.rm_cert.return_value = 'Certificate removed'
+        fake_client.cert_store.rm_key.return_value = 'Key removed'
+        instance.return_value = fake_client
+
+        self._delete('{}/rgw.orphaned'.format(self.URL_CERTIFICATE))
+        self.assertStatus(204)
+
+    @mock.patch('dashboard.controllers.certificate.OrchClient.instance')
+    def test_delete_certificate_not_found(self, instance):
+        """Test deleting certificate when no certificate exists."""
+        fake_client = self._setup_fake_client(mock.Mock())
+        service = mock.Mock()
+        service.spec = mock.Mock()
+        service.spec.service_type = 'rgw'
+        service.spec.service_name = mock.Mock(return_value='rgw.test')
+        fake_client.services.get.return_value = [service]
+        fake_client.cert_store.cert_ls.return_value = {}
+        fake_client.services.list_daemons.return_value = []
+        instance.return_value = fake_client
+
+        self._delete('{}/rgw.test'.format(self.URL_CERTIFICATE))
+        self.assertStatus(404)
+
+    @mock.patch('dashboard.controllers.certificate.OrchClient.instance')
+    def test_delete_certificate_host_scope(self, instance):
+        """Test deleting certificate with HOST scope removes from all hosts."""
+        fake_client = self._setup_fake_client(mock.Mock())
+        service = mock.Mock()
+        service.spec = mock.Mock()
+        service.spec.service_type = 'grafana'
+        service.spec.service_name = mock.Mock(return_value='grafana.test')
+        fake_client.services.get.return_value = [service]
+
+        cert_details = self._create_mock_cert_details()
+        cert_ls_data = {
+            'grafana_ssl_cert': {
+                'scope': 'HOST',
+                'certificates': {
+                    'node0': cert_details,
+                    'node1': cert_details
+                }
+            }
+        }
+        fake_client.cert_store.cert_ls.return_value = cert_ls_data
+        fake_client.services.list_daemons.return_value = [
+            DaemonDescription(daemon_type='grafana', daemon_id='test1', hostname='node0'),
+            DaemonDescription(daemon_type='grafana', daemon_id='test2', hostname='node1')
+        ]
+        fake_client.cert_store.rm_cert.return_value = 'Certificate removed'
+        fake_client.cert_store.rm_key.return_value = 'Key removed'
+        instance.return_value = fake_client
+
+        self._delete('{}/grafana.test'.format(self.URL_CERTIFICATE))
+        self.assertStatus(204)
+
+    @mock.patch('dashboard.controllers.certificate.OrchClient.instance')
+    def test_delete_certificate_cephadm_signed(self, instance):
+        """Test deleting cephadm-signed certificate."""
+        fake_client = self._setup_fake_client(mock.Mock())
+        service = mock.Mock()
+        service.spec = mock.Mock()
+        service.spec.service_type = 'rgw'
+        service.spec.service_name = mock.Mock(return_value='rgw.test')
+        fake_client.services.get.return_value = [service]
+
+        cert_details = self._create_mock_cert_details()
+        cert_ls_data = {
+            'cephadm-signed_rgw_cert': {
+                'scope': 'HOST',
+                'certificates': {
+                    'node0': cert_details
+                }
+            }
+        }
+        fake_client.cert_store.cert_ls.return_value = cert_ls_data
+        fake_client.services.list_daemons.return_value = [
+            DaemonDescription(daemon_type='rgw', daemon_id='test', hostname='node0')
+        ]
+        fake_client.cert_store.rm_cert.return_value = 'Certificate removed'
+        fake_client.cert_store.rm_key.return_value = 'Key removed'
+        instance.return_value = fake_client
+
+        self._delete('{}/rgw.test'.format(self.URL_CERTIFICATE))
+        self.assertStatus(204)
+
+    @mock.patch('dashboard.controllers.certificate.OrchClient.instance')
+    def test_delete_certificate_with_errors(self, instance):
+        """Test deleting certificate when removal fails."""
+        fake_client = self._setup_fake_client(mock.Mock())
+        service = mock.Mock()
+        service.spec = mock.Mock()
+        service.spec.service_type = 'rgw'
+        service.spec.service_name = mock.Mock(return_value='rgw.test')
+        fake_client.services.get.return_value = [service]
+
+        cert_details = self._create_mock_cert_details()
+        cert_ls_data = self._create_mock_cert_ls_data(
+            cert_name='rgw_ssl_cert',
+            scope='SERVICE',
+            service_name='rgw.test',
+            cert_details=cert_details
+        )
+        fake_client.cert_store.cert_ls.return_value = cert_ls_data
+        fake_client.services.list_daemons.return_value = []
+        fake_client.cert_store.rm_cert.side_effect = OrchestratorError('Permission denied')
+        fake_client.cert_store.rm_key.side_effect = OrchestratorError('Permission denied')
+        instance.return_value = fake_client
+
+        self._delete('{}/rgw.test'.format(self.URL_CERTIFICATE))
+        self.assertStatus(400)
 
 
 class CertificateRootCAControllerTest(CertificateTestBase):


### PR DESCRIPTION
Signed-off-by: Abhishek Desai <abhishek.desai1@ibm.com>

This API is not used in UI.

### Delete Certificate API

<img width="2502" height="2218" alt="image" src="https://github.com/user-attachments/assets/09801370-2adb-4df1-a15c-795133bd3c02" />


<img width="2506" height="2186" alt="image" src="https://github.com/user-attachments/assets/d8fbefbc-9d1e-449c-99cd-5b5fb83555a3" />




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
