### PR TITLE
rgw: add tcmalloc heap profiler support via admin socket

### DIFF
--- a/doc/rados/troubleshooting/memory-profiling.rst
+++ b/doc/rados/troubleshooting/memory-profiling.rst
@@ -2,7 +2,7 @@
  Memory Profiling
 ==================
 
-Ceph Monitor, OSD, and MDS can report ``TCMalloc`` heap profiles. Install
+Ceph Monitor, OSD, MDS, and RGW can report ``TCMalloc`` heap profiles. Install
 ``google-perftools`` if you want to generate these. Your OS distribution might
 package this under a different name (for example, ``gperftools``), and your OS
 distribution might use a different package manager. Run a command similar to
@@ -74,8 +74,8 @@ the heap profiler. You can enable or disable the heap profiler at runtime, or
 ensure that it runs continuously. When running commands based on the examples
 that follow, do the following:
 
-#. replace ``{daemon-type}`` with ``mon``, ``osd`` or ``mds`` 
-#. replace ``{daemon-id}`` with the OSD number or the MON ID or the MDS ID 
+#. replace ``{daemon-type}`` with ``mon``, ``osd``, or ``mds``
+#. replace ``{daemon-id}`` with the OSD number, the MON ID, or the MDS ID
 
 
 Starting the Profiler
@@ -114,6 +114,26 @@ For example:
 .. note:: The reporting of stats with this command does not require the
    profiler to be running and does not dump the heap allocation information to
    a file.
+
+RGW Heap Profiling
+------------------
+
+For RGW daemons, heap profiling commands are available via the admin socket
+using ``ceph daemon`` instead of ``ceph tell``:
+
+.. prompt:: bash
+
+   ceph daemon /var/run/ceph/ceph-client.rgw.<id>.asok heap stats
+
+For example, in a vstart environment:
+
+.. prompt:: bash
+
+   ceph daemon ./run/ceph-client.rgw.8000.asok heap stats
+
+All heap subcommands (``stats``, ``start_profiler``, ``stop_profiler``,
+``dump``, ``release``, ``get_release_rate``, ``set_release_rate``) are
+supported for RGW.
 
 
 Dumping Heap Information

--- a/qa/suites/rgw/tools/tasks.yaml
+++ b/qa/suites/rgw/tools/tasks.yaml
@@ -10,6 +10,7 @@ tasks:
     clients:
        client.0:
            - rgw/test_rgw_orphan_list.sh
+           - rgw/test_rgw_heap_profiler.sh
 overrides:
   ceph:
     conf:

--- a/qa/workunits/rgw/test_rgw_heap_profiler.sh
+++ b/qa/workunits/rgw/test_rgw_heap_profiler.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# -*- mode:shell-script; tab-width:8; sh-basic-offset:2; indent-tabs-mode:nil -*-
+#
+# Test RGW tcmalloc heap profiler via admin socket (ceph daemon).
+# Run after vstart.sh or in teuthology with at least one RGW running.
+
+set -e
+
+TEST_TMPDIR=$(mktemp -d)
+PROFILER_RUNNING=0
+
+cleanup() {
+  # If we're exiting (e.g. via set -e or fail()) while the profiler is
+  # still on, stop it so we don't leave profiling enabled in this shared
+  # RGW daemon after the test exits.
+  if [ "$PROFILER_RUNNING" = "1" ]; then
+    rgw_admin heap stop_profiler >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TEST_TMPDIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+if [ -x ./bin/ceph ]; then
+  CEPH=$(readlink -f ./bin/ceph)
+elif command -v ceph >/dev/null 2>&1; then
+  CEPH=$(command -v ceph)
+else
+  echo "ceph not found in PATH or ./bin/ceph; skipping test."
+  exit 0
+fi
+
+get_rgw_socket() {
+  if [ -n "$RGW_ADMIN_SOCKET" ]; then
+    echo "$RGW_ADMIN_SOCKET"
+    return
+  fi
+  # In teuthology, qa/tasks/rgw.py starts radosgw as "-n client.$CEPH_ID",
+  # and the workunit runner exports CEPH_ID for the client role running this
+  # script.  The admin socket path may or may not include the daemon PID
+  # (ceph-client.$ID.asok vs ceph-client.$ID.$PID.asok) depending on the
+  # cluster's "admin socket" config template.
+  if [ -n "$CEPH_ID" ]; then
+    if [ -S "/var/run/ceph/ceph-client.${CEPH_ID}.asok" ]; then
+      echo "/var/run/ceph/ceph-client.${CEPH_ID}.asok"
+      return
+    fi
+    local socket
+    socket=$(ls /var/run/ceph/ceph-client.${CEPH_ID}.*.asok 2>/dev/null | head -1)
+    if [ -n "$socket" ]; then
+      echo "$socket"
+      return
+    fi
+  fi
+  local socket
+  # vstart.sh dev builds: socket is in ./out/ relative to the build dir
+  socket=$(ls ./out/radosgw.*.asok 2>/dev/null | head -1)
+  if [ -n "$socket" ]; then
+    echo "$socket"
+    return
+  fi
+  for dir in ./run /var/run/ceph; do
+    socket=$(ls "${dir}"/ceph-client.rgw.*.asok 2>/dev/null | head -1)
+    if [ -n "$socket" ]; then
+      echo "$socket"
+      return
+    fi
+  done
+  echo ""
+}
+
+RGW_SOCKET=$(get_rgw_socket)
+if [ -z "$RGW_SOCKET" ]; then
+  echo "No RGW admin socket found; is RGW running? Set RGW_ADMIN_SOCKET if needed."
+  exit 1
+fi
+echo "Using RGW admin socket: $RGW_SOCKET"
+
+# radosgw runs under sudo in teuthology (see qa/tasks/rgw.py), so its admin
+# socket there is root-owned; qa/tasks/admin_socket.py accordingly invokes
+# "ceph --admin-daemon" via sudo. Detect that case and route our commands
+# through sudo too, while keeping direct access for user-owned sockets
+# (e.g. a local vstart.sh run) so this also works without sudo configured.
+if [ -r "$RGW_SOCKET" ] && [ -w "$RGW_SOCKET" ]; then
+  NEED_SUDO=""
+else
+  NEED_SUDO="sudo"
+fi
+
+rgw_admin() {
+  $NEED_SUDO $CEPH daemon "$RGW_SOCKET" "$@"
+}
+
+# --- Test 1: heap stats (does not require profiler to be running) ---
+echo "=== Test: heap stats ==="
+set +e
+rgw_admin heap stats > "$TEST_TMPDIR/stats.out" 2>&1
+rc=$?
+set -e
+
+if grep -q "not using tcmalloc" "$TEST_TMPDIR/stats.out"; then
+  echo "tcmalloc not in use; skipping remaining tests."
+  exit 0
+fi
+
+if [ $rc -ne 0 ]; then
+  echo "heap stats failed with rc=$rc:"
+  cat "$TEST_TMPDIR/stats.out"
+  exit $rc
+fi
+
+grep -q "tcmalloc heap stats" "$TEST_TMPDIR/stats.out" ||
+  grep -q "MALLOC:" "$TEST_TMPDIR/stats.out" ||
+  fail "heap stats output missing expected content"
+echo "heap stats OK"
+
+# --- Test 2: start_profiler ---
+echo "=== Test: heap start_profiler ==="
+rgw_admin heap start_profiler > "$TEST_TMPDIR/start.out" 2>&1
+grep -q "started profiler" "$TEST_TMPDIR/start.out" ||
+  fail "start_profiler did not report success"
+PROFILER_RUNNING=1
+echo "start_profiler OK"
+
+# --- Test 3: heap dump (requires profiler running) ---
+echo "=== Test: heap dump ==="
+rgw_admin heap dump > "$TEST_TMPDIR/dump.out" 2>&1
+grep -q "dumping heap profile" "$TEST_TMPDIR/dump.out" ||
+  fail "heap dump did not report expected output"
+echo "heap dump OK"
+
+# --- Test 4: stop_profiler ---
+echo "=== Test: heap stop_profiler ==="
+rgw_admin heap stop_profiler > "$TEST_TMPDIR/stop.out" 2>&1
+grep -q "stopped profiler" "$TEST_TMPDIR/stop.out" ||
+  fail "stop_profiler did not report success"
+PROFILER_RUNNING=0
+echo "stop_profiler OK"
+
+# --- Test 5: heap release ---
+echo "=== Test: heap release ==="
+rgw_admin heap release > "$TEST_TMPDIR/release.out" 2>&1
+grep -q "releasing free RAM" "$TEST_TMPDIR/release.out" ||
+  fail "heap release did not report expected output"
+echo "heap release OK"
+
+# --- Test 6: get_release_rate ---
+echo "=== Test: heap get_release_rate ==="
+rgw_admin heap get_release_rate > "$TEST_TMPDIR/getrate.out" 2>&1
+grep -q "release rate" "$TEST_TMPDIR/getrate.out" ||
+  fail "get_release_rate did not report expected output"
+echo "get_release_rate OK"
+
+# --- Test 7: set_release_rate (round-trips the rate read above back to
+# itself, so the value-forwarding/argument-parsing path is exercised
+# without actually changing daemon state) ---
+echo "=== Test: heap set_release_rate ==="
+current_rate=$(sed -n 's/.*release rate: *\([^[:space:]]*\).*/\1/p' "$TEST_TMPDIR/getrate.out")
+if [ -z "$current_rate" ]; then
+  fail "could not parse current release rate from get_release_rate output"
+fi
+rgw_admin heap set_release_rate "$current_rate" > "$TEST_TMPDIR/setrate.out" 2>&1
+grep -q "release rate changed" "$TEST_TMPDIR/setrate.out" ||
+  fail "set_release_rate did not report expected output"
+echo "set_release_rate OK"
+
+echo ""
+echo "All RGW heap profiler tests passed."
+exit 0

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -683,6 +683,7 @@ if(WITH_RADOSGW_STANDALONE)
     PRIVATE
     rgw_schedulers
     kmip
+    heap_profiler
     legacy-option-headers
     common_utf8 global
     ${CRYPTO_LIBS}
@@ -741,6 +742,7 @@ target_include_directories(radosgw
 target_link_libraries(radosgw PRIVATE
   legacy-option-headers
   ${rgw_libs}
+  heap_profiler
   ${ALLOC_LIBS})
 
 if(WITH_RADOSGW_FDB)
@@ -953,6 +955,7 @@ target_link_libraries(rgw
   PRIVATE
   ${rgw_libs}
   rgw_common
+  heap_profiler
   librados
   cls_rgw_client
   cls_otp_client

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -17,6 +17,8 @@
 #include <boost/intrusive/list.hpp>
 #include "global/global_init.h"
 #include "global/signal_handler.h"
+#include "common/admin_socket.h"
+#include "common/cmdparse.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/Timer.h"
@@ -26,6 +28,7 @@
 #include "include/compat.h"
 #include "include/str_list.h"
 #include "include/stringify.h"
+#include "perfglue/heap_profiler.h"
 #include "rgw_kms_cache.h"
 #include "rgw_main.h"
 #include "rgw_asio_thread.h"
@@ -85,18 +88,63 @@
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
+using TOPNSPC::common::cmd_getval;
 
 namespace {
   TracepointProvider::Traits rgw_op_tracepoint_traits(
     "librgw_op_tp.so", "rgw_op_tracing");
   TracepointProvider::Traits rgw_rados_tracepoint_traits(
     "librgw_rados_tp.so", "rgw_rados_tracing");
-}
+
+class RGWHeapProfilerHook : public AdminSocketHook {
+public:
+  int call(std::string_view command,
+	   const cmdmap_t& cmdmap,
+	   const ceph::buffer::list&,
+	   ceph::Formatter*,
+	   std::ostream& errss,
+	   ceph::buffer::list& out) override {
+    if (!ceph_using_tcmalloc()) {
+      errss << "not using tcmalloc";
+      return -EOPNOTSUPP;
+    }
+    string heapcmd;
+    if (!cmd_getval(cmdmap, "heapcmd", heapcmd)) {
+      errss << "unable to get value for command \"heap\"";
+      return -EINVAL;
+    }
+    vector<string> cmd_vec;
+    get_str_vec(heapcmd, cmd_vec);
+    string value;
+    if (cmd_getval(cmdmap, "value", value)) {
+      cmd_vec.push_back(value);
+    }
+    ostringstream ss;
+    ceph_heap_profiler_handle_command(cmd_vec, ss);
+    out.append(ss.str());
+    return 0;
+  }
+};
+
+} // anonymous namespace
 
 OpsLogFile* rgw::AppMain::ops_log_file;
 
 rgw::AppMain::AppMain(const DoutPrefixProvider* dpp) : dpp(dpp), context_pool(dpp) {}
-rgw::AppMain::~AppMain() = default;
+
+rgw::AppMain::~AppMain()
+{
+  unregister_heap_profiler_hook();
+}
+
+void rgw::AppMain::unregister_heap_profiler_hook()
+{
+  if (heap_profiler_hook) {
+    g_ceph_context->get_admin_socket()->unregister_commands(heap_profiler_hook);
+    delete heap_profiler_hook;
+    heap_profiler_hook = nullptr;
+  }
+}
 
 void rgw::AppMain::init_frontends1(bool nfs) 
 {
@@ -260,6 +308,21 @@ int rgw::AppMain::init_storage()
 void rgw::AppMain::init_perfcounters()
 {
   (void) rgw_perf_start(dpp->get_cct());
+
+  ceph_heap_profiler_init();
+  unregister_heap_profiler_hook();
+  heap_profiler_hook = new RGWHeapProfilerHook();
+  int r = g_ceph_context->get_admin_socket()->register_command(
+    "heap "
+    "name=heapcmd,type=CephChoices,strings="
+    "dump|start_profiler|stop_profiler|release|get_release_rate|set_release_rate|stats "
+    "name=value,type=CephString,req=false",
+    heap_profiler_hook,
+    "show heap usage info (available only if compiled with tcmalloc)");
+  if (r < 0) {
+    delete heap_profiler_hook;
+    heap_profiler_hook = nullptr;
+  }
 } /* init_perfcounters */
 
 void rgw::AppMain::init_http_clients()
@@ -689,6 +752,7 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
   rgw::curl::cleanup_curl();
   g_conf().remove_observer(implicit_tenant_context.get());
   implicit_tenant_context.reset(); // deletes
+  unregister_heap_profiler_hook();
   rgw_perf_stop(g_ceph_context);
   ratelimiter.reset(); // deletes--ensure this happens before we destruct
 } /* AppMain::shutdown */

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -94,6 +94,8 @@ class AppMain {
   SiteConfig site;
   const DoutPrefixProvider* dpp;
   RGWProcessEnv env;
+  class AdminSocketHook* heap_profiler_hook{nullptr};
+  void unregister_heap_profiler_hook(); // idempotent; used by shutdown() and ~AppMain()
 
   class IOContextPoolHolder {
   private:


### PR DESCRIPTION
rgw: add tcmalloc heap profiler support via admin socket

Add RGWHeapProfilerHook to rgw_appmain.cc that registers a "heap" admin socket command, forwarding subcommands to the shared ceph_heap_profiler_handle_command() implementation. This enables heap stats, start_profiler, stop_profiler, dump, release, and release rate commands for RGW via "ceph daemon <socket> heap <cmd>".

Link radosgw against heap_profiler library, update memory-profiling documentation, and add an integration test script.

Signed-off-by: Vinayak Tiwari <tiwarivinayak10@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
