### PR TITLE
rgw: add per-zone sharded datalog backends

### DIFF
--- a/src/common/async/service.h
+++ b/src/common/async/service.h
@@ -65,11 +65,10 @@ class service : public boost::asio::execution_context::service {
   /// Unregister an object
   void remove(IoObject& entry) {
     auto lock = std::scoped_lock{mutex};
-    if (entries.empty()) {
-      // already shut down
-    } else {
+    if (entry.is_linked()) {
       entries.erase(entries.iterator_to(entry));
     }
+    // else: already removed by shutdown() or a previous remove()
   }
 };
 

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1397,9 +1397,16 @@ class Notifier : public async::service_list_base_hook {
     if (neoref) {
       neoref = nullptr;
     }
-    linger_op.reset();
-    std::unique_lock l(m);
-    handlers.clear();
+    // Clear handlers before resetting linger_op. The Notifier and
+    // LingerOp have circular references (Notifier holds intrusive_ptr
+    // to LingerOp, LingerOp holds shared_ptr to Notifier in
+    // user_data). Resetting linger_op may break this cycle and
+    // destroy 'this', so we must not access any members after.
+    {
+      std::unique_lock l(m);
+      handlers.clear();
+    }
+    linger_op.reset(); // may destroy 'this' via circular ref - must be last
   }
 
 public:

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -259,9 +259,11 @@ public:
         yield {
           char buf[16];
           snprintf(buf, sizeof(buf), "%d", shard_id);
+          auto my_zone_id = sync_env->svc->zone->zone_id().id;
           rgw_http_param_pair pairs[] = { { "type" , "data" },
                                           { "id", buf },
                                           { "info" , NULL },
+                                          { "zone-id", my_zone_id.c_str() },
                                           { NULL, NULL } };
 
           string p = "/admin/log/";
@@ -354,10 +356,12 @@ public:
         yield {
           char buf[16];
           snprintf(buf, sizeof(buf), "%d", shard_id);
+          auto my_zone_id = sync_env->svc->zone->zone_id().id;
           rgw_http_param_pair pairs[] = { { "type" , "data" },
                                           { "id", buf },
                                           { "marker", marker.c_str() },
                                           { "extra-info", "true" },
+                                          { "zone-id", my_zone_id.c_str() },
                                           { NULL, NULL } };
 
           string p = "/admin/log/";
@@ -479,11 +483,12 @@ public:
     snprintf(max_entries_buf, sizeof(max_entries_buf), "%d", (int)max_entries);
 
     const char *marker_key = (marker.empty() ? "" : "marker");
-
+    auto my_zone_id = sync_env->svc->zone->zone_id().id;
     rgw_http_param_pair pairs[] = { { "type", "data" },
       { "id", buf },
       { "max-entries", max_entries_buf },
       { marker_key, marker.c_str() },
+      { "zone-id", my_zone_id.c_str() },
       { NULL, NULL } };
 
     string p = "/admin/log/";
@@ -691,7 +696,9 @@ RGWRemoteDataLog::RGWRemoteDataLog(const DoutPrefixProvider *dpp,
 
 int RGWRemoteDataLog::read_log_info(const DoutPrefixProvider *dpp, rgw_datalog_info *log_info)
 {
+  auto my_zone_id = sc.env->svc->zone->zone_id().id;
   rgw_http_param_pair pairs[] = { { "type", "data" },
+                                  { "zone-id", my_zone_id.c_str() },
                                   { NULL, NULL } };
 
   int ret = sc.conn->get_json_resource(dpp, "/admin/log", pairs, null_yield, *log_info);

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
+#include <atomic>
 #include <exception>
 #include <ranges>
 #include <shared_mutex> // for std::shared_lock
@@ -138,8 +139,10 @@ public:
 		     neorados::IOContext loc,
 		     RGWDataChangesLog& datalog,
 		     uint64_t gen_id,
-		     int num_shards)
-    : RGWDataChangesBE(r, std::move(loc), datalog, gen_id) {
+                    int num_shards,
+                    std::optional<rgw_zone_id> zone_id = std::nullopt)
+    : RGWDataChangesBE(r, std::move(loc), datalog, gen_id,
+                      std::move(zone_id)) {
     oids.reserve(num_shards);
     for (auto i = 0; i < num_shards; ++i) {
       oids.push_back(get_oid(i));
@@ -279,8 +282,10 @@ public:
 		     neorados::IOContext loc,
 		     RGWDataChangesLog& datalog,
 		     uint64_t gen_id,
-		     int num_shards)
-    : RGWDataChangesBE(r, std::move(loc), datalog, gen_id),
+                    int num_shards,
+                    std::optional<rgw_zone_id> zone_id = std::nullopt)
+    : RGWDataChangesBE(r, std::move(loc), datalog, gen_id,
+                      std::move(zone_id)),
       fifos(num_shards, [&r, &loc, this](std::size_t i, auto emplacer) {
 	emplacer.emplace(r, get_oid(i), loc);
       }) {}
@@ -394,12 +399,14 @@ void DataLogBackends::handle_init(entries_t e) {
       case log_type::omap:
 	emplace(gen_id,
 		boost::intrusive_ptr<RGWDataChangesBE>(
-		  new RGWDataChangesOmap(rados, loc, datalog, gen_id, shards)));
+                 new RGWDataChangesOmap(rados, loc, datalog, gen_id, shards,
+                                       zone_id)));
 	break;
       case log_type::fifo:
 	emplace(gen_id,
 		boost::intrusive_ptr<RGWDataChangesBE>(
-		  new RGWDataChangesFIFO(rados, loc, datalog, gen_id, shards)));
+                 new RGWDataChangesFIFO(rados, loc, datalog, gen_id, shards,
+                                        zone_id)));
 	break;
       default:
 	lderr(datalog.cct)
@@ -441,11 +448,95 @@ void DataLogBackends::handle_empty_to(uint64_t new_tail) {
 int RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
 			     const RGWZone* zone,
 			     const RGWZoneParams& zoneparams,
+                            const std::map<rgw_zone_id, RGWRESTConn*>& notify_zones,
+                            bool legacy_writes_disabled,
 			     bool background_tasks) noexcept
 {
   log_data = zone->log_data;
+  // Create per-zone logs when there are actual peer zones to sync with
+  target_zone_ids_.clear();
+  if (!notify_zones.empty()) {
+    target_zone_ids_.reserve(notify_zones.size());
+    for (const auto& [zid, _] : notify_zones) {
+      target_zone_ids_.push_back(zid);
+    }
+  }
+
+  legacy_writes_disabled_ = legacy_writes_disabled;
   try {
     // Blocking in startup code, not ideal, but won't hurt anything.
+    // Background tasks are NOT started here when per-zone backends
+    // need to be initialized; they'll be started after
+    // init_zone_backends() completes to avoid data races on zone_logs.
+    asio::co_spawn(executor,
+                  start(dpp, zoneparams.log_pool,
+                        background_tasks, background_tasks,
+                        background_tasks),
+                  async::use_blocked);
+  } catch (const sys::system_error& e) {
+    ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+                      << ": Failed to start datalog: " << e.what()
+                      << dendl;
+    return ceph::from_error_code(e.code());
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+                      << ": Failed to start datalog: " << e.what()
+                      << dendl;
+    return ceph::from_exception(std::current_exception());
+  }
+
+  // Initialize per-zone backends only when the per_zone_datalog feature
+  // is enabled. When disabled, all writes go to the legacy backend.
+  if (legacy_writes_disabled_ && !target_zone_ids_.empty()) {
+    auto defbacking = to_log_type(
+      cct->_conf.get_val<std::string>("rgw_default_data_log_backing"));
+    ceph_assert(defbacking);
+    try {
+      init_zone_backends(dpp, *defbacking);
+    } catch (const sys::system_error& e) {
+      ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+                        << ": Failed to init per-zone backends: "
+                        << e.what() << dendl;
+      return ceph::from_error_code(e.code());
+    } catch (const std::exception& e) {
+      ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+                        << ": Failed to init per-zone backends: "
+                        << e.what() << dendl;
+      return ceph::from_exception(std::current_exception());
+    }
+
+    // Now that zone_logs is fully populated, start background tasks.
+    // This ensures renew_entries() and recover() see a consistent
+    // zone_logs and can properly handle per-zone backends.
+    if (background_tasks && log_data) {
+      try {
+       asio::co_spawn(executor,
+                      start_background(dpp, true, true, true),
+                      async::use_blocked);
+      } catch (const sys::system_error& e) {
+       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+                          << ": Failed to start background tasks: "
+                          << e.what() << dendl;
+       return ceph::from_error_code(e.code());
+      } catch (const std::exception& e) {
+       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
+                          << ": Failed to start background tasks: "
+                          << e.what() << dendl;
+       return ceph::from_exception(std::current_exception());
+      }
+    }
+  }
+
+  return 0;
+}
+
+int RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
+                            const RGWZone* zone,
+                            const RGWZoneParams& zoneparams,
+                            bool background_tasks) noexcept
+{
+  log_data = zone->log_data;
+  try {
     asio::co_spawn(executor,
 		   start(dpp, zoneparams.log_pool,
 			 background_tasks, background_tasks,
@@ -502,10 +593,33 @@ RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
     throw;
   }
 
+  // NOTE: per-zone backend init is done in the 7-param start() sync
+  // wrapper via init_zone_backends(), not here. Adding any co_await
+  // to this coroutine triggers GCC coroutine frame corruption.
+  //
+  // Background tasks (renew, watch, recovery) are started via
+  // start_background() AFTER init_zone_backends() completes, to
+  // avoid data races on zone_logs.
+
   if (!log_data) {
     co_return;
   }
 
+  // Start background tasks only when there are no per-zone backends
+  // to initialize (i.e. the original 4-param start path used by
+  // tests). When per-zone backends exist, the 7-param start()
+  // wrapper calls start_background() after init_zone_backends().
+  if (target_zone_ids_.empty()) {
+    co_await start_background(dpp, recovery, watch, renew);
+  }
+  co_return;
+}
+
+asio::awaitable<void>
+RGWDataChangesLog::start_background(const DoutPrefixProvider *dpp,
+                                   bool recovery, bool watch,
+                                   bool renew)
+{
   if (renew) {
     renew_future = asio::co_spawn(
       renew_strand,
@@ -540,6 +654,32 @@ RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
 						       asio::use_future)));
   }
   co_return;
+}
+
+void
+RGWDataChangesLog::init_zone_backends(const DoutPrefixProvider *dpp,
+                                     log_type defbacking)
+{
+  // Initialize each zone's backends via individual co_spawn calls
+  // rather than a single coroutine with a loop. This avoids GCC
+  // coroutine code generation bugs that corrupt the coroutine frame
+  // and cause double-free in string::_M_dispose().
+  for (const auto& zone_id : target_zone_ids_) {
+    auto zone_bes = asio::co_spawn(executor,
+      logback_generations::init<DataLogBackends>(
+       dpp, *rados, metadata_log_oid(zone_id), loc,
+       [this, zone_id](uint64_t gen_id, int shard) {
+         return get_oid(zone_id, gen_id, shard);
+       }, num_shards, defbacking, *this, zone_id),
+      async::use_blocked);
+    ZoneLog zlog;
+    zlog.zone_id = zone_id;
+    zlog.bes = std::move(zone_bes);
+    zlog.semaphores.resize(num_shards);
+    zone_logs.emplace(zone_id, std::move(zlog));
+    ldpp_dout(dpp, 10) << "Initialized per-zone datalog for zone "
+                      << zone_id << dendl;
+  }
 }
 
 asio::awaitable<bool>
@@ -730,20 +870,28 @@ RGWDataChangesLog::renew_entries(const DoutPrefixProvider* dpp)
 
   /* we can't keep the bucket name as part of the datalog entry, and
    * we need it later, so we keep two lists under the map */
-  bc::flat_map<int, std::pair<std::vector<BucketGen>,
-			      RGWDataChangesBE::entries>> m;
+  using shard_entries_t = bc::flat_map<int, std::pair<std::vector<BucketGen>,
+                                                     RGWDataChangesBE::entries>>;
+  shard_entries_t legacy_m;
+  std::map<rgw_zone_id, shard_entries_t> per_zone_m;
 
   std::unique_lock l(lock);
   decltype(cur_cycle) entries;
   entries.swap(cur_cycle);
   for (const auto& [bs, gen] : entries) {
     unsigned index = choose_oid(bs);
-    semaphores[index].insert(BucketGen{bs, gen}.get_key());
+    auto key = BucketGen{bs, gen}.get_key();
+    if (legacy_writes_disabled_) {
+      for (auto& [zid, zlog] : zone_logs) {
+       zlog.semaphores[index].insert(key);
+      }
+    } else {
+      semaphores[index].insert(key);
+    }
   }
   l.unlock();
 
   auto ut = real_clock::now();
-  auto be = bes->head();
 
   for (const auto& [bs, gen] : entries) {
     auto index = choose_oid(bs);
@@ -756,55 +904,114 @@ RGWDataChangesLog::renew_entries(const DoutPrefixProvider* dpp)
     change.gen = gen;
     encode(change, bl);
 
-    m[index].first.push_back({bs, gen});
-    be->prepare(ut, change.key, std::move(bl), m[index].second);
-  }
-
-  auto push_failed = false;
-  for (auto& [index, p] : m) {
-    auto& [buckets, entries] = p;
-
-    auto now = real_clock::now();
-    // Failure on push isn't fatal.
-    try {
-      co_await be->push(dpp, index, std::move(entries));
-    } catch (const std::exception& e) {
-      push_failed = true;
-      ldpp_dout(dpp, 5) << "RGWDataChangesLog::renew_entries(): Backend push failed "
-			<< "with exception: " << e.what() << dendl;
-    }
-
-    auto expiration = now;
-    expiration += ceph::make_timespan(cct->_conf->rgw_data_log_window);
-    for (auto& [bs, gen] : buckets) {
-      update_renewed(bs, gen, expiration);
+    if (legacy_writes_disabled_) {
+      for (auto& [zid, zlog] : zone_logs) {
+       auto zone_be = zlog.bes->head();
+       per_zone_m[zid][index].first.push_back({bs, gen});
+       zone_be->prepare(ut, change.key, buffer::list{bl},
+                        per_zone_m[zid][index].second);
+      }
+    } else {
+      auto be = bes->head();
+      legacy_m[index].first.push_back({bs, gen});
+      be->prepare(ut, change.key, buffer::list{bl}, legacy_m[index].second);
     }
   }
+
+  std::atomic<bool> push_failed{false};
+
+  {
+    auto ex = co_await asio::this_coro::executor;
+
+    if (legacy_writes_disabled_) {
+      auto group = async::spawn_group(ex, zone_logs.size());
+      for (auto& [zid, zlog] : zone_logs) {
+       asio::co_spawn(ex, [&, zid = zid, &zlog = zlog]()
+                      -> asio::awaitable<void> {
+         auto zone_be = zlog.bes->head();
+         for (auto& [index, p] : per_zone_m[zid]) {
+           auto& [buckets, shard_entries] = p;
+           try {
+             co_await zone_be->push(dpp, index, std::move(shard_entries));
+           } catch (const std::exception& e) {
+             push_failed.store(true, std::memory_order_relaxed);
+             ldpp_dout(dpp, 5) << "RGWDataChangesLog::renew_entries(): "
+                               << "Per-zone push failed for zone " << zid
+                               << ": " << e.what() << dendl;
+           }
+         }
+       }, group);
+      }
+      co_await group.wait();
+    } else {
+      auto be = bes->head();
+      for (auto& [index, p] : legacy_m) {
+       auto& [buckets, shard_entries] = p;
+       try {
+         co_await be->push(dpp, index, std::move(shard_entries));
+       } catch (const std::exception& e) {
+         push_failed.store(true, std::memory_order_relaxed);
+         ldpp_dout(dpp, 5) << "RGWDataChangesLog::renew_entries(): "
+                           << "Legacy push failed: " << e.what() << dendl;
+       }
+      }
+    }
+  }
+
+  // Update renewed timestamps (shared, not per-zone)
+  // Use entries directly since legacy_m may be empty when legacy disabled
+  auto now = real_clock::now();
+  auto expiration = now;
+  expiration += ceph::make_timespan(cct->_conf->rgw_data_log_window);
+  for (const auto& [bs, gen] : entries) {
+    update_renewed(bs, gen, expiration);
+  }
+
   if (push_failed) {
     co_return;
   }
 
   // If we didn't error in pushing, we can now decrement the semaphores
   l.lock();
-  for (auto index = 0u; index < unsigned(num_shards); ++index) {
-    using neorados::WriteOp;
-    auto& keys = semaphores[index];
-    while (!keys.empty()) {
-      bc::flat_set<std::string> batch;
-      // Can't use a move iterator here, since the keys have to stay
-      // until they're safely on the OSD to avoid the risk of
-      // double-decrement from recovery.
-      auto to_copy = std::min(sem_max_keys, keys.size());
-      std::copy_n(keys.begin(), to_copy,
-		  std::inserter(batch, batch.end()));
-      auto op = WriteOp{}.exec(ss::decrement(std::move(batch)));
-      l.unlock();
-      co_await rados->execute(get_sem_set_oid(index), loc, std::move(op),
-			      asio::use_awaitable);
-      l.lock();
-      auto iter = keys.cbegin();
-      std::advance(iter, to_copy);
-      keys.erase(keys.cbegin(), iter);
+  if (legacy_writes_disabled_) {
+    for (auto& [zid, zlog] : zone_logs) {
+      for (auto index = 0u; index < unsigned(num_shards); ++index) {
+       using neorados::WriteOp;
+       auto& keys = zlog.semaphores[index];
+       while (!keys.empty()) {
+         bc::flat_set<std::string> batch;
+         auto to_copy = std::min(sem_max_keys, keys.size());
+         std::copy_n(keys.begin(), to_copy,
+                     std::inserter(batch, batch.end()));
+         auto op = WriteOp{}.exec(ss::decrement(std::move(batch)));
+         l.unlock();
+         co_await rados->execute(get_sem_set_oid(zid, index), loc,
+                                 std::move(op), asio::use_awaitable);
+         l.lock();
+         auto iter = keys.cbegin();
+         std::advance(iter, to_copy);
+         keys.erase(keys.cbegin(), iter);
+       }
+      }
+    }
+  } else {
+    for (auto index = 0u; index < unsigned(num_shards); ++index) {
+      using neorados::WriteOp;
+      auto& keys = semaphores[index];
+      while (!keys.empty()) {
+       bc::flat_set<std::string> batch;
+       auto to_copy = std::min(sem_max_keys, keys.size());
+       std::copy_n(keys.begin(), to_copy,
+                   std::inserter(batch, batch.end()));
+       auto op = WriteOp{}.exec(ss::decrement(std::move(batch)));
+       l.unlock();
+       co_await rados->execute(get_sem_set_oid(index), loc, std::move(op),
+                               asio::use_awaitable);
+       l.lock();
+       auto iter = keys.cbegin();
+       std::advance(iter, to_copy);
+       keys.erase(keys.cbegin(), iter);
+      }
     }
   }
   co_return;
@@ -866,8 +1073,37 @@ std::string RGWDataChangesLog::get_oid(uint64_t gen_id, int i) const {
 	  fmt::format("{}.{}", prefix, i));
 }
 
+std::string RGWDataChangesLog::get_oid(const rgw_zone_id& zone,
+                                      uint64_t gen_id, int i) const {
+  auto zone_prefix = fmt::format("data_log.{}", zone.id);
+  return (gen_id > 0 ?
+         fmt::format("{}@G{}.{}", zone_prefix, gen_id, i) :
+         fmt::format("{}.{}", zone_prefix, i));
+}
+
 std::string RGWDataChangesLog::get_sem_set_oid(int i) const {
   return fmt::format("_sem_set{}.{}", prefix, i);
+}
+
+std::string RGWDataChangesLog::get_sem_set_oid(const rgw_zone_id& zone,
+                                              int i) const {
+  return fmt::format("_sem_setdata_log.{}.{}", zone.id, i);
+}
+
+std::string RGWDataChangesBE::get_oid(int shard_id) {
+  if (zone_id) {
+    return datalog.get_oid(*zone_id, gen_id, shard_id);
+  }
+  return datalog.get_oid(gen_id, shard_id);
+}
+
+std::vector<rgw_zone_id> RGWDataChangesLog::get_zone_ids() const {
+  std::vector<rgw_zone_id> ids;
+  ids.reserve(zone_logs.size());
+  for (const auto& [zid, _] : zone_logs) {
+    ids.push_back(zid);
+  }
+  return ids;
 }
 
 asio::awaitable<void>
@@ -923,9 +1159,16 @@ void RGWDataChangesLog::add_entry(const DoutPrefixProvider* dpp,
     change.gen = gen.gen;
     encode(change, bl);
 
-    auto be = bes->head();
     // Failure on push is fatal if we're bypassing semaphores.
-    be->push(dpp, index, now, change.key, std::move(bl), y);
+    if (legacy_writes_disabled_) {
+      for (auto& [zid, zlog] : zone_logs) {
+       auto zone_be = zlog.bes->head();
+       zone_be->push(dpp, index, now, change.key, buffer::list{bl}, y);
+      }
+    } else {
+      auto be = bes->head();
+      be->push(dpp, index, now, change.key, buffer::list{bl}, y);
+    }
     return;
   }
 
@@ -953,8 +1196,15 @@ void RGWDataChangesLog::add_entry(const DoutPrefixProvider* dpp,
     auto need_sem_set = register_renew(std::move(bg));
     if (need_sem_set) {
       using neorados::WriteOp;
-      rados->execute(get_sem_set_oid(index), loc,
-		     WriteOp{}.exec(ss::increment(std::move(key))), y);
+      if (legacy_writes_disabled_) {
+       for (auto& [zid, zlog] : zone_logs) {
+         rados->execute(get_sem_set_oid(zid, index), loc,
+                        WriteOp{}.exec(ss::increment(std::string{key})), y);
+       }
+      } else {
+       rados->execute(get_sem_set_oid(index), loc,
+                      WriteOp{}.exec(ss::increment(std::string{key})), y);
+      }
     }
     return;
   }
@@ -986,13 +1236,26 @@ void RGWDataChangesLog::add_entry(const DoutPrefixProvider* dpp,
 
   ldpp_dout(dpp, 20) << "RGWDataChangesLog::add_entry() sending update with now=" << now << " cur_expiration=" << expiration << dendl;
 
-  auto be = bes->head();
   // Failure on push isn't fatal.
-  try {
-    be->push(dpp, index, now, change.key, std::move(bl), y);
-  } catch (const std::exception& e) {
-    ldpp_dout(dpp, 5) << "RGWDataChangesLog::add_entry(): Backend push failed "
-		      << "with exception: " << e.what() << dendl;
+  if (legacy_writes_disabled_) {
+    for (auto& [zid, zlog] : zone_logs) {
+      try {
+       auto zone_be = zlog.bes->head();
+       zone_be->push(dpp, index, now, change.key, buffer::list{bl}, y);
+      } catch (const std::exception& e) {
+       ldpp_dout(dpp, 5) << "RGWDataChangesLog::add_entry(): Per-zone push "
+                         << "failed for zone " << zid
+                         << " with exception: " << e.what() << dendl;
+      }
+    }
+  } else {
+    auto be = bes->head();
+    try {
+      be->push(dpp, index, now, change.key, buffer::list{bl}, y);
+    } catch (const std::exception& e) {
+      ldpp_dout(dpp, 5) << "RGWDataChangesLog::add_entry(): Backend push failed "
+                       << "with exception: " << e.what() << dendl;
+    }
   }
 
 
@@ -1146,7 +1409,7 @@ asio::awaitable<RGWDataChangesLogInfo>
 RGWDataChangesLog::get_info(const DoutPrefixProvider* dpp, int shard_id)
 {
   if (shard_id >= num_shards) [[unlikely]] {
-    throw sys::system_error{-EINVAL, sys::generic_category(),
+    throw sys::system_error{EINVAL, sys::generic_category(),
       fmt::format(
 	"{} is not a valid shard. Valid shards are integers in [0, {})",
 	shard_id, num_shards)};
@@ -1191,7 +1454,7 @@ RGWDataChangesLog::trim_entries(const DoutPrefixProvider *dpp, int shard_id,
 				    std::string_view marker)
 {
   if (shard_id >= num_shards) [[unlikely]] {
-    throw sys::system_error{-EINVAL, sys::generic_category(),
+    throw sys::system_error{EINVAL, sys::generic_category(),
       fmt::format(
 	"{} is not a valid shard. Valid shards are integers in [0, {})",
 	shard_id, num_shards)};
@@ -1347,6 +1610,12 @@ void RGWDataChangesLog::blocking_shutdown()
     bes->shutdown();
     bes.reset();
   }
+  for (auto& [zid, zlog] : zone_logs) {
+    if (zlog.bes) {
+      zlog.bes->shutdown();
+      zlog.bes.reset();
+    }
+  }
   return;
 }
 
@@ -1426,16 +1695,33 @@ void RGWDataChangesLog::mark_modified(int shard_id, const rgw_bucket_shard& bs, 
   }
 
   auto key = bs.get_key();
+  rgw_data_notify_entry entry{key, gen};
   {
     std::shared_lock rl{modified_lock}; // read lock to check for existence
-    auto shard = modified_shards.find(shard_id);
-    if (shard != modified_shards.end() && shard->second.count({key, gen})) {
-      return;
+    if (legacy_writes_disabled_) {
+      for (const auto& [_, zone_shards] : zone_modified_shards) {
+       auto zshard = zone_shards.find(shard_id);
+       if (zshard != zone_shards.end() && zshard->second.count(entry)) {
+         return;
+       }
+       break; // all zones receive identical entries, check one
+      }
+    } else {
+      auto shard = modified_shards.find(shard_id);
+      if (shard != modified_shards.end() && shard->second.count(entry)) {
+       return;
+      }
     }
   }
 
   std::unique_lock wl{modified_lock}; // write lock for insertion
-  modified_shards[shard_id].insert(rgw_data_notify_entry{key, gen});
+  if (legacy_writes_disabled_) {
+    for (const auto& [zid, _] : zone_logs) {
+      zone_modified_shards[zid][shard_id].insert(entry);
+    }
+  } else {
+    modified_shards[shard_id].insert(entry);
+  }
 }
 
 std::string RGWDataChangesLog::max_marker() const {
@@ -1454,6 +1740,162 @@ RGWDataChangesLog::trim_generations(const DoutPrefixProvider *dpp,
 				    std::optional<uint64_t>& through)
 {
   co_return co_await bes->trim_generations(dpp, through);
+}
+
+// --- Per-zone API overloads ---
+
+asio::awaitable<std::tuple<std::vector<rgw_data_change_log_entry>,
+                          std::string, bool>>
+RGWDataChangesLog::list_entries(const DoutPrefixProvider* dpp,
+                               const rgw_zone_id& zone,
+                               int shard, int max_entries,
+                               std::string marker)
+{
+  auto it = zone_logs.find(zone);
+  if (it == zone_logs.end()) {
+    throw sys::system_error{
+      ENOENT, sys::generic_category(),
+      fmt::format("No per-zone datalog for zone {}", zone.id)};
+  }
+  if (shard >= num_shards) [[unlikely]] {
+    throw sys::system_error{
+      EINVAL, sys::generic_category(),
+      fmt::format("{} is not a valid shard. Valid shards are integers in [0, {})",
+                 shard, num_shards)};
+  }
+  if (max_entries <= 0) {
+    co_return std::make_tuple(std::vector<rgw_data_change_log_entry>{},
+                             std::string{}, false);
+  }
+  std::vector<rgw_data_change_log_entry> entries(max_entries);
+  auto [spanentries, outmark] =
+    co_await it->second.bes->list(dpp, shard, entries, marker);
+  entries.resize(spanentries.size());
+  bool truncated = !outmark.empty();
+  co_return std::make_tuple(std::move(entries), std::move(outmark), truncated);
+}
+
+asio::awaitable<std::tuple<std::vector<rgw_data_change_log_entry>,
+                          RGWDataChangesLogMarker, bool>>
+RGWDataChangesLog::list_entries(const DoutPrefixProvider* dpp,
+                               const rgw_zone_id& zone,
+                               int max_entries, RGWDataChangesLogMarker marker)
+{
+  auto it = zone_logs.find(zone);
+  if (it == zone_logs.end()) {
+    throw sys::system_error{
+      ENOENT, sys::generic_category(),
+      fmt::format("No per-zone datalog for zone {}", zone.id)};
+  }
+  if (max_entries <= 0) {
+    co_return std::make_tuple(std::vector<rgw_data_change_log_entry>{},
+                             RGWDataChangesLogMarker{}, false);
+  }
+
+  std::vector<rgw_data_change_log_entry> entries(max_entries);
+  std::span remaining{entries};
+
+  do {
+    std::span<rgw_data_change_log_entry> outspan;
+    std::string outmark;
+    std::tie(outspan, outmark) = co_await it->second.bes->list(
+      dpp, marker.shard, remaining, marker.marker);
+    remaining = remaining.last(remaining.size() - outspan.size());
+    if (!outmark.empty()) {
+      marker.marker = std::move(outmark);
+    } else if (outmark.empty() && marker.shard < (num_shards - 1)) {
+      ++marker.shard;
+      marker.marker.clear();
+    } else {
+      marker.clear();
+    }
+  } while (!remaining.empty() && marker);
+  if (!remaining.empty()) {
+    entries.resize(entries.size() - remaining.size());
+  }
+  bool truncated = marker;
+  co_return std::make_tuple(std::move(entries), std::move(marker), truncated);
+}
+
+asio::awaitable<RGWDataChangesLogInfo>
+RGWDataChangesLog::get_info(const DoutPrefixProvider* dpp,
+                           const rgw_zone_id& zone, int shard_id)
+{
+  auto it = zone_logs.find(zone);
+  if (it == zone_logs.end()) {
+    throw sys::system_error{
+      ENOENT, sys::generic_category(),
+      fmt::format("No per-zone datalog for zone {}", zone.id)};
+  }
+  if (shard_id >= num_shards) [[unlikely]] {
+    throw sys::system_error{EINVAL, sys::generic_category(),
+      fmt::format(
+       "{} is not a valid shard. Valid shards are integers in [0, {})",
+       shard_id, num_shards)};
+  }
+  auto be = it->second.bes->head();
+  auto info = co_await be->get_info(dpp, shard_id);
+  if (!info.marker.empty()) {
+    info.marker = gencursor(be->gen_id, info.marker);
+  }
+  co_return info;
+}
+
+asio::awaitable<void>
+RGWDataChangesLog::trim_entries(const DoutPrefixProvider* dpp,
+                               const rgw_zone_id& zone,
+                               int shard_id, std::string_view marker)
+{
+  auto it = zone_logs.find(zone);
+  if (it == zone_logs.end()) {
+    throw sys::system_error{
+      ENOENT, sys::generic_category(),
+      fmt::format("No per-zone datalog for zone {}", zone.id)};
+  }
+  if (shard_id >= num_shards) [[unlikely]] {
+    throw sys::system_error{EINVAL, sys::generic_category(),
+      fmt::format(
+       "{} is not a valid shard. Valid shards are integers in [0, {})",
+       shard_id, num_shards)};
+  }
+  co_return co_await it->second.bes->trim_entries(dpp, shard_id, marker);
+}
+
+void RGWDataChangesLog::trim_entries(const DoutPrefixProvider* dpp,
+                                    const rgw_zone_id& zone,
+                                    int shard_id, std::string_view marker,
+                                    librados::AioCompletion* c)
+{
+  asio::co_spawn(rados->get_executor(),
+                trim_entries(dpp, zone, shard_id, marker),
+                c);
+}
+
+asio::awaitable<void>
+RGWDataChangesLog::trim_generations(const DoutPrefixProvider* dpp,
+                                   const rgw_zone_id& zone,
+                                   std::optional<uint64_t>& through)
+{
+  auto it = zone_logs.find(zone);
+  if (it == zone_logs.end()) {
+    throw sys::system_error{
+      ENOENT, sys::generic_category(),
+      fmt::format("No per-zone datalog for zone {}", zone.id)};
+  }
+  co_return co_await it->second.bes->trim_generations(dpp, through);
+}
+
+asio::awaitable<void>
+RGWDataChangesLog::change_format(const DoutPrefixProvider* dpp,
+                                const rgw_zone_id& zone, log_type type)
+{
+  auto it = zone_logs.find(zone);
+  if (it == zone_logs.end()) {
+    throw sys::system_error{
+      ENOENT, sys::generic_category(),
+      fmt::format("No per-zone datalog for zone {}", zone.id)};
+  }
+  co_return co_await it->second.bes->new_backing(dpp, type);
 }
 
 asio::awaitable<std::pair<bc::flat_map<std::string, uint64_t>,
@@ -1590,6 +2032,134 @@ RGWDataChangesLog::decrement_sems(
   }
 }
 
+// Per-zone recovery methods
+asio::awaitable<std::pair<bc::flat_map<std::string, uint64_t>, std::string>>
+RGWDataChangesLog::read_sems(const rgw_zone_id& zone, int index,
+                            std::string cursor) {
+  bc::flat_map<std::string, uint64_t> out;
+  try {
+    co_await rados->execute(
+      get_sem_set_oid(zone, index), loc,
+      neorados::ReadOp{}.exec(ss::list(sem_max_keys, std::move(cursor),
+                                      &out, &cursor)),
+      nullptr, asio::use_awaitable);
+  } catch (const sys::system_error& e) {
+    if (e.code() != sys::errc::no_such_file_or_directory) {
+      throw;
+    }
+  }
+  co_return std::make_pair(std::move(out), std::move(cursor));
+}
+
+asio::awaitable<bool>
+RGWDataChangesLog::synthesize_entries(
+  const DoutPrefixProvider* dpp,
+  const rgw_zone_id& zone,
+  int index,
+  const bc::flat_map<std::string, uint64_t>& semcount)
+{
+  auto it = zone_logs.find(zone);
+  if (it == zone_logs.end()) {
+    ldpp_dout(dpp, 5) << "RGWDataChangesLog::synthesize_entries(): "
+                     << "No per-zone datalog for zone " << zone << dendl;
+    co_return false;
+  }
+  const auto timestamp = real_clock::now();
+  auto be = it->second.bes->head();
+  auto push_failed = false;
+
+  RGWDataChangesBE::entries batch;
+  for (const auto& [key, sem] : semcount) {
+    try {
+      BucketGen bg{key};
+      rgw_data_change change;
+      buffer::list bl;
+      change.entity_type = ENTITY_TYPE_BUCKET;
+      change.key = bg.shard.get_key();
+      change.timestamp = timestamp;
+      change.gen = bg.gen;
+      encode(change, bl);
+      be->prepare(timestamp, change.key, std::move(bl), batch);
+    } catch (const sys::system_error& e) {
+      push_failed = true;
+      ldpp_dout(dpp, -1) << "RGWDataChangesLog::synthesize_entries(zone): "
+                        << "Unable to parse BucketGen key: " << key
+                        << " Got exception: " << e.what() << dendl;
+    }
+  }
+  try {
+    co_await be->push(dpp, index, std::move(batch));
+  } catch (const std::exception& e) {
+    push_failed = true;
+    ldpp_dout(dpp, 5) << "RGWDataChangesLog::synthesize_entries(zone): "
+                     << "Backend push failed with exception: "
+                     << e.what() << dendl;
+  }
+  co_return !push_failed;
+}
+
+asio::awaitable<void>
+RGWDataChangesLog::decrement_sems(
+  const rgw_zone_id& zone, int index,
+  ceph::mono_time fetch_time,
+  bc::flat_map<std::string, uint64_t>&& semcount)
+{
+  namespace sem_set = neorados::cls::sem_set;
+  while (!semcount.empty()) {
+    bc::flat_set<std::string> batch;
+    for (auto j = 0u; j < sem_max_keys && !semcount.empty(); ++j) {
+      auto iter = std::begin(semcount);
+      batch.insert(iter->first);
+      semcount.erase(std::move(iter));
+    }
+    auto grace = ((ceph::mono_clock::now() - fetch_time) * 4) / 3;
+    co_await rados->execute(
+      get_sem_set_oid(zone, index), loc, neorados::WriteOp{}.exec(
+       ss::decrement(std::move(batch), grace)),
+      asio::use_awaitable);
+  }
+}
+
+asio::awaitable<void>
+RGWDataChangesLog::recover_zone_shard(const DoutPrefixProvider* dpp,
+                                     const rgw_zone_id& zone, int index)
+{
+  std::string cursor;
+  do {
+    bc::flat_map<std::string, uint64_t> semcount;
+
+    auto fetch_time = ceph::mono_clock::now();
+    std::tie(semcount, cursor) = co_await read_sems(zone, index,
+                                                   std::move(cursor));
+    if (semcount.empty()) {
+      break;
+    }
+
+    auto pushed = co_await synthesize_entries(dpp, zone, index, semcount);
+    if (!pushed) {
+      ldpp_dout(dpp, 5) << "RGWDataChangesLog::recover_zone_shard(): "
+                       << "Pushing zone=" << zone << " shard=" << index
+                       << " failed, skipping decrement" << dendl;
+      continue;
+    }
+
+    // For per-zone recovery, use the per-zone sem_set OID for coordination.
+    // We use gather_working_sets on the legacy OID since all gateways
+    // share the same coordination channel. The per-zone semaphores track
+    // the same keys, so the working set check is still valid.
+    auto notified = co_await gather_working_sets(dpp, index, semcount);
+    if (!notified) {
+      ldpp_dout(dpp, 5) << "RGWDataChangesLog::recover_zone_shard(): "
+                       << "Gathering working sets for zone=" << zone
+                       << " shard=" << index
+                       << " failed, skipping decrement" << dendl;
+      continue;
+    }
+    co_await decrement_sems(zone, index, fetch_time, std::move(semcount));
+  } while (!cursor.empty());
+  co_return;
+}
+
 asio::awaitable<void>
 RGWDataChangesLog::recover_shard(const DoutPrefixProvider* dpp, int index)
 {
@@ -1637,9 +2207,19 @@ asio::awaitable<void> RGWDataChangesLog::recover(
     recovery_strand,
     [this](const DoutPrefixProvider* dpp)-> asio::awaitable<void, strand_t> {
       auto ex = recovery_strand;
-      auto group = async::spawn_group{ex, static_cast<size_t>(num_shards)};
+      // Legacy shards + per-zone shards
+      auto total = static_cast<size_t>(num_shards) *
+                  (1 + zone_logs.size());
+      auto group = async::spawn_group{ex, total};
+      // Recover legacy shards
       for (auto i = 0; i < num_shards; ++i) {
 	boost::asio::co_spawn(ex, recover_shard(dpp, i), group);
+      }
+      // Recover per-zone shards
+      for (const auto& [zid, _] : zone_logs) {
+       for (auto i = 0; i < num_shards; ++i) {
+         boost::asio::co_spawn(ex, recover_zone_shard(dpp, zid, i), group);
+       }
       }
       co_await group.wait();
     }(dpp),

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -47,8 +47,11 @@
 #include "rgw_sync_policy.h"
 #include "rgw_trim_bilog.h"
 #include "rgw_zone.h"
+#include "rgw_zone_features.h"
 
 #include "common/async/spawn_group.h"
+
+class RGWRESTConn;
 
 namespace asio = boost::asio;
 namespace bc = boost::container;
@@ -207,15 +210,18 @@ class DataLogBackends final
 
   std::mutex m;
   RGWDataChangesLog& datalog;
+  std::optional<rgw_zone_id> zone_id; // nullopt for legacy backends
 
   DataLogBackends(neorados::RADOS rados,
 		  const neorados::Object oid,
 		  const neorados::IOContext& loc,
 		  fu2::unique_function<std::string(
 		    uint64_t, int) const>&& get_oid,
-		  int shards, RGWDataChangesLog& datalog) noexcept
+                 int shards, RGWDataChangesLog& datalog,
+                 std::optional<rgw_zone_id> zone_id = std::nullopt) noexcept
     : logback_generations(rados, oid, loc, std::move(get_oid),
-			  shards), datalog(datalog) {}
+                         shards), datalog(datalog),
+      zone_id(std::move(zone_id)) {}
 public:
 
   boost::intrusive_ptr<RGWDataChangesBE> head() {
@@ -352,6 +358,12 @@ struct hash<BucketGen> {
 };
 }
 
+struct ZoneLog {
+  rgw_zone_id zone_id;
+  std::unique_ptr<DataLogBackends> bes;
+  std::vector<bc::flat_set<std::string>> semaphores;
+};
+
 class RGWDataChangesLog {
   friend class DataLogTestBase;
   friend DataLogBackends;
@@ -360,7 +372,10 @@ class RGWDataChangesLog {
   neorados::IOContext loc;
   rgw::BucketChangeObserver *observer = nullptr;
   bool log_data = false;
-  std::unique_ptr<DataLogBackends> bes;
+  std::unique_ptr<DataLogBackends> bes; // legacy backend
+  std::map<rgw_zone_id, ZoneLog> zone_logs; // per-zone backends
+  std::vector<rgw_zone_id> target_zone_ids_; // zones to create per-zone logs for
+  bool legacy_writes_disabled_ = false; // when per_zone_datalog feature enabled everywhere
 
   using executor_t = asio::io_context::executor_type;
   executor_t executor;
@@ -379,14 +394,23 @@ class RGWDataChangesLog {
 
   const int num_shards;
   std::string get_prefix() { return "data_log"; }
+  std::string get_prefix(const rgw_zone_id& zone) {
+    return fmt::format("data_log.{}", zone.id);
+  }
   std::string metadata_log_oid() {
     return get_prefix() + "generations_metadata";
+  }
+  std::string metadata_log_oid(const rgw_zone_id& zone) {
+    return get_prefix(zone) + "generations_metadata";
   }
   std::string prefix;
 
   std::mutex lock;
   std::shared_mutex modified_lock;
   bc::flat_map<int, bc::flat_set<rgw_data_notify_entry>> modified_shards;
+  // Per-zone modified shards for zone-specific notifications
+  std::map<rgw_zone_id, bc::flat_map<int, bc::flat_set<rgw_data_notify_entry>>>
+    zone_modified_shards;
 
   std::atomic<bool> down_flag = { true };
   bool ran_background = false;
@@ -447,9 +471,24 @@ public:
 			      // they're either all on (radosgw) or
 			      // all off (radosgw-admin)
 			      bool recovery, bool watch, bool renew);
-
+  // Start background tasks (renew, watch, recovery) after all
+  // backends (including per-zone) are fully initialized.
+  asio::awaitable<void> start_background(const DoutPrefixProvider* dpp,
+                                        bool recovery, bool watch,
+                                        bool renew);
+  // Non-coroutine per-zone backend initialization. Uses individual
+  // co_spawn calls per zone to avoid GCC coroutine frame corruption.
+  void init_zone_backends(const DoutPrefixProvider* dpp,
+                         log_type defbacking);
   int start(const DoutPrefixProvider *dpp, const RGWZone* _zone,
-	    const RGWZoneParams& zoneparams, bool background_tasks) noexcept;
+           const RGWZoneParams& zoneparams,
+           const std::map<rgw_zone_id, RGWRESTConn*>& notify_zones,
+           bool legacy_writes_disabled,
+           bool background_tasks) noexcept;
+  // Original signature for testing - bypasses per-zone setup
+  int start(const DoutPrefixProvider *dpp, const RGWZone* _zone,
+           const RGWZoneParams& zoneparams,
+           bool background_tasks) noexcept;
   asio::awaitable<bool> establish_watch(const DoutPrefixProvider* dpp,
 					std::string_view oid);
   asio::awaitable<void> process_notification(const DoutPrefixProvider* dpp,
@@ -497,6 +536,14 @@ public:
     modified_shards.clear();
     return modified;
   }
+  // Per-zone: returns a map of zone_id -> modified_shards for zone-specific notifications
+  auto read_clear_zone_modified() {
+    std::unique_lock wl{modified_lock};
+    decltype(zone_modified_shards) modified;
+    modified.swap(zone_modified_shards);
+    zone_modified_shards.clear();
+    return modified;
+  }
 
   void set_observer(rgw::BucketChangeObserver *observer) {
     this->observer = observer;
@@ -508,7 +555,37 @@ public:
   // a marker that compares greater than any other
   std::string max_marker() const;
   std::string get_oid(uint64_t gen_id, int shard_id) const;
+  std::string get_oid(const rgw_zone_id& zone, uint64_t gen_id,
+                     int shard_id) const;
   std::string get_sem_set_oid(int shard_id) const;
+  std::string get_sem_set_oid(const rgw_zone_id& zone, int shard_id) const;
+
+  // Per-zone API overloads
+  asio::awaitable<std::tuple<std::vector<rgw_data_change_log_entry>,
+                            std::string, bool>>
+  list_entries(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+              int shard, int max_entries, std::string marker);
+  asio::awaitable<std::tuple<std::vector<rgw_data_change_log_entry>,
+                            RGWDataChangesLogMarker, bool>>
+  list_entries(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+              int max_entries, RGWDataChangesLogMarker marker);
+  asio::awaitable<RGWDataChangesLogInfo>
+  get_info(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+          int shard_id);
+  asio::awaitable<void>
+  trim_entries(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+              int shard_id, std::string_view marker);
+  void trim_entries(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+                   int shard_id, std::string_view marker,
+                   librados::AioCompletion* c);
+  asio::awaitable<void>
+  trim_generations(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+                  std::optional<uint64_t>& through);
+  asio::awaitable<void>
+  change_format(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+               log_type type);
+
+  std::vector<rgw_zone_id> get_zone_ids() const;
 
 
   asio::awaitable<std::pair<bc::flat_map<std::string, uint64_t>,
@@ -526,6 +603,20 @@ public:
 		 ceph::mono_time fetch_time,
 		 bc::flat_map<std::string, uint64_t>&& semcount);
   asio::awaitable<void> recover_shard(const DoutPrefixProvider* dpp, int index);
+  // Per-zone recovery methods
+  asio::awaitable<std::pair<bc::flat_map<std::string, uint64_t>,
+                           std::string>>
+  read_sems(const rgw_zone_id& zone, int index, std::string cursor);
+  asio::awaitable<bool>
+  synthesize_entries(const DoutPrefixProvider* dpp, const rgw_zone_id& zone,
+                    int index,
+                    const bc::flat_map<std::string, uint64_t>& semcount);
+  asio::awaitable<void>
+  decrement_sems(const rgw_zone_id& zone, int index,
+                ceph::mono_time fetch_time,
+                bc::flat_map<std::string, uint64_t>&& semcount);
+  asio::awaitable<void> recover_zone_shard(const DoutPrefixProvider* dpp,
+                                          const rgw_zone_id& zone, int index);
   asio::awaitable<void> recover(const DoutPrefixProvider* dpp);
   asio::awaitable<void> async_shutdown();
   void blocking_shutdown();
@@ -544,12 +635,11 @@ protected:
   neorados::RADOS r;
   neorados::IOContext loc;
   RGWDataChangesLog& datalog;
+  std::optional<rgw_zone_id> zone_id; // nullopt for legacy backends
 
   CephContext* cct{r.cct()};
 
-  std::string get_oid(int shard_id) {
-    return datalog.get_oid(gen_id, shard_id);
-  }
+  std::string get_oid(int shard_id);
 public:
   using entries = std::variant<std::vector<cls::log::entry>,
 			       std::deque<ceph::buffer::list>>;
@@ -559,8 +649,10 @@ public:
   RGWDataChangesBE(neorados::RADOS r,
 		   neorados::IOContext loc,
 		   RGWDataChangesLog& datalog,
-		   uint64_t gen_id)
-    : r(r), loc(std::move(loc)), datalog(datalog), gen_id(gen_id) {}
+                  uint64_t gen_id,
+                  std::optional<rgw_zone_id> zone_id = std::nullopt)
+    : r(r), loc(std::move(loc)), datalog(datalog),
+      zone_id(std::move(zone_id)), gen_id(gen_id) {}
   virtual ~RGWDataChangesBE() = default;
 
   virtual void prepare(ceph::real_time now, const std::string& key,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -338,6 +338,29 @@ public:
 
     return run(dpp, stacks);
   }
+
+  // Per-zone: send each zone only its own modified shards
+  int notify_per_zone(
+      const DoutPrefixProvider *dpp,
+      map<rgw_zone_id, RGWRESTConn *>& conn_map,
+      std::map<rgw_zone_id, bc::flat_map<int, bc::flat_set<rgw_data_notify_entry>>>& zone_shards) {
+    list<RGWCoroutinesStack *> stacks;
+    const char *source_zone = store->svc.zone->get_zone_params().get_id().c_str();
+    for (auto& [zone_id, conn] : conn_map) {
+      auto it = zone_shards.find(zone_id);
+      if (it == zone_shards.end() || it->second.empty()) {
+       continue; // no modifications for this zone
+      }
+      RGWCoroutinesStack *stack = new RGWCoroutinesStack(store->ctx(), this);
+      stack->call(new RGWDataPostNotifyCR(store, http_manager, it->second,
+                                         source_zone, conn));
+      stacks.push_back(stack);
+    }
+    if (stacks.empty()) {
+      return 0;
+    }
+    return run(dpp, stacks);
+  }
 };
 
 /* class RGWRadosThread */
@@ -456,21 +479,34 @@ int RGWDataNotifier::process(const DoutPrefixProvider *dpp)
     return 0;
   }
 
-  auto shards = data_log->read_clear_modified();
-
-  if (shards.empty()) {
-    return 0;
-  }
-
-  for (const auto& [shard_id, entries] : shards) {
-    bc::flat_set<rgw_data_notify_entry>::iterator it;
-    for (const auto& entry : entries) {
-      ldpp_dout(dpp, 20) << __func__ << "(): notifying datalog change, shard_id="
-        << shard_id << ":" << entry.gen << ":" << entry.key << dendl;
+  // Per-zone notifications: send each zone only its own modified shards
+  auto zone_shards = data_log->read_clear_zone_modified();
+  if (!zone_shards.empty()) {
+    for (const auto& [zone_id, shards] : zone_shards) {
+      for (const auto& [shard_id, entries] : shards) {
+       for (const auto& entry : entries) {
+         ldpp_dout(dpp, 20) << __func__
+           << "(): notifying per-zone datalog change, zone=" << zone_id
+           << " shard_id=" << shard_id << ":" << entry.gen
+           << ":" << entry.key << dendl;
+       }
+      }
     }
+    notify_mgr.notify_per_zone(dpp,
+      store->svc.zone->get_zone_data_notify_to_map(), zone_shards);
   }
 
-  notify_mgr.notify_all(dpp, store->svc.zone->get_zone_data_notify_to_map(), shards);
+  // Legacy notifications (when legacy writes are active)
+  auto shards = data_log->read_clear_modified();
+  if (!shards.empty()) {
+    for (const auto& [shard_id, entries] : shards) {
+      for (const auto& entry : entries) {
+       ldpp_dout(dpp, 20) << __func__ << "(): notifying datalog change, shard_id="
+         << shard_id << ":" << entry.gen << ":" << entry.key << dendl;
+      }
+    }
+    notify_mgr.notify_all(dpp, store->svc.zone->get_zone_data_notify_to_map(), shards);
+  }
 
   return 0;
 }

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -654,6 +654,7 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
 
 void RGWOp_DATALog_List::execute(optional_yield y) {
   string   shard = s->info.args.get("id");
+  string   zone_id_str = s->info.args.get("zone-id");
 
   string   max_entries_str = s->info.args.get("max-entries"),
            marker = s->info.args.get("marker"),
@@ -690,23 +691,40 @@ void RGWOp_DATALog_List::execute(optional_yield y) {
   // Note that last_marker is updated to be the marker of the last
   // entry listed
   auto store = static_cast<rgw::sal::RadosStore*>(driver);
-  op_ret = rgw::run_coro(
-    this,
-    store->get_io_context(),
-    store->svc()->datalog_rados->list_entries(this, shard_id,
-					      max_entries, marker),
-    std::tie(entries, last_marker, truncated),
-    "RGWDataChangesLog::list_entries", y);
+  auto datalog = store->svc()->datalog_rados;
 
+  if (!zone_id_str.empty()) {
+    // Per-zone datalog query
+    rgw_zone_id zone_id{zone_id_str};
+    op_ret = rgw::run_coro(
+      this, store->get_io_context(),
+      datalog->list_entries(this, zone_id, shard_id, max_entries, marker),
+      std::tie(entries, last_marker, truncated),
+      "RGWDataChangesLog::list_entries(zone)", y);
+    if (op_ret < 0) return;
 
-  RGWDataChangesLogInfo info;
-  op_ret = rgw::run_coro(
-    this,
-    store->get_io_context(),
-    store->svc()->datalog_rados->get_info(this, shard_id),
-    info, "RGWDataChangesLog::get_info", y);
+    RGWDataChangesLogInfo info;
+    op_ret = rgw::run_coro(
+      this, store->get_io_context(),
+      datalog->get_info(this, zone_id, shard_id),
+      info, "RGWDataChangesLog::get_info(zone)", y);
+    last_update = info.last_update;
+  } else {
+    // Legacy datalog query
+    op_ret = rgw::run_coro(
+      this, store->get_io_context(),
+      datalog->list_entries(this, shard_id, max_entries, marker),
+      std::tie(entries, last_marker, truncated),
+      "RGWDataChangesLog::list_entries", y);
+    if (op_ret < 0) return;
 
-  last_update = info.last_update;
+    RGWDataChangesLogInfo info;
+    op_ret = rgw::run_coro(
+      this, store->get_io_context(),
+      datalog->get_info(this, shard_id),
+      info, "RGWDataChangesLog::get_info", y);
+    last_update = info.last_update;
+  }
 }
 
 void RGWOp_DATALog_List::send_response() {
@@ -757,6 +775,7 @@ void RGWOp_DATALog_Info::send_response() {
 
 void RGWOp_DATALog_ShardInfo::execute(optional_yield y) {
   string shard = s->info.args.get("id");
+  string zone_id_str = s->info.args.get("zone-id");
   string err;
 
   unsigned shard_id = (unsigned)strict_strtol(shard.c_str(), 10, &err);
@@ -767,9 +786,18 @@ void RGWOp_DATALog_ShardInfo::execute(optional_yield y) {
   }
 
   auto store = static_cast<rgw::sal::RadosStore*>(driver);
-  op_ret = rgw::run_coro(this, store->get_io_context(),
-			 store->svc()->datalog_rados->get_info(this, shard_id),
-			 info, "RGWDataChangesLog::get_info", y);
+  auto datalog = store->svc()->datalog_rados;
+
+  if (!zone_id_str.empty()) {
+    rgw_zone_id zone_id{zone_id_str};
+    op_ret = rgw::run_coro(this, store->get_io_context(),
+                          datalog->get_info(this, zone_id, shard_id),
+                          info, "RGWDataChangesLog::get_info(zone)", y);
+  } else {
+    op_ret = rgw::run_coro(this, store->get_io_context(),
+                          datalog->get_info(this, shard_id),
+                          info, "RGWDataChangesLog::get_info", y);
+  }
 }
 
 void RGWOp_DATALog_ShardInfo::send_response() {
@@ -882,6 +910,7 @@ void RGWOp_DATALog_Notify2::execute(optional_yield y) {
 void RGWOp_DATALog_Delete::execute(optional_yield y) {
   string   marker = s->info.args.get("marker"),
            shard = s->info.args.get("id"),
+           zone_id_str = s->info.args.get("zone-id"),
            err;
   unsigned shard_id;
 
@@ -919,10 +948,20 @@ void RGWOp_DATALog_Delete::execute(optional_yield y) {
   }
 
   auto store = static_cast<rgw::sal::RadosStore*>(driver);
-  op_ret = rgw::run_coro(
-    this, store->get_io_context(),
-    store->svc()->datalog_rados->trim_entries(this, shard_id, marker),
-    "RGWDataChangesLog::trim_entries", y);
+  auto datalog = store->svc()->datalog_rados;
+
+  if (!zone_id_str.empty()) {
+    rgw_zone_id zone_id{zone_id_str};
+    op_ret = rgw::run_coro(
+      this, store->get_io_context(),
+      datalog->trim_entries(this, zone_id, shard_id, marker),
+      "RGWDataChangesLog::trim_entries(zone)", y);
+  } else {
+    op_ret = rgw::run_coro(
+      this, store->get_io_context(),
+      datalog->trim_entries(this, shard_id, marker),
+      "RGWDataChangesLog::trim_entries", y);
+  }
 }
 
 // not in header to avoid pulling in rgw_sync.h

--- a/src/rgw/driver/rados/rgw_rest_realm.cc
+++ b/src/rgw/driver/rados/rgw_rest_realm.cc
@@ -162,23 +162,11 @@ void RGWOp_Period_Post::execute(optional_yield y)
     return;
   }
 
-  // write the period to rados
+  // write the period to rados. create_period() also updates
+  // the latest epoch internally, so no separate update is needed.
   op_ret = s->penv.cfgstore->create_period(this, y, false, period);
   if (op_ret < 0) {
     ldpp_dout(this, -1) << "failed to store period " << period.get_id() << dendl;
-    return;
-  }
-  // set as latest epoch
-  op_ret = s->penv.cfgstore->update_latest_epoch(this, y, period.get_id(), period.get_epoch());
-  if (op_ret == -EEXIST) {
-    // already have this epoch (or a more recent one)
-    ldpp_dout(this, 4) << "already have epoch >= " << period.get_epoch()
-        << " for period " << period.get_id() << dendl;
-    op_ret = 0;
-    return;
-  }
-  if (op_ret < 0) {
-    ldpp_dout(this, -1) << "failed to set latest epoch" << dendl;
     return;
   }
 

--- a/src/rgw/driver/rados/rgw_service.cc
+++ b/src/rgw/driver/rados/rgw_service.cc
@@ -27,6 +27,7 @@
 #include "rgw_bucket.h"
 #include "rgw_cr_rados.h"
 #include "rgw_datalog.h"
+#include "rgw_zone_features.h"
 #include "rgw_metadata.h"
 #include "rgw_otp.h"
 #include "rgw_sal_rados.h"
@@ -135,6 +136,9 @@ int RGWServices_Def::init(CephContext *cct,
 
     r = datalog_rados->start(dpp, &zone->get_zone(),
 			     zone->get_zone_params(),
+                            zone->get_zone_data_notify_to_map(),
+                            zone->get_zonegroup().supports(
+                              rgw::zone_features::per_zone_datalog),
 			     background_tasks);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: failed to start datalog_rados service (" << cpp_strerror(-r) << dendl;

--- a/src/rgw/driver/rados/rgw_trim_datalog.cc
+++ b/src/rgw/driver/rados/rgw_trim_datalog.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
+#include <algorithm>
+#include <map>
 #include <vector>
 #include <string>
 
@@ -68,6 +70,52 @@ class DatalogTrimImplCR : public RGWSimpleCoroutine {
   }
 };
 
+/// Per-zone variant: trims a specific zone's datalog shards
+class DatalogZoneTrimImplCR : public RGWSimpleCoroutine {
+  const DoutPrefixProvider *dpp;
+  rgw::sal::RadosStore* store;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
+  rgw_zone_id zone_id;
+  int shard;
+  std::string marker;
+  std::string* last_trim_marker;
+
+ public:
+  DatalogZoneTrimImplCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store,
+                       const rgw_zone_id& zone_id, int shard,
+                       const std::string& marker, std::string* last_trim_marker)
+  : RGWSimpleCoroutine(store->ctx()), dpp(dpp), store(store),
+    zone_id(zone_id), shard(shard),
+    marker(marker), last_trim_marker(last_trim_marker) {
+    set_description() << "Datalog zone trim zone=" << zone_id
+                     << " shard=" << shard << " marker=" << marker;
+  }
+
+  int send_request(const DoutPrefixProvider *dpp) override {
+    set_status() << "sending request";
+    cn = stack->create_completion_notifier();
+    store->svc()->datalog_rados->trim_entries(dpp, zone_id, shard, marker,
+                                             cn->completion());
+    return 0;
+  }
+  int request_complete() override {
+    int r = cn->completion()->get_return_value();
+    ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << "(): trim of zone=" << zone_id
+                 << " shard=" << shard
+                 << " marker=" << marker << " returned r=" << r << dendl;
+
+    set_status() << "request complete; ret=" << r;
+    if (r != -ENODATA) {
+      return r;
+    }
+    if (*last_trim_marker < marker &&
+       marker != store->svc()->datalog_rados->max_marker()) {
+      *last_trim_marker = marker;
+    }
+    return 0;
+  }
+};
+
 /// return the marker that it's safe to trim up to
 const std::string& get_stable_marker(const rgw_data_sync_marker& m)
 {
@@ -98,6 +146,7 @@ void take_min_markers(IterIn first, IterIn last, IterOut dest)
 
 class DataLogTrimCR : public RGWCoroutine {
   using TrimCR = DatalogTrimImplCR;
+  using ZoneTrimCR = DatalogZoneTrimImplCR;
   const DoutPrefixProvider *dpp;
   rgw::sal::RadosStore* store;
   RGWHTTPManager *http;
@@ -106,19 +155,32 @@ class DataLogTrimCR : public RGWCoroutine {
   std::vector<rgw_data_sync_status> peer_status; //< sync status for each peer
   std::vector<std::string> min_shard_markers; //< min marker per shard
   std::vector<std::string>& last_trim; //< last trimmed marker per shard
+  // Per-zone trim tracking: zone_id -> last_trim markers per shard
+  std::map<rgw_zone_id, std::vector<std::string>>& zone_last_trim;
+  // Peer zone IDs in order matching peer_status
+  std::vector<rgw_zone_id> peer_zone_ids;
+  // Zones that have active per-zone backends locally
+  std::vector<rgw_zone_id> active_zone_ids;
   int ret{0};
 
  public:
   DataLogTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http,
-                   int num_shards, std::vector<std::string>& last_trim)
+                   int num_shards, std::vector<std::string>& last_trim,
+                  std::map<rgw_zone_id, std::vector<std::string>>& zone_last_trim)
     : RGWCoroutine(store->ctx()), dpp(dpp), store(store), http(http),
       num_shards(num_shards),
       zone_id(store->svc()->zone->get_zone().id),
       peer_status(store->svc()->zone->get_zone_data_notify_to_map().size()),
       min_shard_markers(num_shards,
 			std::string(store->svc()->datalog_rados->max_marker())),
-      last_trim(last_trim)
-  {}
+      last_trim(last_trim),
+      zone_last_trim(zone_last_trim),
+      active_zone_ids(store->svc()->datalog_rados->get_zone_ids())
+  {
+    for (auto& c : store->svc()->zone->get_zone_data_notify_to_map()) {
+      peer_zone_ids.push_back(rgw_zone_id(c.first));
+    }
+  }
 
   int operate(const DoutPrefixProvider *dpp) override;
 };
@@ -163,10 +225,11 @@ int DataLogTrimCR::operate(const DoutPrefixProvider *dpp)
     ldpp_dout(dpp, 10) << "trimming log shards" << dendl;
     set_status("trimming log shards");
     yield {
-      // determine the minimum marker for each shard
+      // determine the minimum marker for each shard across all peers (legacy)
       take_min_markers(peer_status.begin(), peer_status.end(),
                        min_shard_markers.begin());
 
+      // Trim legacy datalog shards
       for (int i = 0; i < num_shards; i++) {
         const auto& m = min_shard_markers[i];
         if (m <= last_trim[i]) {
@@ -177,6 +240,39 @@ int DataLogTrimCR::operate(const DoutPrefixProvider *dpp)
             << " last_trim=" << last_trim[i] << dendl;
         spawn(new TrimCR(dpp, store, i, m, &last_trim[i]),
               true);
+      }
+
+      // Trim per-zone datalog shards: each zone's datalog is trimmed based
+      // on that specific zone's sync progress (not the min across all peers).
+      // Only trim zones that have active per-zone backends locally.
+      if (!active_zone_ids.empty()) {
+       for (size_t pi = 0; pi < peer_zone_ids.size(); ++pi) {
+         const auto& peer_zid = peer_zone_ids[pi];
+         // Only trim if this zone has an active per-zone backend
+         if (std::find(active_zone_ids.begin(), active_zone_ids.end(),
+                       peer_zid) == active_zone_ids.end()) {
+           continue;
+         }
+         const auto& status = peer_status[pi];
+         auto& zt = zone_last_trim[peer_zid];
+         if (zt.empty()) {
+           zt.resize(num_shards);
+         }
+         for (auto& shard : status.sync_markers) {
+           int shard_id = shard.first;
+           if (shard_id >= num_shards) continue;
+           const auto& m = get_stable_marker(shard.second);
+           if (m <= zt[shard_id]) {
+             continue;
+           }
+           ldpp_dout(dpp, 10) << "trimming per-zone log shard zone="
+               << peer_zid << " shard=" << shard_id
+               << " at marker=" << m
+               << " last_trim=" << zt[shard_id] << dendl;
+           spawn(new ZoneTrimCR(dpp, store, peer_zid, shard_id, m,
+                                &zt[shard_id]), true);
+         }
+       }
       }
     }
     return set_cr_done();
@@ -189,7 +285,8 @@ RGWCoroutine* create_admin_data_log_trim_cr(const DoutPrefixProvider *dpp, rgw::
                                             int num_shards,
                                             std::vector<std::string>& markers)
 {
-  return new DataLogTrimCR(dpp, store, http, num_shards, markers);
+  std::map<rgw_zone_id, std::vector<std::string>> zone_markers;
+  return new DataLogTrimCR(dpp, store, http, num_shards, markers, zone_markers);
 }
 
 class DataLogTrimPollCR : public RGWCoroutine {
@@ -201,6 +298,7 @@ class DataLogTrimPollCR : public RGWCoroutine {
   const std::string lock_oid; //< use first data log shard for lock
   const std::string lock_cookie;
   std::vector<std::string> last_trim; //< last trimmed marker per shard
+  std::map<rgw_zone_id, std::vector<std::string>> zone_last_trim;
 
  public:
   DataLogTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http,
@@ -240,7 +338,8 @@ int DataLogTrimPollCR::operate(const DoutPrefixProvider *dpp)
       }
 
       set_status("trimming");
-      yield call(new DataLogTrimCR(dpp, store, http, num_shards, last_trim));
+      yield call(new DataLogTrimCR(dpp, store, http, num_shards, last_trim,
+                                  zone_last_trim));
 
       // note that the lock is not released. this is intentional, as it avoids
       // duplicating this work in other gateways

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -433,6 +433,7 @@ void usage()
   cout << "   --rgw-zone=<name>                 name of zone in which radosgw is running\n";
   cout << "   --zone-id=<id>                    zone id\n";
   cout << "   --zone-new-name=<name>            zone new name\n";
+  cout << "   --log-zone=<name>                 target zone for per-zone datalog operations\n";
   cout << "   --source-zone                     specify the source zone (for data sync)\n";
   cout << "   --default                         set entity (realm, zonegroup, zone) as default\n";
   cout << "   --read-only                       set zone as read-only (when adding to zonegroup)\n";
@@ -3842,6 +3843,9 @@ int main(int argc, const char **argv)
   std::optional<string> opt_effective_zone_name;
   std::optional<rgw_zone_id> opt_effective_zone_id;
 
+  std::optional<string> opt_log_zone_name;
+  std::optional<rgw_zone_id> opt_log_zone_id;
+
   std::optional<string> opt_prefix;
   std::optional<string> opt_prefix_rm;
 
@@ -4420,6 +4424,8 @@ int main(int argc, const char **argv)
       opt_effective_zone_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--effective-zone-id", (char*)NULL)) {
       opt_effective_zone_id = rgw_zone_id(val);
+    } else if (ceph_argparse_witharg(args, i, &val, "--log-zone", (char*)NULL)) {
+      opt_log_zone_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--prefix", (char*)NULL)) {
       opt_prefix = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--prefix-rm", (char*)NULL)) {
@@ -6773,6 +6779,7 @@ int main(int argc, const char **argv)
   resolve_zone_id_opt(opt_effective_zone_name, opt_effective_zone_id);
   resolve_zone_id_opt(opt_source_zone_name, opt_source_zone_id);
   resolve_zone_id_opt(opt_dest_zone_name, opt_dest_zone_id);
+  resolve_zone_id_opt(opt_log_zone_name, opt_log_zone_id);
   resolve_zone_ids_opt(opt_zone_names, opt_zone_ids);
   resolve_zone_ids_opt(opt_source_zone_names, opt_source_zone_ids);
   resolve_zone_ids_opt(opt_dest_zone_names, opt_dest_zone_ids);
@@ -11217,7 +11224,23 @@ next:
     std::string errstr;
     do {
       std::vector<rgw_data_change_log_entry> entries;
-      if (specified_shard_id) {
+      if (opt_log_zone_id && specified_shard_id) {
+       ret = run_coro(
+         dpp(),
+         context_pool,
+         datalog_svc->list_entries(dpp(), *opt_log_zone_id, shard_id,
+                                   max_entries - count, marker),
+         std::tie(entries, marker, truncated),
+         &errstr);
+      } else if (opt_log_zone_id) {
+       ret = run_coro(
+         dpp(),
+         context_pool,
+         datalog_svc->list_entries(dpp(), *opt_log_zone_id,
+                                   max_entries - count, log_marker),
+         std::tie(entries, log_marker, truncated),
+         &errstr);
+      } else if (specified_shard_id) {
 	ret = run_coro(
 	  dpp(),
 	  context_pool,
@@ -11257,6 +11280,7 @@ next:
 
   if (opt_cmd == OPT::DATALOG_STATUS) {
     int i = (specified_shard_id ? shard_id : 0);
+    auto datalog = static_cast<rgw::sal::RadosStore*>(driver)->svc()->datalog_rados;
 
     formatter->open_array_section("entries");
     for (; i < g_ceph_context->_conf->rgw_data_log_num_shards; i++) {
@@ -11265,10 +11289,16 @@ next:
       std::string errstr;
       RGWDataChangesLogInfo info;
 
-      int r = run_coro(dpp(), context_pool,
-		       static_cast<rgw::sal::RadosStore*>(driver)->svc()->
-		       datalog_rados->get_info(dpp(), i),
-		       info, &errstr);
+      int r;
+      if (opt_log_zone_id) {
+       r = run_coro(dpp(), context_pool,
+                    datalog->get_info(dpp(), *opt_log_zone_id, i),
+                    info, &errstr);
+      } else {
+       r = run_coro(dpp(), context_pool,
+                    datalog->get_info(dpp(), i),
+                    info, &errstr);
+      }
 
       if (r < 0) {
 	std::cerr << "datalog status: " << errstr << std::endl;
@@ -11337,9 +11367,16 @@ next:
 
     std::string errstr;
     auto datalog = static_cast<rgw::sal::RadosStore*>(driver)->svc()->datalog_rados;
-    ret = run_coro(dpp(), context_pool,
-		   datalog->trim_entries(dpp(), shard_id, marker),
-		   &errstr);
+    if (opt_log_zone_id) {
+      ret = run_coro(dpp(), context_pool,
+                    datalog->trim_entries(dpp(), *opt_log_zone_id,
+                                         shard_id, marker),
+                    &errstr);
+    } else {
+      ret = run_coro(dpp(), context_pool,
+                    datalog->trim_entries(dpp(), shard_id, marker),
+                    &errstr);
+    }
 
     if (ret < 0 && ret != -ENODATA) {
       cerr << "ERROR: trim_entries(): " << errstr << std::endl;
@@ -11354,9 +11391,16 @@ next:
     }
     auto datalog = static_cast<rgw::sal::RadosStore*>(driver)->svc()->datalog_rados;
     std::string errstr;
-    ret = run_coro(dpp(), context_pool,
-		   datalog->change_format(dpp(), *opt_log_type),
-		   &errstr);
+    if (opt_log_zone_id) {
+      ret = run_coro(dpp(), context_pool,
+                    datalog->change_format(dpp(), *opt_log_zone_id,
+                                           *opt_log_type),
+                    &errstr);
+    } else {
+      ret = run_coro(dpp(), context_pool,
+                    datalog->change_format(dpp(), *opt_log_type),
+                    &errstr);
+    }
     if (ret < 0) {
       cerr << "ERROR: change_format(): " << errstr << std::endl;
       return -ret;
@@ -11367,9 +11411,16 @@ next:
     auto datalog = static_cast<rgw::sal::RadosStore*>(driver)->svc()->datalog_rados;
     std::optional<uint64_t> through;
     std::string errstr;
-    ret = run_coro(dpp(), context_pool,
-		   datalog->trim_generations(dpp(), through),
-		   &errstr);
+    if (opt_log_zone_id) {
+      ret = run_coro(dpp(), context_pool,
+                    datalog->trim_generations(dpp(), *opt_log_zone_id,
+                                              through),
+                    &errstr);
+    } else {
+      ret = run_coro(dpp(), context_pool,
+                    datalog->trim_generations(dpp(), through),
+                    &errstr);
+    }
 
     if (ret < 0) {
       cerr << "ERROR: trim_generations(): " << errstr << std::endl;

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -250,6 +250,16 @@ RGWCoroutinesStack::~RGWCoroutinesStack()
 int RGWCoroutinesStack::operate(const DoutPrefixProvider *dpp, RGWCoroutinesEnv *_env)
 {
   env = _env;
+  if (pos == ops.end()) {
+    lderr(cct) << "ERROR: " << __func__ << " stack=" << (void *)this
+              << " operate() called on done stack (ops empty)"
+              << " nref=" << get_nref()
+              << " is_scheduled=" << is_scheduled
+              << dendl;
+    done_flag = true;
+    blocked_flag = false;
+    return 0;
+  }
   RGWCoroutine *op = *pos;
   op->stack = this;
   ldpp_dout(dpp, 20) << *op << ": operate()" << dendl;

--- a/src/rgw/rgw_zone_features.h
+++ b/src/rgw/rgw_zone_features.h
@@ -16,12 +16,14 @@ namespace rgw::zone_features {
 inline constexpr std::string_view resharding = "resharding";
 inline constexpr std::string_view compress_encrypted = "compress-encrypted";
 inline constexpr std::string_view notification_v2 = "notification_v2";
+inline constexpr std::string_view per_zone_datalog = "per_zone_datalog";
 
 // static list of features supported by this release
 inline constexpr std::initializer_list<std::string_view> supported = {
     resharding,
     compress_encrypted,
     notification_v2,
+    per_zone_datalog,
 };
 
 inline constexpr bool supports(std::string_view feature) {
@@ -37,6 +39,7 @@ inline constexpr bool supports(std::string_view feature) {
 inline constexpr std::initializer_list<std::string_view> enabled = {
     resharding,
     notification_v2,
+    per_zone_datalog,
 };
 
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -293,6 +293,7 @@
      --rgw-zone=<name>                 name of zone in which radosgw is running
      --zone-id=<id>                    zone id
      --zone-new-name=<name>            zone new name
+     --log-zone=<name>                 target zone for per-zone datalog operations
      --source-zone                     specify the source zone (for data sync)
      --default                         set entity (realm, zonegroup, zone) as default
      --read-only                       set zone as read-only (when adding to zonegroup)

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1441,6 +1441,164 @@ def test_datalog_autotrim():
             after_trim = dateutil.parser.isoparse(entries[0]['timestamp'])
             assert before_trim < after_trim, "any datalog entries must be newer than trim"
 
+# --- Per-zone datalog helpers ---
+
+def datalog_list_zone(zone, zone_name, args=None):
+    """List datalog entries for a specific target zone's per-zone datalog."""
+    cmd = ['datalog', 'list', '--log-zone', zone_name]
+    if args:
+        cmd += args
+    (result_json, _) = zone.cluster.admin(cmd, read_only=True)
+    return json.loads(result_json)
+
+def datalog_status_zone(zone, zone_name):
+    """Get datalog status for a specific target zone's per-zone datalog."""
+    cmd = ['datalog', 'status', '--log-zone', zone_name]
+    (result_json, _) = zone.cluster.admin(cmd, read_only=True)
+    return json.loads(result_json)
+
+def datalog_trim_zone(zone, zone_name, shard_id, marker):
+    """Trim datalog entries for a specific target zone's per-zone datalog."""
+    cmd = ['datalog', 'trim', '--log-zone', zone_name,
+           '--shard-id', str(shard_id), '--marker', marker]
+    zone.cluster.admin(cmd)
+
+def test_per_zone_datalog_entries():
+    """Verify that per-zone datalogs are populated and that sync works
+    correctly through per-zone logs (both full and incremental)."""
+    zonegroup = realm.master_zonegroup()
+    if len(zonegroup.rw_zones) < 2:
+        raise SkipTest("test_per_zone_datalog_entries skipped. Requires 2 or more RW zones.")
+
+    zonegroup_conns = ZonegroupConns(zonegroup)
+
+    # create a bucket and upload an object on zone 0
+    source_conn = zonegroup_conns.rw_zones[0]
+    bucket_name = gen_bucket_name()
+    log.info('create bucket zone=%s name=%s', source_conn.name, bucket_name)
+    source_conn.create_bucket(bucket_name)
+    zonegroup_meta_checkpoint(zonegroup)
+
+    key1 = 'perzone-key-1'
+    source_conn.s3_client.put_object(
+        Bucket=bucket_name, Key=key1, Body='perzone-body-1')
+
+    # before sync completes, per-zone datalogs on the source should
+    # already have entries for every peer zone
+    for target_conn in zonegroup_conns.rw_zones:
+        if target_conn.zone.id == source_conn.zone.id:
+            continue
+        entries = datalog_list_zone(source_conn.zone, target_conn.zone.name)
+        assert len(entries) > 0, \
+            "Per-zone datalog on %s for target %s should have entries" % \
+            (source_conn.zone.name, target_conn.zone.name)
+
+    # wait for full sync and verify data arrived
+    zonegroup_data_checkpoint(zonegroup_conns)
+    for target_conn in zonegroup_conns.rw_zones:
+        if target_conn.zone.id == source_conn.zone.id:
+            continue
+        zone_bucket_checkpoint(target_conn.zone, source_conn.zone, bucket_name)
+        resp = target_conn.s3_client.get_object(Bucket=bucket_name, Key=key1)
+        assert resp['Body'].read() == b'perzone-body-1', \
+            "Zone %s has wrong data for %s" % (target_conn.zone.name, key1)
+
+    # incremental sync: upload another object
+    key2 = 'perzone-key-2'
+    source_conn.s3_client.put_object(
+        Bucket=bucket_name, Key=key2, Body='perzone-body-2')
+
+    zonegroup_data_checkpoint(zonegroup_conns)
+    for target_conn in zonegroup_conns.rw_zones:
+        if target_conn.zone.id == source_conn.zone.id:
+            continue
+        zone_bucket_checkpoint(target_conn.zone, source_conn.zone, bucket_name)
+        resp = target_conn.s3_client.get_object(Bucket=bucket_name, Key=key2)
+        assert resp['Body'].read() == b'perzone-body-2', \
+            "Zone %s has wrong data for %s after incremental sync" % \
+            (target_conn.zone.name, key2)
+
+def test_per_zone_datalog_trim_independence():
+    """Verify that trimming a caught-up zone's datalog preserves entries
+    for a zone that is still behind.
+
+    Stop zone C so it falls behind, write data on zone A, wait for zone B
+    to pull and sync, then trim zone B's per-zone datalog on zone A.
+    Zone C's per-zone datalog on zone A must still contain the entries so
+    zone C can catch up once it comes back.
+    """
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+
+    if len(zonegroup_conns.rw_zones) < 3:
+        raise SkipTest("Requires 3 or more RW zones.")
+
+    zone_a_conn = zonegroup_conns.rw_zones[0]  # source — writes data
+    zone_b_conn = zonegroup_conns.rw_zones[1]  # consumer — stays up, pulls
+    zone_c_conn = zonegroup_conns.rw_zones[2]  # consumer — stopped, falls behind
+    zone_a = zone_a_conn.zone
+    zone_b = zone_b_conn.zone
+    zone_c = zone_c_conn.zone
+
+    # make sure everything is in sync before we start
+    zonegroup_meta_checkpoint(zonegroup)
+    zonegroup_data_checkpoint(zonegroup_conns)
+
+    # --- stop zone C so it falls behind ---
+    zone_c.stop()
+
+    # write an object on zone A (the source)
+    bucket_name = gen_bucket_name()
+    log.info('create bucket zone=%s name=%s', zone_a.name, bucket_name)
+    zone_a_conn.create_bucket(bucket_name)
+    # only checkpoint zones that are up (zone C is stopped)
+    zone_meta_checkpoint(zone_b)
+    zone_a_conn.s3_client.put_object(
+        Bucket=bucket_name, Key='trim-ind-key', Body='trim-ind-body')
+
+    # wait for zone B to pull from zone A (zone C is down, skip it)
+    zone_bucket_checkpoint(zone_b, zone_a, bucket_name)
+
+    # zone C's per-zone datalog on zone A should have entries (it hasn't
+    # pulled yet)
+    entries_c = datalog_list_zone(zone_a, zone_c.name)
+    assert len(entries_c) > 0, \
+        "Zone C per-zone datalog should have entries (zone C hasn't synced)"
+
+    # trim zone B's per-zone datalog on zone A (zone B already synced)
+    status_b = datalog_status_zone(zone_a, zone_b.name)
+    for shard_id, shard_status in enumerate(status_b):
+        marker = shard_status.get('marker', '')
+        if marker:
+            datalog_trim_zone(zone_a, zone_b.name, shard_id, marker)
+
+    # zone B's entries should be gone after the trim
+    entries_b_after = datalog_list_zone(zone_a, zone_b.name)
+    assert len(entries_b_after) == 0, \
+        "Zone B entries should be trimmed"
+
+    # zone C's entries must still be there after zone B's trim
+    entries_c_after = datalog_list_zone(zone_a, zone_c.name)
+    assert len(entries_c_after) > 0, \
+        "Zone C entries must survive zone B's trim"
+
+    # --- bring zone C back and verify it catches up ---
+    zone_c.start()
+    # zone C missed the metadata for the bucket while it was down
+    zone_meta_checkpoint(zone_c)
+    zone_bucket_checkpoint(zone_c, zone_a, bucket_name)
+
+    # now that zone C has synced, trim its datalog and verify entries are gone
+    status_c = datalog_status_zone(zone_a, zone_c.name)
+    for shard_id, shard_status in enumerate(status_c):
+        marker = shard_status.get('marker', '')
+        if marker:
+            datalog_trim_zone(zone_a, zone_c.name, shard_id, marker)
+
+    entries_c_final = datalog_list_zone(zone_a, zone_c.name)
+    assert len(entries_c_final) == 0, \
+        "Zone C entries should be trimmed after sync and trim"
+
 def test_multi_zone_redirect():
     zonegroup = realm.master_zonegroup()
     if len(zonegroup.rw_zones) < 2:

--- a/src/test/rgw/test_datalog.cc
+++ b/src/test/rgw/test_datalog.cc
@@ -14,6 +14,7 @@
  */
 
 #include "rgw_datalog.h"
+#include "rgw_log_backing.h"
 
 #include <string_view>
 
@@ -184,6 +185,99 @@ protected:
     datalog->semaphores[datalog->choose_oid(bg.shard)].insert(bg.get_key());
   }
 
+  // Per-zone helpers (friendship doesn't inherit, so derived classes
+  // must use these base-class methods to access private members)
+  void add_to_zone_semaphores(const rgw_zone_id& zone, const BucketGen& bg) {
+    std::unique_lock l(datalog->lock);
+    auto it = datalog->zone_logs.find(zone);
+    if (it != datalog->zone_logs.end()) {
+      it->second.semaphores[datalog->choose_oid(bg.shard)].insert(bg.get_key());
+    }
+  }
+
+  auto zone_sem_set_oid(const rgw_zone_id& zone, const BucketGen& bg) {
+    return datalog->get_sem_set_oid(zone, datalog->choose_oid(bg.shard));
+  }
+
+  void set_legacy_writes_disabled(bool val) {
+    datalog->legacy_writes_disabled_ = val;
+  }
+
+  // Set target zone IDs for per-zone datalog testing (accesses private
+  // member via DataLogTestBase friendship with RGWDataChangesLog)
+  static void set_target_zone_ids(RGWDataChangesLog& dl,
+                                 std::vector<rgw_zone_id> ids) {
+    dl.target_zone_ids_ = std::move(ids);
+  }
+
+  // Initialize per-zone backends in a test coroutine context.
+  // Unlike the production init_zone_backends() which uses
+  // async::use_blocked (and would deadlock inside a coroutine on the
+  // same executor), this version uses co_await directly.
+  static asio::awaitable<void>
+  init_test_zone_backends(const DoutPrefixProvider* dpp_,
+                         RGWDataChangesLog& dl) {
+    auto defbacking = to_log_type(
+      dl.cct->_conf.get_val<std::string>("rgw_default_data_log_backing"));
+    ceph_assert(defbacking);
+    for (const auto& zone_id : dl.target_zone_ids_) {
+      auto zone_bes = co_await logback_generations::init<DataLogBackends>(
+       dpp_, *dl.rados, dl.metadata_log_oid(zone_id), dl.loc,
+       [&dl, zone_id](uint64_t gen_id, int shard) {
+         return dl.get_oid(zone_id, gen_id, shard);
+       }, dl.num_shards, *defbacking, dl, zone_id);
+      ZoneLog zlog;
+      zlog.zone_id = zone_id;
+      zlog.bes = std::move(zone_bes);
+      zlog.semaphores.resize(dl.num_shards);
+      dl.zone_logs.emplace(zone_id, std::move(zlog));
+    }
+  }
+
+  asio::awaitable<bc::flat_map<std::string, uint64_t>>
+  read_all_zone_sems(const rgw_zone_id& zone) {
+    bc::flat_map<std::string, uint64_t> all_sems;
+    for (auto i = 0; i < datalog->num_shards; ++i) {
+      std::string cursor;
+      do {
+       try {
+         co_await rados().execute(
+           datalog->get_sem_set_oid(zone, i), datalog->loc,
+           neorados::ReadOp{}.exec(ss::list(datalog->sem_max_keys, cursor,
+                                            &all_sems, &cursor)),
+           nullptr, asio::use_awaitable);
+       } catch (const sys::system_error& e) {
+         if (e.code() == sys::errc::no_such_file_or_directory) {
+           break;
+         } else {
+           throw;
+         }
+       }
+      } while (!cursor.empty());
+    }
+    co_return std::move(all_sems);
+  }
+
+  asio::awaitable<bc::flat_map<BucketGen, uint64_t>>
+  read_all_zone_log(const DoutPrefixProvider* dpp, const rgw_zone_id& zone) {
+    bc::flat_map<BucketGen, uint64_t> all_keys;
+    for (auto shard = 0; shard < datalog->num_shards; ++shard) {
+      std::string marker;
+      bool truncated = true;
+      while (truncated) {
+       auto [entries, outmarker, trunc] =
+         co_await datalog->list_entries(dpp, zone, shard, 1'000, marker);
+       truncated = trunc;
+       marker = std::move(outmarker);
+       for (const auto& entry : entries) {
+         auto key = fmt::format("{}:{}", entry.entry.key, entry.entry.gen);
+         all_keys[BucketGen{key}] += 1;
+       }
+      }
+    }
+    co_return std::move(all_keys);
+  }
+
 public:
 
   /// \brief Create RADOS handle and pool for the test
@@ -211,7 +305,8 @@ private:
   asio::awaitable<std::unique_ptr<RGWDataChangesLog>> create_datalog() override {
     auto datalog = std::make_unique<RGWDataChangesLog>(rados().cct(), true,
 						       rados());
-    co_await datalog->start(dpp(), rgw_pool(pool_name()), false, true, false);
+    co_await datalog->start(dpp(), rgw_pool(pool_name()),
+                           false, true, false);
     co_return std::move(datalog);
   }
 };
@@ -221,7 +316,8 @@ private:
   asio::awaitable<std::unique_ptr<RGWDataChangesLog>> create_datalog() override {
     auto datalog = std::make_unique<RGWDataChangesLog>(rados().cct(), true,
 						       rados());
-    co_await datalog->start(dpp(), rgw_pool(pool_name()), false, false, false);
+    co_await datalog->start(dpp(), rgw_pool(pool_name()),
+                           false, false, false);
     co_return std::move(datalog);
   }
 };
@@ -233,7 +329,8 @@ private:
     // can test iterated increment/decrement/list code.
     auto datalog = std::make_unique<RGWDataChangesLog>(rados().cct(), true,
 						       rados(), 1, 7);
-    co_await datalog->start(dpp(), rgw_pool(pool_name()), false, true, false);
+    co_await datalog->start(dpp(), rgw_pool(pool_name()),
+                           false, true, false);
     co_return std::move(datalog);
   }
 };
@@ -467,5 +564,302 @@ CORO_TEST_F(DataLogBulky, BulkySemaphoresRecovery, DataLogBulky) {
   for (const auto& bg : bulky) {
     EXPECT_TRUE(log_entries.contains(bg));
   }
+  co_return;
+}
+
+// --- Multi-zone datalog tests ---
+
+static const rgw_zone_id zone_a{"zone-a-id"};
+static const rgw_zone_id zone_b{"zone-b-id"};
+
+class DataLogMultiZone : public DataLogTestBase {
+private:
+  asio::awaitable<std::unique_ptr<RGWDataChangesLog>> create_datalog() override {
+    auto datalog = std::make_unique<RGWDataChangesLog>(rados().cct(), true,
+                                                      rados());
+    set_target_zone_ids(*datalog, {zone_a, zone_b});
+    co_await datalog->start(dpp(), rgw_pool(pool_name()),
+                           false, true, false);
+    co_await init_test_zone_backends(dpp(), *datalog);
+    co_return std::move(datalog);
+  }
+
+  asio::awaitable<void> CoSetUp() override {
+    co_await DataLogTestBase::CoSetUp();
+    // Enable per-zone writes (feature enabled = legacy writes disabled)
+    set_legacy_writes_disabled(true);
+  }
+};
+
+// Verify that get_zone_ids() returns the configured zones
+CORO_TEST_F(DataLogMultiZone, ZoneIds, DataLogMultiZone) {
+  auto ids = datalog->get_zone_ids();
+  ASSERT_EQ(2u, ids.size());
+  // map iteration order is sorted by key
+  std::sort(ids.begin(), ids.end(),
+           [](const auto& a, const auto& b) { return a.id < b.id; });
+  EXPECT_EQ(zone_a, ids[0]);
+  EXPECT_EQ(zone_b, ids[1]);
+  co_return;
+}
+
+// Verify add_entry writes to per-zone backends only (not legacy) when
+// the per_zone_datalog feature is enabled.
+CORO_TEST_F(DataLogMultiZone, PerZoneWriteOnly, DataLogMultiZone) {
+  for (const auto& bg : ref) {
+    co_await add_entry(dpp(), bg);
+    co_await add_entry(dpp(), bg);
+  }
+  co_await renew_entries(dpp());
+
+  // Legacy log should be empty (feature enabled = legacy writes disabled)
+  auto legacy_entries = co_await read_all_log(dpp());
+  EXPECT_TRUE(legacy_entries.empty())
+    << "Legacy log should be empty when per_zone_datalog is enabled";
+
+  // Verify zone_a log has entries
+  auto zone_a_entries = co_await read_all_zone_log(dpp(), zone_a);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_a_entries.contains(bg))
+      << "Zone A log missing entry for " << bg;
+  }
+
+  // Verify zone_b log has entries
+  auto zone_b_entries = co_await read_all_zone_log(dpp(), zone_b);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_b_entries.contains(bg))
+      << "Zone B log missing entry for " << bg;
+  }
+  co_return;
+}
+
+// Verify that semaphores are created for per-zone backends only
+// (legacy writes are disabled in DataLogMultiZone)
+CORO_TEST_F(DataLogMultiZone, PerZoneSemaphores, DataLogMultiZone) {
+  for (const auto& bg : ref) {
+    co_await add_entry(dpp(), bg);
+    co_await add_entry(dpp(), bg);
+    co_await add_entry(dpp(), bg);
+  }
+
+  // Legacy semaphores should be empty (legacy writes disabled)
+  auto legacy_sems = co_await read_all_sems_all_shards();
+  EXPECT_TRUE(legacy_sems.empty())
+    << "Legacy semaphores should be empty when legacy writes are disabled";
+
+  // Per-zone semaphores should be populated
+  auto zone_a_sems = co_await read_all_zone_sems(zone_a);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_a_sems.contains(bg.get_key()))
+      << "Zone A semaphore missing for " << bg;
+    EXPECT_EQ(1, zone_a_sems[bg.get_key()]);
+  }
+
+  auto zone_b_sems = co_await read_all_zone_sems(zone_b);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_b_sems.contains(bg.get_key()))
+      << "Zone B semaphore missing for " << bg;
+    EXPECT_EQ(1, zone_b_sems[bg.get_key()]);
+  }
+
+  // After renew, per-zone semaphores should be cleared
+  co_await renew_entries(dpp());
+  legacy_sems = co_await read_all_sems_all_shards();
+  EXPECT_TRUE(legacy_sems.empty());
+  zone_a_sems = co_await read_all_zone_sems(zone_a);
+  EXPECT_TRUE(zone_a_sems.empty());
+  zone_b_sems = co_await read_all_zone_sems(zone_b);
+  EXPECT_TRUE(zone_b_sems.empty());
+  co_return;
+}
+
+// Verify per-zone list_entries returns zone-specific entries
+CORO_TEST_F(DataLogMultiZone, PerZoneListEntries, DataLogMultiZone) {
+  for (const auto& bg : ref) {
+    co_await add_entry(dpp(), bg);
+    co_await add_entry(dpp(), bg);
+  }
+  co_await renew_entries(dpp());
+
+  // Each zone should have entries for all ref entries
+  for (const auto& zone : {zone_a, zone_b}) {
+    auto entries = co_await read_all_zone_log(dpp(), zone);
+    EXPECT_EQ(ref.size(), entries.size())
+      << "Zone " << zone << " has wrong number of entries";
+    for (const auto& bg : ref) {
+      EXPECT_TRUE(entries.contains(bg))
+       << "Zone " << zone << " missing entry for " << bg;
+    }
+  }
+  co_return;
+}
+
+// Verify per-zone trim only affects the specified zone
+CORO_TEST_F(DataLogMultiZone, PerZoneTrimIndependent, DataLogMultiZone) {
+  for (const auto& bg : ref) {
+    co_await add_entry(dpp(), bg);
+    co_await add_entry(dpp(), bg);
+  }
+  co_await renew_entries(dpp());
+
+  // Get the current marker for zone_a shard 0
+  auto zone_a_info = co_await datalog->get_info(dpp(), zone_a, 0);
+  if (!zone_a_info.marker.empty()) {
+    // Trim zone_a shard 0 up to its current marker
+    co_await datalog->trim_entries(dpp(), zone_a, 0, zone_a_info.marker);
+  }
+
+  // Zone_a shard 0 should be trimmed (list returns empty or fewer entries)
+  auto [zone_a_entries, zone_a_marker, zone_a_trunc] =
+    co_await datalog->list_entries(dpp(), zone_a, 0, 1'000, {});
+
+  // Zone_b should still have all entries (untouched by zone_a trim)
+  auto zone_b_entries = co_await read_all_zone_log(dpp(), zone_b);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_b_entries.contains(bg))
+      << "Zone B should still have entry for " << bg << " after zone A trim";
+  }
+
+  // Legacy writes are disabled in DataLogMultiZone, so legacy log should
+  // remain empty and be unaffected by per-zone trims
+  auto legacy_entries = co_await read_all_log(dpp());
+  EXPECT_TRUE(legacy_entries.empty())
+    << "Legacy datalog should remain empty when legacy writes are disabled";
+  co_return;
+}
+
+// Verify per-zone get_info works
+CORO_TEST_F(DataLogMultiZone, PerZoneGetInfo, DataLogMultiZone) {
+  for (const auto& bg : ref) {
+    co_await add_entry(dpp(), bg);
+    co_await add_entry(dpp(), bg);
+  }
+  co_await renew_entries(dpp());
+
+  // get_info for each zone should return valid info
+  for (const auto& zone : {zone_a, zone_b}) {
+    bool found_nonempty = false;
+    for (auto i = 0; i < datalog->num_shards; ++i) {
+      auto info = co_await datalog->get_info(dpp(), zone, i);
+      if (!info.marker.empty()) {
+       found_nonempty = true;
+      }
+    }
+    EXPECT_TRUE(found_nonempty)
+      << "Zone " << zone << " should have at least one non-empty shard";
+  }
+  co_return;
+}
+
+// Verify per-zone recovery works
+CORO_TEST_F(DataLogMultiZone, PerZoneRecovery, DataLogMultiZone) {
+  // Manually add semaphores to per-zone sem_sets (simulating crash)
+  for (const auto& bg : ref) {
+    co_await rados().execute(zone_sem_set_oid(zone_a, bg), loc(),
+                            WriteOp{}.exec(ss::increment(bg.get_key())),
+                            asio::use_awaitable);
+    co_await rados().execute(zone_sem_set_oid(zone_b, bg), loc(),
+                            WriteOp{}.exec(ss::increment(bg.get_key())),
+                            asio::use_awaitable);
+    // Also add to legacy sem_set for completeness
+    co_await rados().execute(sem_set_oid(bg), loc(),
+                            WriteOp{}.exec(ss::increment(bg.get_key())),
+                            asio::use_awaitable);
+  }
+
+  co_await recover(dpp());
+
+  // All semaphores should be cleared after recovery
+  auto legacy_sems = co_await read_all_sems_all_shards();
+  EXPECT_TRUE(legacy_sems.empty()) << "Legacy semaphores not cleared";
+
+  auto zone_a_sems = co_await read_all_zone_sems(zone_a);
+  EXPECT_TRUE(zone_a_sems.empty()) << "Zone A semaphores not cleared";
+
+  auto zone_b_sems = co_await read_all_zone_sems(zone_b);
+  EXPECT_TRUE(zone_b_sems.empty()) << "Zone B semaphores not cleared";
+
+  // All backends should have recovered entries
+  auto legacy_entries = co_await read_all_log(dpp());
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(legacy_entries.contains(bg))
+      << "Legacy missing recovered entry for " << bg;
+  }
+
+  auto zone_a_entries = co_await read_all_zone_log(dpp(), zone_a);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_a_entries.contains(bg))
+      << "Zone A missing recovered entry for " << bg;
+  }
+
+  auto zone_b_entries = co_await read_all_zone_log(dpp(), zone_b);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_b_entries.contains(bg))
+      << "Zone B missing recovered entry for " << bg;
+  }
+  co_return;
+}
+
+// --- Legacy writes disabled tests ---
+
+class DataLogLegacyDisabled : public DataLogTestBase {
+private:
+  asio::awaitable<std::unique_ptr<RGWDataChangesLog>> create_datalog() override {
+    auto datalog = std::make_unique<RGWDataChangesLog>(rados().cct(), true,
+                                                      rados());
+    set_target_zone_ids(*datalog, {zone_a, zone_b});
+    co_await datalog->start(dpp(), rgw_pool(pool_name()),
+                           false, true, false);
+    co_await init_test_zone_backends(dpp(), *datalog);
+    co_return std::move(datalog);
+  }
+
+  // Called after base CoSetUp creates the datalog
+  asio::awaitable<void> CoSetUp() override {
+    co_await DataLogTestBase::CoSetUp();
+    // Simulate per_zone_datalog feature enabled
+    set_legacy_writes_disabled(true);
+  }
+};
+
+// When legacy writes are disabled, entries should only appear in per-zone logs
+CORO_TEST_F(DataLogLegacyDisabled, NoLegacyWrites, DataLogLegacyDisabled) {
+  for (const auto& bg : ref) {
+    co_await add_entry(dpp(), bg);
+    co_await add_entry(dpp(), bg);
+  }
+  co_await renew_entries(dpp());
+
+  // Legacy log should be empty (no writes)
+  auto legacy_entries = co_await read_all_log(dpp());
+  EXPECT_TRUE(legacy_entries.empty())
+    << "Legacy log should be empty when legacy writes are disabled";
+
+  // Per-zone logs should still have entries
+  auto zone_a_entries = co_await read_all_zone_log(dpp(), zone_a);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_a_entries.contains(bg))
+      << "Zone A should have entry for " << bg;
+  }
+
+  auto zone_b_entries = co_await read_all_zone_log(dpp(), zone_b);
+  for (const auto& bg : ref) {
+    EXPECT_TRUE(zone_b_entries.contains(bg))
+      << "Zone B should have entry for " << bg;
+  }
+  co_return;
+}
+
+// Verify invalid zone_id throws
+CORO_TEST_F(DataLogMultiZone, InvalidZoneThrows, DataLogMultiZone) {
+  rgw_zone_id bad_zone{"nonexistent-zone"};
+  bool caught = false;
+  try {
+    co_await datalog->list_entries(dpp(), bad_zone, 0, 100, {});
+  } catch (const sys::system_error& e) {
+    caught = true;
+    EXPECT_EQ(ENOENT, e.code().value());
+  }
+  EXPECT_TRUE(caught) << "Expected ENOENT for invalid zone_id";
   co_return;
 }


### PR DESCRIPTION
RGW multisite sync currently uses a single shared datalog that all peer zones read from. When one zone trims entries it has already consumed, those entries become unavailable to other zones that may still need them. Recovery and trim operations must coordinate across all peers, creating unnecessary coupling.

This PR introduces per-zone datalogs: each consuming zone gets its own independent datalog stream on the source zone. The source zone writes entries to the appropriate per-zone backend, and each consumer reads and trims only its own stream without affecting others.

The feature is controlled by the `per_zone_datalog` zone feature flag, which is enabled by default on new zonegroups. When enabled, writes go exclusively to per-zone backends. When disabled, the legacy shared datalog is used unchanged. There is no dual-write phase - the switch is immediate based on the feature flag, keeping the write path simple and avoiding doubled RADOS I/O.

On the sync consumer side, each zone now passes its own `zone-id` in HTTP requests to the source zone. The source zone's REST handlers route to the per-zone backend if one exists for that zone, and fall through to legacy otherwise. The trim path was extended with a per-zone variant that trims each zone's datalog based on that specific zone's sync progress rather than the minimum across all peers.

The `radosgw-admin` CLI gained a `--log-zone` flag that accepts a zone name for per-zone datalog operations (list, status, trim, etc.).

Fixed a pre-existing bug in the period POST handler where `create_period()` internally calls `update_latest_epoch()`, making the subsequent explicit call in the handler always return `-EEXIST`. This caused the handler to skip the realm reload notification, preventing gateways from discovering newly added zones after a period commit.

Added a safety guard in the coroutine framework against operating on completed stacks, and fixed a shutdown crash in neorados caused by circular ownership between Notifier and LingerOp objects.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
