### PR TITLE
osd: fix balanced-or-localized writes-at-primary getting EINVAL

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2056,27 +2056,38 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     }
   }
 
-  // check for op with rwordered and rebalance or localize reads
-  if (m->has_flag(CEPH_OSD_FLAGS_DIRECT_READ) && op->rwordered()) {
-    dout(4) << __func__ << ": rebelance or localized reads with rwordered not allowed "
-       << *m << dendl;
-    osd->reply_op_error(op, -EINVAL);
-    return;
-  }
-
   if (m->get_flags() & CEPH_OSD_FLAG_EC_DIRECT_READ) {
-    if (is_primary() || is_nonprimary()) {
+    if (op->rwordered()) {
+      // EC_DIRECT_READS have been introduced when any rwordered,
+      // balanced-or-localized op was getting `EINVAL`.
+      dout(4) << __func__ << ": EC direct reads with rwordered not allowed "
+              << *m << dendl;
+      osd->reply_op_error(op, -EINVAL);
+    } else if (is_primary() || is_nonprimary()) {
+      // primary or replica case
       op->set_ec_direct_read();
     } else {
       osd->handle_misdirected_op(this, op);
       return;
     }
-  } else if ((m->get_flags() & (CEPH_OSD_FLAG_BALANCE_READS |
-                                CEPH_OSD_FLAG_LOCALIZE_READS)) &&
-      op->may_read() &&
-      !(op->may_write() || op->may_cache())) {
-    // balanced reads; any replica will do
-    if (!(is_primary() || is_nonprimary())) {
+  } else if (m->get_flags() & (CEPH_OSD_FLAG_BALANCE_READS |
+                               CEPH_OSD_FLAG_LOCALIZE_READS)) {
+    if (is_primary()) {
+      // handling at primary is always fine, even it's a write
+      // flagged as balanced-or-localized-read.
+      // FALLTHROUGH
+    } else if (op->rwordered()) {
+      dout(4) << __func__
+              << ": balanced or localized reads with rwordered not allowed "
+                 "at outside primary " << *m << dendl;
+      // an rwordered does not make sense anywhere outside primary.
+      // neither on replica nor outside the acting set.
+      osd->reply_op_error(op, -EINVAL);
+      return;
+    } else if (is_nonprimary() && op->may_read()) {
+      // balanced or localized, non-rwordered read at replica is fine.
+      // FALLTHROUGH
+    } else {
       osd->handle_misdirected_op(this, op);
       return;
     }


### PR DESCRIPTION
Initially `PrimaryLogPG::do_op()` allowed balanced/localized reads, categorized as `OpInfo::rwordered_forced()`, to happen not only at the primary but also on replicas. This was the defect behind https://tracker.ceph.com/issues/70715.

Then, we started rejecting any `CEPH_OSD_FLAG_BALANCE_READS` or `CEPH_OSD_FLAG_LOCALIZED_READS`-flagged op for which `OpInfo::rwordered()` was `true`. Unfortunately, this caused https://tracker.ceph.com/issues/73997 as the kcephfs client was using those flags also for writes being legitimately sent to primaries.

This commit, in contrast to the simple revert we've done for Tentacle, attempts to deal with those (and new ones from FastEC) subtleties by letting current clients execute at the primary any localized-or-balanced, rwordered op while rejecting them anywhere else (on replicas as well as outside the acting set).

Fixes: https://tracker.ceph.com/issues/75076





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
