### PR TITLE
[WIP] qa/suites/crimson-rados: enable cephadm tests

### DIFF
--- a/qa/clusters/crimson/crimson-fixed-2.yaml
+++ b/qa/clusters/crimson/crimson-fixed-2.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, osd.0, osd.1, client.0, node-exporter.a]
-- [mgr.x, osd.2, osd.3, client.1, prometheus.a, node-exporter.b]
+- [mon.a, mgr.x, osd.0, osd.1, client.0, node-exporter.a]
+- [osd.2, osd.3, client.1, prometheus.a, node-exporter.b]
 overrides:
   ceph:
     conf:

--- a/qa/suites/crimson-rados/basic/deploy/cephadm.yaml
+++ b/qa/suites/crimson-rados/basic/deploy/cephadm.yaml
@@ -2,6 +2,7 @@
 verify_ceph_hash: false
 tasks:
 - cephadm:
+    osd_type: crimson
     conf:
       mgr:
         debug ms: 1

--- a/qa/suites/crimson-rados/perf/deploy/cephadm.yaml
+++ b/qa/suites/crimson-rados/perf/deploy/cephadm.yaml
@@ -2,6 +2,8 @@
 verify_ceph_hash: false
 tasks:
 - cephadm:
+    osd_type: crimson
+    no_minimize_config: true
     conf:
       mgr:
         debug ms: 1

--- a/qa/suites/crimson-rados/rbd/deploy/cephadm.yaml
+++ b/qa/suites/crimson-rados/rbd/deploy/cephadm.yaml
@@ -2,6 +2,7 @@
 verify_ceph_hash: false
 tasks:
 - cephadm:
+    osd_type: crimson
     conf:
       mgr:
         debug ms: 1

--- a/qa/suites/crimson-rados/thrash/deploy/cephadm.yaml
+++ b/qa/suites/crimson-rados/thrash/deploy/cephadm.yaml
@@ -2,6 +2,7 @@
 verify_ceph_hash: false
 tasks:
 - cephadm:
+    osd_type: crimson
     conf:
       mgr:
         debug ms: 1

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -46,6 +46,8 @@ def shell(ctx, cluster_name, remote, args, name=None, **kwargs):
             ctx.cephadm,
             '--image', ctx.ceph[cluster_name].image,
             'shell',
+            '-c', '/etc/ceph/{}.conf'.format(cluster_name),
+            '-k', '/etc/ceph/{}.client.admin.keyring'.format(cluster_name),
         ] + extra_args + [
             '--fsid', ctx.ceph[cluster_name].fsid,
             '--',

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -736,6 +736,8 @@ def ceph_bootstrap(ctx, config):
             cmd += ['--single-host-defaults']
         if not config.get('avoid_pacific_features', False):
             cmd += ['--skip-admin-label']
+        if config.get('no_minimize_config', False):
+            cmd += ['--no-minimize-config']
         # bootstrap makes the keyring root 0600, so +r it for our purposes
         cmd += [
             run.Raw('&&'),
@@ -1136,6 +1138,9 @@ def ceph_osds(ctx, config):
             osd_cmd = ['ceph', 'orch', 'apply', 'osd', '--all-available-devices']
             if raw:
                 osd_cmd.extend(['--method', 'raw'])
+            osd_type = config.get('osd_type')
+            if osd_type:
+                osd_cmd.extend(['--osd-type', osd_type])
             _shell(ctx, cluster_name, remote, osd_cmd)
             # expect the number of scratch devs
             num_osds = sum(map(len, devs_by_remote.values()))
@@ -1166,6 +1171,21 @@ def ceph_osds(ctx, config):
         yield
     finally:
         pass
+
+
+@contextlib.contextmanager
+def check_enable_crimson(ctx, config):
+    """
+    Enable crimson-related flags if crimson_compat is set.
+    """
+    cluster_name = config['cluster']
+    if config.get('crimson_compat', False):
+        log.info('Enabling crimson flags...')
+        remote = ctx.ceph[cluster_name].bootstrap_remote
+        _shell(ctx, cluster_name, remote, [
+            'ceph', 'osd', 'set-allow-crimson', '--yes-i-really-mean-it'
+        ])
+    yield
 
 
 @contextlib.contextmanager
@@ -2035,6 +2055,7 @@ def task(ctx, config):
             lambda: module_setup(ctx=ctx, config=config),
             lambda: ceph_mgrs(ctx=ctx, config=config),
             lambda: conf_setup(ctx=ctx, config=config),
+            lambda: check_enable_crimson(ctx=ctx, config=config),
             lambda: ceph_osds(ctx=ctx, config=config),
             lambda: ceph_mdss(ctx=ctx, config=config),
             lambda: cephfs_setup(ctx=ctx, config=config),


### PR DESCRIPTION
This PR enables cephadm tests in the crimson suites. To do the same, we make use of --osd-type flag to deploy crimson OSDs.

Fixes: https://tracker.ceph.com/issues/71946

<details>
<summary> Debugging failed QA Runs:</summary>

https://pulpito.ceph.com/shraddhaag-2026-02-23_09:58:48-crimson-rados-main-distro-debug-trial/ 

|Major Failures|Resolution|
|--------------|----------|
|no mgrs on the same host as first mon a|moved mgr to the node with mon in crimson-fixed-2.yml|
|"2026-02-23T10:12:59.012356+0000 mgr.x (mgr.14152) 64 : cluster [ERR] Unhandled exception from module 'devicehealth' while running on mgr.x: osd pool create failed: set-allow-crimson must be set to create a pool with the crimson flag (--crimson specified or osd_pool_default_crimson set) retval: -22" in cluster log|fixed by introducing `check_enable_crimson` in cephadm.py, similar to https://github.com/shraddhaag/ceph/blob/main/qa/tasks/ceph.py#L435|
|"grep: /var/log/ceph/f0981bfd-10a1-11f1-8b9a-d404e6e7d460/ceph.log: No such file or directory" in cluster log| TODO| 

https://pulpito.ceph.com/shraddhaag-2026-02-24_06:51:01-crimson-rados-main-distro-debug-trial/ 

|Major Failures|Resolution|
|--------------|----------|
|statfs /var/lib/ceph/aa87fcce-1159-11f1-8059-d404e6e7d460/config/ceph.client.admin.keyring: no such file or directory|in ceph_manager.py, give explicit location for config and keyring|
</details>

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
