### PR TITLE
crimson: fix stack-use-after-return in ConfigProxy::parse_argv

### DIFF
--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -192,17 +192,13 @@ public:
   }
   void show_config(ceph::Formatter* f) const;
 
-  seastar::future<> parse_argv(std::vector<const char*>& argv) {
-    // we could pass whatever is unparsed to seastar, but seastar::app_template
-    // is used for driving the seastar application, and
-    // crimson::common::ConfigProxy is not available until seastar engine is up
-    // and running, so we have to feed the command line args to app_template
-    // first, then pass them to ConfigProxy.
-    return do_change([&argv, this](ConfigValues& values) {
-      get_config().parse_argv(values,
-			      obs_mgr,
-			      argv,
-			      CONF_CMDLINE);
+  seastar::future<> parse_argv(std::vector<std::string> args) {
+    // Take args by value so the lambda can safely be invoked on another shard
+    return do_change([args = std::move(args), this](ConfigValues& values) {
+      std::vector<const char*> argv;
+      argv.reserve(args.size());
+      for (const auto& s : args) argv.push_back(s.c_str());
+      get_config().parse_argv(values, obs_mgr, argv, CONF_CMDLINE);
     });
   }
 

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -104,7 +104,7 @@ int main(int argc, const char* argv[])
   INFO("early config parsed successfully");
 
   auto seastar_n_early_args = early_config.get_early_args();
-  auto config_proxy_args = early_config.get_ceph_args();
+  auto config_proxy_args = early_config.ceph_args;
 
   INFO("initializing seastar app_template");
   seastar::app_template::config app_cfg;

--- a/src/crimson/osd/main_config_bootstrap_helpers.cc
+++ b/src/crimson/osd/main_config_bootstrap_helpers.cc
@@ -173,7 +173,10 @@ _get_early_config(int argc, const char *argv[])
 	auto stop_perf_coll = seastar::deferred_stop(sharded_perf_coll());
 
 	local_conf().parse_env().get();
-	local_conf().parse_argv(early_args).get();
+	{
+	  std::vector<std::string> args_copy(early_args.begin(), early_args.end());
+	  local_conf().parse_argv(std::move(args_copy)).get();
+	}
 	local_conf().parse_config_files(ret.conf_file_list).get();
 
 	if (local_conf()->no_mon_config) {

--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -883,11 +883,7 @@ int main(int argc, char **argv) {
         co_await crimson::common::local_conf().start();
 
         {
-          std::vector<const char *> cav;
-          std::transform(
-              std::begin(unrecognized_options), std::end(unrecognized_options),
-              std::back_inserter(cav), [](auto &s) { return s.c_str(); });
-          co_await crimson::common::local_conf().parse_argv(cav);
+          co_await crimson::common::local_conf().parse_argv(unrecognized_options);
         }
 
         auto store = crimson::os::FuturizedStore::create(


### PR DESCRIPTION
# crimson: fix stack-use-after-return in ConfigProxy::parse_argv

ConfigProxy::parse_argv used to take std::vector<const char*>& and capture it by reference in a lambda passed to do_change(), which invokes the lambda on another shard via invoke_on. By the time the target shard ran the lambda, the caller had returned and the referenced vector was destroyed.

Fix: take std::vector<std::string> by value and move it into the closure, so the data outlives the call. Convert to vector<const char*> only on the target shard.

- update callers to pass vector<string>
- unittest-seastar-config-parse-argv-uaf to demonstrate the pattern  available at 9f314d72c9d5addbf6c51981ca644584f287faae jenkins [crash example](https://jenkins.ceph.com/job/ceph-pull-requests/174999/)

Crash example (configured Crimson build):
```
$ ./bin/unittest-seastar-config-parse-argv-uaf --smp 2
INFO  2026-02-23 10:06:06,620 seastar - Reactor backend: linux-aio
INFO  2026-02-23 10:06:06,622 seastar - Perf-based stall detector creation failed (EACCESS), try setting /proc/sys/kernel/perf_event_paranoid to 1 or less to enable kernel backtraces: falling back to posix timer.
INFO  2026-02-23 10:06:06,625 [shard 0:main] io - IO queue was unable to find a suitable maximum request length, the search was cut-off early at: 16MB
INFO  2026-02-23 10:06:06,625 [shard 0:main] io - IO queue was unable to find a suitable maximum request length, the search was cut-off early at: 16MB
INFO  2026-02-23 10:06:06,630 [shard 1:main] io - IO queue was unable to find a suitable maximum request length, the search was cut-off early at: 16MB
INFO  2026-02-23 10:06:06,630 [shard 1:main] io - IO queue was unable to find a suitable maximum request length, the search was cut-off early at: 16MB
=================================================================
==3106307==ERROR: AddressSanitizer: stack-use-after-return on address 0x7ba5a565c448 at pc 0x0000004d5140 bp 0x7ba5a41fb630 sp 0x7ba5a41fb620
READ of size 8 at 0x7ba5a565c448 thread T1
Reactor stalled for 33 ms on shard 1, in scheduling group main. Backtrace: /lib64/libasan.so.8+0x54e93 0x906840 0x906b2c 0x791e9d 0x7933c7 0x793632 0x793784 0x793c49 /lib64/libc.so.6+0x3e6ef /lib64/libasan.so.8+0x14d196 /lib64/libasan.so.8+0x14f3d9 /lib64/libasan.so.8+0x14fd7c /lib64/libc.so.6+0x156423 0x110e670 /lib64/libasan.so.8+0x150083 /lib64/libasan.so.8+0x13931a /lib64/libasan.so.8+0x139439 /lib64/libasan.so.8+0x11eaff /lib64/libasan.so.8+0x120bbc /lib64/libasan.so.8+0x119eee /lib64/libasan.so.8+0x11a2c8 /lib64/libasan.so.8+0x13dc6 /lib64/libasan.so.8+0xfa27b /lib64/libasan.so.8+0xf965d /lib64/libasan.so.8+0xfabc8 0x4d513f 0x4b6f93 0x4b7088 0x4bb908 0x4bbae2 0x4bc748 0x7b8d4f 0x7ac997 0x7ad17a 0x89b764 0x8b03f2 0x8b0a4d 0x606d19 0x11a244c /lib64/libasan.so.8+0x2a549 /lib64/libc.so.6+0x89c51 /lib64/libc.so.6+0x10ec7f
Reactor stalled for 92 ms on shard 1, in scheduling group main. Backtrace: /lib64/libasan.so.8+0x54e93 0x906840 0x906b2c 0x791e9d 0x7933c7 0x793632 0x793784 0x793c49 /lib64/libc.so.6+0x3e6ef /lib64/libasan.so.8+0x1396ea /lib64/libasan.so.8+0x13980f /lib64/libasan.so.8+0x14fb5e /lib64/libasan.so.8+0x14fd7c /lib64/libc.so.6+0x156423 0x110e670 /lib64/libasan.so.8+0x150083 /lib64/libasan.so.8+0x13931a /lib64/libasan.so.8+0x139439 /lib64/libasan.so.8+0x11eaff /lib64/libasan.so.8+0x120bbc /lib64/libasan.so.8+0x119eee /lib64/libasan.so.8+0x11a2c8 /lib64/libasan.so.8+0x13dc6 /lib64/libasan.so.8+0xfa27b /lib64/libasan.so.8+0xf965d /lib64/libasan.so.8+0xfabc8 0x4d513f 0x4b6f93 0x4b7088 0x4bb908 0x4bbae2 0x4bc748 0x7b8d4f 0x7ac997 0x7ad17a 0x89b764 0x8b03f2 0x8b0a4d 0x606d19 0x11a244c /lib64/libasan.so.8+0x2a549 /lib64/libc.so.6+0x89c51 /lib64/libc.so.6+0x10ec7f
Reactor stalled for 201 ms on shard 1, in scheduling group main. Backtrace: /lib64/libasan.so.8+0x54e93 0x906840 0x906b2c 0x791e9d 0x7933c7 0x793632 0x793784 0x793c49 /lib64/libc.so.6+0x3e6ef /lib64/libasan.so.8+0x13488d /lib64/libasan.so.8+0x134eec /lib64/libasan.so.8+0x134eec /lib64/libasan.so.8+0x134eec /lib64/libasan.so.8+0x136b25 /lib64/libasan.so.8+0x137a3e /lib64/libasan.so.8+0x11eaff /lib64/libasan.so.8+0x120bbc /lib64/libasan.so.8+0x119eee /lib64/libasan.so.8+0x11a2c8 /lib64/libasan.so.8+0x13dc6 /lib64/libasan.so.8+0xfa27b /lib64/libasan.so.8+0xf965d /lib64/libasan.so.8+0xfabc8 0x4d513f 0x4b6f93 0x4b7088 0x4bb908 0x4bbae2 0x4bc748 0x7b8d4f 0x7ac997 0x7ad17a 0x89b764 0x8b03f2 0x8b0a4d 0x606d19 0x11a244c /lib64/libasan.so.8+0x2a549 /lib64/libc.so.6+0x89c51 /lib64/libc.so.6+0x10ec7f
    #0 0x0000004d513f in std::vector<char const*, std::allocator<char const*> >::size() const /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:993
    #1 0x0000004b6f93 in operator() /data/code/ceph/src/test/crimson/test_config_parse_argv_uaf.cc:34
    #2 0x0000004b7088 in __invoke_impl<void, buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>, TargetService&> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:61
    #3 0x0000004b7088 in __invoke<buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>, TargetService&> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:96
    #4 0x0000004b7088 in __apply_impl<buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>, std::tuple<TargetService&>, 0> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/tuple:2302
    #5 0x0000004bb908 in apply<buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>, std::tuple<TargetService&> > /opt/rh/gcc-toolset-13/root/usr/include/c++/13/tuple:2313
    #6 0x0000004bb908 in operator() /data/code/ceph/src/seastar/include/seastar/core/sharded.hh:833
    #7 0x0000004bbae2 in __invoke_impl<void, seastar::sharded<TargetService>::invoke_on<buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)> >(unsigned int, seastar::smp_submit_to_options, buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>&&)::<lambda()>&> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:61
    #8 0x0000004bbae2 in __invoke<seastar::sharded<TargetService>::invoke_on<buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)> >(unsigned int, seastar::smp_submit_to_options, buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>&&)::<lambda()>&> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:96
    #9 0x0000004bbae2 in invoke<seastar::sharded<TargetService>::invoke_on<buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)> >(unsigned int, seastar::smp_submit_to_options, buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>&&)::<lambda()>&> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/functional:113
    #10 0x0000004bbae2 in invoke<seastar::sharded<TargetService>::invoke_on<buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)> >(unsigned int, seastar::smp_submit_to_options, buggy_parse_argv_like(std::vector<char const*>&)::<lambda(TargetService&)>&&)::<lambda()>&> /data/code/ceph/src/seastar/include/seastar/core/future.hh:2001
    #11 0x0000004bc748 in run_and_dispose /data/code/ceph/src/seastar/include/seastar/core/smp.hh:250
    #12 0x0000007b8d4f in seastar::reactor::task_queue::run_tasks() /data/code/ceph/src/seastar/src/core/reactor.cc:2666
    #13 0x0000007ac997 in seastar::reactor::task_queue_group::run_tasks() /data/code/ceph/src/seastar/src/core/reactor.cc:3173
    #14 0x0000007ad17a in seastar::reactor::task_queue_group::run_some_tasks() /data/code/ceph/src/seastar/src/core/reactor.cc:3157
    #15 0x00000089b764 in seastar::reactor::do_run() /data/code/ceph/src/seastar/src/core/reactor.cc:3330
    #16 0x0000008b03f2 in operator() /data/code/ceph/src/seastar/src/core/reactor.cc:4626
    #17 0x0000008b0a4d in __invoke_impl<void, seastar::smp::configure(const seastar::smp_options&, const seastar::reactor_options&)::<lambda()>&> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:61
    #18 0x0000008b0a4d in __invoke_r<void, seastar::smp::configure(const seastar::smp_options&, const seastar::reactor_options&)::<lambda()>&> /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:111
    #19 0x0000008b0a4d in _M_invoke /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:290
    #20 0x000000606d19 in std::function<void ()>::operator()() const /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
    #21 0x0000011a244c in seastar::posix_thread::start_routine(void*) /data/code/ceph/src/seastar/src/core/posix.cc:90
    #22 0x7fa5a982a549 in asan_thread_start(void*) (/lib64/libasan.so.8+0x2a549) (BuildId: 147dba505b45c457bb4de235545465e390c3b4d8)
    #23 0x7fa5a7689c51 in start_thread (/lib64/libc.so.6+0x89c51) (BuildId: 516ace448415666817e627312c9168468f154be0)
    #24 0x7fa5a770ec7f in clone3 (/lib64/libc.so.6+0x10ec7f) (BuildId: 516ace448415666817e627312c9168468f154be0)

Address 0x7ba5a565c448 is located in stack of thread T0 at offset 72 in frame
    #0 0x0000004c1561 in operator() /data/code/ceph/src/test/crimson/test_config_parse_argv_uaf.cc:57

  This frame has 3 object(s):
    [48, 49) '<unknown>'
    [64, 88) 'argv' (line 58) <== Memory access at offset 72 is inside this variable
    [128, 144) '<unknown>'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-return /data/code/ceph/src/test/crimson/test_config_parse_argv_uaf.cc:34 in operator()
Shadow bytes around the buggy address:
  0x7ba5a565c180: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ba5a565c200: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ba5a565c280: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ba5a565c300: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ba5a565c380: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7ba5a565c400: f5 f5 f5 f5 f5 f5 f5 f5 f5[f5]f5 f5 f5 f5 f5 f5
  0x7ba5a565c480: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ba5a565c500: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ba5a565c580: f5 f5 f5 f5 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ba5a565c600: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7ba5a565c680: f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Thread T1 created by T0 here:
    #0 0x7fa5a98e4cca in pthread_create (/lib64/libasan.so.8+0xe4cca) (BuildId: 147dba505b45c457bb4de235545465e390c3b4d8)
    #1 0x0000011a2fc5 in seastar::posix_thread::posix_thread(seastar::posix_thread::attr, std::function<void ()>) /data/code/ceph/src/seastar/src/core/posix.cc:132

==3106307==ABORTING
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
