### PR TITLE
Adding new secrets mgr module support

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1925,6 +1925,8 @@ fi
 %{_datadir}/ceph/mgr/mgr_module.*
 %{_datadir}/ceph/mgr/mgr_util.*
 %{_datadir}/ceph/mgr/object_format.*
+%{_datadir}/ceph/mgr/ceph_secrets_client.*
+%{_datadir}/ceph/mgr/ceph_secrets_types.*
 %{_datadir}/ceph/mgr/cherrypy_mgr.*
 %{_unitdir}/ceph-mgr@.service
 %{_unitdir}/ceph-mgr.target

--- a/doc/mgr/ceph_secrets.rst
+++ b/doc/mgr/ceph_secrets.rst
@@ -1,0 +1,437 @@
+.. _mgr-ceph-secrets:
+
+===================
+Ceph Secrets Module
+===================
+
+The ``ceph_secrets`` manager module provides centralised secret storage for
+Ceph operators and Ceph manager modules.  Instead of embedding plaintext
+credentials in service specifications or configuration objects, secrets are
+stored once and referenced by URI.  Ceph manager modules such as cephadm
+and rook can store secret payloads centrally, reference them by URI, and
+resolve them to plaintext only when needed at deploy time.
+
+For example, a cephadm-managed service may need an API token.  Instead of
+embedding that token directly in the service specification, an operator can
+store it once:
+
+.. prompt:: bash $
+
+   ceph secret set cephadm/service/my-service/api_token -i /tmp/api-token
+
+and then use the URI
+``secret:/cephadm/service/my-service/api_token`` in the
+service spec instead of the plaintext token.  A cephadm integration can then
+resolve the URI at deploy time and write the token only into the daemon files
+that need it.
+
+Secrets are stored in the Mon KV store under the ``secret_store/v1/`` prefix
+and are organised by namespace, scope, and name.  Each secret is versioned and
+carries ``created``/``updated`` timestamps.  A per-namespace epoch counter
+is incremented on every ``set`` and on any ``rm`` that actually removes a
+secret, allowing consumers to detect changes without fetching the full secret
+list.
+
+.. note::
+
+   The ``mon`` backend stores secrets in the Mon KV store, which is not an
+   external KMS or vault.  Users and MGR modules with sufficient Ceph
+   permissions can still reveal or resolve stored secret values.  Namespaces
+   provide logical and storage isolation, not an authorisation boundary.
+
+If the module is not already enabled, run::
+
+    ceph mgr module enable ceph_secrets
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Concepts
+========
+
+Namespace
+---------
+
+A namespace is a logical storage boundary, typically matching the name of
+the consuming MGR module (e.g. ``cephadm``, ``rook``).  Secrets in different
+namespaces are stored independently and have independent epoch counters.
+Namespaces are not an authorisation boundary; any caller with access to the
+``ceph_secrets`` module can read secrets from any namespace.
+
+Scope
+-----
+
+Within a namespace, every secret has a scope that encodes what the secret
+belongs to:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 40 45
+
+   * - Scope
+     - Meaning
+     - CLI path form
+   * - ``global``
+     - Cluster-wide secret, not tied to any specific target
+     - ``<namespace>/global/<name>``
+   * - ``service``
+     - Secret for a specific named service
+     - ``<namespace>/service/<service-name>/<name>``
+   * - ``host``
+     - Secret for a specific host
+     - ``<namespace>/host/<hostname>/<name>``
+   * - ``custom``
+     - Arbitrary slash-delimited path under the namespace
+     - ``<namespace>/custom/<path>``
+
+Path grammar
+------------
+
+All path segments (namespace, scope target, name, and each segment of a
+custom path) must match ``[A-Za-z0-9._-]+`` and must not end with ``'.'``.
+Empty segments, percent-encoding, and leading/trailing whitespace are
+rejected.
+
+Custom scope paths may contain multiple slash-separated segments (e.g.
+``cephadm/custom/app/db/password``).  Two custom paths that share a common
+prefix are independent secrets; ``cephadm/custom/a/b`` and
+``cephadm/custom/a/b/c`` do not conflict.
+
+Secret URIs
+-----------
+
+Internally, secrets are identified by URIs of the form::
+
+    secret:/<namespace>/global/<name>
+    secret:/<namespace>/service/<target>/<name>
+    secret:/<namespace>/host/<target>/<name>
+    secret:/<namespace>/custom/<path>
+
+These URIs appear in the output of :ref:`scan_refs <mgr-ceph-secrets-scan>`
+and may be embedded in configuration objects as opaque references to be
+resolved at deploy time.
+
+
+CLI Reference
+=============
+
+All CLI commands use the path form described above.  Responses are JSON by
+default; pass ``--format yaml`` for YAML output.
+
+.. _mgr-ceph-secrets-set:
+
+secret set
+----------
+
+Create or update a secret. The input file content is stored as an opaque string::
+
+    ceph secret set <path> -i <file>
+
+Secret data must not be empty.  Other contents, including leading or trailing
+whitespace and final newlines, are preserved exactly.  Callers that need to
+store structured data should encode it themselves, for example as JSON, and
+decode it after retrieval or resolution.
+
+If the secret already exists its data is replaced and its version
+incremented, unless the existing secret policy marks it non-editable (set via
+the Python API with ``editable=False``), in which case the update is rejected.
+The ``created`` timestamp is set on the first write and is never changed
+thereafter; ``updated`` is refreshed on every write.
+
+Example:
+
+.. prompt:: bash $
+
+   ceph secret set cephadm/service/my-service/api_token -i /tmp/api-token
+   {"metadata": {"version": 1, "created": "2025-06-01T12:00:00Z", "updated": "2025-06-01T12:00:00Z"}}
+
+.. _mgr-ceph-secrets-get:
+
+secret get
+----------
+
+Retrieve the metadata (and, optionally, the data) for a secret::
+
+    ceph secret get <path> [--reveal] [--format {json|yaml}]
+
+Without ``--reveal``, the ``data`` field is omitted from the response to
+avoid accidental exposure in terminal output or logs.  With ``--reveal``,
+``data`` contains the stored opaque string.
+
+Example:
+
+.. prompt:: bash $
+
+   ceph secret get cephadm/service/my-service/api_token
+   {
+     "metadata": {
+       "version": 1,
+       "created": "2025-06-01T12:00:00Z",
+       "updated": "2025-06-01T12:00:00Z"
+     }
+   }
+
+   ceph secret get cephadm/service/my-service/api_token --reveal
+   {
+     "metadata": {
+       "version": 1,
+       "created": "2025-06-01T12:00:00Z",
+       "updated": "2025-06-01T12:00:00Z"
+     },
+     "data": "api-token-value"
+   }
+
+.. _mgr-ceph-secrets-get-value:
+
+secret get-value
+----------------
+
+Return the raw secret data string directly, with no JSON envelope::
+
+    ceph secret get-value <path>
+
+Unlike ``secret get --reveal``, the output is the stored string itself,
+making it suitable for use in shell scripts and pipelines.  Returns an
+error if the secret does not exist.
+
+Example:
+
+.. prompt:: bash $
+
+   ceph secret get-value cephadm/service/my-service/api_token
+   api-token-value
+
+.. _mgr-ceph-secrets-ls:
+
+secret ls
+---------
+
+List secrets, optionally filtered by namespace, scope, and/or target::
+
+    ceph secret ls [--namespace <ns>] [--scope <scope>]
+                   [--sec_target <target>] [--reveal] [--show_internals]
+                   [--format {json|yaml}]
+
+Without filters, all secrets across all namespaces are listed.
+``--reveal`` includes the stored opaque data string in each output record.
+``--show_internals`` additionally includes the ``policy`` object (``user_made``
+and ``editable`` flags) in each record.
+
+Example:
+
+.. prompt:: bash $
+
+   ceph secret ls --namespace cephadm --scope host --sec_target node1
+   {
+     "cephadm/host/node1/ssh_key": {
+       "metadata": {
+         "version": 3,
+         "created": "2025-05-10T08:00:00Z",
+         "updated": "2025-06-01T09:00:00Z"
+       },
+       "ref": {
+         "namespace": "cephadm",
+         "scope": "host",
+         "target": "node1",
+         "name": "ssh_key"
+       }
+     }
+   }
+
+.. _mgr-ceph-secrets-rm:
+
+secret rm
+---------
+
+Remove a secret::
+
+    ceph secret rm <path>
+
+The operation is idempotent: removing a secret that does not exist succeeds
+and reports ``"status": "not_found"`` rather than an error.
+
+Example:
+
+.. prompt:: bash $
+
+   ceph secret rm cephadm/service/my-service/api_token
+   {"status": "removed"}
+
+   ceph secret rm cephadm/service/my-service/api_token
+   {"status": "not_found"}
+
+.. _mgr-ceph-secrets-get-epoch:
+
+Epoch
+-----
+
+The epoch for a namespace is accessible via the Python API only (see
+:ref:`Epoch-based change detection <mgr-ceph-secrets-epoch>`).  There is
+no CLI command for it.
+
+
+Module API
+==========
+
+Other MGR modules should consume ``ceph_secrets`` via ``CephSecretsClient``
+(``src/pybind/mgr/ceph_secrets_client.py``) rather than calling
+``mgr.remote()`` directly.  The client file, along with
+``ceph_secrets_types.py``, lives at the top level of ``src/pybind/mgr/`` so
+any MGR module can import it without depending on the ``ceph_secrets`` package
+internals.
+
+.. code-block:: python
+
+    from ceph_secrets_client import CephSecretsClient
+    from ceph_secrets_types import SecretScope
+
+    client = CephSecretsClient(self)   # self is a MgrModule instance
+
+    # Store a secret as an opaque string
+    client.secret_set(
+        namespace="cephadm",
+        scope=SecretScope.HOST,
+        target="node1",
+        name="ssh_key",
+        data="AQB...==",
+    )
+
+    # Retrieve metadata (no data unless reveal=True)
+    rec = client.secret_get("cephadm", SecretScope.HOST, "node1", "ssh_key")
+    if rec:
+        version = rec["metadata"]["version"]
+
+    # Remove
+    client.secret_rm("cephadm", SecretScope.HOST, "node1", "ssh_key")
+
+CephSecretsClient methods
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Method
+     - Description
+   * - ``secret_set(namespace, scope, target, name, data, ...)``
+     - Create or update a secret.  ``data`` must be a non-empty opaque
+       string.  Increments the version and refreshes ``updated`` on each
+       call; ``created`` is set only on the first write.  Optional
+       ``user_made`` and ``editable`` flags control the stored policy;
+       ``editable=False`` blocks future updates but does not prevent removal.
+   * - ``secret_get(namespace, scope, target, name, reveal=False)``
+     - Return the secret's metadata dict, plus the opaque ``data`` string if
+       *reveal* is True.  Returns ``None`` if the secret does not exist.
+   * - ``secret_get_value(namespace, scope, target, name)``
+     - Return the stored opaque string directly, or ``None`` if the secret
+       does not exist.  Use this when only the value is needed and the
+       metadata envelope is not required.
+   * - ``secret_get_version(namespace, scope, target, name)``
+     - Return the current version integer, or ``None`` if not found.  A
+       cheaper alternative to ``secret_get`` when only change-detection is needed.
+   * - ``secret_get_versions(uris)``
+     - Batch-fetch version numbers for a list of canonical ``secret:/...``
+       URIs.  Returns a dict keyed by URI; missing secrets map to ``None``.
+       Malformed URIs are skipped entirely, so a missing key indicates
+       malformed input rather than an absent secret.
+   * - ``secret_rm(namespace, scope, target, name)``
+     - Remove a secret.  Idempotent: returns ``False`` if not found.
+   * - ``secret_get_epoch(namespace)``
+     - Return the current epoch for the namespace.  Use as a cheap
+       change-detector before a full refresh.
+   * - ``scan_refs(obj, namespace)``
+     - Walk a JSON-like object and return secret-like reference strings found
+       within it.  This includes valid whole-value secret URIs and malformed
+       or embedded secret-like references that should be reported to the
+       caller.  Only canonical ``secret:/...`` URIs should be passed to
+       ``secret_get_versions``.
+   * - ``scan_unresolved_refs(obj, namespace)``
+     - Like ``scan_refs`` but returns only references that are missing,
+       malformed, embedded inside a larger string, or cannot currently be
+       read successfully.  Useful for pre-flight validation.
+   * - ``resolve_object(obj)``
+     - Walk a JSON-like object and replace every whole-value ``secret:/...``
+       URI string with the stored opaque string for the referenced secret.
+
+.. _mgr-ceph-secrets-scan:
+
+Secret URI embedding and resolution
+-----------------------------------
+
+Configuration objects that need to reference secrets without embedding
+plaintext can store ``secret:/...`` URIs as string values.  The module
+resolves them on demand:
+
+.. code-block:: python
+
+    spec = {
+        "service_type": "my-service",
+        "spec": {
+            "api_token": " secret:/cephadm/service/my-service/api_token ",
+        },
+    }
+
+    # Check for missing, malformed, embedded, or unresolvable secret references
+    unresolved = client.scan_unresolved_refs(spec, namespace="cephadm")
+    if unresolved:
+        raise RuntimeError(f"Unresolved secret references: {unresolved}")
+
+    # Replace URI references with plaintext values
+    resolved = client.resolve_object(spec)
+    # resolved["spec"]["api_token"] now holds the stored API token
+
+.. note::
+
+   Resolution replaces the entire string value of a field.  Surrounding
+   whitespace around a URI reference is ignored, so values such as
+   ``" secret:/cephadm/global/foo "`` are accepted.  Embedding a secret URI
+   inside a larger string (for example ``"Bearer secret:/..."``) is not
+   supported; after trimming surrounding whitespace, the field value must be
+   the URI.
+
+   The resolved value is the stored opaque string.  The module does not parse
+   stored data as JSON and does not support field-level URI selection.  If a
+   caller stores structured data, it must encode and decode that structure
+   itself.
+
+.. _mgr-ceph-secrets-epoch:
+
+Epoch-based change detection
+----------------------------
+
+Consumers that maintain a local cache of secrets can use the epoch to avoid
+unnecessary full refreshes:
+
+.. code-block:: python
+
+    def maybe_refresh(client, namespace, last_epoch):
+        current_epoch = client.secret_get_epoch(namespace)
+        if current_epoch == last_epoch:
+            return last_epoch   # nothing changed
+        # ... do a full refresh ...
+        return current_epoch
+
+    last_epoch = 0
+    last_epoch = maybe_refresh(client, "cephadm", last_epoch)
+
+The epoch is incremented by every successful ``set`` operation and by
+``rm`` only when an existing secret is actually removed (an idempotent
+``rm`` returning ``"not_found"`` does not bump the epoch).  It starts at 0
+for a namespace that has never been written to, and mutations in one namespace
+never affect another namespace's epoch.
+
+
+Configuration
+=============
+
+.. mgr_module:: ceph_secrets
+.. confval:: secrets_backend
+
+   :type: str
+   :default: ``mon``
+
+   The storage backend used for secrets.  Currently only the Mon KV store
+   (``mon``) is supported.  This option is reserved for future backends
+   (e.g. HashiCorp Vault).

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -47,5 +47,6 @@ sensible.
     MDS Autoscaler module <mds_autoscaler>
     NFS module <nfs>
     SMB module <smb>
+    Secrets module <ceph_secrets>
     Progress Module <progress>
     CLI API Commands module <cli_api>

--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -59,5 +59,5 @@ set(mgr_modules
 install(DIRECTORY ${mgr_modules}
   DESTINATION ${CEPH_INSTALL_DATADIR}/mgr
   ${mgr_module_install_excludes})
-install(FILES mgr_module.py mgr_util.py object_format.py cherrypy_mgr.py
+install(FILES mgr_module.py mgr_util.py object_format.py cherrypy_mgr.py ceph_secrets_client.py ceph_secrets_types.py
   DESTINATION ${CEPH_INSTALL_DATADIR}/mgr)

--- a/src/pybind/mgr/ceph_secrets/__init__.py
+++ b/src/pybind/mgr/ceph_secrets/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .module import Module

--- a/src/pybind/mgr/ceph_secrets/__init__.py
+++ b/src/pybind/mgr/ceph_secrets/__init__.py
@@ -1,2 +1,8 @@
-# flake8: noqa
+import os
+
+if 'UNITTEST' in os.environ:
+    import tests  # noqa: F401
+
 from .module import Module
+
+__all__ = ['Module']

--- a/src/pybind/mgr/ceph_secrets/backends.py
+++ b/src/pybind/mgr/ceph_secrets/backends.py
@@ -1,0 +1,5 @@
+from .secret_store import SecretStoreMon
+
+BACKENDS = {
+    "mon": SecretStoreMon,
+}

--- a/src/pybind/mgr/ceph_secrets/cli.py
+++ b/src/pybind/mgr/ceph_secrets/cli.py
@@ -1,0 +1,3 @@
+from mgr_module import CLICommandBase
+
+CephSecretsCLICommand = CLICommandBase.make_registry_subtype("CephSecretsCLICommand")

--- a/src/pybind/mgr/ceph_secrets/module.py
+++ b/src/pybind/mgr/ceph_secrets/module.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+import functools
+from typing import Any, Dict, List, Optional, Callable, Tuple, TypeVar, Union
+import errno
+
+from .cli import CephSecretsCLICommand
+from object_format import ObjectFormatAdapter, ErrorResponse, Responder
+from mgr_module import (
+    MgrModule,
+    Option
+)
+from .secret_mgr import SecretMgr
+from ceph_secrets_types import (
+    CephSecretException,
+    CephSecretDataError,
+    CephSecretNotFoundError,
+    SecretRef,
+    SecretScope,
+    parse_secret_path,
+    parse_secret_uri,
+)
+from .backends import BACKENDS
+
+
+_T = TypeVar('_T')
+
+
+def _handle_secret_errors(fn: Callable[..., _T]) -> Callable[..., _T]:
+    """Decorator for CLI handlers: converts CephSecretException into
+    ErrorResponse so that Responder / ErrorResponseHandler can catch it."""
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> _T:
+        try:
+            return fn(*args, **kwargs)
+        except CephSecretException as e:
+            raise ErrorResponse(str(e)) from e
+    return wrapper
+
+
+class Module(MgrModule):
+    """Standalone secrets mgr module.
+
+    This module owns the mgr KV-store entries for secrets (namespace: mgr/secrets)
+    and provides both:
+      - RPC methods for other mgr modules via `remote(...)`
+      - CLI commands: `ceph secret ...`
+
+    Storage keys inside the mgr KV store:
+      secret data:   secret_store/v1/<namespace>/<scope>/...
+      epoch (meta):  secret_store/meta/<namespace>/_epoch
+
+    Epoch is per-namespace: a mutation in namespace A does not affect the epoch
+    of namespace B, so consumers only see changes relevant to their namespace.
+    Epoch logic lives entirely in the store backend so future backends
+    (e.g. Vault) can implement it natively.
+
+    Method organisation:
+      - Public methods (no leading underscore): RPC surface called via
+        mgr.remote(). Accept individual kwargs for wire-format compatibility.
+        Each delegates immediately to the corresponding _secret_* method.
+      - Private _secret_* methods: real implementations, operate on SecretRef.
+        Called directly by CLI handlers and internal code.
+    """
+    CLICommand = CephSecretsCLICommand
+
+    MODULE_OPTIONS = [
+        Option(
+            'secrets_backend',
+            type='str',
+            default='mon',
+            desc='Secrets storage backend. Currently only "mon" (Mon KV store) is supported.',
+        ),
+    ]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        backend_name: str = str(self.get_module_option('secrets_backend'))
+        try:
+            backend_cls = BACKENDS[backend_name]
+        except KeyError as e:
+            raise RuntimeError(
+                f"Unsupported secrets backend: {backend_name}"
+            ) from e
+        try:
+            self.secret_mgr = SecretMgr(backend_cls(self))
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to initialize secrets backend '{backend_name}': {e}"
+            ) from e
+
+    # ------------------------------------------------------------------ epoch
+
+    def secret_get_epoch(self, namespace: str) -> int:
+        """Return the current epoch for *namespace*.
+
+        Consumers (e.g., cephadm) can use this as a cheap change-detector:
+        if the epoch hasn't changed since the last check, no secrets in this
+        namespace have been mutated.
+        """
+        return self.secret_mgr.store.get_epoch(namespace)
+
+    # ------------------------------------------------------------------ RPC surface
+
+    def secret_ls(
+        self,
+        namespace: Optional[str] = None,
+        scope: Optional[str] = None,
+        target: Optional[str] = None,
+        show_values: bool = False,
+        show_internals: bool = False,
+    ) -> Dict[str, Any]:
+        sc = SecretScope.from_str(scope) if scope else None
+        records = self.secret_mgr.ls(namespace=namespace, scope=sc, target=target)
+        out: Dict[str, Any] = {}
+        for r in records:
+            if r.ref.target:
+                key = f'{r.ref.namespace}/{r.ref.scope.value}/{r.ref.target}/{r.ref.name}'
+            else:
+                key = f'{r.ref.namespace}/{r.ref.scope.value}/{r.ref.name}'
+            out[key] = r.to_public_json(
+                include_data=bool(show_values),
+                include_policy=show_internals,
+                include_ref=True,
+            )
+        return out
+
+    def secret_get(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str,
+        name: str,
+        reveal: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """RPC surface — called via mgr.remote(). Internal code uses _secret_get()."""
+        return self._secret_get(
+            self.secret_mgr.make_ref(namespace, scope, target, name),
+            reveal=reveal,
+        )
+
+    def secret_get_value(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str,
+        name: str,
+    ) -> Optional[str]:
+        """RPC surface — return the raw secret data string, or None if not found.
+
+        Called via mgr.remote(). Internal code uses _secret_get_value().
+        """
+        return self._secret_get_value(
+            self.secret_mgr.make_ref(namespace, scope, target, name)
+        )
+
+    def secret_get_version(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str,
+        name: str,
+    ) -> Optional[int]:
+        """RPC surface — called via mgr.remote(). Internal code uses _secret_get_version()."""
+        return self._secret_get_version(
+            self.secret_mgr.make_ref(namespace, scope, target, name)
+        )
+
+    def secret_get_versions(self, uris: List[str]) -> Dict[str, Optional[int]]:
+        """Batch-fetch version numbers for a list of secret URIs.
+
+        Each entry in *uris* must be a canonical ``secret:/...`` URI, such as
+        one returned by ``SecretRef.to_uri()``. URIs that cannot be parsed are
+        skipped and logged at ERROR level; a missing key in the result indicates
+        malformed input rather than a not-found secret.
+
+        Note that ``scan_refs()`` may also return malformed or embedded
+        secret-like strings for validation/reporting. Callers should pass only
+        canonical ``secret:/...`` URIs to this method.
+
+        Returns a dict keyed by the input URI mapping to the current version
+        integer, or ``None`` if the secret does not exist.
+        """
+        out: Dict[str, Optional[int]] = {}
+        for uri in uris or []:
+            try:
+                ref = parse_secret_uri(uri)
+            except CephSecretException:
+                self.log.error(
+                    "secret_get_versions: skipping invalid URI %r",
+                    uri, exc_info=True
+                )
+                continue
+            out[uri] = self._secret_get_version(ref)  # CephSecretDataError propagates
+        return out
+
+    def secret_set(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str,
+        name: str,
+        data: str,
+        user_made: bool = True,
+        editable: bool = True,
+    ) -> Dict[str, Any]:
+        """RPC surface — called via mgr.remote(). Internal code uses _secret_set()."""
+        return self._secret_set(
+            self.secret_mgr.make_ref(namespace, scope, target, name),
+            data=data,
+            user_made=user_made,
+            editable=editable,
+        )
+
+    def secret_rm(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str,
+        name: str,
+    ) -> bool:
+        """RPC surface — called via mgr.remote(). Internal code uses _secret_rm()."""
+        return self._secret_rm(self.secret_mgr.make_ref(namespace, scope, target, name))
+
+    def resolve_object(self, obj: Any) -> Any:
+        return self.secret_mgr.resolve_object(obj)
+
+    def scan_refs(self, obj: Any, namespace: str) -> List[str]:
+        return sorted({u.to_uri() for u in
+                       self.secret_mgr.scan_refs(obj, namespace)})
+
+    def scan_unresolved_refs(self, obj: Any, namespace: str) -> List[str]:
+        return sorted({u.to_uri() for u in
+                       self.secret_mgr.scan_unresolved_refs(obj, namespace)})
+
+    # ------------------------------------------------------------------ ref-based implementations
+
+    def _secret_get(self, ref: SecretRef, reveal: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            rec = self.secret_mgr.get(ref)
+        except CephSecretDataError:
+            # Corruption is not the same as absence; let callers/CLI report a
+            # data error instead of returning the same sentinel as "not found".
+            raise
+        except CephSecretNotFoundError:
+            return None
+        return rec.to_public_json(include_data=reveal, include_policy=False, include_ref=False)
+
+    def _secret_get_value(self, ref: SecretRef) -> Optional[str]:
+        """Return the raw data string for a secret, or None if not found."""
+        try:
+            rec = self.secret_mgr.get(ref)
+        except CephSecretDataError:
+            raise
+        except CephSecretNotFoundError:
+            return None
+        return rec.data
+
+    def _secret_get_version(self, ref: SecretRef) -> Optional[int]:
+        try:
+            rec = self.secret_mgr.get(ref)
+        except CephSecretDataError:
+            raise
+        except CephSecretNotFoundError:
+            return None
+        return rec.metadata.version
+
+    def _secret_set(
+        self,
+        ref: SecretRef,
+        data: str,
+        user_made: bool = True,
+        editable: bool = True,
+    ) -> Dict[str, Any]:
+        rec = self.secret_mgr.set(
+            namespace=ref.namespace,
+            scope=ref.scope,
+            target=ref.target,
+            name=ref.name,
+            data=data,
+            user_made=user_made,
+            editable=editable,
+        )
+        return rec.to_public_json(include_data=False, include_policy=False, include_ref=False)
+
+    def _secret_rm(self, ref: SecretRef) -> bool:
+        return self.secret_mgr.rm(ref.namespace, ref.scope, ref.target, ref.name)
+
+    # ------------------------------------------------------------------ CLI commands
+
+    @CephSecretsCLICommand.Read('secret ls')
+    @Responder(functools.partial(ObjectFormatAdapter, compatible=True))
+    @_handle_secret_errors
+    def _cli_secret_ls(
+        self,
+        namespace: Optional[str] = None,
+        scope: Optional[str] = None,
+        sec_target: Optional[str] = None,
+        reveal: bool = False,
+        show_internals: bool = False,
+    ) -> Dict[str, Any]:
+        return self.secret_ls(
+            namespace=namespace,
+            scope=scope,
+            target=sec_target,
+            show_values=reveal,
+            show_internals=show_internals,
+        )
+
+    @CephSecretsCLICommand.Read('secret get')
+    @Responder(functools.partial(ObjectFormatAdapter, compatible=True))
+    @_handle_secret_errors
+    def _cli_secret_get_by_path(
+        self,
+        path: str,
+        reveal: bool = False,
+    ) -> Dict[str, Any]:
+        ref = parse_secret_path(path)
+        res = self._secret_get(ref, reveal=reveal)
+        if res is None:
+            raise ErrorResponse('secret error: not found', return_value=-errno.ENOENT)
+        return res
+
+    @CephSecretsCLICommand.Read('secret get-value')
+    @_handle_secret_errors
+    def _cli_secret_get_value_by_path(
+        self,
+        path: str,
+    ) -> Tuple[int, str, str]:
+        """Return the raw secret data string for the given path.
+
+        Unlike ``secret get --reveal``, this command outputs the secret value
+        directly as a plain string with no JSON envelope, making it suitable
+        for use in shell scripts and pipelines.
+        """
+        ref = parse_secret_path(path)
+        value = self._secret_get_value(ref)
+        if value is None:
+            raise ErrorResponse('secret error: not found', return_value=-errno.ENOENT)
+        return 0, value, ''
+
+    @CephSecretsCLICommand.Write('secret set')
+    @Responder(functools.partial(ObjectFormatAdapter, compatible=True))
+    @_handle_secret_errors
+    def _cli_secret_set_by_path(
+        self,
+        path: str,
+        inbuf: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if inbuf is None:
+            raise ErrorResponse('secret error: use -i to provide secret data')
+        if inbuf == '':
+            raise ErrorResponse('secret error: secret data must not be empty')
+        ref = parse_secret_path(path)
+        return self._secret_set(ref, data=inbuf)
+
+    @CephSecretsCLICommand.Write('secret rm')
+    @Responder(functools.partial(ObjectFormatAdapter, compatible=True))
+    @_handle_secret_errors
+    def _cli_secret_rm_by_path(
+        self,
+        path: str,
+    ) -> Dict[str, Any]:
+        ref = parse_secret_path(path)
+        existed = self._secret_rm(ref)
+        return {'status': 'removed' if existed else 'not_found'}

--- a/src/pybind/mgr/ceph_secrets/secret_backend.py
+++ b/src/pybind/mgr/ceph_secrets/secret_backend.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, TYPE_CHECKING
+from ceph_secrets_types import SecretScope
+
+
+if TYPE_CHECKING:
+    # Import only for type-checkers to avoid runtime import cycles
+    from .secret_store import SecretRecord
+
+
+class SecretStorageBackend(ABC):
+    """
+    Abstract base class for ceph secrets storage backends.
+
+    Backends store secret instances addressed by:
+      (namespace, scope, target, name)
+
+    For custom scope, target is empty and name stores the free-form path suffix.
+
+    Epoch:
+      Each namespace has an independent monotonic epoch counter that is bumped
+      on every set and on rm only when an existing secret is actually removed.
+      Consumers can use get_epoch(namespace) as a cheap change-detector to
+      avoid re-fetching secrets when nothing changed in their namespace.
+
+    Implementations:
+      - SecretStoreMon  (Mon KV store)
+      - Vault backend (future)
+    """
+
+    @abstractmethod
+    def get(self, namespace: str, scope: SecretScope, target: str, name: str) -> Optional["SecretRecord"]:
+        ...
+
+    @abstractmethod
+    def set(
+        self,
+        namespace: str,
+        scope: SecretScope,
+        target: str,
+        name: str,
+        data: str,
+        user_made: bool = True,
+        editable: bool = True,
+    ) -> "SecretRecord":
+        ...
+
+    @abstractmethod
+    def rm(self, namespace: str, scope: SecretScope, target: str, name: str) -> bool:
+        ...
+
+    @abstractmethod
+    def ls(
+        self,
+        namespace: Optional[str] = None,
+        scope: Optional[SecretScope] = None,
+        target: Optional[str] = None,
+    ) -> List["SecretRecord"]:
+        ...
+
+    @abstractmethod
+    def get_epoch(self, namespace: str) -> int:
+        """Return the current epoch for *namespace*."""
+        ...
+
+    @abstractmethod
+    def bump_epoch(self, namespace: str) -> int:
+        """Increment and persist the epoch for *namespace*; return the new value."""
+        ...

--- a/src/pybind/mgr/ceph_secrets/secret_mgr.py
+++ b/src/pybind/mgr/ceph_secrets/secret_mgr.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+import logging
+from typing import Any, List, Optional, Set, Union, Hashable, Protocol
+
+from .secret_store import SecretRecord, SecretData
+from ceph_secrets_types import (
+    CephSecretException,
+    CephSecretNotFoundError,
+    SecretRef,
+    BadSecretURI,
+    SecretScope,
+    parse_secret_uri,
+    SECRET_SCHEME
+)
+
+
+_SECRET_URI_PREFIX = f'{SECRET_SCHEME}:/'
+
+
+logger = logging.getLogger(__name__)
+
+
+class SecretURI(Protocol, Hashable):
+    def to_uri(self) -> str:
+        ...
+
+
+def _coerce_scope(scope: Union[SecretScope, str]) -> SecretScope:
+    if isinstance(scope, SecretScope):
+        return scope
+    return SecretScope.from_str(str(scope))
+
+
+class SecretMgr:
+    """
+    Phase 1: Mon-store backend only.
+
+    Secret data is an opaque string.  Callers are responsible for any
+    structure within it (e.g. JSON-encoding a dict before storing and
+    decoding after retrieval).  resolve_object() substitutes a secret URI
+    with the stored string directly.
+    """
+
+    def __init__(self, store: Any) -> None:
+        self.store = store
+
+    def make_ref(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str = '',
+        name: str = '',
+    ) -> SecretRef:
+        try:
+            return SecretRef(
+                namespace=namespace,
+                scope=_coerce_scope(scope),
+                target=target or '',
+                name=name,
+            )
+        except ValueError as e:
+            raise CephSecretException(str(e)) from e
+
+    def get(self, ref: SecretRef) -> SecretRecord:
+        rec = self.store.get(ref.namespace, ref.scope, ref.target, ref.name)
+        if rec is None:
+            raise CephSecretNotFoundError(f"Secret not found: {ref.to_uri()}")
+        return rec
+
+    def get_value(self, ref: SecretRef) -> str:
+        """Return the opaque data string for a secret."""
+        rec = self.get(ref)
+        return rec.data
+
+    def set(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str,
+        name: str,
+        data: SecretData,
+        user_made: bool = True,
+        editable: bool = True,
+    ) -> SecretRecord:
+        if not isinstance(data, str):
+            raise CephSecretException('Secret data must be a string')
+        if data == '':
+            raise CephSecretException('Secret data must not be empty')
+
+        ref = self.make_ref(namespace, scope, target, name)
+        return self.store.set(
+            ref.namespace,
+            ref.scope,
+            ref.target,
+            ref.name,
+            data,
+            user_made,
+            editable,
+        )
+
+    def rm(
+        self,
+        namespace: str,
+        scope: Union[SecretScope, str],
+        target: str,
+        name: str,
+    ) -> bool:
+        ref = self.make_ref(namespace, scope, target, name)
+        return self.store.rm(ref.namespace, ref.scope, ref.target, ref.name)
+
+    def ls(
+        self,
+        namespace: Optional[str] = None,
+        scope: Optional[Union[SecretScope, str]] = None,
+        target: Optional[str] = None,
+    ) -> List[SecretRecord]:
+        sc = _coerce_scope(scope) if scope else None
+        return self.store.ls(namespace=namespace, scope=sc, target=target)
+
+    def scan_unresolved_refs(self, obj: Any, namespace: str) -> Set[SecretURI]:
+        """
+        Return secret refs found in `obj` that cannot be fetched.
+        """
+        unresolved: Set[SecretURI] = set()
+        for ref in self.scan_refs(obj, namespace):
+            if isinstance(ref, SecretRef):
+                try:
+                    self.get_value(ref)
+                except CephSecretException:
+                    unresolved.add(ref)
+            else:
+                unresolved.add(ref)
+        return unresolved
+
+    def scan_refs(self, obj: Any, namespace: str) -> Set[SecretURI]:
+        """Collect secret references from *obj*.
+
+        A reference must be the *entire* (stripped) value of a string field —
+        e.g. ``"secret:/ns/global/pw"``.  Embedded URIs inside a larger string
+        (e.g. ``"Bearer secret:/..."``) are not supported and are surfaced as
+        a BadSecretURI rather than silently ignored, so validation can flag
+        them before deploy.
+        """
+        refs: Set[SecretURI] = set()
+
+        def _scan(v: Any) -> None:
+            if isinstance(v, dict):
+                for vv in v.values():
+                    _scan(vv)
+            elif isinstance(v, (list, tuple)):
+                for vv in v:
+                    _scan(vv)
+            elif isinstance(v, str):
+                s = v.strip()
+                if s.startswith(_SECRET_URI_PREFIX):
+                    try:
+                        refs.add(parse_secret_uri(s))
+                    except Exception as e:
+                        logger.warning("Failed to parse secret uri %r: %s", s, e)
+                        refs.add(BadSecretURI(raw=s, namespace=namespace, error=str(e)))
+                elif _SECRET_URI_PREFIX in s:
+                    # Contains a secret URI but is not a whole-value reference.
+                    err = ('embedded secret URIs are not supported; the entire '
+                           'field value must be the secret URI')
+                    logger.warning("Rejecting embedded secret uri in %r", v)
+                    refs.add(BadSecretURI(raw=v, namespace=namespace, error=err))
+                # otherwise: plain data, not a reference
+
+        _scan(obj)
+        return refs
+
+    def _resolve_secret_uri(self, uri: str) -> str:
+        """Resolve a single secret URI to its opaque data string."""
+        try:
+            parsed_secret = parse_secret_uri(uri)
+        except CephSecretException as e:
+            raise CephSecretException(f"Invalid secret URI {uri!r}: {e}") from e
+        if not isinstance(parsed_secret, SecretRef):
+            raise CephSecretException(f"Invalid secret URI {uri!r}")
+        return self.get_value(parsed_secret)
+
+    def _resolve(self, v: Any) -> Any:
+        """Recursively resolve secret URIs within a nested structure."""
+        if isinstance(v, dict):
+            return {k: self._resolve(vv) for k, vv in v.items()}
+        if isinstance(v, list):
+            return [self._resolve(vv) for vv in v]
+        if isinstance(v, tuple):
+            return tuple(self._resolve(vv) for vv in v)
+        if isinstance(v, str):
+            s = v.strip()
+            if s.startswith(_SECRET_URI_PREFIX):
+                return self._resolve_secret_uri(s)
+            if _SECRET_URI_PREFIX in s:
+                # A field that embeds a secret URI inside other text would be
+                # deployed verbatim (leaking the unresolved placeholder).  Fail
+                # loudly rather than silently passing it through.
+                raise CephSecretException(
+                    f"Invalid secret reference {v!r}: embedded secret URIs are "
+                    f"not supported; the entire field value must be the secret URI"
+                )
+        return v
+
+    def resolve_object(self, obj: Any) -> Any:
+        """Resolve secret references within nested dict/list/tuple structures.
+
+        A string whose entire (stripped) value is a secret URI is replaced by
+        the stored opaque data string for that secret.  Surrounding whitespace
+        around an otherwise-clean URI is tolerated; non-secret strings are
+        returned unchanged, preserving their original whitespace.
+
+        A string that embeds a secret URI inside other text (e.g.
+        ``"Bearer secret:/..."``) is rejected with CephSecretException, since
+        partial substitution is not supported and silently emitting the literal
+        URI would leak an unresolved placeholder into deployed configuration.
+        """
+        return self._resolve(obj)

--- a/src/pybind/mgr/ceph_secrets/secret_store.py
+++ b/src/pybind/mgr/ceph_secrets/secret_store.py
@@ -1,0 +1,536 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from ceph_secrets_types import (
+    SecretScope,
+    SecretRef,
+    CephSecretException,
+    CephSecretDataError,
+    validate_secret_namespace,
+)
+from .secret_backend import SecretStorageBackend
+
+
+logger = logging.getLogger(__name__)
+
+
+# Secret data lives under this prefix:  secret_store/v1/<ns>/<scope>/...
+SECRET_STORE_PREFIX = 'secret_store/v1/'
+
+# Storage payload schema version. Stored records are strict: unknown or missing fields are rejected
+SECRET_STORE_FORMAT_VERSION = 1
+
+# Per-namespace epoch keys live under a completely separate prefix so they are
+# never picked up by the secret data scan in ls().
+# Key form:  secret_store/meta/<namespace>/_epoch
+SECRET_META_PREFIX = 'secret_store/meta/'
+
+
+JsonType = Union[
+    None,
+    bool,
+    int,
+    float,
+    str,
+    List["JsonType"],
+    Dict[str, "JsonType"],
+]
+
+JsonDict = Dict[str, JsonType]
+
+# Secret data is an opaque string. Callers are responsible for any structure
+# within it, for example JSON-encoding a dict before storing and decoding after
+# retrieval.
+SecretData = str
+
+
+def _checked_namespace(namespace: str) -> str:
+    try:
+        validate_secret_namespace(namespace)
+    except ValueError as e:
+        raise CephSecretDataError(str(e)) from e
+    return namespace
+
+
+def _epoch_key(namespace: str) -> str:
+    namespace = _checked_namespace(namespace)
+    return f'{SECRET_META_PREFIX}{namespace}/_epoch'
+
+
+def _checked_ref(
+    namespace: str,
+    scope: Union[SecretScope, str],
+    target: str,
+    name: str,
+) -> SecretRef:
+    try:
+        if not isinstance(scope, SecretScope):
+            scope = SecretScope.from_str(str(scope))
+        return SecretRef(
+            namespace=namespace,
+            scope=scope,
+            target=target or '',
+            name=name,
+        )
+    except (CephSecretException, ValueError) as e:
+        raise CephSecretDataError(str(e)) from e
+
+
+def _now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace('+00:00', 'Z')
+    )
+
+
+def _expect_object(label: str, value: Any) -> JsonDict:
+    if not isinstance(value, dict):
+        raise CephSecretDataError(
+            f'{label} must be a JSON object (got {type(value).__name__})'
+        )
+    return value
+
+
+def _reject_unknown_keys(label: str, payload: JsonDict, allowed: set[str]) -> None:
+    unknown = set(payload) - allowed
+    if unknown:
+        raise CephSecretDataError(
+            f'{label} contains unknown field(s): {", ".join(sorted(unknown))}'
+        )
+
+
+def _require_keys(label: str, payload: JsonDict, required: set[str]) -> None:
+    missing = required - set(payload)
+    if missing:
+        raise CephSecretDataError(
+            f'{label} is missing required field(s): {", ".join(sorted(missing))}'
+        )
+
+
+def _expect_bool(label: str, value: Any) -> bool:
+    if not isinstance(value, bool):
+        raise CephSecretDataError(f'{label} must be a boolean')
+    return value
+
+
+def _expect_str(label: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise CephSecretDataError(f'{label} must be a string')
+    return value
+
+
+def _expect_positive_int(label: str, value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise CephSecretDataError(f'{label} must be a positive integer')
+    return value
+
+
+def _ref_json(ref: SecretRef) -> JsonDict:
+    return {
+        'namespace': ref.namespace,
+        'scope': ref.scope.value,
+        'target': ref.target,
+        'name': ref.name,
+    }
+
+
+@dataclass(frozen=True)
+class SecretMetadata:
+    version: int = 1
+    created: str = ''
+    updated: str = ''
+
+    def __post_init__(self) -> None:
+        _expect_positive_int('SecretMetadata.version', self.version)
+        _expect_str('SecretMetadata.created', self.created)
+        _expect_str('SecretMetadata.updated', self.updated)
+
+    def to_json(self) -> JsonDict:
+        return {
+            'version': self.version,
+            'created': self.created,
+            'updated': self.updated,
+        }
+
+    @staticmethod
+    def from_json(payload: JsonDict) -> 'SecretMetadata':
+        payload = _expect_object('SecretMetadata', payload)
+        allowed = {'version', 'created', 'updated'}
+        _reject_unknown_keys('SecretMetadata', payload, allowed)
+        _require_keys('SecretMetadata', payload, allowed)
+        return SecretMetadata(
+            version=_expect_positive_int('SecretMetadata.version', payload['version']),
+            created=_expect_str('SecretMetadata.created', payload['created']),
+            updated=_expect_str('SecretMetadata.updated', payload['updated']),
+        )
+
+
+@dataclass(frozen=True)
+class SecretPolicy:
+    user_made: bool = True
+    editable: bool = True
+
+    def __post_init__(self) -> None:
+        _expect_bool('SecretPolicy.user_made', self.user_made)
+        _expect_bool('SecretPolicy.editable', self.editable)
+
+    def to_json(self) -> JsonDict:
+        return {
+            'user_made': self.user_made,
+            'editable': self.editable,
+        }
+
+    @staticmethod
+    def from_json(payload: JsonDict) -> 'SecretPolicy':
+        payload = _expect_object('SecretPolicy', payload)
+        allowed = {'user_made', 'editable'}
+        _reject_unknown_keys('SecretPolicy', payload, allowed)
+        _require_keys('SecretPolicy', payload, allowed)
+        return SecretPolicy(
+            user_made=_expect_bool('SecretPolicy.user_made', payload['user_made']),
+            editable=_expect_bool('SecretPolicy.editable', payload['editable']),
+        )
+
+
+@dataclass
+class SecretRecord:
+    ref: SecretRef
+    data: SecretData
+    metadata: SecretMetadata = field(default_factory=SecretMetadata)
+    policy: SecretPolicy = field(default_factory=SecretPolicy)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.ref, SecretRef):
+            raise CephSecretDataError('SecretRecord.ref must be a SecretRef')
+        if not isinstance(self.metadata, SecretMetadata):
+            raise CephSecretDataError('SecretRecord.metadata must be SecretMetadata')
+        if not isinstance(self.policy, SecretPolicy):
+            raise CephSecretDataError('SecretRecord.policy must be SecretPolicy')
+        if not isinstance(self.data, str):
+            raise CephSecretDataError('SecretRecord.data must be a string')
+        if self.data == '':
+            raise CephSecretDataError('SecretRecord.data must not be empty')
+
+    # Compatibility/readability helpers for key construction, sorting, and callers
+    # that need the identity but should not mutate it directly.
+    @property
+    def namespace(self) -> str:
+        return self.ref.namespace
+
+    @property
+    def scope(self) -> SecretScope:
+        return self.ref.scope
+
+    @property
+    def target(self) -> str:
+        return self.ref.target
+
+    @property
+    def name(self) -> str:
+        return self.ref.name
+
+    def ident(self) -> Tuple[str, str, str, str]:
+        return self.ref.ident()
+
+    def to_public_json(
+        self,
+        include_data: bool = False,
+        include_policy: bool = False,
+        include_ref: bool = False,
+    ) -> JsonDict:
+        result: JsonDict = {
+            'metadata': self.metadata.to_json(),
+        }
+        if include_ref:
+            result['ref'] = _ref_json(self.ref)
+        if include_data:
+            result['data'] = self.data
+        if include_policy:
+            result['policy'] = self.policy.to_json()
+        return result
+
+    def to_store_json(self) -> JsonDict:
+        return {
+            'format_version': SECRET_STORE_FORMAT_VERSION,
+            'metadata': self.metadata.to_json(),
+            'policy': self.policy.to_json(),
+            'data': self.data,
+        }
+
+    @staticmethod
+    def from_store_json(ref: SecretRef, payload: JsonDict) -> 'SecretRecord':
+        payload = _expect_object('SecretRecord', payload)
+        allowed = {'format_version', 'metadata', 'data', 'policy'}
+        _reject_unknown_keys('SecretRecord', payload, allowed)
+        _require_keys('SecretRecord', payload, allowed)
+
+        format_version = payload['format_version']
+        if (
+            not isinstance(format_version, int)
+            or isinstance(format_version, bool)
+            or format_version != SECRET_STORE_FORMAT_VERSION
+        ):
+            raise CephSecretDataError(
+                f'unsupported SecretRecord.format_version: {format_version!r}'
+            )
+
+        metadata = _expect_object('SecretRecord.metadata', payload['metadata'])
+        data = _expect_str('SecretRecord.data', payload['data'])
+        policy = _expect_object('SecretRecord.policy', payload['policy'])
+        return SecretRecord(
+            ref=ref,
+            metadata=SecretMetadata.from_json(metadata),
+            data=data,
+            policy=SecretPolicy.from_json(policy),
+        )
+
+
+class SecretStoreMon(SecretStorageBackend):
+    """
+    Mon KV-store backed secret store.
+
+    Secret data keys:
+      secret_store/v1/<namespace>/<scope>/<target>/<secret_name>
+
+    Stored payload shape:
+      {
+        "format_version": 1,
+        "metadata": {"version": 1, "created": "...", "updated": "..."},
+        "policy": {"user_made": true, "editable": true}
+        "data": "<opaque string>",
+      }
+
+    Per-namespace epoch keys (never touched by ls()):
+      secret_store/meta/<namespace>/_epoch
+    """
+
+    def __init__(self, mgr: Any) -> None:
+        self.mgr = mgr
+
+    # ------------------------------------------------------------------ epoch
+
+    def get_epoch(self, namespace: str) -> int:
+        """Return the current epoch for *namespace* (0 if never set)."""
+        raw = self.mgr.get_store(_epoch_key(namespace))
+        if raw is None:
+            return 0
+        try:
+            return int(str(raw))
+        except Exception:
+            return 0
+
+    def bump_epoch(self, namespace: str) -> int:
+        """Increment and persist the epoch for *namespace*; return the new value.
+
+        Best-effort: the mon KV store has no atomic read-modify-write, so there
+        is a theoretical TOCTOU window under concurrent mutations.  This is
+        acceptable because the epoch is used only as a cheap change-detector,
+        not as a consistency guarantee.
+        """
+        epoch = self.get_epoch(namespace) + 1
+        self.mgr.set_store(_epoch_key(namespace), str(epoch))
+        return epoch
+
+    # ------------------------------------------------------------------ helpers
+
+    def _kv_key_from_ref(self, ref: SecretRef) -> str:
+        if ref.scope == SecretScope.CUSTOM:
+            return f'{SECRET_STORE_PREFIX}{ref.namespace}/{ref.scope.value}/{ref.name}'
+
+        if ref.scope == SecretScope.GLOBAL:
+            return f'{SECRET_STORE_PREFIX}{ref.namespace}/{ref.scope.value}/{ref.name}'
+
+        return (
+            f'{SECRET_STORE_PREFIX}{ref.namespace}/{ref.scope.value}/'
+            f'{ref.target}/{ref.name}'
+        )
+
+    # ------------------------------------------------------------------ CRUD
+
+    def get(self, namespace: str, scope: SecretScope, target: str, name: str) -> Optional[SecretRecord]:
+        ref = _checked_ref(namespace, scope, target, name)
+        k = self._kv_key_from_ref(ref)
+        raw = self.mgr.get_store(k)
+        if raw is None:
+            return None
+        try:
+            payload = json.loads(raw)
+            if not isinstance(payload, dict):
+                raise CephSecretDataError(
+                    f'expected a JSON object, got {type(payload).__name__}'
+                )
+            return SecretRecord.from_store_json(ref, payload)
+        except CephSecretDataError:
+            raise
+        except Exception as e:
+            msg = f"Corrupted secret entry at {k}: {e}"
+            logger.warning(msg)
+            raise CephSecretDataError(msg) from e
+
+    def set(self,
+            namespace: str,
+            scope: SecretScope,
+            target: str,
+            name: str,
+            data: SecretData,
+            user_made: bool = True,
+            editable: bool = True) -> SecretRecord:
+
+        if not isinstance(data, str):
+            raise CephSecretException('Secret data must be a string')
+        if data == '':
+            raise CephSecretException('Secret data must not be empty')
+
+        ref = _checked_ref(namespace, scope, target, name)
+        existing = None
+        try:
+            existing = self.get(ref.namespace, ref.scope, ref.target, ref.name)
+            if existing and not existing.policy.editable:
+                raise CephSecretException(f'Secret {ref.to_uri()} is not editable')
+        except CephSecretDataError as e:
+            raise CephSecretException(f'Secret {ref.to_uri()} is corrupted.') from e
+
+        now = _now_iso()
+        if existing:
+            metadata = SecretMetadata(
+                version=existing.metadata.version + 1,
+                # Preserve the original creation timestamp across updates.
+                created=existing.metadata.created or now,
+                updated=now,
+            )
+        else:
+            metadata = SecretMetadata(version=1, created=now, updated=now)
+
+        rec = SecretRecord(
+            ref=ref,
+            metadata=metadata,
+            policy=SecretPolicy(user_made=user_made, editable=editable),
+            data=data,
+        )
+        k = self._kv_key_from_ref(ref)
+        self.mgr.set_store(k, json.dumps(rec.to_store_json(), sort_keys=True))
+
+        # Bump epoch after a successful write so consumers can detect any change
+        # in this namespace without enumerating all secrets.
+        self.bump_epoch(ref.namespace)
+        return rec
+
+    def rm(
+        self,
+        namespace: str,
+        scope: SecretScope,
+        target: str,
+        name: str,
+    ) -> bool:
+        ref = _checked_ref(namespace, scope, target, name)
+        k = self._kv_key_from_ref(ref)
+        existed = self.mgr.get_store(k) is not None
+        self.mgr.set_store(k, None)
+        if existed:
+            self.bump_epoch(ref.namespace)
+        return existed
+
+    def ls(
+        self,
+        namespace: Optional[str] = None,
+        scope: Optional[SecretScope] = None,
+        target: Optional[str] = None,
+    ) -> List[SecretRecord]:
+        """
+        List secrets matching the given filters.
+
+        Corrupt/malformed module-owned entries are data errors, not part of the
+        normal listing contract, so they are raised as CephSecretDataError.
+        """
+        if namespace is not None:
+            _checked_namespace(namespace)
+        if scope is not None and not isinstance(scope, SecretScope):
+            scope = SecretScope.from_str(str(scope))
+
+        # list by prefix for efficiency
+        prefix = SECRET_STORE_PREFIX
+        if namespace:
+            prefix += f'{namespace}/'
+            if scope:
+                prefix += f'{scope.value}/'
+                if target and scope not in (SecretScope.GLOBAL, SecretScope.CUSTOM):
+                    prefix += f'{target}/'
+        items = self.mgr.get_store_prefix(prefix) or {}
+        records: List[SecretRecord] = []
+
+        for k, v in items.items():
+            # k is full key: secret_store/v1/ns/scope/target/name
+            suffix = k[len(SECRET_STORE_PREFIX):]
+            parts = suffix.split('/')
+
+            # reject keys with empty segments (double slash, trailing slash, etc.)
+            if '' in parts:
+                raise CephSecretDataError(f'{k}: empty path component in key')
+
+            if len(parts) < 3:
+                raise CephSecretDataError(f'{k}: unexpected key structure')
+
+            ns, sc = parts[0], parts[1]
+
+            try:
+                sc_enum = SecretScope.from_str(sc)
+            except Exception as e:
+                raise CephSecretDataError(f'{k}: invalid scope {sc!r}: {e}') from e
+
+            if sc_enum == SecretScope.CUSTOM:
+                tgt = ''
+                name = '/'.join(parts[2:])
+            elif sc_enum == SecretScope.GLOBAL:
+                if len(parts) != 3:
+                    raise CephSecretDataError(f'{k}: unexpected global key structure')
+                tgt = ''
+                name = parts[2]
+            else:
+                if len(parts) != 4:
+                    raise CephSecretDataError(
+                        f'{k}: unexpected targeted-scope key structure'
+                    )
+                tgt = parts[2]
+                name = parts[3]
+
+            try:
+                ref = SecretRef(ns, sc_enum, tgt, name)
+            except ValueError as e:
+                raise CephSecretDataError(f'{k}: invalid secret key: {e}') from e
+
+            # apply caller filters
+            if namespace and ref.namespace != namespace:
+                continue
+            if scope and ref.scope != scope:
+                continue
+            if target and ref.target != target:
+                continue
+
+            # parse payload
+            try:
+                payload = json.loads(v)
+            except Exception as e:
+                raise CephSecretDataError(f'{k}: invalid JSON payload: {e}') from e
+
+            if not isinstance(payload, dict):
+                raise CephSecretDataError(
+                    f'{k}: payload is not a JSON object (got {type(payload).__name__})'
+                )
+
+            try:
+                records.append(SecretRecord.from_store_json(ref, payload))
+            except CephSecretDataError as e:
+                raise CephSecretDataError(f'{k}: {e}') from e
+            except Exception as e:
+                raise CephSecretDataError(f'{k}: corrupted secret record: {e}') from e
+
+        records.sort(key=lambda r: (r.ref.namespace, r.ref.scope.value, r.ref.target, r.ref.name))
+        return records

--- a/src/pybind/mgr/ceph_secrets/tests/conftest.py
+++ b/src/pybind/mgr/ceph_secrets/tests/conftest.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import pytest
+from mgr_module import MgrModule
+
+
+@pytest.fixture
+def mgr() -> MgrModule:
+    return MgrModule.__new__(MgrModule)
+
+
+@pytest.fixture
+def store(mgr: MgrModule):
+    from ceph_secrets.secret_store import SecretStoreMon
+    return SecretStoreMon(mgr)
+
+
+@pytest.fixture
+def secret_mgr(store):
+    from ceph_secrets.secret_mgr import SecretMgr
+    return SecretMgr(store)

--- a/src/pybind/mgr/ceph_secrets/tests/test_backends.py
+++ b/src/pybind/mgr/ceph_secrets/tests/test_backends.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Tests for ceph_secrets.backends (registry of storage backends)."""
+from __future__ import annotations
+
+from ceph_secrets.backends import BACKENDS
+from ceph_secrets.secret_store import SecretStoreMon
+
+
+class TestBackendsRegistry:
+    def test_mon_backend_registered(self):
+        assert "mon" in BACKENDS
+
+    def test_mon_maps_to_correct_class(self):
+        assert BACKENDS["mon"] is SecretStoreMon
+
+    def test_only_known_backends(self):
+        # Update this test when new backends are added.
+        assert set(BACKENDS.keys()) == {"mon"}
+
+    def test_backend_is_instantiable(self, mgr):
+        cls = BACKENDS["mon"]
+        instance = cls(mgr)
+        assert isinstance(instance, SecretStoreMon)

--- a/src/pybind/mgr/ceph_secrets/tests/test_module.py
+++ b/src/pybind/mgr/ceph_secrets/tests/test_module.py
@@ -1,0 +1,424 @@
+# -*- coding: utf-8 -*-
+"""Tests for ceph_secrets.module.Module — RPC surface and internal methods."""
+from __future__ import annotations
+
+import json
+import pytest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from ceph_secrets.module import Module
+from ceph_secrets.secret_store import SecretStoreMon
+from ceph_secrets.secret_mgr import SecretMgr
+from ceph_secrets_types import (
+    SecretScope,
+    SecretRef,
+    CephSecretException,
+    CephSecretDataError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a Module without going through MgrModule.__init__
+# ---------------------------------------------------------------------------
+
+def _make_module(mgr_stub) -> Module:
+    """Bypass MgrModule.__init__ and wire up manually."""
+    mod = object.__new__(Module)
+    mod.secret_mgr = SecretMgr(SecretStoreMon(mgr_stub))
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Module.__init__ — backend selection
+# ---------------------------------------------------------------------------
+
+class TestModuleInit:
+    def test_default_backend_initialises_secret_mgr(self, mgr):
+        """Module.__init__ with default 'mon' backend wires up SecretMgr."""
+        from mgr_module import MgrModule
+        mod = object.__new__(Module)
+        with patch.object(MgrModule, "__init__", lambda self, *a, **kw: None):
+            with patch.object(MgrModule, "get_module_option", return_value="mon"):
+                Module.__init__(mod, mgr)
+        assert isinstance(mod.secret_mgr, SecretMgr)
+
+    def test_unsupported_backend_raises(self, mgr):
+        """Unknown backend name raises RuntimeError."""
+        from mgr_module import MgrModule
+        with patch.object(MgrModule, "__init__", lambda self, *a, **kw: None):
+            with patch("ceph_secrets.module.BACKENDS", {}):
+                with patch.object(MgrModule, "get_module_option", return_value="vault"):
+                    with pytest.raises(RuntimeError, match="Unsupported secrets backend"):
+                        Module.__init__(object.__new__(Module), mgr)
+
+    def test_backend_init_failure_raises(self, mgr):
+        """Backend constructor failure raises RuntimeError with helpful message."""
+        from mgr_module import MgrModule
+        broken_cls = MagicMock(side_effect=Exception("connection refused"))
+        with patch.object(MgrModule, "__init__", lambda self, *a, **kw: None):
+            with patch("ceph_secrets.module.BACKENDS", {"mon": broken_cls}):
+                with patch.object(MgrModule, "get_module_option", return_value="mon"):
+                    with pytest.raises(RuntimeError, match="Failed to initialize secrets backend"):
+                        Module.__init__(object.__new__(Module), mgr)
+
+
+# ---------------------------------------------------------------------------
+# Module RPC surface
+# ---------------------------------------------------------------------------
+
+class TestModuleRPC:
+    @pytest.fixture
+    def mod(self, mgr):
+        return _make_module(mgr)
+
+    def test_secret_get_epoch_zero(self, mod):
+        assert mod.secret_get_epoch("cephadm") == 0
+
+    def test_secret_get_epoch_after_set(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        assert mod.secret_get_epoch("ns") == 1
+
+    def test_secret_set_and_get(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        result = mod.secret_get("ns", SecretScope.GLOBAL, "", "pw", reveal=True)
+        assert result is not None
+        assert result["data"] == "s3cr3t"
+
+    def test_secret_get_without_reveal_hides_data(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        result = mod.secret_get("ns", SecretScope.GLOBAL, "", "pw", reveal=False)
+        assert result is not None
+        assert "data" not in result
+
+    def test_secret_get_missing_returns_none(self, mod):
+        assert mod.secret_get("ns", SecretScope.GLOBAL, "", "ghost") is None
+
+    def test_secret_get_version_existing(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        assert mod.secret_get_version("ns", SecretScope.GLOBAL, "", "k") == 1
+
+    def test_secret_get_version_missing_returns_none(self, mod):
+        assert mod.secret_get_version("ns", SecretScope.GLOBAL, "", "ghost") is None
+
+    def test_secret_get_value_existing(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        assert mod.secret_get_value("ns", SecretScope.GLOBAL, "", "pw") == "s3cr3t"
+
+    def test_secret_get_value_missing_returns_none(self, mod):
+        assert mod.secret_get_value("ns", SecretScope.GLOBAL, "", "ghost") is None
+
+    def test_secret_get_value_opaque_string(self, mod):
+        # Any string is valid — including one that looks like JSON
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "creds", '{"u": "a", "p": "b"}')
+        assert mod.secret_get_value("ns", SecretScope.GLOBAL, "", "creds") == '{"u": "a", "p": "b"}'
+
+    def test_secret_get_value_corrupt_raises_data_error(self, mgr, mod):
+        mgr.set_store("secret_store/v1/ns/global/bad", "{not json")
+        with pytest.raises(CephSecretDataError):
+            mod.secret_get_value("ns", SecretScope.GLOBAL, "", "bad")
+
+    def test_secret_get_versions_batch(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "a", "data-a")
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "b", "data-b")
+        result = mod.secret_get_versions([
+            "secret:/ns/global/a",
+            "secret:/ns/global/b",
+            "secret:/ns/global/ghost",
+        ])
+        assert result["secret:/ns/global/a"] == 1
+        assert result["secret:/ns/global/b"] == 1
+        assert result["secret:/ns/global/ghost"] is None
+
+    def test_secret_get_versions_skips_invalid_uris(self, mod):
+        result = mod.secret_get_versions(["not-a-uri", "secret:/ns/badscope/key"])
+        assert len(result) == 0
+
+    def test_secret_get_versions_empty_list(self, mod):
+        assert mod.secret_get_versions([]) == {}
+
+    def test_secret_get_versions_corrupt_raises_data_error(self, mgr, mod):
+        """Corruption must not be silently swallowed as a missing/invalid URI."""
+        mgr.set_store("secret_store/v1/ns/global/bad", "{not json")
+        with pytest.raises(CephSecretDataError):
+            mod.secret_get_versions(["secret:/ns/global/bad"])
+
+    def test_secret_set_returns_metadata(self, mod):
+        result = mod.secret_set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        assert "metadata" in result
+        assert result["metadata"]["version"] == 1
+
+    def test_secret_set_empty_data_raises(self, mod):
+        with pytest.raises(CephSecretException, match="must not be empty"):
+            mod.secret_set("ns", SecretScope.GLOBAL, "", "k", "")
+
+    def test_secret_rm_existing(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        assert mod.secret_rm("ns", SecretScope.GLOBAL, "", "k") is True
+
+    def test_secret_rm_nonexistent(self, mod):
+        assert mod.secret_rm("ns", SecretScope.GLOBAL, "", "ghost") is False
+
+    def test_secret_ls_empty(self, mod):
+        assert mod.secret_ls(namespace="ns") == {}
+
+    def test_secret_ls_returns_records(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "a", "data-a")
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "b", "data-b")
+        out = mod.secret_ls(namespace="ns")
+        assert "ns/global/a" in out
+        assert "ns/global/b" in out
+
+    def test_secret_ls_scope_filter(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "g", "data-g")
+        mod.secret_set("ns", SecretScope.SERVICE, "prom", "auth", "data-auth")
+        out = mod.secret_ls(namespace="ns", scope="service")
+        assert all("service" in k for k in out.keys())
+
+    def test_secret_ls_with_target(self, mod):
+        mod.secret_set("ns", SecretScope.SERVICE, "prom", "auth", "data-auth")
+        out = mod.secret_ls(namespace="ns", scope="service", target="prom")
+        assert "ns/service/prom/auth" in out
+
+    def test_secret_ls_show_internals(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        out = mod.secret_ls(namespace="ns", show_internals=True)
+        rec = out["ns/global/k"]
+        assert "policy" in rec
+
+    def test_secret_ls_key_format_global(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        out = mod.secret_ls(namespace="ns")
+        assert "ns/global/k" in out
+        for k in out:
+            assert "//" not in k
+
+    def test_scan_refs(self, mod):
+        result = mod.scan_refs({"key": "secret:/ns/global/pw"}, namespace="ns")
+        assert "secret:/ns/global/pw" in result
+
+    def test_scan_unresolved_refs_all_missing(self, mod):
+        result = mod.scan_unresolved_refs("secret:/ns/global/ghost", namespace="ns")
+        assert "secret:/ns/global/ghost" in result
+
+    def test_scan_unresolved_refs_exists(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "pw", "x")
+        result = mod.scan_unresolved_refs("secret:/ns/global/pw", namespace="ns")
+        assert result == []
+
+    def test_resolve_object(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        result = mod.resolve_object("secret:/ns/global/pw")
+        assert result == "s3cr3t"
+
+
+# ---------------------------------------------------------------------------
+# Module internal ref-based methods
+# ---------------------------------------------------------------------------
+
+class TestModuleInternals:
+    @pytest.fixture
+    def mod(self, mgr):
+        return _make_module(mgr)
+
+    def _ref(self, ns="ns", scope=SecretScope.GLOBAL, target="", name="key"):
+        return SecretRef(ns, scope, target, name)
+
+    def test_secret_get_existing(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "key", "data-x")
+        result = mod._secret_get(self._ref())
+        assert result is not None
+
+    def test_secret_get_not_found(self, mod):
+        assert mod._secret_get(self._ref(name="ghost")) is None
+
+    def test_secret_get_corrupt_raises_data_error(self, mgr, mod):
+        mgr.set_store("secret_store/v1/ns/global/bad", "{not json")
+        with pytest.raises(CephSecretDataError):
+            mod._secret_get(self._ref(name="bad"))
+
+    def test_secret_get_version_existing(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "key", "data-x")
+        assert mod._secret_get_version(self._ref()) == 1
+
+    def test_secret_get_version_not_found(self, mod):
+        assert mod._secret_get_version(self._ref(name="ghost")) is None
+
+    def test_secret_get_version_corrupt_raises_data_error(self, mgr, mod):
+        mgr.set_store("secret_store/v1/ns/global/bad", "{not json")
+        with pytest.raises(CephSecretDataError):
+            mod._secret_get_version(self._ref(name="bad"))
+
+    def test_secret_set_returns_metadata_without_data(self, mod):
+        result = mod._secret_set(self._ref(), "data-x")
+        assert "metadata" in result
+        assert "data" not in result
+
+    def test_secret_rm_existing(self, mod):
+        mod._secret_set(self._ref(), "data-x")
+        assert mod._secret_rm(self._ref()) is True
+
+    def test_secret_rm_nonexistent(self, mod):
+        assert mod._secret_rm(self._ref(name="ghost")) is False
+
+
+# ---------------------------------------------------------------------------
+# CLI handler logic (path-based dispatch)
+# ---------------------------------------------------------------------------
+
+class TestModuleCLIHandlers:
+    @pytest.fixture
+    def mod(self, mgr):
+        return _make_module(mgr)
+
+    def _ok(self, result: Any) -> Any:
+        """Unwrap a Responder tuple (retcode, body, status) → parsed dict.
+        Falls through unchanged when Responder is a no-op stub."""
+        if isinstance(result, tuple):
+            retcode, body, _ = result
+            assert retcode == 0, f"unexpected error retcode {retcode}: {body}"
+            return json.loads(body)
+        return result
+
+    def _assert_error(self, result: Any, match: str = "") -> None:
+        """Assert a CLI call failed — either via a non-zero tuple or ErrorResponse.
+        Never accepts a raw CephSecretException (would mean _handle_secret_errors broke)."""
+        from object_format import ErrorResponse
+        if isinstance(result, tuple):
+            retcode, body, status = result
+            assert retcode != 0, "expected non-zero retcode"
+            if match:
+                assert match in (body + status).lower(), \
+                    f"expected {match!r} in response, got body={body!r} status={status!r}"
+        elif isinstance(result, ErrorResponse):
+            if match:
+                assert match in str(result).lower()
+        else:
+            raise AssertionError(
+                f"expected error tuple or ErrorResponse, got {type(result).__name__}: {result!r}"
+            )
+
+    def test_cli_get_by_path_found(self, mod):
+        mod.secret_set("ns", SecretScope.GLOBAL, "", "key", "data-x")
+        result = self._ok(mod._cli_secret_get_by_path(path="ns/global/key"))
+        assert "metadata" in result
+
+    def test_cli_get_by_path_not_found(self, mod):
+        from object_format import ErrorResponse
+        try:
+            result = mod._cli_secret_get_by_path(path="ns/global/ghost")
+            self._assert_error(result, match="not found")
+        except ErrorResponse as e:
+            assert "not found" in str(e).lower()
+
+    def test_cli_get_by_path_bad_path(self, mod):
+        from object_format import ErrorResponse
+        try:
+            result = mod._cli_secret_get_by_path(path="ns/badscope/key")
+            self._assert_error(result)
+        except ErrorResponse:
+            pass
+
+    def test_cli_get_corrupt_raises_data_error(self, mgr, mod):
+        from object_format import ErrorResponse
+        mgr.set_store("secret_store/v1/ns/global/bad", "{not json")
+        # CephSecretDataError is a CephSecretException subclass so _handle_secret_errors
+        # wraps it into ErrorResponse; Responder formats it as a non-zero tuple.
+        try:
+            result = mod._cli_secret_get_by_path(path="ns/global/bad")
+            self._assert_error(result)
+        except ErrorResponse:
+            pass
+
+    def test_cli_set_by_path(self, mod):
+        result = self._ok(mod._cli_secret_set_by_path(
+            path="ns/global/key",
+            inbuf="s3cr3t"
+        ))
+        assert result["metadata"]["version"] == 1
+
+    def test_cli_set_by_path_no_inbuf(self, mod):
+        from object_format import ErrorResponse
+        try:
+            result = mod._cli_secret_set_by_path(path="ns/global/key", inbuf=None)
+            self._assert_error(result, match="-i")
+        except ErrorResponse as e:
+            assert "-i" in str(e)
+
+    def test_cli_set_by_path_empty_data(self, mod):
+        from object_format import ErrorResponse
+        try:
+            result = mod._cli_secret_set_by_path(path="ns/global/key", inbuf="")
+            self._assert_error(result, match="must not be empty")
+        except ErrorResponse as e:
+            assert "must not be empty" in str(e).lower()
+
+    def test_cli_rm_by_path_existing(self, mod):
+        mod._cli_secret_set_by_path(path="ns/global/key", inbuf='{"v": "x"}')
+        result = self._ok(mod._cli_secret_rm_by_path(path="ns/global/key"))
+        assert result["status"] == "removed"
+
+    def test_cli_rm_by_path_not_found(self, mod):
+        result = self._ok(mod._cli_secret_rm_by_path(path="ns/global/ghost"))
+        assert result["status"] == "not_found"
+
+    def test_cli_rm_by_path_bad_path(self, mod):
+        from object_format import ErrorResponse
+        try:
+            result = mod._cli_secret_rm_by_path(path="ns/badscope/key")
+            self._assert_error(result)
+        except ErrorResponse:
+            pass
+
+    def test_cli_ls(self, mod):
+        mod._cli_secret_set_by_path(path="ns/global/a", inbuf='{"v": "1"}')
+        mod._cli_secret_set_by_path(path="ns/global/b", inbuf='{"v": "2"}')
+        result = self._ok(mod._cli_secret_ls(namespace="ns"))
+        assert "ns/global/a" in result
+        assert "ns/global/b" in result
+
+    def test_cli_get_with_reveal(self, mod):
+        mod._cli_secret_set_by_path(path="ns/global/pw", inbuf="s3cr3t")
+        result = self._ok(mod._cli_secret_get_by_path(path="ns/global/pw", reveal=True))
+        assert result["data"] == "s3cr3t"
+
+    def test_cli_get_without_reveal_hides_data(self, mod):
+        mod._cli_secret_set_by_path(path="ns/global/pw", inbuf="s3cr3t")
+        result = self._ok(mod._cli_secret_get_by_path(path="ns/global/pw", reveal=False))
+        assert "data" not in result
+
+    def _get_value(self, result: Any) -> str:
+        """Unwrap a get-value tuple (retcode, body, status) → raw string."""
+        if isinstance(result, tuple):
+            retcode, body, _ = result
+            assert retcode == 0, f"unexpected error retcode {retcode}: {body}"
+            return body
+        return result
+
+    def test_cli_get_value_returns_raw_string(self, mod):
+        mod._cli_secret_set_by_path(path="ns/global/pw", inbuf="s3cr3t")
+        result = self._get_value(mod._cli_secret_get_value_by_path(path="ns/global/pw"))
+        assert result == "s3cr3t"
+
+    def test_cli_get_value_not_found_raises(self, mod):
+        from object_format import ErrorResponse
+        try:
+            result = mod._cli_secret_get_value_by_path(path="ns/global/ghost")
+            self._assert_error(result)
+        except ErrorResponse:
+            pass
+
+    def test_cli_get_value_bad_path_raises(self, mod):
+        from object_format import ErrorResponse
+        try:
+            result = mod._cli_secret_get_value_by_path(path="ns/badscope/key")
+            self._assert_error(result)
+        except ErrorResponse:
+            pass
+
+    def test_cli_get_value_opaque_json_string(self, mod):
+        payload = '{"u": "a", "p": "b"}'
+        mod._cli_secret_set_by_path(path="ns/global/creds", inbuf=payload)
+        result = self._get_value(mod._cli_secret_get_value_by_path(path="ns/global/creds"))
+        assert result == payload

--- a/src/pybind/mgr/ceph_secrets/tests/test_secret_backend.py
+++ b/src/pybind/mgr/ceph_secrets/tests/test_secret_backend.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Tests for the SecretStorageBackend ABC and contract."""
+from __future__ import annotations
+
+import pytest
+from abc import ABC
+
+from ceph_secrets.secret_backend import SecretStorageBackend
+from ceph_secrets_types import SecretScope
+
+
+class TestSecretStorageBackend:
+    def test_is_abstract(self):
+        assert issubclass(SecretStorageBackend, ABC)
+
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError):
+            SecretStorageBackend()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self, store):
+        """SecretStoreMon (the concrete impl) must satisfy the ABC."""
+        assert isinstance(store, SecretStorageBackend)
+
+    def test_abstract_methods_defined(self):
+        abstract = SecretStorageBackend.__abstractmethods__
+        assert 'get' in abstract
+        assert 'set' in abstract
+        assert 'rm' in abstract
+        assert 'ls' in abstract
+        assert 'get_epoch' in abstract
+        assert 'bump_epoch' in abstract
+
+    def test_partial_implementation_still_abstract(self):
+        """Subclass missing any abstract method stays abstract."""
+        class PartialImpl(SecretStorageBackend):
+            def get(self, ns, scope, target, name):
+                pass
+
+            def set(self, ns, scope, target, name, data, user_made=True, editable=True):
+                pass
+
+            def rm(self, ns, scope, target, name):
+                pass
+
+            def ls(self, namespace=None, scope=None, target=None):
+                pass
+
+            def get_epoch(self, namespace):
+                pass
+            # missing bump_epoch
+
+        with pytest.raises(TypeError):
+            PartialImpl()  # type: ignore[abstract]
+
+    def test_full_implementation_is_instantiable(self):
+
+        class FullImpl(SecretStorageBackend):
+
+            def get(self, ns, scope, target, name):
+                return None
+
+            def set(self, ns, scope, target, name, data, user_made=True, editable=True):
+                pass
+
+            def rm(self, ns, scope, target, name):
+                return False
+
+            def ls(self, namespace=None, scope=None, target=None):
+                return []
+
+            def get_epoch(self, namespace):
+                return 0
+
+            def bump_epoch(self, namespace):
+                return 1
+
+        impl = FullImpl()
+        assert impl.get("ns", SecretScope.GLOBAL, "", "k") is None
+        assert impl.get_epoch("ns") == 0
+        assert impl.bump_epoch("ns") == 1

--- a/src/pybind/mgr/ceph_secrets/tests/test_secret_mgr.py
+++ b/src/pybind/mgr/ceph_secrets/tests/test_secret_mgr.py
@@ -1,0 +1,339 @@
+# -*- coding: utf-8 -*-
+"""Tests for ceph_secrets.secret_mgr (SecretMgr)."""
+from __future__ import annotations
+
+import pytest
+
+from ceph_secrets_types import (
+    SecretScope, SecretRef,
+    CephSecretException, CephSecretNotFoundError,
+    BadSecretURI,
+)
+
+
+# ============================================================
+# make_ref
+# ============================================================
+
+class TestMakeRef:
+    def test_basic(self, secret_mgr):
+        ref = secret_mgr.make_ref("ns", SecretScope.GLOBAL, "", "key")
+        assert isinstance(ref, SecretRef)
+        assert ref.namespace == "ns"
+
+    def test_scope_as_string(self, secret_mgr):
+        ref = secret_mgr.make_ref("ns", "host", "node1", "ssh_key")
+        assert ref.scope == SecretScope.HOST
+
+    def test_bad_scope_raises(self, secret_mgr):
+        with pytest.raises(CephSecretException):
+            secret_mgr.make_ref("ns", "badscope", "", "key")
+
+    def test_bad_namespace_raises(self, secret_mgr):
+        with pytest.raises(CephSecretException):
+            secret_mgr.make_ref("bad ns!", SecretScope.GLOBAL, "", "key")
+
+
+# ============================================================
+# get / get_value
+# ============================================================
+
+class TestGet:
+    def test_get_existing(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "pw")
+        rec = secret_mgr.get(ref)
+        assert rec.data == "s3cr3t"
+
+    def test_get_missing_raises(self, secret_mgr):
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "ghost")
+        with pytest.raises(CephSecretNotFoundError):
+            secret_mgr.get(ref)
+
+    def test_get_value(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "pw")
+        assert secret_mgr.get_value(ref) == "s3cr3t"
+
+    def test_get_value_opaque_string(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "creds", '{"u": "admin", "p": "pw"}')
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "creds")
+        val = secret_mgr.get_value(ref)
+        assert isinstance(val, str)
+        assert val == '{"u": "admin", "p": "pw"}'
+
+    def test_get_value_missing_raises(self, secret_mgr):
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "ghost")
+        with pytest.raises(CephSecretNotFoundError):
+            secret_mgr.get_value(ref)
+
+
+# ============================================================
+# set
+# ============================================================
+
+class TestSet:
+    def test_set_global(self, secret_mgr):
+        rec = secret_mgr.set("ns", SecretScope.GLOBAL, "", "k", "data-v1")
+        assert rec.metadata.version == 1
+        assert rec.data == "data-v1"
+
+    def test_set_service(self, secret_mgr):
+        rec = secret_mgr.set("ns", SecretScope.SERVICE, "prom", "auth", "user-a")
+        assert rec.target == "prom"
+
+    def test_set_custom(self, secret_mgr):
+        rec = secret_mgr.set("ns", SecretScope.CUSTOM, "", "a/b/c", "tok")
+        assert rec.name == "a/b/c"
+
+    def test_set_non_str_raises(self, secret_mgr):
+        with pytest.raises(CephSecretException, match="string"):
+            secret_mgr.set("ns", SecretScope.GLOBAL, "", "k", {"not": "a-string"})  # type: ignore[arg-type]
+
+    def test_set_empty_string_raises(self, secret_mgr):
+        with pytest.raises(CephSecretException, match="must not be empty"):
+            secret_mgr.set("ns", SecretScope.GLOBAL, "", "k", "")
+
+    def test_set_preserves_whitespace_and_newlines(self, secret_mgr):
+        payload = "  secret-value\n"
+        rec = secret_mgr.set("ns", SecretScope.GLOBAL, "", "k", payload)
+        assert rec.data == payload
+        assert secret_mgr.get_value(SecretRef("ns", SecretScope.GLOBAL, "", "k")) == payload
+
+    def test_set_increments_version(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "k", "data-v1")
+        rec = secret_mgr.set("ns", SecretScope.GLOBAL, "", "k", "data-v2")
+        assert rec.metadata.version == 2
+
+    def test_set_scope_string(self, secret_mgr):
+        rec = secret_mgr.set("ns", "global", "", "k", "data-x")
+        assert rec.scope == SecretScope.GLOBAL
+
+
+# ============================================================
+# rm
+# ============================================================
+
+class TestRm:
+    def test_rm_existing(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        assert secret_mgr.rm("ns", SecretScope.GLOBAL, "", "k") is True
+
+    def test_rm_nonexistent(self, secret_mgr):
+        assert secret_mgr.rm("ns", SecretScope.GLOBAL, "", "ghost") is False
+
+
+# ============================================================
+# ls
+# ============================================================
+
+class TestLs:
+    def test_ls_empty(self, secret_mgr):
+        assert secret_mgr.ls(namespace="ns") == []
+
+    def test_ls_returns_records(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "a", "data-a")
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "b", "data-b")
+        recs = secret_mgr.ls(namespace="ns")
+        assert len(recs) == 2
+
+    def test_ls_scope_filter(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "g", "data-g")
+        secret_mgr.set("ns", SecretScope.SERVICE, "prom", "auth", "data-auth")
+        recs = secret_mgr.ls(namespace="ns", scope="service")
+        assert len(recs) == 1
+        assert recs[0].scope == SecretScope.SERVICE
+
+
+# ============================================================
+# scan_refs / scan_unresolved_refs
+# ============================================================
+
+class TestScanRefs:
+    def test_scan_simple_string(self, secret_mgr):
+        obj = "secret:/ns/global/pw"
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        uris = {r.to_uri() for r in refs}
+        assert "secret:/ns/global/pw" in uris
+
+    def test_scan_in_dict(self, secret_mgr):
+        obj = {"key": "secret:/ns/global/pw"}
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        assert len(refs) == 1
+
+    def test_scan_in_list(self, secret_mgr):
+        obj = ["secret:/ns/global/pw", "secret:/ns/host/node1/ssh"]
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        assert len(refs) == 2
+
+    def test_scan_nested(self, secret_mgr):
+        obj = {"a": {"b": "secret:/ns/global/pw"}}
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        assert len(refs) == 1
+
+    def test_scan_no_refs(self, secret_mgr):
+        obj = {"plain": "value"}
+        assert secret_mgr.scan_refs(obj, namespace="ns") == set()
+
+    def test_scan_bad_uri_yields_bad_secret_uri(self, secret_mgr):
+        obj = "secret:/ns/badscope/key"
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        bad = [r for r in refs if isinstance(r, BadSecretURI)]
+        assert len(bad) == 1
+
+    def test_scan_unresolved_all_exist(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "x")
+        obj = "secret:/ns/global/pw"
+        unresolved = secret_mgr.scan_unresolved_refs(obj, namespace="ns")
+        assert len(unresolved) == 0
+
+    def test_scan_unresolved_missing(self, secret_mgr):
+        obj = "secret:/ns/global/ghost"
+        unresolved = secret_mgr.scan_unresolved_refs(obj, namespace="ns")
+        assert len(unresolved) == 1
+
+    def test_scan_unresolved_bad_uri_is_unresolved(self, secret_mgr):
+        obj = "secret:/ns/badscope/key"
+        unresolved = secret_mgr.scan_unresolved_refs(obj, namespace="ns")
+        assert len(unresolved) == 1
+
+    def test_scan_unresolved_embedded_uri_is_unresolved(self, secret_mgr):
+        # Even though the referenced secret exists, an embedded (non-whole-value)
+        # URI is never resolvable, so it must be reported as unresolved so that
+        # pre-deploy validation catches it.
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "x")
+        obj = {"auth": "Bearer secret:/ns/global/pw"}
+        unresolved = secret_mgr.scan_unresolved_refs(obj, namespace="ns")
+        assert len(unresolved) == 1
+
+
+# ============================================================
+# resolve_object
+# ============================================================
+
+class TestResolveObject:
+    def test_resolve_secret(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        result = secret_mgr.resolve_object("secret:/ns/global/pw")
+        assert result == "s3cr3t"
+
+    def test_resolve_opaque_json_string(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "creds", '{"u": "a", "p": "b"}')
+        result = secret_mgr.resolve_object("secret:/ns/global/creds")
+        assert isinstance(result, str)
+        assert result == '{"u": "a", "p": "b"}'
+
+    def test_resolve_in_dict(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        result = secret_mgr.resolve_object({"password": "secret:/ns/global/pw"})
+        assert result["password"] == "s3cr3t"
+
+    def test_resolve_in_list(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "a", "x")
+        result = secret_mgr.resolve_object(["secret:/ns/global/a", "plain"])
+        assert result[0] == "x"
+        assert result[1] == "plain"
+
+    def test_resolve_in_tuple(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "t", "y")
+        result = secret_mgr.resolve_object(("secret:/ns/global/t",))
+        assert result == ("y",)
+
+    def test_resolve_non_secret_string_unchanged(self, secret_mgr):
+        result = secret_mgr.resolve_object("just a normal string")
+        assert result == "just a normal string"
+
+    def test_resolve_non_string_unchanged(self, secret_mgr):
+        assert secret_mgr.resolve_object(42) == 42
+        assert secret_mgr.resolve_object(None) is None
+
+    def test_resolve_missing_secret_raises(self, secret_mgr):
+        with pytest.raises(CephSecretException):
+            secret_mgr.resolve_object("secret:/ns/global/ghost")
+
+    def test_resolve_invalid_uri_raises(self, secret_mgr):
+        with pytest.raises(CephSecretException):
+            secret_mgr.resolve_object("secret:/ns/badscope/key")
+
+    def test_resolve_edge_whitespace_tolerated(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        assert secret_mgr.resolve_object("  secret:/ns/global/pw  ") == "s3cr3t"
+
+    def test_resolve_newline_whitespace_tolerated(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        assert secret_mgr.resolve_object("\nsecret:/ns/global/pw\n") == "s3cr3t"
+
+    def test_resolve_ref_with_suffix_raises(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        with pytest.raises(CephSecretException):
+            secret_mgr.resolve_object("secret:/ns/global/pw suffix")
+
+    def test_resolve_embedded_uri_raises(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        with pytest.raises(CephSecretException, match="embedded"):
+            secret_mgr.resolve_object("Bearer secret:/ns/global/pw")
+
+    def test_resolve_embedded_uri_in_dict_raises(self, secret_mgr):
+        secret_mgr.set("ns", SecretScope.GLOBAL, "", "pw", "s3cr3t")
+        with pytest.raises(CephSecretException, match="embedded"):
+            secret_mgr.resolve_object({"auth": "Bearer secret:/ns/global/pw"})
+
+    def test_resolve_plain_string_whitespace_preserved(self, secret_mgr):
+        # non-secret strings pass through byte-for-byte, including whitespace
+        assert secret_mgr.resolve_object("  plain value  ") == "  plain value  "
+
+
+# ============================================================
+# scan_refs — edge cases
+# ============================================================
+
+class TestScanRefsEdgeCases:
+    def test_embedded_refs_rejected_as_bad(self, secret_mgr):
+        # A string that embeds URIs inside other text is NOT a whole-value
+        # reference; it is surfaced as a single BadSecretURI, not parsed into
+        # multiple SecretRefs.
+        obj = "use secret:/ns/global/a and secret:/ns/global/b"
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        assert len(refs) == 1
+        bad = [r for r in refs if isinstance(r, BadSecretURI)]
+        assert len(bad) == 1
+        assert bad[0].raw == obj
+
+    def test_duplicate_refs_deduped(self, secret_mgr):
+        obj = ["secret:/ns/global/pw", "secret:/ns/global/pw"]
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        uris = [r.to_uri() for r in refs]
+        assert uris.count("secret:/ns/global/pw") == 1
+
+    def test_ref_followed_by_punctuation(self, secret_mgr):
+        # "secret:/ns/global/pw," is a whole-value string that starts with the
+        # prefix but is not a valid URI (trailing comma in name) → BadSecretURI.
+        obj = "secret:/ns/global/pw,"
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        bad = [r for r in refs if isinstance(r, BadSecretURI)]
+        assert len(bad) == 1
+
+    def test_whole_value_ref_with_edge_whitespace(self, secret_mgr):
+        # Surrounding whitespace around an otherwise-clean URI is tolerated.
+        obj = "  secret:/ns/global/pw  "
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        uris = {r.to_uri() for r in refs if isinstance(r, SecretRef)}
+        assert "secret:/ns/global/pw" in uris
+
+    def test_embedded_ref_in_dict_value_is_bad(self, secret_mgr):
+        obj = {"auth": "Bearer secret:/ns/global/pw"}
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        bad = [r for r in refs if isinstance(r, BadSecretURI)]
+        assert len(bad) == 1
+
+    def test_ref_inside_tuple(self, secret_mgr):
+        obj = ("secret:/ns/global/pw",)
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        assert len(refs) == 1
+
+    def test_cross_namespace_ref_is_scanned(self, secret_mgr):
+        """scan_refs finds refs regardless of namespace — namespace arg does not filter."""
+        obj = "secret:/other/global/pw"
+        refs = secret_mgr.scan_refs(obj, namespace="ns")
+        uris = {r.to_uri() for r in refs}
+        assert "secret:/other/global/pw" in uris

--- a/src/pybind/mgr/ceph_secrets/tests/test_secret_store.py
+++ b/src/pybind/mgr/ceph_secrets/tests/test_secret_store.py
@@ -1,0 +1,516 @@
+# -*- coding: utf-8 -*-
+"""Tests for ceph_secrets.secret_store (SecretStoreMon + data model)."""
+from __future__ import annotations
+
+import pytest
+
+# conftest injects stubs; just import production code after.
+from ceph_secrets.secret_store import (
+    SecretRecord,
+    SecretMetadata,
+    SecretPolicy,
+    SECRET_STORE_PREFIX,
+    SECRET_STORE_FORMAT_VERSION,
+    _checked_ref,
+    _checked_namespace,
+    _epoch_key,
+    _now_iso,
+    _expect_bool,
+    _expect_str,
+    _expect_positive_int,
+    _expect_object,
+    _reject_unknown_keys,
+    _require_keys,
+)
+from ceph_secrets_types import (
+    SecretScope, SecretRef,
+    CephSecretException, CephSecretDataError,
+)
+
+
+# ============================================================
+# Helpers / primitive validators
+# ============================================================
+
+class TestPrimitiveHelpers:
+    def test_now_iso_format(self):
+        ts = _now_iso()
+        import re
+        assert re.match(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$', ts)
+
+    def test_expect_bool_ok(self):
+        assert _expect_bool("f", True) is True
+        assert _expect_bool("f", False) is False
+
+    def test_expect_bool_bad(self):
+        with pytest.raises(CephSecretDataError, match="must be a boolean"):
+            _expect_bool("f", 1)
+
+    def test_expect_str_ok(self):
+        assert _expect_str("f", "hello") == "hello"
+
+    def test_expect_str_bad(self):
+        with pytest.raises(CephSecretDataError, match="must be a string"):
+            _expect_str("f", 42)
+
+    def test_expect_positive_int_ok(self):
+        assert _expect_positive_int("f", 1) == 1
+        assert _expect_positive_int("f", 99) == 99
+
+    def test_expect_positive_int_zero(self):
+        with pytest.raises(CephSecretDataError):
+            _expect_positive_int("f", 0)
+
+    def test_expect_positive_int_bool_rejected(self):
+        with pytest.raises(CephSecretDataError):
+            _expect_positive_int("f", True)
+
+    def test_expect_object_ok(self):
+        d = {"a": 1}
+        assert _expect_object("o", d) is d
+
+    def test_expect_object_bad(self):
+        with pytest.raises(CephSecretDataError, match="must be a JSON object"):
+            _expect_object("o", [1, 2])
+
+    def test_reject_unknown_keys(self):
+        with pytest.raises(CephSecretDataError, match="unknown field"):
+            _reject_unknown_keys("L", {"a": 1, "z": 2}, {"a"})
+
+    def test_require_keys_missing(self):
+        with pytest.raises(CephSecretDataError, match="missing required"):
+            _require_keys("L", {"a": 1}, {"a", "b"})
+
+    def test_checked_namespace_valid(self):
+        assert _checked_namespace("cephadm") == "cephadm"
+
+    def test_checked_namespace_bad(self):
+        with pytest.raises(CephSecretDataError):
+            _checked_namespace("bad ns!")
+
+    def test_epoch_key_format(self):
+        assert _epoch_key("cephadm") == "secret_store/meta/cephadm/_epoch"
+
+    def test_checked_ref_valid(self):
+        ref = _checked_ref("ns", SecretScope.GLOBAL, "", "key")
+        assert isinstance(ref, SecretRef)
+
+    def test_checked_ref_bad_scope(self):
+        with pytest.raises(CephSecretDataError):
+            _checked_ref("ns", "bad", "", "key")
+
+
+# ============================================================
+# SecretMetadata
+# ============================================================
+
+class TestSecretMetadata:
+    def test_defaults(self):
+        m = SecretMetadata(version=1, created="2024-01-01T00:00:00Z", updated="2024-01-01T00:00:00Z")
+        assert m.version == 1
+
+    def test_to_json(self):
+        m = SecretMetadata(version=2, created="2024-01-01T00:00:00Z", updated="2024-01-02T00:00:00Z")
+        d = m.to_json()
+        assert d["version"] == 2
+        assert "created" in d
+        assert "updated" in d
+
+    def test_from_json_roundtrip(self):
+        m = SecretMetadata(version=3, created="2024-01-01T00:00:00Z", updated="2024-01-02T00:00:00Z")
+        m2 = SecretMetadata.from_json(m.to_json())
+        assert m2.version == 3
+
+    def test_from_json_missing_field(self):
+        with pytest.raises(CephSecretDataError, match="missing required"):
+            SecretMetadata.from_json({"version": 1, "created": "x"})
+
+    def test_from_json_unknown_field(self):
+        with pytest.raises(CephSecretDataError, match="unknown"):
+            SecretMetadata.from_json({"version": 1, "created": "x", "updated": "y", "extra": 1})
+
+    def test_version_zero_raises(self):
+        with pytest.raises(CephSecretDataError):
+            SecretMetadata(version=0, created="x", updated="y")
+
+    def test_non_dict_raises(self):
+        with pytest.raises(CephSecretDataError):
+            SecretMetadata.from_json("not a dict")
+
+
+# ============================================================
+# SecretPolicy
+# ============================================================
+
+class TestSecretPolicy:
+    def test_defaults(self):
+        p = SecretPolicy()
+        assert p.user_made is True
+        assert p.editable is True
+
+    def test_to_json(self):
+        p = SecretPolicy(user_made=False, editable=True)
+        d = p.to_json()
+        assert d["user_made"] is False
+
+    def test_from_json_roundtrip(self):
+        p = SecretPolicy(user_made=True, editable=False)
+        p2 = SecretPolicy.from_json(p.to_json())
+        assert p2.editable is False
+
+    def test_from_json_missing(self):
+        with pytest.raises(CephSecretDataError):
+            SecretPolicy.from_json({"user_made": True})
+
+    def test_from_json_bad_type(self):
+        with pytest.raises(CephSecretDataError, match="must be a boolean"):
+            SecretPolicy.from_json({"user_made": 1, "editable": True})
+
+    def test_non_bool_raises(self):
+        with pytest.raises(CephSecretDataError):
+            SecretPolicy(user_made="yes", editable=True)  # type: ignore[arg-type]
+
+
+# ============================================================
+# SecretRecord
+# ============================================================
+
+class TestSecretRecord:
+    def _ref(self, scope=SecretScope.GLOBAL, target="", name="key"):
+        return SecretRef("ns", scope, target, name)
+
+    def _meta(self):
+        return SecretMetadata(version=1, created="2024-01-01T00:00:00Z", updated="2024-01-01T00:00:00Z")
+
+    def test_basic_construction(self):
+        rec = SecretRecord(ref=self._ref(), metadata=self._meta(), data="s3cr3t")
+        assert rec.namespace == "ns"
+        assert rec.scope == SecretScope.GLOBAL
+        assert rec.name == "key"
+
+    def test_to_public_json_no_data(self):
+        rec = SecretRecord(ref=self._ref(), metadata=self._meta(), data="s3cr3t")
+        out = rec.to_public_json(include_data=False)
+        assert "data" not in out
+        assert "metadata" in out
+
+    def test_to_public_json_with_data(self):
+        rec = SecretRecord(ref=self._ref(), metadata=self._meta(), data="s3cr3t")
+        out = rec.to_public_json(include_data=True)
+        assert out["data"] == "s3cr3t"
+
+    def test_to_public_json_with_ref(self):
+        rec = SecretRecord(ref=self._ref(), metadata=self._meta(), data="x")
+        out = rec.to_public_json(include_ref=True)
+        assert out["ref"]["namespace"] == "ns"
+        assert out["ref"]["scope"] == "global"
+
+    def test_to_public_json_with_policy(self):
+        rec = SecretRecord(ref=self._ref(), metadata=self._meta(), data="x")
+        out = rec.to_public_json(include_policy=True)
+        assert "policy" in out
+
+    def test_to_store_json(self):
+        rec = SecretRecord(ref=self._ref(), metadata=self._meta(), data="x")
+        stored = rec.to_store_json()
+        assert stored["format_version"] == SECRET_STORE_FORMAT_VERSION
+        assert "data" in stored
+        assert "policy" in stored
+
+    def test_from_store_json_roundtrip(self):
+        ref = self._ref()
+        rec = SecretRecord(ref=ref, metadata=self._meta(), data="pw")
+        rec2 = SecretRecord.from_store_json(ref, rec.to_store_json())
+        assert rec2.data == "pw"
+        assert rec2.metadata.version == 1
+
+    def test_from_store_json_wrong_version(self):
+        ref = self._ref()
+        payload = {
+            "format_version": 99,
+            "metadata": {"version": 1, "created": "x", "updated": "y"},
+            "policy": {"user_made": True, "editable": True},
+            "data": "x",
+        }
+        with pytest.raises(CephSecretDataError, match="unsupported"):
+            SecretRecord.from_store_json(ref, payload)
+
+    def test_from_store_json_missing_key(self):
+        ref = self._ref()
+        with pytest.raises(CephSecretDataError, match="missing required"):
+            SecretRecord.from_store_json(ref, {"format_version": 1, "metadata": {}})
+
+    def test_bad_ref_type_raises(self):
+        with pytest.raises(CephSecretDataError, match="must be a SecretRef"):
+            SecretRecord(ref="not-a-ref", metadata=self._meta(), data="x")  # type: ignore[arg-type]
+
+    def test_bad_metadata_type_raises(self):
+        with pytest.raises(CephSecretDataError):
+            SecretRecord(ref=self._ref(), metadata={"version": 1}, data="x")  # type: ignore[arg-type]
+
+    def test_bad_data_type_raises(self):
+        with pytest.raises(CephSecretDataError):
+            SecretRecord(ref=self._ref(), metadata=self._meta(), data={"not": "a-string"})  # type: ignore[arg-type]
+
+    def test_empty_data_raises(self):
+        with pytest.raises(CephSecretDataError, match="must not be empty"):
+            SecretRecord(ref=self._ref(), metadata=self._meta(), data="")
+
+    def test_data_in_store_json(self):
+        rec = SecretRecord(ref=self._ref(), metadata=self._meta(), data="myvalue")
+        stored = rec.to_store_json()
+        assert stored["data"] == "myvalue"
+
+    def test_ident(self):
+        ref = self._ref()
+        rec = SecretRecord(ref=ref, metadata=self._meta(), data="x")
+        assert rec.ident() == ("ns", "global", "", "key")
+
+
+# ============================================================
+# SecretStoreMon – epoch
+# ============================================================
+
+class TestSecretStoreMon_Epoch:
+    def test_initial_epoch_is_zero(self, store):
+        assert store.get_epoch("cephadm") == 0
+
+    def test_bump_epoch(self, store):
+        assert store.bump_epoch("cephadm") == 1
+        assert store.bump_epoch("cephadm") == 2
+
+    def test_namespace_isolation(self, store):
+        store.bump_epoch("cephadm")
+        store.bump_epoch("cephadm")
+        assert store.get_epoch("rook") == 0
+
+    def test_epoch_key_stored_correctly(self, mgr, store):
+        store.bump_epoch("myns")
+        assert mgr.get_store("secret_store/meta/myns/_epoch") == "1"
+
+    def test_corrupted_epoch_returns_zero(self, mgr, store):
+        mgr.set_store("secret_store/meta/ns/_epoch", "notanumber")
+        assert store.get_epoch("ns") == 0
+
+
+# ============================================================
+# SecretStoreMon – CRUD
+# ============================================================
+
+class TestSecretStoreMon_Crud:
+    def test_set_and_get_global(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "pw", "secret")
+        rec = store.get("ns", SecretScope.GLOBAL, "", "pw")
+        assert rec is not None
+        assert rec.data == "secret"
+
+    def test_get_missing_returns_none(self, store):
+        assert store.get("ns", SecretScope.GLOBAL, "", "noexist") is None
+
+    def test_set_increments_version(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v1")
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v2")
+        rec = store.get("ns", SecretScope.GLOBAL, "", "k")
+        assert rec.metadata.version == 2
+
+    def test_set_preserves_created_timestamp(self, store):
+        import time
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v1")
+        rec1 = store.get("ns", SecretScope.GLOBAL, "", "k")
+        time.sleep(1)
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v2")
+        rec2 = store.get("ns", SecretScope.GLOBAL, "", "k")
+        assert rec1.metadata.created == rec2.metadata.created
+        assert rec2.metadata.updated != rec2.metadata.created
+
+    def test_set_service_scope(self, store):
+        store.set("ns", SecretScope.SERVICE, "prometheus", "auth", "admin")
+        rec = store.get("ns", SecretScope.SERVICE, "prometheus", "auth")
+        assert rec.data == "admin"
+
+    def test_set_host_scope(self, store):
+        store.set("ns", SecretScope.HOST, "node1", "ssh", "abc")
+        rec = store.get("ns", SecretScope.HOST, "node1", "ssh")
+        assert rec.data == "abc"
+
+    def test_set_custom_scope(self, store):
+        store.set("ns", SecretScope.CUSTOM, "", "a/b/c", "tok")
+        rec = store.get("ns", SecretScope.CUSTOM, "", "a/b/c")
+        assert rec.data == "tok"
+
+    def test_set_bumps_epoch(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v1")
+        assert store.get_epoch("ns") == 1
+
+    def test_set_non_str_data_raises(self, store):
+        with pytest.raises(CephSecretException):
+            store.set("ns", SecretScope.GLOBAL, "", "k", {"not": "a-string"})  # type: ignore[arg-type]
+
+    def test_set_empty_data_raises(self, store):
+        with pytest.raises(CephSecretException, match="must not be empty"):
+            store.set("ns", SecretScope.GLOBAL, "", "k", "")
+
+    def test_set_non_editable_raises(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v1", editable=False)
+        with pytest.raises(CephSecretException, match="not editable"):
+            store.set("ns", SecretScope.GLOBAL, "", "k", "data-v2")
+
+    def test_rm_existing(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        assert store.rm("ns", SecretScope.GLOBAL, "", "k") is True
+        assert store.get("ns", SecretScope.GLOBAL, "", "k") is None
+
+    def test_rm_nonexistent(self, store):
+        assert store.rm("ns", SecretScope.GLOBAL, "", "ghost") is False
+
+    def test_rm_bumps_epoch(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-x")
+        epoch_after_set = store.get_epoch("ns")
+        store.rm("ns", SecretScope.GLOBAL, "", "k")
+        assert store.get_epoch("ns") == epoch_after_set + 1
+
+    def test_rm_nonexistent_no_epoch_bump(self, store):
+        assert store.get_epoch("ns") == 0
+        store.rm("ns", SecretScope.GLOBAL, "", "ghost")
+        assert store.get_epoch("ns") == 0
+
+    def test_get_corrupted_json_raises(self, mgr, store):
+        mgr.set_store(
+            f"{SECRET_STORE_PREFIX}ns/global/badkey", "NOT JSON"
+        )
+        with pytest.raises(CephSecretDataError):
+            store.get("ns", SecretScope.GLOBAL, "", "badkey")
+
+    def test_set_with_bad_scope_string(self, store):
+        with pytest.raises(CephSecretDataError):
+            store.set("ns", "badscope", "", "k", "data-v1")
+
+
+# ============================================================
+# SecretStoreMon – ls
+# ============================================================
+
+class TestSecretStoreMon_Ls:
+    def test_ls_empty(self, store):
+        assert store.ls(namespace="ns") == []
+
+    def test_ls_returns_all(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "k1", "data-1")
+        store.set("ns", SecretScope.GLOBAL, "", "k2", "data-2")
+        recs = store.ls(namespace="ns")
+        assert len(recs) == 2
+
+    def test_ls_filter_scope(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "g", "data-g")
+        store.set("ns", SecretScope.SERVICE, "prom", "auth", "data-auth")
+        recs = store.ls(namespace="ns", scope=SecretScope.GLOBAL)
+        assert len(recs) == 1
+        assert recs[0].scope == SecretScope.GLOBAL
+
+    def test_ls_filter_target(self, store):
+        store.set("ns", SecretScope.SERVICE, "prom", "a1", "data-a1")
+        store.set("ns", SecretScope.SERVICE, "grafana", "a2", "data-a2")
+        recs = store.ls(namespace="ns", scope=SecretScope.SERVICE, target="prom")
+        assert len(recs) == 1
+        assert recs[0].target == "prom"
+
+    def test_ls_namespace_isolation(self, store):
+        store.set("ns1", SecretScope.GLOBAL, "", "k", "data-ns1")
+        store.set("ns2", SecretScope.GLOBAL, "", "k", "data-ns2")
+        recs = store.ls(namespace="ns1")
+        assert len(recs) == 1
+
+    def test_ls_custom_scope(self, store):
+        store.set("ns", SecretScope.CUSTOM, "", "a/b/c", "data-abc")
+        store.set("ns", SecretScope.CUSTOM, "", "x/y", "data-xy")
+        recs = store.ls(namespace="ns", scope=SecretScope.CUSTOM)
+        assert len(recs) == 2
+
+    def test_ls_sorted(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "zz", "data-zz")
+        store.set("ns", SecretScope.GLOBAL, "", "aa", "data-aa")
+        recs = store.ls(namespace="ns")
+        names = [r.name for r in recs]
+        assert names == sorted(names)
+
+    def test_ls_invalid_namespace(self, store):
+        with pytest.raises(CephSecretDataError):
+            store.ls(namespace="bad ns!")
+
+    def test_ls_scope_as_string(self, store):
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v1")
+        recs = store.ls(namespace="ns", scope="global")
+        assert len(recs) == 1
+
+    def test_ls_corrupted_json_raises(self, mgr, store):
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns/global/bad", "NOT-JSON")
+        with pytest.raises(CephSecretDataError):
+            store.ls(namespace="ns")
+
+    def test_ls_no_filter(self, store):
+        store.set("ns1", SecretScope.GLOBAL, "", "a", "data-a")
+        store.set("ns2", SecretScope.GLOBAL, "", "b", "data-b")
+        recs = store.ls()
+        assert len(recs) == 2
+
+    def test_ls_kv_key_structure_validation(self, mgr, store):
+        """A key with empty segments inside the prefix should raise CephSecretDataError."""
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns//global/k", "{}")
+        with pytest.raises(CephSecretDataError, match="empty path component"):
+            store.ls(namespace="ns")
+
+
+# ============================================================
+# TestSecretStoreMon_Ls — malformed persisted-record cases
+# ============================================================
+
+class TestSecretStoreMon_Ls_Malformed:
+    def test_ls_too_few_segments(self, mgr, store):
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns/global", "{}")
+        with pytest.raises(CephSecretDataError, match="unexpected key structure"):
+            store.ls(namespace="ns")
+
+    def test_ls_invalid_scope_in_key(self, mgr, store):
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns/badscope/key", "{}")
+        with pytest.raises(CephSecretDataError, match="invalid scope"):
+            store.ls(namespace="ns")
+
+    def test_ls_global_with_extra_segment(self, mgr, store):
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns/global/target/name", "{}")
+        with pytest.raises(CephSecretDataError, match="unexpected global key structure"):
+            store.ls(namespace="ns")
+
+    def test_ls_service_with_missing_segment(self, mgr, store):
+        # service needs 4 parts (ns/service/target/name); 3 is too few
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns/service/onlytarget", "{}")
+        with pytest.raises(CephSecretDataError, match="unexpected targeted-scope key structure"):
+            store.ls(namespace="ns")
+
+    def test_ls_payload_not_object(self, mgr, store):
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns/global/k", '["not", "object"]')
+        with pytest.raises(CephSecretDataError, match="not a JSON object"):
+            store.ls(namespace="ns")
+
+    def test_ls_payload_valid_json_missing_fields(self, mgr, store):
+        # Valid JSON object but missing required secret record fields
+        mgr.set_store(f"{SECRET_STORE_PREFIX}ns/global/k", '{"unexpected": 1}')
+        with pytest.raises(CephSecretDataError):
+            store.ls(namespace="ns")
+
+
+# ============================================================
+# TestSecretStoreMon_Crud — editable=False allows rm by design
+# ============================================================
+
+class TestSecretStoreMon_EditableRm:
+    def test_rm_non_editable_secret_is_allowed(self, store):
+        """rm ignores editable — deletion is always permitted by design."""
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v1", editable=False)
+        result = store.rm("ns", SecretScope.GLOBAL, "", "k")
+        assert result is True
+
+    def test_set_non_editable_blocks_update(self, store):
+        """Confirmed: set refuses to update a non-editable secret."""
+        store.set("ns", SecretScope.GLOBAL, "", "k", "data-v1", editable=False)
+        with pytest.raises(CephSecretException):
+            store.set("ns", SecretScope.GLOBAL, "", "k", "data-v2")

--- a/src/pybind/mgr/ceph_secrets_client.py
+++ b/src/pybind/mgr/ceph_secrets_client.py
@@ -1,0 +1,363 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Protocol, Union
+
+from ceph_secrets_types import SecretScope
+
+logger = logging.getLogger(__name__)
+
+ScopeArg = Union[SecretScope, str]
+
+
+class MgrRemote(Protocol):
+    """Minimal interface required from the mgr object."""
+    def remote(self, module: str, method: str, **kwargs: Any) -> Any:
+        ...
+
+
+class CephSecretsClient:
+    """Thin client for calling the ceph_secrets mgr module via mgr.remote().
+
+    This file lives in src/pybind/mgr/ alongside ceph_secrets_types.py so
+    any mgr module can import it without depending on the ceph_secrets module
+    directory directly.
+
+    All methods translate to a single mgr.remote() call and raise RuntimeError
+    if the ceph_secrets module is unreachable (e.g. not enabled).
+
+    Typical usage::
+
+        client = CephSecretsClient(self)   # self is a MgrModule instance
+        rec = client.secret_get("cephadm", SecretScope.HOST, "node1", "ssh_key")
+        if rec:
+            version = rec["metadata"]["version"]
+    """
+
+    DEFAULT_MODULE = "ceph_secrets"
+
+    def __init__(self, mgr: MgrRemote, module: str = DEFAULT_MODULE) -> None:
+        self.mgr = mgr
+        self.module = module
+
+    def _remote(self, method: str, **kwargs: Any) -> Any:
+        try:
+            return self.mgr.remote(self.module, method, **kwargs)
+        except Exception as e:
+            raise RuntimeError(
+                f"Cannot call secrets mgr-module '{self.module}' (is it enabled?) {e}"
+            ) from e
+
+    # ---- epoch ----
+
+    def secret_get_epoch(self, namespace: str) -> int:
+        """Return the current mutation epoch for *namespace*.
+
+        The epoch is a monotonically increasing integer that is incremented on
+        every successful set and on rm only when an existing secret is actually
+        removed (an idempotent rm returning not-found does not bump the epoch).  It is
+        deliberately per-namespace: a mutation in namespace A does not change
+        the epoch of namespace B.
+
+        Use this as a cheap change-detector: cache the epoch value after your
+        last sync; if it is unchanged on the next poll, no secrets in this
+        namespace have been mutated and you can skip a full refresh.
+
+        Args:
+            namespace: The secret namespace to query (e.g. ``"cephadm"``).
+
+        Returns:
+            The current epoch as a non-negative integer.  Starts at 0 for a
+            namespace that has never been written to.
+        """
+        return self._remote("secret_get_epoch", namespace=namespace)
+
+    # ---- module API wrappers ----
+
+    def secret_get(
+        self,
+        namespace: str,
+        scope: ScopeArg,
+        target: str,
+        name: str,
+        reveal: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Retrieve a secret record by its full address.
+
+        Returns the secret's metadata and, if *reveal* is True, its data
+        payload.  Returns ``None`` if the secret does not exist; raises
+        RuntimeError if the module is unreachable.
+
+        The returned dict contains a ``metadata`` object with fields such as ``version``,
+        ``created``, and ``updated``, etc.  It intentionally does not include a
+        ``ref`` object because the caller already supplied the identity.
+        The ``data`` key is only present when *reveal* is True.
+
+        Args:
+            namespace: The secret namespace (e.g. ``"cephadm"``).
+            scope:     The secret scope — a :class:`SecretScope` value or its
+                       string equivalent (``"global"``, ``"service"``,
+                       ``"host"``, ``"custom"``).
+            target:    The scope target.  Must be non-empty for ``service`` and
+                       ``host`` scopes; must be empty for ``global`` and
+                       ``custom``.
+            name:      The secret name or, for ``custom`` scope, the
+                       slash-delimited path (e.g. ``"app/db/password"``).
+            reveal:    If True, include the secret's data payload in the
+                       response.  Defaults to False to avoid accidental
+                       exposure in logs.
+
+        Returns:
+            A dict of the form ``{"metadata": {...}}`` plus optional ``data``,
+        or ``None`` if not found.
+        """
+        return self._remote(
+            "secret_get",
+            namespace=namespace,
+            scope=scope,
+            target=target,
+            name=name,
+            reveal=reveal,
+        )
+
+    def secret_get_value(
+        self,
+        namespace: str,
+        scope: ScopeArg,
+        target: str,
+        name: str,
+    ) -> Optional[str]:
+        """Return the raw secret data string.
+
+        Returns the stored opaque string directly, without any JSON envelope
+        or metadata.  Returns ``None`` if the secret does not exist.
+
+        Use this when you need the secret value itself — for example, to pass
+        a password to a subprocess or to resolve a credential at deploy time.
+        For metadata inspection or change-detection, use :meth:`secret_get` or
+        :meth:`secret_get_version` instead.
+
+        Args:
+            namespace: The secret namespace.
+            scope:     The secret scope.
+            target:    The scope target (empty for ``global`` and ``custom``).
+            name:      The secret name or custom path.
+
+        Returns:
+            The stored string, or ``None`` if the secret does not exist.
+        """
+        return self._remote(
+            "secret_get_value",
+            namespace=namespace,
+            scope=scope,
+            target=target,
+            name=name,
+        )
+
+    def secret_get_version(
+        self,
+        namespace: str,
+        scope: ScopeArg,
+        target: str,
+        name: str,
+    ) -> Optional[int]:
+        """Return the current version number of a secret.
+
+        A convenience wrapper around :meth:`secret_get` for callers that only
+        need to check whether a secret has changed since they last read it,
+        without fetching its payload.
+
+        The version is incremented on every successful :meth:`secret_set` call
+        for the same address.  The first write produces version 1.
+
+        Args:
+            namespace: The secret namespace.
+            scope:     The secret scope.
+            target:    The scope target (empty for ``global`` and ``custom``).
+            name:      The secret name or custom path.
+
+        Returns:
+            The current version as a positive integer, or ``None`` if the
+            secret does not exist.
+        """
+        return self._remote(
+            "secret_get_version",
+            namespace=namespace,
+            scope=scope,
+            target=target,
+            name=name,
+        )
+
+    def secret_get_versions(self, uris: List[str]) -> Dict[str, Optional[int]]:
+        """Batch-fetch version numbers for a list of secret URIs.
+
+        More efficient than calling :meth:`secret_get_version` in a loop when
+        you need to check many secrets at once (e.g. during a cephadm
+        reconciliation pass).
+
+        Each entry in *uris* must be a canonical ``secret:/...`` URI, such as
+        one returned by ``SecretRef.to_uri()``. URIs that cannot be parsed are
+        skipped and logged at ERROR level on the module side; a missing key in
+        the result indicates malformed input rather than a not-found secret.
+
+        Note that :meth:`scan_refs` may also return malformed or embedded
+        secret-like strings for validation/reporting. Pass only canonical
+        ``secret:/...`` URIs to this method.
+
+        Args:
+            uris: A list of canonical secret URIs.  Example::
+
+                    [
+                        "secret:/cephadm/host/node1/ssh_key",
+                        "secret:/cephadm/global/dashboard_password",
+                    ]
+
+        Returns:
+            A dict keyed by the input URI mapping to the current version
+            integer, or ``None`` if the secret does not exist.
+        """
+        return self._remote("secret_get_versions", uris=uris)
+
+    def secret_set(
+        self,
+        namespace: str,
+        scope: ScopeArg,
+        target: str,
+        name: str,
+        data: str,
+        user_made: bool = True,
+        editable: bool = True,
+    ) -> Dict[str, Any]:
+        """Create or update a secret.
+
+        If a secret at the given address already exists its data is replaced
+        and its version is incremented.  If it does not exist it is created at
+        version 1.  The ``created`` timestamp is set on first write and never
+        changed thereafter; ``updated`` is refreshed on every write.
+
+        Args:
+            namespace: The secret namespace.
+            scope:     The secret scope.
+            target:    The scope target (empty for ``global`` and ``custom``).
+            name:      The secret name or custom path.
+            data:      The secret payload as an opaque string.  Callers are
+                       responsible for any structure within it (e.g.
+                       JSON-encoding a dict before storing and decoding after
+                       retrieval).
+            user_made: Whether this secret was created by a human operator
+                       rather than automatically by a Ceph component.  Defaults
+                       to True; set to False for programmatically generated
+                       secrets.
+            editable:  Whether the secret may be updated or removed by
+                       automated tooling.  Defaults to True.
+
+        Returns:
+            A dict containing the written record's ``metadata`` object.  The
+            response intentionally omits ``ref`` and never includes the data
+            payload.
+        """
+        return self._remote(
+            "secret_set",
+            namespace=namespace,
+            scope=scope,
+            target=target,
+            name=name,
+            data=data,
+            user_made=user_made,
+            editable=editable,
+        )
+
+    def secret_rm(
+        self,
+        namespace: str,
+        scope: ScopeArg,
+        target: str,
+        name: str,
+    ) -> bool:
+        """Remove a secret.
+
+        Idempotent: returns False if the secret did not exist rather than
+        raising.  Raises RuntimeError only if the module is unreachable.
+
+        Args:
+            namespace: The secret namespace.
+            scope:     The secret scope.
+            target:    The scope target (empty for ``global`` and ``custom``).
+            name:      The secret name or custom path.
+
+        Returns:
+            True if the secret existed and was removed; False if it was not
+            found.
+        """
+        return bool(
+            self._remote(
+                "secret_rm",
+                namespace=namespace,
+                scope=scope,
+                target=target,
+                name=name,
+            )
+        )
+
+    def scan_unresolved_refs(self, obj: Any, namespace: str) -> Any:
+        """Return all unresolved secret URI references found in *obj*.
+
+        Walks *obj* recursively (dicts, lists, strings) and collects every
+        secret-like reference that cannot currently be resolved because it is
+        missing, malformed, embedded inside a larger string, or cannot be read
+        successfully.
+
+        Useful for validation: call this before deploying a configuration
+        object to detect missing or invalid secret references early.
+
+        Args:
+            obj:       The object to scan.  May be a dict, list, or any
+                       JSON-like structure.
+            namespace: The namespace context used while scanning/reporting
+                       references.
+
+        Returns:
+            A collection of unresolved reference strings found in *obj*.
+        """
+        return self._remote("scan_unresolved_refs", obj=obj, namespace=namespace)
+
+    def scan_refs(self, obj: Any, namespace: str) -> Any:
+        """Return all secret URI references found in *obj*.
+
+        Like :meth:`scan_unresolved_refs` but returns every whole-value secret
+        URI and every malformed or embedded secret-like reference found while
+        scanning. Malformed or embedded entries are returned as their raw string
+        value so callers can report them.
+
+        Useful for auditing which secrets a configuration object depends on and
+        for surfacing malformed or embedded references before deployment.
+
+        Args:
+            obj:       The object to scan.
+            namespace: The namespace context for the scan.
+
+        Returns:
+            A collection of all secret URI strings found in *obj*.
+        """
+        return self._remote("scan_refs", obj=obj, namespace=namespace)
+
+    def resolve_object(self, obj: Any) -> Any:
+        """Resolve all secret URI references in *obj*.
+
+        Walks *obj* recursively and replaces every whole-value ``secret:/...``
+        URI string with the stored opaque string for the referenced secret.
+        Surrounding whitespace around a URI reference is ignored, but embedding
+        a secret URI inside a larger string is rejected because partial
+        substitution is not supported.
+
+        Args:
+            obj: The object to resolve. May be a dict, list, or any JSON-like
+                  structure containing ``secret:/...`` URI strings.
+
+        Returns:
+             A resolved copy of *obj* with all secret URIs replaced by their stored opaque strings.
+             Raises RuntimeError if any referenced secret cannot be resolved
+             or if the module is unreachable.
+        """
+        return self._remote("resolve_object", obj=obj)

--- a/src/pybind/mgr/ceph_secrets_client.py
+++ b/src/pybind/mgr/ceph_secrets_client.py
@@ -249,8 +249,9 @@ class CephSecretsClient:
                        rather than automatically by a Ceph component.  Defaults
                        to True; set to False for programmatically generated
                        secrets.
-            editable:  Whether the secret may be updated or removed by
-                       automated tooling.  Defaults to True.
+            editable:  Whether the secret may be updated by automated
+                       tooling.  Deletion is always permitted regardless of
+                       this flag.  Defaults to True.
 
         Returns:
             A dict containing the written record's ``metadata`` object.  The

--- a/src/pybind/mgr/ceph_secrets_types.py
+++ b/src/pybind/mgr/ceph_secrets_types.py
@@ -196,6 +196,11 @@ def parse_secret_uri(uri: str) -> SecretRef:
         if not isinstance(uri, str):
             raise CephSecretException('secret uri must be a string')
 
+        if uri != uri.strip():
+            raise CephSecretException(
+                f'Invalid secret uri {uri!r}: leading/trailing whitespace is not allowed'
+            )
+
         parsed = urlparse(uri)
         if parsed.scheme != SECRET_SCHEME:
             raise CephSecretException(f'Not a secret uri: {uri!r}')
@@ -288,6 +293,11 @@ def parse_secret_path(path: str) -> SecretRef:
     """
     if not isinstance(path, str):
         raise CephSecretException('secret path must be a string')
+
+    if path != path.strip():
+        raise CephSecretException(
+            f'Invalid secret path {path!r}: leading/trailing whitespace is not allowed'
+        )
 
     p = path.strip()
     if not p:

--- a/src/pybind/mgr/ceph_secrets_types.py
+++ b/src/pybind/mgr/ceph_secrets_types.py
@@ -1,0 +1,342 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Tuple
+from urllib.parse import urlparse, quote
+
+
+# Internal URI scheme for secret references.
+# Canonical form has no authority: secret:/<namespace>/<scope>/...
+SECRET_SCHEME = 'secret'
+
+
+class CephSecretException(Exception):
+    pass
+
+
+class CephSecretDataError(CephSecretException):
+    pass
+
+
+class CephSecretNotFoundError(CephSecretException):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Segment grammar
+# ---------------------------------------------------------------------------
+# Accepted characters: alphanumeric, dot, hyphen, underscore.
+# Additional rule: a segment must not end with '.' (Vault API restriction).
+# Applies to: namespace, global name, service/host target and name,
+# and each individual segment of a custom path.
+
+_SEGMENT_RE = re.compile(r'^[A-Za-z0-9._-]+$')
+
+
+def _validate_segment(label: str, value: str) -> None:
+    """Raise ValueError with a field-level message. No URI context — callers re-wrap."""
+    if not isinstance(value, str):
+        raise ValueError(f'{label} must be a string')
+    if not value:
+        raise ValueError(f'{label} must not be empty')
+    if not _SEGMENT_RE.fullmatch(value):
+        raise ValueError(f'{label} contains unsupported characters')
+    if value.endswith('.'):
+        raise ValueError(f"{label} must not end with '.'")
+
+
+def validate_secret_namespace(namespace: str) -> None:
+    """Validate a secret namespace segment. Raises ValueError."""
+    _validate_segment('namespace', namespace)
+
+
+def _validate_custom_path(value: str) -> None:
+    """Validate a slash-delimited custom path. Raises ValueError."""
+    if not isinstance(value, str):
+        raise ValueError('custom path must be a string')
+    if not value:
+        raise ValueError('custom path must not be empty')
+    parts = value.split('/')
+    if any(p == '' for p in parts):
+        raise ValueError('custom path must not contain empty segments')
+    for part in parts:
+        _validate_segment('custom path segment', part)
+
+
+# ---------------------------------------------------------------------------
+# URI serialisation helpers
+# ---------------------------------------------------------------------------
+# With strict segment validation, quoting is effectively a no-op. Kept as
+# defensive correctness for round-trip safety.
+
+def _quote_segment(v: str) -> str:
+    """Percent-encode a single path segment (slashes not preserved)."""
+    return quote(v, safe='')
+
+
+def _quote_custom_path(v: str) -> str:
+    """Percent-encode a custom path, preserving '/' as segment delimiters."""
+    return quote(v, safe='/')
+
+
+# ---------------------------------------------------------------------------
+# Scope
+# ---------------------------------------------------------------------------
+
+class SecretScope(str, Enum):
+    GLOBAL = 'global'
+    SERVICE = 'service'
+    HOST = 'host'
+    CUSTOM = 'custom'
+
+    @classmethod
+    def from_str(cls, s: str) -> 'SecretScope':
+        try:
+            return SecretScope(s)
+        except Exception as e:
+            allowed = ', '.join(x.value for x in SecretScope)
+            raise CephSecretException(
+                f'Invalid secret scope {s!r}. Expected one of: {allowed}'
+            ) from e
+
+    def validate_fields(self, target: str, name: str) -> None:
+        """Validate target/name for this scope. Raises ValueError."""
+        if self == SecretScope.GLOBAL:
+            if target:
+                raise ValueError('target must be empty for global scope')
+            _validate_segment('name', name)
+
+        elif self == SecretScope.CUSTOM:
+            if target:
+                raise ValueError('target must be empty for custom scope')
+            _validate_custom_path(name)
+
+        elif self in (SecretScope.SERVICE, SecretScope.HOST):
+            _validate_segment('target', target)
+            _validate_segment('name', name)
+
+        else:
+            raise ValueError(f'unsupported scope {self!r}')
+
+
+# ---------------------------------------------------------------------------
+# SecretRef
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SecretRef:
+    namespace: str
+    scope: SecretScope
+    target: str
+    name: str
+
+    def __post_init__(self) -> None:
+        try:
+            scope = (
+                self.scope
+                if isinstance(self.scope, SecretScope)
+                else SecretScope.from_str(str(self.scope))
+            )
+        except CephSecretException as e:
+            raise ValueError(str(e)) from e
+        object.__setattr__(self, 'scope', scope)
+        _validate_segment('namespace', self.namespace)
+        scope.validate_fields(self.target, self.name)
+
+    def ident(self) -> Tuple[str, str, str, str]:
+        return (self.namespace, self.scope.value, self.target, self.name)
+
+    def to_uri(self) -> str:
+        ns = _quote_segment(self.namespace)
+        scope = self.scope.value
+
+        if self.scope == SecretScope.CUSTOM:
+            return f'{SECRET_SCHEME}:/{ns}/{scope}/{_quote_custom_path(self.name)}'
+
+        if self.scope == SecretScope.GLOBAL:
+            return f'{SECRET_SCHEME}:/{ns}/{scope}/{_quote_segment(self.name)}'
+
+        return (
+            f'{SECRET_SCHEME}:/{ns}/{scope}/'
+            f'{_quote_segment(self.target)}/{_quote_segment(self.name)}'
+        )
+
+
+@dataclass(frozen=True)
+class BadSecretURI:
+    raw: str
+    error: str
+    namespace: str
+
+    def to_uri(self) -> str:
+        return self.raw
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+def parse_secret_uri(uri: str) -> SecretRef:
+    """
+    Parse a secret reference URI.
+
+    Canonical forms:
+      secret:/<namespace>/global/<name>
+      secret:/<namespace>/service/<target>/<name>
+      secret:/<namespace>/host/<target>/<name>
+      secret:/<namespace>/custom/<path>
+
+    All segments must match [A-Za-z0-9._-]+ and must not end with '.'.
+    Percent-encoding, query strings, fragments, and URI authority are not supported.
+    """
+    try:
+        if not isinstance(uri, str):
+            raise CephSecretException('secret uri must be a string')
+
+        parsed = urlparse(uri)
+        if parsed.scheme != SECRET_SCHEME:
+            raise CephSecretException(f'Not a secret uri: {uri!r}')
+        if parsed.query or parsed.fragment:
+            raise CephSecretException(
+                f'Invalid secret uri {uri!r}: query strings and fragments are not supported'
+            )
+        if uri.startswith(f'{SECRET_SCHEME}://') or parsed.netloc:
+            raise CephSecretException(
+                f'Invalid secret uri {uri!r}: authority is not supported; '
+                f'use secret:/<namespace>/<scope>/<path>'
+            )
+
+        # Canonical form: secret:/<namespace>/<scope>/<path>.
+        path = parsed.path or ''
+        if not path.startswith('/'):
+            raise CephSecretException(
+                f'Invalid secret uri {uri!r}: expected secret:/<namespace>/<scope>/<path>'
+            )
+
+        # Reject percent-encoding: the strict segment grammar has a single canonical
+        # spelling for every valid identifier. Accepting encoded aliases (e.g.
+        # db%2Dpassword → db-password, app%2Fdb → app/db) would silently create
+        # multiple URIs that resolve to the same secret.
+        if '%' in path:
+            raise CephSecretException(
+                f'Invalid secret uri {uri!r}: percent-encoding is not supported'
+            )
+
+        # Split on raw '/' — no unquote() needed since percent-encoding is rejected.
+        namespace_raw, sep, remainder = path.lstrip('/').partition('/')
+        scope_raw, sep2, rest_raw = remainder.partition('/') if sep else ('', '', '')
+        if not (sep and sep2):
+            raise CephSecretException(
+                f'Invalid secret uri {uri!r}: expected secret:/<namespace>/<scope>/<path>'
+            )
+
+        scope = SecretScope.from_str(scope_raw)
+
+        if scope in (SecretScope.GLOBAL, SecretScope.CUSTOM):
+            target = ''
+            name = rest_raw
+        else:
+            target_raw, _, name_raw = rest_raw.partition('/')
+            target = target_raw
+            name = name_raw
+
+        # Single construction point: SecretRef validates all fields.
+        # ValueError is re-raised with the original URI for user-facing messages.
+        try:
+            return SecretRef(namespace=namespace_raw, scope=scope, target=target, name=name)
+        except ValueError as e:
+            raise CephSecretException(f'Invalid secret uri {uri!r}: {e}') from e
+
+    except CephSecretException:
+        raise
+    except ValueError as e:
+        raise CephSecretException(str(e)) from e
+    except Exception as e:
+        raise CephSecretException(f'Invalid secret uri {uri!r}: {e}') from e
+
+
+def _coerce_scope(s: str) -> 'SecretScope':
+    # Accept both enum values ('global') and enum names ('GLOBAL').
+    if not s.strip():
+        raise CephSecretException('Scope must not be empty')
+    s_norm = s.strip()
+    try:
+        return SecretScope(s_norm)
+    except Exception:
+        try:
+            return SecretScope[s_norm.upper()]
+        except Exception:
+            allowed = ', '.join(x.value for x in SecretScope)
+            raise CephSecretException(
+                f'Unknown scope {s!r}. Expected one of: {allowed}'
+            )
+
+
+def parse_secret_path(path: str) -> SecretRef:
+    """
+    Parse a secret locator path (no URI scheme, no percent-encoding):
+      <namespace>/global/<name>
+      <namespace>/service/<target>/<name>
+      <namespace>/host/<target>/<name>
+      <namespace>/custom/<any-path>
+
+    Returns a validated SecretRef. Raises CephSecretException on any
+    structural or content error.
+    """
+    if not isinstance(path, str):
+        raise CephSecretException('secret path must be a string')
+
+    p = path.strip()
+    if not p:
+        raise CephSecretException('Invalid secret path: empty')
+
+    if p.startswith('//'):
+        raise CephSecretException(
+            f"Invalid secret path {path!r}: multiple leading slashes are not allowed"
+        )
+    p = p.lstrip('/')
+
+    segs = p.split('/')
+    if any(s == '' for s in segs):
+        raise CephSecretException(
+            f"Invalid secret path {path!r}: empty segment (check for '//' or trailing '/')"
+        )
+    if any(s != s.strip() for s in segs):
+        raise CephSecretException(
+            f"Invalid secret path {path!r}: segments must not contain leading/trailing whitespace"
+        )
+    if len(segs) < 3:
+        raise CephSecretException(
+            f"Invalid secret path {path!r}. Use '<namespace>/<scope>/<path>'."
+        )
+
+    ns, scope_s = segs[0], segs[1]
+    scope = _coerce_scope(scope_s)
+    rest = segs[2:]
+
+    if scope == SecretScope.GLOBAL:
+        if len(rest) != 1:
+            raise CephSecretException(
+                f"Invalid secret path {path!r}: global scope expects '<namespace>/global/<name>'"
+            )
+        target, name = '', rest[0]
+
+    elif scope == SecretScope.CUSTOM:
+        target, name = '', '/'.join(rest)
+
+    elif len(rest) != 2:
+        raise CephSecretException(
+            f"Invalid secret path {path!r}: {scope.value!r} scope expects "
+            f"'<namespace>/{scope.value}/<target>/<name>'"
+        )
+
+    else:
+        target, name = rest[0], rest[1]
+
+    try:
+        return SecretRef(ns, scope, target, name)
+    except ValueError as e:
+        raise CephSecretException(f'Invalid secret path {path!r}: {e}') from e

--- a/src/pybind/mgr/tests/test_ceph_secrets_client.py
+++ b/src/pybind/mgr/tests/test_ceph_secrets_client.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for ceph_secrets_client.py.
+Placed at the same level as the module under test (src/pybind/mgr/).
+"""
+from __future__ import annotations
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pytest
+from typing import Any
+from unittest.mock import MagicMock, call
+
+from ceph_secrets_client import CephSecretsClient, MgrRemote
+from ceph_secrets_types import SecretScope
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_mgr(return_value: Any = None, raise_exc: Exception = None) -> MagicMock:
+    """Return a mock that satisfies the MgrRemote Protocol."""
+    mgr = MagicMock()
+    if raise_exc is not None:
+        mgr.remote.side_effect = raise_exc
+    else:
+        mgr.remote.return_value = return_value
+    return mgr
+
+
+def _client(return_value: Any = None, raise_exc: Exception = None) -> CephSecretsClient:
+    return CephSecretsClient(_make_mgr(return_value, raise_exc))
+
+
+# ============================================================
+# CephSecretsClient construction
+# ============================================================
+
+class TestConstruction:
+    def test_default_module_name(self):
+        mgr = MagicMock()
+        client = CephSecretsClient(mgr)
+        assert client.module == "ceph_secrets"
+
+    def test_custom_module_name(self):
+        mgr = MagicMock()
+        client = CephSecretsClient(mgr, module="my_secrets")
+        assert client.module == "my_secrets"
+
+    def test_stores_mgr(self):
+        mgr = MagicMock()
+        client = CephSecretsClient(mgr)
+        assert client.mgr is mgr
+
+
+# ============================================================
+# _remote error handling
+# ============================================================
+
+class TestRemoteErrorHandling:
+    def test_passes_through_return_value(self):
+        client = _client(return_value=42)
+        assert client._remote("some_method", foo="bar") == 42
+
+    def test_wraps_exception_as_runtime_error(self):
+        client = _client(raise_exc=RuntimeError("module down"))
+        with pytest.raises(RuntimeError, match="Cannot call secrets mgr-module"):
+            client._remote("any_method")
+
+    def test_exception_includes_module_name(self):
+        mgr = _make_mgr(raise_exc=Exception("boom"))
+        client = CephSecretsClient(mgr, module="my_secrets")
+        with pytest.raises(RuntimeError, match="my_secrets"):
+            client._remote("any_method")
+
+    def test_exception_is_enabled_hint(self):
+        client = _client(raise_exc=Exception("unavailable"))
+        with pytest.raises(RuntimeError, match="enabled"):
+            client._remote("any_method")
+
+
+# ============================================================
+# secret_get_epoch
+# ============================================================
+
+class TestSecretGetEpoch:
+    def test_calls_correct_method(self):
+        mgr = _make_mgr(return_value=5)
+        client = CephSecretsClient(mgr)
+        result = client.secret_get_epoch("cephadm")
+        mgr.remote.assert_called_once_with("ceph_secrets", "secret_get_epoch", namespace="cephadm")
+        assert result == 5
+
+    def test_returns_zero_epoch(self):
+        assert _client(return_value=0).secret_get_epoch("ns") == 0
+
+
+# ============================================================
+# secret_get
+# ============================================================
+
+class TestSecretGet:
+    def test_calls_remote_correctly(self):
+        mgr = _make_mgr(return_value={"metadata": {"version": 1}})
+        client = CephSecretsClient(mgr)
+        result = client.secret_get("ns", SecretScope.GLOBAL, "", "pw")
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "secret_get",
+            namespace="ns", scope=SecretScope.GLOBAL,
+            target="", name="pw", reveal=False,
+        )
+        assert result["metadata"]["version"] == 1
+
+    def test_reveal_kwarg_forwarded(self):
+        mgr = _make_mgr(return_value={"metadata": {}, "data": "s3cr3t"})
+        client = CephSecretsClient(mgr)
+        client.secret_get("ns", SecretScope.GLOBAL, "", "pw", reveal=True)
+        _, kwargs = mgr.remote.call_args
+        assert kwargs["reveal"] is True
+
+    def test_returns_none_when_not_found(self):
+        assert _client(return_value=None).secret_get("ns", "global", "", "ghost") is None
+
+    def test_scope_as_string(self):
+        mgr = _make_mgr(return_value=None)
+        client = CephSecretsClient(mgr)
+        client.secret_get("ns", "host", "node1", "ssh")
+        _, kwargs = mgr.remote.call_args
+        assert kwargs["scope"] == "host"
+
+
+# ============================================================
+# secret_get_value
+# ============================================================
+
+class TestSecretGetValue:
+    def test_calls_remote(self):
+        mgr = _make_mgr(return_value="s3cr3t")
+        client = CephSecretsClient(mgr)
+        result = client.secret_get_value("ns", SecretScope.GLOBAL, "", "pw")
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "secret_get_value",
+            namespace="ns", scope=SecretScope.GLOBAL, target="", name="pw",
+        )
+        assert result == "s3cr3t"
+
+    def test_returns_none_if_not_found(self):
+        assert _client(return_value=None).secret_get_value("ns", "global", "", "ghost") is None
+
+    def test_returns_opaque_string(self):
+        payload = '{"u": "a", "p": "b"}'
+        result = _client(return_value=payload).secret_get_value("ns", "global", "", "creds")
+        assert result == payload
+
+    def test_module_unreachable_raises(self):
+        with pytest.raises(RuntimeError, match="Cannot call"):
+            _client(raise_exc=Exception("down")).secret_get_value("ns", "global", "", "pw")
+
+
+# secret_get_version
+# ============================================================
+
+class TestSecretGetVersion:
+    def test_calls_remote(self):
+        mgr = _make_mgr(return_value=3)
+        client = CephSecretsClient(mgr)
+        result = client.secret_get_version("ns", SecretScope.GLOBAL, "", "k")
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "secret_get_version",
+            namespace="ns", scope=SecretScope.GLOBAL, target="", name="k",
+        )
+        assert result == 3
+
+    def test_returns_none_if_not_found(self):
+        assert _client(return_value=None).secret_get_version("ns", "global", "", "ghost") is None
+
+
+# ============================================================
+# secret_get_versions
+# ============================================================
+
+class TestSecretGetVersions:
+    def test_calls_remote_with_list(self):
+        uris = ["secret:/ns/global/a", "secret:/ns/global/b"]
+        expected = {"secret:/ns/global/a": 1, "secret:/ns/global/b": None}
+        mgr = _make_mgr(return_value=expected)
+        client = CephSecretsClient(mgr)
+        result = client.secret_get_versions(uris)
+        mgr.remote.assert_called_once_with("ceph_secrets", "secret_get_versions", uris=uris)
+        assert result == expected
+
+    def test_returns_empty_dict_for_empty_list(self):
+        result = _client(return_value={}).secret_get_versions([])
+        assert result == {}
+
+
+# ============================================================
+# secret_set
+# ============================================================
+
+class TestSecretSet:
+    def test_calls_remote_with_defaults(self):
+        expected = {"metadata": {"version": 1}}
+        mgr = _make_mgr(return_value=expected)
+        client = CephSecretsClient(mgr)
+        result = client.secret_set("ns", SecretScope.GLOBAL, "", "pw", "x")
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "secret_set",
+            namespace="ns", scope=SecretScope.GLOBAL,
+            target="", name="pw", data="x",
+            user_made=True, editable=True,
+        )
+        assert result == expected
+
+    def test_user_made_editable_overrides(self):
+        mgr = _make_mgr(return_value={})
+        client = CephSecretsClient(mgr)
+        client.secret_set("ns", "global", "", "k", "x", user_made=False, editable=False)
+        _, kwargs = mgr.remote.call_args
+        assert kwargs["user_made"] is False
+        assert kwargs["editable"] is False
+
+    def test_raises_on_module_error(self):
+        with pytest.raises(RuntimeError):
+            _client(raise_exc=Exception("down")).secret_set("ns", "global", "", "k", "x")
+
+
+# ============================================================
+# secret_rm
+# ============================================================
+
+class TestSecretRm:
+    def test_calls_remote(self):
+        mgr = _make_mgr(return_value=True)
+        client = CephSecretsClient(mgr)
+        result = client.secret_rm("ns", SecretScope.GLOBAL, "", "k")
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "secret_rm",
+            namespace="ns", scope=SecretScope.GLOBAL, target="", name="k",
+        )
+        assert result is True
+
+    def test_returns_false_when_not_found(self):
+        assert _client(return_value=False).secret_rm("ns", "global", "", "ghost") is False
+
+    def test_truthy_value_coerced_to_bool(self):
+        # remote might return 1 instead of True
+        assert _client(return_value=1).secret_rm("ns", "global", "", "k") is True
+
+    def test_falsy_value_coerced_to_bool(self):
+        assert _client(return_value=0).secret_rm("ns", "global", "", "k") is False
+
+
+# ============================================================
+# scan_unresolved_refs
+# ============================================================
+
+class TestScanUnresolvedRefs:
+    def test_calls_remote(self):
+        expected = ["secret:/ns/global/missing"]
+        mgr = _make_mgr(return_value=expected)
+        client = CephSecretsClient(mgr)
+        result = client.scan_unresolved_refs({"k": "secret:/ns/global/missing"}, "ns")
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "scan_unresolved_refs",
+            obj={"k": "secret:/ns/global/missing"}, namespace="ns",
+        )
+        assert result == expected
+
+    def test_returns_empty_when_all_resolved(self):
+        assert _client(return_value=[]).scan_unresolved_refs({}, "ns") == []
+
+
+# ============================================================
+# scan_refs
+# ============================================================
+
+class TestScanRefs:
+    def test_calls_remote(self):
+        expected = ["secret:/ns/global/pw"]
+        mgr = _make_mgr(return_value=expected)
+        client = CephSecretsClient(mgr)
+        result = client.scan_refs("secret:/ns/global/pw", "ns")
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "scan_refs",
+            obj="secret:/ns/global/pw", namespace="ns",
+        )
+        assert result == expected
+
+    def test_returns_empty_for_no_refs(self):
+        assert _client(return_value=[]).scan_refs("no refs here", "ns") == []
+
+
+# ============================================================
+# resolve_object
+# ============================================================
+
+class TestResolveObject:
+    def test_calls_remote(self):
+        mgr = _make_mgr(return_value={"password": "s3cr3t"})
+        client = CephSecretsClient(mgr)
+        result = client.resolve_object({"password": "secret:/ns/global/pw"})
+        mgr.remote.assert_called_once_with(
+            "ceph_secrets", "resolve_object",
+            obj={"password": "secret:/ns/global/pw"},
+        )
+        assert result["password"] == "s3cr3t"
+
+    def test_raises_on_unresolvable(self):
+        with pytest.raises(RuntimeError):
+            _client(raise_exc=Exception("missing")).resolve_object("secret:/ns/global/ghost")
+
+    def test_returns_plain_value_unchanged(self):
+        result = _client(return_value="plain").resolve_object("plain")
+        assert result == "plain"

--- a/src/pybind/mgr/tests/test_ceph_secrets_types.py
+++ b/src/pybind/mgr/tests/test_ceph_secrets_types.py
@@ -1,0 +1,487 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for ceph_secrets_types.py.
+Placed at the same level as the module under test (src/pybind/mgr/).
+"""
+from __future__ import annotations
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pytest
+
+from ceph_secrets_types import (
+    CephSecretException,
+    CephSecretDataError,
+    CephSecretNotFoundError,
+    SecretScope,
+    SecretRef,
+    BadSecretURI,
+    parse_secret_uri,
+    parse_secret_path,
+    validate_secret_namespace,
+    SECRET_SCHEME,
+    _validate_segment,
+    _validate_custom_path,
+    _quote_segment,
+    _quote_custom_path,
+)
+
+
+# ============================================================
+# Module constants
+# ============================================================
+
+class TestConstants:
+    def test_secret_scheme(self):
+        assert SECRET_SCHEME == "secret"
+
+
+# ============================================================
+# Exception hierarchy
+# ============================================================
+
+class TestExceptions:
+    def test_base_is_exception(self):
+        assert issubclass(CephSecretException, Exception)
+
+    def test_data_error_inherits_base(self):
+        assert issubclass(CephSecretDataError, CephSecretException)
+
+    def test_not_found_inherits_base(self):
+        assert issubclass(CephSecretNotFoundError, CephSecretException)
+
+    def test_can_raise_and_catch_base(self):
+        with pytest.raises(CephSecretException):
+            raise CephSecretException("test")
+
+    def test_can_raise_and_catch_data_error_as_base(self):
+        with pytest.raises(CephSecretException):
+            raise CephSecretDataError("data")
+
+    def test_can_raise_and_catch_not_found_as_base(self):
+        with pytest.raises(CephSecretException):
+            raise CephSecretNotFoundError("gone")
+
+
+# ============================================================
+# _validate_segment
+# ============================================================
+
+class TestValidateSegment:
+    @pytest.mark.parametrize("v", [
+        "simple", "with-dashes", "under_score", "dot.dot", "a1b2",
+        "UPPER", "Mixed123",
+    ])
+    def test_valid(self, v):
+        _validate_segment("f", v)
+
+    @pytest.mark.parametrize("bad", [
+        "", " ", "has space", "a/b", "a:b", "star*",
+    ])
+    def test_invalid(self, bad):
+        with pytest.raises(ValueError):
+            _validate_segment("f", bad)
+
+    def test_ends_with_dot_invalid(self):
+        with pytest.raises(ValueError, match="must not end"):
+            _validate_segment("f", "end.")
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            _validate_segment("f", None)
+
+
+# ============================================================
+# _validate_custom_path
+# ============================================================
+
+class TestValidateCustomPath:
+    @pytest.mark.parametrize("p", [
+        "single", "a/b", "a/b/c", "deep/path/here",
+    ])
+    def test_valid(self, p):
+        _validate_custom_path(p)
+
+    def test_empty_string(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_custom_path("")
+
+    def test_empty_segment_in_middle(self):
+        with pytest.raises(ValueError, match="empty segments"):
+            _validate_custom_path("a//b")
+
+    def test_trailing_slash(self):
+        with pytest.raises(ValueError, match="empty segments"):
+            _validate_custom_path("a/b/")
+
+    def test_leading_slash_empty_first_segment(self):
+        with pytest.raises(ValueError, match="empty segments"):
+            _validate_custom_path("/a/b")
+
+    def test_segment_with_bad_chars(self):
+        with pytest.raises(ValueError):
+            _validate_custom_path("a/b c/d")
+
+
+# ============================================================
+# _quote helpers
+# ============================================================
+
+class TestQuoteHelpers:
+    def test_quote_segment_no_slash(self):
+        # clean identifiers are unchanged
+        assert _quote_segment("cephadm") == "cephadm"
+
+    def test_quote_custom_path_preserves_slash(self):
+        assert _quote_custom_path("a/b/c") == "a/b/c"
+
+
+# ============================================================
+# validate_secret_namespace
+# ============================================================
+
+class TestValidateSecretNamespace:
+    def test_valid_namespace(self):
+        validate_secret_namespace("cephadm")
+
+    def test_empty_namespace(self):
+        with pytest.raises(ValueError):
+            validate_secret_namespace("")
+
+    def test_namespace_with_space(self):
+        with pytest.raises(ValueError):
+            validate_secret_namespace("bad name")
+
+
+# ============================================================
+# SecretScope
+# ============================================================
+
+class TestSecretScope:
+    def test_all_values(self):
+        assert SecretScope.GLOBAL.value == "global"
+        assert SecretScope.SERVICE.value == "service"
+        assert SecretScope.HOST.value == "host"
+        assert SecretScope.CUSTOM.value == "custom"
+
+    def test_from_str_valid(self):
+        for v in ("global", "service", "host", "custom"):
+            scope = SecretScope.from_str(v)
+            assert scope.value == v
+
+    def test_from_str_invalid(self):
+        with pytest.raises(CephSecretException, match="Invalid secret scope"):
+            SecretScope.from_str("vault")
+
+    def test_is_str_subclass(self):
+        assert isinstance(SecretScope.GLOBAL, str)
+
+    # validate_fields – global
+    def test_global_valid(self):
+        SecretScope.GLOBAL.validate_fields("", "mykey")
+
+    def test_global_nonempty_target_fails(self):
+        with pytest.raises(ValueError, match="target must be empty"):
+            SecretScope.GLOBAL.validate_fields("target", "key")
+
+    def test_global_empty_name_fails(self):
+        with pytest.raises(ValueError):
+            SecretScope.GLOBAL.validate_fields("", "")
+
+    # validate_fields – service / host
+    def test_service_valid(self):
+        SecretScope.SERVICE.validate_fields("prometheus", "auth")
+
+    def test_service_empty_target_fails(self):
+        with pytest.raises(ValueError):
+            SecretScope.SERVICE.validate_fields("", "auth")
+
+    def test_host_valid(self):
+        SecretScope.HOST.validate_fields("node1", "ssh_key")
+
+    def test_host_empty_name_fails(self):
+        with pytest.raises(ValueError):
+            SecretScope.HOST.validate_fields("node1", "")
+
+    # validate_fields – custom
+    def test_custom_valid_flat(self):
+        SecretScope.CUSTOM.validate_fields("", "some-key")
+
+    def test_custom_valid_nested(self):
+        SecretScope.CUSTOM.validate_fields("", "a/b/c")
+
+    def test_custom_nonempty_target_fails(self):
+        with pytest.raises(ValueError, match="target must be empty"):
+            SecretScope.CUSTOM.validate_fields("badtarget", "key")
+
+    def test_custom_empty_name_fails(self):
+        with pytest.raises(ValueError):
+            SecretScope.CUSTOM.validate_fields("", "")
+
+
+# ============================================================
+# SecretRef
+# ============================================================
+
+class TestSecretRef:
+    def test_global_ref_construction(self):
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "pw")
+        assert ref.namespace == "ns"
+        assert ref.scope == SecretScope.GLOBAL
+        assert ref.target == ""
+        assert ref.name == "pw"
+
+    def test_service_ref(self):
+        ref = SecretRef("ns", SecretScope.SERVICE, "prom", "auth")
+        assert ref.target == "prom"
+
+    def test_host_ref(self):
+        ref = SecretRef("ns", SecretScope.HOST, "n1", "k")
+        assert ref.name == "k"
+
+    def test_custom_ref(self):
+        ref = SecretRef("ns", SecretScope.CUSTOM, "", "a/b/c")
+        assert ref.name == "a/b/c"
+
+    def test_is_frozen(self):
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "k")
+        with pytest.raises(Exception):
+            ref.name = "other"  # type: ignore[misc]
+
+    def test_scope_coerced_from_string(self):
+        ref = SecretRef("ns", "host", "node1", "k")
+        assert ref.scope == SecretScope.HOST
+
+    def test_invalid_scope_raises(self):
+        with pytest.raises(ValueError):
+            SecretRef("ns", "badscope", "", "k")
+
+    def test_invalid_namespace_raises(self):
+        with pytest.raises(ValueError):
+            SecretRef("bad ns", SecretScope.GLOBAL, "", "k")
+
+    def test_ident_global(self):
+        ref = SecretRef("ns", SecretScope.GLOBAL, "", "k")
+        assert ref.ident() == ("ns", "global", "", "k")
+
+    def test_ident_service(self):
+        ref = SecretRef("ns", SecretScope.SERVICE, "t", "n")
+        assert ref.ident() == ("ns", "service", "t", "n")
+
+    def test_to_uri_global(self):
+        ref = SecretRef("cephadm", SecretScope.GLOBAL, "", "pw")
+        assert ref.to_uri() == "secret:/cephadm/global/pw"
+
+    def test_to_uri_service(self):
+        ref = SecretRef("ns", SecretScope.SERVICE, "prom", "auth")
+        assert ref.to_uri() == "secret:/ns/service/prom/auth"
+
+    def test_to_uri_host(self):
+        ref = SecretRef("ns", SecretScope.HOST, "node1", "ssh")
+        assert ref.to_uri() == "secret:/ns/host/node1/ssh"
+
+    def test_to_uri_custom(self):
+        ref = SecretRef("ns", SecretScope.CUSTOM, "", "a/b/c")
+        assert ref.to_uri() == "secret:/ns/custom/a/b/c"
+
+    def test_equality(self):
+        r1 = SecretRef("ns", SecretScope.GLOBAL, "", "k")
+        r2 = SecretRef("ns", SecretScope.GLOBAL, "", "k")
+        assert r1 == r2
+
+    def test_inequality_different_name(self):
+        r1 = SecretRef("ns", SecretScope.GLOBAL, "", "k1")
+        r2 = SecretRef("ns", SecretScope.GLOBAL, "", "k2")
+        assert r1 != r2
+
+
+# ============================================================
+# BadSecretURI
+# ============================================================
+
+class TestBadSecretURI:
+    def test_construction(self):
+        b = BadSecretURI(raw="secret:/bad/scope/key", error="bad scope", namespace="ns")
+        assert b.raw == "secret:/bad/scope/key"
+        assert b.error == "bad scope"
+
+    def test_to_uri_returns_raw(self):
+        b = BadSecretURI(raw="secret:/bad", error="err", namespace="ns")
+        assert b.to_uri() == "secret:/bad"
+
+    def test_is_frozen(self):
+        b = BadSecretURI(raw="x", error="e", namespace="n")
+        with pytest.raises(Exception):
+            b.raw = "y"  # type: ignore[misc]
+
+
+# ============================================================
+# parse_secret_uri
+# ============================================================
+
+class TestParseSecretUri:
+    # --- valid inputs ---
+    def test_global(self):
+        ref = parse_secret_uri("secret:/ns/global/pw")
+        assert ref.scope == SecretScope.GLOBAL
+        assert ref.name == "pw"
+
+    def test_service(self):
+        ref = parse_secret_uri("secret:/ns/service/prom/auth")
+        assert ref.scope == SecretScope.SERVICE
+        assert ref.target == "prom"
+        assert ref.name == "auth"
+
+    def test_host(self):
+        ref = parse_secret_uri("secret:/ns/host/node1/ssh")
+        assert ref.target == "node1"
+        assert ref.name == "ssh"
+
+    def test_custom_flat(self):
+        ref = parse_secret_uri("secret:/ns/custom/single")
+        assert ref.scope == SecretScope.CUSTOM
+        assert ref.name == "single"
+
+    def test_custom_nested(self):
+        ref = parse_secret_uri("secret:/ns/custom/a/b/c")
+        assert ref.name == "a/b/c"
+
+    # --- invalid inputs ---
+    def test_wrong_scheme(self):
+        with pytest.raises(CephSecretException, match="Not a secret uri"):
+            parse_secret_uri("http://example.com/foo")
+
+    def test_authority_rejected(self):
+        with pytest.raises(CephSecretException, match="authority"):
+            parse_secret_uri("secret://ns/global/key")
+
+    def test_query_string_rejected(self):
+        with pytest.raises(CephSecretException, match="query"):
+            parse_secret_uri("secret:/ns/global/key?x=y")
+
+    def test_fragment_rejected(self):
+        with pytest.raises(CephSecretException, match="query"):
+            parse_secret_uri("secret:/ns/global/key#frag")
+
+    def test_percent_encoding_rejected(self):
+        with pytest.raises(CephSecretException, match="percent-encoding"):
+            parse_secret_uri("secret:/ns/global/my%2Dkey")
+
+    def test_too_short(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_uri("secret:/ns/global")
+
+    def test_bad_scope(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_uri("secret:/ns/vault/key")
+
+    def test_non_string_input(self):
+        with pytest.raises(CephSecretException, match="must be a string"):
+            parse_secret_uri(42)  # type: ignore[arg-type]
+
+    def test_global_with_extra_segment_rejected(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_uri("secret:/ns/global/target/name")
+
+    def test_service_missing_name(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_uri("secret:/ns/service/prom")
+
+
+# ============================================================
+# parse_secret_path
+# ============================================================
+
+class TestParseSecretPath:
+    # --- valid inputs ---
+    def test_global(self):
+        ref = parse_secret_path("cephadm/global/pw")
+        assert ref.namespace == "cephadm"
+        assert ref.scope == SecretScope.GLOBAL
+        assert ref.name == "pw"
+
+    def test_service(self):
+        ref = parse_secret_path("ns/service/prom/auth")
+        assert ref.target == "prom"
+        assert ref.name == "auth"
+
+    def test_host(self):
+        ref = parse_secret_path("ns/host/node1/ssh_key")
+        assert ref.name == "ssh_key"
+
+    def test_custom_flat(self):
+        ref = parse_secret_path("ns/custom/flat")
+        assert ref.scope == SecretScope.CUSTOM
+        assert ref.name == "flat"
+
+    def test_custom_nested(self):
+        ref = parse_secret_path("ns/custom/a/b/c")
+        assert ref.name == "a/b/c"
+
+    def test_leading_slash_stripped(self):
+        ref = parse_secret_path("/ns/global/k")
+        assert ref.namespace == "ns"
+
+    # --- invalid inputs ---
+    def test_empty_string(self):
+        with pytest.raises(CephSecretException, match="empty"):
+            parse_secret_path("")
+
+    def test_non_string(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_path(None)  # type: ignore[arg-type]
+
+    def test_too_few_segments(self):
+        with pytest.raises(CephSecretException, match="Use"):
+            parse_secret_path("ns/global")
+
+    def test_double_slash(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_path("ns//global/key")
+
+    def test_trailing_slash(self):
+        with pytest.raises(CephSecretException, match="empty segment"):
+            parse_secret_path("ns/global/key/")
+
+    def test_bad_scope(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_path("ns/badscope/key")
+
+    def test_global_extra_segment(self):
+        with pytest.raises(CephSecretException, match="global scope"):
+            parse_secret_path("ns/global/target/name")
+
+    def test_service_missing_name(self):
+        with pytest.raises(CephSecretException, match="service"):
+            parse_secret_path("ns/service/target")
+
+    def test_host_missing_name(self):
+        with pytest.raises(CephSecretException, match="host"):
+            parse_secret_path("ns/host/target")
+
+
+# ============================================================
+# Whitespace / canonicality
+# ============================================================
+
+class TestParseSecretPathWhitespace:
+    @pytest.mark.parametrize("path", [
+        " ns/global/key",
+        "ns/global/key ",
+        "\tns/global/key",
+        "ns/global/key\n",
+    ])
+    def test_rejects_outer_whitespace(self, path):
+        with pytest.raises(CephSecretException):
+            parse_secret_path(path)
+
+
+class TestParseSecretUriWhitespace:
+    def test_rejects_leading_whitespace(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_uri(" secret:/ns/global/key")
+
+    def test_rejects_trailing_whitespace(self):
+        with pytest.raises(CephSecretException):
+            parse_secret_uri("secret:/ns/global/key ")

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -112,6 +112,7 @@ commands =
            -m alerts \
            -m balancer \
            -m cephadm \
+           -m ceph_secrets \
            -m crash \
            -m dashboard \
            -m devicehealth \
@@ -166,6 +167,9 @@ modules =
     alerts \
     balancer \
     cephadm \
+    ceph_secrets \
+    ceph_secrets_client.py \
+    ceph_secrets_types.py \
     cli_api \
     crash \
     devicehealth \


### PR DESCRIPTION
**Tracker:** https://tracker.ceph.com/issues/74562

**Authorship note:** This feature was designed by a human and co-developed using AI assistants (Claude and ChatGPT).

**Scope note:** This module is currently in a PoC phase and is not yet integrated with cephadm or any other mgr module. The goal of this PR is to validate the concept and the core code before proceeding with broader integration.

---

## Summary

This PR introduces **`ceph_secrets`**, a new dedicated MGR module for centralized secret management in Ceph.

The module provides a common place to store secret material and reference it symbolically through `secret:/...` URIs, instead of embedding plaintext credentials directly in service specifications or scattering them across individual module KV stores.

Secret payloads are stored as **non-empty opaque strings**. Callers that need structured payloads can encode/decode that structure themselves.

The design follows a layered architecture:

```text
CLI / RPC surface (ceph secret …)
         │
    SecretMgr  (resolution, scanning, ref tracking)
         │
 SecretStoreMon (Mon KV backend, versioning, per-namespace epochs)
         │
   MGR KV store (get_store / set_store)
```

Consumers, such as future cephadm integrations, interact through the thin **`CephSecretsClient`** wrapper instead of touching module internals directly.

---

## Motivation

Prior to this work:

- Credentials were stored in disparate `set_store` / `get_store` keys with no consistent naming, versioning, or lifecycle.
- There was no common API for Ceph components to store, retrieve, list, or resolve secret values.
- Sensitive data could not be referenced symbolically from service specifications or configuration objects.
- Consumers had no cheap way to detect secret changes without broader reconciliation work.
- There was no common storage layout that could later be migrated to another backend.

This PR adds the core module and API needed to validate the concept before integrating it with cephadm or other mgr modules.

---

## Architecture Overview

### 1. Core Types (`ceph_secrets_types.py`)

| Type | Purpose |
|------|---------|
| `SecretScope` | `str` enum: `GLOBAL`, `SERVICE`, `HOST`, `CUSTOM` |
| `SecretRef` | Frozen dataclass for a parsed, validated secret identity: `(namespace, scope, target, name)` |
| `BadSecretURI` | Carries a raw secret-like reference that failed to parse, alongside its error |
| `SecretURI` | `Protocol` covering both `SecretRef` and `BadSecretURI` |
| `CephSecretException` | Module-specific exception hierarchy, including `CephSecretDataError` and `CephSecretNotFoundError` |

#### Path grammar

Segment characters are restricted to `[A-Za-z0-9._-]+`; segments must not end with `.`. Percent-encoding and URI authority are explicitly rejected.

Secrets are addressed by a short CLI path:

```text
<namespace>/global/<name>
<namespace>/service/<target>/<name>
<namespace>/host/<target>/<name>
<namespace>/custom/<any/sub/path>
```

or by the equivalent canonical URI form used for embedded references:

```text
secret:/cephadm/service/my-service/api_token
secret:/cephadm/global/registry_token
secret:/cephadm/custom/a/b/deep_secret
```

Parsing is handled by `parse_secret_path()` for CLI/RPC paths and `parse_secret_uri()` for embedded URI references. Both return a validated `SecretRef`.

#### Scopes

| Scope | Path structure | `target` |
|-------|----------------|----------|
| `global` | `<ns>/global/<name>` | empty |
| `service` | `<ns>/service/<target>/<name>` | service name |
| `host` | `<ns>/host/<target>/<name>` | host name |
| `custom` | `<ns>/custom/<path>` | empty; `name` holds the full sub-path |

`custom` accepts arbitrary slash-delimited sub-paths. Each segment must individually satisfy the grammar. Paths at different depths are independent keys, so `a/b` and `a/b/c` can coexist without collision.

---

### 2. Storage Backend (`secret_backend.py`)

`SecretStorageBackend` defines the backend contract:

```python
def get(namespace, scope, target, name) -> SecretRecord | None
def set(namespace, scope, target, name, data, ...) -> SecretRecord
def rm(namespace, scope, target, name) -> bool
def ls(namespace, scope, target) -> list[SecretRecord]
def get_epoch(namespace) -> int
def bump_epoch(namespace) -> int
```

This decouples the module from any specific persistence mechanism. The epoch methods are part of the contract so future backends can provide the same change-detection behavior.

A `BACKENDS` registry maps backend names to backend classes. The active backend is selected through the `secrets_backend` module option, currently defaulting to `"mon"`.

---

### 3. Mon KV Backend (`secret_store.py`)

#### Data model

The stored unit is `SecretRecord`:

```python
@dataclass
class SecretRecord:
    ref:      SecretRef        # identity: namespace, scope, target, name
    data:     str              # non-empty opaque string
    metadata: SecretMetadata   # version, created, updated
    policy:   SecretPolicy     # user_made, editable
```

Serialization is split across dedicated methods:

- `to_public_json(include_data, include_policy, include_ref)` — safe output for CLI/RPC; `data` is omitted unless `include_data=True`.
- `to_store_json()` — full storage format including `format_version`, `metadata`, `policy`, and `data`.
- `from_store_json(ref, payload)` — strict deserialization; rejects unknown fields and validates types.

#### Key layout

```text
secret_store/v1/<namespace>/<scope>/<target>/<name>   →  stored SecretRecord
secret_store/meta/<namespace>/_epoch                  →  monotonic integer
```

Secret data and epoch metadata live under separate KV prefixes (`v1/` vs `meta/`) so epoch keys are never scanned or surfaced during `ls()`.

`format_version = 1` is the first supported on-disk format.

#### Behavior

- `set()` preserves `created` on update, increments `metadata.version`, writes the new record, then bumps the namespace epoch.
- `rm()` only bumps the epoch if the record actually existed.
- `ls()` uses prefix queries for namespace/scope/target filtering.
- Corrupt entries raise `CephSecretDataError` rather than being silently skipped.
- Public output hides `data` by default.
- Schema validation is strict: `format_version` is checked, extra fields are rejected, and required fields are enforced.

---

### 4. Secret Manager (`secret_mgr.py`)

`SecretMgr` is the coordination layer above the backend. It owns ref construction, not-found mapping, scanning, and URI resolution.

| Method | Description |
|--------|-------------|
| `get(ref)` | Fetch a `SecretRecord`; raise `CephSecretNotFoundError` if absent |
| `get_value(ref)` | Return the stored opaque string |
| `set(...)` | Validate and delegate to the store |
| `rm(...)` | Delegate; return `True` if the record existed |
| `ls(...)` | Filter-aware delegation to the store |
| `scan_refs(obj, namespace)` | Walk a nested object and collect valid whole-value secret URIs plus malformed/embedded secret-like refs for reporting |
| `scan_unresolved_refs(obj, namespace)` | Return refs that are missing, malformed, embedded, or unreadable |
| `resolve_object(obj)` | Deep-walk and replace whole-value `secret:/...` strings with stored opaque strings |

#### Resolution behavior

A string whose entire stripped value is a canonical `secret:/...` URI is resolved to the stored secret string:

```text
"secret:/cephadm/service/my-service/api_token"
" secret:/cephadm/service/my-service/api_token "
```

Both are accepted.

Embedded partial-string substitution is not supported and is rejected:

```text
"Bearer secret:/cephadm/service/my-service/api_token"
"prefix secret:/cephadm/service/my-service/api_token suffix"
```

This avoids silently deploying unresolved placeholders into service configuration.

---

### 5. MGR Module Entrypoint (`ceph_secrets/module.py`)

#### CLI commands

```bash
ceph secret ls  [--namespace <ns>] [--scope <scope>] [--sec_target <target>] [--reveal] [--show_internals]
ceph secret get <path> [--reveal]
ceph secret set <path> -i <file>
ceph secret rm  <path>
```

Examples:

```bash
printf 's3cr3t-token' | ceph secret set cephadm/service/my-service/api_token -i -

ceph secret get cephadm/service/my-service/api_token
ceph secret get cephadm/service/my-service/api_token --reveal
ceph secret ls --namespace cephadm --scope service --sec_target my-service
ceph secret rm cephadm/service/my-service/api_token
```

CLI handlers parse the path into a `SecretRef`, delegate to the corresponding private implementation, and return structured output through `Responder` / `ObjectFormatAdapter`.

#### RPC API

| Method | Description |
|--------|-------------|
| `secret_get(namespace, scope, target, name, reveal)` | Retrieve a secret record as a dict; `None` if not found |
| `secret_set(namespace, scope, target, name, data, ...)` | Store/update a non-empty opaque string; returns the new record without data |
| `secret_rm(namespace, scope, target, name)` | Delete; returns `bool` |
| `secret_get_version(namespace, scope, target, name)` | Return the version integer; `None` if not found |
| `secret_get_versions(uris)` | Batch-fetch versions for canonical `secret:/...` URI strings |
| `secret_get_epoch(namespace)` | Return the current epoch for a namespace |
| `secret_ls(namespace, scope, target, show_values, show_internals)` | List secrets as a dict keyed by path |
| `scan_refs(obj, namespace)` | Scan an object for valid and invalid secret-like refs |
| `scan_unresolved_refs(obj, namespace)` | Scan for missing, malformed, embedded, or unreadable refs |
| `resolve_object(obj)` | Resolve whole-value refs in an object |

#### Delegation pattern

Public RPC methods are thin wrappers that accept loose kwargs for wire-format compatibility and delegate to private `_secret_*` implementations. CLI handlers call the private implementations directly. No business logic lives in the public surface.

#### Per-namespace epoch tracking

Each namespace has an independent monotonic epoch counter stored at:

```text
secret_store/meta/<namespace>/_epoch
```

The epoch is bumped automatically by the backend on every `set()` and on any `rm()` that actually removes an existing secret. Idempotent removes do not bump the epoch.

Consumers can cheaply poll `secret_get_epoch(namespace)` to detect whether any secret changed in their namespace without listing or fetching all secrets.

Keeping epoch logic in the backend ensures:

- epoch updates are tied to the actual mutation path;
- callers cannot forget to bump it;
- future backends must implement equivalent behavior through the backend contract.

---

### 6. `CephSecretsClient` (`ceph_secrets_client.py`)

`CephSecretsClient` is a typed wrapper around:

```python
mgr.remote("ceph_secrets", method, **kwargs)
```

It lets consumers avoid repeating boilerplate and gives them typed method signatures.

Example:

```python
client = CephSecretsClient(mgr)

client.secret_set(
    namespace="cephadm",
    scope=SecretScope.SERVICE,
    target="my-service",
    name="api_token",
    data="s3cr3t-token",
)

record = client.secret_get(
    namespace="cephadm",
    scope=SecretScope.SERVICE,
    target="my-service",
    name="api_token",
)
if record:
    version = record["metadata"]["version"]

epoch = client.secret_get_epoch(namespace="cephadm")
```

The client raises `RuntimeError` if the `ceph_secrets` module is unreachable, for example if it is not enabled.

---

### 7. Testing

The development test coverage exercises the core module behavior, including:

1. Global, service, host, and custom scopes.
2. Nested custom paths and prefix/path independence.
3. `set`, `get`, `ls`, and `rm` behavior.
4. `--reveal` hiding/showing secret data correctly.
5. Opaque-string payload handling, including whitespace/newline preservation.
6. Empty secret rejection.
7. Version increments and timestamp preservation.
8. Per-namespace epoch isolation.
9. Idempotent `rm` behavior.
10. Path grammar and invalid path handling.
11. Serialization and strict store deserialization.
12. Malformed, embedded, missing, and unreadable URI reference handling.
13. `resolve_object()` behavior for whole-value URI references.
14. `secret_get_versions()` behavior for canonical URIs, missing secrets, and malformed URI input.

### 8. Unit Test Coverage

```
---------- coverage: platform linux, python 3.10.6-final-0 -----------
Name                             Stmts   Miss  Cover
----------------------------------------------------
ceph_secrets/__init__.py             5      0   100%
ceph_secrets/backends.py             2      0   100%
ceph_secrets/cli.py                  2      0   100%
ceph_secrets/module.py             120      0   100%
ceph_secrets/secret_backend.py       9      0   100%
ceph_secrets/secret_mgr.py          97      1    99%
ceph_secrets/secret_store.py       278     11    96%
----------------------------------------------------
TOTAL                              513     12    98%
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
