### PR TITLE
tentacle: mgr/dashboard: Adding RADOS namespace option into add_ns_req

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -498,6 +498,7 @@ else:
             "Create a new NVMeoF namespace.",
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "rados_namespace": Param(str, "RADOS namespace name", True, None),
                 "rbd_pool": Param(str, "RBD pool name"),
                 "rbd_image_name": Param(str, "RBD image name"),
                 "create_image": Param(bool, "Create RBD image"),
@@ -540,12 +541,14 @@ else:
             read_only: Optional[bool] = False,
             gw_group: Optional[str] = None,
             traddr: Optional[str] = None,
+            rados_namespace: Optional[str] = None,
         ):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add(
                 NVMeoFClient.pb2.namespace_add_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid) if nsid else None,
                     rbd_image_name=rbd_image_name,
+                    rados_namespace_name=rados_namespace,
                     rbd_pool_name=rbd_pool,
                     block_size=block_size,
                     create_image=create_image,
@@ -567,6 +570,7 @@ else:
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "rbd_pool": Param(str, "RBD pool name"),
+                "rados_namespace": Param(str, "RADOS namespace name", True, None),
                 "rbd_image_name": Param(str, "RBD image name"),
                 "create_image": Param(bool, "Create RBD image"),
                 "size": Param(str, "Deprecated. Use `rbd_image_size` instead", True, None),
@@ -608,6 +612,8 @@ else:
             read_only: Optional[bool] = False,
             gw_group: Optional[str] = None,
             traddr: Optional[str] = None,
+            rados_namespace: Optional[str] = None,
+
         ):
             if size and rbd_image_size:
                 raise DashboardException(
@@ -627,6 +633,7 @@ else:
                     subsystem_nqn=nqn,
                     nsid=int(nsid) if nsid else None,
                     rbd_image_name=rbd_image_name,
+                    rados_namespace_name=rados_namespace,
                     rbd_pool_name=rbd_pool,
                     block_size=block_size,
                     create_image=create_image,

--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -126,6 +126,7 @@ class NamespaceCreation(NamedTuple):
 class Namespace(NamedTuple):
     bdev_name: str
     rbd_image_name: Annotated[str, CliHeader("RBD Image")]
+    rados_namespace_name: Annotated[Optional[str], CliHeader("RADOS Namespace")]
     rbd_pool_name: Annotated[str, CliHeader("RBD Pool")]
     load_balancing_group: Annotated[int, CliHeader('LB Group')]
     rbd_image_size: Annotated[int, CliFlags.SIZE]

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -10223,6 +10223,9 @@ paths:
                   type: boolean
                 nsid:
                   type: string
+                rados_namespace:
+                  description: RADOS namespace name
+                  type: string
                 rbd_image_name:
                   description: RBD image name
                   type: string


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75105

---

backport of https://github.com/ceph/ceph/pull/67330
parent tracker: https://tracker.ceph.com/issues/74283

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh