### PR TITLE
tentacle: Mark s390x CRC assembly code as not requiring ELF execstack

### DIFF
--- a/src/common/crc32c_s390x_vx-insn.h
+++ b/src/common/crc32c_s390x_vx-insn.h
@@ -491,4 +491,9 @@ name:
     MRXBOPC	0, 0x7D, v1, v2, v3
 .endm
 
+/* inform linker that this doesn't require executable stack */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
+
 #endif	/* __ASM_S390_VX_INSN_H */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74836

---

backport of https://github.com/ceph/ceph/pull/67217
parent tracker: https://tracker.ceph.com/issues/74751