### PR TITLE
Adding snapshot removal tests

### DIFF
--- a/qa/workunits/rbd/rbd_mirror.sh
+++ b/qa/workunits/rbd/rbd_mirror.sh
@@ -82,6 +82,59 @@ compare_images ${CLUSTER1} ${CLUSTER2} ${POOL} ${POOL} ${image}
 compare_image_meta ${CLUSTER1} ${POOL} ${image} "key1" "value1"
 compare_image_meta ${CLUSTER1} ${POOL} ${image} "key2" "value2"
 
+testlog "TEST: mirror image snapshot removal"
+start_mirrors ${CLUSTER2}
+start_mirrors ${CLUSTER1}
+if [ "${RBD_MIRROR_MODE}" = "snapshot" ]; then
+  snap_id=''
+  demote_snap_id=''
+  promote_snap_id=''
+  cluster1_uuid=''
+  cluster2_uuid=''
+  promote_snap_id_new=''
+  get_peer_uuid ${CLUSTER2} ${POOL} cluster1_uuid
+  get_peer_uuid ${CLUSTER1} ${POOL} cluster2_uuid
+  testlog " - snapshot removal during demoting and promoting on same cluster"
+  mirror_image_snapshot ${CLUSTER2} ${POOL} ${image}
+  get_newest_mirror_snapshot_id_on_primary ${CLUSTER2} ${POOL}/${image} snap_id
+  wait_for_non_primary_snap_present ${CLUSTER1} ${POOL} ${image} ${snap_id}
+  demote_image ${CLUSTER2} ${POOL} ${image}
+  wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+unknown'
+  wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+unknown'
+  get_newest_mirror_snapshot_id_on_primary ${CLUSTER2} ${POOL}/${image} demote_snap_id
+  wait_for_non_primary_snap_present ${CLUSTER1} ${POOL} ${image} ${demote_snap_id}
+  wait_for_snap_id_not_present ${CLUSTER1} ${POOL}/${image} ${snap_id}
+  promote_image ${CLUSTER2} ${POOL} ${image}
+  wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+stopped'
+  wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
+  get_newest_mirror_snapshot_id_on_primary ${CLUSTER2} ${POOL}/${image} promote_snap_id
+  wait_for_non_primary_snap_present ${CLUSTER1} ${POOL} ${image} ${promote_snap_id}
+  #wait_for_snap_id_not_present ${CLUSTER1} ${POOL}/${image} ${demote_snap_id} # happening for group not for images
+  wait_for_image_snap_peer_uuid_not_present ${CLUSTER2} ${POOL} ${image} ${demote_snap_id} ${CLUSTER1_UUID}
+
+  testlog " - snapshot removal during failover/failback"
+  stop_mirrors ${CLUSTER1} -KILL
+  promote_image ${CLUSTER1} ${POOL} ${image} '--force'
+  start_mirrors ${CLUSTER1}
+  wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+stopped'
+  wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+stopped'
+  wait_for_snap_id_not_present ${CLUSTER1} ${POOL}/${image} ${promote_snap_id}
+  get_newest_mirror_snapshot_id_on_primary ${CLUSTER1} ${POOL}/${image} promote_snap_id_new
+  demote_image ${CLUSTER1} ${POOL} ${image}
+  wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+error' 'split-brain'
+  get_newest_mirror_snapshot_id_on_primary ${CLUSTER1} ${POOL}/${image} demote_snap_id
+  request_resync_image ${CLUSTER1} ${POOL} ${image} image_id
+  wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'deleted' ${image_id}
+  wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'present'
+  wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+  wait_for_replaying_status_in_pool_dir ${CLUSTER1} ${POOL} ${image}
+  wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
+  wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+stopped'
+  wait_for_snap_id_not_present ${CLUSTER1} ${POOL}/${image} ${demote_snap_id}
+  wait_for_snap_id_not_present ${CLUSTER1} ${POOL}/${image} ${promote_snap_id_new}
+  wait_for_snap_id_present ${CLUSTER1} ${POOL}/${image} ${promote_snap_id}
+fi
+
 testlog "TEST: stop mirror, add image, start mirror and test replay"
 stop_mirrors ${CLUSTER1}
 image1=test1

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2382,6 +2382,163 @@ test_create_multiple_groups_do_io()
   done
 }
 
+# Test that checks for a maximum of 5 mirror group snapshots on primary cluster
+declare -a test_max_mirror_group_snapshots_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${group0}" "${image_prefix}" 2 5)
+
+test_max_mirror_group_snapshots_scenarios=1
+
+test_max_mirror_group_snapshots()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local group=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+  local max_snapshots=$1 ; shift
+  local secondary_cluster_uuid
+  local group_snapshot_id
+
+  group_create "${primary_cluster}" "${pool}/${group}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  group_images_add "${primary_cluster}" "${pool}/${group}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group}"
+
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}/${group}" "${secondary_cluster}" "${pool}"/"${group}"
+
+  get_peer_uuid "${primary_cluster}" "${pool}" secondary_cluster_uuid
+
+  # Create mirror group snapshots on the primary cluster
+  local snapshot_ids=()
+  local count=0
+  for i in $(seq 1 ${max_snapshots}); do
+    mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}/${group}" group_snapshot_id
+    snapshot_ids+=("${group_snapshot_id}")
+  done
+
+  # test removal of non-primary snapshots on secondary cluster
+  for i in $(seq 0 $((${max_snapshots} - 2))); do
+    # test unlinking
+    wait_for_peer_uuid_not_in_group_snap_peers "${primary_cluster}" "${pool}/${group}" "${snapshot_ids[$i]}" "${secondary_cluster_uuid}"
+    # test removal
+    wait_for_group_snap_not_present "${secondary_cluster}" "${pool}/${group}" "${snapshot_ids[$i]}"
+  done
+
+  # create additional snapshots to exceed the max snapshot count
+  mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}/${group}"
+  mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}/${group}" group_snapshot_id
+
+  # test syncing of new snapshots
+  wait_for_group_snap_present "${secondary_cluster}" "${pool}/${group}" "${group_snapshot_id}"
+  wait_for_group_snap_sync_complete "${secondary_cluster}" "${pool}/${group}" "${group_snapshot_id}"
+
+  # Check that only the latest 5 snapshots are retained on primary
+  get_group_snap_count "${primary_cluster}" "${pool}"/"${group}" '*' count
+  test "${count}" -le 5 || { fail "expected max 5 snapshots on primary, but got ${count}"; return 1; }
+  get_group_snap_count "${secondary_cluster}" "${pool}"/"${group}" '*' count
+  test "${count}" -le 5 || { fail "expected max 5 snapshots on secondary, but got ${count}"; return 1; }
+
+  mirror_group_disable "${primary_cluster}" "${pool}/${group}"
+  group_remove "${primary_cluster}" "${pool}/${group}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+}
+
+# test creation and deletion of regular (user) group snapshots
+declare -a test_user_group_snapshots_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${group0}" "${image_prefix}" 2)
+
+test_user_group_snapshots_scenarios=1
+
+test_user_group_snapshots()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local group=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+  local snap_name="regular_snap"
+  local group_id_before
+  local group_snap_id
+
+  start_mirrors "${primary_cluster}"
+  start_mirrors "${secondary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  group_images_add "${primary_cluster}" "${pool}/${group}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group}"
+
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}/${group}" 'up+stopped' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}/${group}" "${secondary_cluster}" "${pool}"/"${group}"
+
+  check_group_snap_doesnt_exist "${primary_cluster}" "${pool}/${group}" "${snap_name}"
+  group_snap_create "${primary_cluster}" "${pool}/${group}" "${snap_name}"
+  check_group_snap_exists "${primary_cluster}" "${pool}/${group}" "${snap_name}"
+  get_newest_created_group_snapshot_id "${primary_cluster}" "${pool}/${group}" group_snap_id
+
+  # test group snap sync with disabled and then enabled mirroring
+  mirror_group_disable "${primary_cluster}" "${pool}/${group}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group}"
+  mirror_group_enable "${primary_cluster}" "${pool}/${group}"
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}/${group}" 'up+stopped' "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' "${image_count}"
+  wait_for_group_snap_present "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}"
+  wait_for_group_snap_sync_complete "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}" "user"
+
+  # test group snap removal with daemon interrupted
+  stop_mirrors "${secondary_cluster}" '-9'
+  group_snap_remove "${primary_cluster}" "${pool}/${group}" "${snap_name}"
+  check_group_snap_doesnt_exist "${primary_cluster}" "${pool}/${group}" "${snap_name}"
+  check_group_snap_exists "${secondary_cluster}" "${pool}/${group}" "${snap_name}"
+  start_mirrors "${secondary_cluster}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' "${image_count}"
+  wait_for_group_snap_not_present "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}"
+
+  # test group snap sync with failover and failback
+  group_snap_create "${primary_cluster}" "${pool}/${group}" "${snap_name}"
+  check_group_snap_exists "${primary_cluster}" "${pool}/${group}" "${snap_name}"
+  get_newest_created_group_snapshot_id "${primary_cluster}" "${pool}/${group}" group_snap_id
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}/${group}" 'up+stopped' "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group}" "${secondary_cluster}" "${pool}/${group}"
+  stop_mirrors "${secondary_cluster}" '-9'
+  check_group_snap_doesnt_exist "${secondary_cluster}" "${pool}/${group}" "${snap_name}"
+  mirror_group_promote "${secondary_cluster}" "${pool}/${group}" "--force"
+  start_mirrors "${secondary_cluster}"
+  group_snap_create "${secondary_cluster}" "${pool}/${group}" "${snap_name}2"
+  get_newest_created_group_snapshot_id "${secondary_cluster}" "${pool}/${group}" group_snap_id2
+  mirror_group_demote "${secondary_cluster}" "${pool}/${group}"
+  wait_for_group_snap_not_present "${secondary_cluster}" "${pool}/${group}" "${group_snap_id2}"
+  get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
+  mirror_group_resync "${secondary_cluster}" "${pool}/${group}"
+  wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}/${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}/${group0}" 'up+stopped' "${image_count}"
+  check_group_snap_doesnt_exist "${secondary_cluster}" "${pool}/${group}" "${snap_name}"
+  mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}/${group}"
+  wait_for_group_snap_present "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}"
+  wait_for_group_snap_sync_complete "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}" "user"
+
+  mirror_group_disable "${primary_cluster}" "${pool}/${group}"
+  group_remove "${primary_cluster}" "${pool}/${group}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+}
+
 # mirror a group then remove an image from that group and add to a different mirrored group.
 declare -a test_image_move_group_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 5)
 
@@ -3060,6 +3217,173 @@ test_demote_snap_unlink_and_removal_post_relocation()
   images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
 }
 
+# test snapshot removal with failover/failback
+declare -a test_snapshot_removal_with_failover_failback_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128 1)
+declare -a test_snapshot_removal_with_failover_failback_2=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128 2)
+
+test_snapshot_removal_with_failover_failback_scenarios=2
+
+test_snapshot_removal_with_failover_failback()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_count=$1 ; shift
+  local image_size=$1 ; shift
+  local scenario=$1 ; shift
+
+  local group0=test-group0
+  local image_prefix="test_image"
+  # UUID of ${primary_cluster} used by ${secondary_cluster}
+  local primary_cluster_uuid
+  local group_id_before_resync
+  local group_snap_id
+  local group_promote_snap_id
+  local group_demote_snap_id
+  start_mirrors "${primary_cluster}"
+  start_mirrors "${secondary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}" "${image_size}"
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+
+  get_peer_uuid "${secondary_cluster}" "${pool}" primary_cluster_uuid
+
+  group_snap_id=''
+  # get newest snapshot ID - this will be the one that gets rolled back to
+  wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'primary' group_snap_id
+  # wait for presence of the snapshot on the secondary
+  wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}" 1
+
+  # failover to secondary by force promoting the group on the secondary
+  stop_mirrors "${secondary_cluster}" '-9'
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'down+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+  mirror_group_promote "${secondary_cluster}" "${pool}/${group0}" '--force'
+  start_mirrors "${secondary_cluster}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}/${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}/${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_snap_not_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+  wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${secondary_cluster}" "${pool}/${group0}" 'primary' group_promote_snap_id
+  wait_for_peer_uuid_in_group_snap_peers "${secondary_cluster}" "${pool}/${group0}" "${group_promote_snap_id}" "${primary_cluster_uuid}"
+
+  # CASE 1: demote primary
+  if [ "${scenario}" -eq 1 ]; then
+    mirror_group_demote "${primary_cluster}" "${pool}/${group0}"
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'demoted' group_demote_snap_id
+    get_id_from_group_info "${primary_cluster}" "${pool}/${group0}" group_id_before_resync
+    mirror_group_resync "${primary_cluster}" "${pool}/${group0}"
+    wait_for_group_id_changed  "${primary_cluster}" "${pool}/${group0}" "${group_id_before_resync}"
+    wait_for_group_synced "${secondary_cluster}" "${pool}"/"${group0}" "${primary_cluster}" "${pool}"/"${group0}"
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}/${group0}" 'up+replaying' "${image_count}"
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}/${group0}" 'up+stopped' "${image_count}"
+    wait_for_group_snap_not_present "${secondary_cluster}" "${pool}/${group0}" "${group_demote_snap_id}"
+    wait_for_group_snap_not_present "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+    wait_for_group_snap_not_present "${primary_cluster}" "${pool}/${group0}" "${group_demote_snap_id}"
+    wait_for_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${group_promote_snap_id}"
+
+    # cleanup
+    mirror_group_disable "${secondary_cluster}" "${pool}/${group0}"
+    group_remove "${secondary_cluster}" "${pool}/${group0}"
+    wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+    wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+    images_remove "${secondary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  fi
+
+  # CASE 2: demote secondary - failback
+  if [ "${scenario}" -eq 2 ]; then
+    mirror_group_demote "${secondary_cluster}" "${pool}/${group0}"
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${secondary_cluster}" "${pool}/${group0}" 'demoted' group_demote_snap_id
+    get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before_resync
+    mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+    wait_for_group_id_changed  "${secondary_cluster}" "${pool}/${group0}" "${group_id_before_resync}"
+    wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}/${group0}" 'up+replaying' "${image_count}"
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}/${group0}" 'up+stopped' "${image_count}"
+    wait_for_group_snap_not_present "${primary_cluster}" "${pool}/${group0}" "${group_demote_snap_id}"
+    wait_for_group_snap_not_present "${secondary_cluster}" "${pool}/${group0}" "${group_demote_snap_id}"
+    wait_for_group_snap_not_present "${secondary_cluster}" "${pool}/${group0}" "${group_promote_snap_id}"
+    wait_for_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+
+    # cleanup
+    mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+    group_remove "${primary_cluster}" "${pool}/${group0}"
+    wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+    wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+    images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  fi
+}
+
+# test group snapshot removal with demote and promote
+declare -a test_group_snapshot_removal_with_demote_promote_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128)
+
+test_group_snapshot_removal_with_demote_promote_scenarios=1
+
+test_group_snapshot_removal_with_demote_promote()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_count=$1 ; shift
+  local image_size=$1 ; shift
+
+  local group0=test-group0
+  local image_prefix="test_image"
+  local group_snap_id
+  local group_demote_snap_id
+  local group_promote_snap_id
+  local secondary_cluster_uuid
+
+  start_mirrors "${primary_cluster}"
+  start_mirrors "${secondary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}" "${image_size}"
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+
+  get_peer_uuid "${primary_cluster}" "${pool}" secondary_cluster_uuid
+
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+
+  wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'primary' group_snap_id
+  wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}" 1
+
+  mirror_group_demote "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+  wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'demoted' group_demote_snap_id
+  wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_demote_snap_id}" 1
+
+  mirror_group_promote "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' ${image_count}
+  wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'primary' group_promote_snap_id
+  wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_promote_snap_id}" 1
+  wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_demote_snap_id}" 0 # images don't follow similar behavior
+  wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}" 0
+  wait_for_test_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" 0
+  wait_for_peer_uuid_not_in_group_snap_peers "${primary_cluster}" "${pool}/${group0}" "${group_demote_snap_id}" "${secondary_cluster_uuid}"
+
+  # cleanup
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+}
+
 # test group snapshot resync after relocate and force promote of primary
 declare -a test_resync_after_relocate_and_force_promote_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128)
 
@@ -3542,6 +3866,8 @@ test_odf_failover_failback()
   stop_mirrors "${primary_cluster}"
   check_daemon_running "${secondary_cluster}"
 }
+
+
 
 # test ODF failover/failback sequence
 declare -a test_resync_marker_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 'no_change' 3)
@@ -4102,6 +4428,8 @@ run_all_tests()
   #run_test_all_scenarios test_invalid_actions
   run_test_all_scenarios test_remote_namespace
   run_test_all_scenarios test_create_multiple_groups_do_io
+  run_test_all_scenarios test_max_mirror_group_snapshots
+  run_test_all_scenarios test_snapshot_removal_with_failover_failback
 }
 
 if [ -n "${RBD_MIRROR_HIDE_BASH_DEBUGGING}" ]; then

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2954,6 +2954,112 @@ test_force_promote_before_initial_sync()
   start_mirrors "${secondary_cluster}"
 }
 
+# test demote snapshot unlink and removal post relocation
+declare -a test_demote_snap_unlink_and_removal_post_relocation_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128)
+
+test_demote_snap_unlink_and_removal_post_relocation_scenarios=1
+
+test_demote_snap_unlink_and_removal_post_relocation()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_count=$1 ; shift
+  local image_size=$1 ; shift
+
+  local group0=test-group0
+  local image_prefix="test_image"
+  # UUID of ${primary_cluster} used by ${secondary_cluster}
+  local primary_cluster_uuid
+  # UUID of ${secondary_cluster} used by ${primary_cluster}
+  local secondary_cluster_uuid
+  local group_promote_snap_id_old group_demote_snap_id_old
+  local group_promote_snap_id_new group_demote_snap_id_new
+
+  start_mirrors "${primary_cluster}"
+  start_mirrors "${secondary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}" "${image_size}"
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+
+  get_peer_uuid "${secondary_cluster}" "${pool}" primary_cluster_uuid
+  get_peer_uuid "${primary_cluster}" "${pool}" secondary_cluster_uuid
+
+  for i in $(seq 1 10); do
+    # relocation: demote primary and promote secondary
+    mirror_group_demote "${primary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    # get newest demote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'demoted' group_demote_snap_id_old
+    # wait for presence of demote snapshot on secondary
+    wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_demote_snap_id_old}" 1
+    # test for UUID presence in demote snapshot
+    wait_for_peer_uuid_in_group_snap_peers "${secondary_cluster}" "${pool}/${group0}" "${group_demote_snap_id_old}" "${primary_cluster_uuid}"
+
+    mirror_group_promote "${secondary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+replaying' ${image_count}
+    # get newest promote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${secondary_cluster}" "${pool}/${group0}" 'primary' group_promote_snap_id_old
+    # wait for presence of promote snapshot on primary
+    wait_for_test_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${group_promote_snap_id_old}" 1
+
+    mirror_group_demote "${secondary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+unknown'
+    # get newest demote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${secondary_cluster}" "${pool}/${group0}" 'demoted' group_demote_snap_id_new
+    # wait for presence of demote snapshot on primary
+    wait_for_test_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${group_demote_snap_id_new}" 1
+    # test for UUID presence in demote snapshot
+    wait_for_peer_uuid_in_group_snap_peers "${primary_cluster}" "${pool}/${group0}" "${group_demote_snap_id_new}" "${secondary_cluster_uuid}"
+
+    # go back to original state
+    mirror_group_promote "${primary_cluster}" "${pool}/${group0}"
+    wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}
+    wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' ${image_count}
+    # get newest promote snapshot ID
+    wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type "${primary_cluster}" "${pool}/${group0}" 'primary' group_promote_snap_id_new
+    # wait for presence of promote snapshot on secondary
+    wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_promote_snap_id_new}" 1
+    # wait for old demote snapshot's peer_uuid to be removed
+    wait_for_peer_uuid_not_in_group_snap_peers "${primary_cluster}" "${pool}/${group0}" "${group_demote_snap_id_old}" "${secondary_cluster_uuid}"
+
+    # cleanup
+    group_promote_snap_id_old=''
+    group_demote_snap_id_old=''
+    group_promote_snap_id_new=''
+    group_demote_snap_id_new=''
+  done
+
+  local count
+  # FIXME: change the count comparison to 3 when all snap cleanup is implemented correctly
+  # After each iteration:
+  # A cluster can have three mirror group snapshots:
+  # 1. demote primary, 2. demote non-primary or non-primary and 3. primary
+  # Hence at most 3 snapshots can be present in each cluster
+  get_group_snap_count "${primary_cluster}" "${pool}"/"${group0}" '*' count
+  test "${count}" -gt 4 && { fail "unexpected snap count=${count} after multiple relocation cycles"; return 1; }
+  get_group_snap_count "${secondary_cluster}" "${pool}"/"${group0}" '*' count
+  test "${count}" -gt 4 && { fail "unexpected snap count=${count} after multiple relocation cycles"; return 1; }
+
+  # cleanup
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+}
+
 # test group snapshot resync after relocate and force promote of primary
 declare -a test_resync_after_relocate_and_force_promote_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 2 128)
 
@@ -3978,6 +4084,7 @@ run_all_tests()
   run_test_all_scenarios test_interrupted_sync_restarted_daemon
   run_test_all_scenarios test_interrupted_sync
   run_test_all_scenarios test_resync_after_relocate_and_force_promote
+  run_test_all_scenarios test_demote_snap_unlink_and_removal_post_relocation
   run_test_all_scenarios test_multiple_mirror_group_snapshot_unlink_time
   run_test_all_scenarios test_force_promote_delete_group
   run_test_all_scenarios test_create_group_stop_daemon_then_recreate

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -986,6 +986,124 @@ mirror_image_snapshot()
     rbd --cluster "${cluster}" mirror image snapshot "${pool}/${image}"
 }
 
+# get the uuid of the remote cluster from the ${cluster}'s pool info'
+# FIXME: works only for single peer, return uuid of first peer from list
+get_peer_uuid()
+{
+    local cluster=$1
+    local pool=$2
+    local -n _uuid=$3
+
+    run_cmd "rbd --cluster ${cluster} mirror pool info --pool ${pool} --format xml --pretty-format"
+    _uuid=$(xmlstarlet sel -t -v "//peers/peer/uuid[1]" < "$CMD_STDOUT" )
+    if [[ -z "${_uuid}" ]]; then
+        fail "failed to get uuid of pool ${pool}"
+	return 1
+    fi
+}
+
+# wait until a newest/last complete snapshot id is found by snapshot type
+# snap_type values: "demoted", "primary", "non-primary"
+wait_to_get_newest_complete_mirror_group_snapshot_id_by_snap_type()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_type=$3
+    local -n _new_snap_id=$4
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
+        sleep ${s}
+        _new_snap_id=""
+        if get_newest_complete_mirror_group_snapshot_id_by_snap_type \
+                "${cluster}" "${group_spec}" "${snap_type}" _new_snap_id; then
+            [[ -n "${_new_snap_id}" ]] && return 0
+        fi
+    done
+
+    fail "wait for newest complete mirror group snapshot id failed on ${cluster}"
+    return 1
+}
+
+# get newest/last complete snapshot id by snapshot type
+# snap_type values: "demoted", "primary", "non-primary"
+# "demoted" can be primary or non-primary depending on which cluster it is run against
+get_newest_complete_mirror_group_snapshot_id_by_snap_type()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_type=$3
+    local -n _snap_id=$4
+
+    run_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format"
+    _snap_id=$(xmlstarlet sel -t -v "(//group_snaps/group_snap[last()][namespace/complete='true' and namespace/state='${snap_type}']/id)" "$CMD_STDOUT" )
+    [[ -n "${_snap_id}" ]]
+}
+
+# get the list of peer UUIDs for a specific group snapshot
+get_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local -n _peers=$4
+
+    run_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format"
+    _peers=$(xmlstarlet sel -t -v "//group_snap[id='${snap_id}']/namespace/mirror_peer_uuids/peer_uuid" "$CMD_STDOUT")
+}
+
+test_peer_uuid_in_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local peer_uuid=$4
+
+    test -n "${peer_uuid}" || { fail "peer_uuid is empty"; return 1; }
+    local peers
+    get_group_snap_peers "${cluster}" "${group_spec}" "${snap_id}" peers
+    echo "${peers}" | grep -qxF "${peer_uuid}" || {
+        fail "peer_uuid ${peer_uuid} not found in group snap ${snap_id}"
+        return 1
+    }
+}
+
+wait_for_peer_uuid_in_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local peer_uuid=$4
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
+        sleep ${s}
+        test_peer_uuid_in_group_snap_peers "${cluster}" "${group_spec}" "${snap_id}" "${peer_uuid}" && return 0
+    done
+
+    fail "wait for peer_uuid ${peer_uuid} in group snap peers failed on ${cluster}"
+    return 1
+}
+
+wait_for_peer_uuid_not_in_group_snap_peers()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_id=$3
+    local peer_uuid=$4
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
+        sleep ${s}
+        if ! test_peer_uuid_in_group_snap_peers "${cluster}" "${group_spec}" "${snap_id}" "${peer_uuid}"; then
+            return 0
+        fi
+    done
+
+    fail "failed to wait to unlink peer_uuid ${peer_uuid} from group snap ${snap_id} on ${cluster}"
+    return 1
+}
+
 # get the primary_snap_id for the most recent complete snap on the secondary cluster
 get_primary_snap_id_for_newest_mirror_snapshot_on_secondary()
 {

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -1233,6 +1233,70 @@ wait_for_snapshot_sync_complete()
     return 1
 }
 
+get_image_snap_peers()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+    local snap_id=$4
+    local -n _peers=$5
+
+    run_cmd "rbd --cluster ${cluster} snap list -a ${pool}/${image} --format xml --pretty-format"
+    _peers=$(xmlstarlet sel -t -v "//snapshots/snapshot/namespace[primary_snap_id='${snap_id}']/mirror_peer_uuids/peer_uuid" "$CMD_STDOUT")
+}
+
+test_peer_uuid_in_image_snap_peers()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+    local snap_id=$4
+    local peer_uuid=$5
+
+    test -n "${peer_uuid}" || { fail "peer_uuid is empty"; return 1; }
+    local peers
+    get_image_snap_peers "${cluster}" "${pool}" "${image}" "${snap_id}" peers
+    echo "${peers}" | grep -qxF "${peer_uuid}" || { fail; return 1; }
+}
+
+wait_for_image_snap_peer_uuid_present()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+    local primary_snap_id=$4
+    local peer_uuid=$5
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
+        sleep ${s}
+        test_peer_uuid_in_image_snap_peers "${cluster}" "${pool}" "${image}" "${primary_snap_id}" "${peer_uuid}" && return 0
+    done
+
+    fail "wait for presence of peer uuid ${peer_uuid} in peer uuid list of primary snap id ${primary_snap_id} on cluster ${cluster} failed"
+    return 1
+}
+
+wait_for_image_snap_peer_uuid_not_present()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+    local primary_snap_id=$4
+    local peer_uuid=$5
+    local s
+
+    for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
+        sleep ${s}
+        if ! test_peer_uuid_in_image_snap_peers "${cluster}" "${pool}" "${image}" "${primary_snap_id}" "${peer_uuid}"; then
+            return 0
+        fi
+    done
+
+    fail "wait for absense of peer uuid ${peer_uuid} in peer uuid list of primary snap id ${primary_snap_id} on cluster ${cluster} failed"
+    return 1
+}
+
 wait_for_replay_complete()
 {
     local local_cluster=$1 #sec
@@ -2886,12 +2950,18 @@ test_group_snap_sync_state()
     local group_spec=$2
     local group_snap_id=$3
     local expected_state=$4
+    local has_complete_field=$5
 
     run_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format"
 
     # Get <state> and <snaps_synced> for the given group snapshot ID
     local state snaps_synced
     state=$(xmlstarlet sel -t -v "//group_snaps/group_snap[id='${group_snap_id}']/state" < "$CMD_STDOUT")
+    if ! $has_complete_field; then
+        test "$state" = "created" || { fail; return 1; }
+        return 0
+    fi
+
     snaps_synced=$(xmlstarlet sel -t -v "//group_snaps/group_snap[id='${group_snap_id}']/namespace/complete" < "$CMD_STDOUT")
 
     if [ "$expected_state" = "complete" ]; then
@@ -2932,8 +3002,9 @@ test_group_snap_sync_complete()
     local cluster=$1
     local group_spec=$2
     local group_snap_id=$3
+    local has_complete_field=$4
 
-    test_group_snap_sync_state "${cluster}" "${group_spec}" "${group_snap_id}" 'complete'
+    test_group_snap_sync_state "${cluster}" "${group_spec}" "${group_snap_id}" 'complete' "${has_complete_field}"
 }
 
 test_group_snap_sync_incomplete()
@@ -2961,11 +3032,12 @@ wait_for_test_group_snap_sync_complete()
     local cluster=$1
     local group_spec=$2
     local group_snap_id=$3
+    local has_complete_field=$4
     local s
 
     for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32 32 32 64 64 64 64 64; do
         sleep ${s}
-        test_group_snap_sync_complete "${cluster}" "${group_spec}" "${group_snap_id}" && return 0
+        test_group_snap_sync_complete "${cluster}" "${group_spec}" "${group_snap_id}" "${has_complete_field}" && return 0
 
         if  (( $(bc <<<"$s > 32") )); then
             # query the snap progress for each image in the group - debug info to check that sync is progressing
@@ -2983,8 +3055,13 @@ wait_for_group_snap_sync_complete()
     local cluster=$1
     local group_spec=$2
     local group_snap_id=$3
+    local snap_type=${4:-}
+    local has_complete_field=true
+    if [ "${snap_type}" = "user" ]; then
+        has_complete_field=false
+    fi
 
-    wait_for_test_group_snap_sync_complete "${cluster}" "${group_spec}" "${group_snap_id}"
+    wait_for_test_group_snap_sync_complete "${cluster}" "${group_spec}" "${group_snap_id}" "${has_complete_field}"
 }
 
 test_group_replay_state()
@@ -3139,6 +3216,11 @@ mirror_group_snapshot_and_wait_for_sync_complete()
     mirror_group_snapshot "${primary_cluster}" "${group_spec}" group_snap_id
     wait_for_group_snap_present "${secondary_cluster}" "${group_spec}" "${group_snap_id}"
     wait_for_group_snap_sync_complete "${secondary_cluster}" "${group_spec}" "${group_snap_id}"
+
+    if [ "$#" -gt 3 ]; then
+        local -n _group_snap_id=$4
+        _group_snap_id="${group_snap_id}"
+    fi
 }
 
 test_group_synced_image_status()

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -662,7 +662,8 @@ void Replayer<I>::handle_load_remote_group_snapshots(int r) {
     schedule_load_group_snapshots();
     return;
   }
-
+  std::string unlink_snap_id;
+  bool has_newer_snap = false;
   for (auto remote_snap = m_remote_group_snaps.begin();
        remote_snap != m_remote_group_snaps.end(); ) {
     auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
@@ -677,9 +678,44 @@ void Replayer<I>::handle_load_remote_group_snapshots(int r) {
                << remote_snap_ns->mirror_peer_uuids << " (expected: "
                << m_remote_mirror_peer_uuid << ")" << dendl;
       remote_snap = m_remote_group_snaps.erase(remote_snap);
-    } else {
-      ++remote_snap;
+      continue;
     }
+    if (!has_newer_snap) {
+      if (!unlink_snap_id.empty()) {
+        // check if next remote snap has a matching complete local snap
+        auto itr = std::find_if(
+          m_local_group_snaps.begin(), m_local_group_snaps.end(),
+          [remote_snap](const cls::rbd::GroupSnapshot &s) {
+          return s.id == remote_snap->id;
+        });
+        if (itr == m_local_group_snaps.end()) {
+          dout(10) << "Local mirror group snapshot not found for remote_snap_id: " << remote_snap->id << dendl;
+          ++remote_snap;
+          continue;
+        }
+        auto next_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+          &itr->snapshot_namespace);
+        if (!is_mirror_group_snapshot_complete(itr->state,
+                                              next_local_snap_ns->complete)) {
+          dout(10) << "Next local mirror snapshot is incomplete: "
+                   << itr->id << dendl;
+          ++remote_snap;
+          continue;
+        }
+        has_newer_snap = true;
+      }
+      if (remote_snap_ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
+        unlink_snap_id = remote_snap->id;
+      }
+    }
+    ++remote_snap;
+  }
+  if (has_newer_snap) {
+    ceph_assert(!unlink_snap_id.empty());
+    mirror_group_snapshot_unlink_peer(unlink_snap_id);
+    locker.unlock();
+    schedule_load_group_snapshots();
+    return;
   }
   check_local_group_snapshots(&locker);
 }

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -1764,7 +1764,6 @@ bool Replayer<I>::prune_all_image_snapshots(
       derr << "failed getting snap info for snap id: " << spec.snap_id
            << ", : " << cpp_strerror(r) << dendl;
     }
-    prune_done = false;
     auto ir = std::find_if(
         m_replayers_by_image_id.begin(),
         m_replayers_by_image_id.end(),
@@ -1775,6 +1774,7 @@ bool Replayer<I>::prune_all_image_snapshots(
       ImageReplayer<I>* image_replayer = ir->second;
       dout(10) << "pruning snapshot " << spec.snap_id
                << " for image " << spec.image_id << dendl;
+      prune_done = false;
       // The ImageReplayer can have m_replayer empty, so no guaranty that
       // this will succeed in one shot, but we keep retry for this and
       // acheive anyway.
@@ -1911,10 +1911,15 @@ template <typename I>
 void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     const std::vector<cls::rbd::GroupSnapshot>& prune_group_snaps) {
-  int r = 0;
   {
     std::unique_lock locker{m_lock};
     for (const auto& local_snap : prune_group_snaps) {
+      if (m_pruning_group_snaps_inflight.count(local_snap.id) == 0) {
+        m_pruning_group_snaps_inflight.insert(local_snap.id);
+        m_in_flight_op_tracker.start_op();
+        dout(10) << "starting pruning of group snap: "
+                 << local_snap.name << ", with id: " << local_snap.id << dendl;
+      }
       if (!prune_all_image_snapshots_by_gsid(
             local_snap.id, local_images, &locker)) {
         // still pending image snapshots; retry later
@@ -1922,14 +1927,10 @@ void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
       }
       dout(10) << "all image snapshots pruned; removing creating group snapshot: "
                << local_snap.id << dendl;
-      r = librbd::cls_client::group_snap_remove(
-          &m_local_io_ctx,
-          librbd::util::group_header_name(m_local_group_id),
-          local_snap.id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot "
-             << local_snap.id << ": "
-             << cpp_strerror(r) << dendl;
+      remove_group_snapshot(&local_snap);
+      if (m_pruning_group_snaps_inflight.count(local_snap.id) != 0) {
+        m_pruning_group_snaps_inflight.erase(local_snap.id);
+        m_in_flight_op_tracker.finish_op();
       }
     }
   }
@@ -1939,7 +1940,6 @@ void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
 template <typename I>
 void Replayer<I>::prune_user_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
   for (auto local_snap = m_local_group_snaps.begin();
       local_snap != m_local_group_snaps.end(); ++local_snap) {
     auto snap_type = cls::rbd::get_group_snap_namespace_type(
@@ -1955,28 +1955,42 @@ void Replayer<I>::prune_user_group_snapshots(
       if (!prune_user_snap) {
         continue;
       }
-      dout(10) << "pruning user group snap in-progress: "
-               << local_snap->name << ", with id: " << local_snap->id << dendl;
+      if (m_pruning_group_snaps_inflight.count(local_snap->id) == 0) {
+        m_pruning_group_snaps_inflight.insert(local_snap->id);
+        m_in_flight_op_tracker.start_op();
+        dout(10) << "starting pruning of user group snap: "
+                 << local_snap->name << ", with id: " << local_snap->id << dendl;
+      }
       // prune all the image snaps of the group snap locally
       if (!prune_all_image_snapshots(&(*local_snap), locker)) {
         continue;
       }
       dout(10) << "all image snaps are pruned, finally pruning user group snap: "
                << local_snap->id << dendl;
-      r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-             librbd::util::group_header_name(m_local_group_id), local_snap->id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot : "
-             << local_snap->id << " : " << cpp_strerror(r) << dendl;
+      remove_group_snapshot(&(*local_snap));
+      if (m_pruning_group_snaps_inflight.count(local_snap->id) != 0) {
+        m_pruning_group_snaps_inflight.erase(local_snap->id);
+        m_in_flight_op_tracker.finish_op();
       }
     }
   }
 }
 
 template <typename I>
+void Replayer<I>::remove_group_snapshot(const cls::rbd::GroupSnapshot *local_snap) {
+  dout(10) << "pruning group snap: "
+           << local_snap->name << ", with id: " << local_snap->id << dendl;
+  int r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
+      librbd::util::group_header_name(m_local_group_id), local_snap->id);
+  if (r < 0) {
+    derr << "failed to remove group snapshot: "
+         << local_snap->id << " : " << cpp_strerror(r) << dendl;
+  }
+}
+
+template <typename I>
 void Replayer<I>::prune_mirror_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
   bool is_prior_snap_user = false;
   bool skip_next_snap_check = false;
   cls::rbd::GroupSnapshot *prune_snap = nullptr;
@@ -2050,25 +2064,35 @@ void Replayer<I>::prune_mirror_group_snapshots(
         }
       }
     }
+    skip_next_snap_check = false;
     mirror_group_snapshot_unlink_peer(prune_snap->id);
     const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
         prune_snap->snapshot_namespace);
-    if (ns.is_primary() ||
-        !prune_all_image_snapshots(prune_snap, locker)) {
+
+    if (ns.is_primary()) {
       prune_snap = nullptr;
-      skip_next_snap_check = false;
+      continue;
+    }
+    if (m_pruning_group_snaps_inflight.count(prune_snap->id) == 0) {
+      m_pruning_group_snaps_inflight.insert(prune_snap->id);
+      m_in_flight_op_tracker.start_op();
+      dout(10) << "starting pruning of mirror group snap: "
+               << prune_snap->name << ", with id: " << prune_snap->id << dendl;
+    }
+    if (!prune_all_image_snapshots(prune_snap, locker)) {
+      prune_snap = nullptr;
       continue;
     }
     dout(10) << "all image snaps are pruned, finally pruning mirror group snap: "
              << prune_snap->id << dendl;
-    r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-        librbd::util::group_header_name(m_local_group_id), prune_snap->id);
-    if (r < 0) {
-      derr << "failed to remove group snapshot : "
-           << prune_snap->id << " : " << cpp_strerror(r) << dendl;
+
+    remove_group_snapshot(prune_snap);
+
+    if (m_pruning_group_snaps_inflight.count(prune_snap->id) != 0) {
+      m_pruning_group_snaps_inflight.erase(prune_snap->id);
+      m_in_flight_op_tracker.finish_op();
     }
     prune_snap = nullptr;
-    skip_next_snap_check = false;
   }
 }
 
@@ -2173,6 +2197,37 @@ void Replayer<I>::set_image_replayer_limits(const std::string &image_id,
 }
 
 template <typename I>
+void Replayer<I>::finish_pending_snapshot_pruning() {
+  dout(10) << dendl;
+  std::unique_lock locker{m_lock};
+  while (!m_pruning_group_snaps_inflight.empty()) {
+    std::string snap_id = *m_pruning_group_snaps_inflight.begin();
+    cls::rbd::GroupSnapshot prune_snap;
+    auto it = std::find_if(
+        m_local_group_snaps.begin(), m_local_group_snaps.end(),
+        [&snap_id](const cls::rbd::GroupSnapshot &s) {
+          return s.id == snap_id;
+        });
+    if (it == m_local_group_snaps.end()) {
+      // snapshot not found locally, skip it
+      m_pruning_group_snaps_inflight.erase(snap_id);
+      m_in_flight_op_tracker.finish_op();
+      continue;
+    }
+    prune_snap = *it;
+    if (prune_all_image_snapshots(&prune_snap, &locker)) {
+      remove_group_snapshot(&prune_snap);
+      m_pruning_group_snaps_inflight.erase(snap_id);
+      m_in_flight_op_tracker.finish_op();
+    } else {
+      locker.unlock();
+      // need to unlock and lock to allow other ops to proceed
+      locker.lock();
+    }
+  }
+}
+
+template <typename I>
 void Replayer<I>::shut_down(Context* on_finish) {
   dout(10) << dendl;
 
@@ -2196,6 +2251,17 @@ void Replayer<I>::shut_down(Context* on_finish) {
 template <typename I>
 void Replayer<I>::wait_for_in_flight_ops() {
   dout(10) << dendl;
+
+  // Ensure all pending snapshot pruning is completed.
+  // This is required before m_in_flight_op_tracker.wait_for_ops(); otherwise,
+  // the wait may block indefinitely if the group snapshot is not fully pruned.
+  {
+    std::unique_lock locker{m_lock};
+    if (!m_pruning_group_snaps_inflight.empty()) {
+      locker.unlock();
+      finish_pending_snapshot_pruning();
+    }
+  }
 
   auto ctx = create_async_context_callback(
     m_threads->work_queue, create_context_callback<

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -130,6 +130,7 @@ private:
 
   bool m_check_creating_snaps = true; // check and identify creating snaps just after restart
   bool m_resync_requested = false;
+  std::set<std::string> m_pruning_group_snaps_inflight;
 
   bool is_replay_interrupted(std::unique_lock<ceph::mutex>* locker);
 
@@ -252,6 +253,8 @@ private:
   void prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_mirror_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  void remove_group_snapshot(const cls::rbd::GroupSnapshot *local_snap);
+  void finish_pending_snapshot_pruning();
   void prune_creating_group_snapshots_if_any(
       std::unique_lock<ceph::mutex>* locker);
   void handle_prune_creating_group_snapshots_if_any(


### PR DESCRIPTION
This PR adds test cases to check unlinking and removal of image and group snapshots.
NOTE:
This PR has dependency on other two PRs (i.e. first 2 commits). 
Please review last commit for now:
b916eec9631e2a048dd95f9ae7ce12b30f6cc0fb

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
