### PR TITLE
crimson/seastore: fixing some 'unused' warnings

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -238,6 +238,8 @@ public:
         assert(parent->is_valid());
         assert(parent->get_node_meta().is_parent_of(child_meta));
         assert(parent->is_viewable_by_trans(c.trans).first);
+        std::ignore = c;
+        std::ignore = this;
         auto iter = parent->upper_bound(child_meta.begin);
         assert(iter != parent->begin());
         --iter;
@@ -562,6 +564,7 @@ public:
         "ret.leaf.pos {}",
         c.trans,
         ret.leaf.pos);
+      std::ignore = min_depth;
 #ifndef NDEBUG
       if (min_depth == 1) {
         ret.assert_valid();
@@ -1711,6 +1714,7 @@ private:
         [[maybe_unused]] auto &cnode = (typename internal_node_t::base_t &)*child;
         assert(cnode.get_node_meta().begin == node_iter.get_key());
         assert(cnode.get_node_meta().end > node_iter.get_key());
+        std::ignore = node_iter;
         return on_found(child->template cast<internal_node_t>());
       });
     }
@@ -1782,6 +1786,7 @@ private:
         [[maybe_unused]] auto &cnode = (typename internal_node_t::base_t &)*child;
         assert(cnode.get_node_meta().begin == node_iter.get_key());
         assert(cnode.get_node_meta().end > node_iter.get_key());
+        std::ignore = node_iter;
         return on_found(child->template cast<leaf_node_t>());
       });
     }
@@ -2346,6 +2351,8 @@ private:
           *parent_pos.node,
           donor_iter.get_offset(),
           *child);
+        std::ignore = donor_is_left;
+        std::ignore = pos;
         [[maybe_unused]] auto &node = (typename internal_node_t::base_t&)*child;
         assert(donor_is_left ?
           node.get_node_meta().end == pos.node->get_node_meta().begin :

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -783,7 +783,7 @@ private:
 
     // step 2: attach extent to transaction to become visible
     assert(!read_set.count(ref->get_paddr(), extent_cmp_t{}));
-    [[maybe_unused]] auto [iter, inserted] = read_set.insert(*it);
+    [[maybe_unused]] auto [_, inserted] = read_set.insert(*it);
     assert(inserted);
   }
 
@@ -802,7 +802,7 @@ private:
     }
 
     // step 2: attach extent to transaction to become visible
-    [[maybe_unused]] auto [iter, inserted] = read_set.insert(read_items.back());
+    [[maybe_unused]] auto [_, inserted] = read_set.insert(read_items.back());
     assert(inserted);
 
     // added


### PR DESCRIPTION
in btree_types compilation. All in all - 9 warnings were removed.

Note: C++26 would allow us to mark specific capture variables as 'maybe_unsued'. We would be able then to clean this code.
C++26 would also introduce '_' as a multi-use, always-maybe-unused, placeholder, cleaning the code below even more.