### PR TITLE
squid: qa/tasks/cephadm: override container image tags

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -2200,6 +2200,16 @@ def task(ctx, config):
               username: registry-user
               password: registry-password
 
+    By default, the image tag is determined as a suite 'branch' value,
+    or 'sha1' if provided. However, the tag value can be overridden by
+    including ':TAG' or '@DIGEST' in the container image name, for example,
+    for the tag 'latest', the 'overrides' section looks like:
+
+        overrides:
+          cephadm:
+            containers:
+              image: 'quay.io/ceph-ci/ceph:latest'
+
     :param ctx: the argparse.Namespace object
     :param config: the config dict
     """
@@ -2246,7 +2256,10 @@ def task(ctx, config):
         sha1 = config.get('sha1')
         flavor = config.get('flavor', 'default')
 
-        if sha1:
+        if any(_ in container_image_name for _ in (':', '@')):
+            log.info('Provided image contains tag or digest, using it as is')
+            ctx.ceph[cluster_name].image = container_image_name
+        elif sha1:
             if flavor == "crimson":
                 ctx.ceph[cluster_name].image = container_image_name + ':' + sha1 + '-' + flavor
             else:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75137

---

backport of https://github.com/ceph/ceph/pull/64184
parent tracker: https://tracker.ceph.com/issues/71844

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh