### PR TITLE
mgr/rbd_support: Stagger mirror group snapshot schedules

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -9,6 +9,12 @@
   Admins can no longer enable the older, deprecated landing page layout by
   adjusting FEATURE_TOGGLE_DASHBOARD.
 * CephFS: The `peer_add` command is deprecated in favor of the `peer_bootstrap` command.
+* RBD: Fixed incorrect behavior of the "start-time" argument for mirror
+  snapshot and trash purge schedules, where it previously offset the schedule
+  anchor instead of defining it. The argument now requires an ISO 8601
+  date-time. The `schedule ls` output displays the start time in UTC, including
+  the date and time in the format "%Y-%m-%d %H:%M:00". The `schedule status`
+  output now displays the next schedule time in UTC.
 
 >=20.0.0
 

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -15,9 +15,10 @@
   date-time. The `schedule ls` output displays the start time in UTC, including
   the date and time in the format "%Y-%m-%d %H:%M:00". The `schedule status`
   output now displays the next schedule time in UTC.
-* RBD: Mirror snapshot creation and trash purge schedules are now automatically
-  staggered when no explicit "start-time" is specified. This reduces scheduling
-  spikes and distributes work more evenly over time.
+* RBD: Mirror snapshot creation, mirror group snapshot creation and trash purge
+  schedules are now automatically staggered when no explicit "start-time" is
+  specified. This reduces scheduling spikes and distributes work more evenly
+  over time.
 
 >=20.0.0
 

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -15,6 +15,9 @@
   date-time. The `schedule ls` output displays the start time in UTC, including
   the date and time in the format "%Y-%m-%d %H:%M:00". The `schedule status`
   output now displays the next schedule time in UTC.
+* RBD: Mirror snapshot creation and trash purge schedules are now automatically
+  staggered when no explicit "start-time" is specified. This reduces scheduling
+  spikes and distributes work more evenly over time.
 
 >=20.0.0
 

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -1037,7 +1037,7 @@ To restore an image from trash and rename it::
 
 To create a mirror snapshot schedule for an image::
 
-       rbd mirror snapshot schedule add --pool mypool --image myimage 12h 14:00:00-05:00
+       rbd mirror snapshot schedule add --pool mypool --image myimage 12h 2020-01-14T11:30+05:30
 
 Availability
 ============

--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -428,10 +428,11 @@ image name; interval; and optional start time::
         rbd mirror snapshot schedule add [--pool {pool-name}] [--image {image-name}] {interval} [{start-time}]
 
 The ``interval`` can be specified in days, hours, or minutes using ``d``, ``h``,
-``m`` suffix respectively. The optional ``start-time`` can be specified using
-the ISO 8601 time format. For example::
+``m`` suffix respectively. The optional ``start-time`` must be specified in
+the ISO 8601 time format. If no UTC offset is provided, UTC is assumed. For
+example::
 
-        $ rbd --cluster site-a mirror snapshot schedule add --pool image-pool 24h 14:00:00-05:00
+        $ rbd --cluster site-a mirror snapshot schedule add --pool image-pool 24h 2020-01-14T11:30+05:30
         $ rbd --cluster site-a mirror snapshot schedule add --pool image-pool --image image1 6h
 
 To remove a mirror-snapshot schedules with ``rbd``, specify the
@@ -441,12 +442,13 @@ corresponding ``add`` schedule command.
 To list all snapshot schedules for a specific level (global, pool, or image)
 with ``rbd``, specify the ``mirror snapshot schedule ls`` command along with
 an optional pool or image name. Additionally, the ``--recursive`` option can
-be specified to list all schedules at the specified level and below. For
-example::
+be specified to list all schedules at the specified level and below.
+
+Schedule start times are always displayed in UTC. For example::
 
         $ rbd --cluster site-a mirror snapshot schedule ls --pool image-pool --recursive
         POOL        NAMESPACE IMAGE  SCHEDULE                            
-        image-pool  -         -      every 1d starting at 14:00:00-05:00 
+        image-pool  -         -      every 1d starting at 2020-01-14 06:00:00
         image-pool            image1 every 6h                            
 
 To view the status for when the next snapshots will be created for
@@ -456,11 +458,12 @@ image name::
 
         rbd mirror snapshot schedule status [--pool {pool-name}] [--image {image-name}]
 
-For example::
+The next schedule time is always displayed in UTC. For example::
 
         $ rbd --cluster site-a mirror snapshot schedule status
         SCHEDULE TIME       IMAGE             
-        2020-02-26 18:00:00 image-pool/image1 
+        2026-01-24 06:00:00 image-pool/image1
+
 
 Disable Image Mirroring
 -----------------------

--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -421,6 +421,10 @@ globally, per-pool, or per-image levels. Multiple mirror-snapshot schedules can
 be defined at any level, but only the most-specific snapshot schedules that
 match an individual mirrored image will run.
 
+When multiple images share the same schedule interval and no explicit
+``start-time`` is defined, snapshot creation is automatically staggered across
+the interval to reduce scheduling spikes.
+
 To create a mirror-snapshot schedule with ``rbd``, specify the
 ``mirror snapshot schedule add`` command along with an optional pool or
 image name; interval; and optional start time::

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1167,12 +1167,21 @@ test_trash_purge_schedule() {
     expect_fail rbd trash purge schedule remove -p rbd dummy
     expect_fail rbd trash purge schedule remove -p rbd 1d dummy
 
-    rbd trash purge schedule add -p rbd 1d 01:30
+    rbd trash purge schedule add -p rbd 1h 2100-01-01T19:00Z
+    test "$(rbd trash purge schedule ls -p rbd)" = 'every 1h starting at 2100-01-01 19:00:00'
+    for i in `seq 12`; do
+        rbd trash purge schedule status -p rbd | grep '2100-01-01 19:00:00' && break
+        sleep 10
+    done
+    test "$(rbd trash purge schedule status -p rbd --format xml |
+        xmlstarlet sel -t -v '//scheduled/item/schedule_time')" = '2100-01-01 19:00:00'
+    rbd trash purge schedule rm -p rbd
 
-    rbd trash purge schedule ls -p rbd | grep 'every 1d starting at 01:30'
+    rbd trash purge schedule add -p rbd 1d 2020-01-14T07:00+05:30
+    rbd trash purge schedule ls -p rbd | grep 'every 1d starting at 2020-01-14 01:30:00'
     expect_fail rbd trash purge schedule ls
-    rbd trash purge schedule ls -R | grep 'every 1d starting at 01:30'
-    rbd trash purge schedule ls -R -p rbd | grep 'every 1d starting at 01:30'
+    rbd trash purge schedule ls -R | grep 'every 1d starting at 2020-01-14 01:30:00'
+    rbd trash purge schedule ls -R -p rbd | grep 'every 1d starting at 2020-01-14 01:30:00'
     expect_fail rbd trash purge schedule ls -p rbd2
     test "$(rbd trash purge schedule ls -p rbd2 -R --format json)" = "[]"
 
@@ -1193,18 +1202,18 @@ test_trash_purge_schedule() {
     test "$(rbd trash purge schedule status -p rbd --format xml |
         xmlstarlet sel -t -v '//scheduled/item/pool')" = 'rbd'
 
-    rbd trash purge schedule add 2d 00:17
-    rbd trash purge schedule ls | grep 'every 2d starting at 00:17'
-    rbd trash purge schedule ls -R | grep 'every 2d starting at 00:17'
+    rbd trash purge schedule add 2d 2020-01-14T05:47+05:30
+    rbd trash purge schedule ls | grep 'every 2d starting at 2020-01-14 00:17:00'
+    rbd trash purge schedule ls -R | grep 'every 2d starting at 2020-01-14 00:17:00'
     expect_fail rbd trash purge schedule ls -p rbd2
-    rbd trash purge schedule ls -p rbd2 -R | grep 'every 2d starting at 00:17'
-    rbd trash purge schedule ls -p rbd2/ns1 -R | grep 'every 2d starting at 00:17'
+    rbd trash purge schedule ls -p rbd2 -R | grep 'every 2d starting at 2020-01-14 00:17:00'
+    rbd trash purge schedule ls -p rbd2/ns1 -R | grep 'every 2d starting at 2020-01-14 00:17:00'
     test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
         xmlstarlet sel -t -v '//schedules/schedule/pool')" = "-"
     test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
         xmlstarlet sel -t -v '//schedules/schedule/namespace')" = "-"
     test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
-        xmlstarlet sel -t -v '//schedules/schedule/items/item/start_time')" = "00:17:00"
+        xmlstarlet sel -t -v '//schedules/schedule/items/item/start_time')" = "2020-01-14 00:17:00"
 
     for i in `seq 12`; do
         rbd trash purge schedule status --format xml |
@@ -1222,18 +1231,18 @@ test_trash_purge_schedule() {
         xmlstarlet sel -t -v '//scheduled/item/pool'))" = 'rbd2 rbd2'
 
     test "$(echo $(rbd trash purge schedule ls -R --format xml |
-        xmlstarlet sel -t -v '//schedules/schedule/items'))" = "2d00:17:00 1d01:30:00"
+        xmlstarlet sel -t -v '//schedules/schedule/items/item'))" = "2d2020-01-14 00:17:00 1d2020-01-14 01:30:00"
 
     rbd trash purge schedule add 1d
-    rbd trash purge schedule ls | grep 'every 2d starting at 00:17'
+    rbd trash purge schedule ls | grep 'every 2d starting at 2020-01-14 00:17:00'
     rbd trash purge schedule ls | grep 'every 1d'
 
     rbd trash purge schedule ls -R --format xml |
-        xmlstarlet sel -t -v '//schedules/schedule/items' | grep '2d00:17'
+        xmlstarlet sel -t -v '//schedules/schedule/items' | grep '2d2020-01-14 00:17:00'
 
     rbd trash purge schedule rm 1d
-    rbd trash purge schedule ls | grep 'every 2d starting at 00:17'
-    rbd trash purge schedule rm 2d 00:17
+    rbd trash purge schedule ls | grep 'every 2d starting at 2020-01-14 00:17:00'
+    rbd trash purge schedule rm 2d 2020-01-14T00:17:00
     expect_fail rbd trash purge schedule ls
 
     for p in rbd2 rbd2/ns1; do
@@ -1272,9 +1281,17 @@ test_trash_purge_schedule() {
     expect_fail rbd trash purge schedule remove -p rbd 1d dummy
     expect_fail rbd trash purge schedule remove dummy
     expect_fail rbd trash purge schedule remove 1d dummy
-    rbd trash purge schedule ls -p rbd | grep 'every 1d starting at 01:30'
+    expect_fail rbd trash purge schedule add -p rbd 30m 00:15
+    expect_fail rbd trash purge schedule add -p rbd 30m 00:15+05:30
+    expect_fail rbd trash purge schedule add -p rbd 30m 2020-13-14T00:15+05:30
+    expect_fail rbd trash purge schedule add -p rbd 30m 2020-01-32T00:15+05:30
+    expect_fail rbd trash purge schedule add -p rbd 30m 2020-01-14T25:15+05:30
+    expect_fail rbd trash purge schedule add -p rbd 30m 2020-01-14T00:60+05:30
+    expect_fail rbd trash purge schedule add -p rbd 30m 2020-01-14T00:15+24:00
+
+    rbd trash purge schedule ls -p rbd | grep 'every 1d starting at 2020-01-14 01:30:00'
     rbd trash purge schedule ls | grep 'every 2m'
-    rbd trash purge schedule remove -p rbd 1d 01:30
+    rbd trash purge schedule remove -p rbd 1d 2020-01-14T01:30
     rbd trash purge schedule remove 2m
     test "$(rbd trash purge schedule ls -R --format json)" = "[]"
 
@@ -1352,6 +1369,16 @@ test_mirror_snapshot_schedule() {
     expect_fail rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 dummy
     expect_fail rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 1h dummy
 
+    rbd mirror snapshot schedule add -p rbd2/ns1 1h 2100-01-01T19:00Z
+    test "$(rbd mirror snapshot schedule ls -p rbd2/ns1)" = 'every 1h starting at 2100-01-01 19:00:00'
+    for i in `seq 12`; do
+        rbd mirror snapshot schedule status -p rbd2/ns1 | grep '2100-01-01 19:00:00' && break
+        sleep 10
+    done
+    test "$(rbd mirror snapshot schedule status -p rbd2/ns1 --format xml |
+        xmlstarlet sel -t -v '//scheduled_images/image/schedule_time')" = '2100-01-01 19:00:00'
+    rbd mirror snapshot schedule rm -p rbd2/ns1
+
     rbd mirror snapshot schedule add -p rbd2/ns1 --image test1 1m
     expect_fail rbd mirror snapshot schedule ls
     rbd mirror snapshot schedule ls -R | grep 'rbd2 *ns1 *test1 *every 1m'
@@ -1403,16 +1430,15 @@ test_mirror_snapshot_schedule() {
     done
     rbd mirror snapshot schedule status | grep 'rbd2/ns1/test1'
 
-    # set a global level mirror image snapshot schedule
-    rbd mirror snapshot schedule add 1h 00:15
-    test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 00:15:00'
-    rbd mirror snapshot schedule ls -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror snapshot schedule add 1h 2020-01-14T04:30+05:30
+    test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 2020-01-13 23:00:00'
+    rbd mirror snapshot schedule ls -R | grep 'every 1h starting at 2020-01-13 23:00:00'
     rbd mirror snapshot schedule ls -R | grep 'rbd2 *ns1 *test1 *every 1m'
     expect_fail rbd mirror snapshot schedule ls -p rbd2
-    rbd mirror snapshot schedule ls -p rbd2 -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror snapshot schedule ls -p rbd2 -R | grep 'every 1h starting at 2020-01-13 23:00:00'
     rbd mirror snapshot schedule ls -p rbd2 -R | grep 'rbd2 *ns1 *test1 *every 1m'
     expect_fail rbd mirror snapshot schedule ls -p rbd2/ns1
-    rbd mirror snapshot schedule ls -p rbd2/ns1 -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror snapshot schedule ls -p rbd2/ns1 -R | grep 'every 1h starting at 2020-01-13 23:00:00'
     rbd mirror snapshot schedule ls -p rbd2/ns1 -R | grep 'rbd2 *ns1 *test1 *every 1m'
     test "$(rbd mirror snapshot schedule ls -p rbd2/ns1 --image test1)" = 'every 1m'
 
@@ -1425,7 +1451,14 @@ test_mirror_snapshot_schedule() {
     expect_fail rbd mirror snapshot schedule remove 1h dummy
     expect_fail rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 dummy
     expect_fail rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 1h dummy
-    test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 00:15:00'
+    expect_fail rbd mirror snapshot schedule add 30m 04:30
+    expect_fail rbd mirror snapshot schedule add 30m 04:30+05:30
+    expect_fail rbd mirror snapshot schedule add 30m 2020-13-14T04:30+05:30
+    expect_fail rbd mirror snapshot schedule add 30m 2020-01-32T04:30+05:30
+    expect_fail rbd mirror snapshot schedule add 30m 2020-01-14T25:30+05:30
+    expect_fail rbd mirror snapshot schedule add 30m 2020-01-14T04:60+05:30
+    expect_fail rbd mirror snapshot schedule add 30m 2020-01-14T04:30+24:00
+    test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 2020-01-13 23:00:00'
     test "$(rbd mirror snapshot schedule ls -p rbd2/ns1 --image test1)" = 'every 1m'
 
     rbd create $RBD_CREATE_ARGS -s 1 rbd2/ns1/img1

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1897,6 +1897,16 @@ test_mirror_group_snapshot_schedule() {
 
     test "$(rbd group snap ls rbd2/ns1/gp1 | grep -c mirror.primary)" = '1'
 
+    rbd mirror group snapshot schedule add -p rbd2/ns1 1h 2100-01-01T19:00Z
+    test "$(rbd mirror group snapshot schedule ls -p rbd2/ns1)" = 'every 1h starting at 2100-01-01 19:00:00'
+    for i in `seq 12`; do
+        rbd mirror group snapshot schedule status -p rbd2/ns1 | grep '2100-01-01 19:00:00' && break
+        sleep 10
+    done
+    test "$(rbd mirror group snapshot schedule status -p rbd2/ns1 --format xml |
+        xmlstarlet sel -t -v '//scheduled_groups/group/schedule_time')" = '2100-01-01 19:00:00'
+    rbd mirror group snapshot schedule rm -p rbd2/ns1
+
     rbd mirror group snapshot schedule add -p rbd2/ns1 --group gp1 1m
     expect_fail rbd mirror group snapshot schedule ls
     rbd mirror group snapshot schedule ls -R | grep 'rbd2 *ns1 *gp1 *every 1m'
@@ -1948,21 +1958,21 @@ test_mirror_group_snapshot_schedule() {
     done
     rbd mirror group snapshot schedule status | grep 'rbd2/ns1/gp1'
 
-    rbd mirror group snapshot schedule add 1h 00:15
-    test "$(rbd mirror group snapshot schedule ls)" = 'every 1h starting at 00:15:00'
-    rbd mirror group snapshot schedule ls -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror group snapshot schedule add 1h 2020-01-14T04:30+05:30
+    test "$(rbd mirror group snapshot schedule ls)" = 'every 1h starting at 2020-01-13 23:00:00'
+    rbd mirror group snapshot schedule ls -R | grep 'every 1h starting at 2020-01-13 23:00:00'
     rbd mirror group snapshot schedule ls -R | grep 'rbd2 *ns1 *gp1 *every 1m'
     expect_fail rbd mirror group snapshot schedule ls -p rbd2
-    rbd mirror group snapshot schedule ls -p rbd2 -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror group snapshot schedule ls -p rbd2 -R | grep 'every 1h starting at 2020-01-13 23:00:00'
     rbd mirror group snapshot schedule ls -p rbd2 -R | grep 'rbd2 *ns1 *gp1 *every 1m'
     expect_fail rbd mirror group snapshot schedule ls -p rbd2/ns1
-    rbd mirror group snapshot schedule ls -p rbd2/ns1 -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror group snapshot schedule ls -p rbd2/ns1 -R | grep 'every 1h starting at 2020-01-13 23:00:00'
     rbd mirror group snapshot schedule ls -p rbd2/ns1 -R | grep 'rbd2 *ns1 *gp1 *every 1m'
     test "$(rbd mirror group snapshot schedule ls -p rbd2/ns1 --group gp1)" = 'every 1m'
 
     rbd mirror group snapshot schedule remove -p rbd2/ns1 --group gp1 1m
     test "$(rbd mirror group snapshot schedule ls -p rbd2/ns1 --group gp1)" = ""
-    test "$(rbd mirror group snapshot schedule ls)" = 'every 1h starting at 00:15:00'
+    test "$(rbd mirror group snapshot schedule ls)" = 'every 1h starting at 2020-01-13 23:00:00'
 
     rbd mirror group snapshot schedule add -p rbd2/ns1 --group gp1 1m
 
@@ -1971,7 +1981,14 @@ test_mirror_group_snapshot_schedule() {
     expect_fail rbd mirror group snapshot schedule add -p rbd2/ns1 --group gp1 dummy
     expect_fail rbd mirror group snapshot schedule remove dummy
     expect_fail rbd mirror group snapshot schedule remove -p rbd2/ns1 --group gp1 dummy
-    test "$(rbd mirror group snapshot schedule ls)" = 'every 1h starting at 00:15:00'
+    expect_fail rbd mirror group snapshot schedule add 30m 04:30
+    expect_fail rbd mirror group snapshot schedule add 30m 04:30+05:30
+    expect_fail rbd mirror group snapshot schedule add 30m 2020-13-14T04:30+05:30
+    expect_fail rbd mirror group snapshot schedule add 30m 2020-01-32T04:30+05:30
+    expect_fail rbd mirror group snapshot schedule add 30m 2020-01-14T25:30+05:30
+    expect_fail rbd mirror group snapshot schedule add 30m 2020-01-14T04:60+05:30
+    expect_fail rbd mirror group snapshot schedule add 30m 2020-01-14T04:30+24:00
+    test "$(rbd mirror group snapshot schedule ls)" = 'every 1h starting at 2020-01-13 23:00:00'
     test "$(rbd mirror group snapshot schedule ls -p rbd2/ns1 --group gp1)" = 'every 1m'
 
     rbd group rm rbd2/ns1/gp1
@@ -2037,6 +2054,153 @@ test_mirror_group_snapshot_schedule_recovery() {
     rbd snap purge rbd2/ns1/img1
     rbd snap purge rbd2/ns1/img1
     rbd group rm rbd2/ns1/gp1
+    ceph osd pool rm rbd2 rbd2 --yes-i-really-really-mean-it
+}
+
+test_mirror_group_snapshot_schedule_staggering() {
+    echo "Testing mirror group snapshot schedule staggering..."
+
+    remove_images
+    ceph osd pool create rbd2 8
+    rbd pool init rbd2
+    rbd mirror pool enable rbd2 image
+    rbd mirror pool peer add rbd2 cluster1
+
+    # Initial empty check
+    test "$(ceph rbd mirror group snapshot schedule list)" = "{}"
+    ceph rbd mirror group snapshot schedule status | fgrep '"scheduled_groups": []'
+
+    # Create 80 groups
+    for i in {1..80}; do
+        rbd group create "rbd2/test$i"
+        rbd mirror group enable "rbd2/test$i" snapshot
+    done
+
+    # Helper to get status JSON and verify all groups are scheduled
+    get_mirror_group_snapshot_schedule_status() {
+        local num_scheduled=$1
+        local -n status_ref=$2
+
+        # Verify number of groups in list output
+        local list_json
+        list_json=$(rbd mirror group snapshot schedule ls -p rbd2 -R --format json)
+        [ "$(jq 'length' <<< "$list_json")" -eq "$num_scheduled" ] || return 1
+
+        # Poll status until it reflects the same number of scheduled groups
+        for ((j=0; j<12; j++)); do
+            status_ref=$(rbd mirror group snapshot schedule status -p rbd2 --format json)
+            [ "$(jq 'length' <<< "$status_ref")" -eq "$num_scheduled" ] && break
+            sleep 10
+        done
+        [ "$(jq 'length' <<< "$status_ref")" -eq "$num_scheduled" ] || return 1
+
+        # Verify groups in list and status outputs match
+        local list_groups
+        list_groups=$(jq -r 'sort_by(.group) | .[].group' <<< "$list_json")
+        # In status JSON, '.group' contains full group spec, not just the name
+        local status_groups
+        status_groups=$(
+            jq -r 'sort_by(.group) | .[].group | split("/")[-1]' <<< "$status_ref"
+        )
+        [ "$list_groups" = "$status_groups" ] || return 1
+        return 0
+    }
+
+    # Verify that `schedule add/rm` maintains proper staggering
+    local interval_min=5
+    local status_json
+    # Schedule groups test1..test60
+    for ((i=1; i<=60; i++)); do
+        rbd mirror group snapshot schedule add -p rbd2 --group "test$i" "${interval_min}m"
+    done
+    get_mirror_group_snapshot_schedule_status 60 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Modify scheduling range to test61..test70 (add 10 groups)
+    for ((i=61; i<=70; i++)); do
+        rbd mirror group snapshot schedule add -p rbd2 --group "test$i" "${interval_min}m"
+    done
+    get_mirror_group_snapshot_schedule_status 70 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Modify scheduling range to test71..test80 (add 10 more groups)
+    for ((i=70; i<=80; i++)); do
+        rbd mirror group snapshot schedule add -p rbd2 --group "test$i" "${interval_min}m"
+    done
+    get_mirror_group_snapshot_schedule_status 80 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Split into:
+    #   first half = test1..test40
+    #   second half = test41..test80
+    local first_half_json
+    first_half_json=$(jq '
+        map(select(.group | test("^rbd2/test([1-9]|[1-3][0-9]|40)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$first_half_json")" -eq 40 ] || return 1
+    local second_half_json
+    second_half_json=$(jq '
+        map(select(.group | test("^rbd2/test(4[1-9]|[5-7][0-9]|80)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$second_half_json")" -eq 40 ] || return 1
+    # Both halves must be staggered
+    are_schedules_staggered "$first_half_json" "$interval_min"
+    are_schedules_staggered "$second_half_json" "$interval_min"
+
+    # Modify scheduling range to test41..test80 (drop first half)
+    for ((i=1; i<=40; i++)); do
+        rbd mirror group snapshot schedule rm -p rbd2 --group "test$i"
+    done
+    get_mirror_group_snapshot_schedule_status 40 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Re-add schedules for first half with explicit start time.
+    # These should all share the same next schedule_time.
+    for ((i=1; i<=40; i++)); do
+        rbd mirror group snapshot schedule add -p rbd2 --group "test$i" "${interval_min}m" 2020-01-01
+    done
+    # Get updated status
+    get_mirror_group_snapshot_schedule_status 80 status_json
+
+    # Verify first half share the same next schedule_time
+    first_half_json=$(jq '
+        map(select(.group | test("^rbd2/test([1-9]|[1-3][0-9]|40)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$first_half_json")" -eq 40 ] || return 1
+    local anchored_times=()
+    mapfile -t anchored_times < <(
+        jq -r '.[].schedule_time' <<< "$first_half_json" | sort -u
+    )
+    (( ${#anchored_times[@]} == 1 )) || return 1
+
+    # Verify second half remains staggered
+    second_half_json=$(jq '
+        map(select(.group | test("^rbd2/test(4[1-9]|[5-7][0-9]|80)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$second_half_json")" -eq 40 ] || return 1
+    are_schedules_staggered "$second_half_json" "$interval_min"
+
+    # Cleanup: remove all schedules
+    for ((i=1; i<=80; i++)); do
+        rbd mirror group snapshot schedule rm -p rbd2 --group "test$i"
+    done
+
+    # Wait until schedule status becomes empty
+    for ((j=0; j<12; j++)); do
+        status_json=$(rbd mirror group snapshot schedule status -p rbd2 --format json)
+        [ "$(jq 'length' <<< "$status_json")" -eq 0 ] && break
+        sleep 10
+    done
+    [ "$(jq 'length' <<< "$status_json")" -eq 0 ] || {
+        echo "Error: mirror group snapshot schedule status not empty after removals"
+        return 1
+    }
+
+    # Remove groups
+    for ((i=1; i<=80; i++)); do
+        rbd group rm "rbd2/test$i"
+    done
+
     ceph osd pool rm rbd2 rbd2 --yes-i-really-really-mean-it
 }
 
@@ -2304,6 +2468,7 @@ test_mirror_snapshot_schedule_recovery
 test_mirror_snapshot_schedule_staggering
 test_mirror_group_snapshot_schedule
 test_mirror_group_snapshot_schedule_recovery
+test_mirror_group_snapshot_schedule_staggering
 test_perf_image_iostat
 test_perf_image_iostat_recovery
 test_mirror_pool_peer_bootstrap_create

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -25,6 +25,35 @@ remove_images() {
     done
 }
 
+# Verifies that the provided schedule status JSON represents a properly
+# staggered schedule for the given interval.
+are_schedules_staggered() {
+    # $1: Status JSON output of a scheduler in the rbd_support mgr module
+    #     (e.g. `rbd trash purge schedule status --format json`)
+    local status_json=$1
+    # $2: Schedule interval in minutes
+    local interval_min=$2
+
+    local unique_times=()
+    mapfile -t unique_times < <(jq -r '.[].schedule_time' <<< "$status_json" | sort -u)
+
+    # Expect one unique time slot per interval minute (1-minute scheduler granularity).
+    # Allow one extra time slot in case status is observed during cycle rollover
+    (( ${#unique_times[@]} == interval_min ||
+       ${#unique_times[@]} == interval_min + 1 )) || return 1
+
+    # Check that consecutive schedule times are exactly 1 minute apart
+    local prev_epoch
+    prev_epoch=$(date -d "${unique_times[0]}" +%s)
+    for ((i=1; i<${#unique_times[@]}; i++)); do
+        local curr
+        curr=$(date -d "${unique_times[i]}" +%s)
+        [ $((curr - prev_epoch)) -eq 60 ] || return 1
+        prev_epoch=$curr
+    done
+    return 0
+}
+
 test_others() {
     echo "testing import, export, resize, and snapshots..."
     TMP_FILES="/tmp/img1 /tmp/img1.new /tmp/img2 /tmp/img2.new /tmp/img3 /tmp/img3.new /tmp/img-diff1.new /tmp/img-diff2.new /tmp/img-diff3.new /tmp/img1.snap1 /tmp/img1.snap1 /tmp/img-diff1.snap1"
@@ -1336,6 +1365,146 @@ test_trash_purge_schedule_recovery() {
 
 }
 
+test_trash_purge_schedule_staggering() {
+    echo "Testing trash purge schedule staggering..."
+    remove_images
+    ceph osd pool create rbd2 8
+    rbd pool init rbd2
+
+    # Initial empty check
+    test "$(ceph rbd trash purge schedule list)" = "{}"
+    ceph rbd trash purge schedule status | fgrep '"scheduled": []'
+
+    # Create 80 namespaces
+    for i in {1..80}; do
+        rbd namespace create "rbd2/test$i"
+    done
+
+    # Helper to get status JSON and verify all namespaces are scheduled
+    get_trash_purge_schedule_status() {
+        local num_scheduled=$1
+        local -n status_ref=$2
+
+        # Verify number of namespaces in list output
+        local list_json
+        list_json=$(rbd trash purge schedule ls -p rbd2 -R --format json)
+        [ "$(jq 'length' <<< "$list_json")" -eq "$num_scheduled" ] || return 1
+
+        # Poll status until it reflects the same number of scheduled namespaces
+        for ((j=0; j<12; j++)); do
+            status_ref=$(rbd trash purge schedule status -p rbd2 --format json)
+            [ "$(jq 'length' <<< "$status_ref")" -eq "$num_scheduled" ] && break
+            sleep 10
+        done
+        [ "$(jq 'length' <<< "$status_ref")" -eq "$num_scheduled" ] || return 1
+
+        # Verify namespaces in list and status outputs match
+        local list_namespaces
+        list_namespaces=$(jq -r 'sort_by(.namespace) | .[].namespace' <<< "$list_json")
+        local status_namespaces
+        status_namespaces=$(jq -r 'sort_by(.namespace) | .[].namespace' <<< "$status_ref")
+        [ "$list_namespaces" = "$status_namespaces" ] || return 1
+        return 0
+    }
+
+    # Verify that `schedule add/rm` maintains proper staggering
+    local interval_min=5
+    local status_json
+    # Schedule namespaces test1..test60
+    for ((i=1; i<=60; i++)); do
+        rbd trash purge schedule add -p "rbd2/test$i" "${interval_min}m"
+    done
+    get_trash_purge_schedule_status 60 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Modify scheduling range to test1..test70 (add 10 namespaces)
+    for ((i=61; i<=70; i++)); do
+        rbd trash purge schedule add -p "rbd2/test$i" "${interval_min}m"
+    done
+    get_trash_purge_schedule_status 70 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Modify scheduling range to test1..test80 (add 10 more namespaces)
+    for ((i=71; i<=80; i++)); do
+        rbd trash purge schedule add -p "rbd2/test$i" "${interval_min}m"
+    done
+    get_trash_purge_schedule_status 80 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Split into:
+    #   first half = test1..test40
+    #   second half = test41..test80
+    local first_half_json
+    first_half_json=$(jq '
+        map(select(.namespace | test("^test([1-9]|[1-3][0-9]|40)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$first_half_json")" -eq 40 ] || return 1
+    local second_half_json
+    second_half_json=$(jq '
+        map(select(.namespace | test("^test(4[1-9]|[5-7][0-9]|80)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$second_half_json")" -eq 40 ] || return 1
+    # Both halves must be staggered
+    are_schedules_staggered "$first_half_json" "$interval_min"
+    are_schedules_staggered "$second_half_json" "$interval_min"
+
+    # Modify scheduling range to test41..test80 (drop first half)
+    for ((i=1; i<=40; i++)); do
+        rbd trash purge schedule rm -p "rbd2/test$i"
+    done
+    get_trash_purge_schedule_status 40 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Re-add schedules for first half with explicit start time.
+    # These should all share the same next schedule_time.
+    for ((i=1; i<=40; i++)); do
+        rbd trash purge schedule add -p "rbd2/test$i" "${interval_min}m" 2020-01-01
+    done
+    # Get updated status
+    get_trash_purge_schedule_status 80 status_json
+
+    # Verify first half share the same next schedule_time
+    first_half_json=$(jq '
+        map(select(.namespace | test("^test([1-9]|[1-3][0-9]|40)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$first_half_json")" -eq 40 ] || return 1
+    local anchored_times=()
+    mapfile -t anchored_times < <(
+        jq -r '.[].schedule_time' <<< "$first_half_json" | sort -u
+    )
+    (( ${#anchored_times[@]} == 1 )) || return 1
+
+    # Verify second half remains staggered
+    second_half_json=$(jq '
+        map(select(.namespace | test("^test(4[1-9]|[5-7][0-9]|80)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$second_half_json")" -eq 40 ] || return 1
+    are_schedules_staggered "$second_half_json" "$interval_min"
+
+    # Cleanup: remove all schedules
+    for ((i=1; i<=80; i++)); do
+        rbd trash purge schedule rm -p "rbd2/test$i"
+    done
+
+    # Wait until schedule status becomes empty
+    for ((j=0; j<12; j++)); do
+        status_json=$(rbd trash purge schedule status -p rbd2 --format json)
+        [ "$(jq 'length' <<< "$status_json")" -eq 0 ] && break
+        sleep 10
+    done
+    [ "$(jq 'length' <<< "$status_json")" -eq 0 ] || {
+        echo "Error: trash purge schedule status not empty after removals"
+        return 1
+    }
+
+    # Remove namespaces
+    for ((i=1; i<=80; i++)); do
+        rbd namespace rm "rbd2/test$i"
+    done
+
+    ceph osd pool rm rbd2 rbd2 --yes-i-really-really-mean-it
+}
+
 test_mirror_snapshot_schedule() {
     echo "testing mirror snapshot schedule..."
     remove_images
@@ -1544,6 +1713,153 @@ test_mirror_snapshot_schedule_recovery() {
     rbd snap purge rbd3/ns1/test1
     rbd rm rbd3/ns1/test1
     ceph osd pool rm rbd3 rbd3 --yes-i-really-really-mean-it
+}
+
+test_mirror_snapshot_schedule_staggering() {
+    echo "Testing mirror snapshot schedule staggering..."
+
+    remove_images
+    ceph osd pool create rbd2 8
+    rbd pool init rbd2
+    rbd mirror pool enable rbd2 image
+    rbd mirror pool peer add rbd2 cluster1
+
+    # Initial empty check
+    test "$(ceph rbd mirror snapshot schedule list)" = "{}"
+    ceph rbd mirror snapshot schedule status | fgrep '"scheduled_images": []'
+
+    # Create 80 images
+    for i in {1..80}; do
+        rbd create $RBD_CREATE_ARGS -s 1 "rbd2/test$i"
+        rbd mirror image enable "rbd2/test$i" snapshot
+    done
+
+    # Helper to get status JSON and verify all images are scheduled
+    get_mirror_snapshot_schedule_status() {
+        local num_scheduled=$1
+        local -n status_ref=$2
+
+        # Verify number of images in list output
+        local list_json
+        list_json=$(rbd mirror snapshot schedule ls -p rbd2 -R --format json)
+        [ "$(jq 'length' <<< "$list_json")" -eq "$num_scheduled" ] || return 1
+
+        # Poll status until it reflects the same number of scheduled images
+        for ((j=0; j<12; j++)); do
+            status_ref=$(rbd mirror snapshot schedule status -p rbd2 --format json)
+            [ "$(jq 'length' <<< "$status_ref")" -eq "$num_scheduled" ] && break
+            sleep 10
+        done
+        [ "$(jq 'length' <<< "$status_ref")" -eq "$num_scheduled" ] || return 1
+
+        # Verify images in list and status outputs match
+        local list_images
+        list_images=$(jq -r 'sort_by(.image) | .[].image' <<< "$list_json")
+        # In status JSON, '.image' contains full image spec, not just the name
+        local status_images
+        status_images=$(
+            jq -r 'sort_by(.image) | .[].image | split("/")[-1]' <<< "$status_ref"
+        )
+        [ "$list_images" = "$status_images" ] || return 1
+        return 0
+    }
+
+    # Verify that `schedule add/rm` maintains proper staggering
+    local interval_min=5
+    local status_json
+    # Schedule images test1..test60
+    for ((i=1; i<=60; i++)); do
+        rbd mirror snapshot schedule add -p rbd2 --image "test$i" "${interval_min}m"
+    done
+    get_mirror_snapshot_schedule_status 60 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Modify scheduling range to test61..test70 (add 10 images)
+    for ((i=61; i<=70; i++)); do
+        rbd mirror snapshot schedule add -p rbd2 --image "test$i" "${interval_min}m"
+    done
+    get_mirror_snapshot_schedule_status 70 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Modify scheduling range to test71..test80 (add 10 more images)
+    for ((i=70; i<=80; i++)); do
+        rbd mirror snapshot schedule add -p rbd2 --image "test$i" "${interval_min}m"
+    done
+    get_mirror_snapshot_schedule_status 80 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Split into:
+    #   first half = test1..test40
+    #   second half = test41..test80
+    local first_half_json
+    first_half_json=$(jq '
+        map(select(.image | test("^rbd2/test([1-9]|[1-3][0-9]|40)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$first_half_json")" -eq 40 ] || return 1
+    local second_half_json
+    second_half_json=$(jq '
+        map(select(.image | test("^rbd2/test(4[1-9]|[5-7][0-9]|80)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$second_half_json")" -eq 40 ] || return 1
+    # Both halves must be staggered
+    are_schedules_staggered "$first_half_json" "$interval_min"
+    are_schedules_staggered "$second_half_json" "$interval_min"
+
+    # Modify scheduling range to test41..test80 (drop first half)
+    for ((i=1; i<=40; i++)); do
+        rbd mirror snapshot schedule rm -p rbd2 --image "test$i"
+    done
+    get_mirror_snapshot_schedule_status 40 status_json
+    are_schedules_staggered "$status_json" "$interval_min"
+
+    # Re-add schedules for first half with explicit start time.
+    # These should all share the same next schedule_time.
+    for ((i=1; i<=40; i++)); do
+        rbd mirror snapshot schedule add -p rbd2 --image "test$i" "${interval_min}m" 2020-01-01
+    done
+    # Get updated status
+    get_mirror_snapshot_schedule_status 80 status_json
+
+    # Verify first half share the same next schedule_time
+    first_half_json=$(jq '
+        map(select(.image | test("^rbd2/test([1-9]|[1-3][0-9]|40)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$first_half_json")" -eq 40 ] || return 1
+    local anchored_times=()
+    mapfile -t anchored_times < <(
+        jq -r '.[].schedule_time' <<< "$first_half_json" | sort -u
+    )
+    (( ${#anchored_times[@]} == 1 )) || return 1
+
+    # Verify second half remains staggered
+    second_half_json=$(jq '
+        map(select(.image | test("^rbd2/test(4[1-9]|[5-7][0-9]|80)$")))
+    ' <<< "$status_json")
+    [ "$(jq 'length' <<< "$second_half_json")" -eq 40 ] || return 1
+    are_schedules_staggered "$second_half_json" "$interval_min"
+
+    # Cleanup: remove all schedules
+    for ((i=1; i<=80; i++)); do
+        rbd mirror snapshot schedule rm -p rbd2 --image "test$i"
+    done
+
+    # Wait until schedule status becomes empty
+    for ((j=0; j<12; j++)); do
+        status_json=$(rbd mirror snapshot schedule status -p rbd2 --format json)
+        [ "$(jq 'length' <<< "$status_json")" -eq 0 ] && break
+        sleep 10
+    done
+    [ "$(jq 'length' <<< "$status_json")" -eq 0 ] || {
+        echo "Error: mirror snapshot schedule status not empty after removals"
+        return 1
+    }
+
+    # Remove images
+    for ((i=1; i<=80; i++)); do
+        rbd rm "rbd2/test$i"
+    done
+
+    ceph osd pool rm rbd2 rbd2 --yes-i-really-really-mean-it
 }
 
 test_mirror_group_snapshot_schedule() {
@@ -1982,8 +2298,10 @@ test_thick_provision
 test_namespace
 test_trash_purge_schedule
 test_trash_purge_schedule_recovery
+test_trash_purge_schedule_staggering
 test_mirror_snapshot_schedule
 test_mirror_snapshot_schedule_recovery
+test_mirror_snapshot_schedule_staggering
 test_mirror_group_snapshot_schedule
 test_mirror_group_snapshot_schedule_recovery
 test_perf_image_iostat

--- a/src/pybind/mgr/rbd_support/mirror_group_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_group_snapshot_schedule.py
@@ -1,10 +1,11 @@
 import errno
 import json
 import rados
+import random
 import rbd
 import traceback
 
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import Condition, Lock, Thread
 from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
@@ -265,7 +266,7 @@ class MirrorGroupSnapshotScheduleHandler:
         self.condition = Condition(self.lock)
         self.module = module
         self.log = module.log
-        self.last_refresh_groups = datetime(1970, 1, 1)
+        self.last_refresh_groups = datetime(1970, 1, 1, tzinfo=timezone.utc)
         self.create_snapshot_requests = GroupCreateSnapshotRequests(self)
 
         self.stop_thread = False
@@ -297,7 +298,7 @@ class MirrorGroupSnapshotScheduleHandler:
                 pool_id, namespace, group_id = group_spec
                 self.create_snapshot_requests.add(pool_id, namespace, group_id)
                 with self.lock:
-                    self.enqueue(datetime.now(), pool_id, namespace, group_id)
+                    self.enqueue(datetime.now(timezone.utc), pool_id, namespace, group_id)
 
         except (rados.ConnectionShutdown, rbd.ConnectionShutdown):
             self.log.exception("MirrorGroupSnapshotScheduleHandler: client blocklisted")
@@ -308,7 +309,7 @@ class MirrorGroupSnapshotScheduleHandler:
 
     def init_schedule_queue(self) -> None:
         # schedule_time => group_spec
-        self.queue: Dict[str, List[GroupSpec]] = {}
+        self.queue: Dict[datetime, List[GroupSpec]] = {}
         # pool_id => {namespace => {group_id => group_name}}
         self.groups: Dict[str, Dict[str, Dict[str, str]]] = {}
         self.schedules = Schedules(self)
@@ -320,7 +321,7 @@ class MirrorGroupSnapshotScheduleHandler:
         self.schedules.load(namespace_validator, group_validator=group_validator)
 
     def refresh_groups(self) -> float:
-        elapsed = (datetime.now() - self.last_refresh_groups).total_seconds()
+        elapsed = (datetime.now(timezone.utc) - self.last_refresh_groups).total_seconds()
         if elapsed < self.REFRESH_DELAY_SECONDS:
             return self.REFRESH_DELAY_SECONDS - elapsed
 
@@ -332,7 +333,7 @@ class MirrorGroupSnapshotScheduleHandler:
                 self.log.debug("MirrorGroupSnapshotScheduleHandler: no schedules")
                 self.groups = {}
                 self.queue = {}
-                self.last_refresh_groups = datetime.now()
+                self.last_refresh_groups = datetime.now(timezone.utc)
                 return self.REFRESH_DELAY_SECONDS
 
         groups: Dict[str, Dict[str, Dict[str, str]]] = {}
@@ -348,7 +349,7 @@ class MirrorGroupSnapshotScheduleHandler:
             self.refresh_queue(groups)
             self.groups = groups
 
-        self.last_refresh_groups = datetime.now()
+        self.last_refresh_groups = datetime.now(timezone.utc)
         return self.REFRESH_DELAY_SECONDS
 
     def load_pool_groups(self,
@@ -400,13 +401,10 @@ class MirrorGroupSnapshotScheduleHandler:
                     pool_name, e))
 
     def rebuild_queue(self) -> None:
-        now = datetime.now()
-
         # don't remove from queue "due" groups
-        now_string = datetime.strftime(now, "%Y-%m-%d %H:%M:00")
-
+        now = datetime.now(timezone.utc)
         for schedule_time in list(self.queue):
-            if schedule_time > now_string:
+            if schedule_time > now:
                 del self.queue[schedule_time]
 
         if not self.schedules:
@@ -421,7 +419,7 @@ class MirrorGroupSnapshotScheduleHandler:
 
     def refresh_queue(self,
                       current_groups: Dict[str, Dict[str, Dict[str, str]]]) -> None:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         for pool_id in self.groups:
             for namespace in self.groups[pool_id]:
@@ -449,7 +447,8 @@ class MirrorGroupSnapshotScheduleHandler:
                     pool_id, namespace, group_id))
             return
 
-        schedule_time = schedule.next_run(now)
+        schedule_time = schedule.next_run(
+            now, "{}/{}/{}".format(pool_id, namespace, group_id))
         if schedule_time not in self.queue:
             self.queue[schedule_time] = []
         self.log.debug(
@@ -463,16 +462,15 @@ class MirrorGroupSnapshotScheduleHandler:
         if not self.queue:
             return None, 1000.0
 
-        now = datetime.now()
-        schedule_time = sorted(self.queue)[0]
+        now = datetime.now(timezone.utc)
+        schedule_time = min(self.queue)
 
-        if datetime.strftime(now, "%Y-%m-%d %H:%M:%S") < schedule_time:
-            wait_time = (datetime.strptime(schedule_time,
-                                           "%Y-%m-%d %H:%M:%S") - now)
-            return None, wait_time.total_seconds()
+        if now < schedule_time:
+            return None, (schedule_time - now).total_seconds()
 
         groups = self.queue[schedule_time]
-        group = groups.pop(0)
+        rng = random.Random(schedule_time.timestamp())
+        group = groups.pop(rng.randrange(len(groups)))
         if not groups:
             del self.queue[schedule_time]
         return group, 0.0
@@ -543,7 +541,7 @@ class MirrorGroupSnapshotScheduleHandler:
                         continue
                     group_name = self.groups[pool_id][namespace][group_id]
                     scheduled_groups.append({
-                        'schedule_time': schedule_time,
+                        'schedule_time': schedule_time.strftime("%Y-%m-%d %H:%M:00"),
                         'group': group_name
                     })
         return 0, json.dumps({'scheduled_groups': scheduled_groups},

--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -1,6 +1,7 @@
 import errno
 import json
 import rados
+import random
 import rbd
 import traceback
 
@@ -525,7 +526,8 @@ class MirrorSnapshotScheduleHandler:
                     pool_id, namespace, image_id))
             return
 
-        schedule_time = schedule.next_run(now)
+        schedule_time = schedule.next_run(
+            now, "{}/{}/{}".format(pool_id, namespace, image_id))
         if schedule_time not in self.queue:
             self.queue[schedule_time] = []
         self.log.debug(
@@ -546,7 +548,8 @@ class MirrorSnapshotScheduleHandler:
             return None, (schedule_time - now).total_seconds()
 
         images = self.queue[schedule_time]
-        image = images.pop(0)
+        rng = random.Random(schedule_time.timestamp())
+        image = images.pop(rng.randrange(len(images)))
         if not images:
             del self.queue[schedule_time]
         return image, 0.0

--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -4,7 +4,7 @@ import rados
 import rbd
 import traceback
 
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import Condition, Lock, Thread
 from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
@@ -341,7 +341,7 @@ class MirrorSnapshotScheduleHandler:
         self.condition = Condition(self.lock)
         self.module = module
         self.log = module.log
-        self.last_refresh_images = datetime(1970, 1, 1)
+        self.last_refresh_images = datetime(1970, 1, 1, tzinfo=timezone.utc)
         self.create_snapshot_requests = CreateSnapshotRequests(self)
 
         self.stop_thread = False
@@ -373,7 +373,7 @@ class MirrorSnapshotScheduleHandler:
                 pool_id, namespace, image_id = image_spec
                 self.create_snapshot_requests.add(pool_id, namespace, image_id)
                 with self.lock:
-                    self.enqueue(datetime.now(), pool_id, namespace, image_id)
+                    self.enqueue(datetime.now(timezone.utc), pool_id, namespace, image_id)
 
         except (rados.ConnectionShutdown, rbd.ConnectionShutdown):
             self.log.exception("MirrorSnapshotScheduleHandler: client blocklisted")
@@ -384,7 +384,7 @@ class MirrorSnapshotScheduleHandler:
 
     def init_schedule_queue(self) -> None:
         # schedule_time => image_spec
-        self.queue: Dict[str, List[ImageSpec]] = {}
+        self.queue: Dict[datetime, List[ImageSpec]] = {}
         # pool_id => {namespace => image_id}
         self.images: Dict[str, Dict[str, Dict[str, str]]] = {}
         self.schedules = Schedules(self)
@@ -396,7 +396,7 @@ class MirrorSnapshotScheduleHandler:
         self.schedules.load(namespace_validator, image_validator)
 
     def refresh_images(self) -> float:
-        elapsed = (datetime.now() - self.last_refresh_images).total_seconds()
+        elapsed = (datetime.now(timezone.utc) - self.last_refresh_images).total_seconds()
         if elapsed < self.REFRESH_DELAY_SECONDS:
             return self.REFRESH_DELAY_SECONDS - elapsed
 
@@ -408,7 +408,7 @@ class MirrorSnapshotScheduleHandler:
                 self.log.debug("MirrorSnapshotScheduleHandler: no schedules")
                 self.images = {}
                 self.queue = {}
-                self.last_refresh_images = datetime.now()
+                self.last_refresh_images = datetime.now(timezone.utc)
                 return self.REFRESH_DELAY_SECONDS
 
         images: Dict[str, Dict[str, Dict[str, str]]] = {}
@@ -424,7 +424,7 @@ class MirrorSnapshotScheduleHandler:
             self.refresh_queue(images)
             self.images = images
 
-        self.last_refresh_images = datetime.now()
+        self.last_refresh_images = datetime.now(timezone.utc)
         return self.REFRESH_DELAY_SECONDS
 
     def load_pool_images(self,
@@ -479,13 +479,10 @@ class MirrorSnapshotScheduleHandler:
                     pool_name, e))
 
     def rebuild_queue(self) -> None:
-        now = datetime.now()
-
         # don't remove from queue "due" images
-        now_string = datetime.strftime(now, "%Y-%m-%d %H:%M:00")
-
+        now = datetime.now(timezone.utc)
         for schedule_time in list(self.queue):
-            if schedule_time > now_string:
+            if schedule_time > now:
                 del self.queue[schedule_time]
 
         if not self.schedules:
@@ -500,7 +497,7 @@ class MirrorSnapshotScheduleHandler:
 
     def refresh_queue(self,
                       current_images: Dict[str, Dict[str, Dict[str, str]]]) -> None:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         for pool_id in self.images:
             for namespace in self.images[pool_id]:
@@ -542,13 +539,11 @@ class MirrorSnapshotScheduleHandler:
         if not self.queue:
             return None, 1000.0
 
-        now = datetime.now()
-        schedule_time = sorted(self.queue)[0]
+        now = datetime.now(timezone.utc)
+        schedule_time = min(self.queue)
 
-        if datetime.strftime(now, "%Y-%m-%d %H:%M:%S") < schedule_time:
-            wait_time = (datetime.strptime(schedule_time,
-                                           "%Y-%m-%d %H:%M:%S") - now)
-            return None, wait_time.total_seconds()
+        if now < schedule_time:
+            return None, (schedule_time - now).total_seconds()
 
         images = self.queue[schedule_time]
         image = images.pop(0)
@@ -622,7 +617,7 @@ class MirrorSnapshotScheduleHandler:
                         continue
                     image_name = self.images[pool_id][namespace][image_id]
                     scheduled_images.append({
-                        'schedule_time': schedule_time,
+                        'schedule_time': schedule_time.strftime("%Y-%m-%d %H:%M:00"),
                         'image': image_name
                     })
         return 0, json.dumps({'scheduled_images': scheduled_images},

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import rados
 import rbd
@@ -379,12 +380,27 @@ class Schedule:
                start_time: Optional[StartTime] = None) -> None:
         self.items.discard((interval, start_time))
 
-    def next_run(self, now: datetime) -> datetime:
+    @staticmethod
+    def _compute_phase_offset_minutes(entity_id: str, period_minutes: int) -> int:
+        key = entity_id + "|" + str(period_minutes)
+        h = hashlib.md5(key.encode("utf-8")).hexdigest()
+        val = int(h, 16)
+        return (val % period_minutes)
+
+    def next_run(self, now: datetime, entity_id: str) -> datetime:
         schedule_time = None
 
         for interval, start_time in self.items:
             period = timedelta(minutes=interval.minutes)
-            anchor_time = start_time.dt if start_time else datetime(1970, 1, 1, tzinfo=timezone.utc)
+            if start_time:
+                anchor_time = start_time.dt
+            else:
+                phase_offset_minutes = self._compute_phase_offset_minutes(
+                    entity_id, interval.minutes)
+                anchor_time = (
+                    datetime(1970, 1, 1, tzinfo=timezone.utc)
+                    + timedelta(minutes=phase_offset_minutes)
+                )
 
             if anchor_time > now:
                 candidate_time = anchor_time

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -1,11 +1,11 @@
-import datetime
 import json
 import rados
 import rbd
 import re
 
-from dateutil.parser import parse
-from typing import cast, Any, Callable, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
+from datetime import date, datetime, timezone, timedelta
+from dateutil.parser import parse, isoparse
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
 from .common import get_rbd_pools
 if TYPE_CHECKING:
@@ -319,36 +319,45 @@ class Interval:
 
 class StartTime:
 
-    def __init__(self,
-                 hour: int,
-                 minute: int,
-                 tzinfo: Optional[datetime.tzinfo]) -> None:
-        self.time = datetime.time(hour, minute, tzinfo=tzinfo)
-        self.minutes = self.time.hour * 60 + self.time.minute
-        if self.time.tzinfo:
-            utcoffset = cast(datetime.timedelta, self.time.utcoffset())
-            self.minutes += int(utcoffset.seconds / 60)
+    def __init__(self, dt: datetime) -> None:
+        self.dt = self._to_utc(dt)
 
-    def __eq__(self, start_time: Any) -> bool:
-        return self.minutes == start_time.minutes
+    @staticmethod
+    def _to_utc(dt: datetime) -> datetime:
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc, second=0, microsecond=0)
+        return dt.astimezone(timezone.utc).replace(second=0, microsecond=0)
+
+    def __eq__(self, other: Any) -> bool:
+        return self.dt == other.dt
 
     def __hash__(self) -> int:
-        return hash(self.minutes)
+        return hash(self.dt)
 
     def to_string(self) -> str:
-        return self.time.isoformat()
+        return self.dt.strftime("%Y-%m-%d %H:%M:00")
 
     @classmethod
-    def from_string(cls, start_time: Optional[str]) -> Optional['StartTime']:
+    def from_string(cls,
+                    start_time: Optional[str],
+                    allow_legacy: bool = False) -> Optional['StartTime']:
         if not start_time:
             return None
 
         try:
-            t = parse(start_time).timetz()
+            dt = isoparse(start_time)
         except ValueError as e:
-            raise ValueError("Invalid start time {}: {}".format(start_time, e))
+            if not allow_legacy:
+                raise ValueError("Invalid start time {}: {}".format(start_time, e))
 
-        return StartTime(t.hour, t.minute, tzinfo=t.tzinfo)
+            try:
+                t = parse(start_time).timetz()
+            except ValueError as e:
+                raise ValueError("Invalid legacy start time {}: {}".format(start_time, e))
+
+            dt = datetime.combine(date(1970, 1, 1), t)
+
+        return cls(dt)
 
 
 class Schedule:
@@ -370,33 +379,35 @@ class Schedule:
                start_time: Optional[StartTime] = None) -> None:
         self.items.discard((interval, start_time))
 
-    def next_run(self, now: datetime.datetime) -> str:
+    def next_run(self, now: datetime) -> datetime:
         schedule_time = None
-        for interval, opt_start in self.items:
-            period = datetime.timedelta(minutes=interval.minutes)
-            start_time = datetime.datetime(1970, 1, 1)
-            if opt_start:
-                start = cast(StartTime, opt_start)
-                start_time += datetime.timedelta(minutes=start.minutes)
-            time = start_time + \
-                (int((now - start_time) / period) + 1) * period
-            if schedule_time is None or time < schedule_time:
-                schedule_time = time
+
+        for interval, start_time in self.items:
+            period = timedelta(minutes=interval.minutes)
+            anchor_time = start_time.dt if start_time else datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+            if anchor_time > now:
+                candidate_time = anchor_time
+            else:
+                q, r = divmod(now - anchor_time, period)
+                candidate_time = anchor_time + (q + bool(r)) * period
+
+            if schedule_time is None or candidate_time < schedule_time:
+                schedule_time = candidate_time
+
         if schedule_time is None:
             raise ValueError('no items is added')
-        return datetime.datetime.strftime(schedule_time, "%Y-%m-%d %H:%M:00")
+
+        return schedule_time
 
     def to_list(self) -> List[Dict[str, Optional[str]]]:
-        def item_to_dict(interval: Interval,
-                         start_time: Optional[StartTime]) -> Dict[str, Optional[str]]:
-            if start_time:
-                schedule_start_time: Optional[str] = start_time.to_string()
-            else:
-                schedule_start_time = None
-            return {SCHEDULE_INTERVAL: interval.to_string(),
-                    SCHEDULE_START_TIME: schedule_start_time}
-        return [item_to_dict(interval, start_time)
-                for interval, start_time in self.items]
+        return [
+            {
+                SCHEDULE_INTERVAL: interval.to_string(),
+                SCHEDULE_START_TIME: start_time.to_string() if start_time else None
+            }
+            for interval, start_time in self.items
+        ]
 
     def to_json(self) -> str:
         return json.dumps(self.to_list(), indent=4, sort_keys=True)
@@ -408,8 +419,9 @@ class Schedule:
             schedule = Schedule(name)
             for item in items:
                 interval = Interval.from_string(item[SCHEDULE_INTERVAL])
-                start_time = item[SCHEDULE_START_TIME] and \
-                    StartTime.from_string(item[SCHEDULE_START_TIME]) or None
+                # Allow loading 'start_time' values in legacy format for backwards compatibility
+                start_time = StartTime.from_string(
+                    item.get(SCHEDULE_START_TIME), allow_legacy=True)
                 schedule.add(interval, start_time)
             return schedule
         except json.JSONDecodeError as e:

--- a/src/pybind/mgr/rbd_support/trash_purge_schedule.py
+++ b/src/pybind/mgr/rbd_support/trash_purge_schedule.py
@@ -3,7 +3,7 @@ import rados
 import rbd
 import traceback
 
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import Condition, Lock, Thread
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -21,7 +21,7 @@ class TrashPurgeScheduleHandler:
         self.condition = Condition(self.lock)
         self.module = module
         self.log = module.log
-        self.last_refresh_pools = datetime(1970, 1, 1)
+        self.last_refresh_pools = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
         self.stop_thread = False
         self.thread = Thread(target=self.run)
@@ -51,7 +51,7 @@ class TrashPurgeScheduleHandler:
                 pool_id, namespace = ns_spec
                 self.trash_purge(pool_id, namespace)
                 with self.lock:
-                    self.enqueue(datetime.now(), pool_id, namespace)
+                    self.enqueue(datetime.now(timezone.utc), pool_id, namespace)
 
         except (rados.ConnectionShutdown, rbd.ConnectionShutdown):
             self.log.exception("TrashPurgeScheduleHandler: client blocklisted")
@@ -64,7 +64,7 @@ class TrashPurgeScheduleHandler:
         try:
             with self.module.rados.open_ioctx2(int(pool_id)) as ioctx:
                 ioctx.set_namespace(namespace)
-                rbd.RBD().trash_purge(ioctx, datetime.now())
+                rbd.RBD().trash_purge(ioctx, datetime.now(timezone.utc))
         except (rados.ConnectionShutdown, rbd.ConnectionShutdown):
             raise
         except Exception as e:
@@ -72,7 +72,7 @@ class TrashPurgeScheduleHandler:
                 pool_id, namespace, e))
 
     def init_schedule_queue(self) -> None:
-        self.queue: Dict[str, List[Tuple[str, str]]] = {}
+        self.queue: Dict[datetime, List[Tuple[str, str]]] = {}
         # pool_id => {namespace => pool_name}
         self.pools: Dict[str, Dict[str, str]] = {}
         self.schedules = Schedules(self)
@@ -84,7 +84,7 @@ class TrashPurgeScheduleHandler:
         self.schedules.load()
 
     def refresh_pools(self) -> float:
-        elapsed = (datetime.now() - self.last_refresh_pools).total_seconds()
+        elapsed = (datetime.now(timezone.utc) - self.last_refresh_pools).total_seconds()
         if elapsed < self.REFRESH_DELAY_SECONDS:
             return self.REFRESH_DELAY_SECONDS - elapsed
 
@@ -96,7 +96,7 @@ class TrashPurgeScheduleHandler:
                 self.log.debug("TrashPurgeScheduleHandler: no schedules")
                 self.pools = {}
                 self.queue = {}
-                self.last_refresh_pools = datetime.now()
+                self.last_refresh_pools = datetime.now(timezone.utc)
                 return self.REFRESH_DELAY_SECONDS
 
         pools: Dict[str, Dict[str, str]] = {}
@@ -112,7 +112,7 @@ class TrashPurgeScheduleHandler:
             self.refresh_queue(pools)
             self.pools = pools
 
-        self.last_refresh_pools = datetime.now()
+        self.last_refresh_pools = datetime.now(timezone.utc)
         return self.REFRESH_DELAY_SECONDS
 
     def load_pool(self, ioctx: rados.Ioctx, pools: Dict[str, Dict[str, str]]) -> None:
@@ -137,13 +137,10 @@ class TrashPurgeScheduleHandler:
             pools[pool_id][namespace] = pool_name
 
     def rebuild_queue(self) -> None:
-        now = datetime.now()
-
         # don't remove from queue "due" images
-        now_string = datetime.strftime(now, "%Y-%m-%d %H:%M:00")
-
+        now = datetime.now(timezone.utc)
         for schedule_time in list(self.queue):
-            if schedule_time > now_string:
+            if schedule_time > now:
                 del self.queue[schedule_time]
 
         if not self.schedules:
@@ -156,7 +153,7 @@ class TrashPurgeScheduleHandler:
         self.condition.notify()
 
     def refresh_queue(self, current_pools: Dict[str, Dict[str, str]]) -> None:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         for pool_id, namespaces in self.pools.items():
             for namespace in namespaces:
@@ -194,13 +191,11 @@ class TrashPurgeScheduleHandler:
         if not self.queue:
             return None, 1000.0
 
-        now = datetime.now()
-        schedule_time = sorted(self.queue)[0]
+        now = datetime.now(timezone.utc)
+        schedule_time = min(self.queue)
 
-        if datetime.strftime(now, "%Y-%m-%d %H:%M:%S") < schedule_time:
-            wait_time = (datetime.strptime(schedule_time,
-                                           "%Y-%m-%d %H:%M:%S") - now)
-            return None, wait_time.total_seconds()
+        if now < schedule_time:
+            return None, (schedule_time - now).total_seconds()
 
         namespaces = self.queue[schedule_time]
         namespace = namespaces.pop(0)
@@ -273,7 +268,7 @@ class TrashPurgeScheduleHandler:
                         continue
                     pool_name = self.pools[pool_id][namespace]
                     scheduled.append({
-                        'schedule_time': schedule_time,
+                        'schedule_time': schedule_time.strftime("%Y-%m-%d %H:%M:00"),
                         'pool_id': pool_id,
                         'pool_name': pool_name,
                         'namespace': namespace

--- a/src/pybind/mgr/rbd_support/trash_purge_schedule.py
+++ b/src/pybind/mgr/rbd_support/trash_purge_schedule.py
@@ -1,5 +1,6 @@
 import json
 import rados
+import random
 import rbd
 import traceback
 
@@ -177,7 +178,8 @@ class TrashPurgeScheduleHandler:
                     pool_id, namespace))
             return
 
-        schedule_time = schedule.next_run(now)
+        schedule_time = schedule.next_run(now,
+                                          "{}/{}".format(pool_id, namespace))
         if schedule_time not in self.queue:
             self.queue[schedule_time] = []
         self.log.debug(
@@ -198,7 +200,8 @@ class TrashPurgeScheduleHandler:
             return None, (schedule_time - now).total_seconds()
 
         namespaces = self.queue[schedule_time]
-        namespace = namespaces.pop(0)
+        rng = random.Random(schedule_time.timestamp())
+        namespace = namespaces.pop(rng.randrange(len(namespaces)))
         if not namespaces:
             del self.queue[schedule_time]
         return namespace, 0.0


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
