### PR TITLE
tentacle: mgr/dashboard: create-namespace-form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -285,6 +285,11 @@ const routes: Routes = [
     children: [
       { path: '', redirectTo: 'subsystems', pathMatch: 'full' },
       {
+        path: `namespaces/${URLVerbs.CREATE}`,
+        component: NvmeofNamespacesFormComponent,
+        data: { breadcrumbs: ActionLabels.CREATE + ' ' + $localize`Namespace` }
+      },
+      {
         path: 'subsystems',
         component: NvmeofSubsystemsComponent,
         data: { breadcrumbs: 'Subsystems' },
@@ -306,12 +311,12 @@ const routes: Routes = [
           {
             path: `${URLVerbs.CREATE}/:subsystem_nqn/namespace`,
             component: NvmeofNamespacesFormComponent,
-            outlet: 'modal'
+            data: { breadcrumbs: ActionLabels.CREATE + ' ' + $localize`Namespace` }
           },
           {
             path: `${URLVerbs.EDIT}/:subsystem_nqn/namespace/:nsid`,
             component: NvmeofNamespacesFormComponent,
-            outlet: 'modal'
+            data: { breadcrumbs: ActionLabels.EDIT + ' ' + $localize`Namespace` }
           },
           // initiators
           {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.spec.ts
@@ -1,10 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { NvmeofGatewayComponent } from './nvmeof-gateway.component';
 import { NvmeofService } from '../../../shared/api/nvmeof.service';
 import { HttpClientModule } from '@angular/common/http';
 import { SharedModule } from '~/app/shared/shared.module';
-import { ComboBoxModule, GridModule } from 'carbon-components-angular';
+import { ComboBoxModule, GridModule, TabsModule } from 'carbon-components-angular';
 import { NvmeofTabsComponent } from '../nvmeof-tabs/nvmeof-tabs.component';
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
@@ -116,10 +117,16 @@ describe('NvmeofGatewayComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NvmeofGatewayComponent, NvmeofTabsComponent],
-      imports: [HttpClientModule, SharedModule, ComboBoxModule, GridModule],
+      imports: [HttpClientModule, SharedModule, ComboBoxModule, GridModule, TabsModule],
       providers: [
         { provide: NvmeofService, useClass: MockNvmeOfService },
-        { provide: CephServiceService, useClass: MockCephServiceService }
+        { provide: CephServiceService, useClass: MockCephServiceService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({})
+          }
+        }
       ]
     }).compileComponents();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
@@ -46,14 +46,14 @@ describe('NvmeofInitiatorsFormComponent', () => {
   describe('should test form', () => {
     beforeEach(() => {
       nvmeofService = TestBed.inject(NvmeofService);
-      spyOn(nvmeofService, 'addInitiators').and.stub();
+      spyOn(nvmeofService, 'addSubsystemInitiators').and.stub();
     });
 
     it('should be creating request correctly', () => {
       const subsystemNQN = 'nqn.2001-07.com.ceph:' + mockTimestamp;
       component.subsystemNQN = subsystemNQN;
       component.onSubmit();
-      expect(nvmeofService.addInitiators).toHaveBeenCalledWith(subsystemNQN, {
+      expect(nvmeofService.addSubsystemInitiators).toHaveBeenCalledWith(subsystemNQN, {
         host_nqn: ''
       });
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
@@ -3,6 +3,7 @@ import { UntypedFormArray, UntypedFormControl, Validators } from '@angular/forms
 
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
+import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { Permission } from '~/app/shared/models/permissions';
@@ -126,7 +127,7 @@ export class NvmeofInitiatorsFormComponent implements OnInit {
         task: new FinishedTask(taskUrl, {
           nqn: this.subsystemNQN
         }),
-        call: this.nvmeofService.addInitiators(this.subsystemNQN, request)
+        call: this.nvmeofService.addSubsystemInitiators(this.subsystemNQN, request)
       })
       .subscribe({
         error() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
@@ -1,115 +1,370 @@
-<cd-modal [pageURL]="pageURL"
-          [modalRef]="activeModal">
-  <span class="modal-title"
-        i18n>{{ action | titlecase }} {{ resource | upperFirst }}</span>
-  <ng-container class="modal-content">
-    <form name="nsForm"
-          #formDir="ngForm"
-          [formGroup]="nsForm"
-          novalidate>
-      <div class="modal-body">
-        <!-- Block Pool -->
-        <div class="form-group row">
-          <label class="cd-col-form-label"
-                 for="pool">
-            <span [ngClass]="{'required': !edit}"
-                  i18n>Pool</span>
-          </label>
-          <div class="cd-col-form-input">
-            <input *ngIf="edit"
-                   class="form-control"
+<form
+  [formGroup]="nsForm"
+  novalidate>
+  <div cdsGrid
+       [useCssGrid]="true"
+       [narrow]="true"
+       [fullWidth]="true">
+
+    <div cdsCol
+         [columnNumbers]="{sm: 4, md: 8}">
+      <div cdsRow
+           class="form-heading form-item">
+        <h3>{{ action | titlecase }} {{ resource | titlecase }}</h3>
+        <cd-help-text [formAllFieldsRequired]="true">
+          <span i18n>
+            Namespaces define the storage volumes that subsystems present to hosts.
+          </span>
+        </cd-help-text>
+      </div>
+
+      <!-- Namespace Count (Create only) -->
+      @if (!edit) {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-number
+            formControlName="nsCount"
+            cdValidate
+            #nsCountRef="cdValidate"
+            label="Number of namespaces"
+            helperText="No. of namespaces to generate. Value must be between 1 and 5."
+            [min]="MIN_NAMESPACE_CREATE"
+            [max]="MAX_NAMESPACE_CREATE"
+            [invalid]="nsCountRef.isInvalid"
+            [invalidText]="nsCountError"
+            i18n-label
+            i18n-helperText>
+          </cds-number>
+          <ng-template #nsCountError>
+            <ng-container *ngTemplateOutlet="validationErrors; context: { control: nsForm.get('nsCount') }"></ng-container>
+          </ng-template>
+        </div>
+      </div>
+      }
+
+      <!-- Namespace Size (sent as block_size) -->
+      @if (!edit) {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-number
+            formControlName="namespace_size"
+            cdOptionalField="Namespace size (GiB)"
+            label="Namespace size (GiB)"
+            helperText="Specify the size to expose to hosts. Leave blank for full device/file."
+            placeholder="e.g. 100"
+            [min]="0"
+            [invalid]="nsForm.controls['namespace_size'].invalid && (nsForm.controls['namespace_size'].dirty || nsForm.controls['namespace_size'].touched)"
+            invalidText="Value must be greater than or equal to 0."
+            i18n-label
+            i18n-helperText
+            i18n-invalidText>
+          </cds-number>
+        </div>
+      </div>
+      }
+
+      <!-- Host Access (drives no_auto_visible in create request) -->
+      @if (!edit) {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <legend
+            class="cds--type-label-01"
+            i18n>Host access (Initiators)</legend>
+          <div class="form-item">
+            <cds-radio-group
+              formControlName="host_access"
+              orientation="horizontal">
+              <cds-radio
+                value="all"
+                [checked]="true">
+                <div>
+                  <span
+                    class="cds--type-body-compact-01"
+                    i18n>All hosts on the subsystem</span>
+                  <span
+                    class="cds--type-helper-text-01 cds-ml-1 d-block"
+                    i18n>Allow all hosts associated with the selected subsystem to access the namespace.</span>
+                </div>
+              </cds-radio>
+              <cds-radio value="specific">
+                <div>
+                  <span
+                    class="cds--type-body-compact-01"
+                    i18n>Select specific hosts</span>
+                  <span
+                    class="cds--type-helper-text-01 cds-ml-1 d-block"
+                    i18n>Only the selected hosts will be able to access this namespace.</span>
+                </div>
+              </cds-radio>
+            </cds-radio-group>
+          </div>
+        </div>
+      </div>
+      }
+
+      <!-- Host Selection (Visible only when 'specific' is selected) -->
+      @if (!edit && nsForm.getValue('host_access') === 'specific') {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <div class="form-item">
+            <cds-combo-box
+              type="multi"
+              selectionFeedback="top-after-reopen"
+              label="Select hosts"
+              i18n-label
+              placeholder="Select one or more hosts"
+              [appendInline]="true"
+              [items]="initiatorCandidates"
+              (selected)="onInitiatorSelection($event)"
+              [invalid]="nsForm.controls['initiators'].invalid && (nsForm.controls['initiators'].dirty || nsForm.controls['initiators'].touched)"
+              invalidText="This field is required."
+              i18n-invalidText
+              i18n-placeholder>
+              <cds-dropdown-list></cds-dropdown-list>
+            </cds-combo-box>
+          </div>
+        </div>
+      </div>
+      }
+
+      <!-- Subsystem -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          @if (edit) {
+          <cds-text-label
+            label="Subsystem"
+            i18n-label>
+            <input cdsText
+                   readonly
+                   [value]="nsForm.get('subsystem').value" />
+          </cds-text-label>
+          } @else {
+          <cds-select
+            formControlName="subsystem"
+            cdValidate
+            #subsystemRef="cdValidate"
+            label="Select subsystem"
+            [invalid]="subsystemRef.isInvalid"
+            invalidText="This field is required."
+            i18n-label
+            i18n-invalidText>
+            @if (subsystems === undefined) {
+            <option
+              [ngValue]="null"
+              disabled>Loading...</option>
+            }
+            @if (subsystems && subsystems.length === 0) {
+            <option
+              [ngValue]="null"
+              disabled>-- No subsystems available --</option>
+            }
+            @if (subsystems && subsystems.length > 0) {
+            <option
+              value=""
+              selected>Select a subsystem</option>
+            }
+            @for (subsystem of subsystems; track subsystem.nqn) {
+            <option
+              [value]="subsystem.nqn">{{ subsystem.nqn }}</option>
+            }
+          </cds-select>
+          }
+        </div>
+      </div>
+
+      <!-- Pool -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          @if (edit) {
+          <cds-text-label
+            label="RBD image pool"
+            i18n-label>
+            <input cdsText
+                   readonly
+                   [value]="nsForm.get('pool').value" />
+          </cds-text-label>
+          } @else {
+          <cds-select
+            formControlName="pool"
+            cdValidate
+            #poolRef="cdValidate"
+            label="RBD image pool"
+            [invalid]="poolRef.isInvalid"
+            invalidText="This field is required."
+            helperText="Pool where the backing Ceph block device resides."
+            i18n-label
+            i18n-invalidText
+            i18n-helperText>
+            @if (rbdPools === null) {
+            <option
+              [ngValue]="null"
+              disabled>Loading...</option>
+            }
+            @if (rbdPools && rbdPools.length === 0) {
+            <option
+              [ngValue]="null"
+              disabled>-- No block pools available --</option>
+            }
+            @if (rbdPools && rbdPools.length > 0) {
+            <option
+              value=""
+              selected>Select a RBD image pool</option>
+            }
+            @for (pool of rbdPools; track pool.pool_name) {
+            <option
+              [value]="pool.pool_name">{{ pool.pool_name }}</option>
+            }
+          </cds-select>
+          }
+        </div>
+      </div>
+
+      <!-- RBD image creation (drives create_image flag in request) -->
+      @if (!edit) {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <legend
+            class="cds--type-label-01"
+            i18n>RBD image creation</legend>
+          <cds-radio-group
+            formControlName="rbd_image_creation"
+            orientation="vertical">
+            <cds-radio
+              value="gateway_provisioned"
+              i18n>Gateway-provisioned image</cds-radio>
+            <cds-radio
+              value="externally_managed"
+              [disabled]="nsForm.getValue('nsCount') > 1"
+              [title]="nsForm.getValue('nsCount') > 1 ? 'Unavailable during bulk creation. RBD images are created automatically.' : ''"
+              i18n>Externally managed image</cds-radio>
+          </cds-radio-group>
+        </div>
+      </div>
+      }
+
+      <!-- Image Name (Visible when 'gateway_provisioned' and nsCount > 1) -->
+      @if (!edit && nsForm.getValue('rbd_image_creation') === 'gateway_provisioned' && nsForm.getValue('nsCount') > 1) {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cd-alert-panel
+            type="info"
+            [dismissible]="false"
+            [showTitle]="false">
+            <strong i18n>For bulk namespace creation, RBD images are provisioned automatically.</strong>
+          </cd-alert-panel>
+
+          <div class="form-item"
+               cdOptionalField="Image name">
+            <label
+              class="cds--type-label-01 cds--label"
+              i18n>Image name</label>
+            <cds-text-label
+              helperText="Provide a name for the images. For bulk creation, this will be used as the base prefix with numeric suffixes (e.g., img-1, img-2). Leave blank to auto-generate."
+              [invalid]="rbdImageNameRef.isInvalid"
+              [invalidText]="rbdImageNameError"
+              i18n-helperText>
+              <input cdsText
+                     placeholder="Enter a name"
+                     formControlName="rbd_image_name"
+                     cdValidate
+                     #rbdImageNameRef="cdValidate"
+                     [invalid]="rbdImageNameRef.isInvalid" />
+            </cds-text-label>
+            <ng-template #rbdImageNameError>
+              <ng-container *ngTemplateOutlet="validationErrors; context: { control: nsForm.get('rbd_image_name') }"></ng-container>
+            </ng-template>
+          </div>
+        </div>
+      </div>
+      }
+
+      <!-- Image Selection (Visible only when 'externally_managed' is selected) -->
+      @if (!edit && nsForm.getValue('rbd_image_creation') === 'externally_managed') {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-select
+            formControlName="rbd_image_name"
+            cdValidate
+            #rbdImageSelectRef="cdValidate"
+            label="RBD Image"
+            [invalid]="rbdImageSelectRef.isInvalid"
+            invalidText="This field is required."
+            helperText="Select an existing RBD image from the pool to expose as a namespace."
+            i18n-label
+            i18n-invalidText
+            i18n-helperText>
+            <option
+              [ngValue]="null"
+              disabled
+              selected>Select an image</option>
+            @for (img of rbdImages; track img.name) {
+            <option
+              [value]="img.name">{{ img.name }} ({{ img.size | dimlessBinary }})</option>
+            }
+          </cds-select>
+        </div>
+      </div>
+      }
+
+      <!-- Image Size -->
+      @if (!edit && nsForm.getValue('rbd_image_creation') !== 'externally_managed') {
+      <div cdsRow
+           class="form-item">
+        <div
+          cdsCol
+          [columnNumbers]="{md: 4}">
+          <cds-text-label
+            helperText="The size of the namespace image."
+            [invalid]="imageSizeRef.isInvalid"
+            [invalidText]="sizeError"
+            i18n-helperText>
+            Image Size
+            <input cdsText
                    type="text"
-                   id="pool-edit"
-                   formControlName="pool">
-            <select *ngIf="!edit"
-                    id="pool-create"
-                    class="form-select"
-                    formControlName="pool">
-              <option *ngIf="rbdPools === null"
-                      [ngValue]="null"
-                      i18n>Loading...</option>
-              <option *ngIf="rbdPools && rbdPools.length === 0"
-                      [ngValue]="null"
-                      i18n>-- No block pools available --</option>
-              <option *ngIf="rbdPools && rbdPools.length > 0"
-                      [ngValue]="null"
-                      i18n>-- Select a pool --</option>
-              <option *ngFor="let pool of rbdPools"
-                      [value]="pool.pool_name">{{ pool.pool_name }}</option>
-            </select>
-            <cd-help-text i18n>
-              An RBD application-enabled pool where the image will be created.
-            </cd-help-text>
-            <span class="invalid-feedback"
-                  *ngIf="nsForm.showError('pool', formDir, 'required')"
-                  i18n>This field is required.</span>
-          </div>
-        </div>
-        <!-- Namespace Count -->
-        <div *ngIf="!edit"
-             class="form-group row"
-             id="namespace-count">
-          <label class="cd-col-form-label"
-                 for="nsCount">
-            <span [ngClass]="{'required': !edit}"
-                  i18n>Namespace Count</span>
-          </label>
-          <div class="cd-col-form-input">
-            <cds-number
-              formControlName="nsCount"
-              helperText="The number of namespaces to create"
-              i18n-helperText
-              [min]="MIN_NAMESPACE_CREATE"
-              [max]="MAX_NAMESPACE_CREATE"
-              [invalid]="nsForm.showError('nsCount', formDir, 'max') || nsForm.showError('nsCount', formDir, 'min') || nsForm.showError('nsCount', formDir, 'required')"
-              [invalidText]="nsForm.get('nsCount').hasError('required') ? requiredInvalidText: nsCountInvalidText"
-              size="sm"></cds-number>
-          </div>
-        </div>
-        <!-- Image Size -->
-        <div class="form-group row">
-          <label class="cd-col-form-label"
-                 for="image_size">
-            <span [ngClass]="{'required': edit}"
-                  i18n>Image Size</span>
-          </label>
-          <div class="cd-col-form-input">
-            <div class="input-group">
-              <input id="size"
-                     class="form-control"
-                     type="text"
-                     formControlName="image_size">
-              <select id="unit"
-                      class="form-input form-select"
-                      formControlName="unit">
-                <option *ngFor="let u of units"
-                        [value]="u"
-                        i18n>{{ u }}</option>
-              </select>
-              <span class="invalid-feedback"
-                    *ngIf="nsForm.showError('image_size', formDir, 'pattern')">
-                <ng-container i18n>Enter a positive integer.</ng-container>
-              </span>
-              <span class="invalid-feedback"
-                    *ngIf="edit && nsForm.showError('image_size', formDir, 'required')">
-                <ng-container i18n>This field is required</ng-container>
-              </span>
-              <span class="invalid-feedback"
-                    id="image-size-invalid"
-                    *ngIf="edit && invalidSizeError">
-                <ng-container i18n>Enter a value above than previous. A block device image can be expanded but not reduced.</ng-container>
-              </span>
-            </div>
-          </div>
+                   placeholder="e.g. 100 GiB"
+                   id="image_size"
+                   formControlName="image_size"
+                   cdValidate
+                   #imageSizeRef="cdValidate"
+                   [invalid]="imageSizeRef.isInvalid"
+                   defaultUnit="GiB"
+                   [min]="0"
+                   cdDimlessBinary>
+          </cds-text-label>
+          <ng-template #sizeError>
+            <ng-container *ngTemplateOutlet="validationErrors; context: { control: nsForm.get('image_size') }"></ng-container>
+          </ng-template>
         </div>
       </div>
-      <div class="modal-footer">
-        <div class="text-right">
-          <cd-form-button-panel (submitActionEvent)="onSubmit()"
-                                [form]="nsForm"
-                                [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
-        </div>
+      }
+
+      <div cdsRow>
+        <cd-form-button-panel
+          (submitActionEvent)="onSubmit()"
+          [form]="nsForm"
+          [submitText]="(action | titlecase) + ' ' + (resource | titlecase)"
+          wrappingClass="text-right form-button">
+        </cd-form-button-panel>
       </div>
-    </form>
-  </ng-container>
-</cd-modal>
+
+    </div>
+  </div>
+</form>
+
+<ng-template #validationErrors
+             let-control="control">
+  @if (control.errors) {
+  @for (err of control.errors | keyvalue; track err.key) {
+  <span class="invalid-feedback">{{ INVALID_TEXTS[err.key] }}</span>
+  }
+  }
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
@@ -1,24 +1,35 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import {
   NamespaceCreateRequest,
+  NamespaceInitiatorRequest,
   NamespaceUpdateRequest,
   NvmeofService
 } from '~/app/shared/api/nvmeof.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
-import { NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
+import {
+  NvmeofSubsystem,
+  NvmeofSubsystemInitiator,
+  NvmeofSubsystemNamespace,
+  NvmeofNamespaceListResponse,
+  NvmeofInitiatorCandidate,
+  NsFormField,
+  RbdImageCreation,
+  HOST_TYPE
+} from '~/app/shared/models/nvmeof';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { Pool } from '../../pool/pool';
 import { PoolService } from '~/app/shared/api/pool.service';
+import { RbdPool, RbdImage } from '~/app/shared/api/rbd.model';
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, Observable, of, Subject } from 'rxjs';
+import { filter, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { HttpResponse } from '@angular/common/http';
@@ -28,7 +39,7 @@ import { HttpResponse } from '@angular/common/http';
   templateUrl: './nvmeof-namespaces-form.component.html',
   styleUrls: ['./nvmeof-namespaces-form.component.scss']
 })
-export class NvmeofNamespacesFormComponent implements OnInit {
+export class NvmeofNamespacesFormComponent implements OnInit, OnDestroy {
   action: string;
   permission: Permission;
   poolPermission: Permission;
@@ -37,16 +48,30 @@ export class NvmeofNamespacesFormComponent implements OnInit {
   edit: boolean = false;
   nsForm: CdFormGroup;
   subsystemNQN: string;
-  rbdPools: Array<Pool> = null;
-  units: Array<string> = ['MiB', 'GiB', 'TiB'];
+  subsystems?: NvmeofSubsystem[];
+  rbdPools: Pool[] | null = null;
+  rbdImages: RbdImage[] = [];
+  initiatorCandidates: NvmeofInitiatorCandidate[] = [];
+
+  // Stores all RBD images fetched for the selected pool
+  private allRbdImages: RbdImage[] = [];
+  // Maps pool name to a Set of used image names for O(1) lookup
+  private usedRbdImages: Map<string, Set<string>> = new Map();
+  private lastSubsystemNqn: string;
+
   nsid: string;
-  currentBytes: number;
-  invalidSizeError: boolean;
+  currentBytes: number = 0;
   group: string;
   MAX_NAMESPACE_CREATE: number = 5;
   MIN_NAMESPACE_CREATE: number = 1;
-  requiredInvalidText: string = $localize`This field is required`;
-  nsCountInvalidText: string = $localize`The namespace count should be between 1 and 5`;
+  private destroy$ = new Subject<void>();
+  INVALID_TEXTS: Record<string, string> = {
+    required: $localize`This field is required.`,
+    min: $localize`The namespace count should be between 1 and 5.`,
+    max: $localize`The namespace count should be between 1 and 5.`,
+    minSize: $localize`Enter a value larger than previous. A block device image can be expanded but not reduced.`,
+    rbdImageName: $localize`Image name contains invalid characters.`
+  };
 
   constructor(
     public actionLabels: ActionLabelsI18n,
@@ -57,20 +82,28 @@ export class NvmeofNamespacesFormComponent implements OnInit {
     private rbdService: RbdService,
     private router: Router,
     private route: ActivatedRoute,
-    public activeModal: NgbActiveModal,
     public formatterService: FormatterService,
     public dimlessBinaryPipe: DimlessBinaryPipe
   ) {
     this.permission = this.authStorageService.getPermissions().nvmeof;
     this.poolPermission = this.authStorageService.getPermissions().pool;
     this.resource = $localize`Namespace`;
-    this.pageURL = 'block/nvmeof/subsystems';
+    this.pageURL = 'block/nvmeof/gateways';
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   init() {
     this.route.queryParams.subscribe((params) => {
       this.group = params?.['group'];
+      if (params?.['subsystem_nqn']) {
+        this.subsystemNQN = params?.['subsystem_nqn'];
+      }
     });
+
     this.createForm();
     this.action = this.actionLabels.CREATE;
     this.route.params.subscribe((params: { subsystem_nqn: string; nsid: string }) => {
@@ -85,23 +118,41 @@ export class NvmeofNamespacesFormComponent implements OnInit {
     this.nvmeofService
       .getNamespace(this.subsystemNQN, this.nsid, this.group)
       .subscribe((res: NvmeofSubsystemNamespace) => {
-        const convertedSize = this.dimlessBinaryPipe.transform(res.rbd_image_size).split(' ');
-        this.currentBytes = res.rbd_image_size;
-        this.nsForm.get('pool').setValue(res.rbd_pool_name);
-        this.nsForm.get('unit').setValue(convertedSize[1]);
-        this.nsForm.get('image_size').setValue(convertedSize[0]);
-        this.nsForm.get('image_size').addValidators(Validators.required);
-        this.nsForm.get('pool').disable();
+        this.currentBytes =
+          typeof res.rbd_image_size === 'string' ? Number(res.rbd_image_size) : res.rbd_image_size;
+        this.nsForm.get(NsFormField.POOL).setValue(res.rbd_pool_name);
+        this.nsForm
+          .get(NsFormField.IMAGE_SIZE)
+          .setValue(this.dimlessBinaryPipe.transform(res.rbd_image_size));
+        this.nsForm.get(NsFormField.IMAGE_SIZE).addValidators(Validators.required);
+        this.nsForm.get(NsFormField.POOL).disable();
+        this.nsForm.get(NsFormField.SUBSYSTEM).disable();
+        this.nsForm.get(NsFormField.SUBSYSTEM).setValue(this.subsystemNQN);
       });
   }
 
   initForCreate() {
     this.poolService.getList().subscribe((resp: Pool[]) => {
       this.rbdPools = resp.filter(this.rbdService.isRBDPool);
-      if (this.rbdPools?.length) {
-        this.nsForm.get('pool').setValue(this.rbdPools[0].pool_name);
-      }
     });
+    this.route.queryParams
+      .pipe(
+        filter((params) => params?.['group']),
+        tap((params) => {
+          this.group = params['group'];
+          this.fetchUsedImages();
+        }),
+        switchMap(() => this.nvmeofService.listSubsystems(this.group))
+      )
+      .subscribe((subsystems: NvmeofSubsystem[]) => {
+        this.subsystems = subsystems;
+        if (this.subsystemNQN) {
+          const selectedSubsystem = this.subsystems.find((s) => s.nqn === this.subsystemNQN);
+          if (selectedSubsystem) {
+            this.nsForm.get(NsFormField.SUBSYSTEM).setValue(selectedSubsystem.nqn);
+          }
+        }
+      });
   }
 
   ngOnInit() {
@@ -111,21 +162,195 @@ export class NvmeofNamespacesFormComponent implements OnInit {
     } else {
       this.initForCreate();
     }
+    const subsystemControl = this.nsForm.get(NsFormField.SUBSYSTEM);
+    if (subsystemControl) {
+      subsystemControl.valueChanges.subscribe((nqn: string) => {
+        this.onSubsystemChange(nqn);
+      });
+    }
+  }
+
+  onPoolChange(): void {
+    const pool = this.nsForm.getValue(NsFormField.POOL);
+    if (!pool) return;
+
+    this.rbdService
+      .list({ pool_name: pool, offset: '0', limit: '-1' })
+      .subscribe((pools: RbdPool[]) => {
+        const selectedPool = pools.find((p) => p.pool_name === pool);
+        this.allRbdImages = selectedPool?.value ?? [];
+        this.filterImages();
+
+        const imageControl = this.nsForm.get(NsFormField.RBD_IMAGE_NAME);
+        const currentImage = this.nsForm.getValue(NsFormField.RBD_IMAGE_NAME);
+        if (currentImage && !this.rbdImages.some((img) => img.name === currentImage)) {
+          imageControl.setValue(null);
+        }
+        imageControl.markAsUntouched();
+        imageControl.markAsPristine();
+      });
+  }
+
+  fetchUsedImages(): void {
+    if (!this.group) return;
+
+    this.nvmeofService
+      .listNamespaces(this.group)
+      .subscribe((response: NvmeofNamespaceListResponse) => {
+        const namespaces: NvmeofSubsystemNamespace[] = Array.isArray(response)
+          ? response
+          : response?.namespaces ?? [];
+        this.usedRbdImages = namespaces.reduce((map, ns) => {
+          if (!map.has(ns.rbd_pool_name)) {
+            map.set(ns.rbd_pool_name, new Set<string>());
+          }
+          map.get(ns.rbd_pool_name)!.add(ns.rbd_image_name);
+          return map;
+        }, new Map<string, Set<string>>());
+        this.filterImages();
+      });
+  }
+
+  onSubsystemChange(nqn: string): void {
+    if (!nqn || nqn === this.lastSubsystemNqn) return;
+    this.lastSubsystemNqn = nqn;
+    this.nvmeofService
+      .getInitiators(nqn, this.group)
+      .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
+        const initiators = Array.isArray(response) ? response : response?.hosts || [];
+        this.initiatorCandidates = initiators.map((initiator) => ({
+          content: initiator.nqn,
+          selected: false
+        }));
+      });
+  }
+
+  onInitiatorSelection(event: NvmeofInitiatorCandidate[]) {
+    // Carbon ComboBox (selected) emits the full array of selected items
+    const selectedInitiators = Array.isArray(event) ? event.map((e) => e.content) : [];
+    this.nsForm
+      .get(NsFormField.INITIATORS)
+      .setValue(selectedInitiators.length > 0 ? selectedInitiators : null);
+    this.nsForm.get(NsFormField.INITIATORS).markAsDirty();
+    this.nsForm.get(NsFormField.INITIATORS).markAsTouched();
+  }
+
+  private filterImages(): void {
+    const pool = this.nsForm.getValue(NsFormField.POOL);
+    if (!pool) {
+      this.rbdImages = [];
+      return;
+    }
+    const usedInPool = this.usedRbdImages.get(pool);
+    this.rbdImages = usedInPool
+      ? this.allRbdImages.filter((img) => !usedInPool.has(img.name))
+      : [...this.allRbdImages];
   }
 
   createForm() {
     this.nsForm = new CdFormGroup({
-      pool: new UntypedFormControl(null, {
+      [NsFormField.POOL]: new UntypedFormControl('', {
         validators: [Validators.required]
       }),
-      image_size: new UntypedFormControl(1, [CdValidators.number(false), Validators.min(1)]),
-      unit: new UntypedFormControl(this.units[1]),
-      nsCount: new UntypedFormControl(this.MAX_NAMESPACE_CREATE, [
+      [NsFormField.SUBSYSTEM]: new UntypedFormControl('', {
+        validators: [Validators.required]
+      }),
+      [NsFormField.IMAGE_SIZE]: new UntypedFormControl(null, {
+        validators: [
+          Validators.required,
+          CdValidators.custom('minSize', (value: any) => {
+            if (value !== null && value !== undefined && value !== '') {
+              const bytes = this.formatterService.toBytes(value);
+              if (
+                (!this.edit && bytes <= 0) ||
+                (this.edit && this.currentBytes && bytes <= this.currentBytes)
+              ) {
+                return { minSize: true };
+              }
+            }
+            return null;
+          })
+        ],
+        updateOn: 'blur'
+      }),
+      [NsFormField.NS_COUNT]: new UntypedFormControl(this.MAX_NAMESPACE_CREATE, [
         Validators.required,
         Validators.max(this.MAX_NAMESPACE_CREATE),
         Validators.min(this.MIN_NAMESPACE_CREATE)
-      ])
+      ]),
+      [NsFormField.RBD_IMAGE_CREATION]: new UntypedFormControl(
+        RbdImageCreation.GATEWAY_PROVISIONED
+      ),
+
+      [NsFormField.RBD_IMAGE_NAME]: new UntypedFormControl(null, [
+        CdValidators.custom('rbdImageName', (value: any) => {
+          if (!value) return null;
+          return /^[^@/]+$/.test(value) ? null : { rbdImageName: true };
+        })
+      ]),
+      [NsFormField.NAMESPACE_SIZE]: new UntypedFormControl(null, [Validators.min(0)]), // sent as block_size in create request
+      [NsFormField.HOST_ACCESS]: new UntypedFormControl(HOST_TYPE.ALL), // drives no_auto_visible in create request
+      [NsFormField.INITIATORS]: new UntypedFormControl([]) // sent via addNamespaceInitiators API
     });
+
+    this.nsForm
+      .get(NsFormField.POOL)
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.onPoolChange();
+      });
+
+    this.nsForm
+      .get(NsFormField.NS_COUNT)
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((count: number) => {
+        if (count > 1) {
+          const creationControl = this.nsForm.get(NsFormField.RBD_IMAGE_CREATION);
+          if (creationControl.value === RbdImageCreation.EXTERNALLY_MANAGED) {
+            creationControl.setValue(RbdImageCreation.GATEWAY_PROVISIONED);
+          }
+        }
+      });
+
+    this.nsForm
+      .get(NsFormField.RBD_IMAGE_CREATION)
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((mode: string) => {
+        const nameControl = this.nsForm.get(NsFormField.RBD_IMAGE_NAME);
+        const countControl = this.nsForm.get(NsFormField.NS_COUNT);
+        const imageSizeControl = this.nsForm.get(NsFormField.IMAGE_SIZE);
+
+        if (mode === RbdImageCreation.EXTERNALLY_MANAGED) {
+          countControl.setValue(1);
+          countControl.disable();
+          this.onPoolChange();
+          nameControl.addValidators(Validators.required);
+          imageSizeControl.disable();
+          imageSizeControl.removeValidators(Validators.required);
+        } else {
+          countControl.enable();
+          nameControl.removeValidators(Validators.required);
+          imageSizeControl.enable();
+          imageSizeControl.addValidators(Validators.required);
+        }
+        nameControl.updateValueAndValidity();
+        imageSizeControl.updateValueAndValidity();
+      });
+
+    this.nsForm
+      .get(NsFormField.HOST_ACCESS)
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((mode: string) => {
+        const initiatorsControl = this.nsForm.get(NsFormField.INITIATORS);
+        if (mode === HOST_TYPE.SPECIFIC) {
+          initiatorsControl.addValidators(Validators.required);
+        } else {
+          initiatorsControl.removeValidators(Validators.required);
+          initiatorsControl.setValue([]);
+          this.initiatorCandidates.forEach((i) => (i.selected = false));
+        }
+        initiatorsControl.updateValueAndValidity();
+      });
   }
 
   buildUpdateRequest(rbdImageSize: number): Observable<HttpResponse<Object>> {
@@ -144,80 +369,131 @@ export class NvmeofNamespacesFormComponent implements OnInit {
     return Math.random().toString(36).substring(2);
   }
 
-  buildCreateRequest(rbdImageSize: number, nsCount: number): Observable<HttpResponse<Object>>[] {
-    const pool = this.nsForm.getValue('pool');
+  buildCreateRequest(
+    rbdImageSize: number,
+    nsCount: number,
+    noAutoVisible: boolean
+  ): Observable<HttpResponse<Object>>[] {
+    const pool = this.nsForm.getValue(NsFormField.POOL);
     const requests: Observable<HttpResponse<Object>>[] = [];
+    const creationMode = this.nsForm.getValue(NsFormField.RBD_IMAGE_CREATION);
+    const isGatewayProvisioned = creationMode === RbdImageCreation.GATEWAY_PROVISIONED;
 
-    for (let i = 1; i <= nsCount; i++) {
+    const loopCount = isGatewayProvisioned ? nsCount : 1;
+
+    for (let i = 1; i <= loopCount; i++) {
       const request: NamespaceCreateRequest = {
         gw_group: this.group,
-        rbd_image_name: `nvme_${pool}_${this.group}_${this.randomString()}`,
         rbd_pool: pool,
-        create_image: true
+        create_image: isGatewayProvisioned,
+        no_auto_visible: noAutoVisible
       };
-      if (rbdImageSize) {
-        request['rbd_image_size'] = rbdImageSize;
+
+      const blockSize = this.nsForm.getValue(NsFormField.NAMESPACE_SIZE);
+      if (blockSize) {
+        request.block_size = blockSize;
       }
-      requests.push(this.nvmeofService.createNamespace(this.subsystemNQN, request));
+
+      if (isGatewayProvisioned) {
+        request.rbd_image_name = `nvme_${pool}_${this.group}_${this.randomString()}`;
+        if (rbdImageSize) {
+          request['rbd_image_size'] = rbdImageSize;
+        }
+      }
+
+      const rbdImageName = this.nsForm.getValue(NsFormField.RBD_IMAGE_NAME);
+      if (rbdImageName) {
+        request['rbd_image_name'] = loopCount > 1 ? `${rbdImageName}-${i}` : rbdImageName;
+      }
+
+      const subsystemNQN = this.nsForm.getValue(NsFormField.SUBSYSTEM) || this.subsystemNQN;
+      requests.push(this.nvmeofService.createNamespace(subsystemNQN, request));
     }
 
     return requests;
   }
 
-  validateSize() {
-    const unit = this.nsForm.getValue('unit');
-    const image_size = this.nsForm.getValue('image_size');
-    if (image_size && unit) {
-      const bytes = this.formatterService.toBytes(image_size + unit);
-      return bytes <= this.currentBytes;
-    }
-    return null;
-  }
-
   onSubmit() {
-    if (this.validateSize()) {
-      this.invalidSizeError = true;
+    if (this.nsForm.invalid) {
       this.nsForm.setErrors({ cdSubmitButton: true });
+      this.nsForm.markAllAsTouched();
+      return;
+    }
+
+    const component = this;
+    const taskUrl: string = `nvmeof/namespace/${this.edit ? URLVerbs.EDIT : URLVerbs.CREATE}`;
+    const image_size = this.nsForm.getValue(NsFormField.IMAGE_SIZE);
+    const nsCount = this.nsForm.getValue(NsFormField.NS_COUNT);
+    const hostAccess = this.nsForm.getValue(NsFormField.HOST_ACCESS);
+    const selectedHosts: string[] = this.nsForm.getValue(NsFormField.INITIATORS) || [];
+    const noAutoVisible = hostAccess === HOST_TYPE.SPECIFIC;
+    let action: Observable<any>;
+    let rbdImageSize: number = null;
+
+    if (image_size) {
+      rbdImageSize = this.formatterService.toBytes(image_size);
+    }
+
+    if (this.edit) {
+      action = this.taskWrapperService.wrapTaskAroundCall({
+        task: new FinishedTask(taskUrl, {
+          nqn: this.subsystemNQN,
+          nsid: this.nsid
+        }),
+        call: this.buildUpdateRequest(rbdImageSize)
+      });
     } else {
-      this.invalidSizeError = false;
-      const component = this;
-      const taskUrl: string = `nvmeof/namespace/${this.edit ? URLVerbs.EDIT : URLVerbs.CREATE}`;
-      const image_size = this.nsForm.getValue('image_size');
-      const nsCount = this.nsForm.getValue('nsCount');
-      let action: Observable<HttpResponse<Object>>;
-      let rbdImageSize: number = null;
+      const subsystemNQN = this.nsForm.getValue(NsFormField.SUBSYSTEM);
 
-      if (image_size) {
-        const image_size_unit = this.nsForm.getValue('unit');
-        const value: number = this.formatterService.toBytes(image_size + image_size_unit);
-        rbdImageSize = value;
-      }
-      if (this.edit) {
-        action = this.taskWrapperService.wrapTaskAroundCall({
-          task: new FinishedTask(taskUrl, {
-            nqn: this.subsystemNQN,
-            nsid: this.nsid
-          }),
-          call: this.buildUpdateRequest(rbdImageSize)
-        });
-      } else {
-        action = this.taskWrapperService.wrapTaskAroundCall({
-          task: new FinishedTask(taskUrl, {
-            nqn: this.subsystemNQN,
-            nsCount
-          }),
-          call: forkJoin(this.buildCreateRequest(rbdImageSize, nsCount))
-        });
-      }
+      // Step 1: Create namespaces
+      // Step 2: If specific hosts selected, chain addNamespaceInitiators calls
+      const createObs = forkJoin(this.buildCreateRequest(rbdImageSize, nsCount, noAutoVisible));
 
-      action.subscribe({
-        error() {
-          component.nsForm.setErrors({ cdSubmitButton: true });
-        },
-        complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
-        }
+      const combinedObs = createObs.pipe(
+        switchMap((responses: HttpResponse<Object>[]) => {
+          if (noAutoVisible && selectedHosts.length > 0) {
+            const initiatorObs: Observable<any>[] = [];
+
+            responses.forEach((res) => {
+              const body: any = res.body;
+              if (body && body.nsid) {
+                selectedHosts.forEach((host: string) => {
+                  const req: NamespaceInitiatorRequest = {
+                    gw_group: this.group,
+                    subsystem_nqn: subsystemNQN || this.subsystemNQN,
+                    host_nqn: host
+                  };
+                  initiatorObs.push(this.nvmeofService.addNamespaceInitiators(body.nsid, req));
+                });
+              }
+            });
+
+            if (initiatorObs.length > 0) {
+              return forkJoin(initiatorObs);
+            }
+          }
+          return of(responses);
+        })
+      );
+
+      action = this.taskWrapperService.wrapTaskAroundCall({
+        task: new FinishedTask(taskUrl, {
+          nqn: subsystemNQN,
+          nsCount
+        }),
+        call: combinedObs
       });
     }
+
+    action.subscribe({
+      error: () => {
+        component.nsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.router.navigate([this.pageURL], {
+          queryParams: { group: this.group, tab: 'namespace' }
+        });
+      }
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
@@ -4,6 +4,7 @@ import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
+
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -14,6 +15,7 @@ import { IopsPipe } from '~/app/shared/pipes/iops.pipe';
 import { MbpersecondPipe } from '~/app/shared/pipes/mbpersecond.pipe';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 
 const BASE_URL = 'block/nvmeof/subsystems';
@@ -118,12 +120,16 @@ export class NvmeofNamespacesListComponent implements OnInit {
         name: this.actionLabels.CREATE,
         permission: 'create',
         icon: Icons.add,
-        click: () =>
-          this.router.navigate(
-            [BASE_URL, { outlets: { modal: [URLVerbs.CREATE, this.subsystemNQN, 'namespace'] } }],
-            { queryParams: { group: this.group } }
-          ),
-        canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
+        click: () => {
+          this.router.navigate(['block/nvmeof/namespaces/create'], {
+            queryParams: {
+              group: this.group,
+              subsystem_nqn: this.subsystemNQN
+            }
+          });
+        },
+        canBePrimary: (selection: CdTableSelection) => !selection.hasSelection,
+        disable: () => !this.group
       },
       {
         name: this.actionLabels.EDIT,
@@ -133,16 +139,10 @@ export class NvmeofNamespacesListComponent implements OnInit {
           this.router.navigate(
             [
               BASE_URL,
-              {
-                outlets: {
-                  modal: [
-                    URLVerbs.EDIT,
-                    this.subsystemNQN,
-                    'namespace',
-                    this.selection.first().nsid
-                  ]
-                }
-              }
+              URLVerbs.EDIT,
+              this.selection.first().ns_subsystem_nqn,
+              'namespace',
+              this.selection.first().nsid
             ],
             { queryParams: { group: this.group } }
           )
@@ -154,6 +154,7 @@ export class NvmeofNamespacesListComponent implements OnInit {
         click: () => this.deleteNamespaceModal()
       }
     ];
+
   }
 
   updateSelection(selection: CdTableSelection) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -63,7 +63,8 @@ describe('NvmeofService', () => {
         nqn: mockNQN,
         enable_ha: true,
         initiators: '*',
-        gw_group: mockGroupName
+        gw_group: mockGroupName,
+        dhchap_key: ''
       };
       service.createSubsystem(request).subscribe();
       const req = httpTesting.expectOne(`${API_PATH}/subsystem`);
@@ -94,13 +95,13 @@ describe('NvmeofService', () => {
       );
       expect(req.request.method).toBe('GET');
     });
-    it('should call addInitiators', () => {
-      service.addInitiators(mockNQN, request).subscribe();
+    it('should call addSubsystemInitiators', () => {
+      service.addSubsystemInitiators(mockNQN, request).subscribe();
       const req = httpTesting.expectOne(`${UI_API_PATH}/subsystem/${mockNQN}/host`);
       expect(req.request.method).toBe('POST');
     });
-    it('should call removeInitiators', () => {
-      service.removeInitiators(mockNQN, request).subscribe();
+    it('should call removeSubsystemInitiators', () => {
+      service.removeSubsystemInitiators(mockNQN, request).subscribe();
       const req = httpTesting.expectOne(
         `${UI_API_PATH}/subsystem/${mockNQN}/host/${request.host_nqn}/${mockGroupName}`
       );

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import _ from 'lodash';
-import { Observable, of as observableOf } from 'rxjs';
-import { catchError, mapTo } from 'rxjs/operators';
+import { Observable, forkJoin, of as observableOf } from 'rxjs';
+import { catchError, map, mapTo, mergeMap } from 'rxjs/operators';
+import { NvmeofSubsystemNamespace } from '../models/nvmeof';
 import { CephServiceSpec } from '../models/service.interface';
 
 export const DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM = 512;
@@ -27,10 +28,12 @@ export type ListenerRequest = NvmeofRequest & {
 };
 
 export type NamespaceCreateRequest = NvmeofRequest & {
-  rbd_image_name: string;
+  rbd_image_name?: string;
   rbd_pool: string;
   rbd_image_size?: number;
+  no_auto_visible?: boolean;
   create_image: boolean;
+  block_size?: number;
 };
 
 export type NamespaceUpdateRequest = NvmeofRequest & {
@@ -39,6 +42,10 @@ export type NamespaceUpdateRequest = NvmeofRequest & {
 
 export type InitiatorRequest = NvmeofRequest & {
   host_nqn: string;
+};
+
+export type NamespaceInitiatorRequest = InitiatorRequest & {
+  subsystem_nqn: string;
 };
 
 const API_PATH = 'api/nvmeof';
@@ -121,15 +128,30 @@ export class NvmeofService {
     return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}/host?gw_group=${group}`);
   }
 
-  addInitiators(subsystemNQN: string, request: InitiatorRequest) {
+  addSubsystemInitiators(subsystemNQN: string, request: InitiatorRequest) {
     return this.http.post(`${UI_API_PATH}/subsystem/${subsystemNQN}/host`, request, {
       observe: 'response'
     });
   }
 
-  removeInitiators(subsystemNQN: string, request: InitiatorRequest) {
+  removeSubsystemInitiators(subsystemNQN: string, request: InitiatorRequest) {
     return this.http.delete(
       `${UI_API_PATH}/subsystem/${subsystemNQN}/host/${request.host_nqn}/${request.gw_group}`,
+      {
+        observe: 'response'
+      }
+    );
+  }
+
+  addNamespaceInitiators(nsid: string, request: NamespaceInitiatorRequest) {
+    return this.http.post(`${UI_API_PATH}/namespace/${nsid}/host`, request, {
+      observe: 'response'
+    });
+  }
+
+  removeNamespaceInitiators(nsid: string, request: NamespaceInitiatorRequest) {
+    return this.http.delete(
+      `${UI_API_PATH}/namespace/${nsid}/host/${request.subsystem_nqn}/${request.host_nqn}/${request.gw_group}`,
       {
         observe: 'response'
       }
@@ -164,6 +186,11 @@ export class NvmeofService {
           force: 'true'
         }
       }
+    );
+  }
+  listSubsystemNamespaces(subsystemNQN: string) {
+    return this.http.get<NvmeofSubsystemNamespace[]>(
+      `${API_PATH}/subsystem/${subsystemNQN}/namespace`
     );
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
@@ -47,3 +47,30 @@ export interface NvmeofSubsystemNamespace {
   r_mbytes_per_second: number;
   w_mbytes_per_second: number;
 }
+
+// Form control names for NvmeofNamespacesFormComponent
+export enum NsFormField {
+  POOL = 'pool',
+  SUBSYSTEM = 'subsystem',
+  IMAGE_SIZE = 'image_size',
+  NS_COUNT = 'nsCount',
+  RBD_IMAGE_CREATION = 'rbd_image_creation',
+  RBD_IMAGE_NAME = 'rbd_image_name',
+  NAMESPACE_SIZE = 'namespace_size',
+  HOST_ACCESS = 'host_access',
+  INITIATORS = 'initiators'
+}
+
+export enum RbdImageCreation {
+  GATEWAY_PROVISIONED = 'gateway_provisioned',
+  EXTERNALLY_MANAGED = 'externally_managed'
+}
+
+export type NvmeofNamespaceListResponse =
+  | NvmeofSubsystemNamespace[]
+  | { namespaces: NvmeofSubsystemNamespace[] };
+
+export type NvmeofInitiatorCandidate = {
+  content: string;
+  selected: boolean;
+};


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/74826

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>
(cherry picked from commit fcbb9c8788437a2800e346a7297286dca690d656)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.spec.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
	src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
