### PR TITLE
tentacle: qa: suppress false positive delete map mismatch errors

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -932,4 +932,24 @@
    fun:*ProtocolV2*
    ...
 }
-
+{
+   rocky10_gcc14_mismatch_delete_map_erase
+   Memcheck:Free
+   fun:_Zda*align_val_t*
+   ...
+   fun:*global_init_prefork*
+}
+{
+   rocky10_gcc14_mismatch_delete_map_erase
+   Memcheck:Free
+   fun:_Zda*align_val_t*
+   ...
+   fun:*ceph6common11CephContext*
+}
+{
+   rocky10_gcc14_mismatch_delete_map_erase
+   Memcheck:Free
+   fun:_Zda*align_val_t*
+   ...
+   fun:exit
+}


### PR DESCRIPTION
Backport #67230 

Valgrind reports "Mismatched free() / delete / delete []" errors during
OSD startup.

Standard library containers (like std::map) correctly call delete, but
Valgrind falsely interprets this as a call to delete[] because GCC 14
folds the identical aligned delete operators into a single symbol. This
causes Valgrind to flag a mismatch against the non-array allocation.

Fixes: https://tracker.ceph.com/issues/74604
Signed-off-by: Nitzan Mordechai <nmordech@ibm.com>
(cherry picked from commit 7fb83c0f4cb914305d9ae91c2f291b0a6fe991c0)
