### PR TITLE
tentacle: qa/workunits/ceph-helpers-root: Add Rocky support for install packages

### DIFF
--- a/qa/workunits/ceph-helpers-root.sh
+++ b/qa/workunits/ceph-helpers-root.sh
@@ -50,7 +50,7 @@ function install_one() {
         ubuntu|debian|devuan|softiron)
             sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
             ;;
-        centos|fedora|rhel)
+        centos|fedora|rhel|rocky)
             sudo yum install -y "$@"
             ;;
         opensuse*|suse|sles)

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -22,7 +22,7 @@ case $(distro_id) in
 	ubuntu|debian|devuan|softiron)
 		install git g++ libsnappy-dev zlib1g-dev libbz2-dev libradospp-dev cmake
 		;;
-	centos|fedora|rhel)
+	centos|fedora|rhel|rocky)
         case $(distro_id) in
             rhel)
                 # RHEL needs CRB repo for snappy-devel


### PR DESCRIPTION
Backports #67102 

Fixes: https://tracker.ceph.com/issues/75643
