### PR TITLE
tentacle: debian: package mgr/smb in ceph-mgr-modules-core

### DIFF
--- a/debian/ceph-mgr-modules-core.install
+++ b/debian/ceph-mgr-modules-core.install
@@ -17,6 +17,7 @@ usr/share/ceph/mgr/prometheus
 usr/share/ceph/mgr/rbd_support
 usr/share/ceph/mgr/rgw
 usr/share/ceph/mgr/selftest
+usr/share/ceph/mgr/smb
 usr/share/ceph/mgr/snap_schedule
 usr/share/ceph/mgr/stats
 usr/share/ceph/mgr/status


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74703

---

backport of https://github.com/ceph/ceph/pull/67133
parent tracker: https://tracker.ceph.com/issues/74268

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh