### PR TITLE
tentacle: mgr: add config to load modules in main interpreter instead of subinterpreter

### DIFF
--- a/src/common/options/CMakeLists.txt
+++ b/src/common/options/CMakeLists.txt
@@ -82,6 +82,8 @@ if(WITH_MGR)
   endif()
 endif()
 
+set(mgr_subinterpreter_modules "")
+
 add_options(global)
 add_options(cephfs-mirror)
 add_options(crimson)

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -145,6 +145,19 @@ options:
   - mgr_module_path
   flags:
   - startup
+- name: mgr_subinterpreter_modules
+  type: str
+  level: advanced
+  desc: List of manager modules to load in independent subinterpreters
+  long_desc: A comma delimited list of module names. This list is read by manager
+    when it starts. By default, manager loads each module into the main interpreter.
+    Modules in this list will instead be loaded into independent subinterpreters.
+    Specifying '*' will cause all modules to be run in independent subinterpreters.
+  default: @mgr_subinterpreter_modules@
+  services:
+  - mgr
+  flags:
+  - startup
 - name: mgr_initial_modules
   type: str
   level: basic

--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -128,22 +128,48 @@ bool ActivePyModule::method_exists(const std::string &method) const
   }
 }
 
-PyObject *ActivePyModule::dispatch_remote(
+std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
     const std::string &method,
-    PyObject *args,
-    PyObject *kwargs,
+    std::span<std::byte const> pickled_args,
+    std::span<std::byte const> pickled_kwargs,
     std::string *err)
 {
   ceph_assert(err != nullptr);
 
-  // Rather than serializing arguments, pass the CPython objects.
-  // Works because we happen to know that the subinterpreter
-  // implementation shares a GIL, allocator, deallocator and GC state, so
-  // it's okay to pass the objects between subinterpreters.
-  // But in future this might involve serialization to support a CSP-aware
-  // future Python interpreter a la PEP554
+  // deserialize arguments.
 
   Gil gil(py_module->pMyThreadState, true);
+
+  auto pmodule = py_module->pPickleModule;
+  auto pickled_args_bytes = py_bytes_from_span(pickled_args);
+  auto args = PyObject_CallMethodObjArgs(
+    pmodule,
+    PyUnicode_FromString("loads"),
+    pickled_args_bytes,
+    nullptr);
+  Py_DECREF(pickled_args_bytes);
+  if (args == nullptr) {
+    std::string caller = "ActivePyModule::dispatch_remote "s + method;
+    *err = handle_pyerror(true, get_name(), caller);
+    derr << "Failed to deserialize (pickle.loads) args: " << *err << dendl;
+    return std::nullopt;
+  }
+
+  auto pickled_kwargs_bytes = py_bytes_from_span(pickled_kwargs);
+  auto kwargs = PyObject_CallMethodObjArgs(
+    pmodule,
+    PyUnicode_FromString("loads"),
+    pickled_kwargs_bytes,
+    nullptr);
+  Py_DECREF(pickled_kwargs_bytes);
+  if (kwargs == nullptr) {
+    std::string caller = "ActivePyModule::dispatch_remote "s + method;
+    *err = handle_pyerror(true, get_name(), caller);
+    derr << "Failed to deserialize (pickle.loads) kwargs: " << *err << dendl;
+
+    Py_DECREF(args);
+    return std::nullopt;
+  }
 
   // Fire the receiving method
   auto boundMethod = PyObject_GetAttrString(pClassInstance, method.c_str());
@@ -154,21 +180,37 @@ PyObject *ActivePyModule::dispatch_remote(
   dout(20) << "Calling " << py_module->get_name()
            << "." << method << "..." << dendl;
 
-  auto remoteResult = PyObject_Call(boundMethod,
+  auto ret = PyObject_Call(boundMethod,
       args, kwargs);
   Py_DECREF(boundMethod);
-
-  if (remoteResult == nullptr) {
+  Py_DECREF(kwargs);
+  Py_DECREF(args);
+  if (ret == nullptr) {
     // Because the caller is in a different context, we can't let this
     // exception bubble up, need to re-raise it from the caller's
     // context later.
     std::string caller = "ActivePyModule::dispatch_remote "s + method;
     *err = handle_pyerror(true, get_name(), caller);
-  } else {
-    dout(20) << "Success calling '" << method << "'" << dendl;
+    return std::nullopt;
+  }
+  dout(20) << "Success calling '" << method << "'" << dendl;
+
+  auto pickled_ret = PyObject_CallMethodObjArgs(
+    pmodule,
+    PyUnicode_FromString("dumps"),
+    ret,
+    nullptr);
+  Py_DECREF(ret);
+  if (pickled_ret == nullptr) {
+    std::string caller = "ActivePyModule::dispatch_remote "s + method;
+    *err = handle_pyerror(true, get_name(), caller);
+    derr << "Failed to serialize (pickle.dumps) ret: " << *err << dendl;
+    return std::nullopt;
   }
 
-  return remoteResult;
+  std::vector<std::byte> pickled_ret_str = py_bytes_as_vec(pickled_ret);
+  Py_DECREF(pickled_ret);
+  return pickled_ret_str;
 }
 
 void ActivePyModule::config_notify()

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -66,10 +66,10 @@ public:
 
   bool method_exists(const std::string &method) const;
 
-  PyObject *dispatch_remote(
+  std::optional<std::vector<std::byte>> dispatch_remote(
       const std::string &method,
-      PyObject *args,
-      PyObject *kwargs,
+      std::span<std::byte const> pickled_args,
+      std::span<std::byte const> pickled_kwargs,
       std::string *err);
 
   int handle_command(

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -636,18 +636,20 @@ bool ActivePyModules::get_store(const std::string &module_name,
   }
 }
 
-PyObject *ActivePyModules::dispatch_remote(
+std::optional<std::vector<std::byte>> ActivePyModules::dispatch_remote(
     const std::string &other_module,
     const std::string &method,
-    PyObject *args,
-    PyObject *kwargs,
+    std::span<std::byte const> pickled_args,
+    std::span<std::byte const> pickled_kwargs,
     std::string *err)
 {
   auto mod_iter = modules.find(other_module);
   ceph_assert(mod_iter != modules.end());
 
-  return mod_iter->second->dispatch_remote(method, args, kwargs, err);
+  return mod_iter->second->dispatch_remote(
+    method, pickled_args, pickled_kwargs, err);
 }
+
 
 bool ActivePyModules::get_config(const std::string &module_name,
     const std::string &key, std::string *val) const

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -240,11 +240,11 @@ public:
     return modules.at(module_name)->method_exists(method_name);
   }
 
-  PyObject *dispatch_remote(
+  std::optional<std::vector<std::byte>> dispatch_remote(
       const std::string &other_module,
       const std::string &method,
-      PyObject *args,
-      PyObject *kwargs,
+      std::span<std::byte const> pickled_args,
+      std::span<std::byte const> pickled_kwargs,
       std::string *err);
 
   int init();

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -40,6 +40,7 @@
 
 using std::list;
 using std::string;
+using namespace std::literals;
 
 typedef struct {
   PyObject_HEAD
@@ -828,6 +829,7 @@ ceph_clear_all_progress_events(BaseMgrModule *self, PyObject *args)
 static PyObject *
 ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
 {
+  // PyArgs_ParseTuple doesn't give us refcounts here
   char *other_module = nullptr;
   char *method = nullptr;
   PyObject *remote_args = nullptr;
@@ -846,6 +848,38 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
     return nullptr;
   }
 
+  auto pmodule = self->this_module->py_module->pPickleModule;
+  auto pickled_args = PyObject_CallMethodObjArgs(
+    pmodule,
+    PyUnicode_FromString("dumps"),
+    remote_args,
+    nullptr);
+  if (pickled_args == nullptr) {
+    std::string caller = "ceph_dispatch_remote "s + " " + method;
+    std::string err = handle_pyerror(true, other_module, caller);
+    PyErr_SetString(PyExc_RuntimeError, err.c_str());
+    derr << err << dendl;
+    return nullptr;
+  }
+  std::span<std::byte const> pickled_args_span = py_bytes_as_span(pickled_args);
+
+  auto pickled_kwargs = PyObject_CallMethodObjArgs(
+    pmodule,
+    PyUnicode_FromString("dumps"),
+    remote_kwargs,
+    nullptr);
+  if (pickled_kwargs == nullptr) {
+    std::string caller = "ceph_dispatch_remote "s + " " + method;
+    std::string err = handle_pyerror(true, other_module, caller);
+    PyErr_SetString(PyExc_RuntimeError, err.c_str());
+    derr << err << dendl;
+
+    Py_DECREF(pickled_args);
+    return nullptr;
+  }
+  std::span<std::byte const> pickled_kwargs_span =
+    py_bytes_as_span(pickled_kwargs);
+
   // Drop GIL from calling python thread state, it will be taken
   // both for checking for method existence and for executing method.
   PyThreadState *tstate = PyEval_SaveThread();
@@ -853,23 +887,50 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
   if (!self->py_modules->method_exists(other_module, method)) {
     PyEval_RestoreThread(tstate);
     PyErr_SetString(PyExc_NameError, "Method not found");
+
+    Py_DECREF(pickled_args);
+    Py_DECREF(pickled_kwargs);
     return nullptr;
   }
 
   std::string err;
-  auto result = self->py_modules->dispatch_remote(other_module, method,
-      remote_args, remote_kwargs, &err);
+  std::optional<std::vector<std::byte>> maybe_pickled_ret =
+    self->py_modules->dispatch_remote(
+      other_module,
+      method,
+      pickled_args_span,
+      pickled_kwargs_span,
+      &err);
 
   PyEval_RestoreThread(tstate);
 
-  if (result == nullptr) {
+  // we retain these references across the dispatch_remote call so that
+  // we can pass string_view and avoid the copy
+  Py_XDECREF(pickled_kwargs);
+  Py_XDECREF(pickled_args);
+
+  if (!maybe_pickled_ret) {
     std::stringstream ss;
     ss << "Remote method threw exception: " << err;
     PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
     derr << ss.str() << dendl;
+    return nullptr;
   }
 
-  return result;
+  auto pickled_ret_bytes = py_bytes_from_vec(*maybe_pickled_ret);
+  auto ret = PyObject_CallMethodObjArgs(
+    pmodule,
+    PyUnicode_FromString("loads"),
+    pickled_ret_bytes,
+    nullptr);
+  if (ret == nullptr) {
+    std::string caller = "ceph_dispatch_remote "s + " " + method;
+    std::string err = handle_pyerror(true, other_module, caller);
+    PyErr_SetString(PyExc_RuntimeError, err.c_str());
+    derr << err << dendl;
+  }
+  Py_XDECREF(pickled_ret_bytes);
+  return ret;
 }
 
 static PyObject*

--- a/src/mgr/Gil.cc
+++ b/src/mgr/Gil.cc
@@ -57,10 +57,6 @@ SafeThreadState::SafeThreadState(PyThreadState *ts_)
 
 Gil::Gil(SafeThreadState &ts, bool new_thread) : pThreadState(ts)
 {
-  // Acquire the GIL, set the current thread state
-  PyEval_RestoreThread(pThreadState.ts);
-  dout(25) << "GIL acquired for thread state " << pThreadState.ts << dendl;
-
   //
   // If called from a separate OS thread (i.e. a thread not created
   // by Python, that does't already have a python thread state that
@@ -81,23 +77,28 @@ Gil::Gil(SafeThreadState &ts, bool new_thread) : pThreadState(ts)
   //
   if (new_thread) {
     pNewThreadState = PyThreadState_New(pThreadState.ts->interp);
-    PyThreadState_Swap(pNewThreadState);
+    PyEval_RestoreThread(pNewThreadState);
     dout(20) << "Switched to new thread state " << pNewThreadState << dendl;
   } else {
+    // Acquire the GIL, set the current thread state
+    PyEval_RestoreThread(pThreadState.ts);
+    dout(25) << "GIL acquired for thread state " << pThreadState.ts << dendl;
     ceph_assert(pthread_self() == pThreadState.thread);
   }
+  assert_gil();
 }
 
 Gil::~Gil()
 {
+  // Release the GIL, reset the thread state to NULL
   if (pNewThreadState != nullptr) {
     dout(20) << "Destroying new thread state " << pNewThreadState << dendl;
-    PyThreadState_Swap(pThreadState.ts);
     PyThreadState_Clear(pNewThreadState);
+    PyEval_SaveThread();
     PyThreadState_Delete(pNewThreadState);
+  } else {
+    PyEval_SaveThread();
   }
-  // Release the GIL, reset the thread state to NULL
-  PyEval_SaveThread();
   dout(25) << "GIL released for thread state " << pThreadState.ts << dendl;
 }
 

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -154,6 +154,48 @@ std::string peek_pyerror()
   return exc_msg;
 }
 
+std::span<std::byte const> py_bytes_as_span(PyObject *bytes)
+{
+  assert(bytes);
+  assert(PyBytes_CheckExact(bytes));
+  Py_ssize_t length;
+  char *buf;
+  int r = PyBytes_AsStringAndSize(
+    bytes, &buf, &length);
+  assert(r == 0);
+  return std::span<std::byte const>((const std::byte*)buf, size_t(length));
+}
+
+PyObject *py_bytes_from_span(std::span<std::byte const> s)
+{
+  auto ret = PyBytes_FromStringAndSize(
+    reinterpret_cast<const char*>(s.data()), s.size_bytes());
+  assert(ret);
+  return ret;
+}
+
+std::vector<std::byte> py_bytes_as_vec(PyObject *bytes)
+{
+  assert(bytes);
+  assert(PyBytes_CheckExact(bytes));
+  Py_ssize_t length;
+  char *buf;
+  int r = PyBytes_AsStringAndSize(
+    bytes, &buf, &length);
+  assert(r == 0);
+  return std::vector<std::byte>{
+    reinterpret_cast<const std::byte*>(buf),
+    reinterpret_cast<const std::byte*>(buf) + size_t(length)};
+}
+
+PyObject *py_bytes_from_vec(const std::vector<std::byte> &s)
+{
+  auto ret = PyBytes_FromStringAndSize(
+    reinterpret_cast<const char *>(s.data()), s.size());
+  assert(ret);
+  return ret;
+}
+
 
 namespace {
   PyObject* log_write(PyObject*, PyObject* args) {
@@ -309,6 +351,13 @@ int PyModule::load(PyThreadState *pMainThreadState)
     Gil gil(pMyThreadState);
 
     int r;
+
+    pPickleModule = PyImport_ImportModuleNoBlock("pickle");
+    if (!pPickleModule) {
+      derr << "Unable to load pickle" << dendl;
+      return -EINVAL;
+    }
+
     r = load_subclass_of("MgrModule", &pClass);
     if (r) {
       derr << "Class not found in module '" << module_name << "'" << dendl;
@@ -707,6 +756,7 @@ PyModule::~PyModule()
     Gil gil(pMyThreadState, true);
     Py_XDECREF(pClass);
     Py_XDECREF(pStandbyClass);
+    Py_XDECREF(pPickleModule);
   }
 }
 

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -21,6 +21,7 @@
 
 #include "include/stringify.h"
 #include "common/BackTrace.h"
+#include "common/split.h"
 #include "global/signal_handler.h"
 
 #include "common/debug.h"
@@ -333,8 +334,23 @@ int PyModule::load(PyThreadState *pMainThreadState)
 {
   ceph_assert(pMainThreadState != nullptr);
 
-  // Configure sub-interpreter
-  {
+  const auto subinterpreter_modules_opt = g_conf().get_val<std::string>(
+    "mgr_subinterpreter_modules"
+  );
+  auto subinterpreter_modules = ceph::split(subinterpreter_modules_opt);
+  use_main_interpreter = std::count(
+    subinterpreter_modules.begin(), subinterpreter_modules.end(), "*"
+  ) == 0 && std::count(
+    subinterpreter_modules.begin(), subinterpreter_modules.end(), module_name
+  ) == 0;
+
+  if (use_main_interpreter) {
+    // Use main interpreter
+    derr << "Loading module " << module_name << " in main interpreter" << dendl;
+    pMyThreadState.set(pMainThreadState);
+  } else {
+    // Configure sub-interpreter
+    derr << "Loading module " << module_name << " in sub-interpreter" << dendl;
     SafeThreadState sts(pMainThreadState);
     Gil gil(sts);
 
@@ -346,6 +362,7 @@ int PyModule::load(PyThreadState *pMainThreadState)
       pMyThreadState.set(thread_state);
     }
   }
+
   // Environment is all good, import the external module
   {
     Gil gil(pMyThreadState);
@@ -757,6 +774,9 @@ PyModule::~PyModule()
     Py_XDECREF(pClass);
     Py_XDECREF(pStandbyClass);
     Py_XDECREF(pPickleModule);
+    if (use_main_interpreter) {
+      Py_EndInterpreter(pMyThreadState.ts);
+    }
   }
 }
 

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -104,6 +104,9 @@ public:
   PyObject *pStandbyClass = nullptr;
   PyObject *pPickleModule = nullptr;
 
+  // true unless module in mgr_subinterpreter_modules
+  bool use_main_interpreter = true;
+
   explicit PyModule(const std::string &module_name_)
     : module_name(module_name_)
   {

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -32,6 +32,13 @@ std::string handle_pyerror(bool generate_crash_dump = false,
 
 std::string peek_pyerror();
 
+std::span<std::byte const> py_bytes_as_span(PyObject*);
+PyObject *py_bytes_from_span(std::span<std::byte const>);
+
+std::vector<std::byte> py_bytes_as_vec(PyObject*);
+PyObject *py_bytes_from_vec(const std::vector<std::byte> &);
+
+
 /**
  * A Ceph CLI command description provided from a Python module
  */
@@ -95,6 +102,7 @@ public:
   SafeThreadState pMyThreadState;
   PyObject *pClass = nullptr;
   PyObject *pStandbyClass = nullptr;
+  PyObject *pPickleModule = nullptr;
 
   explicit PyModule(const std::string &module_name_)
     : module_name(module_name_)

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -20,7 +20,7 @@ from . import APIDoc, APIRouter, ControllerAuthMixin, EndpointDoc, RESTControlle
 if sys.version_info < (3, 8):
     http.cookies.Morsel._reserved["samesite"] = "SameSite"  # type: ignore  # pylint: disable=W0212
 
-logger = logging.getLogger('controllers.auth')
+logger = logging.getLogger(__name__)
 
 AUTH_CHECK_SCHEMA = {
     "username": (str, "Username"),

--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -11,7 +11,7 @@ from ._version import APIVersion
 
 NO_DESCRIPTION_AVAILABLE = "*No description available*"
 
-logger = logging.getLogger('controllers.docs')
+logger = logging.getLogger(__name__)
 
 
 @Router('/docs', secure=False)

--- a/src/pybind/mgr/dashboard/controllers/frontend_logging.py
+++ b/src/pybind/mgr/dashboard/controllers/frontend_logging.py
@@ -2,7 +2,7 @@ import logging
 
 from . import BaseController, Endpoint, UIRouter
 
-logger = logging.getLogger('frontend.error')
+logger = logging.getLogger(__name__)
 
 
 @UIRouter('/logging', secure=False)

--- a/src/pybind/mgr/dashboard/controllers/multi_cluster.py
+++ b/src/pybind/mgr/dashboard/controllers/multi_cluster.py
@@ -20,7 +20,7 @@ from ..tools import configure_cors
 from . import APIDoc, APIRouter, CreatePermission, DeletePermission, Endpoint, \
     EndpointDoc, ReadPermission, RESTController, UIRouter, UpdatePermission
 
-logger = logging.getLogger('controllers.multi_cluster')
+logger = logging.getLogger(__name__)
 
 
 @APIRouter('/multi-cluster', Scope.CONFIG_OPT)

--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -19,7 +19,7 @@ from . import APIDoc, APIRouter, BaseController, Endpoint, EndpointDoc, \
     ReadPermission, RESTController, Task, UIRouter
 from ._version import APIVersion
 
-logger = logging.getLogger('controllers.nfs')
+logger = logging.getLogger(__name__)
 
 
 class NFSException(DashboardException):

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -24,7 +24,7 @@ from . import APIDoc, APIRouter, CreatePermission, DeletePermission, Endpoint, \
 from ._version import APIVersion
 from .orchestrator import raise_if_no_orchestrator
 
-logger = logging.getLogger('controllers.osd')
+logger = logging.getLogger(__name__)
 
 SAFE_TO_DESTROY_SCHEMA = {
     "safe_to_destroy": ([str], "Is OSD safe to destroy?"),

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -22,7 +22,7 @@ from . import APIDoc, APIRouter, BaseController, CreatePermission, Endpoint, \
     EndpointDoc, ReadPermission, RESTController, Task, UIRouter, \
     UpdatePermission, allow_empty_body
 
-logger = logging.getLogger('controllers.rbd_mirror')
+logger = logging.getLogger(__name__)
 
 
 class MirrorHealth(IntEnum):

--- a/src/pybind/mgr/dashboard/controllers/smb.py
+++ b/src/pybind/mgr/dashboard/controllers/smb.py
@@ -17,7 +17,7 @@ from .. import mgr
 from ..security import Scope
 from . import APIDoc, APIRouter, Endpoint, ReadPermission, RESTController, UIRouter
 
-logger = logging.getLogger('controllers.smb')
+logger = logging.getLogger(__name__)
 
 CLUSTER_SCHEMA = {
     "resource_type": (str, "ceph.smb.cluster"),

--- a/src/pybind/mgr/dashboard/grafana.py
+++ b/src/pybind/mgr/dashboard/grafana.py
@@ -10,7 +10,7 @@ import requests
 from .exceptions import GrafanaError
 from .settings import Settings
 
-logger = logging.getLogger('grafana')
+logger = logging.getLogger(__name__)
 
 
 class GrafanaRestClient(object):

--- a/src/pybind/mgr/dashboard/rest_client.py
+++ b/src/pybind/mgr/dashboard/rest_client.py
@@ -31,7 +31,7 @@ from typing import List, Optional
 
 from mgr_util import build_url
 
-logger = logging.getLogger('rest_client')
+logger = logging.getLogger(__name__)
 
 
 class TimeoutRequestsSession(requests.Session):

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -25,7 +25,7 @@ from ..exceptions import PasswordPolicyException, PermissionNotValid, \
 from ..security import Permission, Scope
 from ..settings import Settings
 
-logger = logging.getLogger('access_control')
+logger = logging.getLogger(__name__)
 DEFAULT_FILE_DESC = 'password/secret'
 
 

--- a/src/pybind/mgr/dashboard/services/auth/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth/auth.py
@@ -113,7 +113,7 @@ class JwtManager(object):
 
     @classmethod
     def init(cls):
-        cls.logger = logging.getLogger('jwt')  # type: ignore
+        cls.logger = logging.getLogger(__name__)  # type: ignore
         # generate a new secret if it does not exist
         secret = mgr.get_store('jwt_secret')
         if secret is None:
@@ -309,7 +309,7 @@ class AuthManagerTool(cherrypy.Tool):
     def __init__(self):
         super(AuthManagerTool, self).__init__(
             'before_handler', self._check_authentication, priority=20)
-        self.logger = logging.getLogger('auth')
+        self.logger = logging.getLogger(__name__)
 
     def _check_authentication(self):
         JwtManager.reset_user()

--- a/src/pybind/mgr/dashboard/services/auth/oauth2.py
+++ b/src/pybind/mgr/dashboard/services/auth/oauth2.py
@@ -18,7 +18,7 @@ try:
 except ModuleNotFoundError:
     logging.error("Module 'jmespath' is not installed.")
 
-logger = logging.getLogger('services.oauth2')
+logger = logging.getLogger(__name__)
 
 
 class OAuth2(SSOAuth):

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     pass  # For typing only
 
-logger = logging.getLogger('ceph_service')
+logger = logging.getLogger(__name__)
 
 
 class SendCommandError(rados.Error):

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -9,7 +9,7 @@ import cephfs
 
 from .. import mgr
 
-logger = logging.getLogger('cephfs')
+logger = logging.getLogger(__name__)
 
 
 class CephFS(object):

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -14,7 +14,7 @@ from ..exceptions import DashboardException, ViewCacheNoDataException
 from ..rest_client import RequestException
 from ..services.ceph_service import SendCommandError
 
-logger = logging.getLogger('exception')
+logger = logging.getLogger(__name__)
 
 
 def serialize_dashboard_exception(e, include_http_status=False, task=None):

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -15,7 +15,7 @@ from ..rest_client import RestClient
 from ..settings import Settings
 from .iscsi_config import IscsiGatewaysConfig
 
-logger = logging.getLogger('iscsi_client')
+logger = logging.getLogger(__name__)
 
 
 class IscsiClient(RestClient):

--- a/src/pybind/mgr/dashboard/services/nvmeof_conf.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_conf.py
@@ -9,7 +9,7 @@ from .. import mgr
 from ..exceptions import DashboardException
 from ..services.orchestrator import OrchClient
 
-logger = logging.getLogger('nvmeof_conf')
+logger = logging.getLogger(__name__)
 
 
 class NvmeofGatewayAlreadyExists(Exception):

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -12,7 +12,7 @@ from orchestrator import DaemonDescription, DeviceLightLoc, HostSpec, \
 from .. import mgr
 from ._paginate import ListPaginator
 
-logger = logging.getLogger('orchestrator')
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=abstract-method

--- a/src/pybind/mgr/dashboard/services/progress.py
+++ b/src/pybind/mgr/dashboard/services/progress.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from .. import mgr
 from . import rbd  # pylint: disable=no-name-in-module
 
-logger = logging.getLogger('progress')
+logger = logging.getLogger(__name__)
 
 
 def _progress_event_to_dashboard_task_common(event, task):

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     pass  # For typing only
 
-logger = logging.getLogger('rgw_client')
+logger = logging.getLogger(__name__)
 
 _SYNC_GROUP_ID = 'dashboard_admin_group'
 _SYNC_FLOW_ID = 'dashboard_admin_flow'

--- a/src/pybind/mgr/dashboard/services/service.py
+++ b/src/pybind/mgr/dashboard/services/service.py
@@ -13,7 +13,7 @@ from ..exceptions import DashboardException
 from ..settings import Settings
 from .orchestrator import OrchClient
 
-logger = logging.getLogger('service')
+logger = logging.getLogger(__name__)
 
 
 class NoCredentialsException(Exception):

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -20,7 +20,7 @@ from ..cli import DBCLICommand
 from ..services.auth import AuthType, BaseAuth, OAuth2, Saml2  # noqa
 from ..tools import prepare_url_prefix
 
-logger = logging.getLogger('sso')
+logger = logging.getLogger(__name__)
 
 try:
     jmespath = importlib.import_module('jmespath')

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -31,7 +31,7 @@ PLUGIN_MANAGER.hook.init()
 PLUGIN_MANAGER.hook.register_commands()
 
 
-logger = logging.getLogger('tests')
+logger = logging.getLogger(__name__)
 
 
 class ModuleTestClass(Module):

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -30,7 +30,7 @@ class RequestLoggingTool(cherrypy.Tool):
     def __init__(self):
         cherrypy.Tool.__init__(self, 'before_handler', self.request_begin,
                                priority=10)
-        self.logger = logging.getLogger('request')
+        self.logger = logging.getLogger(__name__)
 
     def _setup(self):
         cherrypy.Tool._setup(self)
@@ -180,7 +180,7 @@ class ViewCache(object):
             self.latency = 0
             self.exception = None
             self.lock = threading.Lock()
-            self.logger = logging.getLogger('viewcache')
+            self.logger = logging.getLogger(__name__)
 
         def reset(self):
             with self.lock:
@@ -271,7 +271,7 @@ class NotificationQueue(threading.Thread):
                 return
             cls._running = True
             cls._instance = NotificationQueue()
-        cls.logger = logging.getLogger('notification_queue')  # type: ignore
+        cls.logger = logging.getLogger(__name__)  # type: ignore
         cls.logger.debug("starting notification queue")  # type: ignore
         cls._instance.start()
 
@@ -413,7 +413,7 @@ class TaskManager(object):
 
     @classmethod
     def init(cls):
-        cls.logger = logging.getLogger('taskmgr')  # type: ignore
+        cls.logger = logging.getLogger(__name__)  # type: ignore
         NotificationQueue.register(cls._handle_finished_task, 'cd_task_finished')
 
     @classmethod
@@ -510,7 +510,7 @@ class TaskManager(object):
 # pylint: disable=protected-access
 class TaskExecutor(object):
     def __init__(self):
-        self.logger = logging.getLogger('taskexec')
+        self.logger = logging.getLogger(__name__)
         self.task = None
 
     def init(self, task):
@@ -573,7 +573,7 @@ class Task(object):
         self._end_time: Optional[float] = None
         self.duration = 0.0
         self.exception = None
-        self.logger = logging.getLogger('task')
+        self.logger = logging.getLogger(__name__)
         self.lock = threading.Lock()
 
     def __hash__(self):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -677,14 +677,15 @@ class CPlusPlusHandler(logging.Handler):
         if record.levelno >= self.level:
             self._module._ceph_log(self.format(record))
 
+
 class MgrRootHandler(CPlusPlusHandler):
-    def __init__(self, module_inst):
+    def __init__(self, module_inst: 'MgrModuleLoggingMixin') -> None:
         super().__init__(module_inst)
         self.setFormatter(logging.Formatter(
             "[mgr %(levelname)-4s %(name)s] %(message)s"
         ))
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         record.name = "mgr"
         super().emit(record)
 
@@ -723,6 +724,8 @@ class FileHandler(logging.FileHandler):
 
 
 class MgrModuleLoggingMixin(object):
+    module_name: str
+
     def _configure_logging(self,
                            mgr_level: str,
                            module_level: str,
@@ -846,10 +849,13 @@ class MgrModuleLoggingMixin(object):
             log_level = "INFO"
         return log_level
 
-    def getLogger(self, name=None):
+    def getLogger(self, name: Optional[str] = None) -> logging.Logger:
+        logger = getattr(self, '_module_logger', None) \
+            or logging.getLogger(self.module_name)
         if name is None:
-            return self._module_logger
-        return self._module_logger.getChild(name)
+            return logger
+        return logger.getChild(name)
+
 
 class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
     """

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -677,6 +677,17 @@ class CPlusPlusHandler(logging.Handler):
         if record.levelno >= self.level:
             self._module._ceph_log(self.format(record))
 
+class MgrRootHandler(CPlusPlusHandler):
+    def __init__(self, module_inst):
+        super().__init__(module_inst)
+        self.setFormatter(logging.Formatter(
+            "[mgr %(levelname)-4s %(name)s] %(message)s"
+        ))
+
+    def emit(self, record):
+        record.name = "mgr"
+        super().emit(record)
+
 
 class ClusterLogHandler(logging.Handler):
     def __init__(self, module_inst: Any):
@@ -720,7 +731,7 @@ class MgrModuleLoggingMixin(object):
                            log_to_cluster: bool) -> None:
         self._mgr_level: Optional[str] = None
         self._module_level: Optional[str] = None
-        self._root_logger = logging.getLogger()
+        self._module_logger = logging.getLogger(self.module_name)
 
         self._unconfigure_logging()
 
@@ -732,24 +743,29 @@ class MgrModuleLoggingMixin(object):
         self.log_to_file = log_to_file
         self.log_to_cluster = log_to_cluster
 
-        self._root_logger.addHandler(self._mgr_log_handler)
-        if log_to_file:
-            self._root_logger.addHandler(self._file_log_handler)
-        if log_to_cluster:
-            self._root_logger.addHandler(self._cluster_log_handler)
+        root = logging.getLogger()
+        if not any(isinstance(h, MgrRootHandler) for h in root.handlers):
+            root.addHandler(MgrRootHandler(self))
+            root.setLevel(logging.NOTSET)
 
-        self._root_logger.setLevel(logging.NOTSET)
+        self._module_logger.addHandler(self._mgr_log_handler)
+        if log_to_file:
+            self._module_logger.addHandler(self._file_log_handler)
+        if log_to_cluster:
+            self._module_logger.addHandler(self._cluster_log_handler)
+
+        self._module_logger.propagate = False
         self._set_log_level(mgr_level, module_level, cluster_level)
 
     def _unconfigure_logging(self) -> None:
         # remove existing handlers:
         rm_handlers = [
-            h for h in self._root_logger.handlers
+            h for h in self._module_logger.handlers
             if (isinstance(h, CPlusPlusHandler)
                 or isinstance(h, FileHandler)
                 or isinstance(h, ClusterLogHandler))]
         for h in rm_handlers:
-            self._root_logger.removeHandler(h)
+            self._module_logger.removeHandler(h)
         self.log_to_file = False
         self.log_to_cluster = False
 
@@ -792,25 +808,25 @@ class MgrModuleLoggingMixin(object):
         # enable file log
         self.getLogger().warning("enabling logging to file")
         self.log_to_file = True
-        self._root_logger.addHandler(self._file_log_handler)
+        self._module_logger.addHandler(self._file_log_handler)
 
     def _disable_file_log(self) -> None:
         # disable file log
         self.getLogger().warning("disabling logging to file")
         self.log_to_file = False
-        self._root_logger.removeHandler(self._file_log_handler)
+        self._module_logger.removeHandler(self._file_log_handler)
 
     def _enable_cluster_log(self) -> None:
         # enable cluster log
         self.getLogger().warning("enabling logging to cluster")
         self.log_to_cluster = True
-        self._root_logger.addHandler(self._cluster_log_handler)
+        self._module_logger.addHandler(self._cluster_log_handler)
 
     def _disable_cluster_log(self) -> None:
         # disable cluster log
         self.getLogger().warning("disabling logging to cluster")
         self.log_to_cluster = False
-        self._root_logger.removeHandler(self._cluster_log_handler)
+        self._module_logger.removeHandler(self._cluster_log_handler)
 
     def _ceph_log_level_to_python(self, log_level: str) -> str:
         if log_level:
@@ -830,9 +846,10 @@ class MgrModuleLoggingMixin(object):
             log_level = "INFO"
         return log_level
 
-    def getLogger(self, name: Optional[str] = None) -> logging.Logger:
-        return logging.getLogger(name)
-
+    def getLogger(self, name=None):
+        if name is None:
+            return self._module_logger
+        return self._module_logger.getChild(name)
 
 class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
     """

--- a/src/pybind/mgr/orchestrator/cli.py
+++ b/src/pybind/mgr/orchestrator/cli.py
@@ -18,7 +18,7 @@ class OrchestratorCLICommandBase(CLICommandBase):
                 return func(*args, **kwargs)
             except (OrchestratorError, SpecValidationError) as e:
                 # Do not print Traceback for expected errors.
-                return HandleCommandResult(retval=e.errno, stderr=str(e))
+                return HandleCommandResult(retval=-e.errno, stderr=str(e))
             except ImportError as e:
                 return HandleCommandResult(retval=-errno.ENOENT, stderr=str(e))
             except NotImplementedError:

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -143,7 +143,7 @@ def test_handle_command():
     m = OrchestratorCli('orchestrator', 0, 0)
     r = m._handle_command(None, cmd)
     assert r == HandleCommandResult(
-        retval=2, stdout='', stderr='No orchestrator configured (try `ceph orch set backend`)')
+        retval=-2, stdout='', stderr='No orchestrator configured (try `ceph orch set backend`)')
 
 
 r = OrchResult([ServiceDescription(spec=ServiceSpec(service_type='osd'), running=123)])

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -558,11 +558,11 @@ class Module(MgrModule):
         captured_root = []
 
         class ModCaptureHandler(logging.Handler):
-            def emit(self, record):
+            def emit(self, record: logging.LogRecord) -> None:
                 captured_mod.append(record)
 
         class RootCaptureHandler(logging.Handler):
-            def emit(self, record):
+            def emit(self, record: logging.LogRecord) -> None:
                 captured_root.append(record)
 
         mod_capture = ModCaptureHandler()

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -866,6 +866,14 @@ class ServiceSpec(object):
         sub_cls: Any = cls._cls(service_type)
         return object.__new__(sub_cls)
 
+    def __getnewargs__(self):
+        """
+        Pickle will pass the return of this function to __new__ upon
+        unpickle.  We need to ensure it gets service_type in order
+        to get the right subtype.
+        """
+        return (self.service_type,)
+
     def __init__(self,
                  service_type: str,
                  service_id: Optional[str] = None,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -866,7 +866,7 @@ class ServiceSpec(object):
         sub_cls: Any = cls._cls(service_type)
         return object.__new__(sub_cls)
 
-    def __getnewargs__(self):
+    def __getnewargs__(self) -> tuple[str]:
         """
         Pickle will pass the return of this function to __new__ upon
         unpickle.  We need to ensure it gets service_type in order


### PR DESCRIPTION
Backports: #66244 
Includes also #67954 and #67588 (backport of https://github.com/ceph/ceph/pull/67327)

Fixes: https://tracker.ceph.com/issues/75644
Fixes: https://tracker.ceph.com/issues/75645
Fixes: https://tracker.ceph.com/issues/76382

- **mgr: serialize python objects sent between subinterpreters via remote**
- **python-common/.../service_spec: implement ServiceSpec.__getnewargs__ to allow unpickle to work correctly**
- **mgr: add mgr_subinterpreter_modules config**
- **mgr/Gil.cc: do not use PyGILState_Check()**
- **mgr/Gil.cc: simplify Gil(), ~Gil()**
