### PR TITLE
tentacle: qa/tasks: update egrep to 'grep -E'

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1199,11 +1199,11 @@ def cluster(ctx, config):
             """
             args = [
                 'sudo',
-                'egrep', pattern,
+                'grep', '-E', pattern,
                 '/var/log/ceph/{cluster}.log'.format(cluster=cluster_name),
             ]
             for exclude in excludes:
-                args.extend([run.Raw('|'), 'egrep', '-v', exclude])
+                args.extend([run.Raw('|'), 'grep', '-E', '-v', exclude])
             args.extend([
                 run.Raw('|'), 'head', '-n', '1',
             ])
@@ -1681,7 +1681,7 @@ def restart(ctx, config):
             cluster, type_, id_ = teuthology.split_role(role)
             remote.run(
                args = ['sudo',
-                       'egrep', expected_fail,
+                       'grep', '-E', expected_fail,
                        '/var/log/ceph/{cluster}-{type_}.{id_}.log'.format(cluster=cluster, type_=type_, id_=id_),
                 ])
     yield

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -463,15 +463,15 @@ def ceph_log(ctx, config):
             """
             args = [
                 'sudo',
-                'egrep', pattern,
+                'grep', '-E', pattern,
                 '/var/log/ceph/{fsid}/ceph.log'.format(
                     fsid=fsid),
             ]
             if only_match:
-                args.extend([run.Raw('|'), 'egrep', '|'.join(only_match)])
+                args.extend([run.Raw('|'), 'grep', '-E', '|'.join(only_match)])
             if excludes:
                 for exclude in excludes:
-                    args.extend([run.Raw('|'), 'egrep', '-v', exclude])
+                    args.extend([run.Raw('|'), 'grep', '-E', '-v', exclude])
             args.extend([
                 run.Raw('|'), 'head', '-n', '1',
             ])


### PR DESCRIPTION
Backports: #66155 

egrep marked as obsolete, update it to grep -E

Signed-off-by: Nitzan Mordechai <nmordech@ibm.com>
Signed-off-by: Samuel Just <sjust@redhat.com>
(cherry picked from commit 6dfb84e8246d625642fd751c63a3954fdd36cf88)
