### PR TITLE
tentacle: qa/suites: remove centos restriction from valgrind yamls

### DIFF
--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -1,6 +1,3 @@
-# see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
-
 overrides:
   install:
     ceph:


### PR DESCRIPTION
Backports: #66193 

http://tracker.ceph.com/issues/20360 and
http://tracker.ceph.com/issues/18126 were quite some time
ago.  It's causing trouble now because it only overrides the
os_type bit leaving the os_version alone causing teuthology
to look for centos 10 (centos + rocky 10).

Signed-off-by: Samuel Just <sjust@redhat.com>
(cherry picked from commit 53c2197115f6a5cb9687ac5734e556f13ac7e683)
