### PR TITLE
smb: add debug level options to smb cluster resource

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -683,6 +683,13 @@ external_ceph_cluster:
     Optional object. The fields are described in :ref:`external Ceph cluster
     source fields<external-ceph-cluster-source-fields>`. This is an
     advanced option and should be used with caution.
+debug_level:
+    Optional object. Specify subsystem based default logging level values.
+    Supported keys are ``samba`` and ``ctdb``. Supported values include
+    numbers (``1`` through ``10`` typically) or level names such as ``INFO``
+    or ``DEBUG``. The system will translate names to numbers (for ``samba``)
+    or vice-versa as needed. Example YAML snippet:
+    ``debug_level: {smb: 8, ctdb: INFO}``.
 custom_smb_global_options
     Optional mapping. Specify key-value pairs that will be directly added to
     the global ``smb.conf`` options (or equivalent) of a Samba server.  Do

--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -614,6 +614,7 @@ class SMB(ContainerDaemonForm):
         cluster_lock_uri = configs.get('cluster_lock_uri', '')
         cluster_public_addrs = configs.get('cluster_public_addrs', [])
         bind_networks = configs.get('bind_networks', [])
+        tunables = configs.get('tunables', {})
 
         if not instance_id:
             raise Error('invalid instance (cluster) id')
@@ -682,6 +683,7 @@ class SMB(ContainerDaemonForm):
             proxy_image=proxy_image,
             bind_to=self._network_mapper.bind_interfaces(bind_networks),
             remote_control=remote_control_cfg,
+            ctdb_log_level=tunables.get('log_level.ctdb', ''),
         )
         logger.debug('SMB Instance Config: %s', self._instance_cfg)
         logger.debug('Configured files: %s', self._files)

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -189,6 +189,8 @@ class SMBService(CephService):
             _add_cfg(files, c_name, _to_conf(ext_cluster))
             k_name = f'{ext_cluster.alias}.ceph.keyring'
             _add_cfg(files, k_name, _to_keyring(ext_cluster))
+        if smb_spec.tunables:
+            config_blobs['tunables'] = smb_spec.tunables
 
         logger.debug('smb generate_config: %r', config_blobs)
         self._configure_cluster_meta(smb_spec, daemon_spec)

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -17,6 +17,7 @@ import dataclasses
 import logging
 import time
 
+import ceph.smb.constants
 from ceph.deployment.service_spec import SMBExternalCephCluster, SMBSpec
 from ceph.fs.earmarking import EarmarkTopScope
 
@@ -944,6 +945,7 @@ def _generate_config(conf: _ClusterConf) -> Dict[str, Any]:
         cluster_global_opts['idmap config * : backend'] = 'autorid'
         cluster_global_opts['idmap config * : range'] = '2000-9999999'
     cluster_global_opts['smb ports'] = str(_smb_port(cluster))
+    _set_debug_level(cluster_global_opts, conf)
 
     share_configs = {
         share.resource.name: _generate_share(share) for share in conf.shares
@@ -1069,6 +1071,7 @@ def _generate_smb_service_spec(
         remote_control_ssl_key=rc_key,
         remote_control_ca_cert=rc_ca_cert,
         ceph_cluster_configs=ceph_cluster_configs,
+        tunables=_service_spec_tunables(cluster),
     )
 
 
@@ -1235,3 +1238,61 @@ def _tls_uri(
         return None
     uri = tls_credential_entries[src.ref].uri
     return f'URI:{uri}'
+
+
+def _get_log_level(cluster: resources.Cluster, key: str) -> str:
+    if not cluster.debug_level:
+        return ''
+    return str(cluster.debug_level.get(key) or '').upper()
+
+
+def _smb_log_level(cluster: resources.Cluster) -> str:
+    level = orig = _get_log_level(cluster, 'samba')
+    if not level:
+        return ''
+    if level.isdigit():
+        return level
+    # tier mapping
+    for word, low, hi in ceph.smb.constants.DEBUG_LEVEL_TIERS:
+        if level == word:
+            level = str(hi)
+    if not level:
+        level = '1'
+    log.info('Mapped debug level %s to %s', orig, level)
+    return level
+
+
+def _ctdb_log_level(cluster: resources.Cluster) -> str:
+    level = orig = _get_log_level(cluster, 'ctdb')
+    if not level:
+        return ''
+    if level in ceph.smb.constants.DEBUG_LEVEL_TERMS:
+        return level
+    # tier mapping
+    for word, low, hi in ceph.smb.constants.DEBUG_LEVEL_TIERS:
+        try:
+            lval = int(level)
+        except ValueError:
+            continue
+        if lval in range(low, hi + 1):
+            level = word
+    if not level:
+        level = 'INFO'
+    log.info('Mapped debug level %s to %s', orig, level)
+    return level
+
+
+def _set_debug_level(opts: Dict[str, Any], conf: _ClusterConf) -> None:
+    level = _smb_log_level(conf.resource)
+    if not level:
+        return
+    opts['log level'] = level
+
+
+def _service_spec_tunables(
+    cluster: resources.Cluster,
+) -> Optional[Dict[str, str]]:
+    level = _ctdb_log_level(cluster)
+    if not level:
+        return None
+    return {'log_level.ctdb': level}

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -647,6 +647,9 @@ class Cluster(_RBase):
     # connect the smb cluster and all its shares to cephfs file systems
     # hosted on an external ceph cluster
     external_ceph_cluster: Optional[ExternalCephClusterSource] = None
+    # debug_level can be used to change the smb services
+    # default debugging levels
+    debug_level: Optional[dict[str, str]] = None
 
     def validate(self) -> None:
         if not self.cluster_id:
@@ -678,11 +681,13 @@ class Cluster(_RBase):
             raise ValueError(
                 'bind_addrs must have at least one value or not be set'
             )
+        validation.check_debug_level(self.debug_level)
 
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.on_condition(_present)
         rc.on_construction_error(InvalidResourceError.wrap)
+        rc.debug_level.quiet = True
         return rc
 
     @property

--- a/src/pybind/mgr/smb/validation.py
+++ b/src/pybind/mgr/smb/validation.py
@@ -141,3 +141,27 @@ def check_custom_ports(ports: Optional[Dict[str, int]]) -> None:
                 'port numbers must be unique:'
                 f' {port} used for {", ".join(sorted(using_port))}'
             )
+
+
+def check_debug_level(debug_level: Optional[dict[str, str]]) -> None:
+    """Check the types of the debug_level parameter.
+    NOTE: this is intentionally fairly loose with regards to values in order
+    to retain state and lazily translate values as needed.
+    """
+    if debug_level is None:
+        return
+    if not isinstance(debug_level, dict):
+        raise ValueError(f'invalid debug_level type: {type(debug_level)}')
+    _keys = {'samba', 'ctdb'}
+    for key, value in debug_level.items():
+        if not isinstance(key, str):
+            raise ValueError(f'invalid type in debug_level: {type(key)}')
+        if not isinstance(value, str):
+            raise ValueError(f'invalid type in debug_level: {type(value)}')
+        if key not in _keys:
+            raise ValueError(f'invalid key in debug_level: {key!r}')
+        if not (
+            value.isdigit()
+            or value.upper() in ceph.smb.constants.DEBUG_LEVEL_TERMS
+        ):
+            raise ValueError(f'invalid value in debug_level: {value!r}')

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -3837,6 +3837,9 @@ class SMBSpec(ServiceSpec):
         # typically external to the current cluster that the smb services
         # may be permitted to connect to
         ceph_cluster_configs: Optional[List[SMBExternalCephCluster]] = None,
+        # tunables - fine grained options/overrides to be used when deploying
+        # smb services
+        tunables: Optional[Dict[str, str]] = None,
         # --- general tweaks ---
         extra_container_args: Optional[GeneralArgList] = None,
         extra_entrypoint_args: Optional[GeneralArgList] = None,
@@ -3877,6 +3880,7 @@ class SMBSpec(ServiceSpec):
         self.ceph_cluster_configs = SMBExternalCephCluster.convert_list(
             ceph_cluster_configs
         )
+        self.tunables = tunables or {}
         self.validate()
 
     def validate(self) -> None:

--- a/src/python-common/ceph/smb/constants.py
+++ b/src/python-common/ceph/smb/constants.py
@@ -47,3 +47,14 @@ DEFAULT_PORTS = {
     CTDB: CTDB_PORT,
     REMOTE_CONTROL: REMOTE_CONTROL_PORT,
 }
+
+
+# Debugging levels (names/translation)
+DEBUG_LEVEL_TIERS = [
+    ("ERROR", 0, 0),
+    ("WARNING", 1, 2),
+    ("NOTICE", 3, 4),
+    ("INFO", 5, 8),
+    ("DEBUG", 9, 10),
+]
+DEBUG_LEVEL_TERMS = {t[0] for t in DEBUG_LEVEL_TIERS}


### PR DESCRIPTION
Add a new cluster level option `debug_level` that users can use to specify initial deubgging/logging levels for subsystems that make up the smb cluster.

For example:
```yaml                                                     
resources:
-   resource_type: ceph.smb.cluster
    cluster_id: example1
    auth_mode: active-directory
    domain_settings:
        realm: DOMAIN1.SINK.TEST
        join_sources:
        - {source_type: resource, ref: join1-admin}
    placement:
      count: 3
    debug_level: {samba: "10", ctdb: "debug"}
```

In this case the smb debug_level applies to core smb services (smbd, winbindd). The "ctdb" key applies to ctdbd. Other keys can be added in the future as needed.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
