### PR TITLE
tentacle: qa/tasks/keystone: restart mariadb for rocky and alma linux too

### DIFF
--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -163,7 +163,7 @@ def setup_database(ctx, config):
 
         # MariaDB on RHEL/CentOS needs service started after package install
         # while Ubuntu starts service by default.
-        if remote.os.name == 'rhel' or remote.os.name == 'centos':
+        if remote.os.name in ('rhel', 'centos', 'alma', 'rocky'):
             remote.run(args=['sudo', 'systemctl', 'restart', 'mariadb'])
 
         run_mysql_query(ctx, remote, "CREATE USER 'keystone'@'localhost' IDENTIFIED BY 'SECRET';")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75184

---

backport of https://github.com/ceph/ceph/pull/67123
parent tracker: https://tracker.ceph.com/issues/74653

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh