### PR TITLE
tools/cephfs_mirror: Distribute datasync threads evenly across snapshots

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -556,6 +556,8 @@ Configuration Options
 
 .. confval:: cephfs_mirror_max_concurrent_directory_syncs
 .. confval:: cephfs_mirror_max_datasync_threads
+.. confval:: cephfs_mirror_distribute_datasync_threads
+.. confval:: cephfs_mirror_datasync_files_per_batch
 .. confval:: cephfs_mirror_action_update_interval
 .. confval:: cephfs_mirror_restart_mirror_on_blocklist_interval
 .. confval:: cephfs_mirror_max_snapshot_sync_per_cycle

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -76,6 +76,7 @@ class TestMirroring(CephFSTestCase):
         self.secondary_fs_name = self.backup_fs.name
         self.secondary_fs_id = self.backup_fs.id
         self.enable_mirroring_module()
+        self.config_set('client.mirror', 'cephfs_mirror_directory_scan_interval', 1)
 
     def tearDown(self):
         self.disable_mirroring_module()
@@ -1636,4 +1637,143 @@ class TestMirroring(CephFSTestCase):
                                     peer_spec, f'/{dir_name}', snap_b, expected_snap_count)
         self.verify_snapshot(dir_name, snap_a)
         self.verify_snapshot(dir_name, snap_b)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_multithread_snapshot_starvation(self):
+        """
+        Test that newly added mirrored directories are starved until the current syncing one is completed.
+
+        ... when multiple directories are mirrored, with cephfs_mirror_distribute_datasync_threads option
+        disabled, validate that the newly added mirrored directory snapshots are starved until the current
+        syncing one is completed.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        peer_spec = "client.mirror_remote@ceph"
+
+        # create 3 directories to snap
+        self.mount_a.run_shell(["mkdir", "d0"])
+        self.mount_a.run_shell(["mkdir", "d1"])
+        self.mount_a.run_shell(["mkdir", "d2"])
+
+        # Create d1, d2 with small number of files and d0 with large number of files
+        self.mount_a.create_n_files("d0/myfile", 10000)
+        self.mount_a.create_n_files("d1/myfile", 100)
+        self.mount_a.create_n_files("d2/myfile", 100)
+
+        log.debug('enabling mirroring')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        # disable distribute_datasync_threads options
+        log.debug('disabling cephfs_mirror_distribute_datasync_threads config')
+        self.config_set('client.mirror', 'cephfs_mirror_distribute_datasync_threads', 'false')
+
+        log.debug('adding directory paths')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d1')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d2')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+
+        # take /d0 snapshot first, so that it starts syncing
+        log.debug('take /d0 snapshot first')
+        snap_name = "snap0"
+        self.mount_a.run_shell(["mkdir", f"d0/.snap/{snap_name}"])
+        log.debug('checking /d0/.snap/snap0 in progress')
+        self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
+                                         peer_spec, '/d0', 'snap0')
+
+        # now that /d0 is in progress, take snaps of /d1 and /d2.
+        self.mount_a.run_shell(["mkdir", f"d1/.snap/{snap_name}"])
+        self.mount_a.run_shell(["mkdir", f"d2/.snap/{snap_name}"])
+
+        # Wait for d0, d1, d2 to finish sync
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id, peer_spec, '/d2', 'snap0', 1)
+        self.verify_snapshot('d2', 'snap0')
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id, peer_spec, '/d1', 'snap0', 1)
+        self.verify_snapshot('d1', 'snap0')
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id, peer_spec, '/d0', 'snap0', 1)
+        self.verify_snapshot('d0', 'snap0')
+
+        # Even though /d1 and /d2 had only 100 files and added while d0 is already syncing, with
+        # cephfs_mirror_distribute_datasync_threads option disabled, /d1 and /d2 syncs after /d0
+        # proving the starvation
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        res = self.mirror_daemon_command(f'peer status for fs: {self.primary_fs_name}',
+                                         'fs', 'mirror', 'peer', 'status',
+                                         f'{self.primary_fs_name}@{self.primary_fs_id}',
+                                         peer_uuid)
+        d0_sync_time_stamp = float(res["/d0"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+        d1_sync_time_stamp = float(res["/d1"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+        d2_sync_time_stamp = float(res["/d2"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+
+        self.assertGreaterEqual(d1_sync_time_stamp, d0_sync_time_stamp)
+        self.assertGreaterEqual(d2_sync_time_stamp, d0_sync_time_stamp)
+
+        self.config_set('client.mirror', 'cephfs_mirror_distribute_datasync_threads', 'true')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_multithread_snapshot_no_starvation(self):
+        """
+        Test that newly added mirrored directories are not starved until the current syncing one is completed.
+
+        ... when multiple directories are mirrored, with cephfs_mirror_distribute_datasync_threads option
+        enabled, validate that the newly added mirrored directory snapshots are not starved until the current
+        one is completed.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        peer_spec = "client.mirror_remote@ceph"
+
+        # create 3 directories to snap
+        self.mount_a.run_shell(["mkdir", "d0"])
+        self.mount_a.run_shell(["mkdir", "d1"])
+        self.mount_a.run_shell(["mkdir", "d2"])
+
+        # Idea is d1, d2 with small number of files should not starve while d0 is syncing
+        self.mount_a.create_n_files("d0/myfile", 10000)
+        self.mount_a.create_n_files("d1/myfile", 100)
+        self.mount_a.create_n_files("d2/myfile", 100)
+
+        log.debug('enabling mirroring')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        # distribute_datasync_threads for fair scheduling of sync threads is enabled by default
+        log.debug('cephfs_mirror_distribute_datasync_threads config is enabled by default...')
+
+        log.debug('adding directory paths')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d1')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d2')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+
+        # take /d0 snapshot first, so that it starts syncing
+        log.debug('take /d0 snapshot first')
+        snap_name = "snap0"
+        self.mount_a.run_shell(["mkdir", f"d0/.snap/{snap_name}"])
+        log.debug('checking /d0/.snap/snap0 in progress')
+        self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
+                                         peer_spec, '/d0', 'snap0')
+
+        # now that /d0 is in progress, take snaps of /d1 and /d2.
+        self.mount_a.run_shell(["mkdir", f"d1/.snap/{snap_name}"])
+        self.mount_a.run_shell(["mkdir", f"d2/.snap/{snap_name}"])
+
+        # Wait for d0, d1, d2 to finish sync
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id, peer_spec, '/d2', 'snap0', 1)
+        self.verify_snapshot('d2', 'snap0')
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id, peer_spec, '/d1', 'snap0', 1)
+        self.verify_snapshot('d1', 'snap0')
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id, peer_spec, '/d0', 'snap0', 1)
+        self.verify_snapshot('d0', 'snap0')
+
+        # since /d1 and /d2 had only 100 files and added while d0 is already syncing, with
+        # cephfs_mirror_distribute_datasync_threads option enabled, /d1 and /d2 should have synced ahead of /d0
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        res = self.mirror_daemon_command(f'peer status for fs: {self.primary_fs_name}',
+                                         'fs', 'mirror', 'peer', 'status',
+                                         f'{self.primary_fs_name}@{self.primary_fs_id}',
+                                         peer_uuid)
+        d0_sync_time_stamp = float(res["/d0"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+        d1_sync_time_stamp = float(res["/d1"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+        d2_sync_time_stamp = float(res["/d2"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+
+        self.assertLess(d1_sync_time_stamp, d0_sync_time_stamp)
+        self.assertLess(d2_sync_time_stamp, d0_sync_time_stamp)
+
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -25,6 +25,21 @@ options:
   services:
   - cephfs-mirror
   min: 1
+- name: cephfs_mirror_distribute_datasync_threads
+  type: bool
+  level: advanced
+  desc: distribute data synchronization threads evenly across multiple snapshots.
+  long_desc: controls how datasync worker threads are scheduled when multiple snapshots are
+    queued for synchronization. When enabled, worker threads are distributed fairly across
+    active snapshots, preventing a single large snapshot from monopolizing all available
+    threads and causing other snapshots to starve. When disabled, datasync threads process
+    one snapshot until completion before switching to another, which can improve
+    throughput for individual large snapshots but may increase latency for other queued snapshots.
+    Enabling this option improves responsiveness and reduces starvation in environments
+    where multiple directories are configured to be mirrored.
+  default: true
+  services:
+  - cephfs-mirror
 - name: cephfs_mirror_blockdiff_min_file_size
   type: size
   level: advanced

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -40,6 +40,20 @@ options:
   default: true
   services:
   - cephfs-mirror
+- name: cephfs_mirror_datasync_files_per_batch
+  type: uint
+  level: advanced
+  desc: maximum number of files processed by datasync threads per scheduling cycle before yielding.
+  long_desc: defines the maximum number of files a data synchronization thread will process for a
+    specific snapshot before yielding the thread to re-check scheduling logic. This is applicable
+    only when cephfs_mirror_distribute_datasync_threads is enabled. This batch size determines the
+    granularity of thread distribution; smaller batches allow threads to rotate between snapshots
+    more frequently, while larger batches improve throughput by minimizing the overhead of thread
+    re-assignment.
+  default: 64
+  services:
+  - cephfs-mirror
+  min: 1
 - name: cephfs_mirror_blockdiff_min_file_size
   type: size
   level: advanced

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1407,6 +1407,15 @@ bool PeerReplayer::SyncMechanism::has_pending_work() const {
   if (m_datasync_error || job_done)
     return false;
 
+  // Distribute threads fairly if enabled
+  if (m_peer_replayer.get_distribute_datasync_threads()) {
+    int total_threads = m_peer_replayer.m_data_replayers.size();
+    int snapshots_queued = m_peer_replayer.get_num_queued_snapshots_unlocked();
+    //Cieling division to avoid unused remainder threads and zero allocation
+    int fair_share = (total_threads + snapshots_queued - 1) / snapshots_queued;
+    if (m_in_flight >= fair_share)
+      return false;
+  }
   return true;
 }
 
@@ -1695,7 +1704,7 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
   dout(20) << ": dir_root=" << m_dir_root << ", epath=" << epath
            << ", sync_check=" << sync_check << dendl;
 
-  if (!sync_check || stx.stx_size <= m_peer_replayer.blockdiff_min_file_size) {
+  if (!sync_check || stx.stx_size <= m_peer_replayer.get_blockdiff_min_file_size()) {
     return SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
   }
 
@@ -2082,6 +2091,27 @@ int PeerReplayer::synchronize(const std::string &dir_root, const Snapshot &curre
   return r;
 }
 
+void PeerReplayer::set_changed_mirroring_configurations() {
+  // Get configs
+  uint64_t blockdiff_min_file_size_conf = g_ceph_context->_conf.get_val<Option::size_t>(
+                                          "cephfs_mirror_blockdiff_min_file_size");
+  bool distribute_datasync_threads_conf = g_ceph_context->_conf.get_val<bool>(
+                                          "cephfs_mirror_distribute_datasync_threads");
+
+  // Compare and set configs
+  uint64_t blockdiff_min_file_size = set_blockdiff_min_file_size(blockdiff_min_file_size_conf);
+  if (blockdiff_min_file_size != blockdiff_min_file_size_conf) {
+    dout(10) << ":  blockdiff_min_file_size changed" << " old=" << blockdiff_min_file_size
+             << " new=" << blockdiff_min_file_size_conf << dendl;
+  }
+  bool distribute_datasync_threads = set_distribute_datasync_threads(distribute_datasync_threads_conf);
+  if (distribute_datasync_threads != distribute_datasync_threads_conf) {
+    dout(10) << ": cephfs_mirror_distribute_datasync_threads changed"
+            << " old=" << distribute_datasync_threads
+            << " new=" << distribute_datasync_threads_conf << dendl;
+  }
+}
+
 int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
   dout(20) << ": dir_root=" << dir_root << dendl;
 
@@ -2149,7 +2179,6 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
   double start = 0;
   double end = 0;
   double duration = 0;
-  uint64_t blockdiff_min_file_size_conf = 0;
   for (; it != local_snap_map.end(); ++it) {
     if (m_perf_counters) {
       start = std::chrono::duration_cast<std::chrono::seconds>(clock::now().time_since_epoch()).count();
@@ -2158,17 +2187,8 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
       m_perf_counters->tset(l_cephfs_mirror_peer_replayer_last_synced_start, t);
     }
     set_current_syncing_snap(dir_root, it->first, it->second);
-    // Check for blockdiff_min_file_size config change at the beginning of snapshot sync
-    blockdiff_min_file_size_conf = g_ceph_context->_conf.get_val<Option::size_t>(
-                                     "cephfs_mirror_blockdiff_min_file_size");
-    {
-      std::scoped_lock locker(m_lock);
-      if (blockdiff_min_file_size != blockdiff_min_file_size_conf) {
-        dout(10) << ":  blockdiff_min_file_size changed" << " old=" << blockdiff_min_file_size
-                 << " new=" << blockdiff_min_file_size_conf << dendl;
-        blockdiff_min_file_size = blockdiff_min_file_size_conf;
-      }
-    }
+    // Check for changed mirroring configurations
+    set_changed_mirroring_configurations();
     boost::optional<Snapshot> prev = boost::none;
     if (last_snap_id != 0) {
       prev = std::make_pair(last_snap_name, last_snap_id);
@@ -2416,8 +2436,9 @@ void PeerReplayer::run_datasync(SnapshotDataSyncThread *data_replayer) {
     }
 
     // Wait on data sync queue for entries to process
+    uint64_t batch = 100;
     SyncEntry entry;
-    while (syncm->pop_dataq_entry(entry)) {
+    while (batch-- && syncm->pop_dataq_entry(entry)) {
       bool need_data_sync = true;
       bool need_attr_sync = true;
       if (entry.sync_check) {
@@ -2471,7 +2492,7 @@ void PeerReplayer::run_datasync(SnapshotDataSyncThread *data_replayer) {
       const bool sync_error =
         syncm->get_datasync_error_unlocked() ||
         syncm->get_crawl_error_unlocked();
-      if (!syncm_q.empty() && last_in_flight_syncm && (crawl_finished || sync_error)) {
+      if (!syncm_q.empty() && last_in_flight_syncm && ((crawl_finished && syncm->is_dataq_empty_unlocked()) || sync_error)) {
         if (sync_error && !is_syncm_active(syncm)){
           dout(20) << ": syncm object=" << syncm << " already dequeued" << dendl;
         } else {

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2097,6 +2097,8 @@ void PeerReplayer::set_changed_mirroring_configurations() {
                                           "cephfs_mirror_blockdiff_min_file_size");
   bool distribute_datasync_threads_conf = g_ceph_context->_conf.get_val<bool>(
                                           "cephfs_mirror_distribute_datasync_threads");
+  uint64_t datasync_files_per_batch_conf = g_ceph_context->_conf.get_val<uint64_t>(
+                                          "cephfs_mirror_datasync_files_per_batch");
 
   // Compare and set configs
   uint64_t blockdiff_min_file_size = set_blockdiff_min_file_size(blockdiff_min_file_size_conf);
@@ -2109,6 +2111,12 @@ void PeerReplayer::set_changed_mirroring_configurations() {
     dout(10) << ": cephfs_mirror_distribute_datasync_threads changed"
             << " old=" << distribute_datasync_threads
             << " new=" << distribute_datasync_threads_conf << dendl;
+  }
+  uint64_t datasync_files_per_batch = set_datasync_files_per_batch(datasync_files_per_batch_conf);
+  if (datasync_files_per_batch != datasync_files_per_batch_conf) {
+    dout(10) << ":  cephfs_mirror_datasync_files_per_batch changed"
+             << " old=" << datasync_files_per_batch
+             << " new=" << datasync_files_per_batch_conf << dendl;
   }
 }
 
@@ -2436,9 +2444,10 @@ void PeerReplayer::run_datasync(SnapshotDataSyncThread *data_replayer) {
     }
 
     // Wait on data sync queue for entries to process
-    uint64_t batch = 100;
+    uint64_t batch = get_datasync_files_per_batch();
     SyncEntry entry;
-    while (batch-- && syncm->pop_dataq_entry(entry)) {
+    //Only batch if distribute datasync threads config is enabled
+    while ((!distribute_datasync_threads || batch--) && syncm->pop_dataq_entry(entry)) {
       bool need_data_sync = true;
       bool need_attr_sync = true;
       if (entry.sync_check) {

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -227,6 +227,9 @@ private:
     bool pop_dataq_entry(PeerReplayer::SyncEntry &out);
     bool has_pending_work() const;
     void mark_crawl_finished(int ret);
+    bool is_dataq_empty_unlocked() const {
+      return m_sync_dataq.empty();
+    }
     bool get_crawl_finished_unlocked() {
       return m_crawl_finished;
     }
@@ -514,7 +517,8 @@ private:
   ceph::condition_variable smq_cv;
   std::deque<std::shared_ptr<SyncMechanism>> syncm_q;
 
-  uint64_t blockdiff_min_file_size = 0;
+  std::atomic<uint64_t> blockdiff_min_file_size{0};
+  std::atomic<bool> distribute_datasync_threads{true};
 
   ServiceDaemonStats m_service_daemon_stats;
 
@@ -580,6 +584,22 @@ private:
   void enqueue_syncm(const std::shared_ptr<SyncMechanism>& item);
   ceph::mutex& get_smq_lock() {
     return smq_lock;
+  }
+  int get_num_queued_snapshots_unlocked() {
+    return syncm_q.size();
+  }
+  void set_changed_mirroring_configurations();
+  uint64_t get_blockdiff_min_file_size() const {
+    return blockdiff_min_file_size.load(std::memory_order_relaxed);
+  }
+  uint64_t set_blockdiff_min_file_size(uint64_t value) {
+    return blockdiff_min_file_size.exchange(value, std::memory_order_relaxed);
+  }
+  bool get_distribute_datasync_threads() const {
+    return distribute_datasync_threads.load(std::memory_order_relaxed);
+  }
+  bool set_distribute_datasync_threads(bool value) {
+    return distribute_datasync_threads.exchange(value, std::memory_order_relaxed);
   }
 };
 

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -519,6 +519,7 @@ private:
 
   std::atomic<uint64_t> blockdiff_min_file_size{0};
   std::atomic<bool> distribute_datasync_threads{true};
+  std::atomic<uint64_t> datasync_files_per_batch{64};
 
   ServiceDaemonStats m_service_daemon_stats;
 
@@ -600,6 +601,12 @@ private:
   }
   bool set_distribute_datasync_threads(bool value) {
     return distribute_datasync_threads.exchange(value, std::memory_order_relaxed);
+  }
+  uint64_t get_datasync_files_per_batch() const {
+    return datasync_files_per_batch.load(std::memory_order_relaxed);
+  }
+  uint64_t set_datasync_files_per_batch(uint64_t value) {
+    return datasync_files_per_batch.exchange(value, std::memory_order_relaxed);
   }
 };
 


### PR DESCRIPTION
All datasync threads consume one snapshot at a time.
This starves the other queued snapshots for sync.
Provide an option to distribute the datasync threads
equally among queued snapshots.

Add the configuration cephfs_mirror_distribute_datasync_threads
to enable/disable data sync threads fair scheduling among
snapshots queued for syncing.

Fixes: https://tracker.ceph.com/issues/75091
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
