### PR TITLE
rgw/lua: Add new Lua postAuth hook that is being run after authorization

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -8,11 +8,12 @@ Lua Scripting
 
 This feature allows users to assign execution context to Lua scripts. The supported contexts are:
 
-- ``prerequest`` which will execute a script before each operation is performed
-- ``postrequest`` which will execute after each operation is performed
-- ``background`` which will execute within a specified time interval
-- ``getdata`` which will execute on objects' data when objects are downloaded
-- ``putdata`` which will execute on objects' data when objects are uploaded
+ - ``prerequest`` which will execute a script before each operation is performed
+ - ``postauth`` which will execute a script after each operation is authorized but before it is performed
+ - ``postrequest`` which will execute after each operation is performed
+ - ``background`` which will execute within a specified time interval
+ - ``getdata`` which will execute on objects' data when objects are downloaded
+ - ``putdata`` which will execute on objects' data when objects are uploaded
 
 A request (pre or post) or data (get or put) context script may be constrained to operations belonging to a specific tenant's users.
 The request context script can also access fields in the request and modify certain fields, as well as the `Global RGW Table`_.
@@ -49,7 +50,7 @@ To upload a script:
 
 ::
 
-   # radosgw-admin script put --infile={lua-file-path} --context={prerequest|postrequest|background|getdata|putdata} [--tenant={tenant-name}]
+   # radosgw-admin script put --infile={lua-file-path} --context={prerequest|postauth|postrequest|background|getdata|putdata} [--tenant={tenant-name}]
 
 * When uploading a script with the ``background`` context, a tenant name should not be specified.
 
@@ -62,14 +63,14 @@ To print the content of the script to standard output:
 
 ::
 
-   # radosgw-admin script get --context={preRequest|postRequest|background|getdata|putdata} [--tenant={tenant-name}]
+   # radosgw-admin script get --context={preRequest|postAuth|postRequest|background|getdata|putdata} [--tenant={tenant-name}]
 
 
 To remove the script:
 
 ::
 
-   # radosgw-admin script rm --context={preRequest|postRequest|background|getdata|putdata} [--tenant={tenant-name}]
+   # radosgw-admin script rm --context={preRequest|postAuth|postRequest|background|getdata|putdata} [--tenant={tenant-name}]
 
 
 Package Management via CLI
@@ -351,7 +352,7 @@ The script's return value determines how RGW proceeds with the request:
 
 Return Value Context
 ~~~~~~~~~~~~~~~~~~~~
-The Lua script’s return value is evaluated only during the prerequest context and is ignored in any other RGW request-processing context.
+The Lua script’s return value is evaluated only during the prerequest and postauth context and is ignored in any other RGW request-processing context.
 The HTTP response status code is 403 (Forbidden) by default when a request is blocked by Lua. The response code can be changed using ``Request.Response.HTTPStatusCode`` and ``Request.Response.HTTPStatus``.
 If a request is aborted this way, the ``data`` and ``postrequest`` context will also be aborted.
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -135,7 +135,7 @@ inline int posix_errortrans(int r)
  return ERR_NO_SUCH_BUCKET == r ? ENOENT : r;
 }
 
-static const std::string LUA_CONTEXT_LIST("prerequest, postrequest, background, getdata, putdata");
+static const std::string LUA_CONTEXT_LIST("prerequest, postauth, postrequest, background, getdata, putdata");
 
 void usage()
 {

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -26,6 +26,9 @@ context to_context(const std::string& s)
   if (strcasecmp(s.c_str(), "prerequest") == 0) {
     return context::preRequest;
   }
+  if (strcasecmp(s.c_str(), "postauth") == 0) {
+    return context::postAuth;
+  }
   if (strcasecmp(s.c_str(), "postrequest") == 0) {
     return context::postRequest;
   }
@@ -46,6 +49,8 @@ std::string to_string(context ctx)
   switch (ctx) {
     case context::preRequest:
       return "prerequest";
+    case context::postAuth:
+      return "postauth";
     case context::postRequest:
       return "postrequest";
     case context::background:

--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -21,6 +21,7 @@ namespace rgw::lua {
 
 enum class context {
   preRequest,
+  postAuth,
   postRequest,
   background,
   getData,

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -261,6 +261,34 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
   if (rate_limit(driver, s)) {
     return -ERR_RATE_LIMITED;
   }
+
+  bool is_health_request = (op->get_type() == RGW_OP_GET_HEALTH_CHECK);
+  {
+    if (!is_health_request) {
+      std::string script;
+      auto rc = rgw::lua::read_script(s, s->penv.lua.manager.get(),
+                                      s->bucket_tenant, s->yield,
+                                      rgw::lua::context::postAuth, script);
+      if (rc == -ENOENT) {
+        // no script, nothing to do
+      } else if (rc < 0) {
+        ldpp_dout(op, 5) <<
+          "WARNING: failed to execute post authorization script. "
+          "error: " << rc << dendl;
+      } else {
+        int script_return_code = 0;
+        rc = rgw::lua::request::execute(s->penv.rest, s->penv.olog.get(), s, op, script, script_return_code);
+        if (rc < 0) {
+          ldpp_dout(op, 5) <<
+            "WARNING: failed to execute post authorization script. "
+            "error: " << rc << dendl;
+        }
+        if (script_return_code == -EPERM) {
+          return script_return_code;
+        }
+      }
+    }
+  }
   ldpp_dout(op, 2) << "executing" << dendl;
   {
     auto span = tracing::rgw::tracer.add_span("execute", s->trace);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -408,7 +408,7 @@
      --notification-id             bucket notifications id
   
   Script options:
-     --context                     context in which the script runs. one of: prerequest, postrequest, background, getdata, putdata
+     --context                     context in which the script runs. one of: prerequest, postauth, postrequest, background, getdata, putdata
      --package                     name of the Lua package that should be added/removed to/from the allowlist
      --allow-compilation           package is allowed to compile C code as part of its installation
   

--- a/src/test/rgw/lua/test_lua.py
+++ b/src/test/rgw/lua/test_lua.py
@@ -208,7 +208,7 @@ class UnixSocket:
 
 @pytest.mark.basic_test
 def test_script_management():
-    contexts = ['prerequest', 'postrequest', 'background', 'getdata', 'putdata']
+    contexts = ['prerequest', 'postauth', 'postrequest', 'background', 'getdata', 'putdata']
     scripts = {}
     for context in contexts:
         script = 'print("hello from ' + context + '")'
@@ -232,7 +232,7 @@ def test_script_management():
 def test_script_management_with_tenant():
     tenant = 'mytenant'
     conn2 = another_user(tenant)
-    contexts = ['prerequest', 'postrequest', 'getdata', 'putdata']
+    contexts = ['prerequest', 'postauth', 'postrequest', 'getdata', 'putdata']
     scripts = {}
     for context in contexts:
         for t in ['', tenant]:
@@ -297,7 +297,7 @@ end
     # cleanup
     conn.delete_object(Bucket=bucket_name, Key=key)
     conn.delete_bucket(Bucket=bucket_name)
-    contexts = ['prerequest', 'postrequest', 'getdata', 'putdata']
+    contexts = ['prerequest', 'postauth', 'postrequest', 'getdata', 'putdata']
     for context in contexts:
         result = admin(['script', 'rm', '--context', context])
         assert result[1] == 0
@@ -323,7 +323,7 @@ end
 RGWDebugLog("op was: "..Request.RGWOp)
 '''
 
-    contexts = ['prerequest', 'postrequest', 'getdata', 'putdata']
+    contexts = ['prerequest', 'postauth', 'postrequest', 'getdata', 'putdata']
     for context in contexts:
         footer = '\nRGWDebugLog("context was: '+context+'\\n\\n")'
         result = put_script(script+footer, context)
@@ -349,7 +349,7 @@ RGWDebugLog("op was: "..Request.RGWOp)
     # cleanup
     delete_all_objects(conn, bucket_name)
     conn.delete_bucket(Bucket=bucket_name)
-    contexts = ['prerequest', 'postrequest', 'getdata', 'putdata']
+    contexts = ['prerequest', 'postauth', 'postrequest', 'getdata', 'putdata']
     for context in contexts:
         result = admin(['script', 'rm', '--context', context])
         assert result[1] == 0
@@ -406,7 +406,7 @@ RGWDebugLog("payload size of chunk of: " .. full_name .. " is: " .. #Data)
     # cleanup
     delete_all_objects(conn, bucket_name)
     conn.delete_bucket(Bucket=bucket_name)
-    contexts = ['prerequest', 'postrequest', 'background', 'getdata', 'putdata']
+    contexts = ['prerequest', 'postauth', 'postrequest', 'background', 'getdata', 'putdata']
     for context in contexts:
         result = admin(['script', 'rm', '--context', context])
         assert result[1] == 0
@@ -477,7 +477,7 @@ end
         socket_server.shutdown()
         delete_all_objects(conn, bucket_name)
         conn.delete_bucket(Bucket=bucket_name)
-        contexts = ['prerequest', 'postrequest', 'background', 'getdata', 'putdata']
+        contexts = ['prerequest', 'postauth', 'postrequest', 'background', 'getdata', 'putdata']
         for context in contexts:
             result = admin(['script', 'rm', '--context', context])
             assert result[1] == 0
@@ -504,6 +504,38 @@ def test_interrupt_request():
         pass
 
     out, err = admin(['script', 'rm', '--context', 'prerequest'])
+    assert err == 0
+
+    try:
+        conn.get_object(Bucket=bucket_name, Key=key)
+        pytest.fail("The object was written to the bucket despite the error.")
+    except Exception as e:
+        assert e.response['Error']['Code'] == 'NoSuchKey'
+        log.info("Successfully confirmed that the request was interrupted.")
+
+    conn.delete_bucket(Bucket=bucket_name)
+
+@pytest.mark.example_test
+def test_interrupt_request_postauth():
+    script = '''
+        return RGW_ABORT_REQUEST
+    '''
+
+    conn = connection()
+    bucket_name = gen_bucket_name()
+    conn.create_bucket(Bucket=bucket_name)
+    
+    result = put_script(script, "postauth")
+    assert result[1] == 0
+    key = "hello"
+    
+    try:
+        conn.put_object(Body="this should be blocked".encode("ascii"), Bucket=bucket_name, Key=key)
+        pytest.fail("The put_object operation was not blocked by the Lua script.")
+    except Exception as e:
+        pass
+
+    out, err = admin(['script', 'rm', '--context', 'postauth'])
     assert err == 0
 
     try:


### PR DESCRIPTION
Currently, the prerequest Lua context runs after authentication is done, but before the authorization. Because of this, bucket specific data like bucket tags and tenant info are not loaded yet into the environment when the prerequest script runs.

PR implements a new Lua hook after user is authorized and bucket context is ready, but before we handle the actual request.

Fixes: https://tracker.ceph.com/issues/75195





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
