### PR TITLE
tentacle: Containerfile updates to support Rocky 10 as base image

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -152,7 +152,7 @@ rbd-mirror" \
 
 # Optional crimson package(s)
 RUN if [[ "${OSD_FLAVOR}" == "crimson-debug" || "${OSD_FLAVOR}" == "crimson-release" ]]; then \
-    echo "ceph-crimson-osd" >> packages.txt ; \
+    echo "ceph-osd-crimson" >> packages.txt ; \
 fi
 
 # Ceph "Recommends"

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -22,6 +22,8 @@ ARG OSD_FLAVOR="default"
 # (optional) Should be 'true' for CI builds (pull from shaman, etc.)
 ARG CI_CONTAINER="true"
 
+# (optional, for hackers) Use the following URL for ceph repo.
+ARG CUSTOM_CEPH_REPO_URL
 
 RUN /bin/echo -e "\
 FROM_IMAGE: ${FROM_IMAGE}\n\
@@ -85,6 +87,11 @@ RUN set -ex && \
 
 # Ceph repo
 RUN --mount=type=secret,id=prerelease_creds set -ex && \
+    if [ "$CUSTOM_CEPH_REPO_URL" ]; then \
+        curl -L -o /tmp/custom-ceph.repo "$CUSTOM_CEPH_REPO_URL" && \
+        mv /tmp/custom-ceph.repo  /etc/yum.repos.d/custom-ceph.repo && \
+        exit 0 ; \
+    fi && \
     rpm --import 'https://download.ceph.com/keys/release.asc' && \
     ARCH=$(arch); if [ "${ARCH}" == "aarch64" ]; then ARCH="arm64"; fi ;\
     IS_RELEASE=0 ;\

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -46,6 +46,23 @@ CEPH_GIT_REPO=${CEPH_GIT_REPO} \
 GANESHA_REPO_BASEURL=${GANESHA_REPO_BASEURL} \
 OSD_FLAVOR=${OSD_FLAVOR}
 
+# Use bash so var setting works.
+SHELL ["/bin/bash", "-c"]
+
+# Derive EL_VER (el9/el10) and DIST_PATH (centos/9|rocky/10|almalinux/X)
+# from /etc/os-release for later use in repo URLs.
+RUN set -euo pipefail; \
+    source /etc/os-release; \
+    MAJOR="${VERSION_ID%%.*}"; \
+    case "${ID}" in \
+      centos)    DIST_PATH="centos/${MAJOR}" ;; \
+      rocky)     DIST_PATH="rocky/${MAJOR}" ;; \
+      almalinux) DIST_PATH="almalinux/${MAJOR}" ;; \
+      *) echo "Unsupported base: ID=${ID} VERSION_ID=${VERSION_ID}" >&2; exit 1 ;; \
+    esac; \
+    EL_VER="el${MAJOR}"; \
+    printf 'EL_VER=%s\nDIST_PATH=%s\nID=%s\nVERSION_ID=%s\nMAJOR=%s\n' \
+           "$EL_VER" "$DIST_PATH" "$ID" "$VERSION_ID" "$MAJOR" > /etc/ceph-distro.env
 
 #===================================================================================================
 # Install ceph and dependencies, and clean up
@@ -65,28 +82,37 @@ RUN \
 # Pre-reqs
 RUN dnf install -y --setopt=install_weak_deps=False epel-release jq
 
-# Add NFS-Ganesha repo
-RUN \
-    echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo && \
-    echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo && \
-    echo "baseurl=${GANESHA_REPO_BASEURL}" >> /etc/yum.repos.d/ganesha.repo && \
-    echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo && \
-    echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo
+# NFS-Ganesha repo
+RUN set -eux; \
+    source /etc/ceph-distro.env; \
+    if [[ "${DIST_PATH}" == rocky/* ]]; then \
+        curl -fs -L "https://shaman.ceph.com/api/repos/nfs-ganesha/main/latest/${DIST_PATH}/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo; \
+    else \
+      { \
+        printf '%s\n' '[ganesha]'; \
+        printf '%s\n' 'name=ganesha'; \
+        printf '%s\n' "baseurl=${GANESHA_REPO_BASEURL}"; \
+        printf '%s\n' 'gpgcheck=0'; \
+        printf '%s\n' 'enabled=1'; \
+      } > /etc/yum.repos.d/ganesha.repo; \
+    fi
 
 # ISCSI repo
-RUN set -ex && \
-    curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/main/latest/centos/9/repo?arch=$(arch) -o /etc/yum.repos.d/tcmu-runner.repo && \
+RUN set -eux && \
+    source /etc/ceph-distro.env && \
+    curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/main/latest/${DIST_PATH}/repo?arch=$(arch) -o /etc/yum.repos.d/tcmu-runner.repo && \
     case "${CEPH_REF}" in \
         quincy|reef) \
-            curl -fs -L https://download.ceph.com/ceph-iscsi/3/rpm/el9/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
+            curl -fs -L https://download.ceph.com/ceph-iscsi/3/rpm/${EL_VER}/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
             ;;\
         main|*) \
-            curl -fs -L https://shaman.ceph.com/api/repos/ceph-iscsi/main/latest/centos/9/repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
+            curl -fs -L https://shaman.ceph.com/api/repos/ceph-iscsi/main/latest/${DIST_PATH}/repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
             ;;\
     esac
 
 # Ceph repo
 RUN --mount=type=secret,id=prerelease_creds set -ex && \
+    source /etc/ceph-distro.env && \
     if [ "$CUSTOM_CEPH_REPO_URL" ]; then \
         curl -L -o /tmp/custom-ceph.repo "$CUSTOM_CEPH_REPO_URL" && \
         mv /tmp/custom-ceph.repo  /etc/yum.repos.d/custom-ceph.repo && \
@@ -97,13 +123,13 @@ RUN --mount=type=secret,id=prerelease_creds set -ex && \
     IS_RELEASE=0 ;\
     if [[ "${CI_CONTAINER}" == "true" ]] ; then \
         # TODO: this can return different ceph builds (SHA1) for x86 vs. arm runs. is it important to fix?
-        REPO_URL=$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/${ARCH}&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -r .[0].url) ;\
+        REPO_URL=$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=${DIST_PATH}/${ARCH}&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -r .[0].url) ;\
     else \
         IS_RELEASE=1 ;\
         source /run/secrets/prerelease_creds; \
-        REPO_URL="https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/rpm-${CEPH_REF}/el9/" ;\
+        REPO_URL="https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/rpm-${CEPH_REF}/${EL_VER}/" ;\
     fi && \
-    rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${IS_RELEASE}.el9.noarch.rpm" ; \
+    rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${IS_RELEASE}.${EL_VER}.noarch.rpm" ; \
     if [[ "$IS_RELEASE" == 1 ]] ; then \
         sed -i "s;http://download.ceph.com/;https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/;" /etc/yum.repos.d/ceph.repo ; \
         dnf clean expire-cache ; \
@@ -113,9 +139,12 @@ RUN --mount=type=secret,id=prerelease_creds set -ex && \
 # Copr repos
 # scikit for mgr-diskprediction-local
 # ref: https://github.com/ceph/ceph-container/pull/1821
-RUN \
-    dnf install -y --setopt=install_weak_deps=False dnf-plugins-core && \
-    dnf copr enable -y tchaikov/python-scikit-learn
+RUN set -euo pipefail; \
+    source /etc/ceph-distro.env; \
+    if [ "$MAJOR" -le 9 ]; then \
+        dnf install -y --setopt=install_weak_deps=False dnf-plugins-core && \
+        dnf copr enable -y tchaikov/python-scikit-learn; \
+    fi
 
 # Update package mgr
 RUN dnf update -y --setopt=install_weak_deps=False
@@ -156,7 +185,13 @@ RUN if [[ "${OSD_FLAVOR}" == "crimson-debug" || "${OSD_FLAVOR}" == "crimson-rele
 fi
 
 # Ceph "Recommends"
-RUN echo "nvme-cli python3-saml smartmontools" >> packages.txt
+RUN set -euo pipefail; \
+    echo "nvme-cli smartmontools" >> packages.txt; \
+    source /etc/ceph-distro.env; \
+    if [ "$MAJOR" -le 9 ]; then \
+        echo "python3-saml" >> packages.txt; \
+    fi
+
 # NFS-Ganesha
 RUN echo "\
 dbus-daemon \


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
