### PR TITLE
tentacle: mgr/dashboard: nfs export creation fails with obj deserialization

### DIFF
--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -180,8 +180,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """Reset NFS-Ganesha Config to default"""
         return self.nfs.reset_nfs_cluster_config(cluster_id=cluster_id)
 
-    def fetch_nfs_export_obj(self) -> ExportMgr:
-        return self.export_mgr
+    def export_apply(self, cluster_id: str, export_config: str) -> AppliedExportResults:
+        """Create or update an export by `export_config` which can be json string or ganesha export specification"""
+        earmark_resolver = CephFSEarmarkResolver(self)
+        return self.export_mgr.apply_export(cluster_id, export_config=export_config,
+                                            earmark_resolver=earmark_resolver)
 
     def export_ls(self, cluster_id: Optional[str] = None, detailed: bool = False) -> List[Dict[Any, Any]]:
         if not (cluster_id):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75228

---

backport of https://github.com/ceph/ceph/pull/67345
parent tracker: https://tracker.ceph.com/issues/74930

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh