### PR TITLE
rgw: use std::optional for storage_class_stats to track conversion status

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -847,6 +847,18 @@ int rgw_bucket_update_stats(cls_method_context_t hctx, bufferlist *in, bufferlis
     }
   }
 
+  for (auto& s : op.storage_class_stats) {
+    auto& dest = header.storage_class_stats[s.first];
+    if (op.absolute) {
+      dest = s.second;
+    } else {
+      dest.total_size += s.second.total_size;
+      dest.total_size_rounded += s.second.total_size_rounded;
+      dest.num_entries += s.second.num_entries;
+      dest.actual_size += s.second.actual_size;
+    }
+  }
+
   return write_bucket_header(hctx, &header);
 }
 
@@ -1034,7 +1046,21 @@ static void unaccount_entry(rgw_bucket_dir_header& header,
 			    rgw_bucket_dir_entry& entry)
 {
   if (entry.exists) {
+    auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
     rgw_bucket_category_stats& stats = header.stats[entry.meta.category];
+    rgw_bucket_category_stats &sc_stats = header.storage_class_stats[storage_class];
+    if ((sc_stats.num_entries - 1) > sc_stats.num_entries) { // unsigned long overflow
+      sc_stats.num_entries = 0;
+      sc_stats.total_size = 0;
+      sc_stats.total_size_rounded = 0;
+      sc_stats.actual_size = 0;
+    } else {
+      sc_stats.num_entries--;
+      sc_stats.total_size -= entry.meta.accounted_size;
+      sc_stats.total_size_rounded -=
+              cls_rgw_get_rounded_size(entry.meta.accounted_size);
+      sc_stats.actual_size -= entry.meta.size;
+    }
     stats.num_entries--;
     stats.total_size -= entry.meta.accounted_size;
     stats.total_size_rounded -=
@@ -1322,6 +1348,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     unaccount_entry(header, entry);
 
     rgw_bucket_dir_entry_meta& meta = op.meta;
+    auto& storage_class = rgw_placement_rule::get_canonical_storage_class(meta.storage_class);
     rgw_bucket_category_stats& stats = header.stats[meta.category];
     entry.meta = meta;
     entry.key = op.key;
@@ -1332,6 +1359,12 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     stats.total_size += meta.accounted_size;
     stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
     stats.actual_size += meta.size;
+    rgw_bucket_category_stats& sc_stats = header.storage_class_stats[storage_class];
+    sc_stats.num_entries++;
+    sc_stats.total_size += meta.accounted_size;
+    sc_stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
+    sc_stats.actual_size += meta.size;
+
     CLS_LOG_BITX(bitx_inst, 20,
 		 "INFO: %s: setting map entry at key=%s",
 		 __func__, escape_str(idx).c_str());
@@ -2520,15 +2553,30 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
     if (cur_disk.pending_map.empty()) {
       CLS_LOG_BITX(bitx_inst, 10, "INFO: %s: cur_disk.pending_map is empty", __func__);
       if (cur_disk.exists) {
-        rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
+          auto& storage_class = rgw_placement_rule::get_canonical_storage_class(cur_disk.meta.storage_class);
+          rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
 	CLS_LOG_BITX(bitx_inst, 10, "INFO: %s: stats.num_entries: %ld -> %ld",
 		     __func__, old_stats.num_entries, old_stats.num_entries - 1);
         old_stats.num_entries--;
         old_stats.total_size -= cur_disk.meta.accounted_size;
         old_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
         old_stats.actual_size -= cur_disk.meta.size;
+        rgw_bucket_category_stats &old_sc_stats = header.storage_class_stats[storage_class];
+        if ((old_sc_stats.num_entries - 1) > old_sc_stats.num_entries) { // unsigned long overflow
+          old_sc_stats.num_entries = 0;
+          old_sc_stats.total_size = 0;
+          old_sc_stats.total_size_rounded = 0;
+          old_sc_stats.actual_size = 0;
+        } else {
+          old_sc_stats.num_entries--;
+          old_sc_stats.total_size -= cur_disk.meta.accounted_size;
+          old_sc_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
+          old_sc_stats.actual_size -= cur_disk.meta.size;
+        }
         header_changed = true;
       }
+      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(cur_change.meta.storage_class);
+      std::unordered_map<std::string, rgw_bucket_category_stats> storage_class_stats = header.storage_class_stats;
       rgw_bucket_category_stats& stats = header.stats[cur_change.meta.category];
 
       switch(op) {
@@ -2567,6 +2615,12 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         stats.total_size += cur_change.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
         stats.actual_size += cur_change.meta.size;
+        rgw_bucket_category_stats sc_stats = storage_class_stats[storage_class];
+        sc_stats.num_entries++;
+        sc_stats.total_size += cur_change.meta.accounted_size;
+        sc_stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
+        sc_stats.actual_size += cur_change.meta.size;
+
         header_changed = true;
         cur_change.index_ver = header.ver;
 
@@ -2949,7 +3003,8 @@ static int rgw_bi_put_entries(cls_method_context_t hctx, bufferlist *in, bufferl
       cls_rgw_obj_key key;
       RGWObjCategory category;
       rgw_bucket_category_stats stats;
-      const bool account = entry.get_info(&key, &category, &stats);
+      string storage_class;
+      const bool account = entry.get_info(&key, &category, &stats, &storage_class);
       if (account) {
         auto& dest = header.stats[category];
         dest.total_size -= stats.total_size;
@@ -2975,7 +3030,8 @@ static int rgw_bi_put_entries(cls_method_context_t hctx, bufferlist *in, bufferl
     cls_rgw_obj_key key;
     RGWObjCategory category;
     rgw_bucket_category_stats stats;
-    const bool account = entry.get_info(&key, &category, &stats);
+    string storage_class;
+    const bool account = entry.get_info(&key, &category, &stats, &storage_class);
     if (account) {
       auto& dest = header.stats[category];
       dest.total_size += stats.total_size;
@@ -3424,11 +3480,17 @@ static int check_index(cls_method_context_t hctx,
       }
 
       if (entry.exists && entry.flags == 0) {
+        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
         rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
         stats.num_entries++;
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
+        rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats[storage_class];
+        sc_stats.num_entries++;
+        sc_stats.total_size += entry.meta.accounted_size;
+        sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+        sc_stats.actual_size += entry.meta.size;
       }
       start_obj = bientry.idx;
     }
@@ -3453,11 +3515,17 @@ static int check_index(cls_method_context_t hctx,
       }
 
       if (entry.exists) {
+        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
         rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
         stats.num_entries++;
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
+        rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats[storage_class];
+        sc_stats.num_entries++;
+        sc_stats.total_size += entry.meta.accounted_size;
+        sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+        sc_stats.actual_size += entry.meta.size;
       }
       start_obj = bientry.idx;
     }

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -847,8 +847,13 @@ int rgw_bucket_update_stats(cls_method_context_t hctx, bufferlist *in, bufferlis
     }
   }
 
+  // Initialize storage class stats if needed
+  if (!header.storage_class_stats.has_value()) {
+    header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  }
+
   for (auto& s : op.storage_class_stats) {
-    auto& dest = header.storage_class_stats[s.first];
+    auto& dest = (*header.storage_class_stats)[s.first];
     if (op.absolute) {
       dest = s.second;
     } else {
@@ -1048,7 +1053,11 @@ static void unaccount_entry(rgw_bucket_dir_header& header,
   if (entry.exists) {
     auto& storage_class = rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
     rgw_bucket_category_stats& stats = header.stats[entry.meta.category];
-    rgw_bucket_category_stats &sc_stats = header.storage_class_stats[storage_class];
+    // Initialize storage class stats if needed
+    if (!header.storage_class_stats.has_value()) {
+      header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+    }
+    rgw_bucket_category_stats &sc_stats = (*header.storage_class_stats)[storage_class];
     if ((sc_stats.num_entries - 1) > sc_stats.num_entries) { // unsigned long overflow
       sc_stats.num_entries = 0;
       sc_stats.total_size = 0;
@@ -1359,7 +1368,11 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     stats.total_size += meta.accounted_size;
     stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
     stats.actual_size += meta.size;
-    rgw_bucket_category_stats& sc_stats = header.storage_class_stats[storage_class];
+    // Initialize storage class stats if needed
+    if (!header.storage_class_stats.has_value()) {
+      header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+    }
+    rgw_bucket_category_stats& sc_stats = (*header.storage_class_stats)[storage_class];
     sc_stats.num_entries++;
     sc_stats.total_size += meta.accounted_size;
     sc_stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
@@ -2561,7 +2574,12 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         old_stats.total_size -= cur_disk.meta.accounted_size;
         old_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
         old_stats.actual_size -= cur_disk.meta.size;
-        rgw_bucket_category_stats &old_sc_stats = header.storage_class_stats[storage_class];
+        // Initialize storage class stats if needed
+        if (!header.storage_class_stats.has_value()) {
+          header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+        }
+
+        rgw_bucket_category_stats &old_sc_stats = (*header.storage_class_stats)[storage_class];
         if ((old_sc_stats.num_entries - 1) > old_sc_stats.num_entries) { // unsigned long overflow
           old_sc_stats.num_entries = 0;
           old_sc_stats.total_size = 0;
@@ -2576,7 +2594,12 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         header_changed = true;
       }
       auto& storage_class = rgw_placement_rule::get_canonical_storage_class(cur_change.meta.storage_class);
-      std::unordered_map<std::string, rgw_bucket_category_stats> storage_class_stats = header.storage_class_stats;
+      // Initialize storage class stats if needed
+      if (!header.storage_class_stats.has_value()) {
+        header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+      }
+      // Create a local copy of the map 
+      std::unordered_map<std::string, rgw_bucket_category_stats> storage_class_stats = *header.storage_class_stats;
       rgw_bucket_category_stats& stats = header.stats[cur_change.meta.category];
 
       switch(op) {
@@ -2615,7 +2638,10 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         stats.total_size += cur_change.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
         stats.actual_size += cur_change.meta.size;
-        rgw_bucket_category_stats sc_stats = storage_class_stats[storage_class];
+        if (!header.storage_class_stats.has_value()) {
+          header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+        }
+        rgw_bucket_category_stats& sc_stats = storage_class_stats[storage_class];
         sc_stats.num_entries++;
         sc_stats.total_size += cur_change.meta.accounted_size;
         sc_stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
@@ -3486,7 +3512,12 @@ static int check_index(cls_method_context_t hctx,
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
-        rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats[storage_class];
+        // Initialize storage class stats if needed
+        if (!calc_header->storage_class_stats.has_value()) {
+          calc_header->storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+        }
+
+        rgw_bucket_category_stats& sc_stats = (*calc_header->storage_class_stats)[storage_class];
         sc_stats.num_entries++;
         sc_stats.total_size += entry.meta.accounted_size;
         sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
@@ -3521,7 +3552,12 @@ static int check_index(cls_method_context_t hctx,
         stats.total_size += entry.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         stats.actual_size += entry.meta.size;
-        rgw_bucket_category_stats& sc_stats = calc_header->storage_class_stats[storage_class];
+        // Initialize storage class stats if needed
+        if (!calc_header->storage_class_stats.has_value()) {
+          calc_header->storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+        }
+
+        rgw_bucket_category_stats& sc_stats = (*calc_header->storage_class_stats)[storage_class];
         sc_stats.num_entries++;
         sc_stats.total_size += entry.meta.accounted_size;
         sc_stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -72,12 +72,14 @@ void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
 				 bool absolute,
-                                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats,
-                                 const map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats)
+                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats,
+                 const std::unordered_map<std::string, rgw_bucket_category_stats>& storage_class_stats,
+                 const std::map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats)
 {
   rgw_cls_bucket_update_stats_op call;
   call.absolute = absolute;
   call.stats = stats;
+  call.storage_class_stats = storage_class_stats;
   if (dec_stats != NULL)
     call.dec_stats = *dec_stats;
   bufferlist in;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -135,6 +135,7 @@ void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  bool absolute,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>& stats,
+                                 const std::unordered_map<std::string, rgw_bucket_category_stats>& storage_class_stats,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>* dec_stats = nullptr);
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, const std::string& tag,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -499,22 +499,26 @@ struct rgw_cls_bucket_update_stats_op
   bool absolute{false};
   std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
   std::map<RGWObjCategory, rgw_bucket_category_stats> dec_stats;
+  std::unordered_map<std::string, rgw_bucket_category_stats> storage_class_stats;
 
   rgw_cls_bucket_update_stats_op() {}
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(absolute, bl);
     encode(stats, bl);
     encode(dec_stats, bl);
+    encode(storage_class_stats, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(absolute, bl);
     decode(stats, bl);
     if (struct_v >= 2)
       decode(dec_stats, bl);
+    if (struct_v >= 3)
+      decode(storage_class_stats, bl);
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -413,7 +413,8 @@ void rgw_cls_bi_entry::dump(Formatter *f) const
 
 bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
                                 RGWObjCategory *category,
-                                rgw_bucket_category_stats *accounted_stats) const
+                                rgw_bucket_category_stats *accounted_stats,
+                                string *storage_class) const
 {
   using ceph::decode;
   auto iter = data.cbegin();
@@ -433,6 +434,7 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
   rgw_bucket_dir_entry entry;
   decode(entry, iter);
   *key = entry.key;
+  *storage_class = entry.meta.storage_class;
   *category = entry.meta.category;
   accounted_stats->num_entries++;
   accounted_stats->total_size += entry.meta.accounted_size;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -842,7 +842,8 @@ struct rgw_bucket_dir_header {
   cls_rgw_bucket_instance_entry new_instance;
   bool syncstopped;
   uint32_t reshardlog_entries;
-  std::unordered_map<std::string, rgw_bucket_category_stats> storage_class_stats;
+  std::optional<std::unordered_map<std::string, rgw_bucket_category_stats>> storage_class_stats;
+
 
   rgw_bucket_dir_header() : tag_timeout(0), ver(0), master_ver(0), syncstopped(false),
                             reshardlog_entries(0) {}

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -162,10 +162,12 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     header.stats.total_entries = 0;
     header.stats.total_bytes = 0;
     header.stats.total_bytes_rounded = 0;
-    for(auto &idx: header.storage_class_stats){
-      header.storage_class_stats[idx.first].total_entries = 0;
-      header.storage_class_stats[idx.first].total_bytes = 0;
-      header.storage_class_stats[idx.first].total_bytes_rounded = 0;
+    if (header.storage_class_stats.has_value()) {
+      for(auto &idx: *header.storage_class_stats){
+        (*header.storage_class_stats)[idx.first].total_entries = 0;
+        (*header.storage_class_stats)[idx.first].total_bytes = 0;
+        (*header.storage_class_stats)[idx.first].total_bytes_rounded = 0;
+      }
     }
     bufferlist bl;
     encode(header, bl);
@@ -201,7 +203,8 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
       // creation date may have changed (ie delete/recreate bucket)
       entry.creation_time = update_entry.creation_time;
       // updating bucket id for storage classes entries
-      for (auto& idx: header.storage_class_stats) {
+      if (header.storage_class_stats.has_value()) {
+        for (auto& idx: *header.storage_class_stats) {
         cls_user_bucket_entry storage_class_entry;
         string storage_class_key = old_key + "-" + idx.first;
         int s_ret = get_existing_bucket_entry(hctx, storage_class_key, storage_class_entry);
@@ -219,20 +222,25 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
         }
       }
     }
+    }
 
     if (ret < 0) {
       CLS_LOG(0, "ERROR: get_existing_bucket_entry() key=%s returned %d", key.c_str(), ret);
       return ret;
     } else if (ret >= 0 && entry.user_stats_sync) {
       if (storage_class){
-        if ((header.storage_class_stats[*storage_class].total_entries - entry.count) > header.storage_class_stats[*storage_class].total_entries) { // unsigned long overflow
-          header.storage_class_stats[*storage_class].total_entries = 0;
-          header.storage_class_stats[*storage_class].total_bytes = 0;
-          header.storage_class_stats[*storage_class].total_bytes_rounded = 0;
+        // Initialize storage class stats if needed
+        if (!header.storage_class_stats.has_value()) {
+          header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+        }
+        if (((*header.storage_class_stats)[*storage_class].total_entries - entry.count) > (*header.storage_class_stats)[*storage_class].total_entries) {
+          (*header.storage_class_stats)[*storage_class].total_entries = 0;
+          (*header.storage_class_stats)[*storage_class].total_bytes = 0;
+          (*header.storage_class_stats)[*storage_class].total_bytes_rounded = 0;
         } else {
-          header.storage_class_stats[*storage_class].total_entries -= entry.count;
-          header.storage_class_stats[*storage_class].total_bytes -= entry.size;
-          header.storage_class_stats[*storage_class].total_bytes_rounded -= entry.size_rounded;
+          (*header.storage_class_stats)[*storage_class].total_entries -= entry.count;
+          (*header.storage_class_stats)[*storage_class].total_bytes -= entry.size;
+          (*header.storage_class_stats)[*storage_class].total_bytes_rounded -= entry.size_rounded;
         }
       } else {
         dec_header_stats(&header.stats, entry);
@@ -255,9 +263,14 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
       return ret;
 
     if (storage_class){
-      header.storage_class_stats[*storage_class].total_entries += entry.count;
-      header.storage_class_stats[*storage_class].total_bytes += entry.size;
-      header.storage_class_stats[*storage_class].total_bytes_rounded += entry.size_rounded;
+      // Initialize storage class stats if needed
+      if (!header.storage_class_stats.has_value()) {
+        header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+      }
+
+      (*header.storage_class_stats)[*storage_class].total_entries += entry.count;
+      (*header.storage_class_stats)[*storage_class].total_bytes += entry.size;
+      (*header.storage_class_stats)[*storage_class].total_bytes_rounded += entry.size_rounded;
     } else {
       add_header_stats(&header.stats, entry);
     }
@@ -344,10 +357,12 @@ static int cls_user_remove_bucket(cls_method_context_t hctx, bufferlist *in, buf
     CLS_LOG(0, "ERROR: get existing bucket entry, key=%s ret=%d", key.c_str(), ret);
     return ret;
   }
-  for(auto it = header.storage_class_stats.begin(); it != header.storage_class_stats.end(); ++it){
-    auto new_key = key + "-" + it->first;
-    CLS_LOG(20, "removing entry at %s", new_key.c_str());
-    remove_entry(hctx, new_key);
+  if (header.storage_class_stats.has_value()) {
+    for(auto it = header.storage_class_stats->begin(); it != header.storage_class_stats->end(); ++it){
+      auto new_key = key + "-" + it->first;
+      CLS_LOG(20, "removing entry at %s", new_key.c_str());
+      remove_entry(hctx, new_key);
+    }
   }
   CLS_LOG(20, "removing entry at %s", key.c_str());
 

--- a/src/cls/user/cls_user_client.cc
+++ b/src/cls/user/cls_user_client.cc
@@ -16,12 +16,13 @@ using librados::IoCtx;
 using librados::ObjectOperationCompletion;
 using librados::ObjectReadOperation;
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add)
+void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add, bool reset)
 {
   bufferlist in;
   cls_user_set_buckets_op call;
   call.entries = entries;
   call.add = add;
+  call.reset = reset;
   call.time = real_clock::now();
   encode(call, in);
   op.exec("user", "set_buckets_info", in);

--- a/src/cls/user/cls_user_client.h
+++ b/src/cls/user/cls_user_client.h
@@ -18,7 +18,7 @@ public:
  * user objclass
  */
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add);
+void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add, bool reset);
 void cls_user_complete_stats_sync(librados::ObjectWriteOperation& op);
 void cls_user_remove_bucket(librados::ObjectWriteOperation& op,  const cls_user_bucket& bucket);
 void cls_user_bucket_list(librados::ObjectReadOperation& op,

--- a/src/cls/user/cls_user_ops.h
+++ b/src/cls/user/cls_user_ops.h
@@ -9,23 +9,28 @@
 struct cls_user_set_buckets_op {
   std::list<cls_user_bucket_entry> entries;
   bool add;
+  bool reset;
   ceph::real_time time; /* op time */
 
-  cls_user_set_buckets_op() : add(false) {}
+  cls_user_set_buckets_op() : add(false), reset(false) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(entries, bl);
     encode(add, bl);
     encode(time, bl);
+    encode(reset, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(entries, bl);
     decode(add, bl);
     decode(time, bl);
+    if (struct_v >= 2) {
+        decode(reset, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -198,7 +198,7 @@ WRITE_CLASS_ENCODER(cls_user_stats)
  */
 struct cls_user_header {
   cls_user_stats stats;
-  std::unordered_map<std::string, cls_user_stats> storage_class_stats;
+  std::optional<std::unordered_map<std::string, cls_user_stats>> storage_class_stats;
   ceph::real_time last_stats_sync;     /* last time a full stats sync completed */
   ceph::real_time last_stats_update;   /* last time a stats update was done */
 

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2698,6 +2698,7 @@ int POSIXBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int POSIXBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                  bool reset,
                                   RGWBucketEnt* ent)
 {
   return 0;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -901,7 +901,7 @@ public:
   virtual int read_stats_async(const DoutPrefixProvider *dpp,
 			       const bucket_index_layout_generation& idx_layout,
 			       int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-  virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+  virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                                RGWBucketEnt* ent) override;
   virtual int check_bucket_shards(const DoutPrefixProvider* dpp,
                                   uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/driver/rados/buckets.cc
+++ b/src/rgw/driver/rados/buckets.cc
@@ -18,6 +18,7 @@
 #include "common/async/yield_context.h"
 #include "common/dout.h"
 #include "cls/user/cls_user_client.h"
+#include "cls/rgw/cls_rgw_types.h"
 #include "rgw_common.h"
 #include "rgw_sal.h"
 #include "rgw_tools.h"
@@ -185,15 +186,26 @@ int read_stats(const DoutPrefixProvider* dpp, optional_yield y,
   stats.size = header.stats.total_bytes;
   stats.size_rounded = header.stats.total_bytes_rounded;
   stats.num_objects = header.stats.total_entries;
-  uint64_t total_size = stats.size;
-  for (auto it = header.storage_class_stats.begin(); it != header.storage_class_stats.end(); ++it) {
-    std::string storage_class = it->first;
-    total_size -= it->second.total_bytes;
-    stats.storage_class_stats[storage_class].size = it->second.total_bytes;
-    stats.storage_class_stats[storage_class].size_rounded = it->second.total_bytes_rounded;
-    stats.storage_class_stats[storage_class].num_objects = it->second.total_entries;
+  // Initialize storage class stats for new buckets
+  if (!header.storage_class_stats.has_value()) {
+    if (header.stats.total_entries == 0) {
+      // New empty bucket - initialize as converted
+      header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+    }
+    // If has objects but no storage_class_stats, it's legacy - leave as nullopt
   }
-  if (total_size != 0){
+
+  // Only process if bucket has storage class support
+  if (header.storage_class_stats.has_value()) {
+    for (auto it = header.storage_class_stats->begin(); it != header.storage_class_stats->end(); ++it) {
+      std::string storage_class = it->first;
+      
+      stats.storage_class_stats[storage_class].size = it->second.total_bytes;
+      stats.storage_class_stats[storage_class].size_rounded = it->second.total_bytes_rounded;
+      stats.storage_class_stats[storage_class].num_objects = it->second.total_entries;
+    }
+  } else {
+    // Legacy bucket - clear storage class stats
     stats.storage_class_stats.clear();
   }
 

--- a/src/rgw/driver/rados/buckets.h
+++ b/src/rgw/driver/rados/buckets.h
@@ -64,7 +64,8 @@ int write_stats(const DoutPrefixProvider* dpp,
                 optional_yield y,
                 librados::Rados& rados,
                 const rgw_raw_obj& obj,
-                const RGWBucketEnt& bucket);
+                const RGWBucketEnt& bucket,
+                bool reset);
 
 /// Read the total usage stats of all buckets.
 int read_stats(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -702,6 +702,7 @@ public:
                        const rgw_owner& owner,
                        const RGWBucketInfo& bucket_info,
                        optional_yield y,
+                       bool reset,
                        RGWBucketEnt* pent);
 
   /* bucket sync */

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9917,7 +9917,7 @@ int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, op
   BucketIndexShardsManager master_ver_mgr;
   BucketIndexShardsManager marker_mgr;
   for(; iter != headers.end(); ++iter, ++viter) {
-    if (iter->storage_class_stats.empty() && !iter->stats.empty()){
+    if ((!iter->storage_class_stats.has_value() || iter->storage_class_stats->empty()) && !iter->stats.empty()){
       sc_stats.clear();
       return 0;
     }
@@ -9925,7 +9925,8 @@ int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, op
     for (auto it = iter->stats.begin(); it != iter->stats.end(); ++it) {
       stats_total_size += it->second.total_size;
     }
-    for (auto it = iter->storage_class_stats.begin(); it != iter->storage_class_stats.end(); ++it) {
+    if (iter->storage_class_stats.has_value()){
+    for (auto it = iter->storage_class_stats->begin(); it != iter->storage_class_stats->end(); ++it) {
       std::string storage_class = it->first;
       rgw_bucket_category_stats stats = it->second;
       RGWStorageStats& s = sc_stats[storage_class];
@@ -9936,6 +9937,7 @@ int RGWRados::get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, op
       s.num_objects += stats.num_entries;
       stats_total_size -= stats.total_size;
     }
+  }
     if (stats_total_size != 0) {
       sc_stats.clear();
       return 0;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1496,6 +1496,10 @@ public:
     rctx->set_compressed(obj);
   }
   int decode_policy(const DoutPrefixProvider *dpp, bufferlist& bl, ACLOwner *owner);
+  int get_bucket_storage_classes_stats(const DoutPrefixProvider *dpp, optional_yield y, const RGWBucketInfo& bucket_info,
+                                       int shard_id, std::string *bucket_ver, std::string *master_ver,
+                                       std::map<std::string, RGWStorageStats>& sc_stats, std::string *max_marker,
+                                       const rgw::bucket_index_layout_generation& idx_layout, bool* syncstopped = NULL);
   int get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
                        RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, std::string *bucket_ver, std::string *master_ver,
       std::map<RGWObjCategory, RGWStorageStats>& stats, std::string *max_marker, bool* syncstopped = NULL);

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -156,6 +156,7 @@ class BucketReshardShard {
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
   map<RGWObjCategory, rgw_bucket_category_stats> stats;
+  unordered_map<string, rgw_bucket_category_stats> storage_class_stats;
   deque<librados::AioCompletion *>& aio_completions;
   uint64_t max_aio_completions;
   uint64_t reshard_shard_batch_size;
@@ -212,11 +213,17 @@ public:
   }
 
   int add_entry(rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
-                const rgw_bucket_category_stats& entry_stats,
+                const rgw_bucket_category_stats& entry_stats, string& storage_class,
                 bool process_log = false) {
     entries.push_back(entry);
     if (account) {
       rgw_bucket_category_stats& target = stats[category];
+      storage_class = rgw_placement_rule::get_canonical_storage_class(storage_class);
+      rgw_bucket_category_stats& sc_target = storage_class_stats[storage_class];
+      sc_target.num_entries += entry_stats.num_entries;
+      sc_target.total_size += entry_stats.total_size;
+      sc_target.total_size_rounded += entry_stats.total_size_rounded;
+      sc_target.actual_size += entry_stats.actual_size;
       target.num_entries += entry_stats.num_entries;
       target.total_size += entry_stats.total_size;
       target.total_size_rounded += entry_stats.total_size_rounded;
@@ -248,7 +255,7 @@ public:
       for (auto& entry : entries) {
         store->getRados()->bi_put(op, bs, entry, null_yield);
       }
-      cls_rgw_bucket_update_stats(op, false, stats);
+      cls_rgw_bucket_update_stats(op, false, stats, storage_class_stats);
     }
 
     librados::AioCompletion *c;
@@ -263,7 +270,7 @@ public:
     }
     entries.clear();
     stats.clear();
-
+    storage_class_stats.clear();
     return 0;
   }
 
@@ -313,9 +320,10 @@ public:
   int add_entry(int shard_index,
                 rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
                 const rgw_bucket_category_stats& entry_stats,
+                string& storage_class,
                 bool process_log = false) {
     int ret = target_shards[shard_index].add_entry(entry, account, category,
-						   entry_stats, process_log);
+						   entry_stats, storage_class, process_log);
     if (ret < 0) {
       derr << "ERROR: target_shards.add_entry(" << entry.idx <<
 	") returned error: " << cpp_strerror(-ret) << dendl;
@@ -1136,7 +1144,8 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
         cls_rgw_obj_key cls_key;
         RGWObjCategory category;
         rgw_bucket_category_stats stats;
-        bool account = entry.get_info(&cls_key, &category, &stats);
+        string storage_class;
+        bool account = entry.get_info(&cls_key, &category, &stats, &storage_class);
         rgw_obj_key key(cls_key);
         if (entry.type == BIIndexType::OLH && key.empty()) {
           // bogus entry created by https://tracker.ceph.com/issues/46456
@@ -1153,7 +1162,7 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
         }
 
         ret = target_shards_mgr.add_entry(shard_index, entry, account,
-                  category, stats, process_log);
+                  category, stats, storage_class, process_log);
         if (ret < 0) {
           return ret;
         }

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -450,7 +450,7 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
 
   librados::Rados& rados = *store->getRados()->get_rados_handle();
   if (own_bucket) {
-    ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, nullptr);
+    ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, false, nullptr);
     if (ret < 0) {
       ldout(store->ctx(), 1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
     }
@@ -610,7 +610,7 @@ int RadosBucket::remove_bypass_gc(int concurrent_max, bool
     return ret;
   }
 
-  sync_owner_stats(dpp, y, nullptr);
+  sync_owner_stats(dpp, y, false, nullptr);
   if (ret < 0) {
      ldpp_dout(dpp, 1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
   }
@@ -672,10 +672,11 @@ int RadosBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int RadosBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                  bool reset,
                                   RGWBucketEnt* ent)
 {
   librados::Rados& rados = *store->getRados()->get_rados_handle();
-  return store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, ent);
+  return store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, reset, ent);
 }
 
 int RadosBucket::check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -744,7 +744,7 @@ class RadosBucket : public StoreBucket {
                                  const bucket_index_layout_generation& idx_layout,
                                  int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
     int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
-                         RGWBucketEnt* ent) override;
+						 bool reset, RGWBucketEnt* ent) override;
     int check_bucket_shards(const DoutPrefixProvider* dpp, uint64_t num_objs,
                             optional_yield y) override;
     virtual int chown(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -169,6 +169,11 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
   encode_json("group_ids", info.group_ids, f);
   if (stats) {
     encode_json("stats", *stats, f);
+    f->open_object_section("stats.storage-classes");
+    for(auto it = stats->storage_class_stats.begin(); it != stats->storage_class_stats.end(); ++it){
+      encode_json(it->first.c_str(), it->second, f);
+    }
+    f->close_section();
   }
   f->close_section();
 }
@@ -2321,7 +2326,7 @@ int RGWUserAdminOp_User::info(const DoutPrefixProvider *dpp,
   }
 
   if (op_state.sync_stats) {
-    ret = rgw_sync_all_stats(dpp, y, driver, owner, ruser->get_tenant());
+    ret = rgw_sync_all_stats(dpp, y, driver, owner, false, ruser->get_tenant());
     if (ret < 0) {
       return ret;
     }

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -170,12 +170,15 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
   if (stats) {
     encode_json("stats", *stats, f);
     f->open_object_section("stats.storage-classes");
+    if (!stats->storage_class_stats.empty()) {
     for(auto it = stats->storage_class_stats.begin(); it != stats->storage_class_stats.end(); ++it){
+
       encode_json(it->first.c_str(), it->second, f);
     }
     f->close_section();
   }
   f->close_section();
+}
 }
 
 static int user_add_helper(RGWUserAdminOpState& op_state, std::string *err_msg)

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -80,7 +80,7 @@ struct bucket_meta_entry {
 
 int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
                        optional_yield y, rgw::sal::Driver* driver,
-                       const rgw_owner& owner, const std::string& tenant);
+                       const rgw_owner& owner, bool reset, const std::string& tenant);
 extern int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
   rgw::sal::Driver* driver, rgw::sal::User* user,
   std::map<std::string, bucket_meta_entry>& buckets_usage_map, optional_yield y);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -9759,8 +9759,10 @@ next:
       Formatter::ObjectSection os(*formatter, "result");
       encode_json("stats", stats, formatter.get());
       formatter->open_object_section("stats.storage-classes");
+      if (!stats.storage_class_stats.empty()) {
       for(auto it = stats.storage_class_stats.begin(); it != stats.storage_class_stats.end(); ++it){
         encode_json(it->first.c_str(), it->second, formatter.get());
+      }
       }
       formatter->close_section();
       utime_t last_sync_ut(last_stats_sync);

--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -450,7 +450,7 @@ int stats(const DoutPrefixProvider* dpp,
   const rgw_owner owner = rgw_account_id{info.id};
 
   if (sync_stats) {
-    ret = rgw_sync_all_stats(dpp, y, driver, owner, info.tenant);
+    ret = rgw_sync_all_stats(dpp, y, driver, owner, false, info.tenant);
     if (ret < 0) {
       err_msg = "failed to sync account stats";
       return ret;

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -229,7 +229,7 @@ static void log_usage(req_state *s, const string& op_name)
   uint64_t bytes_sent = ACCOUNTING_IO(s)->get_bytes_sent();
   uint64_t bytes_received = ACCOUNTING_IO(s)->get_bytes_received();
 
-  rgw_usage_data data(bytes_sent, bytes_received);
+  rgw_usage_data data(bytes_sent, bytes_received, s->dest_placement.get_storage_class());
 
   data.ops = 1;
   if (!s->is_err())
@@ -242,7 +242,7 @@ static void log_usage(req_state *s, const string& op_name)
 	<< ", bytes_processed=" << s->s3select_usage.bytes_processed
 	<< ", bytes_returned=" << s->s3select_usage.bytes_returned << dendl;
 
-  entry.add_usage(op_name, data);
+  entry.add_usage(s->dest_placement.name + "::" + s->dest_placement.get_storage_class(), op_name, data);
   entry.s3select_usage = s->s3select_usage;
 
   utime_t ts = ceph_clock_now();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2887,7 +2887,7 @@ void RGWGetUsage::execute(optional_yield y)
   }
 
   op_ret = rgw_sync_all_stats(this, y, driver, s->user->get_id(),
-                              s->user->get_tenant());
+                              false, s->user->get_tenant());
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "ERROR: failed to sync user stats" << dendl;
     return;
@@ -4035,7 +4035,7 @@ void RGWDeleteBucket::execute(optional_yield y)
 
   if (own_bucket) {
     // only if we own the bucket
-    op_ret = s->bucket->sync_owner_stats(this, y, nullptr);
+    op_ret = s->bucket->sync_owner_stats(this, y, false, nullptr);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "WARNING: failed to sync user stats before bucket delete: op_ret= " << op_ret << dendl;
     }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -610,7 +610,7 @@ int RGWOwnerStatsCache::sync_bucket(const rgw_owner& owner, const rgw_bucket& b,
   }
 
   RGWBucketEnt ent;
-  r = bucket->sync_owner_stats(dpp, y, &ent);
+  r = bucket->sync_owner_stats(dpp, y, false, &ent);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: sync_owner_stats() for bucket=" << bucket << " returned " << r << dendl;
     return r;
@@ -676,7 +676,7 @@ int RGWOwnerStatsCache::sync_owner(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  ret = rgw_sync_all_stats(dpp, y, driver, owner, tenant);
+  ret = rgw_sync_all_stats(dpp, y, driver, owner, false, tenant);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed user stats sync, ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -951,6 +951,7 @@ class Bucket {
 				 int shard_id, boost::intrusive_ptr<ReadStatsCB> cb) = 0;
     /** Sync this bucket's stats to the owning user's stats in the backing store */
     virtual int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                 bool reset,
                                  RGWBucketEnt* optional_ent) = 0;
     /** Check if this bucket needs resharding, and schedule it if it does */
     virtual int check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -219,6 +219,7 @@ namespace rgw::sal {
   }
 
   int DBBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                 bool reset,
                                  RGWBucketEnt* ent)
   {
     return 0;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -160,7 +160,7 @@ protected:
           std::string *max_marker = nullptr,
           bool *syncstopped = nullptr) override;
       virtual int read_stats_async(const DoutPrefixProvider *dpp, const bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-      int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+      int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                            RGWBucketEnt* ent) override;
       int check_bucket_shards(const DoutPrefixProvider *dpp,
                               uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -874,9 +874,10 @@ int FilterBucket::read_stats_async(const DoutPrefixProvider *dpp,
 }
 
 int FilterBucket::sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                                   bool reset,
                                    RGWBucketEnt* ent)
 {
-  return next->sync_owner_stats(dpp, y, ent);
+  return next->sync_owner_stats(dpp, y, reset, ent);
 }
 
 int FilterBucket::check_bucket_shards(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -595,7 +595,7 @@ public:
   virtual int read_stats_async(const DoutPrefixProvider *dpp,
 			       const bucket_index_layout_generation& idx_layout,
 			       int shard_id, boost::intrusive_ptr<ReadStatsCB> ctx) override;
-  int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y,
+  int sync_owner_stats(const DoutPrefixProvider *dpp, optional_yield y, bool reset,
                        RGWBucketEnt* ent) override;
   int check_bucket_shards(const DoutPrefixProvider* dpp,
                           uint64_t num_objs, optional_yield y) override;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -15,7 +15,7 @@ using namespace std;
 
 int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
                        optional_yield y, rgw::sal::Driver* driver,
-                       const rgw_owner& owner, const std::string& tenant)
+                       const rgw_owner& owner, bool reset, const std::string& tenant)
 {
   size_t max_entries = dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
 
@@ -36,7 +36,7 @@ int rgw_sync_all_stats(const DoutPrefixProvider *dpp,
         ldpp_dout(dpp, 0) << "ERROR: could not read bucket info: bucket=" << bucket << " ret=" << ret << dendl;
         continue;
       }
-      ret = bucket->sync_owner_stats(dpp, y, &ent);
+      ret = bucket->sync_owner_stats(dpp, y, reset, &ent);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "ERROR: could not sync bucket stats: ret=" << ret << dendl;
         return ret;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -584,6 +584,15 @@ int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
       result->size += stats.total_size;
       result->size_rounded += stats.total_size_rounded;
     }
+    for(auto it = hiter->storage_class_stats.begin(); it != hiter->storage_class_stats.end(); ++it){
+      std::string storage_class = it->first;
+      struct rgw_bucket_category_stats& stats = it->second;
+      result->storage_class_ents[storage_class].count += stats.num_entries;
+      result->storage_class_ents[storage_class].size += stats.total_size;
+      result->storage_class_ents[storage_class].size_rounded += stats.total_size_rounded;
+      result->storage_class_ents[storage_class].bucket = result->bucket;
+    }
+
   }
 
   result->placement_rule = std::move(bucket_info.placement_rule);

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -584,15 +584,16 @@ int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
       result->size += stats.total_size;
       result->size_rounded += stats.total_size_rounded;
     }
-    for(auto it = hiter->storage_class_stats.begin(); it != hiter->storage_class_stats.end(); ++it){
-      std::string storage_class = it->first;
+    if (hiter->storage_class_stats.has_value()) {
+    for(auto it = hiter->storage_class_stats->begin(); it != hiter->storage_class_stats->end(); ++it){
+          std::string storage_class = it->first;
       struct rgw_bucket_category_stats& stats = it->second;
       result->storage_class_ents[storage_class].count += stats.num_entries;
       result->storage_class_ents[storage_class].size += stats.total_size;
       result->storage_class_ents[storage_class].size_rounded += stats.total_size_rounded;
       result->storage_class_ents[storage_class].bucket = result->bucket;
     }
-
+  }
   }
 
   result->placement_rule = std::move(bucket_info.placement_rule);

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -408,6 +408,18 @@ target_link_libraries(ceph_test_datalog
 install(TARGETS ceph_test_datalog DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
+# Test for storage class stats with std::optional
+add_executable(unittest_rgw_storage_class_stats
+               test_rgw_storage_class_stats.cc
+              )
+target_link_libraries(unittest_rgw_storage_class_stats
+                      cls_rgw_client
+                      cls_user_client
+                      global
+                      ${UNITTEST_LIBS}
+                      )
+add_ceph_unittest(unittest_rgw_storage_class_stats)
+
 #
 # Helper for adding RGW tests built with Catch2:
 # Note: to define a test that does not use Catch2::main(), use:

--- a/src/test/rgw/test_rgw_storage_class_stats.cc
+++ b/src/test/rgw/test_rgw_storage_class_stats.cc
@@ -1,0 +1,753 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <gtest/gtest.h>
+#include "cls/rgw/cls_rgw_types.h"
+#include "cls/user/cls_user_types.h"
+#include <chrono>
+
+using namespace std;
+
+TEST(StorageClassStats, OptionalInitialization) {
+  rgw_bucket_dir_header header;
+  
+  // New buckets should initialize storage_class_stats as nullopt initially
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // After initialization, should have value
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_TRUE(header.storage_class_stats->empty());
+}
+
+TEST(StorageClassStats, OptionalEmptyVsNull) {
+  rgw_bucket_dir_header legacy_header;
+  rgw_bucket_dir_header new_empty_header;
+  rgw_bucket_dir_header converted_header;
+  
+  // Legacy bucket - nullopt (not converted)
+  EXPECT_FALSE(legacy_header.storage_class_stats.has_value());
+  
+  // New empty bucket - empty map (converted)
+  new_empty_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(new_empty_header.storage_class_stats.has_value());
+  EXPECT_TRUE(new_empty_header.storage_class_stats->empty());
+  
+  // Converted bucket with data
+  converted_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 10;
+  stats.total_size = 1024;
+  (*converted_header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_TRUE(converted_header.storage_class_stats.has_value());
+  EXPECT_FALSE(converted_header.storage_class_stats->empty());
+  EXPECT_EQ((*converted_header.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, OptionalAfterDeletion) {
+  rgw_bucket_dir_header header;
+  
+  // Initialize with data
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 5;
+  stats.total_size = 2048;
+  (*header.storage_class_stats)["HDD"] = stats;
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 5);
+  
+  // Simulate deletion - set to 0 but keep entry
+  (*header.storage_class_stats)["HDD"].num_entries = 0;
+  (*header.storage_class_stats)["HDD"].total_size = 0;
+  
+  // Field should still have value (not nullopt)
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 0);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].total_size, 0);
+}
+
+TEST(StorageClassStats, UserHeaderOptional) {
+  cls_user_header header;
+  
+  // Should start as nullopt
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // Initialize
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Add stats
+  cls_user_stats user_stats;
+  user_stats.total_entries = 100;
+  user_stats.total_bytes = 10240;
+  (*header.storage_class_stats)["default-placement::STANDARD"] = user_stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["default-placement::STANDARD"].total_entries, 100);
+}
+
+TEST(StorageClassStats, MultipleStorageClasses) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add multiple storage classes
+  rgw_bucket_category_stats standard_stats;
+  standard_stats.num_entries = 10;
+  standard_stats.total_size = 5120;
+  
+  rgw_bucket_category_stats hdd_stats;
+  hdd_stats.num_entries = 20;
+  hdd_stats.total_size = 10240;
+  
+  (*header.storage_class_stats)["STANDARD"] = standard_stats;
+  (*header.storage_class_stats)["HDD"] = hdd_stats;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*header.storage_class_stats)["HDD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, SafeAccess) {
+  rgw_bucket_dir_header header;
+  
+  // Accessing without initialization should be safe with has_value check
+  if (header.storage_class_stats.has_value()) {
+    // This should not execute
+    FAIL() << "Should not have value before initialization";
+  }
+  
+  // Initialize
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Now access is safe
+  if (header.storage_class_stats.has_value()) {
+    EXPECT_TRUE(header.storage_class_stats->empty());
+  } else {
+    FAIL() << "Should have value after initialization";
+  }
+}
+
+TEST(StorageClassStats, ResetToNullopt) {
+  rgw_bucket_dir_header header;
+  
+  // Initialize with value
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Reset to nullopt (simulate legacy bucket state)
+  header.storage_class_stats = std::nullopt;
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+  
+  // Re-initialize
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  EXPECT_TRUE(header.storage_class_stats->empty()); // Should be empty after reset
+}
+
+TEST(StorageClassStats, EmptyStringStorageClassName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with empty string as storage class name (edge case)
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 5;
+  stats.total_size = 1024;
+  (*header.storage_class_stats)[""] = stats;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)[""].num_entries, 5);
+}
+
+TEST(StorageClassStats, VeryLongStorageClassName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with very long storage class name (1000 characters)
+  std::string long_name(1000, 'A');
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 10;
+  (*header.storage_class_stats)[long_name] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)[long_name].num_entries, 10);
+}
+
+TEST(StorageClassStats, SpecialCharactersInName) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with special characters
+  std::vector<std::string> special_names = {
+    "STANDARD-IA",
+    "storage_class_1",
+    "storage.class.dots",
+    "storage:class:colons",
+    "UTF8-名称",
+    "with spaces",
+    "with\ttabs",
+    "with\nnewlines"
+  };
+  
+  for (const auto& name : special_names) {
+    rgw_bucket_category_stats stats;
+    stats.num_entries = 1;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), special_names.size());
+}
+
+TEST(StorageClassStats, MaximumValues) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with maximum uint64_t values
+  rgw_bucket_category_stats stats;
+  stats.num_entries = UINT64_MAX;
+  stats.total_size = UINT64_MAX;
+  stats.total_size_rounded = UINT64_MAX;
+  stats.actual_size = UINT64_MAX;
+  
+  (*header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, UINT64_MAX);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_size, UINT64_MAX);
+}
+
+TEST(StorageClassStats, ManyStorageClasses) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test with 100 different storage classes
+  for (int i = 0; i < 100; i++) {
+    std::string name = "SC_" + std::to_string(i);
+    rgw_bucket_category_stats stats;
+    stats.num_entries = i;
+    stats.total_size = i * 1024;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 100);
+  EXPECT_EQ((*header.storage_class_stats)["SC_50"].num_entries, 50);
+  EXPECT_EQ((*header.storage_class_stats)["SC_50"].total_size, 50 * 1024);
+}
+
+TEST(StorageClassStats, OverwriteExistingEntry) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add entry
+  rgw_bucket_category_stats stats1;
+  stats1.num_entries = 10;
+  stats1.total_size = 1024;
+  (*header.storage_class_stats)["STANDARD"] = stats1;
+  
+  // Overwrite with new values
+  rgw_bucket_category_stats stats2;
+  stats2.num_entries = 20;
+  stats2.total_size = 2048;
+  (*header.storage_class_stats)["STANDARD"] = stats2;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 20);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].total_size, 2048);
+}
+
+TEST(StorageClassStats, EraseEntry) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add multiple entries
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*header.storage_class_stats)["HDD"].num_entries = 20;
+  (*header.storage_class_stats)["GLACIER"].num_entries = 30;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 3);
+  
+  // Erase one entry
+  header.storage_class_stats->erase("HDD");
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  EXPECT_EQ(header.storage_class_stats->count("STANDARD"), 1);
+  EXPECT_EQ(header.storage_class_stats->count("HDD"), 0);
+  EXPECT_EQ(header.storage_class_stats->count("GLACIER"), 1);
+}
+
+TEST(StorageClassStats, ClearAll) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add entries
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*header.storage_class_stats)["HDD"].num_entries = 20;
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 2);
+  
+  // Clear all entries
+  header.storage_class_stats->clear();
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value()); // Still has_value
+  EXPECT_TRUE(header.storage_class_stats->empty());    // But is empty
+  EXPECT_EQ(header.storage_class_stats->size(), 0);
+}
+
+// ============================================================================
+// COPY/MOVE SEMANTICS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, CopyConstruction) {
+  rgw_bucket_dir_header header1;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Copy construct
+  rgw_bucket_dir_header header2 = header1;
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+  
+  // Modify copy - original should not change
+  (*header2.storage_class_stats)["STANDARD"].num_entries = 20;
+  EXPECT_EQ((*header1.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, MoveConstruction) {
+  rgw_bucket_dir_header header1;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Move construct
+  rgw_bucket_dir_header header2 = std::move(header1);
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, CopyAssignment) {
+  rgw_bucket_dir_header header1, header2;
+  header1.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header1.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  // Copy assign
+  header2 = header1;
+  
+  EXPECT_TRUE(header2.storage_class_stats.has_value());
+  EXPECT_EQ((*header2.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+TEST(StorageClassStats, AssignNulloptToValue) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  
+  // Assign nullopt (e.g., during legacy bucket handling)
+  header.storage_class_stats = std::nullopt;
+  
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+}
+
+// ============================================================================
+// SERIALIZATION TESTS (Ceph encoding/decoding)
+// ============================================================================
+
+TEST(StorageClassStats, EncodeDecodeWithValue) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*original.storage_class_stats)["STANDARD"].num_entries = 10;
+  (*original.storage_class_stats)["HDD"].num_entries = 20;
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify
+  EXPECT_TRUE(decoded.storage_class_stats.has_value());
+  EXPECT_EQ(decoded.storage_class_stats->size(), 2);
+  EXPECT_EQ((*decoded.storage_class_stats)["STANDARD"].num_entries, 10);
+  EXPECT_EQ((*decoded.storage_class_stats)["HDD"].num_entries, 20);
+}
+
+TEST(StorageClassStats, EncodeDecodeNullopt) {
+  rgw_bucket_dir_header original;
+  // Leave storage_class_stats as nullopt
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify nullopt is preserved
+  EXPECT_FALSE(decoded.storage_class_stats.has_value());
+}
+
+TEST(StorageClassStats, EncodeDecodeEmpty) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  // Leave map empty
+  
+  // Encode
+  bufferlist bl;
+  encode(original, bl);
+  
+  // Decode
+  rgw_bucket_dir_header decoded;
+  auto iter = bl.cbegin();
+  decode(decoded, iter);
+  
+  // Verify empty map is preserved (not nullopt)
+  EXPECT_TRUE(decoded.storage_class_stats.has_value());
+  EXPECT_TRUE(decoded.storage_class_stats->empty());
+}
+
+// ============================================================================
+// USER STATS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, UserStatsMultiplePlacements) {
+  cls_user_header header;
+  header.storage_class_stats = std::unordered_map<std::string, cls_user_stats>();
+  
+  // Add stats for multiple placements and storage classes
+  std::vector<std::string> keys = {
+    "default-placement::STANDARD",
+    "default-placement::HDD",
+    "archive-placement::GLACIER",
+    "fast-placement::SSD"
+  };
+  
+  for (size_t i = 0; i < keys.size(); i++) {
+    cls_user_stats stats;
+    stats.total_entries = (i + 1) * 10;
+    stats.total_bytes = (i + 1) * 1024;
+    (*header.storage_class_stats)[keys[i]] = stats;
+  }
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 4);
+  EXPECT_EQ((*header.storage_class_stats)["archive-placement::GLACIER"].total_entries, 30);
+}
+
+// ============================================================================
+// ITERATOR SAFETY TESTS
+// ============================================================================
+
+TEST(StorageClassStats, IterationWhileModifying) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add initial entries
+  for (int i = 0; i < 10; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  // Iterate and collect keys
+  std::vector<std::string> keys;
+  for (const auto& [key, value] : *header.storage_class_stats) {
+    keys.push_back(key);
+  }
+  
+  EXPECT_EQ(keys.size(), 10);
+}
+
+TEST(StorageClassStats, SafeIterationWithHasValue) {
+  rgw_bucket_dir_header header;
+
+  // Should be nullopt initially
+  EXPECT_FALSE(header.storage_class_stats.has_value());
+
+  // Initialize and iterate
+  header.storage_class_stats =
+      std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 10;
+
+  ASSERT_TRUE(header.storage_class_stats.has_value());
+
+  int count = 0;
+  for (const auto& [key, value] : *header.storage_class_stats) {
+    count++;
+    EXPECT_EQ(key, "STANDARD");
+    EXPECT_EQ(value.num_entries, 10);
+  }
+
+  EXPECT_EQ(count, 1);
+}
+
+// ============================================================================
+// THREAD SAFETY TESTS (Basic)
+// ============================================================================
+
+TEST(StorageClassStats, ConcurrentReads) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header.storage_class_stats)["STANDARD"].num_entries = 100;
+  (*header.storage_class_stats)["HDD"].num_entries = 200;
+  
+  // Multiple threads reading simultaneously
+  std::vector<std::thread> threads;
+  std::atomic<int> success_count{0};
+  
+  for (int i = 0; i < 10; i++) {
+    threads.emplace_back([&header, &success_count]() {
+      if (header.storage_class_stats.has_value()) {
+        if (header.storage_class_stats->count("STANDARD") > 0) {
+          auto val = (*header.storage_class_stats)["STANDARD"].num_entries;
+          if (val == 100) {
+            success_count++;
+          }
+        }
+      }
+    });
+  }
+  
+  for (auto& t : threads) {
+    t.join();
+  }
+  
+  EXPECT_EQ(success_count, 10);
+}
+
+// ============================================================================
+// BOUNDARY CONDITION TESTS
+// ============================================================================
+
+TEST(StorageClassStats, ZeroValues) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // All zero values
+  rgw_bucket_category_stats stats;
+  stats.num_entries = 0;
+  stats.total_size = 0;
+  stats.total_size_rounded = 0;
+  stats.actual_size = 0;
+  
+  (*header.storage_class_stats)["STANDARD"] = stats;
+  
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 0);
+  EXPECT_TRUE(header.storage_class_stats.has_value()); // Still has_value even with 0
+}
+
+TEST(StorageClassStats, ValueOrAlternative) {
+  rgw_bucket_dir_header header1, header2;
+  
+  // header1 is nullopt
+  auto map1 = header1.storage_class_stats.value_or(
+    std::unordered_map<std::string, rgw_bucket_category_stats>()
+  );
+  EXPECT_TRUE(map1.empty());
+  
+  // header2 has value
+  header2.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  (*header2.storage_class_stats)["STANDARD"].num_entries = 10;
+  
+  auto map2 = header2.storage_class_stats.value_or(
+    std::unordered_map<std::string, rgw_bucket_category_stats>()
+  );
+  EXPECT_EQ(map2.size(), 1);
+  EXPECT_EQ(map2["STANDARD"].num_entries, 10);
+}
+
+// ============================================================================
+// REGRESSION TESTS
+// ============================================================================
+
+TEST(StorageClassStats, DereferenceSafety) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Test all dereference operators work correctly
+  EXPECT_NO_THROW({
+    (*header.storage_class_stats)["STANDARD"].num_entries = 10;  // operator*
+    header.storage_class_stats->size();                          // operator->
+  });
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 1);
+  EXPECT_EQ((*header.storage_class_stats)["STANDARD"].num_entries, 10);
+}
+
+// ============================================================================
+// PERFORMANCE BENCHMARK TESTS
+// ============================================================================
+
+TEST(StorageClassStats, BenchmarkLargeScale) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  auto start = high_resolution_clock::now();
+  
+  // Add 10,000 storage classes
+  for (int i = 0; i < 10000; i++) {
+    std::string name = "STORAGE_CLASS_" + std::to_string(i);
+    rgw_bucket_category_stats stats;
+    stats.num_entries = i;
+    stats.total_size = i * 1024;
+    (*header.storage_class_stats)[name] = stats;
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  EXPECT_EQ(header.storage_class_stats->size(), 10000);
+  std::cout << "Added 10,000 storage classes in " << duration << " µs" << std::endl;
+  
+  // Should complete in under 100ms
+  EXPECT_LT(duration, 100000); // 100ms in microseconds
+}
+
+TEST(StorageClassStats, BenchmarkIteration) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Setup: 1000 storage classes
+  for (int i = 0; i < 1000; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  auto start = high_resolution_clock::now();
+  
+  // Iterate 1000 times
+  uint64_t sum = 0;
+  for (int iteration = 0; iteration < 1000; iteration++) {
+    if (header.storage_class_stats.has_value()) {
+      for (const auto& [key, value] : *header.storage_class_stats) {
+        sum += value.num_entries;
+      }
+    }
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  std::cout << "1000 iterations over 1000 entries in " << duration << " µs" << std::endl;
+  EXPECT_LT(duration, 50000); // Should be under 50ms
+  EXPECT_GT(sum, 0); // Make sure loop ran
+}
+
+TEST(StorageClassStats, BenchmarkSerialization) {
+  using namespace std::chrono;
+  
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add 100 storage classes
+  for (int i = 0; i < 100; i++) {
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i * 100;
+    (*header.storage_class_stats)["SC_" + std::to_string(i)].total_size = i * 1024 * 1024;
+  }
+  
+  auto start = high_resolution_clock::now();
+  
+  // Encode/decode 100 times
+  for (int i = 0; i < 100; i++) {
+    bufferlist bl;
+    encode(header, bl);
+    
+    rgw_bucket_dir_header decoded;
+    auto iter = bl.cbegin();
+    decode(decoded, iter);
+  }
+  
+  auto end = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(end - start).count();
+  
+  std::cout << "100 encode/decode cycles in " << duration << " µs" << std::endl;
+  EXPECT_LT(duration, 10000); // Should be under 10ms
+}
+
+TEST(StorageClassStats, BenchmarkMemoryUsage) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  size_t initial_size = sizeof(header);
+  std::cout << "Header base size: " << initial_size << " bytes" << std::endl;
+  
+  // Add varying numbers of storage classes and measure
+  std::vector<int> sizes = {1, 10, 100, 1000};
+  
+  for (int size : sizes) {
+    rgw_bucket_dir_header test_header;
+    test_header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+    
+    for (int i = 0; i < size; i++) {
+      (*test_header.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+    }
+    
+    bufferlist bl;
+    encode(test_header, bl);
+    
+    std::cout << "  " << size << " storage classes: " << bl.length() << " bytes encoded" << std::endl;
+  }
+  
+  SUCCEED(); // Informational test
+}
+
+// ============================================================================
+// STRESS TESTS
+// ============================================================================
+
+TEST(StorageClassStats, StressTestRapidChanges) {
+  rgw_bucket_dir_header header;
+  header.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Rapidly add and remove storage classes
+  for (int cycle = 0; cycle < 100; cycle++) {
+    // Add 50
+    for (int i = 0; i < 50; i++) {
+      std::string name = "SC_" + std::to_string(cycle) + "_" + std::to_string(i);
+      (*header.storage_class_stats)[name].num_entries = i;
+    }
+    
+    // Remove half
+    int removed = 0;
+    for (auto it = header.storage_class_stats->begin(); 
+         it != header.storage_class_stats->end() && removed < 25; ) {
+      it = header.storage_class_stats->erase(it);
+      removed++;
+    }
+  }
+  
+  // Should still be valid
+  EXPECT_TRUE(header.storage_class_stats.has_value());
+  std::cout << "Final size after stress test: " 
+            << header.storage_class_stats->size() << " entries" << std::endl;
+}
+
+TEST(StorageClassStats, StressTestDeepCopy) {
+  rgw_bucket_dir_header original;
+  original.storage_class_stats = std::unordered_map<std::string, rgw_bucket_category_stats>();
+  
+  // Add 100 entries
+  for (int i = 0; i < 100; i++) {
+    (*original.storage_class_stats)["SC_" + std::to_string(i)].num_entries = i;
+  }
+  
+  // Make 1000 copies
+  std::vector<rgw_bucket_dir_header> copies;
+  for (int i = 0; i < 1000; i++) {
+    copies.push_back(original);
+  }
+  
+  // Verify all copies are valid
+  for (const auto& copy : copies) {
+    EXPECT_TRUE(copy.storage_class_stats.has_value());
+    EXPECT_EQ(copy.storage_class_stats->size(), 100);
+  }
+  
+  std::cout << "Successfully created 1000 deep copies" << std::endl;
+}


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
