### PR TITLE
smb: add remote-control local mode feature

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -680,6 +680,13 @@ remote_control
     ca_cert
         Optional object. The fields are described in :ref:`tls source
         fields<tls-source-fields>`
+    locally_enabled
+        Optional boolean. If set to ``true`` this field will enable the
+        remote control service local listener. The local listener lets
+        processes on the Ceph cluster host communicate with the remote
+        control service independently of the default TCP/mTLS listener.
+        The TLS certificates configuration values do not apply to this
+        unix socket based listener.
 external_ceph_cluster:
     Optional object. The fields are described in :ref:`external Ceph cluster
     source fields<external-ceph-cluster-source-fields>`. This is an

--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -58,6 +58,7 @@ class Features(enum.Enum):
     CLUSTERED = 'clustered'
     CEPHFS_PROXY = 'cephfs-proxy'
     REMOTE_CONTROL = 'remote-control'
+    REMOTE_CONTROL_LOCAL = 'remote-control-local'
 
     @classmethod
     def valid(cls, value: str) -> bool:
@@ -136,6 +137,11 @@ class Ports(enum.Enum):
         return names[self]
 
 
+class ListenTo(str, enum.Enum):
+    TCP = 'tcp'
+    UNIX = 'unix'
+
+
 @dataclasses.dataclass(frozen=True)
 class TLSFiles:
     cert: str = ''
@@ -181,6 +187,42 @@ class TLSFiles:
 class RemoteControlConfig:
     port: int
     tls_files: TLSFiles
+    listen_to: Optional[List[ListenTo]] = None
+    unix_sock_path: str = '/run/remote-control.s'
+
+    @property
+    def listen_to_tcp(self) -> bool:
+        return bool(
+            self.port
+            and (not self.listen_to or ListenTo.TCP in self.listen_to)
+        )
+
+    @property
+    def listen_to_unix(self) -> bool:
+        return bool(
+            self.unix_sock_path
+            and (self.listen_to and ListenTo.UNIX in self.listen_to)
+        )
+
+    @classmethod
+    def configure(
+        cls,
+        features: List[str],
+        service_ports: Dict,
+        tls_files: Dict[str, str],
+    ) -> Optional['RemoteControlConfig']:
+        listen_to = []
+        if Features.REMOTE_CONTROL.value in features:
+            listen_to.append(ListenTo.TCP)
+        if Features.REMOTE_CONTROL_LOCAL.value in features:
+            listen_to.append(ListenTo.UNIX)
+        if not listen_to:
+            return None
+        return cls(
+            port=Ports.REMOTE_CONTROL.customized(service_ports),
+            tls_files=TLSFiles.match(tls_files, 'remote_control'),
+            listen_to=listen_to,
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -418,6 +460,16 @@ class RemoteControlContainer(SambaContainerCommon):
         assert self.cfg.remote_control, 'remote_control is not configured'
         args.append('serve')
         args.append('--grpc')
+        if self.cfg.remote_control.listen_to_tcp:
+            self._tcp_args(args)
+            if self.cfg.remote_control.listen_to_unix:
+                self._unix_extra_args(args)
+        elif self.cfg.remote_control.listen_to_unix:
+            self._unix_only_args(args)
+        return args
+
+    def _tcp_args(self, args: List[str]) -> None:
+        assert self.cfg.remote_control
         address = self.cfg.bind_to[0].address if self.cfg.bind_to else '*'
         port = self.cfg.remote_control.port
         args.append(f'--address={address}:{port}')
@@ -433,7 +485,17 @@ class RemoteControlContainer(SambaContainerCommon):
             args.append(f'--tls-key={key_path}')
             if ca_cert:
                 args.append(f'--tls-ca-cert={ca_cert}')
-        return args
+
+    def _unix_only_args(self, args: List[str]) -> None:
+        assert self.cfg.remote_control
+        sock_path = self.cfg.remote_control.unix_sock_path
+        args.append(f'--address=unix:{sock_path}')
+        args.append('--verification=rados-object')
+
+    def _unix_extra_args(self, args: List[str]) -> None:
+        assert self.cfg.remote_control
+        sock_path = self.cfg.remote_control.unix_sock_path
+        args.append(f'--extra-listener=unix:{sock_path};rados-object')
 
     def container_args(self) -> List[str]:
         return super().container_args() + [
@@ -648,13 +710,11 @@ class SMB(ContainerDaemonForm):
 
         self._organize_files(files)
 
-        if Features.REMOTE_CONTROL.value in instance_features:
-            remote_control_cfg = RemoteControlConfig(
-                port=Ports.REMOTE_CONTROL.customized(service_ports),
-                tls_files=TLSFiles.match(self._tls_files, 'remote_control'),
-            )
-        else:
-            remote_control_cfg = None
+        remote_control_cfg = RemoteControlConfig.configure(
+            instance_features,
+            service_ports,
+            self._tls_files,
+        )
 
         rank, rank_gen = self._rank_info
         self._instance_cfg = Config(

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1015,7 +1015,8 @@ def _generate_smb_service_spec(
     if needs_proxy:
         features.append(_CEPHFS_PROXY)
     if cluster.remote_control_is_enabled:
-        features.append(_REMOTE_CONTROL)
+        assert cluster.remote_control is not None
+        features.extend(cluster.remote_control.enabled_features())
     # only one config uri can be used, the input list should be
     # ordered from lowest to highest priority and the highest priority
     # item that exists in the store will be used.

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -14,6 +14,7 @@ from ceph.deployment.service_spec import (
     SMBClusterPublicIPSpec,
     SpecValidationError,
 )
+from ceph.smb.constants import REMOTE_CONTROL, REMOTE_CONTROL_LOCAL
 from ceph.smb.network import to_network
 from object_format import ErrorResponseBase
 
@@ -604,6 +605,9 @@ class ExternalCephClusterSource(_RBase):
 class RemoteControl(_RBase):
     # enabled can be set to explicitly toggle the remote control server
     enabled: Optional[bool] = None
+    # locally_enabled can be set to explicitly toggle the remote control
+    # servers local unix socket mode
+    locally_enabled: Optional[bool] = None
     # cert specifies the ssl/tls certificate to use
     cert: Optional[TLSSource] = None
     # cert specifies the ssl/tls server key to use
@@ -617,9 +621,23 @@ class RemoteControl(_RBase):
 
     @property
     def is_enabled(self) -> bool:
+        return self._locally_enabled() or self._remotely_enabled()
+
+    def _locally_enabled(self) -> bool:
+        return bool(self.locally_enabled)
+
+    def _remotely_enabled(self) -> bool:
         if self.enabled is not None:
             return self.enabled
         return bool(self.cert and self.key)
+
+    def enabled_features(self) -> list[str]:
+        out = []
+        if self._locally_enabled():
+            out.append(REMOTE_CONTROL_LOCAL)
+        if self._remotely_enabled():
+            out.append(REMOTE_CONTROL)
+        return out
 
 
 @resourcelib.resource('ceph.smb.cluster')

--- a/src/python-common/ceph/smb/constants.py
+++ b/src/python-common/ceph/smb/constants.py
@@ -12,6 +12,7 @@ CEPHFS_PROXY = 'cephfs-proxy'
 CLUSTERED = 'clustered'
 DOMAIN = 'domain'
 REMOTE_CONTROL = 'remote-control'
+REMOTE_CONTROL_LOCAL = 'remote-control-local'
 SMBMETRICS = 'smbmetrics'
 
 
@@ -23,6 +24,7 @@ FEATURES = {
     CLUSTERED,
     DOMAIN,
     REMOTE_CONTROL,
+    REMOTE_CONTROL_LOCAL,
 }
 
 # Services are components that listen on a "public" network port, to expose


### PR DESCRIPTION
Depends on: #67534 

Recently, the sambacc component of the samba container has been enhanced to support more than one "listener" for the gRPC based Remote-Control sidecar service. Each listener can listen on a different socket & socket type. Thus we can now provide an additional listener that uses a unix domain socket, accessible to only processes running on the same cluster host, as an alternative method of working with the APIs provided by the Remote-Control service. Clients using the unix socket do not need TLS certificites but as an additional layer of validation they do require a ceph user name and key to prove access to rados - mimicking other ceph-based tooling.






## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
