### PR TITLE
src/script/build-with-container.py - Add --custom-image-script for image build hooks

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,6 +6,7 @@ COPY \
     src/script/lib-build.sh \
     src/script/run-make.sh \
     ${CEPH_CTR_SRC}/src/script/
+COPY src/script/custom ${CEPH_CTR_SRC}/src/script/custom
 COPY debian ${CEPH_CTR_SRC}/debian
 COPY \
     ceph.spec.in \
@@ -21,6 +22,7 @@ ARG DISTRO
 ARG CEPH_CTR_SRC=/usr/local/src/ceph
 ARG CLEAN_DNF=yes
 ARG CEPH_BASE_BRANCH=main
+ARG CUSTOM_IMAGE_SCRIPT=
 ARG SCCACHE_VERSION=v0.8.2
 ARG SCCACHE_REPO=https://github.com/mozilla/sccache
 ARG WITH_CRIMSON=true
@@ -31,6 +33,7 @@ COPY --from=bootstrap ${CEPH_CTR_SRC} ${CEPH_CTR_SRC}
 RUN DISTRO=$DISTRO \
     CEPH_BASE_BRANCH=$CEPH_BASE_BRANCH \
     CLEAN_DNF=$CLEAN_DNF \
+    CUSTOM_IMAGE_SCRIPT=$CUSTOM_IMAGE_SCRIPT \
     CEPH_CTR_SRC=${CEPH_CTR_SRC} \
     WITH_CRIMSON=${WITH_CRIMSON} \
     FOR_MAKE_CHECK=${FOR_MAKE_CHECK} \

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -213,6 +213,7 @@ _CONTAINER_SOURCES = [
     "Dockerfile.build",
     "src/script/lib-build.sh",
     "src/script/run-make.sh",
+    "src/script/custom",
     "ceph.spec.in",
     "do_cmake.sh",
     "install-deps.sh",
@@ -724,6 +725,22 @@ def npm_cache_dir(ctx):
 def build_container(ctx):
     """Generate a build environment container image."""
     ctx.build.wants(Steps.DNF_CACHE, ctx)
+    if ctx.cli.custom_image_script:
+        custom_script = pathlib.Path(ctx.cli.custom_image_script)
+        if custom_script.is_absolute():
+            raise ValueError(
+                "--custom-image-script must be a path relative to source root"
+            )
+        resolved_script = custom_script
+        if not resolved_script.is_file():
+            fallback = pathlib.Path("src/script/custom") / custom_script
+            if fallback.is_file():
+                resolved_script = fallback
+        if not resolved_script.is_file():
+            raise FileNotFoundError(
+                f"custom image script not found: {custom_script}"
+            )
+        ctx.cli.custom_image_script = str(resolved_script)
     cmd = [
         ctx.container_engine,
         "build",
@@ -755,6 +772,10 @@ def build_container(ctx):
         cmd.append(f"--build-arg=WITH_CRIMSON={with_crimson}")
     if ctx.cli.build_args:
         cmd.extend([f"--build-arg={v}" for v in ctx.cli.build_args])
+    if ctx.cli.custom_image_script:
+        cmd.append(
+            f"--build-arg=CUSTOM_IMAGE_SCRIPT={ctx.cli.custom_image_script}"
+        )
     cmd += ["-f", ctx.cli.containerfile, ctx.cli.containerdir]
     with ctx.user_command():
         _run(cmd, check=True, ctx=ctx)
@@ -1246,6 +1267,13 @@ def parse_cli(build_step_names):
         help=(
             "Extra argument to pass to container image build."
             " Can be used to override default build image behavior."
+        ),
+    )
+    g_image.add_argument(
+        "--custom-image-script",
+        help=(
+            "Run this script while building the container image. "
+            "Path must be relative to source root and included in build context."
         ),
     )
     g_image.add_argument(

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -342,12 +342,20 @@ def _hash_sources(bsize=4096):
     hh = hashlib.sha256()
     buf = bytearray(bsize)
     for path in sorted(_CONTAINER_SOURCES):
-        with open(path, "rb") as fh:
-            while True:
-                rlen = fh.readinto(buf)
-                hh.update(buf[:rlen])
-                if rlen < len(buf):
-                    break
+        source = pathlib.Path(path)
+        if not source.exists():
+            continue
+        paths = [source]
+        if source.is_dir():
+            paths = sorted(p for p in source.rglob("*") if p.is_file())
+        for fpath in paths:
+            hh.update(str(fpath).encode("utf8"))
+            with open(fpath, "rb") as fh:
+                while True:
+                    rlen = fh.readinto(buf)
+                    hh.update(buf[:rlen])
+                    if rlen < len(buf):
+                        break
     return f"sha256:{hh.hexdigest()}"
 
 

--- a/src/script/buildcontainer-setup.sh
+++ b/src/script/buildcontainer-setup.sh
@@ -15,6 +15,25 @@ dnf_clean() {
     fi
 }
 
+run_custom_image_script() {
+    if [ -z "${CUSTOM_IMAGE_SCRIPT}" ]; then
+        return
+    fi
+    local script_path="${CUSTOM_IMAGE_SCRIPT}"
+    if [ "${script_path#/}" = "${script_path}" ]; then
+        script_path="${CEPH_CTR_SRC}/${script_path}"
+    fi
+    if [ ! -f "${script_path}" ]; then
+        echo "Custom image script not found: ${script_path}" >&2
+        exit 2
+    fi
+    if [ ! -x "${script_path}" ]; then
+        chmod +x "${script_path}"
+    fi
+    echo "Running custom image script: ${script_path}"
+    "${script_path}"
+}
+
 set -e
 export LOCALE=C
 cd ${CEPH_CTR_SRC}
@@ -51,3 +70,5 @@ case "${CEPH_BASE_BRANCH}~${DISTRO_KIND}" in
         exit 2
     ;;
 esac
+
+run_custom_image_script

--- a/src/script/custom/README.md
+++ b/src/script/custom/README.md
@@ -1,0 +1,16 @@
+# Custom image scripts
+
+Use this directory for scripts passed to `src/script/build-with-container.py`
+with `--custom-image-script`.
+
+Example:
+
+```bash
+src/script/build-with-container.py \
+  -d centos9 \
+  --custom-image-script src/script/custom/my-extra-setup.sh \
+  -e build
+```
+
+The script runs near the end of `src/script/buildcontainer-setup.sh` while
+building the container image.


### PR DESCRIPTION
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
