### PR TITLE
rbd: set snapshot hard limit to 2^14-1

### DIFF
--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -68,6 +68,9 @@ Snapshot Basics
 The following procedures demonstrate how to create, list, and remove
 snapshots using the ``rbd`` command.
 
+.. note:: Each RBD image may hold a maximum of 16383 snapshots due to
+   internal limitations.
+
 Create Snapshot
 ---------------
 

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -76,6 +76,7 @@ CLS_VER(2,0)
 CLS_NAME(rbd)
 
 #define RBD_MAX_KEYS_READ 64
+#define RBD_MAX_SNAP_HARD_LIMIT 16383
 #define RBD_SNAP_KEY_PREFIX "snapshot_"
 #define RBD_SNAP_CHILDREN_KEY_PREFIX "snap_children_"
 #define RBD_DIR_ID_KEY_PREFIX "id_"
@@ -2371,6 +2372,9 @@ int snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     return r;
   }
 
+  // Hard cap to prevent MOSDOp __u16 num_ops overflow (4 ops per snapshot)
+  snap_limit = std::min(snap_limit, (uint64_t)RBD_MAX_SNAP_HARD_LIMIT);
+
   snap_meta.timestamp = ceph_clock_now();
 
   uint64_t total_read = 0;
@@ -4389,6 +4393,9 @@ int old_snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   } else if (rc < 0) {
     return rc;
   }
+
+  // Hard cap to prevent MOSDOp __u16 num_ops overflow (4 ops per snapshot)
+  snap_limit = std::min(snap_limit, (uint64_t)RBD_MAX_SNAP_HARD_LIMIT);
 
   if (header->snap_count >= snap_limit)
     return -EDQUOT;


### PR DESCRIPTION
[Tracker Ticket](https://tracker.ceph.com/issues/75253)
**Tl;Dr: rbd images become unusable when they have 16384 snapshots or more; this adds a guardrail to prevent that**

- When librbd refreshes an image (opening it, or any metadata refresh), it builds one single ObjectReadOperation and adds sub-ops for every snapshot
- At 16,384 snapshots, the total op count hits 65,536 which is exactly 2^16 so it wraps to 0 (or some garbage value) in the __u16, and the OSD can't decode the message.
- The image becomes thus permanently inaccessible because every open/refresh attempt fails
- running `rbd info` on a volume with 16,384 snapshots produces these errors:

```
rbd: error opening image xxx
(74) Bad message
2026-02-25T11:22:55.546+0000 7fe35b7fe700 -1 librbd::image::RefreshRequest: failed to retrieve snapshots: (74) Bad message

2026-02-25T11:22:55.546+0000 7fe35affd700 -1 librbd::image::OpenRequest: failed to refresh image: (74) Bad message

2026-02-25T11:22:55.546+0000 7fe35affd700 -1 librbd::ImageState: 0x56263da8eb90 failed to open image: (74) Bad message
```

- To make the rbd image usable again, I had to manually evict a few snapshot keys from its rbd_header omap

- I searched the web for this issue, all I could find is [this Cinder bug](https://bugs.launchpad.net/cinder/+bug/2084476) which mentions Ceph rbd images' behavior when snapshot count reaches 16384 snapshots
- Here's where the overflow happens: https://github.com/ceph/ceph/blob/main/src/messages/MOSDOp.h#L420
- I also updated the documentation to mention Ceph's internal max number of snapshots for any given rbd image; please let me know if there is a more appropriate place in the doc to mention that.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
