### PR TITLE
Add CEPH_OSD_OP_FLAG_EXPECT_EXISTS to panic on write in case of accid…

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -502,6 +502,7 @@ enum {
 									 * and handle them separately from normal ops,
 									 * apply scrub-specific behavior (e.g. bypassing clean cache)
 									 */
+	CEPH_OSD_OP_FLAG_MUST_EXIST = 0x200, /* object must exist, panic if missing */
 };
 
 #define EOLDSNAPC    85  /* ORDERSNAP flag set; writer has old snapc*/

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15926,9 +15926,18 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
     bool create = false;
     if (op->op == Transaction::OP_TOUCH ||
 	op->op == Transaction::OP_CREATE ||
-	op->op == Transaction::OP_WRITE ||
 	op->op == Transaction::OP_ZERO) {
       create = true;
+    }
+
+    if (op->op == Transaction::OP_WRITE) {
+      uint32_t fadvise_flags = i.get_fadvise_flags();
+      if (fadvise_flags & CEPH_OSD_OP_FLAG_MUST_EXIST) {
+          // Object must exist, don't allow implicit creation
+          create = false;
+      } else {
+          create = true;
+      }
     }
 
     // object operations
@@ -15955,9 +15964,9 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
       {
         uint64_t off = op->off;
         uint64_t len = op->len;
-	uint32_t fadvise_flags = i.get_fadvise_flags();
         bufferlist bl;
         i.decode_bl(bl);
+        uint32_t fadvise_flags = i.get_fadvise_flags();
 	r = _write(txc, c, o, off, len, bl, fadvise_flags);
       }
       break;
@@ -16149,6 +16158,10 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
 			     op->op == Transaction::OP_CLONE ||
 			     op->op == Transaction::OP_CLONERANGE2))
 	  msg = "ENOENT on clone suggests osd bug";
+
+  uint32_t fadvise_flags = i.get_fadvise_flags();
+  if (r == -ENOENT && op->op == Transaction::OP_WRITE && (fadvise_flags & CEPH_OSD_OP_FLAG_MUST_EXIST))
+      msg = "ENOENT on write with CEPH_OSD_OP_FLAG_MUST_EXIST flag suggests osd bug (likely EC object removal)";
 
 	if (r == -ENOSPC)
 	  // For now, if we hit _any_ ENOSPC, crash, before we do any damage

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -735,6 +735,9 @@ void ECTransaction::Generate::overlay_writes() {
     sinfo.ro_range_to_shard_extent_map(off, len, bl, to_write);
     debug(oid, "overlay_buffer", to_write, dpp);
   }
+  if (!op.is_fresh_object()) {
+    fadvise_flags |= CEPH_OSD_OP_FLAG_MUST_EXIST;
+  }
 }
 
 void ECTransaction::Generate::appends_and_clone_ranges() {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1130,6 +1130,74 @@ TEST_P(StoreTest, BufferCacheReadTest) {
   }
 }
 
+TEST_P(StoreTest, WriteMustExistSuccess) {
+  int r;
+  coll_t cid;
+  ghobject_t hoid(hobject_t("test_obj", "", CEPH_NOSNAP, 0, 0, ""));
+  // Create object
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    t.touch(cid, hoid);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  // Write with MUST_EXIST should succeed
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl;
+    bl.append("test_data");
+    t.write(cid, hoid, 0, bl.length(), bl, CEPH_OSD_OP_FLAG_MUST_EXIST);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
+TEST_P(StoreTest, WriteMustExistFailure) {
+  int r;
+  coll_t cid;
+  ghobject_t hoid(hobject_t("nonexistent_obj", "", CEPH_NOSNAP, 0, 0, ""));
+  // Create collection but not the object
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  // Write with MUST_EXIST should fail as no object is write
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl;
+    bl.append("test_data");
+    t.write(cid, hoid, 0, bl.length(), bl, CEPH_OSD_OP_FLAG_MUST_EXIST);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, -ENOENT);
+  }
+}
+
+TEST_P(StoreTest, WriteMustExistWithFadvise) {
+  // Test CEPH_OSD_OP_FLAG_MUST_EXIST combined with FADVISE flags
+  int r;
+  coll_t cid;
+  ghobject_t hoid(hobject_t("test_obj", "", CEPH_NOSNAP, 0, 0, ""));
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    t.touch(cid, hoid);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl;
+    bl.append("test_data");
+    uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_MUST_EXIST | CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
+    t.write(cid, hoid, 0, bl.length(), bl, fadvise_flags);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
 void StoreTest::doCompressionTest()
 {
   int r;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1134,6 +1134,7 @@ TEST_P(StoreTest, WriteMustExistSuccess) {
   int r;
   coll_t cid;
   ghobject_t hoid(hobject_t("test_obj", "", CEPH_NOSNAP, 0, 0, ""));
+  auto ch = store->create_new_collection(cid);
   // Create object
   {
     ObjectStore::Transaction t;
@@ -1157,6 +1158,11 @@ TEST_P(StoreTest, WriteMustExistFailure) {
   int r;
   coll_t cid;
   ghobject_t hoid(hobject_t("nonexistent_obj", "", CEPH_NOSNAP, 0, 0, ""));
+  auto ch = store->create_new_collection(cid);
+
+  SetVal(g_conf(), "objectstore_debug_throw_on_failed_txc", "true");
+  g_conf().apply_changes(nullptr);
+
   // Create collection but not the object
   {
     ObjectStore::Transaction t;
@@ -1164,14 +1170,18 @@ TEST_P(StoreTest, WriteMustExistFailure) {
     r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  // Write with MUST_EXIST should fail as no object is write
+  // Write with MUST_EXIST should fail with ENOENT since the object does not exist
   {
     ObjectStore::Transaction t;
     bufferlist bl;
     bl.append("test_data");
     t.write(cid, hoid, 0, bl.length(), bl, CEPH_OSD_OP_FLAG_MUST_EXIST);
-    r = queue_transaction(store, ch, std::move(t));
-    ASSERT_EQ(r, -ENOENT);
+    try {
+      queue_transaction(store, ch, std::move(t));
+      FAIL() << "write with MUST_EXIST on non-existent object should have thrown ENOENT";
+    } catch (int err) {
+      ASSERT_EQ(err, -ENOENT);
+    }
   }
 }
 
@@ -1180,6 +1190,7 @@ TEST_P(StoreTest, WriteMustExistWithFadvise) {
   int r;
   coll_t cid;
   ghobject_t hoid(hobject_t("test_obj", "", CEPH_NOSNAP, 0, 0, ""));
+  auto ch = store->create_new_collection(cid);
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);


### PR DESCRIPTION
…ental object deletion

Fixes: https://tracker.ceph.com/issues/74426

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

Signed-off-by: Guna K Kambalimath [Guna.Kambalimath@ibm.com](mailto:Guna.Kambalimath@ibm.com)