### PR TITLE
dashboard: align icon with notification timestamp

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
@@ -1,17 +1,18 @@
 <div
   [ngClass]="{'empty-body': todayNotifications.length === 0 && previousNotifications.length === 0}"
   class="notification-area">
+
 @if (executingTasks.length > 0) {
-<div
-  class="notification-section-heading"
-  i18n>
+<div class="notification-section-heading" i18n>
   Running tasks
 </div>
 
 @for (task of executingTasks; track task.begin_time) {
 <div class="notification-wrapper">
   <div class="notification-item task-item">
-    <cd-icon type="infoCircle"></cd-icon>
+    <div class="notification-icon-wrap">
+      <cd-icon type="infoCircle"></cd-icon>
+    </div>
 
     <div class="notification-content">
       <div class="notification-title">
@@ -47,25 +48,30 @@
   #notificationItemTemplate
   let-notification="notification"
   let-last="last">
+
   <div class="notification-wrapper">
-    <div class="notification-item"
-         data-testid="notification-item">
+    <div class="notification-item" data-testid="notification-item">
+
       <cd-icon
         id="notification-icon"
         [type]="notificationIconMap[notification.type] || notificationIconMap['default']">
       </cd-icon>
 
+      <div class="notification-timestamp">
+        {{ notification.timestamp | relativeDate }}
+      </div>
+
       <div class="notification-content">
-        <div class="notification-timestamp">
-          {{ notification.timestamp | relativeDate }}
-        </div>
+
         <div class="notification-title">
           {{ notification.title }}
         </div>
+
         <div
           class="notification-message"
           [innerHTML]="notification.message | sanitizeHtml">
         </div>
+
       </div>
 
       <button
@@ -75,18 +81,19 @@
         (click)="removeNotification(notification, $event)">
         <cd-icon type="destroy"></cd-icon>
       </button>
+
     </div>
 
     @if (!last) {
     <div class="notification-divider"></div>
     }
+
   </div>
+
 </ng-template>
 
 @if (todayNotifications.length > 0) {
-<div
-  class="notification-section-heading"
-  i18n>
+<div class="notification-section-heading" i18n>
   Today
 </div>
 
@@ -99,9 +106,7 @@
 }
 
 @if (previousNotifications.length > 0) {
-<div
-  class="notification-section-heading"
-  i18n>
+<div class="notification-section-heading" i18n>
   Previous
 </div>
 
@@ -118,4 +123,5 @@
   <div i18n>No notifications</div>
 </div>
 }
+
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
@@ -20,7 +20,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: var(--cds-spacing-02);
+  margin-top: $spacing-02;
 }
 
 .task-progress {
@@ -35,8 +35,9 @@
 
   color: $text-secondary;
   line-height: 1;
-  margin-top: 0;
+  margin: 0;
   display: block;
+  flex: 0 0 auto;
 }
 
 .notification-title {
@@ -79,41 +80,57 @@
 }
 
 .notification-item {
-  display: flex;
-  gap: $spacing-05;
-  padding: $spacing-03 0;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: $spacing-03;
   position: relative;
+  padding: $spacing-05 0;
+}
 
-  .notification-close {
-    position: absolute;
-    right: 0;
-    top: $spacing-03;
-    padding: $spacing-02;
-    min-height: 0;
-    color: $text-helper;
-    opacity: 0;
-    transition: opacity 0.2s ease-in-out;
+#notification-icon {
+  grid-row: 1;
+  grid-column: 1;
+  flex: 0 0 auto;
+  display: block;
+}
 
-    &:hover {
-      background-color: $layer-hover;
-    }
-  }
-
-  &:hover {
-    .notification-close {
-      opacity: 1;
-    }
-  }
+.notification-timestamp {
+  grid-row: 1;
+  grid-column: 2;
+  @include type.type-style('label-01');
+  color: $text-secondary;
+  margin: 0;
+  display: block;
+  align-self: center;
 }
 
 .notification-content {
-  flex: 1;
-  min-width: 0;
+  grid-row: 2;
+  grid-column: 2;
   display: flex;
   flex-direction: column;
-  gap: $spacing-02;
-  padding-right: $spacing-06;
+  gap: $spacing-01;
+  padding-right: $spacing-07;
+  width: 100%;
+}
+
+.notification-close {
+  position: absolute;
+  right: 0;
+  top: $spacing-03;
+  padding: $spacing-02;
+  min-height: 0;
+  color: $text-helper;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.notification-item:hover .notification-close {
+  opacity: 1;
+}
+
+.notification-close:hover {
+  background-color: $layer-hover;
 }
 
 .notification-divider {


### PR DESCRIPTION

<img width="614" height="574" alt="image" src="https://github.com/user-attachments/assets/fbbe460e-4cf9-49ef-9e24-fe74a8716ab9" />



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->
Aligned the notification icon with the timestamp in the notification panel.

### Update
The icon was previously rendered above the timestamp. This change updates
the layout so the icon aligns correctly with the timestamp text.

The previous version did not correctly follow the Carbon Design System spacing usage. This update replaces the SCSS spacing imports with the global Carbon CSS variables (`var(--cds-spacing-0x)`) and adjusts the styles to match the existing patterns used in the dashboard.

Some minor assistance from GitHub Copilot was used during refactoring, but the changes were manually implemented, reviewed, and tested locally to ensure the layout and alignment remain correct.
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
