### PR TITLE
smb: fix ceph smb show ceph.smb.ext.cluster

### DIFF
--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -33,11 +34,13 @@ from .enums import (
 )
 from .internal import (
     ClusterEntry,
+    CommonResourceEntry,
     ExternalCephClusterEntry,
     JoinAuthEntry,
     ShareEntry,
     TLSCredentialEntry,
     UsersAndGroupsEntry,
+    map_resource_entry,
 )
 from .proto import (
     AccessAuthorizer,
@@ -238,6 +241,9 @@ class _Matcher:
             f'{txt!r} does not match a valid resource type'
         )
 
+    def resources(self) -> List[Type[SMBResource]]:
+        return list(self._match_resources)
+
 
 class ClusterConfigHandler:
     """The central class for ingesting and handling smb configuration change
@@ -382,6 +388,7 @@ class ClusterConfigHandler:
     def _search_resources(self, matcher: _Matcher) -> List[SMBResource]:
         log.debug("performing search with matcher: %s", matcher)
         out: List[SMBResource] = []
+        # clusters and shares (with parent-child relationship)
         if resources.Cluster in matcher or resources.Share in matcher:
             log.debug("searching for clusters and/or shares")
             cluster_shares = self.share_ids_by_cluster()
@@ -395,21 +402,20 @@ class ClusterConfigHandler:
                                 cluster_id, share_id
                             ).get_share()
                         )
-        _resources = (
-            (resources.JoinAuth, JoinAuthEntry),
-            (resources.UsersAndGroups, UsersAndGroupsEntry),
-            (resources.TLSCredential, TLSCredentialEntry),
-        )
-        for rtype, ecls in _resources:
-            if rtype in matcher:
-                log.debug("searching for %s", cast(Any, rtype).resource_type)
-                out.extend(
-                    ecls.from_store(
-                        self.internal_store, rid
-                    ).get_resource_type(rtype)
-                    for rid in ecls.ids(self.internal_store)
-                    if (rtype, rid) in matcher
-                )
+        # other common top-level resources
+        for rtype in matcher.resources():
+            if rtype in (resources.Cluster, resources.Share):
+                continue  # already handled above
+            if rtype not in matcher:
+                continue
+            log.debug("searching for %s", cast(Any, rtype).resource_type)
+            ecls = map_resource_entry(rtype)
+            assert issubclass(ecls, CommonResourceEntry)
+            for rid in ecls.ids(self.internal_store):
+                if (rtype, rid) in matcher:
+                    entry = ecls.from_store(self.internal_store, rid)
+                    res = entry.get_resource_type(rtype)
+                    out.append(cast(SMBResource, res))
         log.debug("search found %d resources", len(out))
         return out
 

--- a/src/pybind/mgr/smb/internal.py
+++ b/src/pybind/mgr/smb/internal.py
@@ -238,9 +238,10 @@ class ExternalCephClusterEntry(CommonResourceEntry):
         return self.get_resource_type(resources.ExternalCephCluster)
 
 
-def _map_resource_entry(
-    resource: Union[SMBResource, Type[SMBResource]]
+def map_resource_entry(
+    resource: Union[SMBResource, Type[SMBResource]],
 ) -> Type[ResourceEntry]:
+    """Return an entry type class given a resource object or resource class."""
     rcls = resource if isinstance(resource, type) else type(resource)
     _map = {
         resources.Cluster: ClusterEntry,
@@ -262,14 +263,14 @@ def resource_entry(
     store: ConfigStore, resource: SMBResource
 ) -> ResourceEntry:
     """Return a bound store entry object given a resource object."""
-    entry_cls = _map_resource_entry(resource)
+    entry_cls = map_resource_entry(resource)
     key = entry_cls.to_key(resource)
     return entry_cls.from_store_by_key(store, key)
 
 
 def resource_key(resource: SMBResource) -> EntryKey:
     """Return a store entry key for an smb resource object."""
-    entry_cls = _map_resource_entry(resource)
+    entry_cls = map_resource_entry(resource)
     key = entry_cls.to_key(resource)
     return str(entry_cls.namespace), str(key)
 


### PR DESCRIPTION
Fix `ceph.smb.ext.cluster` resource types not appearing in ceph smb show output by reimplementing the necessary function to be more dynamic when mapping between types such that this function should not need to be altered every time a new type is added in the future.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
