### PR TITLE
squid: qa: fix TypeError in delay

### DIFF
--- a/qa/tasks/cephfs_mirror_thrash.py
+++ b/qa/tasks/cephfs_mirror_thrash.py
@@ -101,7 +101,7 @@ class CephFSMirrorThrasher(ThrasherGreenlet):
         while not self.is_stopped:
             delay = self.max_thrash_delay
             if self.randomize:
-                delay = random.randrange(self.min_thrash_delay, self.max_thrash_delay)
+                delay = random.uniform(self.min_thrash_delay, self.max_thrash_delay)
 
             if delay > 0.0:
                 self.log('waiting for {delay} secs before thrashing'.format(delay=delay))
@@ -136,7 +136,7 @@ class CephFSMirrorThrasher(ThrasherGreenlet):
                 # wait for a while before restarting
                 delay = self.max_revive_delay
                 if self.randomize:
-                    delay = random.randrange(0.0, self.max_revive_delay)
+                    delay = random.uniform(0.0, self.max_revive_delay)
 
                 self.log('waiting for {delay} secs before reviving daemons'.format(delay=delay))
                 self.sleep_unless_stopped(delay)

--- a/qa/tasks/mds_thrash.py
+++ b/qa/tasks/mds_thrash.py
@@ -230,7 +230,7 @@ class MDSThrasher(ThrasherGreenlet):
         while not self.is_stopped:
             delay = self.max_thrash_delay
             if self.randomize:
-                delay = random.randrange(0.0, self.max_thrash_delay)
+                delay = random.uniform(0.0, self.max_thrash_delay)
 
             if delay > 0.0:
                 self.log('waiting for {delay} secs before thrashing'.format(delay=delay))
@@ -307,7 +307,7 @@ class MDSThrasher(ThrasherGreenlet):
                 # standby
                 delay = self.max_revive_delay
                 if self.randomize:
-                    delay = random.randrange(0.0, self.max_revive_delay)
+                    delay = random.uniform(0.0, self.max_revive_delay)
 
                 self.log('waiting for {delay} secs before reviving {label}'.format(
                     delay=delay, label=label))
@@ -334,17 +334,17 @@ class MDSThrasher(ThrasherGreenlet):
              # don't do replay thrashing right now
 #            for info in status.get_replays(self.fs.id):
 #                # this might race with replay -> active transition...
-#                if status['state'] == 'up:replay' and random.randrange(0.0, 1.0) < self.thrash_in_replay:
+#                if status['state'] == 'up:replay' and random.uniform(0.0, 1.0) < self.thrash_in_replay:
 #                    delay = self.max_replay_thrash_delay
 #                    if self.randomize:
-#                        delay = random.randrange(0.0, self.max_replay_thrash_delay)
+#                        delay = random.uniform(0.0, self.max_replay_thrash_delay)
 #                sleep(delay)
 #                self.log('kill replaying mds.{id}'.format(id=self.to_kill))
 #                self.kill_mds(self.to_kill)
 #
 #                delay = self.max_revive_delay
 #                if self.randomize:
-#                    delay = random.randrange(0.0, self.max_revive_delay)
+#                    delay = random.uniform(0.0, self.max_revive_delay)
 #
 #                self.log('waiting for {delay} secs before reviving mds.{id}'.format(
 #                    delay=delay, id=self.to_kill))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75265

---

backport of https://github.com/ceph/ceph/pull/67476
parent tracker: https://tracker.ceph.com/issues/75090

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh