### PR TITLE
squid: osd: handle all the updated keys in OSD::maybe_override_options_for_qos

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10133,50 +10133,39 @@ bool OSD::maybe_override_options_for_qos(const std::set<std::string> *changed)
         // Recovery options change was attempted without setting
         // the 'osd_mclock_override_recovery_settings' option.
         // Find the key to remove from the configuration db.
-        std::string key;
-        if (changed->count("osd_max_backfills")) {
-          key = "osd_max_backfills";
-        } else if (changed->count("osd_recovery_max_active")) {
-          key = "osd_recovery_max_active";
-        } else if (changed->count("osd_recovery_max_active_hdd")) {
-          key = "osd_recovery_max_active_hdd";
-        } else if (changed->count("osd_recovery_max_active_ssd")) {
-          key = "osd_recovery_max_active_ssd";
-        } else {
-          // No key that we are interested in. Return.
-          return true;
-        }
-
-        // Remove the current entry from the configuration if
-        // different from its default value.
-        auto val = recovery_qos_defaults.find(key);
-        if (val != recovery_qos_defaults.end() &&
+        static const std::vector<std::string> osds = {
+          "osd",
+          "osd." + std::to_string(whoami)
+        };
+        auto check_key = [&](const std::string& key) {
+          // Remove the current entry from the configuration if
+          // different from its default value.
+          auto val = recovery_qos_defaults.find(key);
+          if (val != recovery_qos_defaults.end() &&
             cct->_conf.get_val<uint64_t>(key) != val->second) {
-          static const std::vector<std::string> osds = {
-            "osd",
-            "osd." + std::to_string(whoami)
-          };
+            for (auto osd : osds) {
+              std::string cmd =
+                "{"
+                  "\"prefix\": \"config rm\", "
+                  "\"who\": \"" + osd + "\", "
+                  "\"name\": \"" + key + "\""
+                "}";
 
-          for (auto osd : osds) {
-            std::string cmd =
-              "{"
-                "\"prefix\": \"config rm\", "
-                "\"who\": \"" + osd + "\", "
-                "\"name\": \"" + key + "\""
-              "}";
-            vector<std::string> vcmd{cmd};
+              dout(1) << __func__ << " Removing Key: " << key
+                      << " for " << osd << " from Mon db" << dendl;
+              monc->start_mon_command({std::move(cmd)}, {}, nullptr, nullptr, nullptr);
+            }
 
-            dout(1) << __func__ << " Removing Key: " << key
-                    << " for " << osd << " from Mon db" << dendl;
-            monc->start_mon_command(vcmd, {}, nullptr, nullptr, nullptr);
+            // Raise a cluster warning indicating that the changes did not
+            // take effect and indicate the reason why.
+            clog->warn() << "Change to " << key << " on osd."
+                         << std::to_string(whoami) << " did not take effect."
+                         << " Enable osd_mclock_override_recovery_settings before"
+                         << " setting this option.";
           }
-
-          // Raise a cluster warning indicating that the changes did not
-          // take effect and indicate the reason why.
-          clog->warn() << "Change to " << key << " on osd."
-                       << std::to_string(whoami) << " did not take effect."
-                       << " Enable osd_mclock_override_recovery_settings before"
-                       << " setting this option.";
+        };
+        for(auto& k : *changed) {
+          check_key(k);
         }
       }
     } else { // if (changed != nullptr) (osd boot-up)


### PR DESCRIPTION
Up to now the first matching key from the changeset has been taken into account only. Which is wrong as multiple relevant keys might be present in it.
The primary issue with such a handling is a case when the first config parameter update takes place. The received changset contains a bunch of keys in this case and incorrect/incomplete processing might occur. E.g. as a side effect this could fail TEST_recovery_limit_adjustment_mclock from standalone/osd/mclock-config when mclock's OSD benchmark results are out of expected range (e.g. when run on SSD drive) and hence there
 is no update for 'max_capacity_iops_config' config parameter. The
following update triggered from the test case isn't handled properly then. Hence failing it.

This patch implements iteration over all the keys from the changeset and does proper processing for all of them matching the patterns.

Parent tracker: https://tracker.ceph.com/issues/74678
Fixes: https://tracker.ceph.com/issues/75268
Backports: https://github.com/ceph/ceph/pull/67126

Signed-off-by: Garry Drankovich <garry.drankovich@clyso.com>
(cherry picked from commit 57cc9216519f02b063ffcfbd04a376ebe492f907)

 Conflicts:
	src/osd/OSD.cc
 trivial, caused by lacking another backport





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
