### PR TITLE
tentacle: mgr/dashboard: Misleading warning when no eligible devices are available for OSD creation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -10,12 +10,15 @@
           #formDir="ngForm"
           [formGroup]="form"
           novalidate>
-      <cd-alert-panel *ngIf="!deploymentOptions?.recommended_option"
+      <cd-alert-panel *ngIf="availDevices?.length === 0"
                       type="warning"
                       class="mx-3"
                       i18n>
-        No devices(HDD, SSD or NVME) were found. Creation of OSDs will remain
-        disabled until devices are added.
+        <div cdsStack="vertical"
+             [gap]="2">
+          <span class="cds--type-heading-compact-01">No eligible devices found for OSD creation.</span>
+          <span class="cds--type-body-compact-01">Physical disks may be present, but none meet the requirements (unused, unformatted, and not already configured by Ceph).</span>
+        </div>
       </cd-alert-panel>
       <div class="accordion">
         <div class="accordion-item">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
@@ -230,11 +230,6 @@ describe('OsdFormComponent', () => {
       expect(label.innerHTML).not.toContain('Recommended');
     });
 
-    it('should display form', () => {
-      fixtureHelper.expectElementVisible('cd-alert-panel', false);
-      fixtureHelper.expectElementVisible('.card-body form', true);
-    });
-
     describe('without data devices selected', () => {
       it('should disable preview button', () => {
         component.simpleDeployment = false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75308

---

backport of https://github.com/ceph/ceph/pull/67444
parent tracker: https://tracker.ceph.com/issues/75050

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh