### PR TITLE
Revive nvme module

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -267,6 +267,10 @@
   to ensure compatibility during upgrades, but can be disabled once old usage logs
   are no longer present to avoid performance overhead.
 
+* NVMe-oF: A new Ceph Manager module, `nvmeof`, is now available. When enabled, it provisions the
+  dedicated `.nvmeof` RADOS Block Device (RBD) pool required for NVMe-oF integration,
+  simplifying initial setup and ensuring the pool is created consistently across deployments.
+  
 * MGR: A new command, `ceph osd ok-to-upgrade`, has been added that allows
   users and orchestration tools to determine a safe set of OSDs within a CRUSH
   bucket to upgrade simultaneously without impacting data availability. To help

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2016,6 +2016,7 @@ fi
 %{_datadir}/ceph/mgr/telemetry
 %{_datadir}/ceph/mgr/test_orchestrator
 %{_datadir}/ceph/mgr/volumes
+%{_datadir}/ceph/mgr/nvmeof
 
 %files mgr-rook
 %{_datadir}/ceph/mgr/rook

--- a/debian/ceph-mgr-modules-core.install
+++ b/debian/ceph-mgr-modules-core.install
@@ -25,3 +25,4 @@ usr/share/ceph/mgr/telegraf
 usr/share/ceph/mgr/telemetry
 usr/share/ceph/mgr/test_orchestrator
 usr/share/ceph/mgr/volumes
+usr/share/ceph/mgr/nvmeof

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
@@ -3,15 +3,16 @@ tasks:
     installer: host.a
     gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
-      pool_name: mypool
+      # pool_name: .nvmeof
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 3
       namespaces_count: 20
       cli_image: quay.io/ceph/nvmeof-cli:devel
+      auto_pool_create: True
 
 - cephadm.wait_for_service:
-    service: nvmeof.mypool.mygroup0
+    service: nvmeof.nvmeof.mygroup0
     refresh: True
 
 - workunit:
@@ -20,7 +21,7 @@ tasks:
       client.0:
         - nvmeof/setup_subsystem.sh
     env:
-      RBD_POOL: mypool
+      RBD_POOL: .nvmeof
       RBD_IMAGE_PREFIX: myimage
 
 - workunit:
@@ -34,6 +35,6 @@ tasks:
         - nvmeof/basic_tests.sh
         - nvmeof/fio_test.sh --start_ns 31 --end_ns 60
     env:
-      RBD_POOL: mypool
+      RBD_POOL: .nvmeof
       IOSTAT_INTERVAL: '10'
       RUNTIME: '600'

--- a/qa/tasks/nvmeof.py
+++ b/qa/tasks/nvmeof.py
@@ -84,6 +84,9 @@ class Nvmeof(Task):
         self.port = gateway_config.get('port', '4420')
         self.srport = gateway_config.get('srport', '5500')
         self.create_mtls_secrets = gateway_config.get('create_mtls_secrets', False)
+        self.auto_pool_create = gateway_config.get('auto_pool_create', False)
+        if self.auto_pool_create:
+            self.poolname = ".nvmeof"
 
     def deploy_nvmeof(self):
         """
@@ -117,15 +120,16 @@ class Nvmeof(Task):
 
             poolname = self.poolname
 
-            log.info(f'[nvmeof]: ceph osd pool create {poolname}')
-            _shell(self.ctx, self.cluster_name, self.remote, [
-                'ceph', 'osd', 'pool', 'create', poolname
-            ])
+            if not self.auto_pool_create:
+                log.info(f'[nvmeof]: ceph osd pool create {poolname}')
+                _shell(self.ctx, self.cluster_name, self.remote, [
+                    'ceph', 'osd', 'pool', 'create', poolname
+                ])
 
-            log.info(f'[nvmeof]: rbd pool init {poolname}')
-            _shell(self.ctx, self.cluster_name, self.remote, [
-                'rbd', 'pool', 'init', poolname
-            ])
+                log.info(f'[nvmeof]: rbd pool init {poolname}')
+                _shell(self.ctx, self.cluster_name, self.remote, [
+                    'rbd', 'pool', 'init', poolname
+                ])
 
             if self.enable_groups:
                 group_to_nodes = defaultdict(list)
@@ -134,11 +138,18 @@ class Nvmeof(Task):
                     group_to_nodes[group_name] += [node]
                 for group_name in group_to_nodes:
                     gp_nodes = group_to_nodes[group_name]
-                    log.info(f'[nvmeof]: ceph orch apply nvmeof {poolname} {group_name}')
-                    _shell(self.ctx, self.cluster_name, self.remote, [
-                        'ceph', 'orch', 'apply', 'nvmeof', poolname, group_name,
-                        '--placement', ';'.join(gp_nodes)
-                    ])
+                    if self.auto_pool_create:
+                        log.info(f'[nvmeof]: ceph orch apply nvmeof {group_name}') 
+                        _shell(self.ctx, self.cluster_name, self.remote, [
+                            'ceph', 'orch', 'apply', 'nvmeof', '--group', group_name,
+                            '--placement', ';'.join(gp_nodes)
+                        ])
+                    else:
+                        log.info(f'[nvmeof]: ceph orch apply nvmeof {poolname} {group_name}')
+                        _shell(self.ctx, self.cluster_name, self.remote, [
+                            'ceph', 'orch', 'apply', 'nvmeof', '--pool',poolname, '--group', group_name,
+                            '--placement', ';'.join(gp_nodes)
+                        ])
             else:
                 _shell(self.ctx, self.cluster_name, self.remote, [
                         'ceph', 'orch', 'apply', 'nvmeof', poolname,

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -153,7 +153,7 @@ options:
     first started after installation, to populate the list of enabled manager modules.  Subsequent
     updates are done using the 'mgr module [enable|disable]' commands.  List may be
     comma or space separated.
-  default: iostat nfs
+  default: iostat nfs nvmeof
   services:
   - mon
   - common

--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -27,6 +27,7 @@ set(mgr_modules
   devicehealth
   diskprediction_local
   # hello is an example for developers, not for user
+  nvmeof
   influx
   insights
   iostat

--- a/src/pybind/mgr/nvmeof/__init__.py
+++ b/src/pybind/mgr/nvmeof/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .module import NVMeoF

--- a/src/pybind/mgr/nvmeof/cli.py
+++ b/src/pybind/mgr/nvmeof/cli.py
@@ -1,0 +1,3 @@
+from mgr_module import CLICommandBase
+
+NVMeoFCLICommand = CLICommandBase.make_registry_subtype("NVMeoFCLICommand")

--- a/src/pybind/mgr/nvmeof/module.py
+++ b/src/pybind/mgr/nvmeof/module.py
@@ -1,0 +1,57 @@
+import logging
+from typing import Any
+
+from mgr_module import MgrModule
+import rbd
+
+logger = logging.getLogger(__name__)
+
+POOL_NAME = ".nvmeof"
+
+
+class NVMeoF(MgrModule):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(NVMeoF, self).__init__(*args, **kwargs)
+
+    def _pool_exists(self, pool_name: str) -> bool:
+        logger.info(f"checking if pool {pool_name} exists")
+        pool_exists = self.pool_exists(pool_name)
+        if pool_exists:
+            logger.info(f"pool {pool_name} already exists")
+        else:
+            logger.info(f"pool {pool_name} doesn't exist")
+        return pool_exists
+
+    def _create_pool(self, pool_name: str) -> None:
+        try:
+            self.create_pool(pool_name)
+            logger.info(f"Pool '{pool_name}' created.")
+        except Exception:
+            logger.error(f"Error creating pool '{pool_name}", exc_info=True)
+            raise
+
+    def _enable_rbd_application(self, pool_name: str) -> None:
+        try:
+            self.appify_pool(pool_name, 'rbd')
+            logger.info(f"'rbd' application enabled on pool '{pool_name}'.")
+        except Exception:
+            logger.error(
+                f"Failed to enable 'rbd' application on '{pool_name}'",
+                exc_info=True
+            )
+            raise
+
+    def _rbd_pool_init(self, pool_name: str) -> None:
+        try:
+            with self.rados.open_ioctx(pool_name) as ioctx:
+                rbd.RBD().pool_init(ioctx, False)
+            logger.info(f"RBD pool_init completed on '{pool_name}'.")
+        except Exception:
+            logger.error(f"Failed to initialize RBD pool '{pool_name}'", exc_info=True)
+            raise
+
+    def create_pool_if_not_exists(self) -> None:
+        if not self._pool_exists(POOL_NAME):
+            self._create_pool(POOL_NAME)
+        self._enable_rbd_application(POOL_NAME)
+        self._rbd_pool_init(POOL_NAME)

--- a/src/pybind/mgr/nvmeof/tests/test_nvmeof_module.py
+++ b/src/pybind/mgr/nvmeof/tests/test_nvmeof_module.py
@@ -1,0 +1,85 @@
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import nvmeof.module as nvmeof_mod
+
+
+class FakeRados:
+    def __init__(self, exists: bool):
+        self._exists = exists
+        self.opened_pools = []
+
+    def pool_exists(self, pool_name: str) -> bool:
+        return self._exists
+
+    @contextmanager
+    def open_ioctx(self, pool_name: str):
+        self.opened_pools.append(pool_name)
+        yield object()
+
+
+def patch_rbd_pool_init(monkeypatch):
+    rbd_instance = MagicMock()
+    monkeypatch.setattr(nvmeof_mod.rbd, "RBD", lambda: rbd_instance)
+    return rbd_instance
+
+
+def make_mgr(mon_handler, exists: bool, monkeypatch):
+    mgr = nvmeof_mod.NVMeoF.__new__(nvmeof_mod.NVMeoF)
+    mgr.mon_command = mon_handler
+    mgr._print_log = lambda *args, **kwargs: None
+    mgr.run = False
+
+    mgr._fake_rados = FakeRados(exists)
+    mgr.remote = MagicMock()
+
+    def _pool_exists(self, pool_name: str) -> bool:
+        return self._fake_rados.pool_exists(pool_name)
+
+    def _rbd_pool_init(self, pool_name: str):
+        with self._fake_rados.open_ioctx(pool_name) as ioctx:
+            nvmeof_mod.rbd.RBD().pool_init(ioctx, False)
+
+    monkeypatch.setattr(nvmeof_mod.NVMeoF, "_pool_exists", _pool_exists, raising=True)
+    monkeypatch.setattr(nvmeof_mod.NVMeoF, "_rbd_pool_init", _rbd_pool_init, raising=True)
+
+    return mgr
+
+
+def test_pool_exists_skips_create_calls_enable_and_pool_init(monkeypatch):
+    calls = []
+
+    def mon_command(cmd, inbuf):
+        calls.append(cmd)
+        return 0, "", ""
+
+    rbd_instance = patch_rbd_pool_init(monkeypatch)
+    mgr = make_mgr(mon_command, exists=True, monkeypatch=monkeypatch)
+
+    mgr.create_pool_if_not_exists()
+
+    assert not any(c.get("prefix") == "osd pool create" for c in calls)
+    assert any(c.get("prefix") == "osd pool application enable" for c in calls)
+
+    assert mgr._fake_rados.opened_pools == [".nvmeof"]
+    rbd_instance.pool_init.assert_called_once()
+
+
+def test_pool_missing_creates_then_enables_then_pool_init(monkeypatch):
+    calls = []
+
+    def mon_command(cmd, inbuf):
+        calls.append(cmd)
+        return 0, "", ""
+
+    rbd_instance = patch_rbd_pool_init(monkeypatch)
+    mgr = make_mgr(mon_command, exists=False, monkeypatch=monkeypatch)
+
+    mgr.create_pool_if_not_exists()
+
+    assert any(c.get("prefix") == "osd pool create" for c in calls)
+    assert any(c.get("prefix") == "osd pool application enable" for c in calls)
+
+    assert mgr._fake_rados.opened_pools == [".nvmeof"]
+    rbd_instance.pool_init.assert_called_once()

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -93,6 +93,7 @@ commands =
            -m devicehealth \
            -m diskprediction_local \
            -m hello \
+           -m nvmeof \
            -m influx \
            -m iostat \
            -m localpool \
@@ -146,6 +147,7 @@ modules =
     devicehealth \
     diskprediction_local \
     hello \
+    nvmeof \
     iostat \
     localpool \
     mgr_module.py \


### PR DESCRIPTION
Reapply https://github.com/ceph/ceph/pull/67167 which was reverted.
fixes: https://tracker.ceph.com/issues/74702

**Note:** https://github.com/ceph/ceph/pull/67782 is also needed to complete the work on this PR

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
