### PR TITLE
Code change fix for Mounting NFS export fails when the NFS version is not specified 

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -22,7 +22,6 @@ NFS_CORE_PARAM {
 NFSv4 {
         Delegations = false;
         RecoveryBackend = "rados_cluster";
-        Minor_Versions = 1, 2;
         Server_Scope = "{{ cluster_id }}-{{ namespace }}";
 {% if nfs_idmap_conf %}
         IdmapConf = "{{ nfs_idmap_conf }}";

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -1058,7 +1058,6 @@ class TestIngressService:
             'NFSv4 {\n'
             '        Delegations = false;\n'
             '        RecoveryBackend = "rados_cluster";\n'
-            '        Minor_Versions = 1, 2;\n'
             f'        Server_Scope = "{cephadm_module._cluster_fsid}-foo";\n'
             '        IdmapConf = "/etc/ganesha/idmap.conf";\n'
             '}\n'

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -291,8 +291,7 @@ EXPORT {
                 "dir_chunk": 0
             }),
             RawBlock('NFSV4', values={
-                "recoverybackend": "rados_cluster",
-                "minor_versions": [1, 2]
+                "recoverybackend": "rados_cluster"
             }),
             RawBlock('RADOS_KV', values={
                 "pool": NFS_POOL_NAME,
@@ -322,7 +321,6 @@ NFS_CORE_PARAM {
 
         NFSv4 {
            RecoveryBackend = rados_cluster;
-           Minor_Versions = 1, 2;
         }
 
         RADOS_KV {


### PR DESCRIPTION
Code change fix for Mounting NFS export fails when the NFS version is not specified and when using NFSv4.0, mounts successfully only when NFSv4.1 is explicitly used

Fixes: https://tracker.ceph.com/issues/75327
Signed-off-by: Pooja Dwivedi <pooja.dwivedi@ibm.com>

Description:-  This PR removes the Minor_Versions restriction from the NFS-Ganesha configuration so that it allow all NFSv4 minor versions (ex. 4.0, 4.1, 4.2) to be supported by default at the time of NFS mount.

## Testing steps:

Prerequisites : Create NFS cluster

Testing Logs:

````
[ceph: root@ceph-node-0 /]# ceph nfs export create cephfs mynfs /export5 myfs --path /volumes/_nogroup/subvol/fd30a5fc-0062-434a-852e-97201dae0d58  
{ 
  "bind": "/export5", 
  "cluster": "mynfs", 
  "fs": "myfs", 
  "mode": "RW", 
  "path": "/volumes/_nogroup/subvol/fd30a5fc-0062-434a-852e-97201dae0d58" 
}  
[ceph: root@ceph-node-0 /]# ceph nfs export ls mynfs 
[ 
  "/export3", 
  "/export4", 
  "/export5" 
] 
[root@ceph-node-0 ~]# ss -tlnp | grep 2049 
LISTEN 0      4096                 *:2049             *:*    users:(("ganesha.nfsd",pid=75113,fd=40))      
[root@ceph-node-0 ~]# ssh ceph-node-1 
Last login: Mon Mar  2 08:42:37 2026 from 192.168.100.100 
[root@ceph-node-1 ~]# mkdir -p /dir 
[root@ceph-node-1 ~]# mount -t nfs -o vers=4,addr=192.168.100.100 192.168.100.100:/export5 /dir 
[root@ceph-node-1 ~]# nfsstat -m 
/dir from 192.168.100.100:/export5 
Flags: rw,seclabel,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.100.101,local_lock=none,addr=192.168.100.100 
````


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
