### PR TITLE
mgr/cephadm: nfs rdma support

### DIFF
--- a/doc/cephadm/services/nfs.rst
+++ b/doc/cephadm/services/nfs.rst
@@ -79,6 +79,39 @@ address is not present and ``monitoring_networks`` is specified, an IP address
 that matches one of the specified networks will be used. If neither condition
 is met, the default binding will happen on all available network interfaces.
 
+NFS over RDMA
+-------------
+
+NFS over RDMA is disabled by default. To enable it, set ``enable_rdma: true`` in
+the NFS service spec. You can optionally set ``rdma_port`` to use a custom RDMA
+port, if omitted, NFS Ganesha uses its default.
+
+When RDMA is enabled:
+
+* New exports in the cluster default to **Transports = TCP, RDMA**
+* For colocation, each entry in ``colocation_ports`` must include
+  ``rdma_port`` in addition to ``data_port`` and ``monitoring_port``.
+
+Example with RDMA enabled:
+
+.. code-block:: yaml
+
+    service_type: nfs
+    service_id: mynfs
+    placement:
+      count: 1
+      hosts: [host1]
+    spec:
+      port: 2049
+      monitoring_port: 9587
+      enable_rdma: true
+      rdma_port: 20049   # optional
+
+.. note:: If you use a bind address (e.g. ``virtual_ip``, ``ip_addrs``, or
+   ``networks``) with ``enable_rdma``, ensure the network interface for that
+   address is RDMA-capable. On the host, run ``rdma link show`` and confirm the
+   netdev for the interface with the bind IP is listed.
+
 NFS Daemon Colocation
 ----------------------
 
@@ -134,8 +167,9 @@ In this configuration, 4 daemons total are deployed (2 per host), distributed ac
      ``monitoring_port`` from the spec.
    * The number of entries in ``colocation_ports`` should be ``count - 1``,
      to cover the node down scenario (or ``count_per_host - 1`` when using ``count_per_host``).
-   * Each entry must specify both ``data_port`` and ``monitoring_port``.
-   * **If ``colocation_ports`` is not specified**, ports will be automatically
+   * Each entry must specify both ``data_port`` and ``monitoring_port``. When
+     ``enable_rdma`` is true, each entry must also include ``rdma_port``.
+   * If ``colocation_ports`` is not specified, ports will be automatically
      incremented for colocated daemons (e.g., 2049 → 2050 → 2051 for data ports,
      and 9587 → 9588 → 9589 for monitoring ports).
 

--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -13,7 +13,7 @@ Synopsis
 |               [--log-dir LOG_DIR] [--logrotate-dir LOGROTATE_DIR]
 |               [--unit-dir UNIT_DIR] [--verbose] [--timeout TIMEOUT]
 |               [--retry RETRY] [--no-container-init]
-|               {version,pull,inspect-image,ls,list-networks,adopt,rm-daemon,rm-cluster,run,shell,enter,ceph-volume,unit,logs,bootstrap,deploy,check-host,prepare-host,add-repo,rm-repo,install,list-images,update-osd-service}
+|               {version,pull,inspect-image,ls,list-networks,list-rdma,adopt,rm-daemon,rm-cluster,run,shell,enter,ceph-volume,unit,logs,bootstrap,deploy,check-host,prepare-host,add-repo,rm-repo,install,list-images,update-osd-service}
 |               ...
 
 
@@ -24,6 +24,8 @@ Synopsis
 | **cephadm** **ls** [-h] [--no-detail] [--legacy-dir LEGACY_DIR]
 
 | **cephadm** **list-networks**
+
+| **cephadm** **list-rdma**
 
 | **cephadm** **adopt** [-h] --name NAME --style STYLE [--cluster CLUSTER]
 |                       [--legacy-dir LEGACY_DIR] [--config-json CONFIG_JSON]
@@ -347,6 +349,10 @@ list-networks
 
 list IP networks
 
+list-rdma
+---------
+
+list RDMA devices and their netdev interfaces
 
 ls
 --

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -31,7 +31,7 @@ Create NFS Ganesha Cluster
 
 .. prompt:: bash #
 
-   ceph nfs cluster create <cluster_id> [<placement>] [--ingress] [--virtual_ip <value>] [--ingress-mode {default|keepalive-only|haproxy-standard|haproxy-protocol}] [--port <int>]
+   ceph nfs cluster create <cluster_id> [<placement>] [--ingress] [--virtual_ip <value>] [--ingress-mode {default|keepalive-only|haproxy-standard|haproxy-protocol}] [--port <int>] [--enable-rdma] [--rdma_port <int>] [-i <spec_file>]
 
 This creates a common recovery pool for all NFS Ganesha daemons, new user based on
 ``cluster_id``, and a common NFS Ganesha config RADOS object.
@@ -290,7 +290,7 @@ Create CephFS Export
 
 .. prompt:: bash #
 
-   ceph nfs export create cephfs --cluster-id <cluster_id> --pseudo-path <pseudo_path> --fsname <fsname> [--readonly] [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>] [--sectype <value>...] [--cmount_path <value>] [--xprtsec <value>]
+   ceph nfs export create cephfs --cluster-id <cluster_id> --pseudo-path <pseudo_path> --fsname <fsname> [--readonly] [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>] [--sectype <value>...] [--cmount_path <value>] [--xprtsec <value>] [--transports <value>...]
 
 This creates export RADOS objects containing the export block, where
 
@@ -334,6 +334,12 @@ allowed to be any complete path hierarchy between ``/`` and the ``EXPORT {path}`
 .. note:: If this and the other ``EXPORT { FSAL {} }`` options are the same between multiple exports, those exports will share a single CephFS client.
           If not specified, the default is ``/``.
 
+``<transports>`` is optional. List of NFS transport protocols. Valid values are
+``TCP``, ``UDP``, and ``RDMA``. Multiple values may be passed (e.g.
+``--transports TCP --transports RDMA`` or ``--transports TCP,RDMA``). If omitted,
+the export uses the default (e.g. TCP only, or TCP and RDMA when the cluster
+has RDMA enabled).
+
 .. note:: Specifying values for sectype that require Kerberos will only function on servers
           that are configured to support Kerberos. Setting up NFS-Ganesha to support Kerberos
           can be found here `Kerberos setup for NFS Ganesha in Ceph <https://github.com/nfs-ganesha/nfs-ganesha/wiki/Kerberos-setup-for-NFS-Ganesha-in-Ceph>`_.
@@ -358,7 +364,7 @@ To export a *bucket*:
 
 .. prompt:: bash #
 
-   ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--user-id <user-id>] [--readonly] [--client_addr <value>...] [--squash <value>] [--sectype <value>...] [--xprtsec <value>]
+   ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--user-id <user-id>] [--readonly] [--client_addr <value>...] [--squash <value>] [--sectype <value>...] [--xprtsec <value>] [--transports <value>...]
 
 For example, to export ``mybucket`` via NFS cluster ``mynfs`` at the
 pseudo-path ``/bucketdata`` to any host in the ``192.168.10.0/24`` network
@@ -402,6 +408,10 @@ multiple values may be separated by a comma (example: ``--sectype
 krb5p,krb5i``). The server will negotatiate a supported security type with the
 client preferring the supplied methods left-to-right.
 
+``<transports>`` is optional. Valid values are ``TCP``, ``UDP``, and ``RDMA``.
+Multiple values may be passed. If omitted, defaults apply (e.g. TCP and RDMA
+when the cluster has RDMA enabled).
+
 .. note:: Specifying values for sectype that require Kerberos will only
    function on servers that are configured to support Kerberos. Setting up
    NFS-Ganesha to support Kerberos is outside the scope of this document.
@@ -417,7 +427,7 @@ To export an RGW *user*:
 
 .. prompt:: bash #
 
-   ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --user-id <user-id> [--readonly] [--client_addr <value>...] [--squash <value>]
+   ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --user-id <user-id> [--readonly] [--client_addr <value>...] [--squash <value>] [--transports <value>...]
 
 For example, to export *myuser* via NFS cluster *mynfs* at the pseudo-path */myuser* to any host in the ``192.168.10.0/24`` network
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -155,7 +155,7 @@ from cephadmlib.decorators import (
     executes_early,
     require_image
 )
-from cephadmlib.host_facts import HostFacts, list_networks
+from cephadmlib.host_facts import HostFacts, list_networks, list_rdma
 from cephadmlib.ssh import authorize_ssh_key, check_ssh_connectivity
 from cephadmlib.daemon_form import (
     DaemonForm,
@@ -3563,6 +3563,11 @@ def command_list_networks(ctx):
 
     print(json.dumps(r, indent=4, default=serialize_sets))
 
+
+def command_list_rdma(ctx: CephadmContext) -> None:
+    r = list_rdma(ctx)
+    print(json.dumps(r, indent=4))
+
 ##################################
 
 
@@ -5010,6 +5015,10 @@ def _get_parser():
     parser_list_networks = subparsers.add_parser(
         'list-networks', help='list IP networks')
     parser_list_networks.set_defaults(func=command_list_networks)
+
+    parser_list_rdma = subparsers.add_parser(
+        'list-rdma', help='list RDMA devices and their netdev interfaces')
+    parser_list_rdma.set_defaults(func=command_list_rdma)
 
     parser_adopt = subparsers.add_parser(
         'adopt', help='adopt daemon deployed with a different tool')

--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -61,6 +61,7 @@ class NFSGanesha(ContainerDaemonForm):
         self.extra_args = dict_get(config_json, 'extra_args', [])
         self.files = dict_get(config_json, 'files', {})
         self.rgw = dict_get(config_json, 'rgw', {})
+        self.enable_rdma = dict_get(config_json, 'enable_rdma', False)
 
         # validate the supplied args
         self.validate()
@@ -238,6 +239,17 @@ class NFSGanesha(ContainerDaemonForm):
         self, ctx: CephadmContext, args: List[str]
     ) -> None:
         args.append(ctx.container_engine.unlimited_pids_option)
+        if self.enable_rdma:
+            # Container args when NFS RDMA is enabled
+            rdma_args: List[str] = [
+                '-v',
+                '/dev/infiniband:/dev/infiniband',
+                '--cap-add=IPC_LOCK',
+                '--ulimit',
+                'memlock=-1:-1',
+                '--privileged',
+            ]
+            args.extend(rdma_args)
 
     def default_entrypoint(self) -> str:
         return self.entrypoint

--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -899,7 +899,9 @@ def list_rdma(ctx: CephadmContext) -> List[Dict[str, str]]:
                 }
             )
         else:
-            logger.debug("Skipped RDMA device '%s', as pattern did not match", line)
+            logger.debug(
+                "Skipped RDMA device '%s', as pattern did not match", line
+            )
     return result
 
 

--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -860,6 +860,49 @@ def list_networks(ctx):
     return res
 
 
+def list_rdma(ctx: CephadmContext) -> List[Dict[str, str]]:
+    """List RDMA devices by parsing 'rdma link show' output.
+    Returns a list of dicts with keys: link, state, physical_state, netdev.
+    Returns empty list if rdma tool is not installed or command fails.
+    """
+    execstr: Optional[str] = find_executable('rdma')
+    if not execstr:
+        logger.error("'rdma' command not found, no RDMA devices listed")
+        return []
+    try:
+        out, _, _ = call_throws(
+            ctx,
+            [execstr, 'link', 'show'],
+            verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+        )
+    except Exception as e:
+        logger.error('rdma link show failed: %s', e)
+        return []
+    # Format: link <name> state <state> physical_state <phys> netdev <netdev>
+    pattern = re.compile(
+        r'link\s+(\S+)\s+state\s+(\S+)\s+physical_state\s+(\S+)\s+netdev\s+'
+        r'(\S+)'
+    )
+    result: List[Dict[str, str]] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = pattern.search(line)
+        if m:
+            result.append(
+                {
+                    'link': m.group(1),
+                    'state': m.group(2),
+                    'physical_state': m.group(3),
+                    'netdev': m.group(4),
+                }
+            )
+        else:
+            logger.debug("Skipped RDMA device '%s', as pattern did not match", line)
+    return result
+
+
 def _list_ipv4_networks(
     ctx: CephadmContext,
 ) -> Dict[str, Dict[str, Set[str]]]:

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -950,6 +950,14 @@ class HostCache():
         self.networks[host] = nets
         self.last_network_update[host] = datetime_now()
 
+    def get_interface_for_ip(self, host: str, ip: str) -> Optional[str]:
+        """Return the network interface name that has the given IP on host, or None."""
+        for _subnet, ifaces in self.networks.get(host, {}).items():
+            for iface, ips in ifaces.items():
+                if ip in ips:
+                    return iface
+        return None
+
     def update_daemon_config_deps(self, host: str, name: str, deps: List[str], stamp: datetime.datetime) -> None:
         self.daemon_config_deps[host][name] = {
             'deps': deps,

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -450,6 +450,17 @@ class CephadmServe:
         self.mgr.cache.save_host(host)
         return None
 
+    async def get_rdma_devices(self, host: str) -> List[Dict[str, Any]]:
+        """Return list of RDMA devices on host from cephadm list-rdma, or [] on error."""
+        try:
+            out = await self._run_cephadm_json(
+                host, 'mon', 'list-rdma', [], no_fsid=True,
+                log_output=self.mgr.log_refresh_metadata)
+            return out if isinstance(out, list) else []
+        except OrchestratorError as e:
+            self.log.error('Failed to get RDMA devices for host %s: %s', host, e)
+            return []
+
     def _refresh_host_osdspec_previews(self, host: str) -> Optional[str]:
         self.update_osdspec_previews(host)
         self.mgr.cache.save_host(host)

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -33,6 +33,9 @@ class NFSService(CephService):
         super().__init__(mgr)
         self._fencing_store_lock = Lock()
 
+    def allow_colo(self) -> bool:
+        return True
+
     @property
     def needs_monitoring(self) -> bool:
         return True
@@ -170,7 +173,7 @@ class NFSService(CephService):
         self.create_rados_config_obj(spec)
 
         port = daemon_spec.ports[0] if daemon_spec.ports else 2049
-        monitoring_ip, monitoring_port = self.get_monitoring_details(daemon_spec.service_name, host)
+        monitoring_ip, monitoring_port = self.get_monitoring_details(daemon_spec.service_name, host, daemon_spec)
 
         # create the RGW keyring
         rgw_user = f'{rados_user}-rgw'
@@ -476,9 +479,20 @@ class NFSService(CephService):
                     cluster_ips.append(addrs[0])
         return cluster_ips
 
-    def get_monitoring_details(self, service_name: str, host: str) -> Tuple[Optional[str], Optional[int]]:
+    def get_monitoring_details(
+        self,
+        service_name: str,
+        host: str,
+        daemon_spec: Optional['CephadmDaemonDeploySpec'] = None
+    ) -> Tuple[Optional[str], Optional[int]]:
         spec = cast(NFSServiceSpec, self.mgr.spec_store[service_name].spec)
-        monitoring_port = spec.monitoring_port if spec.monitoring_port else 9587
+
+        # For colocation, use the incremented monitoring port from daemon_spec.ports[1] if available
+        # Otherwise fall back to the spec's monitoring_port
+        if daemon_spec and daemon_spec.ports and len(daemon_spec.ports) > 1:
+            monitoring_port = daemon_spec.ports[1]
+        else:
+            monitoring_port = spec.monitoring_port if spec.monitoring_port else 9587
 
         # check if monitor needs to be bind on specific ip
         monitoring_addr = spec.monitoring_ip_addrs.get(host) if spec.monitoring_ip_addrs else None

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -194,15 +194,28 @@ class NFSService(CephService):
             logger.warning(f'Bind address in {daemon_type}.{daemon_id}\'s ganesha conf is defaulting to empty')
         else:
             logger.debug("using haproxy bind address: %r", bind_addr)
-            if spec.enable_rdma:
-                logger.warning(
-                    'NFS RDMA is enabled with Bind_Addr %s on host %s. '
-                    'Ensure the network interface for this address is RDMA-capable. '
-                    "On the host, run 'rdma link show' and confirm the netdev for the interface "
-                    'with this IP is listed.',
-                    bind_addr.split('/')[0] if bind_addr else bind_addr,
-                    host,
+
+        if spec.enable_rdma:
+            from cephadm.serve import CephadmServe
+            rdma_devices = self.mgr.wait_async(
+                CephadmServe(self.mgr).get_rdma_devices(host))
+            if not rdma_devices:
+                raise OrchestratorError(
+                    f'NFS RDMA is enabled but host {host} has no RDMA devices. '
+                    "Run 'cephadm list-rdma' on the host to verify RDMA is available."
                 )
+            if bind_addr:
+                bind_ip = bind_addr.split('/')[0]
+                iface = self.mgr.cache.get_interface_for_ip(host, bind_ip)
+                if iface:
+                    rdma_netdevs = {d.get('netdev', '') for d in rdma_devices}
+                    if iface not in rdma_netdevs:
+                        raise OrchestratorError(
+                            f'NFS RDMA is enabled with bind address {bind_addr} on host {host}, '
+                            f'but interface {iface} (for this IP) is not RDMA-capable. '
+                            f'RDMA netdevs on host: {sorted(rdma_netdevs)}. '
+                            "Use an IP on an RDMA-capable interface or run 'rdma link show' on the host."
+                        )
 
         if monitoring_ip:
             daemon_spec.port_ips.update({str(monitoring_port): monitoring_ip})
@@ -290,6 +303,7 @@ class NFSService(CephService):
                 'user': rgw_user,
                 'keyring': rgw_keyring,
             }
+            config['enable_rdma'] = spec.enable_rdma
             logger.debug('Generated cephadm config-json: %s' % config)
             return config
 

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -139,6 +139,8 @@ class NFSService(CephService):
         deps.append(f'tls_debug: {nfs_spec.tls_debug}')
         deps.append(f'tls_min_version: {nfs_spec.tls_min_version}')
         deps.append(f'tls_ciphers: {nfs_spec.tls_ciphers}')
+        deps.append(f'enable_rdma: {nfs_spec.enable_rdma}')
+        deps.append(f'rdma_port: {nfs_spec.rdma_port}')
         return sorted(deps)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
@@ -192,11 +194,26 @@ class NFSService(CephService):
             logger.warning(f'Bind address in {daemon_type}.{daemon_id}\'s ganesha conf is defaulting to empty')
         else:
             logger.debug("using haproxy bind address: %r", bind_addr)
+            if spec.enable_rdma:
+                logger.warning(
+                    'NFS RDMA is enabled with Bind_Addr %s on host %s. '
+                    'Ensure the network interface for this address is RDMA-capable. '
+                    "On the host, run 'rdma link show' and confirm the netdev for the interface "
+                    'with this IP is listed.',
+                    bind_addr.split('/')[0] if bind_addr else bind_addr,
+                    host,
+                )
 
         if monitoring_ip:
             daemon_spec.port_ips.update({str(monitoring_port): monitoring_ip})
 
         # generate the ganesha config
+        rdma_port = None
+        if spec.enable_rdma and daemon_spec.ports and len(daemon_spec.ports) > 2:
+            rdma_port = daemon_spec.ports[2]
+        elif spec.enable_rdma:
+            rdma_port = spec.rdma_port
+
         def get_ganesha_conf() -> str:
             context: Dict[str, Any] = {
                 "user": rados_user,
@@ -213,6 +230,8 @@ class NFSService(CephService):
                 "haproxy_hosts": [],
                 "nfs_idmap_conf": nfs_idmap_conf,
                 "enable_nlm": str(spec.enable_nlm).lower(),
+                "enable_rdma": spec.enable_rdma,
+                "rdma_port": rdma_port,
                 "cluster_id": self.mgr._cluster_fsid,
                 "tls_add": spec.ssl,
                 "tls_ciphers": spec.tls_ciphers,

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -208,7 +208,7 @@ class NFSService(CephService):
                 bind_ip = bind_addr.split('/')[0]
                 iface = self.mgr.cache.get_interface_for_ip(host, bind_ip)
                 rdma_netdevs = {d.get('netdev', '') for d in rdma_devices}
-                if iface not in rdma_netdevs:
+                if iface and iface not in rdma_netdevs:
                     raise OrchestratorError(
                         f'NFS RDMA is enabled with bind address {bind_addr} on host {host}, '
                         f'but interface {iface} (for this IP) is not RDMA-capable. '

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -207,15 +207,14 @@ class NFSService(CephService):
             if bind_addr:
                 bind_ip = bind_addr.split('/')[0]
                 iface = self.mgr.cache.get_interface_for_ip(host, bind_ip)
-                if iface:
-                    rdma_netdevs = {d.get('netdev', '') for d in rdma_devices}
-                    if iface not in rdma_netdevs:
-                        raise OrchestratorError(
-                            f'NFS RDMA is enabled with bind address {bind_addr} on host {host}, '
-                            f'but interface {iface} (for this IP) is not RDMA-capable. '
-                            f'RDMA netdevs on host: {sorted(rdma_netdevs)}. '
-                            "Use an IP on an RDMA-capable interface or run 'rdma link show' on the host."
-                        )
+                rdma_netdevs = {d.get('netdev', '') for d in rdma_devices}
+                if iface not in rdma_netdevs:
+                    raise OrchestratorError(
+                        f'NFS RDMA is enabled with bind address {bind_addr} on host {host}, '
+                        f'but interface {iface} (for this IP) is not RDMA-capable. '
+                        f'RDMA netdevs on host: {sorted(rdma_netdevs)}. '
+                        "Use an IP on an RDMA-capable interface or run 'rdma link show' on the host."
+                    )
 
         if monitoring_ip:
             daemon_spec.port_ips.update({str(monitoring_port): monitoring_ip})

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -2,7 +2,11 @@
 NFS_CORE_PARAM {
         Enable_NLM = {{ enable_nlm }};
         Enable_RQUOTA = false;
+{% if enable_rdma %}
+        Protocols = 3, 4, nfsrdma, rpcrdma;
+{% else %}
         Protocols = 3, 4;
+{% endif %}
         mount_path_pseudo = true;
         Enable_UDP = false;
         NFS_Port = {{ port }};
@@ -17,6 +21,9 @@ NFS_CORE_PARAM {
 	Monitoring_Addr = {{ monitoring_addr }};
 {% endif %}
         Monitoring_Port = {{ monitoring_port }};
+{% if enable_rdma and rdma_port %}
+        NFS_RDMA_Port = {{ rdma_port }};
+{% endif %}
 }
 
 NFSv4 {

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -1091,6 +1091,7 @@ class TestIngressService:
         nfs_expected_conf = {
             'files': {'ganesha.conf': nfs_ganesha_txt, 'idmap.conf': ''},
             'config': '',
+            'enable_rdma': False,
             'extra_args': ['-N', 'NIV_EVENT'],
             'keyring': (
                 '[client.nfs.foo.test.0.0]\n'

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -486,14 +486,25 @@ class TestNFS:
                 )
                 assert expected_tls_block in ganesha_conf
 
+    @patch("cephadm.serve.CephadmServe._run_cephadm_json")
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
     @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
     @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
     @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
-    def test_nfs_config_rdma_enabled(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+    def test_nfs_config_rdma_enabled(self, _run_cephadm, _run_cephadm_json, cephadm_module: CephadmOrchestrator):
         """NFS with enable_rdma=True: ganesha.conf has RDMA protocols (nfsrdma, rpcrdma)."""
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        # Mock list-rdma only: return RDMA devices for list-rdma; [] for ls; {} for others (.get)
+
+        async def mock_list_rdma(host, entity, command, *args, **kwargs):
+            if command == 'list-rdma':
+                return [{'link': 'rdma0/1', 'state': 'ACTIVE',
+                         'physical_state': 'LINK_UP', 'netdev': 'eth0'}]
+            if command == 'ls':
+                return []
+            return {}
+        _run_cephadm_json.side_effect = mock_list_rdma
 
         with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
             nfs_spec = NFSServiceSpec(
@@ -512,14 +523,25 @@ class TestNFS:
                 ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
                 assert "Protocols = 3, 4, nfsrdma, rpcrdma" in ganesha_conf
 
+    @patch("cephadm.serve.CephadmServe._run_cephadm_json")
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
     @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
     @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
     @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
-    def test_nfs_config_rdma_custom_port(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+    def test_nfs_config_rdma_custom_port(self, _run_cephadm, _run_cephadm_json, cephadm_module: CephadmOrchestrator):
         """NFS with enable_rdma and rdma_port: ganesha.conf has NFS_RDMA_Port."""
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        # Mock list-rdma only: return RDMA devices for list-rdma; [] for ls; {} for others (.get)
+
+        async def mock_list_rdma(host, entity, command, *args, **kwargs):
+            if command == 'list-rdma':
+                return [{'link': 'rdma0/1', 'state': 'ACTIVE',
+                         'physical_state': 'LINK_UP', 'netdev': 'eth0'}]
+            if command == 'ls':
+                return []
+            return {}
+        _run_cephadm_json.side_effect = mock_list_rdma
 
         with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
             nfs_spec = NFSServiceSpec(

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -692,6 +692,7 @@ def test_nfs_choose_next_action(cephadm_module, mock_cephadm):
         # dependencies are prefixed with 'kmip' but I can't find any code
         # that would produce any dependencies prefixed with 'kmip'!
 
+
 @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
 @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
 @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -1,10 +1,18 @@
 import contextlib
 from unittest.mock import MagicMock, patch, ANY
 
+import pytest
+
 from cephadm.services.service_registry import service_registry
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.module import CephadmOrchestrator
-from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, RGWSpec, IngressSpec
+from ceph.deployment.service_spec import (
+    NFSServiceSpec,
+    PlacementSpec,
+    RGWSpec,
+    IngressSpec,
+    SpecValidationError,
+)
 from cephadm.tests.fixtures import with_host, with_service, wait, async_side_effect
 
 
@@ -478,6 +486,163 @@ class TestNFS:
                 )
                 assert expected_tls_block in ganesha_conf
 
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_config_rdma_enabled(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        """NFS with enable_rdma=True: ganesha.conf has RDMA protocols (nfsrdma, rpcrdma)."""
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['host1']),
+                enable_rdma=True,
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='host1',
+                        daemon_id='foo.host1.0.0',
+                        service_name=nfs_spec.service_name(),
+                        ports=[2049, 9587, 20049],
+                    ))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Protocols = 3, 4, nfsrdma, rpcrdma" in ganesha_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_config_rdma_custom_port(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        """NFS with enable_rdma and rdma_port: ganesha.conf has NFS_RDMA_Port."""
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['host1']),
+                enable_rdma=True,
+                rdma_port=1234,
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='host1',
+                        daemon_id='foo.host1.0.0',
+                        service_name=nfs_spec.service_name(),
+                        ports=[2049, 9587, 1234],
+                    ))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Protocols = 3, 4, nfsrdma, rpcrdma" in ganesha_conf
+                assert "NFS_RDMA_Port = 1234" in ganesha_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_config_rdma_disabled(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        """NFS without RDMA: ganesha.conf has Protocols = 3, 4 and no NFS_RDMA_Port."""
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['host1']),
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='host1',
+                        daemon_id='foo.host1.0.0',
+                        service_name=nfs_spec.service_name(),
+                    ))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Protocols = 3, 4" in ganesha_conf
+                assert "nfsrdma" not in ganesha_conf
+                assert "NFS_RDMA_Port" not in ganesha_conf
+
+
+def test_nfs_colocation_ports_validation():
+    """Test validation of colocation_ports in NFSServiceSpec"""
+    # Valid case: correct number of colocation_ports (count=3, need 2 additional)
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=3),
+        port=2049,
+        monitoring_port=9587,
+        colocation_ports=[
+            {'data_port': 3049, 'monitoring_port': 9588},
+            {'data_port': 4049, 'monitoring_port': 9589}
+        ]
+    )
+    spec.validate()  # Should not raise
+
+    # Invalid case: too few colocation_ports (count=4, need 3 additional, but only 1 provided)
+    with pytest.raises(SpecValidationError) as e:
+        spec = NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=4),
+            port=2049,
+            monitoring_port=9587,
+            colocation_ports=[{'data_port': 3049, 'monitoring_port': 9588}]
+        )
+        spec.validate()
+    assert "colocation_ports requires 3 entries for count=4 (got 1)" in str(e.value)
+
+    # Invalid case: missing required field
+    with pytest.raises(SpecValidationError) as e:
+        spec = NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=3),
+            port=2049,
+            monitoring_port=9587,
+            colocation_ports=[
+                {'data_port': 3049},  # Missing monitoring_port
+                {'data_port': 4049, 'monitoring_port': 9589}
+            ]
+        )
+        spec.validate()
+    assert "missing required fields: monitoring_port" in str(e.value)
+
+
+def test_nfs_colocation_ports_validation_with_rdma():
+    """Test colocation_ports with enable_rdma requires rdma_port in each entry."""
+    # Valid: enable_rdma=True, count=3, 2 colocation entries with data_port, monitoring_port, rdma_port
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=3),
+        port=2049,
+        monitoring_port=9587,
+        enable_rdma=True,
+        rdma_port=20049,
+        colocation_ports=[
+            {'data_port': 3049, 'monitoring_port': 9588, 'rdma_port': 20050},
+            {'data_port': 4049, 'monitoring_port': 9589, 'rdma_port': 20051},
+        ]
+    )
+    spec.validate()
+
+    # Invalid: enable_rdma=True but colocation entry missing rdma_port
+    with pytest.raises(SpecValidationError) as e:
+        spec = NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=3),
+            port=2049,
+            monitoring_port=9587,
+            enable_rdma=True,
+            colocation_ports=[
+                {'data_port': 3049, 'monitoring_port': 9588},  # missing rdma_port
+                {'data_port': 4049, 'monitoring_port': 9589, 'rdma_port': 20051},
+            ]
+        )
+        spec.validate()
+    assert "missing required fields: rdma_port" in str(e.value)
+
 
 @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
 @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
@@ -504,7 +669,6 @@ def test_nfs_choose_next_action(cephadm_module, mock_cephadm):
         # NB: it appears that the code is designed to redeploy unless all
         # dependencies are prefixed with 'kmip' but I can't find any code
         # that would produce any dependencies prefixed with 'kmip'!
-
 
 @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
 @patch("cephadm.services.nfs.NFSService.purge", MagicMock())

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -1328,50 +1328,6 @@ def test_bad_specs(service_type, placement, hosts, daemons, expected):
     assert str(e.value) == expected
 
 
-def test_nfs_colocation_ports_validation():
-    """Test validation of colocation_ports in NFSServiceSpec"""
-    from ceph.deployment.service_spec import SpecValidationError
-    # Valid case: correct number of colocation_ports (count=3, need 2 additional)
-    spec = NFSServiceSpec(
-        service_id='mynfs',
-        placement=PlacementSpec(count=3),
-        port=2049,
-        monitoring_port=9587,
-        colocation_ports=[
-            {'data_port': 3049, 'monitoring_port': 9588},
-            {'data_port': 4049, 'monitoring_port': 9589}
-        ]
-    )
-    spec.validate()  # Should not raise
-
-    # Invalid case: too few colocation_ports (count=4, need 3 additional, but only 1 provided)
-    with pytest.raises(SpecValidationError) as e:
-        spec = NFSServiceSpec(
-            service_id='mynfs',
-            placement=PlacementSpec(count=4),
-            port=2049,
-            monitoring_port=9587,
-            colocation_ports=[{'data_port': 3049, 'monitoring_port': 9588}]
-        )
-        spec.validate()
-    assert "colocation_ports requires 3 entries for count=4 (got 1)" in str(e.value)
-
-    # Invalid case: missing required field
-    with pytest.raises(SpecValidationError) as e:
-        spec = NFSServiceSpec(
-            service_id='mynfs',
-            placement=PlacementSpec(count=3),
-            port=2049,
-            monitoring_port=9587,
-            colocation_ports=[
-                {'data_port': 3049},  # Missing monitoring_port
-                {'data_port': 4049, 'monitoring_port': 9589}
-            ]
-        )
-        spec.validate()
-    assert "missing required fields: monitoring_port" in str(e.value)
-
-
 class ActiveAssignmentTest(NamedTuple):
     service_type: str
     placement: PlacementSpec

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -73,6 +73,8 @@ class NFSCluster:
             tls_debug: bool = False,
             tls_min_version: Optional[str] = None,
             tls_ciphers: Optional[str] = None,
+            enable_rdma: bool = False,
+            rdma_port: Optional[int] = None,
     ) -> None:
         if not port:
             port = 2049   # default nfs port
@@ -114,7 +116,9 @@ class NFSCluster:
                                   tls_ktls=tls_ktls,
                                   tls_debug=tls_debug,
                                   tls_min_version=tls_min_version,
-                                  tls_ciphers=tls_ciphers)
+                                  tls_ciphers=tls_ciphers,
+                                  enable_rdma=enable_rdma,
+                                  rdma_port=rdma_port)
             completion = self.mgr.apply_nfs(spec)
             orchestrator.raise_if_exception(completion)
             ispec = IngressSpec(service_type='ingress',
@@ -140,7 +144,9 @@ class NFSCluster:
                                   tls_ktls=tls_ktls,
                                   tls_debug=tls_debug,
                                   tls_min_version=tls_min_version,
-                                  tls_ciphers=tls_ciphers)
+                                  tls_ciphers=tls_ciphers,
+                                  enable_rdma=enable_rdma,
+                                  rdma_port=rdma_port)
             completion = self.mgr.apply_nfs(spec)
             orchestrator.raise_if_exception(completion)
         log.debug("Successfully deployed nfs daemons with cluster id %s and placement %s",
@@ -172,6 +178,8 @@ class NFSCluster:
             tls_debug: bool = False,
             tls_min_version: Optional[str] = None,
             tls_ciphers: Optional[str] = None,
+            enable_rdma: bool = False,
+            rdma_port: Optional[int] = None,
     ) -> None:
         try:
             if virtual_ip:
@@ -197,7 +205,7 @@ class NFSCluster:
             if cluster_id not in available_clusters(self.mgr):
                 self._call_orch_apply_nfs(cluster_id, placement, virtual_ip, ingress_mode, port,
                                           ssl, ssl_cert, ssl_key, ssl_ca_cert, tls_ktls, tls_debug,
-                                          tls_min_version, tls_ciphers)
+                                          tls_min_version, tls_ciphers, enable_rdma, rdma_port)
                 return
             raise NonFatalError(f"{cluster_id} cluster already exists")
         except Exception as e:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -38,7 +38,9 @@ from .utils import (
     conf_obj_name,
     available_clusters,
     check_fs,
-    restart_nfs_service, cephfs_path_is_dir)
+    get_nfs_spec_for_cluster,
+    restart_nfs_service,
+    cephfs_path_is_dir)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -722,6 +724,11 @@ class ExportMgr:
 
         ex_dict["fsal"] = fsal
         ex_dict["cluster_id"] = cluster_id
+        # When RDMA is enabled at cluster level, default export transports to tcp, RDMA
+        if "transports" not in ex_dict:
+            nfs_spec = get_nfs_spec_for_cluster(self.mgr, cluster_id)
+            if nfs_spec and getattr(nfs_spec, "enable_rdma", False):
+                ex_dict["transports"] = ["TCP", "RDMA"]
         export = Export.from_dict(ex_id, ex_dict)
         if export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0]:
             self._ensure_cephfs_export_user(export)
@@ -742,6 +749,7 @@ class ExportMgr:
                              sectype: Optional[List[str]] = None,
                              xprtsec: Optional[str] = None,
                              cmount_path: Optional[str] = "/",
+                             transports: Optional[List[str]] = None,
                              earmark_resolver: Optional[CephFSEarmarkResolver] = None
                              ) -> Dict[str, Any]:
 
@@ -751,24 +759,27 @@ class ExportMgr:
 
         pseudo_path = normalize_path(pseudo_path)
 
+        export_dict = {
+            "pseudo": pseudo_path,
+            "path": path,
+            "access_type": access_type,
+            "squash": squash,
+            "fsal": {
+                "name": NFS_GANESHA_SUPPORTED_FSALS[0],
+                "cmount_path": cmount_path,
+                "fs_name": fs_name,
+            },
+            "clients": clients,
+            "sectype": sectype,
+            "XprtSec": xprtsec,
+        }
+        if transports is not None:
+            export_dict["transports"] = transports
         if not self._fetch_export(cluster_id, pseudo_path):
             export = self.create_export_from_dict(
                 cluster_id,
                 self._gen_export_id(cluster_id),
-                {
-                    "pseudo": pseudo_path,
-                    "path": path,
-                    "access_type": access_type,
-                    "squash": squash,
-                    "fsal": {
-                        "name": NFS_GANESHA_SUPPORTED_FSALS[0],
-                        "cmount_path": cmount_path,
-                        "fs_name": fs_name,
-                    },
-                    "clients": clients,
-                    "sectype": sectype,
-                    "XprtSec": xprtsec,
-                },
+                export_dict,
                 earmark_resolver
             )
             log.debug("creating cephfs export %s", export)
@@ -794,29 +805,33 @@ class ExportMgr:
                           user_id: Optional[str] = None,
                           clients: list = [],
                           sectype: Optional[List[str]] = None,
-                          xprtsec: Optional[str] = None) -> Dict[str, Any]:
+                          xprtsec: Optional[str] = None,
+                          transports: Optional[List[str]] = None) -> Dict[str, Any]:
         pseudo_path = normalize_path(pseudo_path)
 
         if not bucket and not user_id:
             raise ErrorResponse("Must specify either bucket or user_id")
 
+        export_dict = {
+            "pseudo": pseudo_path,
+            "path": bucket or '/',
+            "access_type": access_type,
+            "squash": squash,
+            "fsal": {
+                "name": NFS_GANESHA_SUPPORTED_FSALS[1],
+                "user_id": user_id,
+            },
+            "clients": clients,
+            "sectype": sectype,
+            "XprtSec": xprtsec,
+        }
+        if transports is not None:
+            export_dict["transports"] = transports
         if not self._fetch_export(cluster_id, pseudo_path):
             export = self.create_export_from_dict(
                 cluster_id,
                 self._gen_export_id(cluster_id),
-                {
-                    "pseudo": pseudo_path,
-                    "path": bucket or '/',
-                    "access_type": access_type,
-                    "squash": squash,
-                    "fsal": {
-                        "name": NFS_GANESHA_SUPPORTED_FSALS[1],
-                        "user_id": user_id,
-                    },
-                    "clients": clients,
-                    "sectype": sectype,
-                    "XprtSec": xprtsec,
-                }
+                export_dict
             )
             log.debug("creating rgw export %s", export)
             self._create_rgw_export_user(export)

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -725,10 +725,13 @@ class ExportMgr:
         ex_dict["fsal"] = fsal
         ex_dict["cluster_id"] = cluster_id
         # When RDMA is enabled at cluster level, default export transports to tcp, RDMA
-        if "transports" not in ex_dict:
-            nfs_spec = get_nfs_spec_for_cluster(self.mgr, cluster_id)
-            if nfs_spec and getattr(nfs_spec, "enable_rdma", False):
-                ex_dict["transports"] = ["TCP", "RDMA"]
+        nfs_spec = get_nfs_spec_for_cluster(self.mgr, cluster_id)
+        rdma_status = getattr(nfs_spec, "enable_rdma", False)
+        if "transports" not in ex_dict and rdma_status:
+            ex_dict["transports"] = ["TCP", "RDMA"]
+        elif "RDMA" in ex_dict.get("transports", []) and not rdma_status:
+            raise NFSInvalidOperation("Can't set Transport as RDMA as RDMA not enabled at NFS cluster level")
+
         export = Export.from_dict(ex_id, ex_dict)
         if export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0]:
             self._ensure_cephfs_export_user(export)

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -523,7 +523,7 @@ class Export:
             if p not in [3, 4]:
                 raise NFSInvalidOperation(f"Invalid protocol {p}")
 
-        valid_transport = ["UDP", "TCP"]
+        valid_transport = ["UDP", "TCP", "RDMA"]
         for trans in self.transports:
             if trans.upper() not in valid_transport:
                 raise NFSInvalidOperation(f'{trans} is not a valid transport protocol')

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -44,7 +44,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             squash: str = 'none',
             sectype: Optional[List[str]] = None,
             xprtsec: Optional[str] = None,
-            cmount_path: Optional[str] = "/"
+            cmount_path: Optional[str] = "/",
+            transports: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         """Create a CephFS export"""
         earmark_resolver = CephFSEarmarkResolver(self)
@@ -60,6 +61,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             sectype=sectype,
             xprtsec=xprtsec,
             cmount_path=cmount_path,
+            transports=transports,
             earmark_resolver=earmark_resolver
         )
 
@@ -76,6 +78,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             squash: str = 'none',
             sectype: Optional[List[str]] = None,
             xprtsec: Optional[str] = None,
+            transports: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         """Create an RGW export"""
         return self.export_mgr.create_export(
@@ -88,7 +91,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             squash=squash,
             addr=client_addr,
             sectype=sectype,
-            xprtsec=xprtsec
+            xprtsec=xprtsec,
+            transports=transports,
         )
 
     @NFSCLICommand('nfs export rm', perm='rw')
@@ -139,6 +143,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                 virtual_ip: Optional[str] = None,
                                 ingress_mode: Optional[IngressType] = None,
                                 port: Optional[int] = None,
+                                enable_rdma: bool = False,
+                                rdma_port: Optional[int] = None,
                                 inbuf: Optional[str] = None) -> None:
         """Create an NFS Cluster"""
         ssl_cert = ssl_key = ssl_ca_cert = tls_min_version = tls_ciphers = None
@@ -164,7 +170,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                            tls_ktls=tls_ktls,
                                            tls_debug=tls_debug,
                                            tls_min_version=tls_min_version,
-                                           tls_ciphers=tls_ciphers)
+                                           tls_ciphers=tls_ciphers,
+                                           enable_rdma=enable_rdma,
+                                           rdma_port=rdma_port)
 
     @NFSCLICommand('nfs cluster rm', perm='rw')
     @object_format.EmptyResponder()

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1166,6 +1166,99 @@ NFS_CORE_PARAM {
         assert export.clients[0].access_type == 'rw'
         assert export.clients[0].addresses == ["192.168.1.0/8"]
         assert export.cluster_id == self.cluster_id
+
+    def test_create_export_default_transports_rdma_cluster(self):
+        """When cluster has enable_rdma=True, new exports get default Transports = tcp, RDMA."""
+        self._do_mock_test(self._do_test_create_export_default_transports_rdma_cluster)
+
+    def _do_test_create_export_default_transports_rdma_cluster(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = ExportMgr(nfs_mod)
+        rdma_spec = NFSServiceSpec(service_id=self.cluster_id, enable_rdma=True)
+        with mock.patch('nfs.export.get_nfs_spec_for_cluster', return_value=rdma_spec):
+            r = conf.create_export(
+                fsal_type='rgw',
+                cluster_id=self.cluster_id,
+                bucket='rdmabucket',
+                pseudo_path='/rdmabucket',
+                read_only=False,
+                squash='root',
+                addr=["192.168.0.0/16"],
+            )
+        assert r["bind"] == "/rdmabucket"
+        export = conf._fetch_export(self.cluster_id, '/rdmabucket')
+        assert export is not None
+        assert sorted(export.transports) == ["RDMA", "TCP"]
+
+    def test_export_transport_rdma_valid(self):
+        """Export with Transports = TCP, RDMA is valid."""
+        export_block = """
+EXPORT {
+    export_id = 1;
+    path = "/";
+    pseudo = "/rdma_export";
+    access_type = "RW";
+    squash = "none";
+    protocols = 4;
+    transports = "TCP", "RDMA";
+    FSAL {
+        name = "CEPH";
+        filesystem = "a";
+        cmount_path = "/";
+    }
+}
+"""
+        blocks = GaneshaConfParser(export_block).parse()
+        export = Export.from_export_block(blocks[0], self.cluster_id)
+        assert set(export.transports) == {"TCP", "RDMA"}
+        # Validate should pass (RDMA is in valid_transport)
+        nfs_mod = Module('nfs', '', '')
+        conf = ExportMgr(nfs_mod)
+        with mock.patch('nfs.export.check_fs', return_value=True), \
+                mock.patch('nfs.ganesha_conf.check_fs', return_value=True):
+            export.validate(conf.mgr)
+
+    def test_update_export_without_transport_rdma_cluster(self):
+        """Apply export update without Transport fields; result has Transports = TCP, RDMA."""
+        self._do_mock_test(self._do_test_update_export_without_transport_rdma_cluster)
+
+    def _do_test_update_export_without_transport_rdma_cluster(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = ExportMgr(nfs_mod)
+        # Existing export at /rgw has Transports = TCP, UDP (from export_2)
+        export_before = conf._fetch_export(self.cluster_id, '/rgw')
+        assert export_before is not None
+        assert set(export_before.transports) == {"TCP", "UDP"}
+
+        # apply_export with no 'transports' field; cluster has enable_rdma -> default TCP, RDMA
+        rdma_spec = NFSServiceSpec(service_id=self.cluster_id, enable_rdma=True)
+        with mock.patch('nfs.export.get_nfs_spec_for_cluster', return_value=rdma_spec):
+            r = conf.apply_export(self.cluster_id, json.dumps({
+                'export_id': 2,
+                'path': '/',
+                'pseudo': '/rgw',
+                'cluster_id': self.cluster_id,
+                'access_type': 'RO',
+                'squash': 'root',
+                'security_label': False,
+                'protocols': [4, 3],
+                'clients': [],
+                'fsal': {
+                    'name': 'RGW',
+                    'user_id': 'nfs.foo.bucket',
+                    'access_key_id': 'the_access_key',
+                    'secret_access_key': 'the_secret_key',
+                },
+            }))
+        assert len(r.changes) == 1
+
+        export_after = conf._fetch_export(self.cluster_id, '/rgw')
+        assert export_after is not None
+        assert export_after.export_id == 2
+        assert export_after.access_type == 'RO'
+        assert export_after.squash == 'root'
+        # Updated export has Transports = TCP, RDMA (default when transports omitted and RDMA enabled)
+        assert set(export_after.transports) == {'TCP', 'RDMA'}
     
     def _do_test_create_export_cephfs_with_cmount_path(self):
         nfs_mod = Module('nfs', '', '')

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import stat
-from typing import List, Tuple, TYPE_CHECKING
+from typing import List, Optional, Tuple, Any, TYPE_CHECKING
 
 from object_format import ErrorResponseBase
 import orchestrator
@@ -79,6 +79,22 @@ def available_clusters(mgr: 'Module') -> List[str]:
     assert completion.result is not None
     return [cluster.spec.service_id for cluster in completion.result
             if cluster.spec.service_id]
+
+
+def get_nfs_spec_for_cluster(mgr: 'Module', cluster_id: str) -> Optional[Any]:
+    """Return the NFS service spec for the given cluster_id, or None if not found."""
+    try:
+        completion = mgr.describe_service(service_type='nfs')
+        orchestrator.raise_if_exception(completion)
+        if completion.result:
+            for svc in completion.result:
+                if getattr(svc.spec, 'service_id', None) == cluster_id:
+                    return svc.spec
+    except NoOrchestrator:
+        log.debug("No orchestrator configured")
+    except Exception:
+        log.debug("Failed to get NFS spec for cluster %s", cluster_id)
+    return None
 
 
 def nfs_rados_configs(rados: 'Rados', nfs_pool: str = POOL_NAME) -> List[str]:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1350,6 +1350,8 @@ yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)
 
 
 class NFSServiceSpec(ServiceSpec):
+    COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port']
+
     def __init__(self,
                  service_type: str = 'nfs',
                  service_id: Optional[str] = None,
@@ -1380,6 +1382,7 @@ class NFSServiceSpec(ServiceSpec):
                  tls_debug: bool = False,
                  tls_min_version: Optional[str] = None,
                  tls_ciphers: Optional[str] = None,
+                 colocation_ports: Optional[List[Dict[str, int]]] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -1405,6 +1408,11 @@ class NFSServiceSpec(ServiceSpec):
         self.idmap_conf = idmap_conf
         self.enable_nlm = enable_nlm
 
+        # colocation_ports is a list of port dicts for ADDITIONAL colocated daemons
+        # The first daemon always uses port and monitoring_port from the spec
+        # Format: [{'data_port': 1234, 'monitoring_port': 5678}, ...]
+        self.colocation_ports = colocation_ports
+
         # TLS fields
         self.tls_ciphers = tls_ciphers
         self.tls_ktls = tls_ktls
@@ -1414,9 +1422,58 @@ class NFSServiceSpec(ServiceSpec):
     def get_port_start(self) -> List[int]:
         return [self.port or 2049, self.monitoring_port or 9587]
 
+    def get_colocation_ports_list(self) -> List[List[int]]:
+        """
+        Convert the colocation_ports dictionary into a list of port lists
+        so the scheduler can handle port assignment in a generic way
+        """
+        if not self.colocation_ports:
+            return []
+        return [[port_dict[field] for field in self.COLOCATION_PORT_FIELDS]
+                for port_dict in self.colocation_ports]
+
     def rados_config_name(self):
         # type: () -> str
         return 'conf-' + self.service_name()
+
+    def validate_colocation_ports(self) -> None:
+        """Validate colocation_ports configuration."""
+        if not self.colocation_ports:
+            return
+        # Validate entry count matches placement requirements
+        if self.placement:
+            actual = len(self.colocation_ports)
+            if self.placement.count_per_host:
+                expected = self.placement.count_per_host - 1
+                if actual < expected:
+                    raise SpecValidationError(
+                        f"colocation_ports requires {expected} entries for "
+                        f"count_per_host={self.placement.count_per_host} (got {actual}). First "
+                        "daemon uses base ports, remaining need custom ports."
+                    )
+            elif self.placement.count:
+                expected = self.placement.count - 1
+                if actual < expected:
+                    raise SpecValidationError(
+                        f"colocation_ports requires {expected} entries for "
+                        f"count={self.placement.count} (got {actual}). First daemon uses base "
+                        "ports, remaining need custom ports."
+                    )
+        # Validate that each entry has the required port fields
+        for idx, port_dict in enumerate(self.colocation_ports):
+            if not isinstance(port_dict, dict):
+                raise SpecValidationError(
+                    f"colocation_ports[{idx}] must be a dict with "
+                    f"fields: {', '.join(self.COLOCATION_PORT_FIELDS)}"
+                )
+            missing = [f for f in self.COLOCATION_PORT_FIELDS if f not in port_dict]
+            if missing:
+                missing_str = ', '.join(missing)
+                format_str = ', '.join(f'{f!r}: <port>' for f in self.COLOCATION_PORT_FIELDS)
+                raise SpecValidationError(
+                    f"Invalid NFS spec: colocation_ports[{idx}] missing required "
+                    f"fields: {missing_str}. Expected format: {{{format_str}}}"
+                )
 
     def validate(self) -> None:
         super(NFSServiceSpec, self).validate()
@@ -1424,6 +1481,9 @@ class NFSServiceSpec(ServiceSpec):
         if self.virtual_ip and (self.ip_addrs or self.networks):
             raise SpecValidationError("Invalid NFS spec: Cannot set virtual_ip and "
                                       f"{'ip_addrs' if self.ip_addrs else 'networks'} fields")
+
+        # Validate colocation_ports
+        self.validate_colocation_ports()
 
         # TLS certificate validation
         if self.ssl and not self.certificate_source:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1351,6 +1351,7 @@ yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)
 
 class NFSServiceSpec(ServiceSpec):
     COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port']
+    COLOCATION_PORT_FIELDS_WITH_RDMA = ['data_port', 'monitoring_port', 'rdma_port']
 
     def __init__(self,
                  service_type: str = 'nfs',
@@ -1368,6 +1369,8 @@ class NFSServiceSpec(ServiceSpec):
                  virtual_ip: Optional[str] = None,
                  enable_nlm: bool = False,
                  enable_haproxy_protocol: bool = False,
+                 enable_rdma: bool = False,
+                 rdma_port: Optional[int] = None,
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  idmap_conf: Optional[Dict[str, Dict[str, str]]] = None,
@@ -1407,6 +1410,8 @@ class NFSServiceSpec(ServiceSpec):
         self.enable_haproxy_protocol = enable_haproxy_protocol
         self.idmap_conf = idmap_conf
         self.enable_nlm = enable_nlm
+        self.enable_rdma = enable_rdma
+        self.rdma_port = rdma_port
 
         # colocation_ports is a list of port dicts for ADDITIONAL colocated daemons
         # The first daemon always uses port and monitoring_port from the spec
@@ -1419,8 +1424,17 @@ class NFSServiceSpec(ServiceSpec):
         self.tls_debug = tls_debug
         self.tls_min_version = tls_min_version
 
+    def get_colocation_port_fields(self) -> List[str]:
+        """Return port fields for colocation; include rdma_port when RDMA is enabled."""
+        if self.enable_rdma:
+            return self.COLOCATION_PORT_FIELDS_WITH_RDMA
+        return self.COLOCATION_PORT_FIELDS
+
     def get_port_start(self) -> List[int]:
-        return [self.port or 2049, self.monitoring_port or 9587]
+        ports = [self.port or 2049, self.monitoring_port or 9587]
+        if self.enable_rdma:
+            ports.append(self.rdma_port or 20049)
+        return ports
 
     def get_colocation_ports_list(self) -> List[List[int]]:
         """
@@ -1429,7 +1443,8 @@ class NFSServiceSpec(ServiceSpec):
         """
         if not self.colocation_ports:
             return []
-        return [[port_dict[field] for field in self.COLOCATION_PORT_FIELDS]
+        fields = self.get_colocation_port_fields()
+        return [[port_dict[field] for field in fields]
                 for port_dict in self.colocation_ports]
 
     def rados_config_name(self):
@@ -1460,16 +1475,17 @@ class NFSServiceSpec(ServiceSpec):
                         "ports, remaining need custom ports."
                     )
         # Validate that each entry has the required port fields
+        fields = self.get_colocation_port_fields()
         for idx, port_dict in enumerate(self.colocation_ports):
             if not isinstance(port_dict, dict):
                 raise SpecValidationError(
                     f"colocation_ports[{idx}] must be a dict with "
-                    f"fields: {', '.join(self.COLOCATION_PORT_FIELDS)}"
+                    f"fields: {', '.join(fields)}"
                 )
-            missing = [f for f in self.COLOCATION_PORT_FIELDS if f not in port_dict]
+            missing = [f for f in fields if f not in port_dict]
             if missing:
                 missing_str = ', '.join(missing)
-                format_str = ', '.join(f'{f!r}: <port>' for f in self.COLOCATION_PORT_FIELDS)
+                format_str = ', '.join(f'{f!r}: <port>' for f in fields)
                 raise SpecValidationError(
                     f"Invalid NFS spec: colocation_ports[{idx}] missing required "
                     f"fields: {missing_str}. Expected format: {{{format_str}}}"

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -552,6 +552,61 @@ def test_alertmanager_spec_2():
     assert 'default_webhook_urls' in spec.user_data.keys()
 
 
+def test_nfs_spec_rdma_default():
+    """NFS spec without RDMA: enable_rdma is False, get_port_start returns 2 ports."""
+    spec = NFSServiceSpec(service_id='mynfs', placement=PlacementSpec(count=1))
+    assert spec.enable_rdma is False
+    assert spec.rdma_port is None
+    assert spec.get_port_start() == [2049, 9587]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port']
+
+
+def test_nfs_spec_rdma_enabled():
+    """NFS spec with enable_rdma: get_port_start returns 3 ports, default rdma_port 20049."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        enable_rdma=True,
+    )
+    assert spec.enable_rdma is True
+    assert spec.rdma_port is None
+    assert spec.get_port_start() == [2049, 9587, 20049]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'rdma_port']
+
+
+def test_nfs_spec_rdma_custom_port():
+    """NFS spec with enable_rdma and custom rdma_port."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        port=3049,
+        monitoring_port=9588,
+        enable_rdma=True,
+        rdma_port=20050,
+    )
+    assert spec.enable_rdma is True
+    assert spec.rdma_port == 20050
+    assert spec.get_port_start() == [3049, 9588, 20050]
+
+
+def test_nfs_spec_from_json_rdma():
+    """NFS spec enable_rdma and rdma_port roundtrip via from_json/to_json."""
+    data = {
+        'service_id': 'mynfs',
+        'service_type': 'nfs',
+        'placement': {'count': 1},
+        'spec': {
+            'enable_rdma': True,
+            'rdma_port': 1234,
+        },
+    }
+    spec = NFSServiceSpec.from_json(data)
+    assert spec.enable_rdma is True
+    assert spec.rdma_port == 1234
+    out = spec.to_json()
+    assert out.get('spec', {}).get('enable_rdma') is True
+    assert out.get('spec', {}).get('rdma_port') == 1234
+
 
 def test_repr():
     val = """ServiceSpec.from_json(yaml.safe_load('''service_type: crash


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75189
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>


PR changes:

1. New optional spec fields enable_rdma and rdma_port. ceph nfs cluster create and ceph orch apply nfs accept them via YAML or CLI.
2. When RDMA is enabled, config uses Protocols = 4, nfsrdma, rpcrdma and  NFS_RDMA_Port is set only when rdma_port is specified.
3. With enable_rdma, colocation uses three ports (data, monitoring, RDMA) each colocation_ports entry must include rdma_port when RDMA is on.
4. If the cluster has RDMA enabled, new exports default to Transports = tcp, RDMA unless overridden. Export validation allows RDMA in the transport list.
5. Export create command parameter to specify transport
6. Added cephadm command to list RDMA device details - 'cephadm list-rdma'
7. Added precheck for rdma capable interface if NFS service has enable_rdma true.


Testing logs:
1. Tested cluster create with and without rdma.
```
[root@ceph-node-0 ~]# cat /var/lib/ceph/6a176322-17b2-11f1-9551-525400bf5065/nfs.test1.0.0.ceph-node-0.asdjam/etc/ganesha/ganesha.conf | grep -i protocol
        Protocols = 3, 4, nfsrdma, rpcrdma;
[root@ceph-node-2 ~]# cat /var/lib/ceph/6a176322-17b2-11f1-9551-525400bf5065/nfs.test2.0.0.ceph-node-2.vedgpj/etc/ganesha/ganesha.conf | grep -i protocol
        Protocols = 3, 4;

```
2. Tested colocation for cluster with and without rdma
```
[ceph: root@ceph-node-0 /]# ceph orch ps | grep nfs
nfs.test1.0.0.ceph-node-0.asdjam  ceph-node-0  *:1234,9587,20049  running (12m)    36s ago  12m    47.3M        -  5.9                    330c123ec8e0  cfa2f976abe8  
nfs.test1.1.0.ceph-node-0.hjbzrl  ceph-node-0  *:1235,9588,20050  running (47s)    36s ago  47s    49.2M        -  5.9                    330c123ec8e0  79f3b97e80b7  
nfs.test2.0.0.ceph-node-2.vedgpj  ceph-node-2  *:2049,9587        running (12m)    38s ago  12m    46.5M        -  5.9                    330c123ec8e0  97a9367ab83d  
nfs.test2.1.0.ceph-node-2.zgxajf  ceph-node-2  *:2050,9588        running (42s)    38s ago  42s    12.2M        -  5.9                    330c123ec8e0  cd3cbb3ec531  
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs1.yml 
Error EINVAL: Invalid NFS spec: colocation_ports[0] missing required fields: rdma_port. Expected format: {'data_port': <port>, 'monitoring_port': <port>, 'rdma_port': <port>}
[ceph: root@ceph-node-0 /]# vi nfs1.yml
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs1.yml 
Error EINVAL: Invalid NFS spec: colocation_ports[0] missing required fields: rdma_port. Expected format: {'data_port': <port>, 'monitoring_port': <port>, 'rdma_port': <port>}
[ceph: root@ceph-node-0 /]# vi nfs1.yml
[ceph: root@ceph-node-0 /]# ceph orch apply -i nfs1.yml 
Error EINVAL: Invalid NFS spec: colocation_ports[0] missing required fields: monitoring_port. Expected format: {'data_port': <port>, 'monitoring_port': <port>}
[ceph: root@ceph-node-0 /]# 

```
3. Export creation testing
```
EXPORT {
    FSAL {
        name = "CEPH";
        user_id = "nfs.test1.myfs.9cc40334";
        filesystem = "myfs";
        secret_access_key = "AQAuEahp6HaSJxAAjCQ9IHYKOUmRPa+KryzA0g==";
        cmount_path = "/";
    }
    export_id = 1;
    path = "/";
    pseudo = "/export1";
    access_type = "RW";
    squash = "none";
    attr_expiration_time = 0;
    security_label = true;
    protocols = 3, 4;
    transports = "TCP", "RDMA";
}

EXPORT {
    FSAL {
        name = "CEPH";
        user_id = "nfs.test2.myfs.5cac081a";
        filesystem = "myfs";
        secret_access_key = "AQAzEahpgPQoOBAAJWJLFKCF5LcgWgcxi0tEqQ==";
        cmount_path = "/";
    }
    export_id = 1;
    path = "/";
    pseudo = "/export2";
    access_type = "RW";
    squash = "none";
    attr_expiration_time = 0;
    security_label = true;
    protocols = 3, 4;
    transports = "TCP";
}

[ceph: root@ceph-node-0 /]# ceph nfs export create cephfs test2 /export3 myfs --transports TCP,RDMA
{
  "bind": "/export3",
  "cluster": "test2",
  "fs": "myfs",
  "mode": "RW",
  "path": "/"
}
[ceph: root@ceph-node-0 /]# 

```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
