### PR TITLE
Bst2002 cephfsdashboard.libsonnet git patch 1

### DIFF
--- a/monitoring/ceph-mixin/dashboards/cephfsdashboard.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/cephfsdashboard.libsonnet
@@ -260,7 +260,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'rgba(50, 172, 45, 0.97)', value: null },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(rate(ceph_mds_server_handle_client_request{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+        expr='sum(rate(ceph_mds_server_handle_client_request{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
         interval='$__rate_interval',
         datasource={ type: 'prometheus', uid: '${datasource}' },
         step=60,
@@ -289,7 +289,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'rgba(50, 172, 45, 0.97)', value: null },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(ceph_mds_sessions_session_count{%(matchers)s} * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+        expr='sum(ceph_mds_sessions_session_count{%(matchers)s} * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
         interval='$__rate_interval',
         datasource={ type: 'prometheus', uid: '${datasource}' },
         step=60,
@@ -318,7 +318,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'rgba(50, 172, 45, 0.97)', value: null },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(ceph_mds_inodes{%(matchers)s} * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+        expr='sum(ceph_mds_inodes{%(matchers)s} * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
         interval='$__rate_interval',
         datasource={ type: 'prometheus', uid: '${datasource}' },
         step=60,
@@ -521,7 +521,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'rgba(50, 172, 45, 0.97)', value: null },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(rate(ceph_mds_forward{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+        expr='sum(rate(ceph_mds_forward{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
         interval='$__rate_interval',
         datasource={ type: 'prometheus', uid: '${datasource}' },
         step=60,
@@ -557,7 +557,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'rgba(50, 172, 45, 0.97)', value: null },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(increase(ceph_mds_reply_latency_sum{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s})) / sum(increase(ceph_mds_reply_latency_count{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+        expr='sum(increase(ceph_mds_reply_latency_sum{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"}) / sum(increase(ceph_mds_reply_latency_count{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
         interval='$__rate_interval',
         range=true,
         datasource={ type: 'prometheus', uid: '${datasource}' },
@@ -587,7 +587,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'rgba(50, 172, 45, 0.97)', value: null },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(ceph_mds_caps{%(matchers)s} * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+        expr='sum(ceph_mds_caps{%(matchers)s} * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
         interval='$__rate_interval',
         datasource={ type: 'prometheus', uid: '${datasource}' },
         step=60,
@@ -800,7 +800,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'green' },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum by (ceph_daemon) (increase(ceph_mds_reply_latency_sum{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s})) / sum by (ceph_daemon) (increase(ceph_mds_reply_latency_count{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+        expr='sum by (ceph_daemon) (increase(ceph_mds_reply_latency_sum{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"}) / sum by (ceph_daemon) (increase(ceph_mds_reply_latency_count{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
         datasource={ type: 'prometheus', uid: '${datasource}' },
         legendFormat='{{ ceph_daemon }}',
       )),
@@ -819,11 +819,11 @@ local g = import 'grafonnet/grafana.libsonnet';
       )
       .addTargets([
         $.addTargetSchema(
-          'sum(rate(ceph_objecter_op_r{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+          'sum(rate(ceph_objecter_op_r{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
           'Read Ops'
         ),
         $.addTargetSchema(
-          'sum(rate(ceph_objecter_op_w{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{%(matchers)s name=~"$name"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{%(matchers)s}))' % $.matchers(),
+          'sum(rate(ceph_objecter_op_w{%(matchers)s}[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{%(matchers)s} * on(fs_id) group_left(name) ceph_fs_metadata{%(matchers)s name=~"$name"})' % $.matchers(),
           'Write Ops'
         ),
       ])

--- a/monitoring/ceph-mixin/dashboards_out/cephfsdashboard.json
+++ b/monitoring/ceph-mixin/dashboards_out/cephfsdashboard.json
@@ -512,7 +512,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "sum(rate(ceph_mds_server_handle_client_request{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(rate(ceph_mds_server_handle_client_request{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "interval": "$__rate_interval",
                "intervalFactor": 1,
@@ -590,7 +590,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "sum(ceph_mds_sessions_session_count{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(ceph_mds_sessions_session_count{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "interval": "$__rate_interval",
                "intervalFactor": 1,
@@ -668,7 +668,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "sum(ceph_mds_inodes{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(ceph_mds_inodes{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "interval": "$__rate_interval",
                "intervalFactor": 1,
@@ -1222,7 +1222,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "sum(rate(ceph_mds_forward{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(rate(ceph_mds_forward{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "interval": "$__rate_interval",
                "intervalFactor": 1,
@@ -1312,7 +1312,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "sum(increase(ceph_mds_reply_latency_sum{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })) / sum(increase(ceph_mds_reply_latency_count{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(increase(ceph_mds_reply_latency_sum{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})) / sum(increase(ceph_mds_reply_latency_count{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "interval": "$__rate_interval",
                "intervalFactor": 1,
@@ -1391,7 +1391,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "sum(ceph_mds_caps{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(ceph_mds_caps{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "interval": "$__rate_interval",
                "intervalFactor": 1,
@@ -1672,7 +1672,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "rate(ceph_mds_server_handle_client_request{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+               "expr": "rate(ceph_mds_server_handle_client_request{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -1764,7 +1764,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "rate(ceph_mds_forward{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+               "expr": "rate(ceph_mds_forward{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -1855,7 +1855,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "rate(ceph_mds_server_handle_slave_request{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+               "expr": "rate(ceph_mds_server_handle_slave_request{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -1946,7 +1946,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "ceph_mds_sessions_session_count{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+               "expr": "ceph_mds_sessions_session_count{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -2037,7 +2037,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "sum by (ceph_daemon) (increase(ceph_mds_reply_latency_sum{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })) / sum by (ceph_daemon) (increase(ceph_mds_reply_latency_count{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum by (ceph_daemon) (increase(ceph_mds_reply_latency_sum{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})) / sum by (ceph_daemon) (increase(ceph_mds_reply_latency_count{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -2126,14 +2126,14 @@
          ],
          "targets": [
             {
-               "expr": "sum(rate(ceph_objecter_op_r{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(rate(ceph_objecter_op_r{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "Read Ops",
                "refId": "A"
             },
             {
-               "expr": "sum(rate(ceph_objecter_op_w{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", }))",
+               "expr": "sum(rate(ceph_objecter_op_w{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"}))",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "Write Ops",
@@ -2243,7 +2243,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "rate(ceph_mds_log_evadd{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+               "expr": "rate(ceph_mds_log_evadd{cluster=~\"$cluster|\", }[$__rate_interval]) * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -2334,7 +2334,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "ceph_mds_log_ev{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+               "expr": "ceph_mds_log_ev{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -2425,7 +2425,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "ceph_mds_log_seg{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+               "expr": "ceph_mds_log_seg{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "{{ ceph_daemon }}",
@@ -2585,7 +2585,7 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                      },
-                     "expr": "ceph_mds_mem_ino{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+                     "expr": "ceph_mds_mem_ino{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{ ceph_daemon }}",
@@ -2677,7 +2677,7 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                      },
-                     "expr": "ceph_mds_exported_inodes{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+                     "expr": "ceph_mds_exported_inodes{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{ ceph_daemon }}",
@@ -2769,7 +2769,7 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                      },
-                     "expr": "ceph_mds_imported_inodes{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+                     "expr": "ceph_mds_imported_inodes{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{ ceph_daemon }}",
@@ -2861,7 +2861,7 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                      },
-                     "expr": "ceph_mds_mem_dn{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+                     "expr": "ceph_mds_mem_dn{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{ ceph_daemon }}",
@@ -2953,7 +2953,7 @@
                         "type": "prometheus",
                         "uid": "${datasource}"
                      },
-                     "expr": "ceph_mds_caps{cluster=~\"$cluster|\", } * on(ceph_daemon) (ceph_fs_metadata{cluster=~\"$cluster|\",  name=~\"$name\"} * on(fs_id) group_left(ceph_daemon) ceph_mds_metadata{cluster=~\"$cluster|\", })",
+                     "expr": "ceph_mds_caps{cluster=~\"$cluster|\", } * on(ceph_daemon) group_left() (ceph_mds_metadata{cluster=~\"$cluster\"} * on(fs_id) group_left(name) ceph_fs_metadata{cluster=~\"$cluster\", name=~\"$name\"})",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "{{ ceph_daemon }}",


### PR DESCRIPTION
when 1 MDS active and 2 MDS standby (on 3Node-Cluster) found duplicate series for the match group {fs_id="-1"} on the right hand-side of the operation many-to-many matching not allowed: matching labels must be unique on one side


Error-Msg:
results	{ A: {…} }
A	{ error: 'execution: found duplicate series for the match group {fs_id="-1"} on the right hand-side of the operation: 
[{__name__="ceph_mds_metadata", ceph_daemon="mds.fs_chegg.ceph03.huljba", ceph_version="ceph version 20.2.0 (69f84cc2651aa259a15bc192ddaabd3baba07489) tentacle (stable - RelWithDebInfo)", cluster="021e2d22-898f-11f0-9a7d-eac00b8c0872", fs_id="-1", hostname="ceph03.local", instance="ceph_cluster", job="ceph", public_addr="1.2.3.5:6801/1812370270", rank="-1"}, 
{__name__="ceph_mds_metadata", ceph_daemon="mds.fs_chegg.ceph01.nzxflb", ceph_version="ceph version 20.2.0 (69f84cc2651aa259a15bc192ddaabd3baba07489) tentacle (stable - RelWithDebInfo)", cluster="021e2d22-898f-11f0-9a7d-eac00b8c0872", fs_id="-1", hostname="ceph01.local", instance="ceph_cluster", job="ceph", public_addr="1.2.3.4:6801/1043964841", rank="-1"}];


many-to-many matching not allowed: matching labels must be unique on one side', errorSource: "downstream", status: 422, … }
error	'execution: found duplicate series for the match group {fs_id="-1"} on the right hand-side of the operation: [{__name__="ceph_mds_metadata", ceph_daemon="mds.fs_chegg.ceph03.huljba", ceph_version="ceph version 20.2.0 (69f84cc2651aa259a15bc192ddaabd3baba07489) tentacle (stable - RelWithDebInfo)", cluster="021e2d22-898f-11f0-9a7d-eac00b8c0872", fs_id="-1", hostname="ceph03.local", instance="ceph_cluster", job="ceph", public_addr="1.2.3.5:6801/1812370270", rank="-1"}, {__name__="ceph_mds_metadata", ceph_daemon="mds.fs_chegg.ceph01.nzxflb", ceph_version="ceph version 20.2.0 (69f84cc2651aa259a15bc192ddaabd3baba07489) tentacle (stable - RelWithDebInfo)", cluster="021e2d22-898f-11f0-9a7d-eac00b8c0872", fs_id="-1", hostname="ceph01.local", instance="ceph_cluster", job="ceph", public_addr="1.2.3.4:6801/1043964841", rank="-1"}];many-to-many matching not allowed: matching labels must be unique on one side'
errorSource	"downstream"
status	422


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
