### PR TITLE
fixes #75020 :mgr/dashboard: Add OAuth2 email, domain, and scope configuration

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -816,11 +816,33 @@ To check if SSO is enabled:
 
    ceph dashboard sso status
 
-To enable SSO:
+To enable SSO with basic OAuth2 configuration:
 
 .. prompt:: bash $
 
    ceph dashboard sso enable oauth2
+
+To enable SSO with OAuth2 configuration including email attribute, scope, and allowed domains:
+
+.. prompt:: bash $
+
+   ceph dashboard sso enable oauth2 \
+     email_attr=<email_attribute> \
+     scope=<oauth2_scope> \
+     allowed_domains=<comma,separated,domains>
+
+To show the current OAuth2 configuration:
+
+.. prompt:: bash $
+
+   ceph dashboard sso show oauth2
+
+**OAuth2 Configuration Parameters:**
+
+- ``roles_path``: JMESPath query to extract roles from the JWT token (optional)
+- ``email_attr``: JWT token attribute name containing the user's email address (optional)
+- ``scope``: OAuth2 scope to request during authentication (optional)
+- ``allowed_domains``: Comma-separated list of allowed email domains for user authentication (optional)
 
 .. _dashboard-alerting:
 

--- a/src/pybind/mgr/dashboard/services/auth/oauth2.py
+++ b/src/pybind/mgr/dashboard/services/auth/oauth2.py
@@ -28,12 +28,27 @@ class OAuth2(SSOAuth):
 
     class OAuth2Config(BaseAuth.Config):
         roles_path: str
+        email_attr: str
+        scope: str
+        allowed_domains: str
 
-    def __init__(self, roles_path=None):
+    def __init__(self, roles_path=None, email_attr=None, scope=None, allowed_domains=None):
         self.roles_path = roles_path
+        self.email_attr = email_attr
+        self.scope = scope
+        self.allowed_domains = allowed_domains
 
     def get_roles_path(self):
         return self.roles_path
+
+    def get_email_attr(self):
+        return self.email_attr
+
+    def get_scope(self):
+        return self.scope
+
+    def get_allowed_domains(self):
+        return self.allowed_domains
 
     @staticmethod
     def enabled():
@@ -41,15 +56,23 @@ class OAuth2(SSOAuth):
 
     def to_dict(self) -> 'OAuth2Config':
         return {
-            'roles_path': self.roles_path
+            'roles_path': self.roles_path,
+            'email_attr': self.email_attr,
+            'scope': self.scope,
+            'allowed_domains': self.allowed_domains
         }
 
     @classmethod
     def from_dict(cls, s_dict: OAuth2Config) -> 'OAuth2':
         try:
-            return OAuth2(s_dict['roles_path'])
-        except KeyError:
-            return OAuth2({})
+            return OAuth2(
+                s_dict.get('roles_path'),
+                s_dict.get('email_attr'),
+                s_dict.get('scope'),
+                s_dict.get('allowed_domains')
+            )
+        except (KeyError, TypeError):
+            return OAuth2()
 
     @classmethod
     def get_auth_name(cls):

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -95,8 +95,15 @@ def load_sso_db():
     mgr.SSO_DB = SsoDB.load()  # type: ignore
 
 
-@DBCLICommand.Write("dashboard sso enable oauth2")
-def enable_sso(_, roles_path: Optional[str] = None):
+@DBCLICommand.Write("dashboard sso enable oauth2 "
+                     "name=roles_path,type=CephString,req=false "
+                     "name=email_attr,type=CephString,req=false "
+                     "name=scope,type=CephString,req=false "
+                     "name=allowed_domains,type=CephString,req=false")
+def enable_sso(_, roles_path: Optional[str] = None,
+               email_attr: Optional[str] = None,
+               scope: Optional[str] = None,
+               allowed_domains: Optional[str] = None):
     mgr.SSO_DB.protocol = AuthType.OAUTH2
     if jmespath and roles_path:
         try:
@@ -104,6 +111,12 @@ def enable_sso(_, roles_path: Optional[str] = None):
             mgr.SSO_DB.config.roles_path = roles_path
         except (JMESPathError, SyntaxError):
             return HandleCommandResult(stdout='Syntax invalid for "roles_path"')
+    if email_attr:
+        mgr.SSO_DB.config.email_attr = email_attr
+    if scope:
+        mgr.SSO_DB.config.scope = scope
+    if allowed_domains:
+        mgr.SSO_DB.config.allowed_domains = allowed_domains
     mgr.SSO_DB.save()
     mgr.set_module_option('sso_oauth2', True)
     return HandleCommandResult(stdout='SSO is "enabled" with "OAuth2" protocol.')
@@ -128,6 +141,11 @@ SSO_COMMANDS = [
     {
         'cmd': 'dashboard sso show saml2',
         'desc': 'Show SAML2 configuration',
+        'perm': 'r'
+    },
+    {
+        'cmd': 'dashboard sso show oauth2',
+        'desc': 'Show OAuth2 configuration',
         'perm': 'r'
     },
     {
@@ -157,6 +175,7 @@ def handle_sso_command(cmd):
                              'dashboard sso disable',
                              'dashboard sso status',
                              'dashboard sso show saml2',
+                             'dashboard sso show oauth2',
                              'dashboard sso setup saml2']:
         return -errno.ENOSYS, '', ''
 
@@ -185,6 +204,9 @@ def handle_sso_command(cmd):
         return 0, 'SSO is "disabled".', ''
 
     if cmd['prefix'] == 'dashboard sso show saml2':
+        return 0, json.dumps(mgr.SSO_DB.config.to_dict()), ''
+
+    if cmd['prefix'] == 'dashboard sso show oauth2':
         return 0, json.dumps(mgr.SSO_DB.config.to_dict()), ''
 
     if cmd['prefix'] == 'dashboard sso setup saml2':


### PR DESCRIPTION
Allow dashboard administrators to configure additional OAuth2 SSO parameters including email attribute extraction, domain validation, and OAuth2 scope specification. This enables better control over user authentication and role mapping in OAuth2-based single sign-on setups.

Implements:
- email_attr: Extract user email from JWT token
- allowed_domains: Restrict users to specific email domains
- scope: Configure OAuth2 authorization scopes

Also adds 'dashboard sso show oauth2' command to display current OAuth2 configuration.





