### PR TITLE
mgr/dashboard: NFS: Toggle visibility of CephFS snapshots - Enhancement

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -830,7 +830,31 @@ class CephFSSubvolume(RESTController):
             )
         return json.loads(out)
 
-    def create(self, vol_name: str, subvol_name: str, **kwargs):
+    def _set_snapshot_visibility(self, vol_name: str, subvol_name: str,
+                                 value: str, group_name: str = ''):
+        """Sets snapshot visibility for a subvolume."""
+        params = {
+            'vol_name': vol_name,
+            'sub_name': subvol_name,
+            'value': value
+        }
+        if group_name:
+            params['group_name'] = group_name
+        error_code, out, err = mgr.remote(
+            'volumes',
+            '_cmd_fs_subvolume_snapshot_visibility_set',
+            None,
+            params
+        )
+        if error_code != 0:
+            raise DashboardException(
+                f'Failed to set snapshot visibility for subvolume {subvol_name}: {err}'
+            )
+        return out
+
+    def create(self, vol_name: str, subvol_name: str,
+               snapshot_visibility: Optional[str] = None, **kwargs):
+        group_name = kwargs.get('group_name', '')
         error_code, _, err = mgr.remote('volumes', '_cmd_fs_subvolume_create', None, {
             'vol_name': vol_name, 'sub_name': subvol_name, **kwargs})
         if error_code != 0:
@@ -838,9 +862,13 @@ class CephFSSubvolume(RESTController):
                 f'Failed to create subvolume {subvol_name}: {err}'
             )
 
+        if snapshot_visibility is not None:
+            self._set_snapshot_visibility(vol_name, subvol_name, snapshot_visibility, group_name)
+
         return f'Subvolume {subvol_name} created successfully'
 
-    def set(self, vol_name: str, subvol_name: str, size: str, group_name: str = ""):
+    def set(self, vol_name: str, subvol_name: str, size: str, group_name: str = "",
+            snapshot_visibility: Optional[str] = None):
         params = {'vol_name': vol_name, 'sub_name': subvol_name}
         if size:
             params['new_size'] = size
@@ -852,6 +880,9 @@ class CephFSSubvolume(RESTController):
                 raise DashboardException(
                     f'Failed to update subvolume {subvol_name}: {err}'
                 )
+
+        if snapshot_visibility is not None:
+            self._set_snapshot_visibility(vol_name, subvol_name, snapshot_visibility, group_name)
 
         return f'Subvolume {subvol_name} updated successfully'
 
@@ -916,7 +947,7 @@ class CephFSSubvolume(RESTController):
 
         return out
 
-    @RESTController.Resource('PUT', path='/snapshot-visibility')
+    @RESTController.Resource('PATCH', path='/snapshot-visibility')
     def set_snapshot_visibility(
         self,
         vol_name: str,
@@ -924,29 +955,7 @@ class CephFSSubvolume(RESTController):
         value: str,
         group_name: str = ''
     ):
-        params = {
-            'vol_name': vol_name,
-            'sub_name': subvol_name,
-            'value': value
-        }
-
-        if group_name:
-            params['group_name'] = group_name
-
-        error_code, out, err = mgr.remote(
-            'volumes',
-            '_cmd_fs_subvolume_snapshot_visibility_set',
-            None,
-            params
-        )
-
-        if error_code != 0:
-            raise DashboardException(
-                f'Failed to set snapshot visibility for subvolume '
-                f'{subvol_name}: {err}'
-            )
-
-        return out
+        return self._set_snapshot_visibility(vol_name, subvol_name, value, group_name)
 
 
 @APIRouter('/cephfs/subvolume/group', Scope.CEPHFS)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.html
@@ -110,7 +110,6 @@
         <!-- Snapshot visibility -->
         <div class="form-item">
           <cds-checkbox id="snapshotVisibility"
-                        name="snapshotVisibility"
                         formControlName="snapshotVisibility">
             <span i18n>Allow snapshot browsing</span>
             <cd-help-text>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { CephfsSubvolumeFormComponent } from './cephfs-subvolume-form.component';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
@@ -12,6 +12,10 @@ import { FormHelper, configureTestBed } from '~/testing/unit-test-helper';
 import { CephfsSubvolumeService } from '~/app/shared/api/cephfs-subvolume.service';
 import { ConfigurationService } from '~/app/shared/api/configuration.service';
 import { CheckboxModule, InputModule, ModalModule, SelectModule } from 'carbon-components-angular';
+import {
+  SNAPSHOT_VISIBILITY_CONFIG_NAME,
+  SNAPSHOT_VISIBILITY_CONFIG_SECTION
+} from '~/app/shared/models/cephfs-subvolume.model';
 
 describe('CephfsSubvolumeFormComponent', () => {
   let component: CephfsSubvolumeFormComponent;
@@ -19,6 +23,10 @@ describe('CephfsSubvolumeFormComponent', () => {
   let formHelper: FormHelper;
   let createSubVolumeSpy: jasmine.Spy;
   let editSubVolumeSpy: jasmine.Spy;
+  let getSnapshotVisibilitySpy: jasmine.Spy;
+  let configFilterSpy: jasmine.Spy;
+  let subvolumeService: CephfsSubvolumeService;
+  let configurationService: ConfigurationService;
 
   configureTestBed({
     declarations: [CephfsSubvolumeFormComponent],
@@ -41,17 +49,19 @@ describe('CephfsSubvolumeFormComponent', () => {
     component = fixture.componentInstance;
     component.fsName = 'test_volume';
     component.pools = [];
-    component.ngOnInit();
-    formHelper = new FormHelper(component.subvolumeForm);
-    const subvolumeService = TestBed.inject(CephfsSubvolumeService);
+    subvolumeService = TestBed.inject(CephfsSubvolumeService);
+    configurationService = TestBed.inject(ConfigurationService);
     createSubVolumeSpy = spyOn(subvolumeService, 'create').and.returnValue(of({ status: 200 }));
     editSubVolumeSpy = spyOn(subvolumeService, 'update').and.returnValue(of({ status: 200 }));
-    spyOn(subvolumeService, 'setSnapshotVisibility').and.returnValue(of({ status: 200 }));
     spyOn(subvolumeService, 'info').and.returnValue(
       of({ bytes_quota: 'infinite', uid: 0, gid: 0, pool_namespace: false, mode: 755 } as any)
     );
-    spyOn(subvolumeService, 'getSnapshotVisibility').and.returnValue(of('1'));
-    spyOn(TestBed.inject(ConfigurationService), 'filter').and.returnValue(of([]));
+    getSnapshotVisibilitySpy = spyOn(subvolumeService, 'getSnapshotVisibility').and.returnValue(
+      of('1')
+    );
+    configFilterSpy = spyOn(configurationService, 'filter').and.returnValue(of([]));
+    component.ngOnInit();
+    formHelper = new FormHelper(component.subvolumeForm);
     fixture.detectChanges();
   });
 
@@ -87,5 +97,263 @@ describe('CephfsSubvolumeFormComponent', () => {
 
     expect(editSubVolumeSpy).toHaveBeenCalled();
     expect(createSubVolumeSpy).not.toHaveBeenCalled();
+  });
+
+  describe('Snapshot Visibility', () => {
+    it('should show snapshot visibility when config is enabled', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.showSnapshotVisibility).toBe(true);
+    });
+
+    it('should hide snapshot visibility when config is disabled', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'false' }]
+          }
+        ])
+      );
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.showSnapshotVisibility).toBe(false);
+    });
+
+    it('should hide snapshot visibility on config error', () => {
+      configFilterSpy.and.returnValue(throwError(() => new Error('Config error')));
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.showSnapshotVisibility).toBe(false);
+    });
+
+    it('should pass snapshotVisibility to create when visibility config is enabled', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.ngOnInit();
+      formHelper = new FormHelper(component.subvolumeForm);
+      formHelper.setValue('subvolumeName', 'test_subvolume');
+      formHelper.setValue('snapshotVisibility', true);
+      component.submit();
+
+      expect(createSubVolumeSpy).toHaveBeenCalled();
+      const createCallArgs = createSubVolumeSpy.calls.mostRecent().args;
+      expect(createCallArgs[9]).toBe(true);
+    });
+
+    it('should not pass snapshotVisibility to create when visibility config is disabled', () => {
+      configFilterSpy.and.returnValue(of([]));
+      component.ngOnInit();
+      formHelper = new FormHelper(component.subvolumeForm);
+      formHelper.setValue('subvolumeName', 'test_subvolume');
+      component.submit();
+
+      expect(createSubVolumeSpy).toHaveBeenCalled();
+      const createCallArgs = createSubVolumeSpy.calls.mostRecent().args;
+      expect(createCallArgs[9]).toBeUndefined();
+    });
+
+    it('should pass snapshotVisibility to update when visibility config is enabled', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.isEdit = true;
+      component.subVolumeName = 'test_subvolume';
+      component.ngOnInit();
+      formHelper = new FormHelper(component.subvolumeForm);
+      formHelper.setValue('size', 10);
+      formHelper.setValue('snapshotVisibility', false);
+      component.submit();
+
+      expect(editSubVolumeSpy).toHaveBeenCalled();
+      const updateCallArgs = editSubVolumeSpy.calls.mostRecent().args;
+      expect(updateCallArgs[4]).toBe(false);
+    });
+
+    it('should set snapshotVisibility to true when getSnapshotVisibility returns 1', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      getSnapshotVisibilitySpy.and.returnValue(of('1'));
+      component.isEdit = true;
+      component.subVolumeName = 'test_subvolume';
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.subvolumeForm.get('snapshotVisibility').value).toBe(true);
+    });
+
+    it('should set snapshotVisibility to false when getSnapshotVisibility returns 0', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      getSnapshotVisibilitySpy.and.returnValue(of('0'));
+      component.isEdit = true;
+      component.subVolumeName = 'test_subvolume';
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.subvolumeForm.get('snapshotVisibility').value).toBe(false);
+    });
+
+    it('should disable snapshotVisibility control when config is disabled', () => {
+      configFilterSpy.and.returnValue(of([]));
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.subvolumeForm.get('snapshotVisibility').disabled).toBe(true);
+    });
+
+    it('should set snapshotVisibility value to false when config is disabled', () => {
+      configFilterSpy.and.returnValue(of([]));
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.subvolumeForm.get('snapshotVisibility').value).toBe(false);
+    });
+
+    it('should default snapshotVisibility to true in create mode when cephfs_mgr_snap_add_sub_vis config is enabled', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.isEdit = false;
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.subvolumeForm.get('snapshotVisibility').value).toBe(true);
+    });
+
+    it('should not call getSnapshotVisibility in create mode since subvolume does not exist yet', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.isEdit = false;
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(getSnapshotVisibilitySpy).not.toHaveBeenCalled();
+    });
+
+    it('should call getSnapshotVisibility only in edit mode when config is enabled', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.isEdit = true;
+      component.subVolumeName = 'test_subvolume';
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(getSnapshotVisibilitySpy).toHaveBeenCalled();
+    });
+
+    it('should pass snapshotVisibility as true to update when checkbox is checked', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      getSnapshotVisibilitySpy.and.returnValue(of('1'));
+      component.isEdit = true;
+      component.subVolumeName = 'test_subvolume';
+      component.ngOnInit();
+      fixture.detectChanges();
+      formHelper = new FormHelper(component.subvolumeForm);
+      formHelper.setValue('snapshotVisibility', true);
+      component.submit();
+
+      expect(editSubVolumeSpy).toHaveBeenCalled();
+      const updateCallArgs = editSubVolumeSpy.calls.mostRecent().args;
+      expect(updateCallArgs[4]).toBe(true);
+    });
+
+    it('should pass snapshotVisibility as true to create when checkbox is checked', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.ngOnInit();
+      formHelper = new FormHelper(component.subvolumeForm);
+      formHelper.setValue('subvolumeName', 'new_subvolume');
+      formHelper.setValue('snapshotVisibility', true);
+      component.submit();
+
+      expect(createSubVolumeSpy).toHaveBeenCalled();
+      const createCallArgs = createSubVolumeSpy.calls.mostRecent().args;
+      expect(createCallArgs[9]).toBe(true);
+    });
+
+    it('should pass snapshotVisibility as false to create when checkbox is unchecked', () => {
+      configFilterSpy.and.returnValue(
+        of([
+          {
+            name: SNAPSHOT_VISIBILITY_CONFIG_NAME,
+            value: [{ section: SNAPSHOT_VISIBILITY_CONFIG_SECTION, value: 'true' }]
+          }
+        ])
+      );
+      component.ngOnInit();
+      formHelper = new FormHelper(component.subvolumeForm);
+      formHelper.setValue('subvolumeName', 'new_subvolume');
+      formHelper.setValue('snapshotVisibility', false);
+      component.submit();
+
+      expect(createSubVolumeSpy).toHaveBeenCalled();
+      const createCallArgs = createSubVolumeSpy.calls.mostRecent().args;
+      expect(createCallArgs[9]).toBe(false);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
@@ -22,7 +22,7 @@ import { CdForm } from '~/app/shared/forms/cd-form';
 import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
 import { CephfsSubvolumeGroup } from '~/app/shared/models/cephfs-subvolume-group.model';
 import { Observable, of } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 
 @Component({
   selector: 'cd-cephfs-subvolume-form',
@@ -122,7 +122,7 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
       }),
       catchError(() => {
         this.showSnapshotVisibility = false;
-        return of(undefined);
+        return of(null);
       })
     );
   }
@@ -205,25 +205,10 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
           this.loadingReady();
         },
         error: () => {
-          this.subvolumeForm.get('snapshotVisibility').setValue(true);
+          this.subvolumeForm.get('snapshotVisibility').setValue(false);
           this.loadingReady();
         }
       });
-  }
-
-  private setSnapshotVisibility(
-    subVolumeName: string,
-    subVolumeGroupName: string,
-    visible: boolean
-  ) {
-    return this.showSnapshotVisibility
-      ? this.cephFsSubvolumeService.setSnapshotVisibility(
-          this.fsName,
-          subVolumeName,
-          visible,
-          subVolumeGroupName
-        )
-      : of({ status: 200 });
   }
 
   submit() {
@@ -235,24 +220,25 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
     const gid = this.subvolumeForm.getValue('gid');
     const mode = this.formatter.toOctalPermission(this.subvolumeForm.getValue('mode'));
     const isolatedNamespace = this.subvolumeForm.getValue('isolatedNamespace');
-    const snapshotVisibility = this.subvolumeForm.getValue('snapshotVisibility');
+    const snapshotVisibility = this.showSnapshotVisibility
+      ? this.subvolumeForm.getValue('snapshotVisibility')
+      : null;
 
     if (this.isEdit) {
       const editSize = size === 0 ? 'infinite' : size;
-      const visibilityCall = this.setSnapshotVisibility(
-        subVolumeName,
-        subVolumeGroupName,
-        snapshotVisibility
-      );
 
       this.taskWrapper
         .wrapTaskAroundCall({
           task: new FinishedTask('cephfs/subvolume/' + URLVerbs.EDIT, {
             subVolumeName: subVolumeName
           }),
-          call: this.cephFsSubvolumeService
-            .update(this.fsName, subVolumeName, String(editSize), subVolumeGroupName)
-            .pipe(switchMap(() => visibilityCall))
+          call: this.cephFsSubvolumeService.update(
+            this.fsName,
+            subVolumeName,
+            String(editSize),
+            subVolumeGroupName,
+            snapshotVisibility
+          )
         })
         .subscribe({
           error: () => {
@@ -268,23 +254,18 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
           task: new FinishedTask('cephfs/subvolume/' + URLVerbs.CREATE, {
             subVolumeName: subVolumeName
           }),
-          call: this.cephFsSubvolumeService
-            .create(
-              this.fsName,
-              subVolumeName,
-              subVolumeGroupName,
-              pool,
-              String(size),
-              uid,
-              gid,
-              mode,
-              isolatedNamespace
-            )
-            .pipe(
-              switchMap(() =>
-                this.setSnapshotVisibility(subVolumeName, subVolumeGroupName, snapshotVisibility)
-              )
-            )
+          call: this.cephFsSubvolumeService.create(
+            this.fsName,
+            subVolumeName,
+            subVolumeGroupName,
+            pool,
+            String(size),
+            uid,
+            gid,
+            mode,
+            isolatedNamespace,
+            snapshotVisibility
+          )
         })
         .subscribe({
           error: () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume.service.ts
@@ -1,6 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { CephfsSubvolume, SubvolumeSnapshot } from '../models/cephfs-subvolume.model';
+import {
+  CephfsSubvolume,
+  SubvolumeSnapshot,
+  UpdateSubvolume
+} from '../models/cephfs-subvolume.model';
 import { Observable, of } from 'rxjs';
 import { catchError, mapTo } from 'rxjs/operators';
 import _ from 'lodash';
@@ -31,23 +35,24 @@ export class CephfsSubvolumeService {
     uid: number,
     gid: number,
     mode: string,
-    namespace: boolean
+    namespace: boolean,
+    snapshotVisibility?: boolean
   ) {
-    return this.http.post(
-      this.baseURL,
-      {
-        vol_name: fsName,
-        subvol_name: subVolumeName,
-        group_name: subVolumeGroupName,
-        pool_layout: poolName,
-        size: size,
-        uid: uid,
-        gid: gid,
-        mode: mode,
-        namespace_isolated: namespace
-      },
-      { observe: 'response' }
-    );
+    const body: Record<string, any> = {
+      vol_name: fsName,
+      subvol_name: subVolumeName,
+      group_name: subVolumeGroupName,
+      pool_layout: poolName,
+      size: size,
+      uid: uid,
+      gid: gid,
+      mode: mode,
+      namespace_isolated: namespace
+    };
+    if (snapshotVisibility !== null) {
+      body['snapshot_visibility'] = snapshotVisibility.toString();
+    }
+    return this.http.post(this.baseURL, body, { observe: 'response' });
   }
 
   info(fsName: string, subVolumeName: string, subVolumeGroupName: string = '') {
@@ -95,12 +100,22 @@ export class CephfsSubvolumeService {
     });
   }
 
-  update(fsName: string, subVolumeName: string, size: string, subVolumeGroupName: string = '') {
-    return this.http.put(`${this.baseURL}/${fsName}`, {
+  update(
+    fsName: string,
+    subVolumeName: string,
+    size: string,
+    subVolumeGroupName: string = '',
+    snapshotVisibility?: boolean
+  ) {
+    const body: UpdateSubvolume = {
       subvol_name: subVolumeName,
       size: size,
       group_name: subVolumeGroupName
-    });
+    };
+    if (snapshotVisibility !== null) {
+      body.snapshot_visibility = snapshotVisibility.toString();
+    }
+    return this.http.put(`${this.baseURL}/${fsName}`, body);
   }
 
   getSnapshotVisibility(fsName: string, subVolumeName: string, groupName: string = '') {
@@ -109,19 +124,6 @@ export class CephfsSubvolumeService {
         subvol_name: subVolumeName,
         group_name: groupName
       }
-    });
-  }
-
-  setSnapshotVisibility(
-    fsName: string,
-    subVolumeName: string,
-    visible: boolean,
-    groupName: string = ''
-  ) {
-    return this.http.put(`${this.baseURL}/${fsName}/snapshot-visibility`, {
-      subvol_name: subVolumeName,
-      group_name: groupName,
-      value: visible.toString()
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs-subvolume.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs-subvolume.model.ts
@@ -27,6 +27,13 @@ export interface SubvolumeSnapshotInfo {
   has_pending_clones: string;
 }
 
+export interface UpdateSubvolume {
+  subvol_name: string;
+  size: string;
+  group_name: string;
+  snapshot_visibility?: string;
+}
+
 export const SNAPSHOT_VISIBILITY_CONFIG_NAME = 'client_respect_subvolume_snapshot_visibility';
 
 export const SNAPSHOT_VISIBILITY_CONFIG_SECTION = 'client';

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3955,6 +3955,8 @@ paths:
           application/json:
             schema:
               properties:
+                snapshot_visibility:
+                  type: string
                 subvol_name:
                   type: string
                 vol_name:
@@ -4589,6 +4591,8 @@ paths:
                   type: string
                 size:
                   type: integer
+                snapshot_visibility:
+                  type: string
                 subvol_name:
                   type: string
               required:
@@ -4745,7 +4749,7 @@ paths:
       - jwt: []
       tags:
       - CephFSSubvolume
-    put:
+    patch:
       parameters:
       - in: path
         name: vol_name
@@ -4778,15 +4782,6 @@ paths:
               schema:
                 type: object
           description: Resource updated.
-        '202':
-          content:
-            application/json:
-              schema:
-                type: object
-            application/vnd.ceph.api.v1.0+json:
-              schema:
-                type: object
-          description: Operation is still executing. Please check the task queue.
         '400':
           description: Operation exception. Please check the response body for details.
         '401':


### PR DESCRIPTION
Signed-off-by: Dnyaneshwari Talwekar <dtalweka@redhat.com>

Fixes: https://tracker.ceph.com/issues/75347





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
