### PR TITLE
Add enhanced logging and performance counters for Client IO operations

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12070,13 +12070,10 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // Release C_Read_Async_Finisher from managed pointer, we need to complete
     // immediately. The C_Read_Async_Finisher is safely handled and won't be
     // abandoned.
-    Context *crf = io_finish.release();
+    io_finish.reset();
 
-    logger->inc(l_c_aio_ops);
-    logger->inc(l_c_aio_in_flight);
-
-    // Complete the crf immediately with 0 bytes
-    crf->complete(0);
+    // Complete the onfinish immediately with 0 bytes
+    onfinish->complete(0);
 
     // Signal async completion
     return 0;
@@ -15875,159 +15872,159 @@ size_t Client::_vxattrcb_client_id(Inode *in, char *val, size_t size)
 #define CEPH_XATTR_NAME(_type, _name) "ceph." #_type "." #_name
 #define CEPH_XATTR_NAME2(_type, _name, _name2) "ceph." #_type "." #_name "." #_name2
 
-#define XATTR_NAME_CEPH(_type, _name, _flags)                 \
-{                                                              \
-  name: CEPH_XATTR_NAME(_type, _name),                         \
-  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,     \
-  readonly: true,                                              \
-  exists_cb: NULL,                                             \
-  flags: _flags,                                               \
-}
-#define XATTR_LAYOUT_FIELD(_type, _name, _field)		\
-{								\
-  name: CEPH_XATTR_NAME2(_type, _name, _field),			\
-  getxattr_cb: &Client::_vxattrcb_ ## _name ## _ ## _field,	\
-  readonly: false,						\
-  exists_cb: &Client::_vxattrcb_layout_exists,			\
-  flags: 0,                                                     \
-}
-#define XATTR_QUOTA_FIELD(_type, _name)		                \
-{								\
-  name: CEPH_XATTR_NAME(_type, _name),			        \
-  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,	\
-  readonly: false,						\
-  exists_cb: &Client::_vxattrcb_quota_exists,			\
-  flags: 0,                                                     \
-}
+#define XATTR_NAME_CEPH(_type, _name, _flags)              \
+  {                                                        \
+      .name = CEPH_XATTR_NAME(_type, _name),               \
+      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
+      .readonly = true,                                    \
+      .exists_cb = NULL,                                   \
+      .flags = _flags,                                     \
+  }
+#define XATTR_LAYOUT_FIELD(_type, _name, _field)            \
+  {                                                         \
+      .name = CEPH_XATTR_NAME2(_type, _name, _field),       \
+      .getxattr_cb = &Client::_vxattrcb_##_name##_##_field, \
+      .readonly = false,                                    \
+      .exists_cb = &Client::_vxattrcb_layout_exists,        \
+      .flags = 0,                                           \
+  }
+#define XATTR_QUOTA_FIELD(_type, _name)                    \
+  {                                                        \
+      .name = CEPH_XATTR_NAME(_type, _name),               \
+      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
+      .readonly = false,                                   \
+      .exists_cb = &Client::_vxattrcb_quota_exists,        \
+      .flags = 0,                                          \
+  }
 
 const Client::VXattr Client::_dir_vxattrs[] = {
-  {
-    name: "ceph.dir.layout",
-    getxattr_cb: &Client::_vxattrcb_layout,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_layout_exists,
-    flags: 0,
-  },
-  // FIXME
-  // Delete the following dir layout field definitions for release "S"
-  XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
-  XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
-  XATTR_LAYOUT_FIELD(dir, layout, object_size),
-  XATTR_LAYOUT_FIELD(dir, layout, pool),
-  XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
-  XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
-  XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
-  XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
-  XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
-  {
-    name: "ceph.quota",
-    getxattr_cb: &Client::_vxattrcb_quota,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_quota_exists,
-    flags: 0,
-  },
-  XATTR_QUOTA_FIELD(quota, max_bytes),
-  XATTR_QUOTA_FIELD(quota, max_files),
-  // FIXME
-  // Delete the following dir pin field definitions for release "S"
-  {
-    name: "ceph.dir.pin",
-    getxattr_cb: &Client::_vxattrcb_dir_pin,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_dir_pin_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.snap.btime",
-    getxattr_cb: &Client::_vxattrcb_snap_btime,
-    readonly: true,
-    exists_cb: &Client::_vxattrcb_snap_btime_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.mirror.info",
-    getxattr_cb: &Client::_vxattrcb_mirror_info,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_mirror_info_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.caps",
-    getxattr_cb: &Client::_vxattrcb_caps,
-    readonly: true,
-    exists_cb: NULL,
-    flags: 0,
-  },
-  { name: "" }     /* Required table terminator */
+    {
+        .name = "ceph.dir.layout",
+        .getxattr_cb = &Client::_vxattrcb_layout,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_layout_exists,
+        .flags = 0,
+    },
+    // FIXME
+    // Delete the following dir layout field definitions for release "S"
+    XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
+    XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
+    XATTR_LAYOUT_FIELD(dir, layout, object_size),
+    XATTR_LAYOUT_FIELD(dir, layout, pool),
+    XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
+    XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
+    XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
+    XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
+    XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
+    {
+        .name = "ceph.quota",
+        .getxattr_cb = &Client::_vxattrcb_quota,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_quota_exists,
+        .flags = 0,
+    },
+    XATTR_QUOTA_FIELD(quota, max_bytes),
+    XATTR_QUOTA_FIELD(quota, max_files),
+    // FIXME
+    // Delete the following dir pin field definitions for release "S"
+    {
+        .name = "ceph.dir.pin",
+        .getxattr_cb = &Client::_vxattrcb_dir_pin,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_dir_pin_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.snap.btime",
+        .getxattr_cb = &Client::_vxattrcb_snap_btime,
+        .readonly = true,
+        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.mirror.info",
+        .getxattr_cb = &Client::_vxattrcb_mirror_info,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_mirror_info_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.caps",
+        .getxattr_cb = &Client::_vxattrcb_caps,
+        .readonly = true,
+        .exists_cb = NULL,
+        .flags = 0,
+    },
+    {.name = ""} /* Required table terminator */
 };
 
 const Client::VXattr Client::_file_vxattrs[] = {
-  {
-    name: "ceph.file.layout",
-    getxattr_cb: &Client::_vxattrcb_layout,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_layout_exists,
-    flags: 0,
-  },
-  XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
-  XATTR_LAYOUT_FIELD(file, layout, stripe_count),
-  XATTR_LAYOUT_FIELD(file, layout, object_size),
-  XATTR_LAYOUT_FIELD(file, layout, pool),
-  XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
-  {
-    name: "ceph.snap.btime",
-    getxattr_cb: &Client::_vxattrcb_snap_btime,
-    readonly: true,
-    exists_cb: &Client::_vxattrcb_snap_btime_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.caps",
-    getxattr_cb: &Client::_vxattrcb_caps,
-    readonly: true,
-    exists_cb: NULL,
-    flags: 0,
-  },
-  { name: "" }     /* Required table terminator */
+    {
+        .name = "ceph.file.layout",
+        .getxattr_cb = &Client::_vxattrcb_layout,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_layout_exists,
+        .flags = 0,
+    },
+    XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
+    XATTR_LAYOUT_FIELD(file, layout, stripe_count),
+    XATTR_LAYOUT_FIELD(file, layout, object_size),
+    XATTR_LAYOUT_FIELD(file, layout, pool),
+    XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
+    {
+        .name = "ceph.snap.btime",
+        .getxattr_cb = &Client::_vxattrcb_snap_btime,
+        .readonly = true,
+        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.caps",
+        .getxattr_cb = &Client::_vxattrcb_caps,
+        .readonly = true,
+        .exists_cb = NULL,
+        .flags = 0,
+    },
+    {.name = ""} /* Required table terminator */
 };
 
 const Client::VXattr Client::_common_vxattrs[] = {
-  {
-    name: "ceph.cluster_fsid",
-    getxattr_cb: &Client::_vxattrcb_cluster_fsid,
-    readonly: true,
-    exists_cb: nullptr,
-    flags: 0,
-  },
-  {
-    name: "ceph.client_id",
-    getxattr_cb: &Client::_vxattrcb_client_id,
-    readonly: true,
-    exists_cb: nullptr,
-    flags: 0,
-  },
-  {
-    name: "ceph.fscrypt.auth",
-    getxattr_cb: &Client::_vxattrcb_fscrypt_auth,
-    setxattr_cb: &Client::_vxattrcb_fscrypt_auth_set,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_fscrypt_auth_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.fscrypt.file",
-    getxattr_cb: &Client::_vxattrcb_fscrypt_file,
-    setxattr_cb: &Client::_vxattrcb_fscrypt_file_set,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_fscrypt_file_exists,
-    flags: 0,
-  },
-  { name: "" }     /* Required table terminator */
+    {
+        .name = "ceph.cluster_fsid",
+        .getxattr_cb = &Client::_vxattrcb_cluster_fsid,
+        .readonly = true,
+        .exists_cb = nullptr,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.client_id",
+        .getxattr_cb = &Client::_vxattrcb_client_id,
+        .readonly = true,
+        .exists_cb = nullptr,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.fscrypt.auth",
+        .getxattr_cb = &Client::_vxattrcb_fscrypt_auth,
+        .setxattr_cb = &Client::_vxattrcb_fscrypt_auth_set,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_fscrypt_auth_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.fscrypt.file",
+        .getxattr_cb = &Client::_vxattrcb_fscrypt_file,
+        .setxattr_cb = &Client::_vxattrcb_fscrypt_file_set,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_fscrypt_file_exists,
+        .flags = 0,
+    },
+    {.name = ""} /* Required table terminator */
 };
 
 const Client::VXattr *Client::_get_vxattrs(Inode *in)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12098,6 +12098,8 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // Release C_Read_Async_Finisher from managed pointer, we need to complete
     // immediately. The C_Read_Async_Finisher is safely handled and won't be
     // abandoned.
+
+    // Complete the crf immediately with 0 bytes
     io_finish.release()->complete(0);
 
     // Signal async completion

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4317,7 +4317,6 @@ void Client::send_cap(Inode *in, MetaSession *session, Cap *cap,
   if (!session->flushing_caps_tids.empty())
     m->set_oldest_flush_tid(*session->flushing_caps_tids.begin());
 
-  inc_caps_release();
   session->con->send_message2(std::move(m));
 }
 
@@ -4506,6 +4505,7 @@ void Client::check_caps(const InodeRef& in, unsigned flags)
     in->delay_cap_item.remove_myself();
     send_cap(in.get(), session.get(), &cap, msg_flags, cap_used, wanted, retain,
 	     flushing, flush_tid);
+    inc_caps_release();
   }
 }
 
@@ -5437,6 +5437,7 @@ void Client::kick_flushing_caps(Inode *in, MetaSession *session)
       int msg_flags = p.first < last_snap_flush ? MClientCaps::FLAG_PENDING_CAPSNAP : 0;
       send_cap(in, session, cap, msg_flags, used, wanted, (cap->issued | cap->implemented),
 	       p.second, p.first);
+      inc_caps_release();
     } else {
       ceph_assert(it != in->cap_snaps.end());
       ceph_assert(it->second.flush_tid == p.first);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -752,6 +752,7 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
     plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
     plb.add_u64_counter(l_c_fscrypt_wr_amp, "fscrypt_wr_amp", "Extra bytes written due to padding and RMW");
+    plb.add_u64_counter(l_c_fscrypt_rd_amp, "fscrypt_rd_amp", "Extra bytes read due to block alignment");
     plb.add_time_avg(l_c_fscrypt_enc_lat, "fscrypt_enc_lat", "Encryption time");
     plb.add_time_avg(l_c_fscrypt_dec_lat, "fscrypt_dec_lat", "Decryption time");
     plb.add_time_avg(l_c_fscrypt_rd_lat, "fscrypt_rd_lat", "Overall fscrypt read latency");
@@ -11719,6 +11720,9 @@ success:
   if (r >= 0) {
 #if defined(__linux__)
     if (fscrypt_denc) {
+      if (read_len > target_len) {
+        clnt->logger->inc(l_c_fscrypt_rd_amp, read_len - target_len);
+      }
       std::vector<ObjectCacher::ObjHole> holes;
       auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
@@ -12158,6 +12162,9 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
   if (r >= 0) {
 #if defined(__linux__) 
     if (fscrypt_denc) {
+      if (read_len > target_len) {
+        logger->inc(l_c_fscrypt_rd_amp, read_len - target_len);
+      }
       auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, bl);
       logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
@@ -12288,6 +12295,9 @@ uint64_t read_start;
   if (r >= 0) {
 #if defined(__linux__)
     if (fscrypt_denc) {
+      if (read_len > target_len) {
+        logger->inc(l_c_fscrypt_rd_amp, read_len - target_len);
+      }
       std::vector<ObjectCacher::ObjHole> holes;
       auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
@@ -12715,6 +12725,7 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
   }
 
   if (need_read_end) {
+    clnt->logger->inc(l_c_fscrypt_wr_amp, FSCRYPT_BLOCK_SIZE);
     finish_read_end_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_end_cb, &aioc));
 
     r = read(end_block_ofs, FSCRYPT_BLOCK_SIZE, &endbl, finish_read_end_ctx.get());

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11983,6 +11983,12 @@ void Client::do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len)
       int r2 = objectcacher->file_read(&in->oset, &in->layout, in->snapid,
 				       readahead_extent.first, readahead_extent.second,
 				       NULL, 0, onfinish2);
+      if (r2 > 0) {
+	logger->inc(l_c_osdc_hit);
+      } else if (r2 == 0) {
+	logger->inc(l_c_osdc_miss);
+      }
+
       if (r2 == 0) {
 	ldout(cct, 20) << "readahead initiated, c " << onfinish2 << dendl;
 	get_cap_ref(in, CEPH_CAP_FILE_RD | CEPH_CAP_FILE_CACHE);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -751,7 +751,8 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_caps_grant, "caps_grant", "Capability grants");
     plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
     plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
-    plb.add_u64_counter(l_c_fscrypt_wr_amp, "fscrypt_wr_amp", "Extra bytes written due to padding and RMW");
+    plb.add_u64_avg(l_c_fscrypt_wr_amp, "fscrypt_wr_amp",
+		    "Average fscrypt write amplification ratio (x100)");
     plb.add_u64_counter(l_c_fscrypt_rd_amp, "fscrypt_rd_amp", "Extra bytes read due to block alignment");
     plb.add_time_avg(l_c_fscrypt_enc_lat, "fscrypt_enc_lat", "Encryption time");
     plb.add_time_avg(l_c_fscrypt_dec_lat, "fscrypt_dec_lat", "Decryption time");
@@ -12709,6 +12710,14 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
   end_block_ofs = fscrypt_block_start(endoff - 1);
   ofs_in_end_block = fscrypt_ofs_in_block(endoff - 1);
 
+  // Write amplification is the ratio of aligned physical span to logical
+  // write size (e.g. write(4000, 8192) spans 0..12288 -> amp 1.5).
+  if (size > 0) {
+    uint64_t aligned_end = fscrypt_next_block_start(offset + size);
+    uint64_t amp_x100 = ((aligned_end - start_block_ofs) * 100) / size;
+    clnt->logger->inc(l_c_fscrypt_wr_amp, amp_x100);
+  }
+
   need_read_start = ofs_in_start_block > 0 || (ofs_in_start_block == 0 && ((endoff - offset) < FSCRYPT_BLOCK_SIZE));
   need_read_end = (endoff <= in->effective_size() && ofs_in_end_block < FSCRYPT_BLOCK_SIZE && start_block != end_block);
   read_start_size = FSCRYPT_BLOCK_SIZE;
@@ -12717,7 +12726,6 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
 
 
   if (need_read_start) {
-    clnt->logger->inc(l_c_fscrypt_wr_amp, read_start_size);
     finish_read_start_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_start_cb, &aioc));
 
     r = read(start_block_ofs, read_start_size, &startbl, finish_read_start_ctx.get());
@@ -12730,7 +12738,6 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
   }
 
   if (need_read_end) {
-    clnt->logger->inc(l_c_fscrypt_wr_amp, FSCRYPT_BLOCK_SIZE);
     finish_read_end_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_end_cb, &aioc));
 
     r = read(end_block_ofs, FSCRYPT_BLOCK_SIZE, &endbl, finish_read_end_ctx.get());
@@ -12856,9 +12863,6 @@ bool Client::WriteEncMgr::do_try_finish(int r)
     }
 
     size = encbl.length();
-    if (size > bl.length()) {
-      clnt->logger->inc(l_c_fscrypt_wr_amp, size - bl.length());
-    }
   }
 
   clnt->put_cap_ref(in, CEPH_CAP_FILE_RD);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12074,10 +12074,7 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // Release C_Read_Async_Finisher from managed pointer, we need to complete
     // immediately. The C_Read_Async_Finisher is safely handled and won't be
     // abandoned.
-    io_finish.reset();
-
-    // Complete the onfinish immediately with 0 bytes
-    onfinish->complete(0);
+    io_finish.release()->complete(0);
 
     // Signal async completion
     return 0;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12602,6 +12602,9 @@ bool Client::C_Write_Finisher::try_complete()
       ldout(clnt->cct, 19) << " complete with iofinished_r " << iofinished_r << dendl;
       onfinish->complete(iofinished_r);
     }
+    if (encrypted) {
+      clnt->logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
+    }
     clnt->logger->inc(l_c_aio_completions);
     clnt->logger->dec(l_c_aio_in_flight);
     onfinish = nullptr;
@@ -12851,7 +12854,6 @@ bool Client::WriteEncMgr::do_try_finish(int r)
     }
 
     size = encbl.length();
-    clnt->logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
     if (size > bl.length()) {
       clnt->logger->inc(l_c_fscrypt_wr_amp, size - bl.length());
     }
@@ -13193,6 +13195,9 @@ success:
   // do not get here if non-blocking caller (onfinish != nullptr)
   ldout(cct, 10) << " _write_filer_succeess" << dendl;
   r = _write_success(f, start, fpos, request_offset, request_size, enc_mgr->get_ofs(), enc_mgr->get_size(), in, enc_mgr->encrypted());
+  if (enc_mgr->encrypted()) {
+    logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
+  }
 
   if (r >= 0 && do_fsync) {
     int64_t r1;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -751,6 +751,11 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_caps_grant, "caps_grant", "Capability grants");
     plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
     plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
+    plb.add_u64_counter(l_c_fscrypt_wr_amp, "fscrypt_wr_amp", "Extra bytes written due to padding and RMW");
+    plb.add_time_avg(l_c_fscrypt_enc_lat, "fscrypt_enc_lat", "Encryption time");
+    plb.add_time_avg(l_c_fscrypt_dec_lat, "fscrypt_dec_lat", "Decryption time");
+    plb.add_time_avg(l_c_fscrypt_rd_lat, "fscrypt_rd_lat", "Overall fscrypt read latency");
+    plb.add_time_avg(l_c_fscrypt_wr_lat, "fscrypt_wr_lat", "Overall fscrypt write latency");
     logger.reset(plb.create_perf_counters());
     cct->get_perfcounters_collection()->add(logger.get());
   }
@@ -8850,7 +8855,9 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
 	header.data_len = (8 + 8 + 4);
 	header.file_offset = 0;
       } else {
+        auto dec_start = mono_clock_now();
         r = fscrypt_denc->decrypt_bl(offset, target_len, read_start, holes, &bl);
+        logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
 
         if (r < 0) {
           ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
@@ -8859,7 +8866,9 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
 
 	// 2. encrypt bl
         if (fscrypt_denc) {
+          auto enc_start = mono_clock_now();
           r = fscrypt_denc->encrypt_bl(offset, bl.length(), bl, &ebl);
+          logger->tinc(l_c_fscrypt_enc_lat, mono_clock_now() - enc_start);
 	}
 
         header.data_len = (8 + 8 + 4 + ebl.length());
@@ -11711,11 +11720,14 @@ success:
 #if defined(__linux__)
     if (fscrypt_denc) {
       std::vector<ObjectCacher::ObjHole> holes;
+      auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
+      clnt->logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
 	ldout(clnt->cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
       }
       bl->claim_append(*pbl);
+      clnt->logger->tinc(l_c_fscrypt_rd_lat, mono_clock_now() - start_time);
     }
 #endif
     // r is expected to hold value of effective bytes read.
@@ -12005,7 +12017,9 @@ void Client::C_Read_Async_Finisher::finish(int r)
 #if defined(__linux__)
   if (denc && r > 0) {
       std::vector<ObjectCacher::ObjHole> holes;
+      auto dec_start = mono_clock_now();
       r = denc->decrypt_bl(off, len, read_start, holes, bl);
+      clnt->logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
         // ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
       } else {
@@ -12144,11 +12158,14 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
   if (r >= 0) {
 #if defined(__linux__) 
     if (fscrypt_denc) {
+      auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, bl);
+      logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
         ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
         return r;
       }
+      logger->tinc(l_c_fscrypt_rd_lat, mono_clock_now() - start_time);
     }
 #endif
     r = bl->length();
@@ -12203,6 +12220,7 @@ uint64_t read_start;
 #endif
   ldout(cct, 10) << __func__ << " " << *in << " " << off << "~" << len << dendl;
 
+  auto start_time = mono_clock_now();
   // 0 success, 1 continue and < 0 error happen.
   auto wait_and_copy = [&](C_SaferCond &onfinish, bufferlist &tbl, int wanted) {
     int r = onfinish.wait();
@@ -12271,13 +12289,16 @@ uint64_t read_start;
 #if defined(__linux__)
     if (fscrypt_denc) {
       std::vector<ObjectCacher::ObjHole> holes;
+      auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
+      logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
         ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
       }
 
       read = pbl->length();
       bl->claim_append(*pbl);
+      logger->tinc(l_c_fscrypt_rd_lat, mono_clock_now() - start_time);
     } else
 #endif
       read = pbl->length();
@@ -12592,6 +12613,7 @@ Client::WriteEncMgr::WriteEncMgr(Client *clnt,
                                                    offset(offset), size(size), bl(bl),
                                                    async(async)
 {
+  start = mono_clock_now();
 #if defined(__linux__)
   denc = fscrypt->get_fdata_denc(in->fscrypt_ctx, &in->fscrypt_key_validator);
 #endif
@@ -12680,6 +12702,7 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
 
 
   if (need_read_start) {
+    clnt->logger->inc(l_c_fscrypt_wr_amp, read_start_size);
     finish_read_start_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_start_cb, &aioc));
 
     r = read(start_block_ofs, read_start_size, &startbl, finish_read_start_ctx.get());
@@ -12809,12 +12832,18 @@ bool Client::WriteEncMgr::do_try_finish(int r)
     offset = start_block_ofs;
 
     pbl = &encbl;
+    auto enc_start = mono_clock_now();
     r = denc->encrypt_bl(offset, bl.length(), bl, &encbl);
+    clnt->logger->tinc(l_c_fscrypt_enc_lat, mono_clock_now() - enc_start);
     if (r < 0) {
       ldout(cct, 0) << "failed to encrypt bl: r=" << r << dendl;
     }
 
     size = encbl.length();
+    clnt->logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
+    if (size > bl.length()) {
+      clnt->logger->inc(l_c_fscrypt_wr_amp, size - bl.length());
+    }
   }
 
   clnt->put_cap_ref(in, CEPH_CAP_FILE_RD);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -692,6 +692,65 @@ void Client::_finish_init()
     plb.add_time(l_c_wr_avg, "writeavg", "Average latency for processing write requests");
     plb.add_u64(l_c_wr_sqsum, "writesqsum", "Sum of squares ((to calculate variability/stdev) for write requests");
     plb.add_u64(l_c_wr_ops, "wrops", "Total write IO operations");
+    plb.add_u64_avg(l_c_rd_sz_avg, "rd_sz_avg", "Average read size");
+    plb.add_u64(l_c_rd_sz_sqsum, "rd_sz_sqsum", "Sum of squares for read size");
+    plb.add_u64_avg(l_c_wr_sz_avg, "wr_sz_avg", "Average write size");
+    plb.add_u64(l_c_wr_sz_sqsum, "wr_sz_sqsum", "Sum of squares for write size");
+    plb.add_u64_counter(l_c_aio_ops, "aio_ops", "Total async IO operations");
+    plb.add_u64_counter(l_c_aio_completions, "aio_completions", "Total async IO completions");
+    plb.add_u64(l_c_aio_in_flight, "aio_in_flight", "Async IO operations in flight");
+    plb.add_u64_counter(l_c_osdc_hit, "osdc_hit", "OSDC cache hits");
+    plb.add_u64_counter(l_c_osdc_miss, "osdc_miss", "OSDC cache misses");
+    plb.add_u64(l_c_osdc_dirty, "osdc_dirty", "OSDC dirty buffer size");
+    plb.add_u64_counter(l_c_mds_req, "mds_req", "Total MDS requests");
+    plb.add_u64_counter(l_c_mds_req_lookup, "mds_req_lookup", "MDS lookup requests");
+    plb.add_u64_counter(l_c_mds_req_getattr, "mds_req_getattr", "MDS getattr requests");
+    plb.add_u64_counter(l_c_mds_req_lookuphash, "mds_req_lookuphash", "MDS lookuphash requests");
+    plb.add_u64_counter(l_c_mds_req_lookupparent, "mds_req_lookupparent", "MDS lookupparent requests");
+    plb.add_u64_counter(l_c_mds_req_lookupino, "mds_req_lookupino", "MDS lookupino requests");
+    plb.add_u64_counter(l_c_mds_req_lookupname, "mds_req_lookupname", "MDS lookupname requests");
+    plb.add_u64_counter(l_c_mds_req_getvxattr, "mds_req_getvxattr", "MDS getvxattr requests");
+    plb.add_u64_counter(l_c_mds_req_dummy, "mds_req_dummy", "MDS dummy requests");
+    plb.add_u64_counter(l_c_mds_req_setxattr, "mds_req_setxattr", "MDS setxattr requests");
+    plb.add_u64_counter(l_c_mds_req_rmxattr, "mds_req_rmxattr", "MDS rmxattr requests");
+    plb.add_u64_counter(l_c_mds_req_setlayout, "mds_req_setlayout", "MDS setlayout requests");
+    plb.add_u64_counter(l_c_mds_req_setattr, "mds_req_setattr", "MDS setattr requests");
+    plb.add_u64_counter(l_c_mds_req_setfilelock, "mds_req_setfilelock", "MDS setfilelock requests");
+    plb.add_u64_counter(l_c_mds_req_getfilelock, "mds_req_getfilelock", "MDS getfilelock requests");
+    plb.add_u64_counter(l_c_mds_req_setdirlayout, "mds_req_setdirlayout", "MDS setdirlayout requests");
+    plb.add_u64_counter(l_c_mds_req_mknod, "mds_req_mknod", "MDS mknod requests");
+    plb.add_u64_counter(l_c_mds_req_link, "mds_req_link", "MDS link requests");
+    plb.add_u64_counter(l_c_mds_req_unlink, "mds_req_unlink", "MDS unlink requests");
+    plb.add_u64_counter(l_c_mds_req_rename, "mds_req_rename", "MDS rename requests");
+    plb.add_u64_counter(l_c_mds_req_mkdir, "mds_req_mkdir", "MDS mkdir requests");
+    plb.add_u64_counter(l_c_mds_req_rmdir, "mds_req_rmdir", "MDS rmdir requests");
+    plb.add_u64_counter(l_c_mds_req_symlink, "mds_req_symlink", "MDS symlink requests");
+    plb.add_u64_counter(l_c_mds_req_create, "mds_req_create", "MDS create requests");
+    plb.add_u64_counter(l_c_mds_req_open, "mds_req_open", "MDS open requests");
+    plb.add_u64_counter(l_c_mds_req_readdir, "mds_req_readdir", "MDS readdir requests");
+    plb.add_u64_counter(l_c_mds_req_lookupsnap, "mds_req_lookupsnap", "MDS lookupsnap requests");
+    plb.add_u64_counter(l_c_mds_req_mksnap, "mds_req_mksnap", "MDS mksnap requests");
+    plb.add_u64_counter(l_c_mds_req_rmsnap, "mds_req_rmsnap", "MDS rmsnap requests");
+    plb.add_u64_counter(l_c_mds_req_lssnap, "mds_req_lssnap", "MDS lssnap requests");
+    plb.add_u64_counter(l_c_mds_req_renamesnap, "mds_req_renamesnap", "MDS renamesnap requests");
+    plb.add_u64_counter(l_c_mds_req_readdir_snapdiff, "mds_req_readdir_snapdiff", "MDS readdir_snapdiff requests");
+    plb.add_u64_counter(l_c_mds_req_file_blockdiff, "mds_req_file_blockdiff", "MDS file_blockdiff requests");
+    plb.add_u64_counter(l_c_mds_req_fragmentdir, "mds_req_fragmentdir", "MDS fragmentdir requests");
+    plb.add_u64_counter(l_c_mds_req_exportdir, "mds_req_exportdir", "MDS exportdir requests");
+    plb.add_u64_counter(l_c_mds_req_flush, "mds_req_flush", "MDS flush requests");
+    plb.add_u64_counter(l_c_mds_req_enqueue_scrub, "mds_req_enqueue_scrub", "MDS enqueue_scrub requests");
+    plb.add_u64_counter(l_c_mds_req_repair_fragstats, "mds_req_repair_fragstats", "MDS repair_fragstats requests");
+    plb.add_u64_counter(l_c_mds_req_repair_inodestats, "mds_req_repair_inodestats", "MDS repair_inodestats requests");
+    plb.add_u64_counter(l_c_mds_req_rdlock_fragsstats, "mds_req_rdlock_fragsstats", "MDS rdlock_fragsstats requests");
+    plb.add_u64_counter(l_c_mds_req_quiesce_path, "mds_req_quiesce_path", "MDS quiesce_path requests");
+    plb.add_u64_counter(l_c_mds_req_quiesce_inode, "mds_req_quiesce_inode", "MDS quiesce_inode requests");
+    plb.add_u64_counter(l_c_mds_req_lock_path, "mds_req_lock_path", "MDS lock_path requests");
+    plb.add_u64_counter(l_c_mds_req_uninline_data, "mds_req_uninline_data", "MDS uninline_data requests");
+    plb.add_u64(l_c_caps, "caps", "Capabilities");
+    plb.add_u64(l_c_caps_dirty, "caps_dirty", "Dirty capabilities");
+    plb.add_u64_counter(l_c_caps_grant, "caps_grant", "Capability grants");
+    plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
+    plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
     logger.reset(plb.create_perf_counters());
     cct->get_perfcounters_collection()->add(logger.get());
   }
@@ -955,6 +1014,38 @@ void Client::trim_dentry(Dentry *dn)
   unlink(dn, false, false);  // drop dir, drop dentry
 }
 
+
+void Client::update_read_io_size(size_t size) {
+  total_read_ops++;
+  total_read_size += size;
+
+  if (logger) {
+    auto o_avg = logger->get(l_c_rd_sz_avg);
+    auto o_sqsum = logger->get(l_c_rd_sz_sqsum);
+
+    auto n_avg = calc_average(o_avg, size, total_read_ops);
+    auto n_sqsum = calc_sq_sum(o_sqsum, o_avg, n_avg, size, total_read_ops);
+
+    logger->set(l_c_rd_sz_avg, (uint64_t)n_avg);
+    logger->set(l_c_rd_sz_sqsum, (uint64_t)n_sqsum);
+  }
+}
+
+void Client::update_write_io_size(size_t size) {
+  total_write_ops++;
+  total_write_size += size;
+
+  if (logger) {
+    auto o_avg = logger->get(l_c_wr_sz_avg);
+    auto o_sqsum = logger->get(l_c_wr_sz_sqsum);
+
+    auto n_avg = calc_average(o_avg, size, total_write_ops);
+    auto n_sqsum = calc_sq_sum(o_sqsum, o_avg, n_avg, size, total_write_ops);
+
+    logger->set(l_c_wr_sz_avg, (uint64_t)n_avg);
+    logger->set(l_c_wr_sz_sqsum, (uint64_t)n_sqsum);
+  }
+}
 
 void Client::update_inode_file_size(Inode *in, int issued, uint64_t size,
 				    uint64_t truncate_seq, uint64_t truncate_size)
@@ -2450,6 +2541,7 @@ int Client::encode_inode_release(Inode *in, MetaRequest *req,
       rel.wanted = cap.wanted;
       rel.dname_len = 0;
       rel.dname_seq = 0;
+      inc_caps_release();
       req->cap_releases.push_back(MClientRequest::Release(rel,""));
     }
   }
@@ -2851,6 +2943,53 @@ void Client::send_request(MetaRequest *request, MetaSession *session,
   }
 
   session->requests.push_back(&request->item);
+
+  logger->inc(l_c_mds_req);
+  switch (request->get_op()) {
+    case CEPH_MDS_OP_LOOKUP: logger->inc(l_c_mds_req_lookup); break;
+    case CEPH_MDS_OP_GETATTR: logger->inc(l_c_mds_req_getattr); break;
+    case CEPH_MDS_OP_LOOKUPHASH: logger->inc(l_c_mds_req_lookuphash); break;
+    case CEPH_MDS_OP_LOOKUPPARENT: logger->inc(l_c_mds_req_lookupparent); break;
+    case CEPH_MDS_OP_LOOKUPINO: logger->inc(l_c_mds_req_lookupino); break;
+    case CEPH_MDS_OP_LOOKUPNAME: logger->inc(l_c_mds_req_lookupname); break;
+    case CEPH_MDS_OP_GETVXATTR: logger->inc(l_c_mds_req_getvxattr); break;
+    case CEPH_MDS_OP_DUMMY: logger->inc(l_c_mds_req_dummy); break;
+    case CEPH_MDS_OP_SETXATTR: logger->inc(l_c_mds_req_setxattr); break;
+    case CEPH_MDS_OP_RMXATTR: logger->inc(l_c_mds_req_rmxattr); break;
+    case CEPH_MDS_OP_SETLAYOUT: logger->inc(l_c_mds_req_setlayout); break;
+    case CEPH_MDS_OP_SETATTR: logger->inc(l_c_mds_req_setattr); break;
+    case CEPH_MDS_OP_SETFILELOCK: logger->inc(l_c_mds_req_setfilelock); break;
+    case CEPH_MDS_OP_GETFILELOCK: logger->inc(l_c_mds_req_getfilelock); break;
+    case CEPH_MDS_OP_SETDIRLAYOUT: logger->inc(l_c_mds_req_setdirlayout); break;
+    case CEPH_MDS_OP_MKNOD: logger->inc(l_c_mds_req_mknod); break;
+    case CEPH_MDS_OP_LINK: logger->inc(l_c_mds_req_link); break;
+    case CEPH_MDS_OP_UNLINK: logger->inc(l_c_mds_req_unlink); break;
+    case CEPH_MDS_OP_RENAME: logger->inc(l_c_mds_req_rename); break;
+    case CEPH_MDS_OP_MKDIR: logger->inc(l_c_mds_req_mkdir); break;
+    case CEPH_MDS_OP_RMDIR: logger->inc(l_c_mds_req_rmdir); break;
+    case CEPH_MDS_OP_SYMLINK: logger->inc(l_c_mds_req_symlink); break;
+    case CEPH_MDS_OP_CREATE: logger->inc(l_c_mds_req_create); break;
+    case CEPH_MDS_OP_OPEN: logger->inc(l_c_mds_req_open); break;
+    case CEPH_MDS_OP_READDIR: logger->inc(l_c_mds_req_readdir); break;
+    case CEPH_MDS_OP_LOOKUPSNAP: logger->inc(l_c_mds_req_lookupsnap); break;
+    case CEPH_MDS_OP_MKSNAP: logger->inc(l_c_mds_req_mksnap); break;
+    case CEPH_MDS_OP_RMSNAP: logger->inc(l_c_mds_req_rmsnap); break;
+    case CEPH_MDS_OP_LSSNAP: logger->inc(l_c_mds_req_lssnap); break;
+    case CEPH_MDS_OP_RENAMESNAP: logger->inc(l_c_mds_req_renamesnap); break;
+    case CEPH_MDS_OP_READDIR_SNAPDIFF: logger->inc(l_c_mds_req_readdir_snapdiff); break;
+    case CEPH_MDS_OP_FILE_BLOCKDIFF: logger->inc(l_c_mds_req_file_blockdiff); break;
+    case CEPH_MDS_OP_FRAGMENTDIR: logger->inc(l_c_mds_req_fragmentdir); break;
+    case CEPH_MDS_OP_EXPORTDIR: logger->inc(l_c_mds_req_exportdir); break;
+    case CEPH_MDS_OP_FLUSH: logger->inc(l_c_mds_req_flush); break;
+    case CEPH_MDS_OP_ENQUEUE_SCRUB: logger->inc(l_c_mds_req_enqueue_scrub); break;
+    case CEPH_MDS_OP_REPAIR_FRAGSTATS: logger->inc(l_c_mds_req_repair_fragstats); break;
+    case CEPH_MDS_OP_REPAIR_INODESTATS: logger->inc(l_c_mds_req_repair_inodestats); break;
+    case CEPH_MDS_OP_RDLOCK_FRAGSSTATS: logger->inc(l_c_mds_req_rdlock_fragsstats); break;
+    case CEPH_MDS_OP_QUIESCE_PATH: logger->inc(l_c_mds_req_quiesce_path); break;
+    case CEPH_MDS_OP_QUIESCE_INODE: logger->inc(l_c_mds_req_quiesce_inode); break;
+    case CEPH_MDS_OP_LOCK_PATH: logger->inc(l_c_mds_req_lock_path); break;
+    case CEPH_MDS_OP_UNINLINE_DATA: logger->inc(l_c_mds_req_uninline_data); break;
+  }
 
   ldout(cct, 10) << __func__ << " " << *r << " to mds." << mds << dendl;
   session->con->send_message2(std::move(r));
@@ -4178,6 +4317,7 @@ void Client::send_cap(Inode *in, MetaSession *session, Cap *cap,
   if (!session->flushing_caps_tids.empty())
     m->set_oldest_flush_tid(*session->flushing_caps_tids.begin());
 
+  inc_caps_release();
   session->con->send_message2(std::move(m));
 }
 
@@ -4791,6 +4931,7 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
     }
   } else {
     inc_pinned_icaps();
+    inc_caps();
   }
 
   check_cap_issue(in, issued);
@@ -4869,6 +5010,7 @@ void Client::remove_cap(Cap *cap, bool queue_release)
   } else {
     dec_pinned_icaps();
   }
+  dec_caps();
 
 
   if (in.auth_cap == cap) {
@@ -6148,6 +6290,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
   // update caps
   auto revoked = cap->issued & ~new_caps;
   if (revoked) {
+    inc_caps_revoke();
     ldout(cct, 10) << "  revocation of " << ccap_string(revoked) << dendl;
     cap->issued = new_caps;
     cap->implemented |= new_caps;
@@ -6175,6 +6318,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
   } else if (cap->issued == new_caps) {
     ldout(cct, 10) << "  caps unchanged at " << ccap_string(cap->issued) << dendl;
   } else {
+    inc_caps_grant();
     ldout(cct, 10) << "  grant, new caps are " << ccap_string(new_caps & ~cap->issued) << dendl;
     cap->issued = new_caps;
     cap->implemented |= new_caps;
@@ -7494,6 +7638,18 @@ void Client::tick()
   if (!mount_aborted)
     collect_and_send_metrics();
 
+  if (objectcacher) {
+    logger->set(l_c_osdc_dirty, objectcacher->get_stat_dirty());
+  }
+
+  if (logger) {
+    uint64_t caps_dirty = 0;
+    for (auto &p : mds_sessions) {
+      caps_dirty += p.second->dirty_list.size();
+    }
+    logger->set(l_c_caps_dirty, caps_dirty);
+  }
+
   delay_put_inodes(is_unmounting());
   trim_cache(true);
 
@@ -8666,6 +8822,12 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       auto target_len = std::min(read_len, stx->stx_size - offset);
       r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
                                      read_start, target_len, &bl, 0, &holes, io_finish.get());
+
+      if (r > 0) {
+        logger->inc(l_c_osdc_hit);
+      } else if (r == 0) {
+        logger->inc(l_c_osdc_miss);
+      }
 
       if (r == 0) {
         client_lock.unlock();
@@ -11846,6 +12008,8 @@ void Client::C_Read_Async_Finisher::finish(int r)
     clnt->do_readahead(f, in, off, len);
 
   onfinish->complete(r);
+  clnt->logger->inc(l_c_aio_completions);
+  clnt->logger->dec(l_c_aio_in_flight);
 }
 
 int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
@@ -11908,11 +12072,19 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // abandoned.
     Context *crf = io_finish.release();
 
+    logger->inc(l_c_aio_ops);
+    logger->inc(l_c_aio_in_flight);
+
     // Complete the crf immediately with 0 bytes
     crf->complete(0);
 
     // Signal async completion
     return 0;
+  }
+
+  if (onfinish != nullptr) {
+    logger->inc(l_c_aio_ops);
+    logger->inc(l_c_aio_in_flight);
   }
   auto target_len = std::min(len, effective_size - off);
   
@@ -11933,6 +12105,12 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
   std::vector<ObjectCacher::ObjHole> holes;
   r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
                                  read_start, read_len, bl, 0, &holes, io_finish.get());
+  if (r > 0) {
+    logger->inc(l_c_osdc_hit);
+  } else if (r == 0) {
+    logger->inc(l_c_osdc_miss);
+  }
+
   if (onfinish != nullptr) {
     // put the cap ref since we're releasing C_Read_Async_Finisher
     put_cap_ref(in, CEPH_CAP_FILE_CACHE);
@@ -12389,6 +12567,8 @@ bool Client::C_Write_Finisher::try_complete()
       ldout(clnt->cct, 19) << " complete with iofinished_r " << iofinished_r << dendl;
       onfinish->complete(iofinished_r);
     }
+    clnt->logger->inc(l_c_aio_completions);
+    clnt->logger->dec(l_c_aio_in_flight);
     onfinish = nullptr;
     return true;
   }
@@ -12852,6 +13032,8 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
                         do_fsync, syncdataonly, enc_mgr->encrypted()));
 
     cwf_iofinish->CWF = cwf.get();
+      logger->inc(l_c_aio_ops);
+      logger->inc(l_c_aio_in_flight);
   }
 
   if (cct->_conf->client_oc &&

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4907,8 +4907,11 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
   const auto &capem = in->caps.emplace(std::piecewise_construct, std::forward_as_tuple(mds), std::forward_as_tuple(*in, mds_session));
   Cap &cap = capem.first->second;
   if (!capem.second) {
-    if (cap.gen < mds_session->cap_gen)
+    if (cap.gen < mds_session->cap_gen) {
       cap.issued = cap.implemented = CEPH_CAP_PIN;
+      inc_pinned_icaps();
+      inc_caps();
+    }
 
     /*
      * auth mds of the inode changed. we received the cap export
@@ -15872,159 +15875,159 @@ size_t Client::_vxattrcb_client_id(Inode *in, char *val, size_t size)
 #define CEPH_XATTR_NAME(_type, _name) "ceph." #_type "." #_name
 #define CEPH_XATTR_NAME2(_type, _name, _name2) "ceph." #_type "." #_name "." #_name2
 
-#define XATTR_NAME_CEPH(_type, _name, _flags)              \
-  {                                                        \
-      .name = CEPH_XATTR_NAME(_type, _name),               \
-      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
-      .readonly = true,                                    \
-      .exists_cb = NULL,                                   \
-      .flags = _flags,                                     \
-  }
-#define XATTR_LAYOUT_FIELD(_type, _name, _field)            \
-  {                                                         \
-      .name = CEPH_XATTR_NAME2(_type, _name, _field),       \
-      .getxattr_cb = &Client::_vxattrcb_##_name##_##_field, \
-      .readonly = false,                                    \
-      .exists_cb = &Client::_vxattrcb_layout_exists,        \
-      .flags = 0,                                           \
-  }
-#define XATTR_QUOTA_FIELD(_type, _name)                    \
-  {                                                        \
-      .name = CEPH_XATTR_NAME(_type, _name),               \
-      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
-      .readonly = false,                                   \
-      .exists_cb = &Client::_vxattrcb_quota_exists,        \
-      .flags = 0,                                          \
-  }
+#define XATTR_NAME_CEPH(_type, _name, _flags)                 \
+{                                                              \
+  name: CEPH_XATTR_NAME(_type, _name),                         \
+  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,     \
+  readonly: true,                                              \
+  exists_cb: NULL,                                             \
+  flags: _flags,                                               \
+}
+#define XATTR_LAYOUT_FIELD(_type, _name, _field)		\
+{								\
+  name: CEPH_XATTR_NAME2(_type, _name, _field),			\
+  getxattr_cb: &Client::_vxattrcb_ ## _name ## _ ## _field,	\
+  readonly: false,						\
+  exists_cb: &Client::_vxattrcb_layout_exists,			\
+  flags: 0,                                                     \
+}
+#define XATTR_QUOTA_FIELD(_type, _name)		                \
+{								\
+  name: CEPH_XATTR_NAME(_type, _name),			        \
+  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,	\
+  readonly: false,						\
+  exists_cb: &Client::_vxattrcb_quota_exists,			\
+  flags: 0,                                                     \
+}
 
 const Client::VXattr Client::_dir_vxattrs[] = {
-    {
-        .name = "ceph.dir.layout",
-        .getxattr_cb = &Client::_vxattrcb_layout,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_layout_exists,
-        .flags = 0,
-    },
-    // FIXME
-    // Delete the following dir layout field definitions for release "S"
-    XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
-    XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
-    XATTR_LAYOUT_FIELD(dir, layout, object_size),
-    XATTR_LAYOUT_FIELD(dir, layout, pool),
-    XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
-    XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
-    XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
-    XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
-    XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
-    {
-        .name = "ceph.quota",
-        .getxattr_cb = &Client::_vxattrcb_quota,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_quota_exists,
-        .flags = 0,
-    },
-    XATTR_QUOTA_FIELD(quota, max_bytes),
-    XATTR_QUOTA_FIELD(quota, max_files),
-    // FIXME
-    // Delete the following dir pin field definitions for release "S"
-    {
-        .name = "ceph.dir.pin",
-        .getxattr_cb = &Client::_vxattrcb_dir_pin,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_dir_pin_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.snap.btime",
-        .getxattr_cb = &Client::_vxattrcb_snap_btime,
-        .readonly = true,
-        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.mirror.info",
-        .getxattr_cb = &Client::_vxattrcb_mirror_info,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_mirror_info_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.caps",
-        .getxattr_cb = &Client::_vxattrcb_caps,
-        .readonly = true,
-        .exists_cb = NULL,
-        .flags = 0,
-    },
-    {.name = ""} /* Required table terminator */
+  {
+    name: "ceph.dir.layout",
+    getxattr_cb: &Client::_vxattrcb_layout,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_layout_exists,
+    flags: 0,
+  },
+  // FIXME
+  // Delete the following dir layout field definitions for release "S"
+  XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
+  XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
+  XATTR_LAYOUT_FIELD(dir, layout, object_size),
+  XATTR_LAYOUT_FIELD(dir, layout, pool),
+  XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
+  XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
+  XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
+  XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
+  XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
+  {
+    name: "ceph.quota",
+    getxattr_cb: &Client::_vxattrcb_quota,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_quota_exists,
+    flags: 0,
+  },
+  XATTR_QUOTA_FIELD(quota, max_bytes),
+  XATTR_QUOTA_FIELD(quota, max_files),
+  // FIXME
+  // Delete the following dir pin field definitions for release "S"
+  {
+    name: "ceph.dir.pin",
+    getxattr_cb: &Client::_vxattrcb_dir_pin,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_dir_pin_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.snap.btime",
+    getxattr_cb: &Client::_vxattrcb_snap_btime,
+    readonly: true,
+    exists_cb: &Client::_vxattrcb_snap_btime_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.mirror.info",
+    getxattr_cb: &Client::_vxattrcb_mirror_info,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_mirror_info_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.caps",
+    getxattr_cb: &Client::_vxattrcb_caps,
+    readonly: true,
+    exists_cb: NULL,
+    flags: 0,
+  },
+  { name: "" }     /* Required table terminator */
 };
 
 const Client::VXattr Client::_file_vxattrs[] = {
-    {
-        .name = "ceph.file.layout",
-        .getxattr_cb = &Client::_vxattrcb_layout,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_layout_exists,
-        .flags = 0,
-    },
-    XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
-    XATTR_LAYOUT_FIELD(file, layout, stripe_count),
-    XATTR_LAYOUT_FIELD(file, layout, object_size),
-    XATTR_LAYOUT_FIELD(file, layout, pool),
-    XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
-    {
-        .name = "ceph.snap.btime",
-        .getxattr_cb = &Client::_vxattrcb_snap_btime,
-        .readonly = true,
-        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.caps",
-        .getxattr_cb = &Client::_vxattrcb_caps,
-        .readonly = true,
-        .exists_cb = NULL,
-        .flags = 0,
-    },
-    {.name = ""} /* Required table terminator */
+  {
+    name: "ceph.file.layout",
+    getxattr_cb: &Client::_vxattrcb_layout,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_layout_exists,
+    flags: 0,
+  },
+  XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
+  XATTR_LAYOUT_FIELD(file, layout, stripe_count),
+  XATTR_LAYOUT_FIELD(file, layout, object_size),
+  XATTR_LAYOUT_FIELD(file, layout, pool),
+  XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
+  {
+    name: "ceph.snap.btime",
+    getxattr_cb: &Client::_vxattrcb_snap_btime,
+    readonly: true,
+    exists_cb: &Client::_vxattrcb_snap_btime_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.caps",
+    getxattr_cb: &Client::_vxattrcb_caps,
+    readonly: true,
+    exists_cb: NULL,
+    flags: 0,
+  },
+  { name: "" }     /* Required table terminator */
 };
 
 const Client::VXattr Client::_common_vxattrs[] = {
-    {
-        .name = "ceph.cluster_fsid",
-        .getxattr_cb = &Client::_vxattrcb_cluster_fsid,
-        .readonly = true,
-        .exists_cb = nullptr,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.client_id",
-        .getxattr_cb = &Client::_vxattrcb_client_id,
-        .readonly = true,
-        .exists_cb = nullptr,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.fscrypt.auth",
-        .getxattr_cb = &Client::_vxattrcb_fscrypt_auth,
-        .setxattr_cb = &Client::_vxattrcb_fscrypt_auth_set,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_fscrypt_auth_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.fscrypt.file",
-        .getxattr_cb = &Client::_vxattrcb_fscrypt_file,
-        .setxattr_cb = &Client::_vxattrcb_fscrypt_file_set,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_fscrypt_file_exists,
-        .flags = 0,
-    },
-    {.name = ""} /* Required table terminator */
+  {
+    name: "ceph.cluster_fsid",
+    getxattr_cb: &Client::_vxattrcb_cluster_fsid,
+    readonly: true,
+    exists_cb: nullptr,
+    flags: 0,
+  },
+  {
+    name: "ceph.client_id",
+    getxattr_cb: &Client::_vxattrcb_client_id,
+    readonly: true,
+    exists_cb: nullptr,
+    flags: 0,
+  },
+  {
+    name: "ceph.fscrypt.auth",
+    getxattr_cb: &Client::_vxattrcb_fscrypt_auth,
+    setxattr_cb: &Client::_vxattrcb_fscrypt_auth_set,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_fscrypt_auth_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.fscrypt.file",
+    getxattr_cb: &Client::_vxattrcb_fscrypt_file,
+    setxattr_cb: &Client::_vxattrcb_fscrypt_file_set,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_fscrypt_file_exists,
+    flags: 0,
+  },
+  { name: "" }     /* Required table terminator */
 };
 
 const Client::VXattr *Client::_get_vxattrs(Inode *in)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12024,6 +12024,12 @@ void Client::do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len)
       int r2 = objectcacher->file_read(&in->oset, &in->layout, in->snapid,
 				       readahead_extent.first, readahead_extent.second,
 				       NULL, 0, onfinish2);
+      if (r2 > 0) {
+	logger->inc(l_c_osdc_hit);
+      } else if (r2 == 0) {
+	logger->inc(l_c_osdc_miss);
+      }
+
       if (r2 == 0) {
 	ldout(cct, 20) << "readahead initiated, c " << onfinish2 << dendl;
 	get_cap_ref(in, CEPH_CAP_FILE_RD | CEPH_CAP_FILE_CACHE);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -692,6 +692,65 @@ void Client::_finish_init()
     plb.add_time(l_c_wr_avg, "writeavg", "Average latency for processing write requests");
     plb.add_u64(l_c_wr_sqsum, "writesqsum", "Sum of squares ((to calculate variability/stdev) for write requests");
     plb.add_u64(l_c_wr_ops, "wrops", "Total write IO operations");
+    plb.add_u64_avg(l_c_rd_sz_avg, "rd_sz_avg", "Average read size");
+    plb.add_u64(l_c_rd_sz_sqsum, "rd_sz_sqsum", "Sum of squares for read size");
+    plb.add_u64_avg(l_c_wr_sz_avg, "wr_sz_avg", "Average write size");
+    plb.add_u64(l_c_wr_sz_sqsum, "wr_sz_sqsum", "Sum of squares for write size");
+    plb.add_u64_counter(l_c_aio_ops, "aio_ops", "Total async IO operations");
+    plb.add_u64_counter(l_c_aio_completions, "aio_completions", "Total async IO completions");
+    plb.add_u64(l_c_aio_in_flight, "aio_in_flight", "Async IO operations in flight");
+    plb.add_u64_counter(l_c_osdc_hit, "osdc_hit", "OSDC cache hits");
+    plb.add_u64_counter(l_c_osdc_miss, "osdc_miss", "OSDC cache misses");
+    plb.add_u64(l_c_osdc_dirty, "osdc_dirty", "OSDC dirty buffer size");
+    plb.add_u64_counter(l_c_mds_req, "mds_req", "Total MDS requests");
+    plb.add_u64_counter(l_c_mds_req_lookup, "mds_req_lookup", "MDS lookup requests");
+    plb.add_u64_counter(l_c_mds_req_getattr, "mds_req_getattr", "MDS getattr requests");
+    plb.add_u64_counter(l_c_mds_req_lookuphash, "mds_req_lookuphash", "MDS lookuphash requests");
+    plb.add_u64_counter(l_c_mds_req_lookupparent, "mds_req_lookupparent", "MDS lookupparent requests");
+    plb.add_u64_counter(l_c_mds_req_lookupino, "mds_req_lookupino", "MDS lookupino requests");
+    plb.add_u64_counter(l_c_mds_req_lookupname, "mds_req_lookupname", "MDS lookupname requests");
+    plb.add_u64_counter(l_c_mds_req_getvxattr, "mds_req_getvxattr", "MDS getvxattr requests");
+    plb.add_u64_counter(l_c_mds_req_dummy, "mds_req_dummy", "MDS dummy requests");
+    plb.add_u64_counter(l_c_mds_req_setxattr, "mds_req_setxattr", "MDS setxattr requests");
+    plb.add_u64_counter(l_c_mds_req_rmxattr, "mds_req_rmxattr", "MDS rmxattr requests");
+    plb.add_u64_counter(l_c_mds_req_setlayout, "mds_req_setlayout", "MDS setlayout requests");
+    plb.add_u64_counter(l_c_mds_req_setattr, "mds_req_setattr", "MDS setattr requests");
+    plb.add_u64_counter(l_c_mds_req_setfilelock, "mds_req_setfilelock", "MDS setfilelock requests");
+    plb.add_u64_counter(l_c_mds_req_getfilelock, "mds_req_getfilelock", "MDS getfilelock requests");
+    plb.add_u64_counter(l_c_mds_req_setdirlayout, "mds_req_setdirlayout", "MDS setdirlayout requests");
+    plb.add_u64_counter(l_c_mds_req_mknod, "mds_req_mknod", "MDS mknod requests");
+    plb.add_u64_counter(l_c_mds_req_link, "mds_req_link", "MDS link requests");
+    plb.add_u64_counter(l_c_mds_req_unlink, "mds_req_unlink", "MDS unlink requests");
+    plb.add_u64_counter(l_c_mds_req_rename, "mds_req_rename", "MDS rename requests");
+    plb.add_u64_counter(l_c_mds_req_mkdir, "mds_req_mkdir", "MDS mkdir requests");
+    plb.add_u64_counter(l_c_mds_req_rmdir, "mds_req_rmdir", "MDS rmdir requests");
+    plb.add_u64_counter(l_c_mds_req_symlink, "mds_req_symlink", "MDS symlink requests");
+    plb.add_u64_counter(l_c_mds_req_create, "mds_req_create", "MDS create requests");
+    plb.add_u64_counter(l_c_mds_req_open, "mds_req_open", "MDS open requests");
+    plb.add_u64_counter(l_c_mds_req_readdir, "mds_req_readdir", "MDS readdir requests");
+    plb.add_u64_counter(l_c_mds_req_lookupsnap, "mds_req_lookupsnap", "MDS lookupsnap requests");
+    plb.add_u64_counter(l_c_mds_req_mksnap, "mds_req_mksnap", "MDS mksnap requests");
+    plb.add_u64_counter(l_c_mds_req_rmsnap, "mds_req_rmsnap", "MDS rmsnap requests");
+    plb.add_u64_counter(l_c_mds_req_lssnap, "mds_req_lssnap", "MDS lssnap requests");
+    plb.add_u64_counter(l_c_mds_req_renamesnap, "mds_req_renamesnap", "MDS renamesnap requests");
+    plb.add_u64_counter(l_c_mds_req_readdir_snapdiff, "mds_req_readdir_snapdiff", "MDS readdir_snapdiff requests");
+    plb.add_u64_counter(l_c_mds_req_file_blockdiff, "mds_req_file_blockdiff", "MDS file_blockdiff requests");
+    plb.add_u64_counter(l_c_mds_req_fragmentdir, "mds_req_fragmentdir", "MDS fragmentdir requests");
+    plb.add_u64_counter(l_c_mds_req_exportdir, "mds_req_exportdir", "MDS exportdir requests");
+    plb.add_u64_counter(l_c_mds_req_flush, "mds_req_flush", "MDS flush requests");
+    plb.add_u64_counter(l_c_mds_req_enqueue_scrub, "mds_req_enqueue_scrub", "MDS enqueue_scrub requests");
+    plb.add_u64_counter(l_c_mds_req_repair_fragstats, "mds_req_repair_fragstats", "MDS repair_fragstats requests");
+    plb.add_u64_counter(l_c_mds_req_repair_inodestats, "mds_req_repair_inodestats", "MDS repair_inodestats requests");
+    plb.add_u64_counter(l_c_mds_req_rdlock_fragsstats, "mds_req_rdlock_fragsstats", "MDS rdlock_fragsstats requests");
+    plb.add_u64_counter(l_c_mds_req_quiesce_path, "mds_req_quiesce_path", "MDS quiesce_path requests");
+    plb.add_u64_counter(l_c_mds_req_quiesce_inode, "mds_req_quiesce_inode", "MDS quiesce_inode requests");
+    plb.add_u64_counter(l_c_mds_req_lock_path, "mds_req_lock_path", "MDS lock_path requests");
+    plb.add_u64_counter(l_c_mds_req_uninline_data, "mds_req_uninline_data", "MDS uninline_data requests");
+    plb.add_u64(l_c_caps, "caps", "Capabilities");
+    plb.add_u64(l_c_caps_dirty, "caps_dirty", "Dirty capabilities");
+    plb.add_u64_counter(l_c_caps_grant, "caps_grant", "Capability grants");
+    plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
+    plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
     logger.reset(plb.create_perf_counters());
     cct->get_perfcounters_collection()->add(logger.get());
   }
@@ -968,6 +1027,38 @@ void Client::trim_dentry(Dentry *dn)
   unlink(dn, false, false);  // drop dir, drop dentry
 }
 
+
+void Client::update_read_io_size(size_t size) {
+  total_read_ops++;
+  total_read_size += size;
+
+  if (logger) {
+    auto o_avg = logger->get(l_c_rd_sz_avg);
+    auto o_sqsum = logger->get(l_c_rd_sz_sqsum);
+
+    auto n_avg = calc_average(o_avg, size, total_read_ops);
+    auto n_sqsum = calc_sq_sum(o_sqsum, o_avg, n_avg, size, total_read_ops);
+
+    logger->set(l_c_rd_sz_avg, (uint64_t)n_avg);
+    logger->set(l_c_rd_sz_sqsum, (uint64_t)n_sqsum);
+  }
+}
+
+void Client::update_write_io_size(size_t size) {
+  total_write_ops++;
+  total_write_size += size;
+
+  if (logger) {
+    auto o_avg = logger->get(l_c_wr_sz_avg);
+    auto o_sqsum = logger->get(l_c_wr_sz_sqsum);
+
+    auto n_avg = calc_average(o_avg, size, total_write_ops);
+    auto n_sqsum = calc_sq_sum(o_sqsum, o_avg, n_avg, size, total_write_ops);
+
+    logger->set(l_c_wr_sz_avg, (uint64_t)n_avg);
+    logger->set(l_c_wr_sz_sqsum, (uint64_t)n_sqsum);
+  }
+}
 
 void Client::update_inode_file_size(Inode *in, int issued, uint64_t size,
 				    uint64_t truncate_seq, uint64_t truncate_size)
@@ -2463,6 +2554,7 @@ int Client::encode_inode_release(Inode *in, MetaRequest *req,
       rel.wanted = cap.wanted;
       rel.dname_len = 0;
       rel.dname_seq = 0;
+      inc_caps_release();
       req->cap_releases.push_back(MClientRequest::Release(rel,""));
     }
   }
@@ -2864,6 +2956,53 @@ void Client::send_request(MetaRequest *request, MetaSession *session,
   }
 
   session->requests.push_back(&request->item);
+
+  logger->inc(l_c_mds_req);
+  switch (request->get_op()) {
+    case CEPH_MDS_OP_LOOKUP: logger->inc(l_c_mds_req_lookup); break;
+    case CEPH_MDS_OP_GETATTR: logger->inc(l_c_mds_req_getattr); break;
+    case CEPH_MDS_OP_LOOKUPHASH: logger->inc(l_c_mds_req_lookuphash); break;
+    case CEPH_MDS_OP_LOOKUPPARENT: logger->inc(l_c_mds_req_lookupparent); break;
+    case CEPH_MDS_OP_LOOKUPINO: logger->inc(l_c_mds_req_lookupino); break;
+    case CEPH_MDS_OP_LOOKUPNAME: logger->inc(l_c_mds_req_lookupname); break;
+    case CEPH_MDS_OP_GETVXATTR: logger->inc(l_c_mds_req_getvxattr); break;
+    case CEPH_MDS_OP_DUMMY: logger->inc(l_c_mds_req_dummy); break;
+    case CEPH_MDS_OP_SETXATTR: logger->inc(l_c_mds_req_setxattr); break;
+    case CEPH_MDS_OP_RMXATTR: logger->inc(l_c_mds_req_rmxattr); break;
+    case CEPH_MDS_OP_SETLAYOUT: logger->inc(l_c_mds_req_setlayout); break;
+    case CEPH_MDS_OP_SETATTR: logger->inc(l_c_mds_req_setattr); break;
+    case CEPH_MDS_OP_SETFILELOCK: logger->inc(l_c_mds_req_setfilelock); break;
+    case CEPH_MDS_OP_GETFILELOCK: logger->inc(l_c_mds_req_getfilelock); break;
+    case CEPH_MDS_OP_SETDIRLAYOUT: logger->inc(l_c_mds_req_setdirlayout); break;
+    case CEPH_MDS_OP_MKNOD: logger->inc(l_c_mds_req_mknod); break;
+    case CEPH_MDS_OP_LINK: logger->inc(l_c_mds_req_link); break;
+    case CEPH_MDS_OP_UNLINK: logger->inc(l_c_mds_req_unlink); break;
+    case CEPH_MDS_OP_RENAME: logger->inc(l_c_mds_req_rename); break;
+    case CEPH_MDS_OP_MKDIR: logger->inc(l_c_mds_req_mkdir); break;
+    case CEPH_MDS_OP_RMDIR: logger->inc(l_c_mds_req_rmdir); break;
+    case CEPH_MDS_OP_SYMLINK: logger->inc(l_c_mds_req_symlink); break;
+    case CEPH_MDS_OP_CREATE: logger->inc(l_c_mds_req_create); break;
+    case CEPH_MDS_OP_OPEN: logger->inc(l_c_mds_req_open); break;
+    case CEPH_MDS_OP_READDIR: logger->inc(l_c_mds_req_readdir); break;
+    case CEPH_MDS_OP_LOOKUPSNAP: logger->inc(l_c_mds_req_lookupsnap); break;
+    case CEPH_MDS_OP_MKSNAP: logger->inc(l_c_mds_req_mksnap); break;
+    case CEPH_MDS_OP_RMSNAP: logger->inc(l_c_mds_req_rmsnap); break;
+    case CEPH_MDS_OP_LSSNAP: logger->inc(l_c_mds_req_lssnap); break;
+    case CEPH_MDS_OP_RENAMESNAP: logger->inc(l_c_mds_req_renamesnap); break;
+    case CEPH_MDS_OP_READDIR_SNAPDIFF: logger->inc(l_c_mds_req_readdir_snapdiff); break;
+    case CEPH_MDS_OP_FILE_BLOCKDIFF: logger->inc(l_c_mds_req_file_blockdiff); break;
+    case CEPH_MDS_OP_FRAGMENTDIR: logger->inc(l_c_mds_req_fragmentdir); break;
+    case CEPH_MDS_OP_EXPORTDIR: logger->inc(l_c_mds_req_exportdir); break;
+    case CEPH_MDS_OP_FLUSH: logger->inc(l_c_mds_req_flush); break;
+    case CEPH_MDS_OP_ENQUEUE_SCRUB: logger->inc(l_c_mds_req_enqueue_scrub); break;
+    case CEPH_MDS_OP_REPAIR_FRAGSTATS: logger->inc(l_c_mds_req_repair_fragstats); break;
+    case CEPH_MDS_OP_REPAIR_INODESTATS: logger->inc(l_c_mds_req_repair_inodestats); break;
+    case CEPH_MDS_OP_RDLOCK_FRAGSSTATS: logger->inc(l_c_mds_req_rdlock_fragsstats); break;
+    case CEPH_MDS_OP_QUIESCE_PATH: logger->inc(l_c_mds_req_quiesce_path); break;
+    case CEPH_MDS_OP_QUIESCE_INODE: logger->inc(l_c_mds_req_quiesce_inode); break;
+    case CEPH_MDS_OP_LOCK_PATH: logger->inc(l_c_mds_req_lock_path); break;
+    case CEPH_MDS_OP_UNINLINE_DATA: logger->inc(l_c_mds_req_uninline_data); break;
+  }
 
   ldout(cct, 10) << __func__ << " " << *r << " to mds." << mds << dendl;
   session->con->send_message2(std::move(r));
@@ -4215,6 +4354,7 @@ void Client::send_cap(Inode *in, MetaSession *session, Cap *cap,
   if (!session->flushing_caps_tids.empty())
     m->set_oldest_flush_tid(*session->flushing_caps_tids.begin());
 
+  inc_caps_release();
   session->con->send_message2(std::move(m));
 }
 
@@ -4828,6 +4968,7 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
     }
   } else {
     inc_pinned_icaps();
+    inc_caps();
   }
 
   check_cap_issue(in, issued);
@@ -4906,6 +5047,7 @@ void Client::remove_cap(Cap *cap, bool queue_release)
   } else {
     dec_pinned_icaps();
   }
+  dec_caps();
 
 
   if (in.auth_cap == cap) {
@@ -6185,6 +6327,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
   // update caps
   auto revoked = cap->issued & ~new_caps;
   if (revoked) {
+    inc_caps_revoke();
     ldout(cct, 10) << "  revocation of " << ccap_string(revoked) << dendl;
     cap->issued = new_caps;
     cap->implemented |= new_caps;
@@ -6212,6 +6355,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
   } else if (cap->issued == new_caps) {
     ldout(cct, 10) << "  caps unchanged at " << ccap_string(cap->issued) << dendl;
   } else {
+    inc_caps_grant();
     ldout(cct, 10) << "  grant, new caps are " << ccap_string(new_caps & ~cap->issued) << dendl;
     cap->issued = new_caps;
     cap->implemented |= new_caps;
@@ -7531,6 +7675,18 @@ void Client::tick()
   if (!mount_aborted)
     collect_and_send_metrics();
 
+  if (objectcacher) {
+    logger->set(l_c_osdc_dirty, objectcacher->get_stat_dirty());
+  }
+
+  if (logger) {
+    uint64_t caps_dirty = 0;
+    for (auto &p : mds_sessions) {
+      caps_dirty += p.second->dirty_list.size();
+    }
+    logger->set(l_c_caps_dirty, caps_dirty);
+  }
+
   delay_put_inodes(is_unmounting());
   trim_cache(true);
 
@@ -8703,6 +8859,12 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       auto target_len = std::min(read_len, stx->stx_size - offset);
       r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
                                      read_start, target_len, &bl, 0, &holes, io_finish.get());
+
+      if (r > 0) {
+        logger->inc(l_c_osdc_hit);
+      } else if (r == 0) {
+        logger->inc(l_c_osdc_miss);
+      }
 
       if (r == 0) {
         client_lock.unlock();
@@ -11887,6 +12049,8 @@ void Client::C_Read_Async_Finisher::finish(int r)
     clnt->do_readahead(f, in, off, len);
 
   onfinish->complete(r);
+  clnt->logger->inc(l_c_aio_completions);
+  clnt->logger->dec(l_c_aio_in_flight);
 }
 
 int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
@@ -11949,11 +12113,19 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // abandoned.
     Context *crf = io_finish.release();
 
+    logger->inc(l_c_aio_ops);
+    logger->inc(l_c_aio_in_flight);
+
     // Complete the crf immediately with 0 bytes
     crf->complete(0);
 
     // Signal async completion
     return 0;
+  }
+
+  if (onfinish != nullptr) {
+    logger->inc(l_c_aio_ops);
+    logger->inc(l_c_aio_in_flight);
   }
   auto target_len = std::min(len, effective_size - off);
   
@@ -11974,6 +12146,12 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
   std::vector<ObjectCacher::ObjHole> holes;
   r = objectcacher->file_read_ex(&in->oset, &in->layout, in->snapid,
                                  read_start, read_len, bl, 0, &holes, io_finish.get());
+  if (r > 0) {
+    logger->inc(l_c_osdc_hit);
+  } else if (r == 0) {
+    logger->inc(l_c_osdc_miss);
+  }
+
   if (onfinish != nullptr) {
     // put the cap ref since we're releasing C_Read_Async_Finisher
     put_cap_ref(in, CEPH_CAP_FILE_CACHE);
@@ -12430,6 +12608,8 @@ bool Client::C_Write_Finisher::try_complete()
       ldout(clnt->cct, 19) << " complete with iofinished_r " << iofinished_r << dendl;
       onfinish->complete(iofinished_r);
     }
+    clnt->logger->inc(l_c_aio_completions);
+    clnt->logger->dec(l_c_aio_in_flight);
     onfinish = nullptr;
     return true;
   }
@@ -12893,6 +13073,8 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
                         do_fsync, syncdataonly, enc_mgr->encrypted()));
 
     cwf_iofinish->CWF = cwf.get();
+      logger->inc(l_c_aio_ops);
+      logger->inc(l_c_aio_in_flight);
   }
 
   if (cct->_conf->client_oc &&

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -699,7 +699,9 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_aio_ops, "aio_ops", "Total async IO operations");
     plb.add_u64_counter(l_c_aio_completions, "aio_completions", "Total async IO completions");
     plb.add_u64(l_c_aio_in_flight, "aio_in_flight", "Async IO operations in flight");
+    plb.add_u64(l_c_aio_in_flight_peak, "aio_in_flight_peak", "Peak async IO operations in flight");
     plb.add_u64(l_c_sync_in_flight, "sync_in_flight", "Sync IO operations in flight");
+    plb.add_u64(l_c_sync_in_flight_peak, "sync_in_flight_peak", "Peak sync IO operations in flight");
     plb.add_u64_counter(l_c_osdc_hit, "osdc_hit", "OSDC cache hits");
     plb.add_u64_counter(l_c_osdc_miss, "osdc_miss", "OSDC cache misses");
     plb.add_u64(l_c_osdc_dirty, "osdc_dirty", "OSDC dirty buffer size");
@@ -11588,7 +11590,7 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
   if (!mref_reader.is_state_satisfied())
     return -ENOTCONN;
   if (logger) {
-    logger->inc(l_c_sync_in_flight);
+    inc_sync_in_flight();
   }
 
   tout(cct) << "read" << std::endl;
@@ -11600,14 +11602,14 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
   Fh *f = get_filehandle(fd);
   if (!f) {
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH) {
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
@@ -11633,7 +11635,7 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
     r = bl.length();
   }
   if (logger) {
-    logger->dec(l_c_sync_in_flight);
+    dec_sync_in_flight();
   }
   return r;
 }
@@ -12094,7 +12096,7 @@ void Client::C_Read_Async_Finisher::finish(int r)
 
   onfinish->complete(r);
   clnt->logger->inc(l_c_aio_completions);
-  clnt->logger->dec(l_c_aio_in_flight);
+  clnt->dec_aio_in_flight();
 }
 
 int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
@@ -12133,6 +12135,8 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
   get_cap_ref(in, CEPH_CAP_FILE_CACHE);
 
   if (onfinish != nullptr) {
+    logger->inc(l_c_aio_ops);
+    inc_aio_in_flight();
     io_finish.reset(new C_Read_Async_Finisher(this, onfinish, f, in, bl,
                                               f->pos, off, len,
 #if defined(__linux__)
@@ -12165,7 +12169,7 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
 
   if (onfinish != nullptr) {
     logger->inc(l_c_aio_ops);
-    logger->inc(l_c_aio_in_flight);
+    inc_aio_in_flight();
   }
   auto target_len = std::min(len, effective_size - off);
   
@@ -12381,7 +12385,7 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
   if (!mref_reader.is_state_satisfied())
     return -ENOTCONN;
   if (logger) {
-    logger->inc(l_c_sync_in_flight);
+    inc_sync_in_flight();
   }
 
   tout(cct) << "write" << std::endl;
@@ -12393,14 +12397,14 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
   Fh *fh = get_filehandle(fd);
   if (!fh) {
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
 #if defined(__linux__) && defined(O_PATH)
   if (fh->flags & O_PATH) {
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
@@ -12422,7 +12426,7 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
   int r = _write(fh, offset, size, std::move(bl));
   ldout(cct, 3) << "write(" << fd << ", \"...\", " << size << ", " << offset << ") = " << r << dendl;
   if (logger) {
-    logger->dec(l_c_sync_in_flight);
+    dec_sync_in_flight();
   }
   return r;
 }
@@ -12521,20 +12525,20 @@ int Client::_preadv_pwritev(int fd, const struct iovec *iov, int iovcnt,
     tout(cct) << offset << std::endl;
 
     if (onfinish == nullptr && logger) {
-      logger->inc(l_c_sync_in_flight);
+      inc_sync_in_flight();
     }
     std::scoped_lock cl(client_lock);
     Fh *fh = get_filehandle(fd);
     if (!fh) {
       if (onfinish == nullptr && logger) {
-        logger->dec(l_c_sync_in_flight);
+        dec_sync_in_flight();
       }
       return -EBADF;
     }
     auto r = _preadv_pwritev_locked(fh, iov, iovcnt, offset, write, true,
                                     onfinish, blp);
     if (onfinish == nullptr && logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return r;
 }
@@ -12690,7 +12694,7 @@ bool Client::C_Write_Finisher::try_complete()
       clnt->logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
     }
     clnt->logger->inc(l_c_aio_completions);
-    clnt->logger->dec(l_c_aio_in_flight);
+    clnt->dec_aio_in_flight();
     onfinish = nullptr;
     return true;
   }
@@ -13166,7 +13170,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
 
     cwf_iofinish->CWF = cwf.get();
       logger->inc(l_c_aio_ops);
-      logger->inc(l_c_aio_in_flight);
+      inc_aio_in_flight();
   }
 
   if (cct->_conf->client_oc &&
@@ -17492,7 +17496,7 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
     return -ENOTCONN;
   }
   if (logger) {
-    logger->inc(l_c_sync_in_flight);
+    inc_sync_in_flight();
   }
 
 #if defined(__linux__)
@@ -17512,7 +17516,7 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
@@ -17527,7 +17531,7 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
   ldout(cct, 3) << "ll_read " << fh << " " << off << "~" << len << " = " << r
 		<< dendl;
   if (logger) {
-    logger->dec(l_c_sync_in_flight);
+    dec_sync_in_flight();
   }
   return r;
 }
@@ -17656,7 +17660,7 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
     return -ENOTCONN;
   }
   if (logger) {
-    logger->inc(l_c_sync_in_flight);
+    inc_sync_in_flight();
   }
 
 #if defined(__linux__)
@@ -17675,7 +17679,7 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
@@ -17693,7 +17697,7 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
   ldout(cct, 3) << "ll_write " << fh << " " << off << "~" << len << " = " << r
 		<< dendl;
   if (logger) {
-    logger->dec(l_c_sync_in_flight);
+    dec_sync_in_flight();
   }
   return r;
 }
@@ -17705,20 +17709,20 @@ int64_t Client::ll_writev(struct Fh *fh, const struct iovec *iov, int iovcnt, in
     return -ENOTCONN;
   }
   if (logger) {
-    logger->inc(l_c_sync_in_flight);
+    inc_sync_in_flight();
   }
 
   std::scoped_lock cl(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
   auto r = _preadv_pwritev_locked(fh, iov, iovcnt, off, true, true);
   if (logger) {
-    logger->dec(l_c_sync_in_flight);
+    dec_sync_in_flight();
   }
   return r;
 }
@@ -17730,20 +17734,20 @@ int64_t Client::ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int
     return -ENOTCONN;
   }
   if (logger) {
-    logger->inc(l_c_sync_in_flight);
+    inc_sync_in_flight();
   }
 
   std::scoped_lock cl(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
     if (logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return -EBADF;
   }
   auto r = _preadv_pwritev_locked(fh, iov, iovcnt, off, false, true);
   if (logger) {
-    logger->dec(l_c_sync_in_flight);
+    dec_sync_in_flight();
   }
   return r;
 }
@@ -17755,7 +17759,7 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
 {
     int64_t retval = -1;
     if (onfinish == nullptr && logger) {
-      logger->inc(l_c_sync_in_flight);
+      inc_sync_in_flight();
     }
 
     RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
@@ -17768,7 +17772,7 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
         retval = 0;
       }
       if (onfinish == nullptr && logger) {
-        logger->dec(l_c_sync_in_flight);
+        dec_sync_in_flight();
       }
       return retval;
     }
@@ -17789,7 +17793,7 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
         retval = 0;
       }
       if (onfinish == nullptr && logger) {
-        logger->dec(l_c_sync_in_flight);
+        dec_sync_in_flight();
       }
       return retval;
     }
@@ -17823,7 +17827,7 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
       }
     }
     if (onfinish == nullptr && logger) {
-      logger->dec(l_c_sync_in_flight);
+      dec_sync_in_flight();
     }
     return retval;
 }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12115,10 +12115,7 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // Release C_Read_Async_Finisher from managed pointer, we need to complete
     // immediately. The C_Read_Async_Finisher is safely handled and won't be
     // abandoned.
-    io_finish.reset();
-
-    // Complete the onfinish immediately with 0 bytes
-    onfinish->complete(0);
+    io_finish.release()->complete(0);
 
     // Signal async completion
     return 0;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -751,7 +751,8 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_caps_grant, "caps_grant", "Capability grants");
     plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
     plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
-    plb.add_u64_counter(l_c_fscrypt_wr_amp, "fscrypt_wr_amp", "Extra bytes written due to padding and RMW");
+    plb.add_u64_avg(l_c_fscrypt_wr_amp, "fscrypt_wr_amp",
+		    "Average fscrypt write amplification ratio (x100)");
     plb.add_u64_counter(l_c_fscrypt_rd_amp, "fscrypt_rd_amp", "Extra bytes read due to block alignment");
     plb.add_time_avg(l_c_fscrypt_enc_lat, "fscrypt_enc_lat", "Encryption time");
     plb.add_time_avg(l_c_fscrypt_dec_lat, "fscrypt_dec_lat", "Decryption time");
@@ -12750,6 +12751,14 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
   end_block_ofs = fscrypt_block_start(endoff - 1);
   ofs_in_end_block = fscrypt_ofs_in_block(endoff - 1);
 
+  // Write amplification is the ratio of aligned physical span to logical
+  // write size (e.g. write(4000, 8192) spans 0..12288 -> amp 1.5).
+  if (size > 0) {
+    uint64_t aligned_end = fscrypt_next_block_start(offset + size);
+    uint64_t amp_x100 = ((aligned_end - start_block_ofs) * 100) / size;
+    clnt->logger->inc(l_c_fscrypt_wr_amp, amp_x100);
+  }
+
   need_read_start = ofs_in_start_block > 0 || (ofs_in_start_block == 0 && ((endoff - offset) < FSCRYPT_BLOCK_SIZE));
   need_read_end = (endoff <= in->effective_size() && ofs_in_end_block < FSCRYPT_BLOCK_SIZE && start_block != end_block);
   read_start_size = FSCRYPT_BLOCK_SIZE;
@@ -12758,7 +12767,6 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
 
 
   if (need_read_start) {
-    clnt->logger->inc(l_c_fscrypt_wr_amp, read_start_size);
     finish_read_start_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_start_cb, &aioc));
 
     r = read(start_block_ofs, read_start_size, &startbl, finish_read_start_ctx.get());
@@ -12771,7 +12779,6 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
   }
 
   if (need_read_end) {
-    clnt->logger->inc(l_c_fscrypt_wr_amp, FSCRYPT_BLOCK_SIZE);
     finish_read_end_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_end_cb, &aioc));
 
     r = read(end_block_ofs, FSCRYPT_BLOCK_SIZE, &endbl, finish_read_end_ctx.get());
@@ -12897,9 +12904,6 @@ bool Client::WriteEncMgr::do_try_finish(int r)
     }
 
     size = encbl.length();
-    if (size > bl.length()) {
-      clnt->logger->inc(l_c_fscrypt_wr_amp, size - bl.length());
-    }
   }
 
   clnt->put_cap_ref(in, CEPH_CAP_FILE_RD);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12139,6 +12139,8 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // Release C_Read_Async_Finisher from managed pointer, we need to complete
     // immediately. The C_Read_Async_Finisher is safely handled and won't be
     // abandoned.
+
+    // Complete the crf immediately with 0 bytes
     io_finish.release()->complete(0);
 
     // Signal async completion

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -751,6 +751,11 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_caps_grant, "caps_grant", "Capability grants");
     plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
     plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
+    plb.add_u64_counter(l_c_fscrypt_wr_amp, "fscrypt_wr_amp", "Extra bytes written due to padding and RMW");
+    plb.add_time_avg(l_c_fscrypt_enc_lat, "fscrypt_enc_lat", "Encryption time");
+    plb.add_time_avg(l_c_fscrypt_dec_lat, "fscrypt_dec_lat", "Decryption time");
+    plb.add_time_avg(l_c_fscrypt_rd_lat, "fscrypt_rd_lat", "Overall fscrypt read latency");
+    plb.add_time_avg(l_c_fscrypt_wr_lat, "fscrypt_wr_lat", "Overall fscrypt write latency");
     logger.reset(plb.create_perf_counters());
     cct->get_perfcounters_collection()->add(logger.get());
   }
@@ -8887,7 +8892,9 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
 	header.data_len = (8 + 8 + 4);
 	header.file_offset = 0;
       } else {
+        auto dec_start = mono_clock_now();
         r = fscrypt_denc->decrypt_bl(offset, target_len, read_start, holes, &bl);
+        logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
 
         if (r < 0) {
           ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
@@ -8896,7 +8903,9 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
 
 	// 2. encrypt bl
         if (fscrypt_denc) {
+          auto enc_start = mono_clock_now();
           r = fscrypt_denc->encrypt_bl(offset, bl.length(), bl, &ebl);
+          logger->tinc(l_c_fscrypt_enc_lat, mono_clock_now() - enc_start);
 	}
 
         header.data_len = (8 + 8 + 4 + ebl.length());
@@ -11752,11 +11761,14 @@ success:
 #if defined(__linux__)
     if (fscrypt_denc) {
       std::vector<ObjectCacher::ObjHole> holes;
+      auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
+      clnt->logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
 	ldout(clnt->cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
       }
       bl->claim_append(*pbl);
+      clnt->logger->tinc(l_c_fscrypt_rd_lat, mono_clock_now() - start_time);
     }
 #endif
     // r is expected to hold value of effective bytes read.
@@ -12046,7 +12058,9 @@ void Client::C_Read_Async_Finisher::finish(int r)
 #if defined(__linux__)
   if (denc && r > 0) {
       std::vector<ObjectCacher::ObjHole> holes;
+      auto dec_start = mono_clock_now();
       r = denc->decrypt_bl(off, len, read_start, holes, bl);
+      clnt->logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
         // ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
       } else {
@@ -12185,11 +12199,14 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
   if (r >= 0) {
 #if defined(__linux__) 
     if (fscrypt_denc) {
+      auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, bl);
+      logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
         ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
         return r;
       }
+      logger->tinc(l_c_fscrypt_rd_lat, mono_clock_now() - start_time);
     }
 #endif
     r = bl->length();
@@ -12244,6 +12261,7 @@ uint64_t read_start;
 #endif
   ldout(cct, 10) << __func__ << " " << *in << " " << off << "~" << len << dendl;
 
+  auto start_time = mono_clock_now();
   // 0 success, 1 continue and < 0 error happen.
   auto wait_and_copy = [&](C_SaferCond &onfinish, bufferlist &tbl, int wanted) {
     int r = onfinish.wait();
@@ -12312,13 +12330,16 @@ uint64_t read_start;
 #if defined(__linux__)
     if (fscrypt_denc) {
       std::vector<ObjectCacher::ObjHole> holes;
+      auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
+      logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
       if (r < 0) {
         ldout(cct, 20) << __func__ << "(): failed to decrypt buffer: r=" << r << dendl;
       }
 
       read = pbl->length();
       bl->claim_append(*pbl);
+      logger->tinc(l_c_fscrypt_rd_lat, mono_clock_now() - start_time);
     } else
 #endif
       read = pbl->length();
@@ -12633,6 +12654,7 @@ Client::WriteEncMgr::WriteEncMgr(Client *clnt,
                                                    offset(offset), size(size), bl(bl),
                                                    async(async)
 {
+  start = mono_clock_now();
 #if defined(__linux__)
   denc = fscrypt->get_fdata_denc(in->fscrypt_ctx, &in->fscrypt_key_validator);
 #endif
@@ -12721,6 +12743,7 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
 
 
   if (need_read_start) {
+    clnt->logger->inc(l_c_fscrypt_wr_amp, read_start_size);
     finish_read_start_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_start_cb, &aioc));
 
     r = read(start_block_ofs, read_start_size, &startbl, finish_read_start_ctx.get());
@@ -12850,12 +12873,18 @@ bool Client::WriteEncMgr::do_try_finish(int r)
     offset = start_block_ofs;
 
     pbl = &encbl;
+    auto enc_start = mono_clock_now();
     r = denc->encrypt_bl(offset, bl.length(), bl, &encbl);
+    clnt->logger->tinc(l_c_fscrypt_enc_lat, mono_clock_now() - enc_start);
     if (r < 0) {
       ldout(cct, 0) << "failed to encrypt bl: r=" << r << dendl;
     }
 
     size = encbl.length();
+    clnt->logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
+    if (size > bl.length()) {
+      clnt->logger->inc(l_c_fscrypt_wr_amp, size - bl.length());
+    }
   }
 
   clnt->put_cap_ref(in, CEPH_CAP_FILE_RD);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12643,6 +12643,9 @@ bool Client::C_Write_Finisher::try_complete()
       ldout(clnt->cct, 19) << " complete with iofinished_r " << iofinished_r << dendl;
       onfinish->complete(iofinished_r);
     }
+    if (encrypted) {
+      clnt->logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
+    }
     clnt->logger->inc(l_c_aio_completions);
     clnt->logger->dec(l_c_aio_in_flight);
     onfinish = nullptr;
@@ -12892,7 +12895,6 @@ bool Client::WriteEncMgr::do_try_finish(int r)
     }
 
     size = encbl.length();
-    clnt->logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
     if (size > bl.length()) {
       clnt->logger->inc(l_c_fscrypt_wr_amp, size - bl.length());
     }
@@ -13234,6 +13236,9 @@ success:
   // do not get here if non-blocking caller (onfinish != nullptr)
   ldout(cct, 10) << " _write_filer_succeess" << dendl;
   r = _write_success(f, start, fpos, request_offset, request_size, enc_mgr->get_ofs(), enc_mgr->get_size(), in, enc_mgr->encrypted());
+  if (enc_mgr->encrypted()) {
+    logger->tinc(l_c_fscrypt_wr_lat, mono_clock_now() - start);
+  }
 
   if (r >= 0 && do_fsync) {
     int64_t r1;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12111,13 +12111,10 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     // Release C_Read_Async_Finisher from managed pointer, we need to complete
     // immediately. The C_Read_Async_Finisher is safely handled and won't be
     // abandoned.
-    Context *crf = io_finish.release();
+    io_finish.reset();
 
-    logger->inc(l_c_aio_ops);
-    logger->inc(l_c_aio_in_flight);
-
-    // Complete the crf immediately with 0 bytes
-    crf->complete(0);
+    // Complete the onfinish immediately with 0 bytes
+    onfinish->complete(0);
 
     // Signal async completion
     return 0;
@@ -15916,159 +15913,159 @@ size_t Client::_vxattrcb_client_id(Inode *in, char *val, size_t size)
 #define CEPH_XATTR_NAME(_type, _name) "ceph." #_type "." #_name
 #define CEPH_XATTR_NAME2(_type, _name, _name2) "ceph." #_type "." #_name "." #_name2
 
-#define XATTR_NAME_CEPH(_type, _name, _flags)                 \
-{                                                              \
-  name: CEPH_XATTR_NAME(_type, _name),                         \
-  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,     \
-  readonly: true,                                              \
-  exists_cb: NULL,                                             \
-  flags: _flags,                                               \
-}
-#define XATTR_LAYOUT_FIELD(_type, _name, _field)		\
-{								\
-  name: CEPH_XATTR_NAME2(_type, _name, _field),			\
-  getxattr_cb: &Client::_vxattrcb_ ## _name ## _ ## _field,	\
-  readonly: false,						\
-  exists_cb: &Client::_vxattrcb_layout_exists,			\
-  flags: 0,                                                     \
-}
-#define XATTR_QUOTA_FIELD(_type, _name)		                \
-{								\
-  name: CEPH_XATTR_NAME(_type, _name),			        \
-  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,	\
-  readonly: false,						\
-  exists_cb: &Client::_vxattrcb_quota_exists,			\
-  flags: 0,                                                     \
-}
+#define XATTR_NAME_CEPH(_type, _name, _flags)              \
+  {                                                        \
+      .name = CEPH_XATTR_NAME(_type, _name),               \
+      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
+      .readonly = true,                                    \
+      .exists_cb = NULL,                                   \
+      .flags = _flags,                                     \
+  }
+#define XATTR_LAYOUT_FIELD(_type, _name, _field)            \
+  {                                                         \
+      .name = CEPH_XATTR_NAME2(_type, _name, _field),       \
+      .getxattr_cb = &Client::_vxattrcb_##_name##_##_field, \
+      .readonly = false,                                    \
+      .exists_cb = &Client::_vxattrcb_layout_exists,        \
+      .flags = 0,                                           \
+  }
+#define XATTR_QUOTA_FIELD(_type, _name)                    \
+  {                                                        \
+      .name = CEPH_XATTR_NAME(_type, _name),               \
+      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
+      .readonly = false,                                   \
+      .exists_cb = &Client::_vxattrcb_quota_exists,        \
+      .flags = 0,                                          \
+  }
 
 const Client::VXattr Client::_dir_vxattrs[] = {
-  {
-    name: "ceph.dir.layout",
-    getxattr_cb: &Client::_vxattrcb_layout,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_layout_exists,
-    flags: 0,
-  },
-  // FIXME
-  // Delete the following dir layout field definitions for release "S"
-  XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
-  XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
-  XATTR_LAYOUT_FIELD(dir, layout, object_size),
-  XATTR_LAYOUT_FIELD(dir, layout, pool),
-  XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
-  XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
-  XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
-  XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
-  XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
-  {
-    name: "ceph.quota",
-    getxattr_cb: &Client::_vxattrcb_quota,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_quota_exists,
-    flags: 0,
-  },
-  XATTR_QUOTA_FIELD(quota, max_bytes),
-  XATTR_QUOTA_FIELD(quota, max_files),
-  // FIXME
-  // Delete the following dir pin field definitions for release "S"
-  {
-    name: "ceph.dir.pin",
-    getxattr_cb: &Client::_vxattrcb_dir_pin,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_dir_pin_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.snap.btime",
-    getxattr_cb: &Client::_vxattrcb_snap_btime,
-    readonly: true,
-    exists_cb: &Client::_vxattrcb_snap_btime_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.mirror.info",
-    getxattr_cb: &Client::_vxattrcb_mirror_info,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_mirror_info_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.caps",
-    getxattr_cb: &Client::_vxattrcb_caps,
-    readonly: true,
-    exists_cb: NULL,
-    flags: 0,
-  },
-  { name: "" }     /* Required table terminator */
+    {
+        .name = "ceph.dir.layout",
+        .getxattr_cb = &Client::_vxattrcb_layout,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_layout_exists,
+        .flags = 0,
+    },
+    // FIXME
+    // Delete the following dir layout field definitions for release "S"
+    XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
+    XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
+    XATTR_LAYOUT_FIELD(dir, layout, object_size),
+    XATTR_LAYOUT_FIELD(dir, layout, pool),
+    XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
+    XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
+    XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
+    XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
+    XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
+    XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
+    {
+        .name = "ceph.quota",
+        .getxattr_cb = &Client::_vxattrcb_quota,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_quota_exists,
+        .flags = 0,
+    },
+    XATTR_QUOTA_FIELD(quota, max_bytes),
+    XATTR_QUOTA_FIELD(quota, max_files),
+    // FIXME
+    // Delete the following dir pin field definitions for release "S"
+    {
+        .name = "ceph.dir.pin",
+        .getxattr_cb = &Client::_vxattrcb_dir_pin,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_dir_pin_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.snap.btime",
+        .getxattr_cb = &Client::_vxattrcb_snap_btime,
+        .readonly = true,
+        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.mirror.info",
+        .getxattr_cb = &Client::_vxattrcb_mirror_info,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_mirror_info_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.caps",
+        .getxattr_cb = &Client::_vxattrcb_caps,
+        .readonly = true,
+        .exists_cb = NULL,
+        .flags = 0,
+    },
+    {.name = ""} /* Required table terminator */
 };
 
 const Client::VXattr Client::_file_vxattrs[] = {
-  {
-    name: "ceph.file.layout",
-    getxattr_cb: &Client::_vxattrcb_layout,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_layout_exists,
-    flags: 0,
-  },
-  XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
-  XATTR_LAYOUT_FIELD(file, layout, stripe_count),
-  XATTR_LAYOUT_FIELD(file, layout, object_size),
-  XATTR_LAYOUT_FIELD(file, layout, pool),
-  XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
-  {
-    name: "ceph.snap.btime",
-    getxattr_cb: &Client::_vxattrcb_snap_btime,
-    readonly: true,
-    exists_cb: &Client::_vxattrcb_snap_btime_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.caps",
-    getxattr_cb: &Client::_vxattrcb_caps,
-    readonly: true,
-    exists_cb: NULL,
-    flags: 0,
-  },
-  { name: "" }     /* Required table terminator */
+    {
+        .name = "ceph.file.layout",
+        .getxattr_cb = &Client::_vxattrcb_layout,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_layout_exists,
+        .flags = 0,
+    },
+    XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
+    XATTR_LAYOUT_FIELD(file, layout, stripe_count),
+    XATTR_LAYOUT_FIELD(file, layout, object_size),
+    XATTR_LAYOUT_FIELD(file, layout, pool),
+    XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
+    {
+        .name = "ceph.snap.btime",
+        .getxattr_cb = &Client::_vxattrcb_snap_btime,
+        .readonly = true,
+        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.caps",
+        .getxattr_cb = &Client::_vxattrcb_caps,
+        .readonly = true,
+        .exists_cb = NULL,
+        .flags = 0,
+    },
+    {.name = ""} /* Required table terminator */
 };
 
 const Client::VXattr Client::_common_vxattrs[] = {
-  {
-    name: "ceph.cluster_fsid",
-    getxattr_cb: &Client::_vxattrcb_cluster_fsid,
-    readonly: true,
-    exists_cb: nullptr,
-    flags: 0,
-  },
-  {
-    name: "ceph.client_id",
-    getxattr_cb: &Client::_vxattrcb_client_id,
-    readonly: true,
-    exists_cb: nullptr,
-    flags: 0,
-  },
-  {
-    name: "ceph.fscrypt.auth",
-    getxattr_cb: &Client::_vxattrcb_fscrypt_auth,
-    setxattr_cb: &Client::_vxattrcb_fscrypt_auth_set,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_fscrypt_auth_exists,
-    flags: 0,
-  },
-  {
-    name: "ceph.fscrypt.file",
-    getxattr_cb: &Client::_vxattrcb_fscrypt_file,
-    setxattr_cb: &Client::_vxattrcb_fscrypt_file_set,
-    readonly: false,
-    exists_cb: &Client::_vxattrcb_fscrypt_file_exists,
-    flags: 0,
-  },
-  { name: "" }     /* Required table terminator */
+    {
+        .name = "ceph.cluster_fsid",
+        .getxattr_cb = &Client::_vxattrcb_cluster_fsid,
+        .readonly = true,
+        .exists_cb = nullptr,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.client_id",
+        .getxattr_cb = &Client::_vxattrcb_client_id,
+        .readonly = true,
+        .exists_cb = nullptr,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.fscrypt.auth",
+        .getxattr_cb = &Client::_vxattrcb_fscrypt_auth,
+        .setxattr_cb = &Client::_vxattrcb_fscrypt_auth_set,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_fscrypt_auth_exists,
+        .flags = 0,
+    },
+    {
+        .name = "ceph.fscrypt.file",
+        .getxattr_cb = &Client::_vxattrcb_fscrypt_file,
+        .setxattr_cb = &Client::_vxattrcb_fscrypt_file_set,
+        .readonly = false,
+        .exists_cb = &Client::_vxattrcb_fscrypt_file_exists,
+        .flags = 0,
+    },
+    {.name = ""} /* Required table terminator */
 };
 
 const Client::VXattr *Client::_get_vxattrs(Inode *in)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -699,6 +699,7 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_aio_ops, "aio_ops", "Total async IO operations");
     plb.add_u64_counter(l_c_aio_completions, "aio_completions", "Total async IO completions");
     plb.add_u64(l_c_aio_in_flight, "aio_in_flight", "Async IO operations in flight");
+    plb.add_u64(l_c_sync_in_flight, "sync_in_flight", "Sync IO operations in flight");
     plb.add_u64_counter(l_c_osdc_hit, "osdc_hit", "OSDC cache hits");
     plb.add_u64_counter(l_c_osdc_miss, "osdc_miss", "OSDC cache misses");
     plb.add_u64(l_c_osdc_dirty, "osdc_dirty", "OSDC dirty buffer size");
@@ -11586,6 +11587,9 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
     return -ENOTCONN;
+  if (logger) {
+    logger->inc(l_c_sync_in_flight);
+  }
 
   tout(cct) << "read" << std::endl;
   tout(cct) << fd << std::endl;
@@ -11594,11 +11598,19 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
 
   std::unique_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
-  if (!f)
+  if (!f) {
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
+  }
 #if defined(__linux__) && defined(O_PATH)
-  if (f->flags & O_PATH)
+  if (f->flags & O_PATH) {
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
+  }
 #endif
   bufferlist bl;
 #if defined(__linux__)
@@ -11619,6 +11631,9 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
     lock.unlock();
     bl.begin().copy(bl.length(), buf);
     r = bl.length();
+  }
+  if (logger) {
+    logger->dec(l_c_sync_in_flight);
   }
   return r;
 }
@@ -12365,6 +12380,9 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
     return -ENOTCONN;
+  if (logger) {
+    logger->inc(l_c_sync_in_flight);
+  }
 
   tout(cct) << "write" << std::endl;
   tout(cct) << fd << std::endl;
@@ -12373,11 +12391,19 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
 
   std::scoped_lock lock(client_lock);
   Fh *fh = get_filehandle(fd);
-  if (!fh)
+  if (!fh) {
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
+  }
 #if defined(__linux__) && defined(O_PATH)
-  if (fh->flags & O_PATH)
+  if (fh->flags & O_PATH) {
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
+  }
 #endif
 #if defined(__linux__)
   /* We can't return bytes written larger than INT_MAX, clamp size to
@@ -12395,6 +12421,9 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
   bl.append(buf, size);
   int r = _write(fh, offset, size, std::move(bl));
   ldout(cct, 3) << "write(" << fd << ", \"...\", " << size << ", " << offset << ") = " << r << dendl;
+  if (logger) {
+    logger->dec(l_c_sync_in_flight);
+  }
   return r;
 }
 
@@ -12491,12 +12520,23 @@ int Client::_preadv_pwritev(int fd, const struct iovec *iov, int iovcnt,
     tout(cct) << fd << std::endl;
     tout(cct) << offset << std::endl;
 
+    if (onfinish == nullptr && logger) {
+      logger->inc(l_c_sync_in_flight);
+    }
     std::scoped_lock cl(client_lock);
     Fh *fh = get_filehandle(fd);
-    if (!fh)
+    if (!fh) {
+      if (onfinish == nullptr && logger) {
+        logger->dec(l_c_sync_in_flight);
+      }
       return -EBADF;
-    return _preadv_pwritev_locked(fh, iov, iovcnt, offset, write, true,
-                                  onfinish, blp);
+    }
+    auto r = _preadv_pwritev_locked(fh, iov, iovcnt, offset, write, true,
+                                    onfinish, blp);
+    if (onfinish == nullptr && logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
+    return r;
 }
 
 int64_t Client::_write_success(Fh *f, utime_t start, uint64_t fpos,
@@ -17451,6 +17491,9 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
   if (!mref_reader.is_state_satisfied()) {
     return -ENOTCONN;
   }
+  if (logger) {
+    logger->inc(l_c_sync_in_flight);
+  }
 
 #if defined(__linux__)
   /* We can't return bytes written larger than INT_MAX, clamp size to
@@ -17468,6 +17511,9 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
   std::scoped_lock lock(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
   }
 
@@ -17480,6 +17526,9 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
   int r = _read(fh, off, len, bl);
   ldout(cct, 3) << "ll_read " << fh << " " << off << "~" << len << " = " << r
 		<< dendl;
+  if (logger) {
+    logger->dec(l_c_sync_in_flight);
+  }
   return r;
 }
 
@@ -17606,6 +17655,9 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
   if (!mref_reader.is_state_satisfied()) {
     return -ENOTCONN;
   }
+  if (logger) {
+    logger->inc(l_c_sync_in_flight);
+  }
 
 #if defined(__linux__)
   /* We can't return bytes written larger than INT_MAX, clamp size to
@@ -17622,6 +17674,9 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
   std::scoped_lock lock(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
   }
 
@@ -17637,6 +17692,9 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
   int r = _write(fh, off, len, std::move(bl));
   ldout(cct, 3) << "ll_write " << fh << " " << off << "~" << len << " = " << r
 		<< dendl;
+  if (logger) {
+    logger->dec(l_c_sync_in_flight);
+  }
   return r;
 }
 
@@ -17646,13 +17704,23 @@ int64_t Client::ll_writev(struct Fh *fh, const struct iovec *iov, int iovcnt, in
   if (!mref_reader.is_state_satisfied()) {
     return -ENOTCONN;
   }
+  if (logger) {
+    logger->inc(l_c_sync_in_flight);
+  }
 
   std::scoped_lock cl(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
   }
-  return _preadv_pwritev_locked(fh, iov, iovcnt, off, true, true);
+  auto r = _preadv_pwritev_locked(fh, iov, iovcnt, off, true, true);
+  if (logger) {
+    logger->dec(l_c_sync_in_flight);
+  }
+  return r;
 }
 
 int64_t Client::ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int64_t off)
@@ -17661,13 +17729,23 @@ int64_t Client::ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int
   if (!mref_reader.is_state_satisfied()) {
     return -ENOTCONN;
   }
+  if (logger) {
+    logger->inc(l_c_sync_in_flight);
+  }
 
   std::scoped_lock cl(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
+    if (logger) {
+      logger->dec(l_c_sync_in_flight);
+    }
     return -EBADF;
   }
-  return _preadv_pwritev_locked(fh, iov, iovcnt, off, false, true);
+  auto r = _preadv_pwritev_locked(fh, iov, iovcnt, off, false, true);
+  if (logger) {
+    logger->dec(l_c_sync_in_flight);
+  }
+  return r;
 }
 
 int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
@@ -17676,6 +17754,9 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
                                   bool do_fsync, bool syncdataonly)
 {
     int64_t retval = -1;
+    if (onfinish == nullptr && logger) {
+      logger->inc(l_c_sync_in_flight);
+    }
 
     RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
     if (!mref_reader.is_state_satisfied()) {
@@ -17685,6 +17766,9 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
         /* async call should always return zero to caller and allow the
         caller to wait on callback for the actual errno. */
         retval = 0;
+      }
+      if (onfinish == nullptr && logger) {
+        logger->dec(l_c_sync_in_flight);
       }
       return retval;
     }
@@ -17703,6 +17787,9 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
         onfinish->complete(retval);
         cl.lock();
         retval = 0;
+      }
+      if (onfinish == nullptr && logger) {
+        logger->dec(l_c_sync_in_flight);
       }
       return retval;
     }
@@ -17734,6 +17821,9 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
         caller to wait on callback for the actual errno/retval. */
         retval = 0;
       }
+    }
+    if (onfinish == nullptr && logger) {
+      logger->dec(l_c_sync_in_flight);
     }
     return retval;
 }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -752,6 +752,7 @@ void Client::_finish_init()
     plb.add_u64_counter(l_c_caps_revoke, "caps_revoke", "Capability revokes");
     plb.add_u64_counter(l_c_caps_release, "caps_release", "Capability releases");
     plb.add_u64_counter(l_c_fscrypt_wr_amp, "fscrypt_wr_amp", "Extra bytes written due to padding and RMW");
+    plb.add_u64_counter(l_c_fscrypt_rd_amp, "fscrypt_rd_amp", "Extra bytes read due to block alignment");
     plb.add_time_avg(l_c_fscrypt_enc_lat, "fscrypt_enc_lat", "Encryption time");
     plb.add_time_avg(l_c_fscrypt_dec_lat, "fscrypt_dec_lat", "Decryption time");
     plb.add_time_avg(l_c_fscrypt_rd_lat, "fscrypt_rd_lat", "Overall fscrypt read latency");
@@ -11760,6 +11761,9 @@ success:
   if (r >= 0) {
 #if defined(__linux__)
     if (fscrypt_denc) {
+      if (read_len > target_len) {
+        clnt->logger->inc(l_c_fscrypt_rd_amp, read_len - target_len);
+      }
       std::vector<ObjectCacher::ObjHole> holes;
       auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
@@ -12199,6 +12203,9 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
   if (r >= 0) {
 #if defined(__linux__) 
     if (fscrypt_denc) {
+      if (read_len > target_len) {
+        logger->inc(l_c_fscrypt_rd_amp, read_len - target_len);
+      }
       auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, bl);
       logger->tinc(l_c_fscrypt_dec_lat, mono_clock_now() - dec_start);
@@ -12329,6 +12336,9 @@ uint64_t read_start;
   if (r >= 0) {
 #if defined(__linux__)
     if (fscrypt_denc) {
+      if (read_len > target_len) {
+        logger->inc(l_c_fscrypt_rd_amp, read_len - target_len);
+      }
       std::vector<ObjectCacher::ObjHole> holes;
       auto dec_start = mono_clock_now();
       r = fscrypt_denc->decrypt_bl(off, target_len, read_start, holes, pbl);
@@ -12756,6 +12766,7 @@ int Client::WriteEncMgr::read_modify_write(Context *_iofinish)
   }
 
   if (need_read_end) {
+    clnt->logger->inc(l_c_fscrypt_wr_amp, FSCRYPT_BLOCK_SIZE);
     finish_read_end_ctx.reset(new iofinish_method_ctx<WriteEncMgr>(*this, &WriteEncMgr::finish_read_end_cb, &aioc));
 
     r = read(end_block_ofs, FSCRYPT_BLOCK_SIZE, &endbl, finish_read_end_ctx.get());

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4944,8 +4944,11 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
   const auto &capem = in->caps.emplace(std::piecewise_construct, std::forward_as_tuple(mds), std::forward_as_tuple(*in, mds_session));
   Cap &cap = capem.first->second;
   if (!capem.second) {
-    if (cap.gen < mds_session->cap_gen)
+    if (cap.gen < mds_session->cap_gen) {
       cap.issued = cap.implemented = CEPH_CAP_PIN;
+      inc_pinned_icaps();
+      inc_caps();
+    }
 
     /*
      * auth mds of the inode changed. we received the cap export
@@ -15913,159 +15916,159 @@ size_t Client::_vxattrcb_client_id(Inode *in, char *val, size_t size)
 #define CEPH_XATTR_NAME(_type, _name) "ceph." #_type "." #_name
 #define CEPH_XATTR_NAME2(_type, _name, _name2) "ceph." #_type "." #_name "." #_name2
 
-#define XATTR_NAME_CEPH(_type, _name, _flags)              \
-  {                                                        \
-      .name = CEPH_XATTR_NAME(_type, _name),               \
-      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
-      .readonly = true,                                    \
-      .exists_cb = NULL,                                   \
-      .flags = _flags,                                     \
-  }
-#define XATTR_LAYOUT_FIELD(_type, _name, _field)            \
-  {                                                         \
-      .name = CEPH_XATTR_NAME2(_type, _name, _field),       \
-      .getxattr_cb = &Client::_vxattrcb_##_name##_##_field, \
-      .readonly = false,                                    \
-      .exists_cb = &Client::_vxattrcb_layout_exists,        \
-      .flags = 0,                                           \
-  }
-#define XATTR_QUOTA_FIELD(_type, _name)                    \
-  {                                                        \
-      .name = CEPH_XATTR_NAME(_type, _name),               \
-      .getxattr_cb = &Client::_vxattrcb_##_type##_##_name, \
-      .readonly = false,                                   \
-      .exists_cb = &Client::_vxattrcb_quota_exists,        \
-      .flags = 0,                                          \
-  }
+#define XATTR_NAME_CEPH(_type, _name, _flags)                 \
+{                                                              \
+  name: CEPH_XATTR_NAME(_type, _name),                         \
+  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,     \
+  readonly: true,                                              \
+  exists_cb: NULL,                                             \
+  flags: _flags,                                               \
+}
+#define XATTR_LAYOUT_FIELD(_type, _name, _field)		\
+{								\
+  name: CEPH_XATTR_NAME2(_type, _name, _field),			\
+  getxattr_cb: &Client::_vxattrcb_ ## _name ## _ ## _field,	\
+  readonly: false,						\
+  exists_cb: &Client::_vxattrcb_layout_exists,			\
+  flags: 0,                                                     \
+}
+#define XATTR_QUOTA_FIELD(_type, _name)		                \
+{								\
+  name: CEPH_XATTR_NAME(_type, _name),			        \
+  getxattr_cb: &Client::_vxattrcb_ ## _type ## _ ## _name,	\
+  readonly: false,						\
+  exists_cb: &Client::_vxattrcb_quota_exists,			\
+  flags: 0,                                                     \
+}
 
 const Client::VXattr Client::_dir_vxattrs[] = {
-    {
-        .name = "ceph.dir.layout",
-        .getxattr_cb = &Client::_vxattrcb_layout,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_layout_exists,
-        .flags = 0,
-    },
-    // FIXME
-    // Delete the following dir layout field definitions for release "S"
-    XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
-    XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
-    XATTR_LAYOUT_FIELD(dir, layout, object_size),
-    XATTR_LAYOUT_FIELD(dir, layout, pool),
-    XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
-    XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
-    XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
-    XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
-    XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
-    XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
-    {
-        .name = "ceph.quota",
-        .getxattr_cb = &Client::_vxattrcb_quota,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_quota_exists,
-        .flags = 0,
-    },
-    XATTR_QUOTA_FIELD(quota, max_bytes),
-    XATTR_QUOTA_FIELD(quota, max_files),
-    // FIXME
-    // Delete the following dir pin field definitions for release "S"
-    {
-        .name = "ceph.dir.pin",
-        .getxattr_cb = &Client::_vxattrcb_dir_pin,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_dir_pin_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.snap.btime",
-        .getxattr_cb = &Client::_vxattrcb_snap_btime,
-        .readonly = true,
-        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.mirror.info",
-        .getxattr_cb = &Client::_vxattrcb_mirror_info,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_mirror_info_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.caps",
-        .getxattr_cb = &Client::_vxattrcb_caps,
-        .readonly = true,
-        .exists_cb = NULL,
-        .flags = 0,
-    },
-    {.name = ""} /* Required table terminator */
+  {
+    name: "ceph.dir.layout",
+    getxattr_cb: &Client::_vxattrcb_layout,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_layout_exists,
+    flags: 0,
+  },
+  // FIXME
+  // Delete the following dir layout field definitions for release "S"
+  XATTR_LAYOUT_FIELD(dir, layout, stripe_unit),
+  XATTR_LAYOUT_FIELD(dir, layout, stripe_count),
+  XATTR_LAYOUT_FIELD(dir, layout, object_size),
+  XATTR_LAYOUT_FIELD(dir, layout, pool),
+  XATTR_LAYOUT_FIELD(dir, layout, pool_namespace),
+  XATTR_NAME_CEPH(dir, entries, VXATTR_DIRSTAT),
+  XATTR_NAME_CEPH(dir, files, VXATTR_DIRSTAT),
+  XATTR_NAME_CEPH(dir, subdirs, VXATTR_DIRSTAT),
+  XATTR_NAME_CEPH(dir, rentries, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rfiles, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
+  XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
+  {
+    name: "ceph.quota",
+    getxattr_cb: &Client::_vxattrcb_quota,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_quota_exists,
+    flags: 0,
+  },
+  XATTR_QUOTA_FIELD(quota, max_bytes),
+  XATTR_QUOTA_FIELD(quota, max_files),
+  // FIXME
+  // Delete the following dir pin field definitions for release "S"
+  {
+    name: "ceph.dir.pin",
+    getxattr_cb: &Client::_vxattrcb_dir_pin,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_dir_pin_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.snap.btime",
+    getxattr_cb: &Client::_vxattrcb_snap_btime,
+    readonly: true,
+    exists_cb: &Client::_vxattrcb_snap_btime_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.mirror.info",
+    getxattr_cb: &Client::_vxattrcb_mirror_info,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_mirror_info_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.caps",
+    getxattr_cb: &Client::_vxattrcb_caps,
+    readonly: true,
+    exists_cb: NULL,
+    flags: 0,
+  },
+  { name: "" }     /* Required table terminator */
 };
 
 const Client::VXattr Client::_file_vxattrs[] = {
-    {
-        .name = "ceph.file.layout",
-        .getxattr_cb = &Client::_vxattrcb_layout,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_layout_exists,
-        .flags = 0,
-    },
-    XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
-    XATTR_LAYOUT_FIELD(file, layout, stripe_count),
-    XATTR_LAYOUT_FIELD(file, layout, object_size),
-    XATTR_LAYOUT_FIELD(file, layout, pool),
-    XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
-    {
-        .name = "ceph.snap.btime",
-        .getxattr_cb = &Client::_vxattrcb_snap_btime,
-        .readonly = true,
-        .exists_cb = &Client::_vxattrcb_snap_btime_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.caps",
-        .getxattr_cb = &Client::_vxattrcb_caps,
-        .readonly = true,
-        .exists_cb = NULL,
-        .flags = 0,
-    },
-    {.name = ""} /* Required table terminator */
+  {
+    name: "ceph.file.layout",
+    getxattr_cb: &Client::_vxattrcb_layout,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_layout_exists,
+    flags: 0,
+  },
+  XATTR_LAYOUT_FIELD(file, layout, stripe_unit),
+  XATTR_LAYOUT_FIELD(file, layout, stripe_count),
+  XATTR_LAYOUT_FIELD(file, layout, object_size),
+  XATTR_LAYOUT_FIELD(file, layout, pool),
+  XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
+  {
+    name: "ceph.snap.btime",
+    getxattr_cb: &Client::_vxattrcb_snap_btime,
+    readonly: true,
+    exists_cb: &Client::_vxattrcb_snap_btime_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.caps",
+    getxattr_cb: &Client::_vxattrcb_caps,
+    readonly: true,
+    exists_cb: NULL,
+    flags: 0,
+  },
+  { name: "" }     /* Required table terminator */
 };
 
 const Client::VXattr Client::_common_vxattrs[] = {
-    {
-        .name = "ceph.cluster_fsid",
-        .getxattr_cb = &Client::_vxattrcb_cluster_fsid,
-        .readonly = true,
-        .exists_cb = nullptr,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.client_id",
-        .getxattr_cb = &Client::_vxattrcb_client_id,
-        .readonly = true,
-        .exists_cb = nullptr,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.fscrypt.auth",
-        .getxattr_cb = &Client::_vxattrcb_fscrypt_auth,
-        .setxattr_cb = &Client::_vxattrcb_fscrypt_auth_set,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_fscrypt_auth_exists,
-        .flags = 0,
-    },
-    {
-        .name = "ceph.fscrypt.file",
-        .getxattr_cb = &Client::_vxattrcb_fscrypt_file,
-        .setxattr_cb = &Client::_vxattrcb_fscrypt_file_set,
-        .readonly = false,
-        .exists_cb = &Client::_vxattrcb_fscrypt_file_exists,
-        .flags = 0,
-    },
-    {.name = ""} /* Required table terminator */
+  {
+    name: "ceph.cluster_fsid",
+    getxattr_cb: &Client::_vxattrcb_cluster_fsid,
+    readonly: true,
+    exists_cb: nullptr,
+    flags: 0,
+  },
+  {
+    name: "ceph.client_id",
+    getxattr_cb: &Client::_vxattrcb_client_id,
+    readonly: true,
+    exists_cb: nullptr,
+    flags: 0,
+  },
+  {
+    name: "ceph.fscrypt.auth",
+    getxattr_cb: &Client::_vxattrcb_fscrypt_auth,
+    setxattr_cb: &Client::_vxattrcb_fscrypt_auth_set,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_fscrypt_auth_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.fscrypt.file",
+    getxattr_cb: &Client::_vxattrcb_fscrypt_file,
+    setxattr_cb: &Client::_vxattrcb_fscrypt_file_set,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_fscrypt_file_exists,
+    flags: 0,
+  },
+  { name: "" }     /* Required table terminator */
 };
 
 const Client::VXattr *Client::_get_vxattrs(Inode *in)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4354,7 +4354,6 @@ void Client::send_cap(Inode *in, MetaSession *session, Cap *cap,
   if (!session->flushing_caps_tids.empty())
     m->set_oldest_flush_tid(*session->flushing_caps_tids.begin());
 
-  inc_caps_release();
   session->con->send_message2(std::move(m));
 }
 
@@ -4543,6 +4542,7 @@ void Client::check_caps(const InodeRef& in, unsigned flags)
     in->delay_cap_item.remove_myself();
     send_cap(in.get(), session.get(), &cap, msg_flags, cap_used, wanted, retain,
 	     flushing, flush_tid);
+    inc_caps_release();
   }
 }
 
@@ -5474,6 +5474,7 @@ void Client::kick_flushing_caps(Inode *in, MetaSession *session)
       int msg_flags = p.first < last_snap_flush ? MClientCaps::FLAG_PENDING_CAPSNAP : 0;
       send_cap(in, session, cap, msg_flags, used, wanted, (cap->issued | cap->implemented),
 	       p.second, p.first);
+      inc_caps_release();
     } else {
       ceph_assert(it != in->cap_snaps.end());
       ceph_assert(it->second.flush_tid == p.first);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -161,6 +161,7 @@ enum {
   l_c_caps_revoke,
   l_c_caps_release,
   l_c_fscrypt_wr_amp,
+  l_c_fscrypt_rd_amp,
   l_c_fscrypt_enc_lat,
   l_c_fscrypt_dec_lat,
   l_c_fscrypt_rd_lat,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -160,6 +160,11 @@ enum {
   l_c_caps_grant,
   l_c_caps_revoke,
   l_c_caps_release,
+  l_c_fscrypt_wr_amp,
+  l_c_fscrypt_enc_lat,
+  l_c_fscrypt_dec_lat,
+  l_c_fscrypt_rd_lat,
+  l_c_fscrypt_wr_lat,
   l_c_last,
 };
 
@@ -1897,6 +1902,7 @@ private:
 
     int64_t get_ofs() { return offset; }
     uint64_t get_size() { return size; }
+    utime_t start;
   };
 
   class WriteEncMgr_Buffered : public WriteEncMgr {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -101,6 +101,65 @@ enum {
   l_c_wr_avg,
   l_c_wr_sqsum,
   l_c_wr_ops,
+  l_c_rd_sz_avg,
+  l_c_rd_sz_sqsum,
+  l_c_wr_sz_avg,
+  l_c_wr_sz_sqsum,
+  l_c_aio_ops,
+  l_c_aio_completions,
+  l_c_aio_in_flight,
+  l_c_osdc_hit,
+  l_c_osdc_miss,
+  l_c_osdc_dirty,
+  l_c_mds_req,
+  l_c_mds_req_lookup,
+  l_c_mds_req_getattr,
+  l_c_mds_req_lookuphash,
+  l_c_mds_req_lookupparent,
+  l_c_mds_req_lookupino,
+  l_c_mds_req_lookupname,
+  l_c_mds_req_getvxattr,
+  l_c_mds_req_dummy,
+  l_c_mds_req_setxattr,
+  l_c_mds_req_rmxattr,
+  l_c_mds_req_setlayout,
+  l_c_mds_req_setattr,
+  l_c_mds_req_setfilelock,
+  l_c_mds_req_getfilelock,
+  l_c_mds_req_setdirlayout,
+  l_c_mds_req_mknod,
+  l_c_mds_req_link,
+  l_c_mds_req_unlink,
+  l_c_mds_req_rename,
+  l_c_mds_req_mkdir,
+  l_c_mds_req_rmdir,
+  l_c_mds_req_symlink,
+  l_c_mds_req_create,
+  l_c_mds_req_open,
+  l_c_mds_req_readdir,
+  l_c_mds_req_lookupsnap,
+  l_c_mds_req_mksnap,
+  l_c_mds_req_rmsnap,
+  l_c_mds_req_lssnap,
+  l_c_mds_req_renamesnap,
+  l_c_mds_req_readdir_snapdiff,
+  l_c_mds_req_file_blockdiff,
+  l_c_mds_req_fragmentdir,
+  l_c_mds_req_exportdir,
+  l_c_mds_req_flush,
+  l_c_mds_req_enqueue_scrub,
+  l_c_mds_req_repair_fragstats,
+  l_c_mds_req_repair_inodestats,
+  l_c_mds_req_rdlock_fragsstats,
+  l_c_mds_req_quiesce_path,
+  l_c_mds_req_quiesce_inode,
+  l_c_mds_req_lock_path,
+  l_c_mds_req_uninline_data,
+  l_c_caps,
+  l_c_caps_dirty,
+  l_c_caps_grant,
+  l_c_caps_revoke,
+  l_c_caps_release,
   l_c_last,
 };
 
@@ -953,15 +1012,8 @@ public:
   void tick();
   void start_tick_thread();
 
-  void update_read_io_size(size_t size) {
-    total_read_ops++;
-    total_read_size += size;
-  }
-
-  void update_write_io_size(size_t size) {
-    total_write_ops++;
-    total_write_size += size;
-  }
+  void update_read_io_size(size_t size);
+  void update_write_io_size(size_t size);
 
   void inc_dentry_nr() {
     ++dentry_nr;
@@ -987,6 +1039,27 @@ public:
   }
   std::pair<uint64_t, uint64_t> get_cap_hit_rates() {
     return std::make_pair(cap_hits, cap_misses);
+  }
+
+  void inc_caps() {
+    if (logger)
+      logger->inc(l_c_caps);
+  }
+  void dec_caps() {
+    if (logger)
+      logger->dec(l_c_caps);
+  }
+  void inc_caps_grant() {
+    if (logger)
+      logger->inc(l_c_caps_grant);
+  }
+  void inc_caps_revoke() {
+    if (logger)
+      logger->inc(l_c_caps_revoke);
+  }
+  void inc_caps_release() {
+    if (logger)
+      logger->inc(l_c_caps_release);
   }
 
   void inc_opened_files() {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -110,6 +110,7 @@ enum {
   l_c_aio_ops,
   l_c_aio_completions,
   l_c_aio_in_flight,
+  l_c_sync_in_flight,
   l_c_osdc_hit,
   l_c_osdc_miss,
   l_c_osdc_dirty,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -162,6 +162,11 @@ enum {
   l_c_caps_grant,
   l_c_caps_revoke,
   l_c_caps_release,
+  l_c_fscrypt_wr_amp,
+  l_c_fscrypt_enc_lat,
+  l_c_fscrypt_dec_lat,
+  l_c_fscrypt_rd_lat,
+  l_c_fscrypt_wr_lat,
   l_c_last,
 };
 
@@ -1914,6 +1919,7 @@ private:
 
     int64_t get_ofs() { return offset; }
     uint64_t get_size() { return size; }
+    utime_t start;
   };
 
   class WriteEncMgr_Buffered : public WriteEncMgr {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -53,6 +53,7 @@
 #endif
 
 #include <fstream>
+#include <atomic>
 #include <locale>
 #include <map>
 #include <memory>
@@ -110,7 +111,9 @@ enum {
   l_c_aio_ops,
   l_c_aio_completions,
   l_c_aio_in_flight,
+  l_c_aio_in_flight_peak,
   l_c_sync_in_flight,
+  l_c_sync_in_flight_peak,
   l_c_osdc_hit,
   l_c_osdc_miss,
   l_c_osdc_dirty,
@@ -1070,6 +1073,38 @@ public:
     if (logger)
       logger->inc(l_c_caps_release);
   }
+  void inc_aio_in_flight() {
+    if (!logger) {
+      return;
+    }
+    auto cur = aio_in_flight.fetch_add(1, std::memory_order_relaxed) + 1;
+    logger->inc(l_c_aio_in_flight);
+    update_in_flight_peak(cur, aio_in_flight_peak, l_c_aio_in_flight_peak);
+  }
+  void dec_aio_in_flight() {
+    if (!logger) {
+      return;
+    }
+    auto prev = aio_in_flight.fetch_sub(1, std::memory_order_relaxed);
+    ceph_assert(prev > 0);
+    logger->dec(l_c_aio_in_flight);
+  }
+  void inc_sync_in_flight() {
+    if (!logger) {
+      return;
+    }
+    auto cur = sync_in_flight.fetch_add(1, std::memory_order_relaxed) + 1;
+    logger->inc(l_c_sync_in_flight);
+    update_in_flight_peak(cur, sync_in_flight_peak, l_c_sync_in_flight_peak);
+  }
+  void dec_sync_in_flight() {
+    if (!logger) {
+      return;
+    }
+    auto prev = sync_in_flight.fetch_sub(1, std::memory_order_relaxed);
+    ceph_assert(prev > 0);
+    logger->dec(l_c_sync_in_flight);
+  }
 
   void inc_opened_files() {
     ++opened_files;
@@ -1122,6 +1157,10 @@ public:
   bool tick_thread_stopped = false;
 
   std::unique_ptr<PerfCounters> logger;
+  std::atomic<uint64_t> aio_in_flight{0};
+  std::atomic<uint64_t> aio_in_flight_peak{0};
+  std::atomic<uint64_t> sync_in_flight{0};
+  std::atomic<uint64_t> sync_in_flight_peak{0};
   std::unique_ptr<MDSMap> mdsmap;
 #if defined(__linux__)
   std::unique_ptr<FSCrypt> fscrypt;
@@ -1130,6 +1169,18 @@ public:
 
 
 protected:
+  void update_in_flight_peak(uint64_t cur,
+                             std::atomic<uint64_t>& peak,
+                             int peak_counter_key) {
+    auto old_peak = peak.load(std::memory_order_relaxed);
+    while (cur > old_peak) {
+      if (peak.compare_exchange_weak(old_peak, cur, std::memory_order_relaxed)) {
+        logger->set(peak_counter_key, cur);
+        break;
+      }
+    }
+  }
+
   struct FSCrypt_Options {
     std::vector<uint8_t> fscrypt_auth;
     std::vector<uint8_t> fscrypt_file;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -103,6 +103,65 @@ enum {
   l_c_wr_avg,
   l_c_wr_sqsum,
   l_c_wr_ops,
+  l_c_rd_sz_avg,
+  l_c_rd_sz_sqsum,
+  l_c_wr_sz_avg,
+  l_c_wr_sz_sqsum,
+  l_c_aio_ops,
+  l_c_aio_completions,
+  l_c_aio_in_flight,
+  l_c_osdc_hit,
+  l_c_osdc_miss,
+  l_c_osdc_dirty,
+  l_c_mds_req,
+  l_c_mds_req_lookup,
+  l_c_mds_req_getattr,
+  l_c_mds_req_lookuphash,
+  l_c_mds_req_lookupparent,
+  l_c_mds_req_lookupino,
+  l_c_mds_req_lookupname,
+  l_c_mds_req_getvxattr,
+  l_c_mds_req_dummy,
+  l_c_mds_req_setxattr,
+  l_c_mds_req_rmxattr,
+  l_c_mds_req_setlayout,
+  l_c_mds_req_setattr,
+  l_c_mds_req_setfilelock,
+  l_c_mds_req_getfilelock,
+  l_c_mds_req_setdirlayout,
+  l_c_mds_req_mknod,
+  l_c_mds_req_link,
+  l_c_mds_req_unlink,
+  l_c_mds_req_rename,
+  l_c_mds_req_mkdir,
+  l_c_mds_req_rmdir,
+  l_c_mds_req_symlink,
+  l_c_mds_req_create,
+  l_c_mds_req_open,
+  l_c_mds_req_readdir,
+  l_c_mds_req_lookupsnap,
+  l_c_mds_req_mksnap,
+  l_c_mds_req_rmsnap,
+  l_c_mds_req_lssnap,
+  l_c_mds_req_renamesnap,
+  l_c_mds_req_readdir_snapdiff,
+  l_c_mds_req_file_blockdiff,
+  l_c_mds_req_fragmentdir,
+  l_c_mds_req_exportdir,
+  l_c_mds_req_flush,
+  l_c_mds_req_enqueue_scrub,
+  l_c_mds_req_repair_fragstats,
+  l_c_mds_req_repair_inodestats,
+  l_c_mds_req_rdlock_fragsstats,
+  l_c_mds_req_quiesce_path,
+  l_c_mds_req_quiesce_inode,
+  l_c_mds_req_lock_path,
+  l_c_mds_req_uninline_data,
+  l_c_caps,
+  l_c_caps_dirty,
+  l_c_caps_grant,
+  l_c_caps_revoke,
+  l_c_caps_release,
   l_c_last,
 };
 
@@ -955,15 +1014,8 @@ public:
   void tick();
   void start_tick_thread();
 
-  void update_read_io_size(size_t size) {
-    total_read_ops++;
-    total_read_size += size;
-  }
-
-  void update_write_io_size(size_t size) {
-    total_write_ops++;
-    total_write_size += size;
-  }
+  void update_read_io_size(size_t size);
+  void update_write_io_size(size_t size);
 
   void inc_dentry_nr() {
     ++dentry_nr;
@@ -989,6 +1041,27 @@ public:
   }
   std::pair<uint64_t, uint64_t> get_cap_hit_rates() {
     return std::make_pair(cap_hits, cap_misses);
+  }
+
+  void inc_caps() {
+    if (logger)
+      logger->inc(l_c_caps);
+  }
+  void dec_caps() {
+    if (logger)
+      logger->dec(l_c_caps);
+  }
+  void inc_caps_grant() {
+    if (logger)
+      logger->inc(l_c_caps_grant);
+  }
+  void inc_caps_revoke() {
+    if (logger)
+      logger->inc(l_c_caps_revoke);
+  }
+  void inc_caps_release() {
+    if (logger)
+      logger->inc(l_c_caps_release);
   }
 
   void inc_opened_files() {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -163,6 +163,7 @@ enum {
   l_c_caps_revoke,
   l_c_caps_release,
   l_c_fscrypt_wr_amp,
+  l_c_fscrypt_rd_amp,
   l_c_fscrypt_enc_lat,
   l_c_fscrypt_dec_lat,
   l_c_fscrypt_rd_lat,

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -482,13 +482,6 @@ class ObjectCacher {
 
   void bh_stat_add(BufferHead *bh);
   void bh_stat_sub(BufferHead *bh);
-  loff_t get_stat_tx() const { return stat_tx; }
-  loff_t get_stat_rx() const { return stat_rx; }
-  loff_t get_stat_dirty() const { return stat_dirty; }
-  loff_t get_stat_clean() const { return stat_clean; }
-  loff_t get_stat_zero() const { return stat_zero; }
-  loff_t get_stat_dirty_waiting() const { return stat_dirty_waiting; }
-  size_t get_stat_nr_dirty_waiters() const { return stat_nr_dirty_waiters; }
 
   void touch_bh(BufferHead *bh) {
     if (bh->is_dirty())
@@ -589,6 +582,14 @@ class ObjectCacher {
 
   void perf_start();
   void perf_stop();
+
+  loff_t get_stat_tx() const { return stat_tx; }
+  loff_t get_stat_rx() const { return stat_rx; }
+  loff_t get_stat_dirty() const { return stat_dirty; }
+  loff_t get_stat_clean() const { return stat_clean; }
+  loff_t get_stat_zero() const { return stat_zero; }
+  loff_t get_stat_dirty_waiting() const { return stat_dirty_waiting; }
+  size_t get_stat_nr_dirty_waiters() const { return stat_nr_dirty_waiters; }
 
 
 


### PR DESCRIPTION
Introduce detailed counters for IO events (read/write sizes, async IO activity, and MDS requests).
Improve metrics tracking and logging to support monitoring and debugging capabilities.

Fixes: https://tracker.ceph.com/issues/75298





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
