### PR TITLE
mgr/smb: add cluster_mode QoS parameter for cluster-wide rate limiting

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -267,7 +267,7 @@ Update Share QoS
 
 .. prompt:: bash #
 
-   ceph smb share update cephfs qos <cluster_id> <share_id> [--read-iops-limit=<int>] [--write-iops-limit=<int>] [--read-bw-limit=<str>] [--write-bw-limit=<str>] [--read-burst-mult=<int>] [--write-burst-mult=<int>]
+   ceph smb share update cephfs qos <cluster_id> <share_id> [--read-iops-limit=<int>] [--write-iops-limit=<int>] [--read-bw-limit=<str>] [--write-bw-limit=<str>] [--read-burst-mult=<int>] [--write-burst-mult=<int>] [--cluster-mode=<bool>]
 
 Update Quality of Service (QoS) settings for a CephFS-backed share. This allows administrators to apply per-share rate limits on SMB input/output (I/O) operations, specifically limits on IOPS (Input/Output Operations per Second) and bandwidth (in bytes per second) for both read and write operations. Additionally, burst multipliers can be configured to allow temporary bursts above the configured limits.
 
@@ -299,6 +299,11 @@ write_burst_mult
     Optional integer. Burst multiplier for write operations (value ÷ 10 = multiplier),
     allowing temporary bursts above the configured limit. Example: ``20`` = 2* the configured limit.
     Range: 10-100 (1* to 10*), default: 15 (1.5*).
+cluster_mode
+    Optional boolean. Controls whether rate limiting is enforced cluster-wide or per-node
+    when using Samba clustering (CTDB). When set to ``true``, limits are enforced across all
+    nodes in the cluster. When set to ``false``, each node enforces limits independently.
+    If not specified, Samba defaults to cluster-wide enforcement when clustering is active.
 
 Behavior:
 
@@ -308,6 +313,7 @@ Behavior:
 - Burst multipliers only apply when their corresponding limit is enabled (non-zero)
 - Bandwidth limits can be specified with human-readable units (e.g., ``"10M"``, ``"5G"``)
 - Burst multipliers are expressed in tenths (e.g., ``15`` = 1.5*, ``20`` = 2*, ``30`` = 3*)
+- ``cluster_mode`` only affects behavior when Samba clustering (CTDB) is enabled
 
 
 Burst Behavior
@@ -339,10 +345,21 @@ Set QoS limits with burst multipliers for a share:
      --write-bw-limit="20M" \
      --read-burst-mult=20 \
      --write-burst-mult=15
+     --cluster-mode=true
 
 In this example:
 - Read burst multiplier of 20 means 2* the read IOPS limit (allowing bursts up to 200 read IOPS)
 - Write burst multiplier of 15 means 1.5* the write IOPS limit (allowing bursts up to 300 write IOPS)
+- Cluster-wide enforcement is enabled, so limits are aggregated across all nodes
+
+Set per-node rate limiting (disable cluster-wide enforcement):
+
+.. prompt:: bash #
+
+   ceph smb share update cephfs qos foo bar \
+     --read-iops-limit=100 \
+     --write-iops-limit=200 \
+     --cluster-mode=false
 
 Disable QoS for a share:
 
@@ -938,6 +955,11 @@ cephfs
             Optional integer. Burst multiplier for write operations (value ÷ 10 = multiplier),
             allowing temporary bursts above the configured limit. Example: ``20`` = 2* the configured limit.
             Default: 15 (1.5*).
+        cluster_mode
+            Optional boolean. Controls whether rate limiting is enforced cluster-wide or per-node
+            when using Samba clustering (CTDB). When set to ``true``, limits are enforced across all
+            nodes in the cluster. When set to ``false``, each node enforces limits independently.
+            If not specified, Samba defaults to cluster-wide enforcement when clustering is active.
 restrict_access
     Optional boolean, defaulting to false. If true the share will only permit
     access by users explicitly listed in ``login_control``.
@@ -1006,6 +1028,7 @@ multipliers and human-readable bandwidth limits:
         write_bw_limit: "5M"
         read_burst_mult: 20
         write_burst_mult: 15
+        cluster_mode: true
 
 Another example with plain byte values:
 

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -859,6 +859,11 @@ def _generate_share(conf: _ShareConf) -> Dict[str, Dict[str, str]]:
         ):
             if value := getattr(qos, field):
                 opts[f"{vfs_rl}:{field}"] = str(value)
+
+        if qos.cluster_mode is not None:
+            cluster_mode_val = "yes" if qos.cluster_mode else "no"
+            opts[f"{vfs_rl}:cluster_mode"] = cluster_mode_val
+
     if share.comment is not None:
         cfg['options']['comment'] = share.comment
 

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -400,6 +400,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         write_bw_limit: Optional[str] = None,
         read_burst_mult: Optional[int] = None,
         write_burst_mult: Optional[int] = None,
+        cluster_mode: Optional[str] = None,
     ) -> results.Result:
         """Update QoS settings for a CephFS share"""
         try:
@@ -413,6 +414,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             if not share.cephfs:
                 raise ValueError("Share has no CephFS configuration")
 
+            cluster_mode_bool = None
+            if cluster_mode is not None:
+                if cluster_mode.lower() == 'true':
+                    cluster_mode_bool = True
+                else:
+                    cluster_mode_bool = False
+
             updated_cephfs = share.cephfs.update_qos(
                 read_iops_limit=read_iops_limit,
                 write_iops_limit=write_iops_limit,
@@ -420,6 +428,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                 write_bw_limit=write_bw_limit,
                 read_burst_mult=read_burst_mult,
                 write_burst_mult=write_burst_mult,
+                cluster_mode=cluster_mode_bool,
             )
 
             updated_share = replace(share, cephfs=updated_cephfs)

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -152,6 +152,7 @@ class QoSConfig(_RBase):
     write_bw_limit: Optional[str] = None
     read_burst_mult: Optional[int] = 15
     write_burst_mult: Optional[int] = 15
+    cluster_mode: Optional[bool] = None
 
 
 @resourcelib.component()
@@ -230,6 +231,7 @@ class CephFSStorage(_RBase):
         write_bw_limit: Optional[str] = None,
         read_burst_mult: Optional[int] = None,
         write_burst_mult: Optional[int] = None,
+        cluster_mode: Optional[bool] = None,
     ) -> Self:
         """Return a new CephFSStorage instance with updated QoS values."""
         qos_updates: Dict[str, Union[int, str, None]] = {}
@@ -264,6 +266,9 @@ class CephFSStorage(_RBase):
             qos_updates["write_burst_mult"] = min(
                 write_burst_mult, BURST_MULT_MAX
             )
+
+        if cluster_mode is not None:
+            qos_updates["cluster_mode"] = cluster_mode
 
         if qos_updates:
             new_qos = replace(self.qos or QoSConfig(), **qos_updates)  # type: ignore

--- a/src/pybind/mgr/smb/tests/test_handler.py
+++ b/src/pybind/mgr/smb/tests/test_handler.py
@@ -1814,3 +1814,73 @@ def test_apply_share_with_qos(thandler):
     assert share_dict['cephfs']['qos']['write_bw_limit'] == "2097152"
     assert share_dict['cephfs']['qos']['read_burst_mult'] == 20
     assert share_dict['cephfs']['qos']['write_burst_mult'] == 15
+
+
+def test_generate_config_with_qos_cluster_mode_true(thandler):
+    """Test that cluster_mode=True generates 'yes' in config."""
+    thandler.internal_store.overwrite(
+        {
+            'clusters.foo': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [{'source_type': 'empty'}],
+            },
+            'shares.foo.s1': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 's1',
+                'name': 'Ess One',
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/',
+                    'provider': 'samba-vfs',
+                    'qos': {
+                        'read_iops_limit': 100,
+                        'cluster_mode': True,
+                    },
+                },
+            },
+        }
+    )
+
+    thandler._sync_clusters(['foo'])
+    cfg = thandler.public_store['foo', 'config.smb'].get()
+    shopts = cfg['shares']['Ess One']['options']
+    assert shopts['aio_ratelimit:cluster_mode'] == 'yes'
+
+
+def test_generate_config_with_qos_cluster_mode_false(thandler):
+    """Test that cluster_mode=False generates 'no' in config."""
+    thandler.internal_store.overwrite(
+        {
+            'clusters.foo': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [{'source_type': 'empty'}],
+            },
+            'shares.foo.s1': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 's1',
+                'name': 'Ess One',
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/',
+                    'provider': 'samba-vfs',
+                    'qos': {
+                        'read_iops_limit': 100,
+                        'cluster_mode': False,
+                    },
+                },
+            },
+        }
+    )
+
+    thandler._sync_clusters(['foo'])
+    cfg = thandler.public_store['foo', 'config.smb'].get()
+    shopts = cfg['shares']['Ess One']['options']
+    assert shopts['aio_ratelimit:cluster_mode'] == 'no'

--- a/src/pybind/mgr/smb/tests/test_resources.py
+++ b/src/pybind/mgr/smb/tests/test_resources.py
@@ -1200,3 +1200,26 @@ def test_share_qos_remove_individual_limit():
     assert updated_cephfs.qos.write_iops_limit == 200  # Preserved
     assert updated_cephfs.qos.read_bw_limit == "10M"  # Preserved
     assert updated_cephfs.qos.write_bw_limit == "20M"  # Preserved
+
+
+def test_share_update_qos_with_cluster_mode():
+    """Test share with QoS including cluster_mode."""
+    share = smb.resources.Share(
+        cluster_id='qoscluster',
+        share_id='qostest',
+        name='QoS Test Share',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/qos',
+            qos=smb.resources.QoSConfig(
+                read_iops_limit=100,
+                cluster_mode=True,
+            ),
+        ),
+    )
+
+    assert share.cephfs.qos.cluster_mode is True
+
+    # Update to disable cluster_mode
+    updated_cephfs = share.cephfs.update_qos(cluster_mode=False)
+    assert updated_cephfs.qos.cluster_mode is False

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -1028,3 +1028,55 @@ def test_cmd_share_update_qos(tmodule):
     assert updated_share.cephfs.qos.write_bw_limit == "524288"
     assert updated_share.cephfs.qos.read_burst_mult == 15  # Default
     assert updated_share.cephfs.qos.write_burst_mult == 15  # Default
+
+
+def test_cmd_share_update_qos_with_cluster_mode(tmodule):
+    """Test updating QoS with cluster_mode via CLI."""
+    cluster = _cluster(
+        cluster_id='qoscluster',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='qoscluster',
+        share_id='qostest',
+        cephfs=smb.resources.CephFSStorage(volume='cephfs', path='/'),
+    )
+    rg = tmodule._handler.apply([cluster, share])
+    assert rg.success
+
+    # Test setting cluster_mode=True - pass as string "true"
+    res, body, status = tmodule.share_update_qos.command(
+        cluster_id='qoscluster',
+        share_id='qostest',
+        read_iops_limit=100,
+        cluster_mode="true",  # Changed from True to "true"
+    )
+    assert res == 0
+    bdata = json.loads(body)
+    assert bdata['success']
+
+    updated = tmodule._handler.matching_resources(
+        ['ceph.smb.share.qoscluster.qostest']
+    )[0]
+    assert updated.cephfs.qos.cluster_mode is True
+
+    # Test setting cluster_mode=False - pass as string "false"
+    res, body, status = tmodule.share_update_qos.command(
+        cluster_id='qoscluster',
+        share_id='qostest',
+        cluster_mode="false",  # Changed from False to "false"
+    )
+    assert res == 0
+    bdata = json.loads(body)
+    assert bdata['success']
+
+    # Verify
+    updated = tmodule._handler.matching_resources(
+        ['ceph.smb.share.qoscluster.qostest']
+    )[0]
+    assert updated.cephfs.qos.cluster_mode is False


### PR DESCRIPTION
Depends on https://github.com/ceph/ceph/pull/67435

This PR adds `cluster_mode` option to QoS settings, allowing users to explicitly enable/disable cluster-wide rate limiting when using CTDB clustering. When not specified, Samba defaults to enabled when clustering is active.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
