### PR TITLE
mgr/dashboard: remove text-right class from form buttons

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -684,7 +684,7 @@
         <cd-form-button-panel (submitActionEvent)="submit()"
                               [form]="targetForm"
                               [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                              wrappingClass="text-right"></cd-form-button-panel>
+                              wrappingClass="form-button-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
@@ -150,7 +150,7 @@
           [form]="groupForm"
           [submitText]="(action | titlecase) + ' ' + (resource)"
           [disabled]="isCreateDisabled"
-          wrappingClass="text-right form-button"
+          wrappingClass="form-button-right form-button"
         >
         </cd-form-button-panel>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
@@ -313,7 +313,7 @@
           (submitActionEvent)="onSubmit()"
           [form]="nsForm"
           [submitText]="(action | titlecase) + ' ' + (resource | titlecase)"
-          wrappingClass="text-right form-button">
+          wrappingClass="form-button-right form-button">
         </cd-form-button-panel>
       </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -406,7 +406,7 @@
       <cd-form-button-panel (submitActionEvent)="submit()"
                             [form]="formDir"
                             [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                            wrappingClass="text-right"></cd-form-button-panel>
+                            wrappingClass="form-button-right"></cd-form-button-panel>
 
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
@@ -225,7 +225,7 @@
                             [form]="formDir"
                             [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
                             [disabled]="editing ? disableRename: false"
-                            wrappingClass="text-right"></cd-form-button-panel>
+                            wrappingClass="form-button-right"></cd-form-button-panel>
     </form>
   </ng-container>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -156,7 +156,7 @@
         <cd-form-button-panel (submitActionEvent)="forceUpdate ? openCriticalConfirmModal() : submit()"
                               [form]="configForm"
                               [submitText]="actionLabels.UPDATE"
-                              wrappingClass="text-right"></cd-form-button-panel>
+                              wrappingClass="form-button-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html
@@ -103,7 +103,7 @@
         <cd-form-button-panel (submitActionEvent)="onSubmit()"
                               [form]="mgrModuleForm"
                               [submitText]="actionLabels.UPDATE"
-                              wrappingClass="text-right"></cd-form-button-panel>
+                              wrappingClass="form-button-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.html
@@ -196,7 +196,7 @@
       <cd-form-button-panel (submitActionEvent)="onSubmit()"
                             [form]="frm"
                             [submitText]="(action | titlecase) + ' ' + 'Cluster'"
-                            wrappingClass="text-right"></cd-form-button-panel>
+                            wrappingClass="form-button-right"></cd-form-button-panel>
 
     </div>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -216,6 +216,6 @@
                           [form]="form"
                           [disabled]="dataDeviceSelectionGroups.devices.length === 0 && !simpleDeployment"
                           [submitText]="simpleDeployment ? 'Create OSDs' : actionLabels.PREVIEW"
-                          wrappingClass="text-right"></cd-form-button-panel>
+                          wrappingClass="form-button-right"></cd-form-button-panel>
   </div>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -455,7 +455,7 @@
                             [form]="nfsForm"
                             [disabled]="!!storageBackendError"
                             [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                            wrappingClass="text-right"></cd-form-button-panel>
+                            wrappingClass="form-button-right"></cd-form-button-panel>
     </form>
   </ng-container>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -1149,7 +1149,7 @@
         (submitActionEvent)="submit()"
         [form]="form"
         [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-        wrappingClass="text-right form-button"
+        wrappingClass="form-button-right form-button"
       >
       </cd-form-button-panel>
     </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -618,7 +618,7 @@
     <cd-form-button-panel (submitActionEvent)="submit()"
                           [form]="bucketForm"
                           [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                          wrappingClass="text-right"></cd-form-button-panel>
+                          wrappingClass="form-button-right"></cd-form-button-panel>
   </form>
 </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
@@ -617,7 +617,7 @@
         (submitActionEvent)="submitAction()"
         [form]="storageClassForm"
         [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-        wrappingClass="text-right"
+        wrappingClass="form-button-right"
       ></cd-form-button-panel>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.html
@@ -548,7 +548,7 @@
       <cd-form-button-panel (submitActionEvent)="submitAction()"
                             [form]="topicForm"
                             [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                            wrappingClass="text-right"></cd-form-button-panel>
+                            wrappingClass="form-button-right"></cd-form-button-panel>
     </div>
   </form>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.html
@@ -169,7 +169,7 @@
       <cd-form-button-panel (submitActionEvent)="submit()"
                             [form]="formDir"
                             [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                            wrappingClass="text-right"></cd-form-button-panel>
+                            wrappingClass="form-button-right"></cd-form-button-panel>
 
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -711,6 +711,6 @@
     <cd-form-button-panel (submitActionEvent)="onSubmit()"
                           [form]="userForm"
                           [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                          wrappingClass="text-right"></cd-form-button-panel>
+                          wrappingClass="form-button-right"></cd-form-button-panel>
   </form>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.html
@@ -452,7 +452,7 @@
         (submitActionEvent)="submitAction()"
         [form]="smbForm"
         [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-        wrappingClass="text-right"
+        wrappingClass="form-button-right"
       ></cd-form-button-panel>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-form/smb-join-auth-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-form/smb-join-auth-form.component.html
@@ -121,6 +121,6 @@
         (submitActionEvent)="submit()"
         [form]="form"
         [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-        wrappingClass="text-right"></cd-form-button-panel>
+        wrappingClass="form-button-right"></cd-form-button-panel>
   </form>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
@@ -335,7 +335,7 @@
         (submitActionEvent)="submitAction()"
         [form]="smbShareForm"
         [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-        wrappingClass="text-right"
+        wrappingClass="form-button-right"
       ></cd-form-button-panel>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component.html
@@ -248,6 +248,6 @@
       (submitActionEvent)="submit()"
       [form]="form"
       [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-      wrappingClass="text-right"></cd-form-button-panel>
+      wrappingClass="form-button-right"></cd-form-button-panel>
     </form>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.html
@@ -84,6 +84,6 @@
                           [form]="userForm"
                           [disabled]="userForm.invalid"
                           [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                          wrappingClass="text-right"></cd-form-button-panel>
+                          wrappingClass="form-button-right"></cd-form-button-panel>
   </form>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
@@ -66,7 +66,7 @@
         <cd-form-button-panel (submitActionEvent)="submit()"
                               [form]="roleForm"
                               [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                              wrappingClass="text-right">
+                              wrappingClass="form-button-right">
         </cd-form-button-panel>
       </div>
     </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -196,7 +196,7 @@
       <cd-form-button-panel (submitActionEvent)="submit()"
                             [form]="userForm"
                             [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                            wrappingClass="text-right">
+                            wrappingClass="form-button-right">
       </cd-form-button-panel>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
@@ -62,7 +62,7 @@
         <cd-form-button-panel (submitActionEvent)="onSubmit()"
                               [form]="userForm"
                               [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                              wrappingClass="text-right form-button"></cd-form-button-panel>
+                              wrappingClass="form-button-right form-button"></cd-form-button-panel>
       </div>
     </div>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.html
@@ -18,7 +18,7 @@
                               [form]="formDir"
                               [submitText]="formUISchema.title"
                               [disabled]="!form.valid"
-                              wrappingClass="text-right"></cd-form-button-panel>
+                              wrappingClass="form-button-right"></cd-form-button-panel>
       </div>
     </form>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
@@ -143,6 +143,10 @@ form {
   margin-top: var(--cds-spacing-09);
 }
 
+.form-button-right {
+  text-align: end;
+}
+
 .form-item-append {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
# Summary
This PR removes the Bootstrap-named `text-right` class from Dashboard form button wrappers and replaces it with a Dashboard-specific class.
Changes:

-Replace `wrappingClass="text-right" `with `wrappingClass="form-button-right" `in form button panel usages.
-Replace `wrappingClass="text-right form-button" `with `wrappingClass="form-button-right form-button".`
-Add a new style utility in Dashboard forms stylesheet:
`.form-button-right { text-align: end; }`

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests