### PR TITLE
tentacle: rgw: fix overflow of outstanding counter in SimpleThrottler

### DIFF
--- a/src/rgw/rgw_dmclock_async_scheduler.h
+++ b/src/rgw/rgw_dmclock_async_scheduler.h
@@ -194,10 +194,12 @@ private:
   int schedule_request_impl(const client_id&, const ReqParams&,
                             const Time&, const Cost&,
                             optional_yield) override {
+    auto c = counters();
+    if (c != nullptr) {
+      c->inc(throttle_counters::l_outstanding);
+    }
     if (outstanding_requests++ >= max_requests) {
-      if (auto c = counters();
-          c != nullptr) {
-        c->inc(throttle_counters::l_outstanding);
+      if (c != nullptr) {
         c->inc(throttle_counters::l_throttle);
       }
       return -EAGAIN;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74993

---

backport of https://github.com/ceph/ceph/pull/66455
parent tracker: https://tracker.ceph.com/issues/74038

This fixes a bug where throttled requests don't increment `l_outstanding`, while `request_complete()` always decrements it, causing the counter to underrun/
overflow.

This is the minimal fix because it only moves the `l_outstanding` increment so that both accepted and throttled requests are accounted for consistently,
without changing throttling behavior.

This should be backported to `tentacle` because the same buggy code path exists there, so the perf counter can still become incorrect under throttling.
