### PR TITLE
tentacle: Use /etc/ceph_version to append vendor release version to the version string

### DIFF
--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -16,6 +16,10 @@
 
 #include <stdlib.h>
 #include <sstream>
+#include <fstream>
+#include <string>
+#include <iterator>
+
 
 #include "ceph_ver.h"
 #include "common/ceph_strings.h"
@@ -43,6 +47,29 @@ const char *git_version_to_str(void)
   return STRINGIFY(CEPH_GIT_VER);
 }
 
+static std::string read_vendor_release_file()
+{
+  auto filename = "/etc/ceph_version";
+  std::ifstream file(filename);
+
+  if(!file.is_open()){
+    return "";
+  }
+
+  std::string content;
+  try {
+    content.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+  } catch (const std::exception &e) {
+    return "";
+  }
+  if (!content.empty()) {
+    return std::string(" release ") + content;
+  }
+
+  return "";
+
+}
+
 std::string const pretty_version_to_str(void)
 {
   std::ostringstream oss;
@@ -54,6 +81,7 @@ std::string const pretty_version_to_str(void)
 #ifdef WITH_CRIMSON
       << " (crimson)"
 #endif
+      << read_vendor_release_file()
       ;
   return oss.str();
 }

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -63,6 +63,9 @@ static std::string read_vendor_release_file()
     return "";
   }
   if (!content.empty()) {
+    while (!content.empty() && (content.back() == '\n' || content.back() == '\r')) {
+      content.pop_back();
+    }
     return std::string(" release ") + content;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75368

---

backport of https://github.com/ceph/ceph/pull/67299
parent tracker: https://tracker.ceph.com/issues/75366

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh