### PR TITLE
Control PG autoscaler during upgrades with pg_autoscale_during_upgrade

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -43,6 +43,23 @@ The automated upgrade process follows Ceph best practices.  For example:
    If the new release changes the above target value, there may be splitting
    or merging of PGs when unsetting after the upgrade.
 
+   Cephadm will automatically pause and resume the PG autoscaler activity 
+   during upgrade unless opted-in by setting:
+
+   .. prompt:: bash #
+
+     ceph config set mgr mgr/cephadm/pg_autoscale_during_upgrade true
+
+   To view the current value:
+
+   .. prompt:: bash #
+
+     ceph config get mgr mgr/cephadm/pg_autoscale_during_upgrade
+
+   If autoscaling was already off before the upgrade, cephadm does not change
+   it unless you have set ``pg_autoscale_during_upgrade`` to ``true`` (opt-in
+   to turn autoscaling on for the duration of the upgrade).
+
 
 Starting the Upgrade
 ====================

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -412,6 +412,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Maximum number of OSD daemons upgraded in parallel.'
         ),
         Option(
+            'pg_autoscale_during_upgrade',
+            type='bool',
+            default=False,
+            desc='Opt-in to keep PG autoscaling enabled during OSD upgrades. '
+            'When False (default), cephadm disables pool autoscaling (sets noautoscale) '
+            'before OSD upgrades and restores it on completion/stop/failure. '
+            'Set to true to keep autoscaling on during upgrade.'
+        ),
+        Option(
             'service_discovery_port',
             type='int',
             default=8765,
@@ -578,6 +587,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.default_registry = ''
             self.autotune_memory_target_ratio = 0.0
             self.autotune_interval = 0
+            self.pg_autoscale_during_upgrade = False
             self.ssh_user: Optional[str] = None
             self._ssh_options: Optional[str] = None
             self.tkey = NamedTemporaryFile()

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -562,6 +562,192 @@ def test_validate_failure_domain_upgrade_options_name_not_consulting_crush_map(
 
 
 @mock.patch('cephadm.serve.CephadmServe._run_cephadm', _run_cephadm('{}'))
+@pytest.mark.parametrize(
+    "prior_autoscale,pg_autoscale_during_upgrade,autoscale_during_upgrade",
+    [
+        # Decision table: prior_autoscale, pg_autoscale_during_upgrade -> autoscale_during_upgrade
+        (False, False, False),  # prior off, no opt-in -> autoscale off during upgrade
+        (False, True, True),   # prior off, opt-in -> autoscale on during upgrade
+        (True, False, False),  # prior on, no opt-in -> autoscale off during upgrade
+        (True, True, True),    # prior on, opt-in -> autoscale on during upgrade
+    ],
+)
+def test_pg_autoscale_decision_table(
+    prior_autoscale,
+    pg_autoscale_during_upgrade,
+    autoscale_during_upgrade,
+    cephadm_module: CephadmOrchestrator,
+):
+    """Test PG autoscaling decision table at upgrade start.
+    Verifies that prior_autoscale and pg_autoscale_during_upgrade produce the
+    expected autoscale_during_upgrade decision, and that _set_noautoscale is
+    called only when autoscale_during_upgrade is False.
+    """
+    expect_set_noautoscale = not autoscale_during_upgrade
+    with with_host(cephadm_module, 'host1'):
+        with with_host(cephadm_module, 'host2'):
+            with with_service(
+                cephadm_module,
+                ServiceSpec('mgr', placement=PlacementSpec(host_pattern='*', count=2)),
+                status_running=True,
+            ):
+                cephadm_module.pg_autoscale_during_upgrade = pg_autoscale_during_upgrade
+
+                with mock.patch.object(
+                    cephadm_module.upgrade,
+                    '_is_upgrade_autoscaling_allowed',
+                    return_value=prior_autoscale,
+                ), mock.patch.object(
+                    cephadm_module.upgrade,
+                    '_set_noautoscale',
+                    return_value=True,
+                ) as mock_set_noautoscale:
+                    result = wait(
+                        cephadm_module,
+                        cephadm_module.upgrade_start('image_id', None),
+                    )
+                    assert result == 'Initiating upgrade to image_id'
+
+                    # Decision: autoscale_during_upgrade=False -> set noautoscale
+                    if expect_set_noautoscale:
+                        mock_set_noautoscale.assert_called_once()
+                        assert cephadm_module.upgrade.upgrade_state.noautoscale_set is True
+                    else:
+                        mock_set_noautoscale.assert_not_called()
+                        assert getattr(
+                            cephadm_module.upgrade.upgrade_state,
+                            'noautoscale_set',
+                            False,
+                        ) is False
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.serve.CephadmServe._get_container_image_info")
+@pytest.mark.parametrize(
+    "daemon_types,expect_set_noautoscale",
+    [
+        (['mon', 'mgr'], False),        # excludes OSDs -> noautoscale not set
+        (['mon', 'mgr', 'osd'], True),  # includes OSDs, prior_autoscale=False -> noautoscale set
+    ],
+)
+def test_pg_autoscale_skipped_when_upgrade_excludes_osds(
+    _get_container_image_info, cephadm_module: CephadmOrchestrator,
+    daemon_types, expect_set_noautoscale
+):
+    """When upgrade excludes OSDs, _set_noautoscale should not be called.
+    When it includes OSDs and prior_autoscale=False, _set_noautoscale should be called.
+    """
+    _get_container_image_info.side_effect = async_side_effect(
+        ('img_id', 'ceph version 18.2.0 (hash)', ['digest'])
+    )
+    with with_host(cephadm_module, 'host1'):
+        with with_host(cephadm_module, 'host2'):
+            with with_service(
+                cephadm_module,
+                ServiceSpec('mgr', placement=PlacementSpec(host_pattern='*', count=2)),
+                status_running=True,
+            ):
+                cephadm_module.pg_autoscale_during_upgrade = False
+
+                with mock.patch.object(
+                    cephadm_module.upgrade,
+                    '_is_upgrade_autoscaling_allowed',
+                    return_value=False,
+                ), mock.patch.object(
+                    cephadm_module.upgrade,
+                    '_set_noautoscale',
+                    return_value=True,
+                ) as mock_set_noautoscale:
+                    result = wait(
+                        cephadm_module,
+                        cephadm_module.upgrade_start(
+                            'image_id', None,
+                            daemon_types=daemon_types,
+                        ),
+                    )
+                    assert result == 'Initiating upgrade to image_id'
+                    if expect_set_noautoscale:
+                        mock_set_noautoscale.assert_called_once()
+                    else:
+                        mock_set_noautoscale.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "prior_autoscale,opt_in,autoscale_after",
+    [
+        # Decision table: prior_autoscale, opt-in -> autoscale_after
+        (False, False, False),  # Case 1: prior off, no opt-in -> autoscale off after
+        (False, True, False),   # Case 2: prior off, opt-in -> autoscale off after (revert)
+        (True, False, True),   # Case 3: prior on, no opt-in -> autoscale on after (revert)
+        (True, True, True),    # Case 4: prior on, opt-in -> autoscale on after
+    ],
+)
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.serve.CephadmServe._get_container_image_info")
+@mock.patch("cephadm.CephadmOrchestrator.check_mon_command")
+def test_pg_autoscale_revert_after_upgrade(
+    check_mon_command,
+    _get_container_image_info,
+    prior_autoscale,
+    opt_in,
+    autoscale_after,
+    cephadm_module: CephadmOrchestrator,
+):
+    """Test autoscale_after per decision table: prior_autoscale, opt-in -> autoscale_after.
+    Cases 1,3: we set noautoscale during upgrade, so we restore to prior on stop.
+    Cases 2,4: we never set noautoscale, so no restore; cluster stays as prior.
+    """
+    _get_container_image_info.side_effect = async_side_effect(
+        ('img_id', 'ceph version 18.2.0 (hash)', ['digest'])
+    )
+    check_mon_command.return_value = (0, '', '')
+
+    with with_host(cephadm_module, 'host1'):
+        with with_host(cephadm_module, 'host2'):
+            with with_service(
+                cephadm_module,
+                ServiceSpec('mgr', placement=PlacementSpec(host_pattern='*', count=2)),
+                status_running=True,
+            ):
+                cephadm_module.pg_autoscale_during_upgrade = opt_in
+
+                with mock.patch.object(
+                    cephadm_module.upgrade,
+                    '_is_upgrade_autoscaling_allowed',
+                    return_value=prior_autoscale,
+                ):
+                    wait(
+                        cephadm_module,
+                        cephadm_module.upgrade_start(
+                            'image_id', None,
+                            daemon_types=['mon', 'mgr', 'osd'],
+                        ),
+                    )
+
+                # upgrade_stop triggers _unset_noautoscale when noautoscale_set
+                check_mon_command.reset_mock()
+                wait(cephadm_module, cephadm_module.upgrade_stop())
+
+                # Verify autoscale_after: restore path (cases 1,3) vs no restore (cases 2,4)
+                config_calls = [
+                    c for c in check_mon_command.call_args_list
+                    if isinstance(c[0][0], dict)
+                    and c[0][0].get('name') == 'osd_pool_default_pg_autoscale_mode'
+                ]
+                if not opt_in:
+                    # Cases 1,3: we set noautoscale, so we restore
+                    assert len(config_calls) >= 1
+                    expected_value = 'on' if autoscale_after else 'off'
+                    assert any(
+                        c[0][0].get('value') == expected_value
+                        for c in config_calls
+                    )
+                else:
+                    # Cases 2,4: we never set noautoscale, so no restore calls
+                    assert len(config_calls) == 0
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
 def test_not_enough_mgrs(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1'):
         with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=1)), CephadmOrchestrator.apply_mgr, ''):

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -202,7 +202,10 @@ class UpgradeState:
                  remaining_count: Optional[int] = None,
                  crush_bucket_type: Optional[str] = None,
                  crush_bucket_name: Optional[str] = None,
+                 noautoscale_set: Optional[bool] = False,
+                 prior_autoscale: Optional[bool] = True,
                  ):
+
         self._target_name: str = target_name  # Use CephadmUpgrade.target_image instead.
         self.progress_id: str = progress_id
         self.target_id: Optional[str] = target_id
@@ -221,6 +224,8 @@ class UpgradeState:
         self.remaining_count = remaining_count
         self.crush_bucket_type = crush_bucket_type
         self.crush_bucket_name = crush_bucket_name
+        self.noautoscale_set = noautoscale_set
+        self.prior_autoscale = prior_autoscale
 
     def to_json(self) -> dict:
         return {
@@ -241,6 +246,8 @@ class UpgradeState:
             'remaining_count': self.remaining_count,
             'crush_bucket_type': self.crush_bucket_type,
             'crush_bucket_name': self.crush_bucket_name,
+            'noautoscale_set': self.noautoscale_set,
+            'prior_autoscale': self.prior_autoscale,
         }
 
     @classmethod
@@ -513,6 +520,37 @@ class CephadmUpgrade:
         """
         return f'retval: {-errno.ENOENT}' in str(err)
 
+    def _hosts_include_osds(self, hosts: List[str]) -> bool:
+        """Return True if any OSD daemon is on one of the given hosts."""
+        osds = self.mgr.cache.get_daemons_by_type('osd')
+        hosts_set = set(hosts)
+        for d in osds:
+            if d.hostname in hosts_set:
+                return True
+        return False
+
+    def _services_include_osds(self, services: List[str]) -> bool:
+        for s in services:
+            if s in self.mgr.spec_store:
+                spec = self.mgr.spec_store[s].spec
+                if (spec is not None
+                        and 'osd' in orchestrator.service_to_daemon_types(spec.service_type)):
+                    return True
+        return False
+
+    def _upgrade_includes_osds(self, daemon_types: Optional[List[str]],
+                               hosts: Optional[List[str]],
+                               services: Optional[List[str]]) -> bool:
+        """Return True if this upgrade will include OSD daemons."""
+        if daemon_types is not None:
+            return 'osd' in daemon_types
+        if services is not None:
+            return self._services_include_osds(services)
+        if hosts is not None:
+            return self._hosts_include_osds(hosts)
+        # No filter = full upgrade, includes OSDs
+        return True
+
     def upgrade_start(self, image: str, version: str, daemon_types: Optional[List[str]] = None,
                       hosts: Optional[List[str]] = None, services: Optional[List[str]] = None, limit: Optional[int] = None,
                       bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> str:
@@ -571,6 +609,25 @@ class CephadmUpgrade:
             crush_bucket_type=bucket_type,
             crush_bucket_name=bucket_name,
         )
+        # One-time PG autoscaling decision when upgrade includes OSDs
+        if self._upgrade_includes_osds(daemon_types, hosts, services):
+            # prior_autoscale: current OSD noautoscale status from osd_map flags (before we touch it)
+            prior_autoscale = self._is_upgrade_autoscaling_allowed()
+            opt_in = bool(self.mgr.pg_autoscale_during_upgrade)
+            # Only opt-in keeps autoscaling on during upgrade; otherwise turn off and restore after
+            autoscale_during_upgrade = opt_in
+            logger.info(
+                'Upgrade: PG autoscaling prior=%s, mgr/cephadm/pg_autoscale_during_upgrade=%s, '
+                'autoscaling during upgrade=%s',
+                prior_autoscale, opt_in, autoscale_during_upgrade
+            )
+            if not autoscale_during_upgrade:
+                # If not opted-in disable the autoscale during upgrade and
+                # restore the state after upgrade complete/stops
+                if self._set_noautoscale():
+                    self.upgrade_state.noautoscale_set = True
+                    # Store prior state from current OSD noautoscale status for restore
+                    self.upgrade_state.prior_autoscale = prior_autoscale
         self._update_upgrade_progress(0.0)
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()
@@ -699,6 +756,8 @@ class CephadmUpgrade:
     def upgrade_stop(self) -> str:
         if not self.upgrade_state:
             return 'No upgrade in progress'
+        if getattr(self.upgrade_state, 'noautoscale_set', False):
+            self._unset_noautoscale()
         if self.upgrade_state.progress_id:
             self.mgr.remote('progress', 'complete',
                             self.upgrade_state.progress_id)
@@ -958,6 +1017,80 @@ class CephadmUpgrade:
 
         return False
 
+    def _is_upgrade_autoscaling_allowed(self) -> bool:
+        """Return True if PG autoscaling is allowed based on current OSD noautoscale status.
+        Reads osd_map flags; True when noautoscale is not set, False when it is set.
+        """
+        osdmap = self.mgr.get("osd_map")
+        flags_str = (osdmap.get('flags') or '') if osdmap else ''
+        return 'noautoscale' not in flags_str
+
+    def _set_noautoscale(self) -> bool:
+        """Set noautoscale (disable PG autoscaling) before OSD upgrade. Returns True on success."""
+        try:
+            self.mgr.check_mon_command({
+                'prefix': 'config set',
+                'who': 'global',
+                'name': 'osd_pool_default_pg_autoscale_mode',
+                'value': 'off',
+            })
+            try:
+                self.mgr.check_mon_command({
+                    'prefix': 'osd set',
+                    'key': 'noautoscale',
+                })
+            except Exception as e:
+                logger.warning('Upgrade: Failed to set noautoscale: %s', e)
+                logger.warning(
+                    'Upgrade: Partial state: osd_pool_default_pg_autoscale_mode set to off '
+                    'but osd noautoscale flag not set. Check cluster config.'
+                )
+                return False
+            logger.info('Upgrade: Set noautoscale (disable PG autoscaling) for OSD upgrade')
+            return True
+        except Exception as e:
+            logger.warning('Upgrade: Failed to set noautoscale: %s', e)
+            return False
+
+    def _unset_noautoscale(self) -> None:
+        """Restore PG autoscaling to prior state on upgrade completion/stop/failure.
+        Retries on failure to improve resilience against transient mon command failures.
+        """
+        prior_autoscale = getattr(self.upgrade_state, 'prior_autoscale', True)
+        restore_on = prior_autoscale
+        retry_delays = [2, 5, 10]
+        for i, sleep_secs in enumerate(retry_delays):
+            try:
+                self.mgr.check_mon_command({
+                    'prefix': 'config set',
+                    'who': 'global',
+                    'name': 'osd_pool_default_pg_autoscale_mode',
+                    'value': 'on' if restore_on else 'off',
+                })
+                if restore_on:
+                    self.mgr.check_mon_command({
+                        'prefix': 'osd unset',
+                        'key': 'noautoscale',
+                    })
+                else:
+                    self.mgr.check_mon_command({
+                        'prefix': 'osd set',
+                        'key': 'noautoscale',
+                    })
+                logger.info(
+                    'Upgrade: Restored PG autoscaling to %s',
+                    'on' if restore_on else 'off'
+                )
+                return
+            except Exception as e:
+                logger.warning(
+                    'Upgrade: Failed to restore noautoscale (retry in %ds): %s',
+                    sleep_secs, e
+                )
+                if i < len(retry_delays) - 1:
+                    time.sleep(sleep_secs)
+        logger.warning('Upgrade: Failed to restore noautoscale after retries')
+
     def _clear_upgrade_health_checks(self) -> None:
         for k in self.UPGRADE_ERRORS:
             if k in self.mgr.health_checks:
@@ -975,6 +1108,9 @@ class CephadmUpgrade:
                                                         alert['summary']))
         self.upgrade_state.error = alert_id + ': ' + alert['summary']
         self.upgrade_state.paused = True
+        # Do not restore PG autoscaling here: upgrade is only paused. Restore
+        # only on upgrade_stop or _mark_upgrade_complete so that resume
+        # continues with autoscaling still disabled for OSD upgrades.
         self._save_upgrade_state()
         self.mgr.health_checks[alert_id] = alert
         self.mgr.set_health_checks(self.mgr.health_checks)
@@ -1553,6 +1689,9 @@ class CephadmUpgrade:
         if not self.upgrade_state:
             logger.debug('_mark_upgrade_complete upgrade already marked complete, exiting')
             return
+        if getattr(self.upgrade_state, 'noautoscale_set', False):
+            self._unset_noautoscale()
+            self.upgrade_state.noautoscale_set = False
         logger.info('Upgrade: Complete!')
         if self.upgrade_state.progress_id:
             self.mgr.remote('progress', 'complete',


### PR DESCRIPTION
The requirement is to be able to control the PG autoscale for OSDs during upgrades with an opt-in option made available with cephadm mgr. More details are in the tracker issue [69477](https://tracker.ceph.com/issues/69477). 

This code introduces the following functionality. The prior setting for autoscale is reverted back to original if it was changed due to pg_autoscale_during_upgrade value. The following flags are evaluated for decision making before the upgrade process:
 
- Prior setting for Autoscale ON based on `osd pool get noautoscale` (False=>Autoscale ON, default:False)
- User opt-in with `mgr/cephadm/pg_autoscale_during_upgrade `(true=>autoscale ON during upgrade, default:False)

| Case | Autoscale ON prior to upgrade (OSD autoscale allowed) | Autoscale ON opted-in by user | Autoscale ON during upgrades | Autoscale ON after upgrade (OSD autoscale allowed) |
|------|--------------------------------------------------------|-----------------------------------------------|-------------------------------|-----------------------------------------------------|
| 1    | No                                                  | False (default)                               | No                         | No                                               |
| 2    | No                                                  | True                                          | Yes                          | No                                               |
| 3    | Yes (default)                                         | False (default)                               | No                         | Yes                                                |
| 4    | Yes (default)                                         | True                                          | Yes                          | Yes                                                |

It must be noted that the `pg_autoscale_during_upgrade` option would be available after mgr gets upgraded first as a part of staged upgrades.


The **case 3 i**s most probable scenario. The unit tests for the same are below:

```
[ceph: root@ceph-node-0 /]# ceph osd pool get noautoscale
noautoscale is off
[ceph: root@ceph-node-0 /]# 
==> autoscale in ON prior to upgrade
```


```
pg_autoscale_during_upgrade won’t be available till the time mgr gets upgrades first.

[ceph: root@ceph-node-0 /]# ceph config get mgr mgr/cephadm/pg_autoscale_during_upgrade
Error ENOENT: unrecognized key 'mgr/cephadm/pg_autoscale_during_upgrade'
[ceph: root@ceph-node-0 /]#


```



**Upgrade mgr**
```
[ceph: root@ceph-node-0 /]# ceph orch upgrade start quay.io/ashjoshi/ceph:upgradetesting --daemon-types mgr
Initiating upgrade to quay.io/ashjoshi/ceph:upgradetesting
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
{
    "in_progress": true,
    "target_image": "quay.io/ashjoshi/ceph@sha256:6a037b9cdc937da29bfd3c9965c9b2f9ca4602adecf3348e5d8f2dcb7e62b0a5",
    "services_complete": [
        "mgr"
    ],
    "which": "Upgrading daemons of type(s) mgr",
    "progress": "2/2 daemons upgraded",
    "message": "",
    "is_paused": false
}
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
There are no upgrades in progress currently.
[ceph: root@ceph-node-0 /]#
```


```
Now pg_autoscale_during_upgrade is false () that means it would disable the autoscaling 
during the upgrade and then restore it to original config.

[ceph: root@ceph-node-0 /]# ceph config get mgr mgr/cephadm/pg_autoscale_during_upgrade
false <<<<<<
[ceph: root@ceph-node-0 /]#
```


**Upgrade osd**
```
[ceph: root@ceph-node-0 /]# ceph orch upgrade start quay.io/ashjoshi/ceph:upgradetesting --daemon-types osd
Initiating upgrade to quay.io/ashjoshi/ceph:upgradetesting
```

```
mgr logs show the previous found configs, set and restore of the PG autoscaler. 

[root@ceph-node-0 263f432e-193b-11f1-a0a4-5254004652b9]# cat ceph-mgr.ceph-node-0.ptnlzz.log |  grep autoscal | grep "Upgrade"
2026-03-06T10:38:03.953+0000 7f3db8a69640  0 [cephadm INFO cephadm.upgrade] Upgrade: PG autoscaling prior=True, mgr/cephadm/pg_autoscale_during_upgrade=False, autoscaling during upgrade=False
2026-03-06T10:38:03.953+0000 7f3db8a69640  0 log_channel(cephadm) log [INF] : Upgrade: PG autoscaling prior=True, mgr/cephadm/pg_autoscale_during_upgrade=False, autoscaling during upgrade=False
2026-03-06T10:38:05.025+0000 7f3db8a69640  0 [cephadm INFO cephadm.upgrade] Upgrade: Set noautoscale for OSD upgrade
2026-03-06T10:38:05.025+0000 7f3db8a69640  0 log_channel(cephadm) log [INF] : Upgrade: Set noautoscale for OSD upgrade
2026-03-06T10:39:29.089+0000 7f3dc02b8640  0 [cephadm INFO cephadm.upgrade] Upgrade: Restored PG autoscaling to on
2026-03-06T10:39:29.089+0000 7f3dc02b8640  0 log_channel(cephadm) log [INF] : Upgrade: Restored PG autoscaling to on
```

**Upgrade complete** 
```
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
There are no upgrades in progress currently.

```

```
Previous config for PG autoscale is restored as expected ==> autoscale in ON as it was prior to upgrade

[ceph: root@ceph-node-0 /]# ceph osd pool get noautoscale
noautoscale is off
[ceph: root@ceph-node-0 /]#

```


Fixes: https://tracker.ceph.com/issues/69477
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
