### PR TITLE
dashboard: sanitize HTML content for toast notifications

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -51,7 +51,8 @@ describe('RbdSnapshotListComponent', () => {
     },
     getPermissions: () => {
       return new Permissions({ 'rbd-image': ['read', 'update', 'create', 'delete'] });
-    }
+    },
+    set: (_key: string, _value: any) => {}
   };
 
   configureTestBed({
@@ -115,9 +116,9 @@ describe('RbdSnapshotListComponent', () => {
       fixture.detectChanges();
       modalService = TestBed.inject(ModalCdsService);
       const actionLabelsI18n = TestBed.inject(ActionLabelsI18n);
-      rbdService = new RbdService(null, null);
-      notificationService = new NotificationService(null, null, null);
-      authStorageService = new AuthStorageService();
+      rbdService = TestBed.inject(RbdService);
+      notificationService = TestBed.inject(NotificationService);
+      authStorageService = TestBed.inject(AuthStorageService);
       authStorageService.set(USER, { 'rbd-image': ['create', 'read', 'update', 'delete'] });
       component = new RbdSnapshotListComponent(
         authStorageService,
@@ -132,17 +133,19 @@ describe('RbdSnapshotListComponent', () => {
         null,
         modalService
       );
-      spyOn(rbdService, 'deleteSnapshot').and.returnValue(observableThrowError({ status: 500 }));
-      spyOn(notificationService, 'notifyTask').and.stub();
-      spyOn(modalService, 'stopLoadingSpinner').and.stub();
+      jest
+        .spyOn(rbdService, 'deleteSnapshot')
+        .mockReturnValue(observableThrowError({ status: 500 }));
+      jest.spyOn(notificationService, 'notifyTask').mockImplementation(() => 0);
     });
 
     it('should call stopLoadingSpinner if the request fails', fakeAsync(() => {
       const modalRef: any = { snapshotForm: 'deletionForm' };
-      spyOn(modalService, 'show').and.callFake((_modalComp: any, config: any) => {
+      jest.spyOn(modalService, 'show').mockImplementation((_modalComp: any, config: any) => {
         modalRef.submitAction = config.submitAction;
         return modalRef;
       });
+      jest.spyOn(modalService, 'stopLoadingSpinner').mockImplementation(() => {});
 
       component.updateSelection(new CdTableSelection([{ name: 'someName' }]));
       component.deleteSnapshotModal();
@@ -224,11 +227,11 @@ describe('RbdSnapshotListComponent', () => {
       component.poolName = 'pool01';
       component.rbdName = 'image01';
       modalRef = {
-        setEditing: jasmine.createSpy('setEditing'),
-        setSnapName: jasmine.createSpy('setSnapName'),
+        setEditing: jest.fn(),
+        setSnapName: jest.fn(),
         onSubmit: new Subject<string>()
       };
-      spyOn(TestBed.inject(ModalCdsService), 'show').and.returnValue(modalRef);
+      jest.spyOn(TestBed.inject(ModalCdsService), 'show').mockReturnValue(modalRef);
     });
 
     it('should display old snapshot name', () => {
@@ -242,9 +245,9 @@ describe('RbdSnapshotListComponent', () => {
       component.openCreateSnapshotModal();
       expect(modalRef.setEditing).not.toHaveBeenCalled();
       expect(modalRef.setSnapName).toHaveBeenCalled();
-      expect(modalRef.setSnapName.calls.mostRecent().args[0]).toMatch(
-        RegExp(`^${component.rbdName}_[\\d-]+T[\\d.:]+[\\+-][\\d:]+$`)
-      );
+      expect(
+        modalRef.setSnapName.mock.calls[modalRef.setSnapName.mock.calls.length - 1][0]
+      ).toMatch(RegExp(`^${component.rbdName}_[\\d-]+T[\\d.:]+[\\+-][\\d:]+$`));
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -3,6 +3,7 @@ import { fakeAsync, TestBed, tick, flush } from '@angular/core/testing';
 import _ from 'lodash';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
+import { DomSanitizer } from '@angular/platform-browser';
 import { RbdService } from '../api/rbd.service';
 import { NotificationType } from '../enum/notification-type.enum';
 import { CdNotificationConfig } from '../models/cd-notification';
@@ -19,6 +20,13 @@ describe('NotificationService', () => {
       NotificationService,
       TaskMessageService,
       { provide: CdDatePipe, useValue: { transform: (d: any) => d } },
+      {
+        provide: DomSanitizer,
+        useValue: {
+          sanitize: () => '',
+          bypassSecurityTrustHtml: (v: string) => v
+        }
+      },
       RbdService
     ],
     imports: [HttpClientTestingModule]
@@ -47,7 +55,10 @@ describe('NotificationService', () => {
       'cdNotifications',
       '[{"type":2,"message":"foobar","timestamp":"2018-05-24T09:41:32.726Z"}]'
     );
-    service = new NotificationService(null, null, null);
+    service = new NotificationService(null, null, null, {
+      sanitize: () => '',
+      bypassSecurityTrustHtml: (v: string) => v
+    } as any);
     expect(service['dataSource'].getValue().length).toBe(1);
   }));
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, NgZone } from '@angular/core';
-
+import { Injectable, NgZone, SecurityContext } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import _ from 'lodash';
 import { BehaviorSubject } from 'rxjs';
 import {
@@ -49,7 +49,8 @@ export class NotificationService {
   constructor(
     private taskMessageService: TaskMessageService,
     private cdDatePipe: CdDatePipe,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private sanitizer: DomSanitizer
   ) {
     this._loadStoredNotifications();
     this._loadMutedState();
@@ -238,10 +239,25 @@ export class NotificationService {
     const carbonType = this.NOTIFICATION_TYPE_MAP[notification.type] || 'info';
     const lowContrast = notification.options?.lowContrast || false;
 
+    const sanitizedTitle =
+      this.sanitizer.sanitize(SecurityContext.HTML, notification.title || '') ||
+      notification.title ||
+      '';
+
+    const sanitizedSubtitle =
+      this.sanitizer.sanitize(SecurityContext.HTML, notification.message || '') ||
+      notification.message ||
+      '';
+
+    const captionHtml = this._renderTimeAndApplicationHtml(notification);
+
+    const sanitizedCaption =
+      this.sanitizer.sanitize(SecurityContext.HTML, captionHtml) || captionHtml;
+
     const toast: ToastContent = {
-      title: notification.title,
-      subtitle: notification.message || '',
-      caption: this._renderTimeAndApplicationHtml(notification),
+      ttitle: sanitizedTitle,
+      subtitle: sanitizedSubtitle,
+      caption: sanitizedCaption,
       type: carbonType,
       lowContrast: lowContrast,
       showClose: true,
@@ -265,8 +281,9 @@ export class NotificationService {
   }
 
   private _renderTimeAndApplicationHtml(notification: CdNotification): string {
-    let html = `<div class="toast-caption-container">
-      <small class="date">${this.cdDatePipe.transform(notification.timestamp)}</small>`;
+    let html = `<div class="toast-caption-container"><small class="date">${this.cdDatePipe.transform(
+      notification.timestamp
+    )}</small>`;
 
     html += '</div>';
     return html;


### PR DESCRIPTION
dashboard: sanitize HTML content for toast notifications

Carbon internally uses innerHTML for toast notification content.
This can potentially allow unsafe HTML to be rendered if input
content is not sanitized before being passed to the component.

This change sanitizes the toast title, subtitle, and caption
fields using Angular DomSanitizer before passing them to the
Carbon toast component. This ensures that unsafe HTML content
cannot be rendered inside toast notifications.

The sanitization is applied only at the point where toast
notifications are created, ensuring minimal impact on the
existing notification workflow while improving security.

Fixes: https://tracker.ceph.com/issues/74770
Signed-off-by: Shashiranjan Singh <singhshashiranjan34@gmail.com>

---

### Before

<img width="1038" height="516" alt="Screenshot 2026-03-06 230145" src="https://github.com/user-attachments/assets/40ad3b0b-d10e-4a62-b810-5de51fd86e65" />


### After

<img width="1015" height="467" alt="Screenshot 2026-03-06 230015" src="https://github.com/user-attachments/assets/ba7e26e0-9e19-4f66-97e0-b2d3f324553d" />
<img width="403" height="269" alt="image" src="https://github.com/user-attachments/assets/ad605f82-2257-48d7-8ae3-97a2caf324eb" />


---

## Contribution Guidelines

- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

---

## Checklist

### Tracker (select at least one)
- [x] References tracker ticket
- [ ] Very recent bug; references commit where it was introduced
- [ ] New feature (ticket optional)
- [ ] Doc update (no ticket needed)
- [ ] Code cleanup (no ticket needed)

### Component impact
- [x] Affects Dashboard, opened tracker ticket
- [ ] Affects Orchestrator, opened tracker ticket
- [ ] No impact that needs to be tracked

### Documentation (select at least one)
- [ ] Updates relevant documentation
- [x] No doc update is appropriate

### Tests (select at least one)
- [ ] Includes unit test(s)
- [ ] Includes integration test(s)
- [ ] Includes bug reproducer
- [x] No tests