### PR TITLE
rgw: group lifecycle versioned deletes to reduce OLH contention

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -32,6 +32,7 @@
 #include "rgw_lc.h"
 #include "rgw_string.h"
 #include "rgw_sal.h"
+#include "rgw_multi_del.h"
 #include "rgw_multipart_meta_filter.h"
 
 #include "fmt/format.h"
@@ -607,6 +608,7 @@ struct lc_op_ctx {
 
   std::unique_ptr<rgw::sal::PlacementTier> tier;
   const RGWObjTags* cached_tags{nullptr};
+  bool skip_update_olh{false};
 
   lc_op_ctx(op_env& env, rgw_bucket_dir_entry& o,
 	    boost::optional<std::string> next_key_name,
@@ -782,6 +784,9 @@ static int remove_expired_obj(const DoutPrefixProvider* dpp,
 
   uint32_t flags = (!remove_indeed || !zonegroup_lc_check(dpp, oc.driver->get_zone()))
                    ? rgw::sal::FLAG_LOG_OP : 0;
+  if (remove_indeed && oc.skip_update_olh) {
+    flags |= rgw::sal::FLAG_SKIP_UPDATE_OLH;
+  }
   ret =  del_op->delete_obj(dpp, y, flags);
   if (ret < 0) {
     ldpp_dout(dpp, 1) <<
@@ -822,6 +827,17 @@ public:
 
   virtual int process(lc_op_ctx& oc, optional_yield y) {
     return 0;
+  }
+
+  /*
+   * True for actions that always hard-delete (remove_indeed=true).
+   * Used to route deletes through rgw::multi_delete::dispatch()
+   * so redundant OLH updates can be skipped. CurrentExpiration
+   * is excluded because on versioned buckets it creates a delete
+   * marker rather than hard-deleting.
+   */
+  virtual bool is_delete() const {
+    return false;
   }
 
   friend class LCOpRule;
@@ -867,6 +883,18 @@ public:
 
   void build();
   void update();
+
+  LCOpAction* evaluate(rgw_bucket_dir_entry& o,
+		       const DoutPrefixProvider *dpp,
+		       const RGWObjTags* cached_tags,
+		       optional_yield y);
+  int execute(LCOpAction& action,
+	      rgw_bucket_dir_entry& o,
+	      const DoutPrefixProvider *dpp,
+	      LCBatchCounters* batch_counters,
+	      const RGWObjTags* cached_tags,
+	      bool skip_update_olh,
+	      optional_yield y);
   int process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp,
               LCBatchCounters* batch_counters, optional_yield y,
               const RGWObjTags* cached_tags = nullptr);
@@ -1048,6 +1076,36 @@ static int read_obj_tags(const DoutPrefixProvider *dpp, rgw::sal::Object* obj, b
   std::unique_ptr<rgw::sal::Object::ReadOp> rop = obj->get_read_op();
 
   return rop->get_attr(dpp, RGW_ATTR_TAGS, tags_bl, y);
+}
+
+/*
+ * Fetch and decode object tags. Returns a pointer into buf on success,
+ * or nullptr if the object is a delete marker, has no tags, or on error.
+ */
+static const RGWObjTags* fetch_obj_tags(
+    const DoutPrefixProvider* dpp, rgw::sal::Bucket* bucket,
+    const rgw_bucket_dir_entry& obj,
+    boost::optional<RGWObjTags>& buf, optional_yield y)
+{
+  if (obj.is_delete_marker()) return nullptr;
+
+  rgw_obj_key key = obj.key;
+  if (key.instance.empty() && bucket->versioned() && !obj.is_current())
+    key.instance = "null";
+
+  bufferlist bl;
+  auto o = bucket->get_object(key);
+  if (read_obj_tags(dpp, o.get(), bl, y) != 0)
+    return nullptr;
+
+  try {
+    buf.emplace();
+    auto it = bl.cbegin();
+    buf->decode(it);
+    return &*buf;
+  } catch (buffer::error&) {
+    return nullptr;
+  }
 }
 
 static bool is_valid_op(const lc_op& op)
@@ -1268,6 +1326,8 @@ public:
   LCOpAction_NonCurrentExpiration(op_env& env)
     {}
 
+  bool is_delete() const override { return true; }
+
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time, const DoutPrefixProvider *dpp, optional_yield y) override {
     auto& o = oc.o;
     if (o.is_current()) {
@@ -1319,6 +1379,8 @@ public:
 class LCOpAction_DMExpiration : public LCOpAction {
 public:
   LCOpAction_DMExpiration(op_env& env) {}
+
+  bool is_delete() const override { return true; }
 
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time, const DoutPrefixProvider *dpp, optional_yield y) override {
     auto& o = oc.o;
@@ -1703,14 +1765,19 @@ void LCOpRule::update()
   effective_mtime = env.ol.get_prev_obj().meta.mtime;
 }
 
-int LCOpRule::process(rgw_bucket_dir_entry& o,
-		      const DoutPrefixProvider *dpp,
-		      LCBatchCounters* batch_counters,
-                      optional_yield y,
-		      const RGWObjTags* cached_tags)
+/*
+ * evaluate() and execute() each construct a fresh lc_op_ctx. If a
+ * check() mutates ctx, those mutations are discarded before execute()
+ * runs — check() implementations must not stash state in ctx.
+ */
+LCOpAction* LCOpRule::evaluate(rgw_bucket_dir_entry& o,
+			       const DoutPrefixProvider *dpp,
+			       const RGWObjTags* cached_tags,
+			       optional_yield y)
 {
-  lc_op_ctx ctx(env, o, next_key_name, num_noncurrent, effective_mtime, dpp, batch_counters);
+  lc_op_ctx ctx(env, o, next_key_name, num_noncurrent, effective_mtime, dpp, nullptr);
   ctx.cached_tags = cached_tags;
+
   shared_ptr<LCOpAction> *selected = nullptr; // n.b., req'd by sharing
   real_time exp;
 
@@ -1725,45 +1792,70 @@ int LCOpRule::process(rgw_bucket_dir_entry& o,
     }
   }
 
-  if (selected &&
-      (*selected)->should_process()) {
-
-    /*
-     * Calling filter checks after action checks because
-     * all action checks (as they are implemented now) do
-     * not access the objects themselves, but return result
-     * from info from bucket index listing. The current tags filter
-     * check does access the objects, so we avoid unnecessary rados calls
-     * having filters check later in the process.
-     */
-
-    bool cont = false;
-    for (auto& f : filters) {
-      if (f->check(dpp, ctx, y)) {
-        cont = true;
-        break;
-      }
-    }
-
-    if (!cont) {
-      ldpp_dout(dpp, 20) << __func__ << "(): key=" << o.key
-			 << ": no rule match, skipping" << dendl;
-      return 0;
-    }
-
-    int r = (*selected)->process(ctx, y);
-    if (r < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: remove_expired_obj " 
-			<< env.bucket << ":" << o.key
-			<< " " << cpp_strerror(r) << dendl;
-      return r;
-    }
-    ldpp_dout(dpp, 20) << "processed:" << env.bucket << ":"
-		       << o.key << dendl;
+  if (!selected || !(*selected)->should_process()) {
+    return nullptr;
   }
 
-  return 0;
+  /*
+   * Calling filter checks after action checks because
+   * all action checks (as they are implemented now) do
+   * not access the objects themselves, but return result
+   * from info from bucket index listing. The current tags filter
+   * check does access the objects, so we avoid unnecessary rados calls
+   * having filters check later in the process.
+   */
+  bool cont = false;
+  for (auto& f : filters) {
+    if (f->check(dpp, ctx, y)) {
+      cont = true;
+      break;
+    }
+  }
 
+  if (!cont) {
+    ldpp_dout(dpp, 20) << __func__ << "(): key=" << o.key
+		       << ": no rule match, skipping" << dendl;
+    return nullptr;
+  }
+
+  return selected->get();
+}
+
+int LCOpRule::execute(LCOpAction& action,
+		      rgw_bucket_dir_entry& o,
+		      const DoutPrefixProvider *dpp,
+		      LCBatchCounters* batch_counters,
+		      const RGWObjTags* cached_tags,
+		      bool skip_update_olh,
+		      optional_yield y)
+{
+  lc_op_ctx ctx(env, o, next_key_name, num_noncurrent, effective_mtime, dpp, batch_counters);
+  ctx.cached_tags = cached_tags;
+  ctx.skip_update_olh = skip_update_olh;
+
+  int r = action.process(ctx, y);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: remove_expired_obj "
+		      << env.bucket << ":" << o.key
+		      << " " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ldpp_dout(dpp, 20) << "processed:" << env.bucket << ":"
+		     << o.key << dendl;
+  return 0;
+}
+
+int LCOpRule::process(rgw_bucket_dir_entry& o,
+		      const DoutPrefixProvider *dpp,
+		      LCBatchCounters* batch_counters,
+		      optional_yield y,
+		      const RGWObjTags* cached_tags)
+{
+  auto* action = evaluate(o, dpp, cached_tags, y);
+  if (!action) {
+    return 0;
+  }
+  return execute(*action, o, dpp, batch_counters, cached_tags, false, y);
 }
 
 int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
@@ -1962,6 +2054,149 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
       rules.back().build(); // why can't ctor do it?
     }
 
+    /*
+     * Buffer versions of the same key so versioned deletes can
+     * skip redundant OLH updates via rgw::multi_delete::dispatch().
+     */
+    struct lc_obj_entry {
+      rgw_bucket_dir_entry obj;
+      std::vector<LCOpRule> rules;
+    };
+    std::vector<lc_obj_entry> key_group;
+
+    auto flush_key_group = [&] {
+      if (key_group.empty()) return;
+
+      if (!bucket->versioned() || key_group.size() == 1) {
+        /*
+         * Non-versioned or single version: spawn per-object.
+         */
+        for (auto& entry : key_group) {
+          // Spawn one coroutine per object to process all rules
+          workpool.spawn([&pf, &batch_counters, dpp=this,
+                          rules_copy=std::move(entry.rules),
+                          obj=std::move(entry.obj), bucket=bucket.get()]
+                         (boost::asio::yield_context yield) mutable {
+            // Fetch tags once per object if any rule needs them
+            boost::optional<RGWObjTags> cached_tags;
+            const RGWObjTags* cached_tags_ptr = nullptr;
+            if (std::any_of(rules_copy.begin(), rules_copy.end(),
+                    [](const LCOpRule& r) { return r.needs_tags(); }))
+              cached_tags_ptr = fetch_obj_tags(dpp, bucket, obj,
+                                               cached_tags, yield);
+
+            for (auto& rule : rules_copy) {
+              if (rule.needs_tags() &&
+                  !obj.is_delete_marker() &&
+                  cached_tags_ptr &&
+                  !has_all_tags(rule.get_op(), *cached_tags_ptr)) {
+                continue;
+              }
+              if (rule.needs_tags() &&
+                  !obj.is_delete_marker() &&
+                  !cached_tags_ptr) {
+                continue;
+              }
+              pf(dpp, yield, rule, obj, cached_tags_ptr);
+            }
+            batch_counters.decrement_pending();
+          });
+        }
+      } else {
+        /*
+         * Versioned with multiple versions: evaluate all entries,
+         * then pass hard deletes to rgw::multi_delete::dispatch()
+         * to skip redundant OLH updates.
+         */
+        workpool.spawn(
+            [dpp=this, group=std::move(key_group), bucket=bucket.get(),
+             &batch_counters]
+            (boost::asio::yield_context yield) mutable {
+
+              struct action_ref { LCOpAction* a; size_t ei, ri; };
+              struct tag_entry {
+                boost::optional<RGWObjTags> buf;
+                const RGWObjTags* ptr{nullptr};
+              };
+
+              std::vector<tag_entry> tags(group.size());
+              std::vector<action_ref> dels, non_dels;
+
+              for (size_t ei = 0; ei < group.size(); ++ei) {
+                auto& obj = group[ei].obj;
+                if (std::any_of(group[ei].rules.begin(),
+                        group[ei].rules.end(),
+                        [](const LCOpRule& r) { return r.needs_tags(); }))
+                  tags[ei].ptr = fetch_obj_tags(dpp, bucket, obj,
+                                                tags[ei].buf, yield);
+                bool has_del = false;
+                std::vector<action_ref> entry_non_dels;
+                entry_non_dels.reserve(group[ei].rules.size());
+                for (size_t ri = 0; ri < group[ei].rules.size(); ++ri) {
+                  auto& rule = group[ei].rules[ri];
+                  if (rule.needs_tags() &&
+                      !obj.is_delete_marker() &&
+                      tags[ei].ptr &&
+                      !has_all_tags(rule.get_op(), *tags[ei].ptr))
+                    continue;
+                  if (rule.needs_tags() &&
+                      !obj.is_delete_marker() &&
+                      !tags[ei].ptr)
+                    continue;
+                  auto* act = rule.evaluate(
+                      group[ei].obj, dpp, tags[ei].ptr, yield);
+                  if (!act) continue;
+                  if (act->is_delete()) {
+                    /*
+                     * S3 lifecycle conflict resolution gives hard deletes
+                     * precedence over transitions for the same version.
+                     * Suppress queued non-delete work once one matches.
+                     */
+                    dels.push_back({act, ei, ri});
+                    has_del = true;
+                    entry_non_dels.clear();
+                    break;
+                  }
+                  entry_non_dels.push_back({act, ei, ri});
+                }
+                if (!has_del) {
+                  non_dels.insert(non_dels.end(),
+                                  entry_non_dels.begin(),
+                                  entry_non_dels.end());
+                }
+              }
+
+              for (auto& r : non_dels)
+                group[r.ei].rules[r.ri].execute(
+                    *r.a, group[r.ei].obj, dpp,
+                    &batch_counters, tags[r.ei].ptr, false, yield);
+
+              std::vector<rgw::multi_delete::Item> items;
+              items.reserve(dels.size());
+              for (size_t i = 0; i < dels.size(); ++i)
+                items.push_back({group[dels[i].ei].obj.key, i});
+
+              /*
+               * max_aio=1: all versions share a bucket index shard,
+               * so parallel deletes would contend on that shard.
+               */
+              rgw::multi_delete::dispatch(
+                  items, true, 1, yield,
+                  [&](const rgw::multi_delete::Item& item,
+                      bool skip_olh, boost::asio::yield_context y) {
+                    auto& r = dels[item.index];
+                    group[r.ei].rules[r.ri].execute(
+                        *r.a, group[r.ei].obj, dpp,
+                        &batch_counters, tags[r.ei].ptr, skip_olh, y);
+                  });
+
+              for (size_t i = 0; i < group.size(); ++i)
+                batch_counters.decrement_pending();
+            });
+      }
+      key_group.clear();
+    };
+
     rgw_bucket_dir_entry* o{nullptr};
     for (auto offset = 0; ol.get_obj(this, yield, &o /* , fetch_barrier */); ++offset, ol.next()) {
       const auto obj = *o;
@@ -1971,60 +2206,13 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
         rule.update();
       }
 
-      // Spawn one coroutine per object to process all rules
-      workpool.spawn([&pf, &batch_counters, dpp=this, rules_copy=rules, obj, bucket=bucket.get()]
-                     (boost::asio::yield_context yield) mutable {
-        // Check if any rule needs tags so we only fetch once per object
-        bool any_rule_needs_tags = std::any_of(rules_copy.begin(), rules_copy.end(),
-          [](const LCOpRule& r) { return r.needs_tags(); });
+      // flush on key change, or at 1000 versions to bound memory
+      if (!key_group.empty()
+          && (obj.key.name != key_group.front().obj.key.name
+              || key_group.size() >= 1000))
+        flush_key_group();
 
-        boost::optional<RGWObjTags> cached_tags;
-        const RGWObjTags* cached_tags_ptr = nullptr;
-
-        if (any_rule_needs_tags && !obj.is_delete_marker()) {
-          bufferlist tags_bl;
-
-          rgw_obj_key obj_key = obj.key;
-          if (obj_key.instance.empty() && bucket->versioned() && !obj.is_current()) {
-            obj_key.instance = "null";
-          }
-
-          auto temp_obj = bucket->get_object(obj_key);
-          std::unique_ptr<rgw::sal::Object::ReadOp> rop = temp_obj->get_read_op();
-          int ret = rop->get_attr(dpp, RGW_ATTR_TAGS, tags_bl, yield);
-          if (ret == 0) {
-            try {
-              cached_tags.emplace();
-              auto iter = tags_bl.cbegin();
-              cached_tags->decode(iter);
-              cached_tags_ptr = &*cached_tags;
-            } catch (buffer::error& err) {
-              ldpp_dout(dpp, 5) << "ERROR: decode tags for " << obj.key << dendl;
-            }
-          }
-        }
-
-        for (auto& rule : rules_copy) {
-          if (rule.needs_tags() &&
-              !obj.is_delete_marker() &&
-              cached_tags_ptr &&
-              !has_all_tags(rule.get_op(), *cached_tags_ptr)) {
-            continue;
-          }
-
-          if (rule.needs_tags() &&
-              !obj.is_delete_marker() &&
-              !cached_tags_ptr) {
-            continue;
-          }
-
-          pf(dpp, yield, rule, const_cast<rgw_bucket_dir_entry&>(obj),
-             cached_tags_ptr);
-        }
-
-        // Decrement pending once per object, after all rules are evaluated
-        batch_counters.decrement_pending();
-      });
+      key_group.push_back({obj, rules});
 
       total_objects_scanned++;
 
@@ -2047,10 +2235,12 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
 	  ldpp_dout(this, 5) << __func__ << " interval budget EXPIRED worker="
 			     << worker->ix << " bucket=" << bucket_name
 			     << dendl;
+	  flush_key_group();
 	  return 0;
 	}
       }
     }
+    flush_key_group();
   }
 
   ret = handle_multipart_expiration(bucket.get(), prefix_map, workpool,

--- a/src/rgw/rgw_multi_del.cc
+++ b/src/rgw/rgw_multi_del.cc
@@ -3,8 +3,11 @@
 
 #include <string.h>
 
+#include <algorithm>
 #include <iostream>
+#include <unordered_map>
 
+#include "common/async/spawn_throttle.h"
 #include "common/strtol.h" // for strict_strtoll()
 #include "include/types.h"
 
@@ -95,3 +98,65 @@ XMLObj *RGWMultiDelXMLParser::alloc_obj(const char *el) {
   return obj;
 }
 
+void rgw::multi_delete::dispatch(const std::vector<Item>& items,
+                                 bool bucket_versioned,
+                                 uint32_t max_aio,
+                                 boost::asio::yield_context yield,
+                                 Exec exec,
+                                 OnDispatch on_dispatch)
+{
+  auto group = ceph::async::spawn_throttle{yield, std::max<uint32_t>(1, max_aio)};
+
+  if (!bucket_versioned) {
+    for (size_t i = 0; i < items.size(); ++i) {
+      group.spawn([&exec, &items, i] (boost::asio::yield_context y) {
+        exec(items[i], false, y);
+      });
+      if (on_dispatch) {
+        on_dispatch();
+      }
+    }
+    group.wait();
+    return;
+  }
+
+  // Preserve first-seen order within each key group so callers can keep
+  // request/result ordering stable while coalescing intermediate OLH updates.
+  std::vector<std::vector<size_t>> grouped_items;
+  grouped_items.reserve(items.size());
+  std::unordered_map<std::string, size_t> group_index;
+  group_index.reserve(items.size());
+
+  for (size_t i = 0; i < items.size(); ++i) {
+    const auto& name = items[i].key.name;
+    auto [it, inserted] = group_index.emplace(name, grouped_items.size());
+    if (inserted) {
+      grouped_items.emplace_back();
+    }
+    grouped_items[it->second].push_back(i);
+  }
+
+  for (const auto& indexes : grouped_items) {
+    for (size_t i = 0; i + 1 < indexes.size(); ++i) {
+      const auto index = indexes[i];
+      group.spawn([&exec, &items, index] (boost::asio::yield_context y) {
+        exec(items[index], true, y);
+      });
+      if (on_dispatch) {
+        on_dispatch();
+      }
+    }
+  }
+  group.wait();
+
+  for (const auto& indexes : grouped_items) {
+    const auto index = indexes.back();
+    group.spawn([&exec, &items, index] (boost::asio::yield_context y) {
+      exec(items[index], false, y);
+    });
+    if (on_dispatch) {
+      on_dispatch();
+    }
+  }
+  group.wait();
+}

--- a/src/rgw/rgw_multi_del.h
+++ b/src/rgw/rgw_multi_del.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include <functional>
 #include <vector>
+
+#include <boost/asio/spawn.hpp>
+
 #include "rgw_xml.h"
 #include "rgw_common.h"
 
@@ -66,3 +70,24 @@ public:
   RGWMultiDelXMLParser() {}
   ~RGWMultiDelXMLParser() override {}
 };
+
+namespace rgw::multi_delete {
+
+struct Item {
+  rgw_obj_key key;
+  size_t index{0};
+};
+
+using Exec = std::function<void(const Item& item,
+                                bool skip_update_olh,
+                                boost::asio::yield_context yield)>;
+using OnDispatch = std::function<void()>;
+
+void dispatch(const std::vector<Item>& items,
+              bool bucket_versioned,
+              uint32_t max_aio,
+              boost::asio::yield_context yield,
+              Exec exec,
+              OnDispatch on_dispatch = {});
+
+} // namespace rgw::multi_delete

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8069,68 +8069,33 @@ void RGWDeleteMultiObj::handle_individual_object(const RGWMultiDelObject& object
   send_partial_response(o, del_op->result.delete_marker, del_op->result.version_id, op_ret);
 }
 
-void RGWDeleteMultiObj::handle_versioned_objects(const std::vector<RGWMultiDelObject>& objects,
-                                                 uint32_t max_aio,
-                                                 boost::asio::yield_context yield)
-{
-  auto group = ceph::async::spawn_throttle{yield, max_aio};
-  std::map<std::string, std::vector<RGWMultiDelObject>> grouped_objects;
-
-  // group objects by their keys
-  for (const auto& object : objects) {
-    const std::string& key = object.get_key();
-    grouped_objects[key].push_back(object);
-  }
-
-  // for each group of objects, handle all but the last object and skip update_olh
-  for (const auto& [_, objects] : grouped_objects) {
-    for (size_t i = 0; i + 1 < objects.size(); ++i) { // skip the last element
-      group.spawn([this, &objects, i] (boost::asio::yield_context yield) {
-        handle_individual_object(objects[i], yield, true /* skip_olh_obj_update */);
-      });
-
-      rgw_flush_formatter(s, s->formatter);
-    }
-  }
-  group.wait();
-
-  // Now handle the last object of each group with update_olh
-  for (const auto& [_, objects] : grouped_objects) {
-    const auto& object = objects.back();
-    group.spawn([this, &object] (boost::asio::yield_context yield) {
-      handle_individual_object(object, yield);
-    });
-
-    rgw_flush_formatter(s, s->formatter);
-  }
-  group.wait();
-}
-
-void RGWDeleteMultiObj::handle_non_versioned_objects(const std::vector<RGWMultiDelObject>& objects,
-                                                     uint32_t max_aio,
-                                                     boost::asio::yield_context yield)
-{
-  auto group = ceph::async::spawn_throttle{yield, max_aio};
-
-  for (const auto& object : objects) {
-    group.spawn([this, &object] (boost::asio::yield_context yield) {
-                  handle_individual_object(object, yield);
-                });
-
-    rgw_flush_formatter(s, s->formatter);
-  }
-  group.wait();
-}
-
 void RGWDeleteMultiObj::handle_objects(const std::vector<RGWMultiDelObject>& objects,
                                        uint32_t max_aio,
                                        boost::asio::yield_context yield)
 {
-  if (bucket->versioned()) {
-    handle_versioned_objects(objects, max_aio, yield);
-  } else {
-    handle_non_versioned_objects(objects, max_aio, yield);
+  std::vector<rgw::multi_delete::Item> items;
+  items.reserve(objects.size());
+
+  for (size_t i = 0; i < objects.size(); ++i) {
+    items.push_back(rgw::multi_delete::Item{
+      rgw_obj_key(objects[i].get_key(), objects[i].get_version_id()),
+      i,
+    });
   }
+
+  rgw::multi_delete::dispatch(
+      items,
+      bucket->versioned(),
+      max_aio,
+      yield,
+      [this, &objects] (const rgw::multi_delete::Item& item,
+                        bool skip_update_olh,
+                        boost::asio::yield_context y) {
+        handle_individual_object(objects[item.index], y, skip_update_olh);
+      },
+      [this] {
+        rgw_flush_formatter(s, s->formatter);
+      });
 }
 
 void RGWDeleteMultiObj::execute(optional_yield y)

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2265,10 +2265,6 @@ class RGWDeleteMultiObj : public RGWOp {
                                 optional_yield y,
                                 const bool skip_olh_obj_update = false);
 
-  void handle_versioned_objects(const std::vector<RGWMultiDelObject>& objects,
-                                uint32_t max_aio, boost::asio::yield_context yield);
-  void handle_non_versioned_objects(const std::vector<RGWMultiDelObject>& objects,
-                                    uint32_t max_aio, boost::asio::yield_context yield);
   void handle_objects(const std::vector<RGWMultiDelObject>& objects,
                       uint32_t max_aio, boost::asio::yield_context yield);
 


### PR DESCRIPTION
When lifecycle expires several versions of the same key, each delete does a read-modify-write of the OLH. Since they all hit the same bucket index shard, these updates contend with each other and only the final result matters.

This pulls the OLH grouping logic out of multi-delete into rgw::multi_delete::dispatch() and reuses it in lifecycle expiration. Versions of the same key are buffered during listing, and all but the last delete skip the OLH update.

No change in behavior for non-versioned buckets or keys with a single version.

Testing with 100k keys (distribution: 45% x1 version, 25% x2, 15% x3, 10% x4, 5% x9) and 128 LC workers, lifecycle processing dropped from 6m43s to 3m23s — roughly a 50% reduction in wall time.

**Baseline**
```
time bin/radosgw-admin lc process --bucket=test-multi-del-1 \
  --rgw-lc-debug-interval=1 --rgw_lc_max_wp_worker=128 \
  --debug_rgw_lifecycle=50 --debug_rgw=50

real    6m42.704s
user    1m53.995s
sys     0m59.943s
```

**This PR**
```
time bin/radosgw-admin lc process --bucket=test-multi-del-2 \
  --rgw-lc-debug-interval=1 --rgw_lc_max_wp_worker=128 \
  --debug_rgw_lifecycle=50 --debug_rgw=50

real    3m23.490s
user    1m6.454s
sys     0m35.938s
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
