### PR TITLE
mgr/dashboard: fix empty state illustration icon in datatable

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -241,7 +241,7 @@ export class TableComponent implements AfterViewInit, OnInit, OnChanges, OnDestr
    * Icon to be displayed when there is no data
    */
   @Input()
-  emptyStateIcon: string = ICON_TYPE.deploy;
+  emptyStateIcon: string = ICON_TYPE.emptySearch;
 
   /**
    * Should be a function to update the input data if undefined nothing will be triggered


### PR DESCRIPTION
Fixes #75287

## Description
Update the default empty state icon used in the dashboard
datatable component.

Previously the icon was set to `deploy`, which does not
accurately represent an empty state.

This PR changes the icon to `emptySearch`.

## Testing
Frontend builds successfully.
Change only affects the default empty state icon.