### PR TITLE
rgw: resolve compilation errors for Attrs custom class transition

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -60,7 +60,40 @@ namespace ceph {
 }
 
 namespace rgw::sal {
-  using Attrs = std::map<std::string, ceph::buffer::list>;
+    class Attrs {
+      public:
+        
+        using iterator = std::map<std::string, ceph::bufferlist>::iterator;
+        using const_iterator = std::map<std::string, ceph::bufferlist>::const_iterator;
+
+        // Constructors
+        Attrs() = default;
+        Attrs(const std::map<std::string, ceph::bufferlist>& attrs);
+        Attrs(std::map<std::string, ceph::bufferlist>&& attrs);
+
+        // Map-like interface
+        ceph::bufferlist& operator[](const std::string& key);
+        const ceph::bufferlist& at(const std::string& key) const;
+        iterator begin();
+        const_iterator begin() const;
+        iterator end();
+        const_iterator end() const;
+        bool empty() const;
+        size_t size() const;
+        void clear();
+        iterator find(const std::string& key);
+        const_iterator find(const std::string& key) const;
+        size_t count(const std::string& key) const;
+        void erase(iterator pos);
+        size_t erase(const std::string& key);
+
+        // Conversion operators
+        explicit operator std::map<std::string, ceph::bufferlist>&();
+        explicit operator const std::map<std::string, ceph::bufferlist>&() const;
+
+      private:
+        std::map<std::string, ceph::bufferlist> attrs_;
+      };
 }
 
 namespace rgw::lua {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -91,9 +91,28 @@ namespace rgw::sal {
         explicit operator std::map<std::string, ceph::bufferlist>&();
         explicit operator const std::map<std::string, ceph::bufferlist>&() const;
 
+
+        void encode(ceph::bufferlist& bl) const {
+          ::ceph::encode(attrs_, bl);
+        }
+
+        void decode(ceph::bufferlist::const_iterator& bl) {
+          ::ceph::decode(attrs_, bl);
+      }
+
+
       private:
         std::map<std::string, ceph::bufferlist> attrs_;
       };
+}
+
+inline void encode(const rgw::sal::Attrs &p, ceph::bufferlist &bl) {
+    p.encode(bl);
+}
+
+inline void decode(rgw::sal::Attrs &o, const ceph::bufferlist &bl) {
+    auto p = bl.begin();
+    o.decode(p);
 }
 
 namespace rgw::lua {

--- a/src/rgw/rgw_sal_fwd.h
+++ b/src/rgw/rgw_sal_fwd.h
@@ -34,8 +34,8 @@ inline auto AccessListFilterPrefix(std::string prefix) {
 namespace sal {
 
 /** A list of key-value attributes */
-using Attrs = std::map<std::string, ceph::buffer::list>;
 
+  class Attrs;
   class Driver;
   class User;
   struct UserList;

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "rgw_common.h"
 #include "rgw_sal.h"
 
 /**
@@ -48,7 +49,7 @@ struct RGWObjState {
 
   RGWObjVersionTracker objv_tracker;
 
-  std::map<std::string, ceph::buffer::list> attrset;
+  rgw::sal::Attrs attrset;
 
   RGWObjState() {};
   RGWObjState(const RGWObjState &rhs) : obj(rhs.obj) {


### PR DESCRIPTION
This PR is a continuation of the discussion in #67303 regarding the replacement of std::map (used for RGW attributes) with a custom class designed for constant lookups of known strings.

The draft in #67303 is currently stalled due to 100+ compilation errors triggered by the type swap. These errors are widespread across multiple RGW files and classes.
This draft focuses strictly on resolving the build failures with no functional changes. The custom class currently mirrors std::map behavior.

I have separated the compilation resolution PR from the optimization PR itself because many fixes require a maintainer's decision, e.g. whether to update a function signature to use the new Attrs class or to have the class return the original underlying map.