### PR TITLE
tools/cephfs: always execute scan_{extents,inodes,frags} and cleanup

### DIFF
--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -600,13 +600,8 @@ int DataScan::scan_extents()
   progress_tracker->set_enable_progress_update(true);
   progress_tracker->start(total_objects);
 
-  if (total_objects == 0) {
-    dout(4) << "No objects found in data pools" << dendl;
-    return 0;
-  }
-
   for (auto ioctx : data_ios) {
-    int r = forall_objects(*ioctx, false, [this, ioctx, &progress_tracker](
+    int r = forall_objects(*ioctx, false, [this, ioctx, &progress_tracker, &total_objects](
         std::string const &oid,
         uint64_t obj_name_ino,
         uint64_t obj_name_offset) -> int
@@ -650,6 +645,11 @@ int DataScan::scan_extents()
       }
 
       progress_tracker->increment();
+      uint64_t _total_objects = get_pool_objects({&data_io});
+      if (_total_objects > total_objects) {
+        progress_tracker->set_total(_total_objects);
+        total_objects = _total_objects;
+        }
       progress_tracker->display_progress();
 
       return r;
@@ -864,14 +864,9 @@ int DataScan::scan_inodes()
   progress_tracker->set_enable_progress_update(true);
   progress_tracker->start(total_objects);
 
-  if (total_objects == 0) {
-    dout(4) << "No objects found in data pool" << dendl;
-    return 0;
-  }
-
   r = forall_objects(
       data_io, true,
-      [this, &progress_tracker](
+      [this, &progress_tracker, &total_objects](
           std::string const& oid, uint64_t obj_name_ino,
           uint64_t obj_name_offset) -> int {
         int r = 0;
@@ -1146,6 +1141,11 @@ int DataScan::scan_inodes()
         }
 
         progress_tracker->increment();
+        uint64_t _total_objects = get_pool_objects({&data_io});
+        if (_total_objects > total_objects) {
+          progress_tracker->set_total(_total_objects);
+          total_objects = _total_objects;
+        }
         progress_tracker->display_progress();
 
         return r;
@@ -1160,15 +1160,10 @@ int DataScan::cleanup()
   progress_tracker->set_enable_progress_update(true);
   progress_tracker->start(total_objects);
 
-  if (total_objects == 0) {
-    dout(4) << "No objects found in data pool" << dendl;
-    return 0;
-  }
-
   // We are looking for only zeroth object
   return forall_objects(
       data_io, true,
-      [this, &progress_tracker](
+      [this, &progress_tracker, &total_objects](
           std::string const& oid, uint64_t obj_name_ino,
           uint64_t obj_name_offset) -> int {
         int r = ClsCephFSClient::delete_inode_accumulate_result(data_io, oid);
@@ -1178,6 +1173,11 @@ int DataScan::cleanup()
         }
 
         progress_tracker->increment();
+        uint64_t _total_objects = get_pool_objects({&data_io});
+        if (_total_objects > total_objects) {
+          progress_tracker->set_total(_total_objects);
+          total_objects = _total_objects;
+        }
         progress_tracker->display_progress();
 
         return r;
@@ -1721,10 +1721,6 @@ int DataScan::scan_frags()
   auto progress_tracker = std::make_unique<ProgressTracker>(get_progress_operation_name("scan_frags"));
   progress_tracker->set_enable_progress_update(true);
   progress_tracker->start(total_objects);
-  if (total_objects == 0) {
-    dout(4) << "No objects found in metadata pool" << dendl;
-    return 0;
-  }
 
   bool roots_present;
   int r = driver->check_roots(&roots_present);
@@ -1740,7 +1736,7 @@ int DataScan::scan_frags()
     return -EIO;
   }
 
-  return forall_objects(metadata_io, true, [this, &progress_tracker](
+  return forall_objects(metadata_io, true, [this, &progress_tracker, &total_objects](
         std::string const &oid,
         uint64_t obj_name_ino,
         uint64_t obj_name_offset) -> int
@@ -1880,7 +1876,11 @@ int DataScan::scan_frags()
       }
     }
 
-    progress_tracker->increment();
+    uint64_t _total_objects = get_pool_objects({&metadata_io});
+    if (_total_objects > total_objects) {
+      progress_tracker->set_total(_total_objects);
+      total_objects = _total_objects;
+    }
     progress_tracker->display_progress();
 
     return r;

--- a/src/tools/cephfs/ProgressTracker.cc
+++ b/src/tools/cephfs/ProgressTracker.cc
@@ -113,7 +113,9 @@ ProgressTracker::set_total(uint64_t total)
 void
 ProgressTracker::display_progress() const
 {
-  if (!started) {
+  auto processed = processed_items.load();
+  auto total = total_items.load();
+  if (!started || !total || (processed > total)) {
     return;
   }
   const time_point now = clock::now();
@@ -298,6 +300,7 @@ ProgressTracker::display_final_summary() const
   if (!started) {
     return;
   }
+
   std::lock_guard<std::mutex> lock(display_mutex);
   std::string completed_status = get_completed_status();
   write_console_line(fmt::format("Completed {}! Processed {}", operation_name, completed_status), false);


### PR DESCRIPTION
Even when the number of objects reported from pool stats is zero. Pool stats metrics are delayed and cannot be fully relied on for accuracy. Trusting the number of objects (esp. when reported as zero) could result in missed steps during data-scan execution.

So, we try to do two things now:

1. ProgressTracker::display_progress() will display progress only when the total items exceeds to the number of progress items.
2. Refresh total object count during each iteration of processing objects. This might be a bit too much, so we probably need to do this periodically rather than on each iteration.

Fixes: http://tracker.ceph.com/issues/75083





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
