### PR TITLE
squid: RGW: Change prerequest hook to run after authorization process

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -327,30 +327,6 @@ int process_request(const RGWProcessEnv& penv,
     abort_early(s, NULL, -ERR_METHOD_NOT_ALLOWED, handler, yield);
     goto done;
   }
-  is_health_request = (op->get_type() == RGW_OP_GET_HEALTH_CHECK);
-  {
-    s->trace_enabled = tracing::rgw::tracer.is_enabled();
-    if (!is_health_request) {
-      std::string script;
-      auto rc = rgw::lua::read_script(s, penv.lua.manager.get(),
-                                      s->bucket_tenant, s->yield,
-                                      rgw::lua::context::preRequest, script);
-      if (rc == -ENOENT) {
-        // no script, nothing to do
-      } else if (rc < 0) {
-        ldpp_dout(op, 5) <<
-          "WARNING: failed to execute pre request script. "
-          "error: " << rc << dendl;
-      } else {
-        rc = rgw::lua::request::execute(driver, rest, penv.olog.get(), s, op, script);
-        if (rc < 0) {
-          ldpp_dout(op, 5) <<
-            "WARNING: failed to execute pre request script. "
-            "error: " << rc << dendl;
-        }
-      }
-    }
-  }
   std::tie(ret,c) = schedule_request(scheduler, s, op);
   if (ret < 0) {
     if (ret == -EAGAIN) {
@@ -399,6 +375,30 @@ int process_request(const RGWProcessEnv& penv,
       goto done;
     }
 
+  is_health_request = (op->get_type() == RGW_OP_GET_HEALTH_CHECK);
+  {
+    s->trace_enabled = tracing::rgw::tracer.is_enabled();
+    if (!is_health_request) {
+      std::string script;
+      auto rc = rgw::lua::read_script(s, penv.lua.manager.get(),
+                                      s->bucket_tenant, s->yield,
+                                      rgw::lua::context::preRequest, script);
+      if (rc == -ENOENT) {
+        // no script, nothing to do
+      } else if (rc < 0) {
+        ldpp_dout(op, 5) <<
+          "WARNING: failed to execute pre request script. "
+          "error: " << rc << dendl;
+      } else {
+        rc = rgw::lua::request::execute(driver, rest, penv.olog.get(), s, op, script);
+        if (rc < 0) {
+          ldpp_dout(op, 5) <<
+            "WARNING: failed to execute pre request script. "
+            "error: " << rc << dendl;
+        }
+      }
+    }
+  }
     s->trace = tracing::rgw::tracer.start_trace(op->name(), s->trace_enabled);
     s->trace->SetAttribute(tracing::rgw::TRANS_ID, s->trans_id);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75003

---

backport of https://github.com/ceph/ceph/pull/66567
parent tracker: https://tracker.ceph.com/issues/73979

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh