### PR TITLE
rgw: add time limit for list requests

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -631,7 +631,8 @@ Quotas can be set for The Ceph Object Gateway on users and buckets. The "rate
 limit" includes the maximum number of read operations and write operations
 per accumulation interval as well as the number of bytes per accumulation interval
 that can be written or read per user or per bucket. It also includes the maximum
-number of list requests and delete operations per accumulation interval.
+number of list requests and delete operations per accumulation interval and the
+maximum processing time consumed by list requests per accumulation interval.
 The accumulation interval is configured by the :confval:`rgw_ratelimit_interval` option.
 The default value is 60 seconds.
 (Note: S3 Multi-Object Delete operation are currently not supported by rate limiting)
@@ -714,6 +715,11 @@ with ``Retry-After`` to ``429 Too Many Requests`` if clients require it.
   specify the maximum number of delete operations per accumulation interval per RGW instance.
   A ``0`` value disables throttling.
 
+- **Maximum List Time:** The ``--max-list-time`` setting allows you to
+  specify the maximum amount of processing time bucket listing requests may consume
+  per accumulation interval per RGW instance.
+  A ``0`` value disables throttling.
+
 - **Rate Limit Scope:** The ``--ratelimit-scope`` option sets the scope for the
   rate limit.  The options are ``bucket`` , ``user`` and ``anonymous``. Bucket
   rate limit apply to buckets.  The user rate limit applies to a user.  The
@@ -731,9 +737,10 @@ parameters:
 .. prompt:: bash #
 
    radosgw-admin ratelimit set --ratelimit-scope=user --uid=<uid> \
-                                 <[--max-read-ops=<num ops>] [--max-read-bytes=<num bytes>] \
+                                 [--max-read-ops=<num ops>] [--max-read-bytes=<num bytes>] \
                                  [--max-write-ops=<num ops>] [--max-write-bytes=<num bytes>] \
-                                 [--max-list-ops=<num ops>] [--max-delete-ops=<num ops>]>
+                                 [--max-list-ops=<num ops>] [--max-delete-ops=<num ops>] \
+                                 [--max-list-time=<seconds>]
 
 An example of using ``radosgw-admin ratelimit set`` to set a rate limit might
 look like this: 
@@ -797,9 +804,10 @@ The following is the general form of commands that set rate limit parameters:
 .. prompt:: bash #
 
    radosgw-admin ratelimit set --ratelimit-scope=bucket --bucket=<bucket> \
-                                 <[--max-read-ops=<num ops>] [--max-read-bytes=<num bytes>] \
+                                 [--max-read-ops=<num ops>] [--max-read-bytes=<num bytes>] \
                                  [--max-write-ops=<num ops>] [--max-write-bytes=<num bytes>] \
-                                 [--max-list-ops=<num ops>] [--max-delete-ops=<num ops>]>
+                                 [--max-list-ops=<num ops>] [--max-delete-ops=<num ops>] \
+                                 [--max-list-time=<seconds>]
 
 An example of using ``radosgw-admin ratelimit set`` to set a rate limit for a
 bucket might look like this: 

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -2814,7 +2814,7 @@ Rate Limit
 ==========
 
 The Admin Operations API enables you to set and get ratelimit configurations on users and on buckets and global rate limit configurations. See :ref:`radosgw-rate-limit-management` for additional details.
-Rate Limit includes the maximum number of operations and/or bytes per accumulation interval, separated by read and/or write (Additionally list and get operations),
+Rate Limit includes the maximum number of operations and/or bytes (additionally time) per accumulation interval, separated by read and/or write (additionally list and delete operations),
 to a bucket and/or by a user and the maximum storage size in megabytes.
 
 To view rate limit, the user must have a ``ratelimit=read`` capability. To set,
@@ -2846,6 +2846,10 @@ Valid parameters for quotas include:
 - **Maximum Delete Ops:** The ``max-delete-ops`` setting allows you to specify
   the maximum number of delete operations per accumulation interval. A 0 value disables throttling.
 
+- **Maximum List Time:** The ``max-list-time`` setting allows you to specify
+  the maximum amount of processing time bucket listing requests may consume per accumulation interval.
+  A 0 value disables throttling.
+
 - **Global:** The ``global`` option allows you to specify a global rate limit.
   The value should be either 'True' or 'False'.
 
@@ -2871,7 +2875,7 @@ Set User Rate Limit
 To set a rate limit, the user must have ``ratelimit`` capability set with ``write``
 permission. ::
 
-	POST /{admin}/ratelimit?ratelimit-scope=user&uid=<uid><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&enabled=<True|False>]>
+	POST /{admin}/ratelimit?ratelimit-scope=user&uid=<uid><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&max-list-time=<seconds>][&enabled=<True|False>]>
 
 
 
@@ -2891,7 +2895,7 @@ Set Rate Limit for an Individual Bucket
 To set a rate limit, the user must have ``ratelimit`` capability set with ``write``
 permission. ::
 
-	POST /{admin}/ratelimit?bucket=<bucket-name>&ratelimit-scope=bucket<[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&enabled=<True|False>]>
+	POST /{admin}/ratelimit?bucket=<bucket-name>&ratelimit-scope=bucket<[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&max-list-time=<seconds>][&enabled=<True|False>]>
 
 
 
@@ -2911,7 +2915,7 @@ Set Global User Rate Limit
 To set a rate limit, the user must have ``ratelimit`` capability set with ``write``
 permission. ::
 
-	POST /{admin}/ratelimit?ratelimit-scope=user&global=<True|False><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&enabled=<True|False>]>
+	POST /{admin}/ratelimit?ratelimit-scope=user&global=<True|False><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&max-list-time=<seconds>][&enabled=<True|False>]>
 
 
 
@@ -2921,7 +2925,7 @@ Set Global Rate Limit Bucket
 To set a rate limit, the user must have ``ratelimit`` capability set with ``write``
 permission. ::
 
-	POST /{admin}/ratelimit?ratelimit-scope=bucket&global=<True|False><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&enabled=<True|False>]>
+	POST /{admin}/ratelimit?ratelimit-scope=bucket&global=<True|False><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&max-list-time=<seconds>][&enabled=<True|False>]>
 
 
 
@@ -2931,7 +2935,7 @@ Set Global Anonymous User Rate Limit
 To set a rate limit, the user must have ``ratelimit`` capability set with ``write``
 permission. ::
 
-	POST /{admin}/ratelimit?ratelimit-scope=anon&global=<True|False><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&enabled=<True|False>]>
+	POST /{admin}/ratelimit?ratelimit-scope=anon&global=<True|False><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&max-list-time=<seconds>][&enabled=<True|False>]>
 
 
 

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -943,6 +943,14 @@ def task(ctx, config):
     user_ratelimit = out['user_ratelimit']
     assert user_ratelimit['max_delete_ops'] == 50
 
+    # TESTCASE 'ratelimit' 'user' 'modify' 'max-list-time = 10' 'succeeds'
+    (ret, out) = rgwadmin_rest(endpoint, ['ratelimit', 'modify'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user, 'max-list-time' : '10'})
+    assert ret == 200
+    (ret, out) = rgwadmin_rest(endpoint, ['ratelimit', 'info'], {'ratelimit-scope' : 'user', 'uid' : ratelimit_user})
+    assert ret == 200
+    user_ratelimit = out['user_ratelimit']
+    assert user_ratelimit['max_list_time'] == 10
+
     # TESTCASE 'ratelimit' 'bucket' 'modify' 'max-list-ops = 200' 'succeeds'
     (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket, 'max-list-ops' : '200'})
     assert ret == 200
@@ -958,6 +966,14 @@ def task(ctx, config):
     assert ret == 200
     bucket_ratelimit = out['bucket_ratelimit']
     assert bucket_ratelimit['max_delete_ops'] == 75
+
+    # TESTCASE 'ratelimit' 'bucket' 'modify' 'max-list-time = 20' 'succeeds'
+    (ret, out) = rgwadmin_rest(endpoint, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket, 'max-list-time' : '20'})
+    assert ret == 200
+    (ret, out) = rgwadmin_rest(endpoint, ['ratelimit', 'info'], {'ratelimit-scope' : 'bucket', 'bucket' : ratelimit_bucket})
+    assert ret == 200
+    bucket_ratelimit = out['bucket_ratelimit']
+    assert bucket_ratelimit['max_list_time'] == 20
 
     # TESTCASE 'ratelimit' 'global' 'modify' 'bucket' 'max-list-ops = 500' 'succeeds'
     (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'global': 'true', 'max-list-ops' : '500'})
@@ -977,6 +993,15 @@ def task(ctx, config):
     assert 'bucket_ratelimit' in out
     assert out['bucket_ratelimit']['max_delete_ops'] == 300
 
+    # TESTCASE 'ratelimit' 'global' 'modify' 'bucket' 'max-list-time = 50' 'succeeds'
+    (ret, out) = rgwadmin_rest(endpoint, ['ratelimit', 'modify'], {'ratelimit-scope' : 'bucket', 'global': 'true', 'max-list-time' : '50'})
+    assert ret == 200
+    (ret, out) = rgwadmin_rest(endpoint, ['ratelimit', 'info'], {'global' : 'true'})
+    assert ret == 200
+    # Check that global bucket ratelimit has the list ops set
+    assert 'bucket_ratelimit' in out
+    assert out['bucket_ratelimit']['max_list_time'] == 50
+
     # TESTCASE 'ratelimit' 'user' 'modify' 'multiple ops at once' 'succeeds'
     (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['ratelimit', 'modify'], {
         'ratelimit-scope' : 'user',
@@ -985,6 +1010,7 @@ def task(ctx, config):
         'max-write-ops' : '800',
         'max-list-ops' : '600',
         'max-delete-ops' : '400',
+        'max-list-time' : '40',
         'enabled' : 'true'
     })
     assert ret == 200
@@ -996,6 +1022,7 @@ def task(ctx, config):
     assert user_ratelimit['max_write_ops'] == 800
     assert user_ratelimit['max_list_ops'] == 600
     assert user_ratelimit['max_delete_ops'] == 400
+    assert user_ratelimit['max_list_time'] == 40
 
     # TESTCASE 'create account' 'account' 'post' 'creating a new account' 'succeeds'
     (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['account', 'post'], {'id' : account_id, 'name': account_id})

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -529,6 +529,7 @@ void usage()
   cout << "   --max-write-bytes             specify max bytes per accumulation interval for WRITE ops per RGW (Not GET or HEAD request methods), 0 means unlimited\n";
   cout << "   --max-list-ops                specify max requests per accumulation interval for bucket listing requests per RGW, 0 means unlimited\n";
   cout << "   --max-delete-ops              specify max requests per accumulation interval for DELETE ops per RGW (DELETE request methods), 0 means unlimited\n";
+  cout << "   --max-list-time               specify max time consumption per accumulation interval for bucket listing requests per RGW, 0 means unlimited\n";
   cout << "   --ratelimit-scope             scope of rate limiting: bucket, user, anonymous\n";
   cout << "                                 anonymous can be configured only with global rate limit\n";
   cout << "\nOrphans search options:\n";
@@ -1532,8 +1533,10 @@ static bool dump_string(const char *field_name, bufferlist& bl, Formatter *f)
 
 bool set_ratelimit_info(RGWRateLimitInfo& ratelimit, OPT opt_cmd, int64_t max_read_ops, int64_t max_write_ops,
                     int64_t max_list_ops, int64_t max_delete_ops, int64_t max_read_bytes, int64_t max_write_bytes,
+                    int64_t max_list_time,
                     bool have_max_read_ops, bool have_max_write_ops, bool have_max_list_ops,
-                    bool have_max_delete_ops, bool have_max_read_bytes, bool have_max_write_bytes)
+                    bool have_max_delete_ops, bool have_max_read_bytes, bool have_max_write_bytes,
+                    bool have_max_list_time)
 {
   bool ratelimit_configured = true;
   switch (opt_cmd) {
@@ -1578,6 +1581,12 @@ bool set_ratelimit_info(RGWRateLimitInfo& ratelimit, OPT opt_cmd, int64_t max_re
       if (have_max_write_bytes) {
         if (max_write_bytes >= 0) {
           ratelimit.max_write_bytes = max_write_bytes;
+          ratelimit_configured = true;
+        }
+      }
+      if (have_max_list_time) {
+        if (max_list_time >= 0) {
+          ratelimit.max_list_time = max_list_time;
           ratelimit_configured = true;
         }
       }
@@ -1655,8 +1664,10 @@ int set_bucket_ratelimit(rgw::sal::Driver* driver, OPT opt_cmd,
                      const string& tenant_name, const string& bucket_name,
                      int64_t max_read_ops, int64_t max_write_ops, int64_t max_list_ops,
                      int64_t max_delete_ops, int64_t max_read_bytes, int64_t max_write_bytes,
+                     int64_t max_list_time,
                      bool have_max_read_ops, bool have_max_write_ops, bool have_max_list_ops,
-                     bool have_max_delete_ops, bool have_max_read_bytes, bool have_max_write_bytes)
+                     bool have_max_delete_ops, bool have_max_read_bytes, bool have_max_write_bytes,
+                     bool have_max_list_time)
 {
   std::unique_ptr<rgw::sal::Bucket> bucket;
   int r = driver->load_bucket(dpp(), rgw_bucket(tenant_name, bucket_name),
@@ -1678,9 +1689,9 @@ int set_bucket_ratelimit(rgw::sal::Driver* driver, OPT opt_cmd,
     }
   }
   bool ratelimit_configured = set_ratelimit_info(ratelimit_info, opt_cmd, max_read_ops, max_write_ops, max_list_ops,
-                         max_delete_ops, max_read_bytes, max_write_bytes,
+                         max_delete_ops, max_read_bytes, max_write_bytes, max_list_time,
                          have_max_read_ops, have_max_write_ops, have_max_list_ops,
-                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
+                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes, have_max_list_time);
   if (!ratelimit_configured) {
     ldpp_dout(dpp(), 0) << "ERROR: no rate limit values have been specified" << dendl;
     return -EINVAL;
@@ -1700,8 +1711,10 @@ int set_bucket_ratelimit(rgw::sal::Driver* driver, OPT opt_cmd,
 int set_user_ratelimit(OPT opt_cmd, std::unique_ptr<rgw::sal::User>& user,
                      int64_t max_read_ops, int64_t max_write_ops, int64_t max_list_ops,
                      int64_t max_delete_ops, int64_t max_read_bytes, int64_t max_write_bytes,
+                     int64_t max_list_time,
                      bool have_max_read_ops, bool have_max_write_ops, bool have_max_list_ops,
-                     bool have_max_delete_ops, bool have_max_read_bytes, bool have_max_write_bytes)
+                     bool have_max_delete_ops, bool have_max_read_bytes, bool have_max_write_bytes,
+                     bool have_max_list_time)
 {
   RGWRateLimitInfo ratelimit_info;
   user->load_user(dpp(), null_yield);
@@ -1717,9 +1730,9 @@ int set_user_ratelimit(OPT opt_cmd, std::unique_ptr<rgw::sal::User>& user,
     }
   }
   bool ratelimit_configured = set_ratelimit_info(ratelimit_info, opt_cmd, max_read_ops, max_write_ops, max_list_ops,
-                         max_delete_ops, max_read_bytes, max_write_bytes,
+                         max_delete_ops, max_read_bytes, max_write_bytes, max_list_time,
                          have_max_read_ops, have_max_write_ops, have_max_list_ops,
-                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
+                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes, have_max_list_time);
   if (!ratelimit_configured) {
     ldpp_dout(dpp(), 0) << "ERROR: no rate limit values have been specified" << dendl;
     return -EINVAL;
@@ -3877,6 +3890,7 @@ int main(int argc, const char **argv)
   int64_t max_delete_ops = 0;
   int64_t max_read_bytes = 0;
   int64_t max_write_bytes = 0;
+  int64_t max_list_time = 0;
 #ifdef WITH_RADOSGW_RADOS
   uint32_t max_bucket_index_ops = 0;
   uint32_t max_metadata_ops = 0;
@@ -3889,6 +3903,7 @@ int main(int argc, const char **argv)
   bool have_max_delete_ops = false;
   bool have_max_write_bytes = false;
   bool have_max_read_bytes = false;
+  bool have_max_list_time = false;
 #ifdef WITH_RADOSGW_RADOS
   bool have_max_bucket_index_ops = false;
   bool have_max_metadata_ops = false;
@@ -4237,6 +4252,13 @@ int main(int argc, const char **argv)
         return EINVAL;
       }
       have_max_write_bytes = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "--max-list-time", (char*)NULL)) {
+      max_list_time = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+      if (!err.empty()) {
+        cerr << "ERROR: failed to parse max list time: " << err << std::endl;
+        return EINVAL;
+      }
+      have_max_list_time = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--max-bucket-index-ops", (char*)NULL)) {
 #ifdef WITH_RADOSGW_RADOS
       max_bucket_index_ops = (int64_t)strict_strtoll(val.c_str(), 10, &err);
@@ -5273,23 +5295,26 @@ int main(int argc, const char **argv)
         if (ratelimit_scope == "bucket") {
           ratelimit_configured = set_ratelimit_info(period_config.bucket_ratelimit, opt_cmd,
                          max_read_ops, max_write_ops, max_list_ops, max_delete_ops,
-                         max_read_bytes, max_write_bytes,
+                         max_read_bytes, max_write_bytes, max_list_time,
                          have_max_read_ops, have_max_write_ops, have_max_list_ops,
-                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
+                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes,
+                         have_max_list_time);
           encode_json("bucket_ratelimit", period_config.bucket_ratelimit, formatter.get());
         } else if (ratelimit_scope == "user") {
           ratelimit_configured = set_ratelimit_info(period_config.user_ratelimit, opt_cmd,
                          max_read_ops, max_write_ops, max_list_ops, max_delete_ops,
-                         max_read_bytes, max_write_bytes,
+                         max_read_bytes, max_write_bytes, max_list_time,
                          have_max_read_ops, have_max_write_ops, have_max_list_ops,
-                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
+                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes,
+                         have_max_list_time);
           encode_json("user_ratelimit", period_config.user_ratelimit, formatter.get());
         } else if (ratelimit_scope == "anonymous") {
           ratelimit_configured = set_ratelimit_info(period_config.anon_ratelimit, opt_cmd,
                          max_read_ops, max_write_ops, max_list_ops,max_delete_ops,
-                         max_read_bytes, max_write_bytes,
+                         max_read_bytes, max_write_bytes, max_list_time,
                          have_max_read_ops, have_max_write_ops, have_max_list_ops,
-                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
+                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes,
+                         have_max_list_time);
           encode_json("anonymous_ratelimit", period_config.anon_ratelimit, formatter.get());
         } else if (ratelimit_scope.empty() && opt_cmd == OPT::GLOBAL_RATELIMIT_GET) {
           // if no scope is given for GET, print both
@@ -11768,15 +11793,15 @@ next:
       }
       return set_bucket_ratelimit(driver, opt_cmd, tenant, bucket_name,
                            max_read_ops, max_write_ops, max_list_ops, max_delete_ops,
-                           max_read_bytes, max_write_bytes,
+                           max_read_bytes, max_write_bytes, max_list_time,
                            have_max_read_ops, have_max_write_ops, have_max_list_ops, have_max_delete_ops,
-                           have_max_read_bytes, have_max_write_bytes);
+                           have_max_read_bytes, have_max_write_bytes, have_max_list_time);
     } else if (!rgw::sal::User::empty(user)) {
       if (ratelimit_scope == "user") {
         return set_user_ratelimit(opt_cmd, user, max_read_ops, max_write_ops, max_list_ops, max_delete_ops,
-                         max_read_bytes, max_write_bytes,
+                         max_read_bytes, max_write_bytes, max_list_time,
                          have_max_read_ops, have_max_write_ops, have_max_list_ops, have_max_delete_ops,
-                         have_max_read_bytes, have_max_write_bytes);
+                         have_max_read_bytes, have_max_write_bytes, have_max_list_time);
       } else {
         cerr << "ERROR: invalid ratelimit scope specification. Please specify either --ratelimit-scope=bucket, or --ratelimit-scope=user" << std::endl;
         return EINVAL;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2784,8 +2784,11 @@ void RGWRateLimitInfo::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("max_read_ops", max_read_ops, obj);
   JSONDecoder::decode_json("max_write_ops", max_write_ops, obj);
+  JSONDecoder::decode_json("max_list_ops", max_list_ops, obj);
+  JSONDecoder::decode_json("max_delete_ops", max_delete_ops, obj);
   JSONDecoder::decode_json("max_read_bytes", max_read_bytes, obj);
   JSONDecoder::decode_json("max_write_bytes", max_write_bytes, obj);
+  JSONDecoder::decode_json("max_list_time", max_list_time, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
 }
 
@@ -2797,6 +2800,7 @@ void RGWRateLimitInfo::dump(Formatter *f) const
   f->dump_int("max_delete_ops", max_delete_ops);
   f->dump_int("max_read_bytes", max_read_bytes);
   f->dump_int("max_write_bytes", max_write_bytes);
+  f->dump_int("max_list_time", max_list_time);
   f->dump_bool("enabled", enabled);
 }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -588,11 +588,12 @@ struct RGWRateLimitInfo {
   int64_t max_write_bytes;
   int64_t max_read_bytes;
   bool enabled = false;
+  int64_t max_list_time;
   RGWRateLimitInfo()
-    : max_write_ops(0), max_read_ops(0), max_list_ops(0), max_delete_ops(0), max_write_bytes(0), max_read_bytes(0)  {}
+    : max_write_ops(0), max_read_ops(0), max_list_ops(0), max_delete_ops(0), max_write_bytes(0), max_read_bytes(0), max_list_time(0) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(max_write_ops, bl);
     encode(max_read_ops, bl);
     encode(max_list_ops, bl);
@@ -600,10 +601,11 @@ struct RGWRateLimitInfo {
     encode(max_write_bytes, bl);
     encode(max_read_bytes, bl);
     encode(enabled, bl);
+    encode(max_list_time, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(max_write_ops, bl);
     decode(max_read_ops, bl);
     if (struct_v >= 2) {
@@ -619,6 +621,11 @@ struct RGWRateLimitInfo {
     decode(max_write_bytes, bl);
     decode(max_read_bytes, bl);
     decode(enabled, bl);
+    if (struct_v >= 3) {
+      decode(max_list_time, bl);
+    } else {
+      max_list_time = 0;
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1308,6 +1315,8 @@ struct req_init_state {
 
 class RGWObjectCtx;
 
+enum class RGWRateLimitOp { None, Read, Write, List, Delete };
+
 /** Store all the state necessary to complete and respond to an HTTP request*/
 struct req_state : DoutPrefixProvider {
   CephContext *cct;
@@ -1320,7 +1329,9 @@ struct req_state : DoutPrefixProvider {
   RGWRateLimitInfo bucket_ratelimit;
   int64_t ratelimit_retry_after{0};
   std::string ratelimit_bucket_marker;
+  RGWRateLimitOp ratelimit_bucket_op;
   std::string ratelimit_user_name;
+  RGWRateLimitOp ratelimit_user_op;
   bool content_started{false};
   RGWFormat format{RGWFormat::PLAIN};
   ceph::Formatter *formatter{nullptr};

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -71,6 +71,7 @@
 #include "rgw_bucket_logging.h"
 #include "rgw_restore.h"
 #include "rgw_restore_waiter.h"
+#include "rgw_ratelimit.h"
 
 #include "services/svc_zone.h"
 #include "services/svc_quota.h"
@@ -3615,6 +3616,10 @@ void RGWListBucket::execute(optional_yield y)
     objs = std::move(results.objs);
     common_prefixes = std::move(results.common_prefixes);
   }
+
+  int64_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(s->time_elapsed()).count();
+  s->ratelimit_data->decrease_time(s->ratelimit_user_op, s->ratelimit_user_name, ms, &s->user_ratelimit);
+  s->ratelimit_data->decrease_time(s->ratelimit_bucket_op, s->ratelimit_bucket_marker, ms, &s->bucket_ratelimit);
 
   auto counters = rgw::op_counters::get(s);
   rgw::op_counters::inc(counters, l_rgw_op_list_obj, 1);

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -108,8 +108,10 @@ bool rate_limit(rgw::sal::Driver* driver, req_state* s) {
   s->user->get_id().to_str(userfind);
   userfind = "u" + userfind;
   s->ratelimit_user_name = userfind;
+  s->ratelimit_user_op = RGWRateLimitOp::None;
   std::string bucketfind = !rgw::sal::Bucket::empty(s->bucket.get()) ? "b" + s->bucket->get_marker() : "";
   s->ratelimit_bucket_marker = bucketfind;
+  s->ratelimit_bucket_op = RGWRateLimitOp::None;
   const char *method = s->info.method;
 
   bool is_sts_user = (s->auth.identity && s->auth.identity->get_identity_type() == TYPE_ROLE);
@@ -141,9 +143,10 @@ bool rate_limit(rgw::sal::Driver* driver, req_state* s) {
     *user_ratelimit = global_anon;
   }
   int64_t limit_bucket = 0;
-  int64_t limit_user = s->ratelimit_data->should_rate_limit(method, s->ratelimit_user_name, s->time, user_ratelimit, s->info.request_params);
+  int64_t limit_user = s->ratelimit_data->should_rate_limit(method, s->ratelimit_user_name, s->time,
+    user_ratelimit, s->info.request_params, s->ratelimit_user_op);
 
-  if(!rgw::sal::Bucket::empty(s->bucket.get()))
+  if (!rgw::sal::Bucket::empty(s->bucket.get()))
   {
     iter = s->bucket->get_attrs().find(RGW_ATTR_RATELIMIT);
     if(iter != s->bucket->get_attrs().end()) {
@@ -161,11 +164,12 @@ bool rate_limit(rgw::sal::Driver* driver, req_state* s) {
       }
     }
     if (!limit_user) {
-      limit_bucket = s->ratelimit_data->should_rate_limit(method, s->ratelimit_bucket_marker, s->time, bucket_ratelimit, s->info.request_params);
+      limit_bucket = s->ratelimit_data->should_rate_limit(method, s->ratelimit_bucket_marker, s->time,
+        bucket_ratelimit, s->info.request_params, s->ratelimit_bucket_op);
     }
   }
-  if(limit_bucket && !limit_user) {
-    s->ratelimit_data->giveback_tokens(method, s->ratelimit_user_name, s->info.request_params, user_ratelimit);
+  if (limit_bucket && !limit_user) {
+    s->ratelimit_data->giveback_tokens(s->ratelimit_user_op, s->ratelimit_user_name, user_ratelimit);
   }
   s->user_ratelimit = *user_ratelimit;
   s->bucket_ratelimit = *bucket_ratelimit;

--- a/src/rgw/rgw_ratelimit.h
+++ b/src/rgw/rgw_ratelimit.h
@@ -5,9 +5,6 @@
 #include <condition_variable>
 #include "rgw_common.h"
 
-enum class OpType { Read, Write, List, Delete };
-
-
 class RateLimiterEntry {
 public:
   /*
@@ -36,6 +33,7 @@ private:
   struct counters {
     int64_t ops = 0;
     int64_t bytes = 0;
+    int64_t seconds = 0;
   };
   counters read;
   counters write;
@@ -44,31 +42,6 @@ private:
   ceph::timespan ts;
   bool first_run = true;
   std::mutex ts_lock;
-  // Those functions are returning the integer value of the tokens 
-  int64_t read_ops () const
-  {
-    return read.ops / fixed_point_rgw_ratelimit;
-  }
-  int64_t write_ops() const
-  {
-    return write.ops / fixed_point_rgw_ratelimit;
-  }
-  int64_t list_ops() const
-  {
-    return list.ops / fixed_point_rgw_ratelimit;
-  }
-  int64_t delete_ops() const
-  {
-    return del.ops / fixed_point_rgw_ratelimit;
-  }
-  int64_t read_bytes() const
-  {
-    return read.bytes / fixed_point_rgw_ratelimit;
-  }
-  int64_t write_bytes() const
-  {
-    return write.bytes / fixed_point_rgw_ratelimit;
-  }
   // Returns 0 if the request is allowed, or the estimated retry delay
   // in seconds if rate-limited. compute_delay() is the sole decision
   // maker: delay > 0 means rate-limited, 0 means allowed.
@@ -84,22 +57,28 @@ private:
     if (delay > 0) {
       return delay;
     }
-    // we don't want to reduce ops' tokens if we've rejected it.
-    if (read_ops() > 0) {
+    // reduce ops' tokens if the op was allowed
+    if (ops_limit > 0) {
+      // only decrease read.ops if not unlimited (i.e. ops_limit == 0)
+      // to avoid large budget
       read.ops -= fixed_point_rgw_ratelimit;
     }
     return 0;
   }
-  int64_t should_rate_limit_list(int64_t ops_limit)
+  int64_t should_rate_limit_list(int64_t ops_limit, int64_t time_limit)
   {
     const int64_t interval = g_ceph_context->_conf->rgw_ratelimit_interval;
-    const int64_t delay = compute_delay(ops_limit * fixed_point_rgw_ratelimit,
+    const int64_t ops_delay = compute_delay(ops_limit * fixed_point_rgw_ratelimit,
                                         fixed_point_rgw_ratelimit - list.ops,
                                         interval);
+    const int64_t time_delay = compute_delay(time_limit * fixed_point_rgw_ratelimit,
+                                           -list.seconds,
+                                           interval);
+    const int64_t delay = std::max(ops_delay, time_delay);
     if (delay > 0) {
       return delay;
     }
-    if (list_ops() > 0) {
+    if (ops_limit > 0) {
       list.ops -= fixed_point_rgw_ratelimit;
     }
     return 0;
@@ -113,7 +92,7 @@ private:
     if (delay > 0) {
       return delay;
     }
-    if (delete_ops() > 0) {
+    if (ops_limit > 0) {
       del.ops -= fixed_point_rgw_ratelimit;
     }
     return 0;
@@ -131,7 +110,7 @@ private:
     if (delay > 0) {
       return delay;
     }
-    if (write_ops() > 0) {
+    if (ops_limit > 0) {
       write.ops -= fixed_point_rgw_ratelimit;
     }
     return 0;
@@ -147,15 +126,10 @@ private:
     const size_t accumulation_interval = g_ceph_context->_conf->rgw_ratelimit_interval;
     const auto min_duration = duration_cast<ceph::timespan>(seconds(accumulation_interval)) / fixed_point_rgw_ratelimit;
     const auto delta = curr_timestamp - ts;
-    if (delta < min_duration)
-    {
-      return false;
-    }
-    return true;
+    return delta >= min_duration;
   }
 
-  void increase_tokens(ceph::timespan curr_timestamp,
-                       const RGWRateLimitInfo* info)
+  void increase_tokens(ceph::timespan curr_timestamp, const RGWRateLimitInfo* info)
   {
     constexpr int fixed_point = fixed_point_rgw_ratelimit;
     if (first_run)
@@ -165,12 +139,13 @@ private:
       read.ops = info->max_read_ops * fixed_point;
       read.bytes = info->max_read_bytes * fixed_point;
       list.ops = info->max_list_ops * fixed_point;
+      list.seconds = info->max_list_time * fixed_point;
       del.ops = info->max_delete_ops * fixed_point;
       ts = curr_timestamp;
       first_run = false;
       return;
     }
-    else if(curr_timestamp > ts && minimum_time_reached(curr_timestamp))
+    if(curr_timestamp > ts && minimum_time_reached(curr_timestamp))
     {
       const size_t accumulation_interval = g_ceph_context->_conf->rgw_ratelimit_interval;
       const int64_t time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(curr_timestamp - ts).count() / static_cast<double>(accumulation_interval) / std::milli::den * fixed_point;
@@ -180,59 +155,87 @@ private:
       const int64_t read_ops = info->max_read_ops * time_in_ms;
       const int64_t read_bw = info->max_read_bytes * time_in_ms;
       const int64_t list_ops = info->max_list_ops * time_in_ms;
+      const int64_t list_seconds = info->max_list_time * time_in_ms;
       const int64_t delete_ops = info->max_delete_ops * time_in_ms;
       read.ops = std::min(info->max_read_ops * fixed_point, read_ops + read.ops);
       read.bytes = std::min(info->max_read_bytes * fixed_point, read_bw + read.bytes);
       write.ops = std::min(info->max_write_ops * fixed_point, write_ops + write.ops);
       write.bytes = std::min(info->max_write_bytes * fixed_point, write_bw + write.bytes);
       list.ops = std::min(info->max_list_ops * fixed_point, list_ops + list.ops);
+      list.seconds = std::min(info->max_list_time * fixed_point, list_seconds + list.seconds);
       del.ops = std::min(info->max_delete_ops * fixed_point, delete_ops + del.ops);
     }
   }
 
   public:
     // Returns 0 if allowed, or the retry delay in seconds if rate-limited.
-    int64_t should_rate_limit(OpType op_type, const RGWRateLimitInfo* ratelimit_info, ceph::timespan curr_timestamp)
+    int64_t should_rate_limit(RGWRateLimitOp op, const RGWRateLimitInfo* ratelimit_info, ceph::timespan curr_timestamp)
     {
       std::unique_lock lock(ts_lock);
       increase_tokens(curr_timestamp, ratelimit_info);
-      switch (op_type) {
-        case OpType::Read:
+      switch (op) {
+        case RGWRateLimitOp::Read:
           return should_rate_limit_read(ratelimit_info->max_read_ops, ratelimit_info->max_read_bytes);
-        case OpType::Write:
+        case RGWRateLimitOp::Write:
           return should_rate_limit_write(ratelimit_info->max_write_ops, ratelimit_info->max_write_bytes);
-        case OpType::List:
-          return should_rate_limit_list(ratelimit_info->max_list_ops);
-        case OpType::Delete:
+        case RGWRateLimitOp::List:
+          return should_rate_limit_list(ratelimit_info->max_list_ops, ratelimit_info->max_list_time);
+        case RGWRateLimitOp::Delete:
           return should_rate_limit_delete(ratelimit_info->max_delete_ops);
+        default:
+          return 0;
       }
-      return 0;
     }
-    void decrease_bytes(bool is_read, int64_t amount, const RGWRateLimitInfo* info) {
+    void decrease_bytes(RGWRateLimitOp op, int64_t amount, const RGWRateLimitInfo* info) {
       std::unique_lock lock(ts_lock);
-      // we don't want the tenant to be with higher debt than 120 seconds(2 min) of its limit
-      if (is_read)
-      {
-        read.bytes = std::max(read.bytes - amount * fixed_point_rgw_ratelimit,info->max_read_bytes * fixed_point_rgw_ratelimit * -2);
-      } else {
-        write.bytes = std::max(write.bytes - amount * fixed_point_rgw_ratelimit,info->max_write_bytes * fixed_point_rgw_ratelimit * -2);
+      // we don't want the tenant to be with higher debt than 2 times of its limit
+      switch (op) {
+        case RGWRateLimitOp::Read:
+          read.bytes = std::max(read.bytes - amount * fixed_point_rgw_ratelimit,
+            info->max_read_bytes * fixed_point_rgw_ratelimit * -2);
+          break;
+        case RGWRateLimitOp::Write:
+          write.bytes = std::max(write.bytes - amount * fixed_point_rgw_ratelimit,
+            info->max_write_bytes * fixed_point_rgw_ratelimit * -2);
+          break;
+        default:
+          break;
       }
     }
-    void giveback_tokens(OpType op_type)
+    void decrease_time(RGWRateLimitOp op, int64_t ms, const RGWRateLimitInfo* info) {
+      std::unique_lock lock(ts_lock);
+      // we don't want the tenant to be with higher debt than 2 times of its limit
+      switch (op) {
+        case RGWRateLimitOp::List:
+          list.seconds = std::max(list.seconds - (ms * fixed_point_rgw_ratelimit) / 1000,
+            info->max_list_time * fixed_point_rgw_ratelimit * -2);
+          break;
+        default:
+          break;
+      }
+    }
+    void giveback_tokens(RGWRateLimitOp op, const RGWRateLimitInfo* info)
     {
       std::unique_lock lock(ts_lock);
-      switch (op_type) {
-        case OpType::Read:
-          read.ops += fixed_point_rgw_ratelimit;
+      switch (op) {
+        case RGWRateLimitOp::Read:
+          // only give back token if one was taken (see should_rate_limit_read())
+          if (info->max_read_ops > 0)
+            read.ops += fixed_point_rgw_ratelimit;
           break;
-        case OpType::Write:
-          write.ops += fixed_point_rgw_ratelimit;
+        case RGWRateLimitOp::Write:
+          if (info->max_write_ops > 0)
+            write.ops += fixed_point_rgw_ratelimit;
           break;
-        case OpType::List:
-          list.ops += fixed_point_rgw_ratelimit;
+        case RGWRateLimitOp::List:
+          if (info->max_list_ops > 0)
+            list.ops += fixed_point_rgw_ratelimit;
           break;
-        case OpType::Delete:
-          del.ops += fixed_point_rgw_ratelimit;
+        case RGWRateLimitOp::Delete:
+          if (info->max_delete_ops > 0)
+            del.ops += fixed_point_rgw_ratelimit;
+          break;
+        default:
           break;
       }
     }
@@ -252,8 +255,9 @@ class RateLimiter : public DoutPrefix {
   static inline constexpr std::string_view RESOURCE_PATTERN_DELIMITER = "delimiter=";
 
 
-  static OpType op_type(const std::string_view method, const std::string_view resource, const RGWRateLimitInfo* ratelimit_info) {
-    const bool ratelimit_list = ratelimit_info && (ratelimit_info->max_list_ops > 0);
+  static RGWRateLimitOp op_type(const std::string_view method, const std::string_view resource, const RGWRateLimitInfo* ratelimit_info) {
+    const bool ratelimit_list = ratelimit_info &&
+      ((ratelimit_info->max_list_ops > 0) || (ratelimit_info->max_list_time > 0));
     const bool ratelimit_delete = ratelimit_info && (ratelimit_info->max_delete_ops > 0);
 
     auto contains_any = [](std::string_view s, auto&&... patterns) {
@@ -261,16 +265,16 @@ class RateLimiter : public DoutPrefix {
     };
     if (ratelimit_list && method == "GET" &&
         !resource.empty() && contains_any(resource, RESOURCE_PATTERN_LIST_TYPE, RESOURCE_PATTERN_PREFIX, RESOURCE_PATTERN_DELIMITER)) {
-      return OpType::List;
+      return RGWRateLimitOp::List;
     }
     if (method == "GET" || method == "HEAD")
     {
-      return OpType::Read;
+      return RGWRateLimitOp::Read;
     }
     if (ratelimit_delete && method == "DELETE") {
-      return OpType::Delete;
+      return RGWRateLimitOp::Delete;
     }
-    return OpType::Write;
+    return RGWRateLimitOp::Write;
   }
 
     // find or create an entry, and return its iterator
@@ -309,40 +313,42 @@ class RateLimiter : public DoutPrefix {
     };
 
     // Returns 0 if allowed, or the retry delay in seconds if rate-limited.
-    int64_t should_rate_limit(const char *method, const std::string& key, ceph::coarse_real_time curr_timestamp, const RGWRateLimitInfo* ratelimit_info, const std::string& resource) {
+    int64_t should_rate_limit(const char *method, const std::string& key, ceph::coarse_real_time curr_timestamp, const RGWRateLimitInfo* ratelimit_info, const std::string& resource, RGWRateLimitOp& op ) {
       ldpp_dout(this, 21) << "checking should_rate_limit: key=" << std::quoted(key) << " enabled=" << ratelimit_info->enabled << dendl;
       if (key.empty() || key.length() == 1 || !ratelimit_info->enabled)
       {
+        op = RGWRateLimitOp::None;
         return 0;
       }
-      OpType type = op_type(method, resource, ratelimit_info);
+      op = op_type(method, resource, ratelimit_info);
       auto& it = find_or_create(key);
       auto curr_ts = curr_timestamp.time_since_epoch();
-      return it.should_rate_limit(type, ratelimit_info, curr_ts);
+      return it.should_rate_limit(op, ratelimit_info, curr_ts);
     }
-    void giveback_tokens(const char *method, const std::string& key, const std::string& resource, const RGWRateLimitInfo* ratelimit_info)
+    void giveback_tokens(RGWRateLimitOp op, const std::string& key, const RGWRateLimitInfo* info)
     {
-      OpType type = op_type(method, resource, ratelimit_info);
-      auto& it = find_or_create(key);
-      it.giveback_tokens(type);
+      if (op != RGWRateLimitOp::None)
+      {
+        auto& it = find_or_create(key);
+        it.giveback_tokens(op, info);
+      }
     }
-    void decrease_bytes(const char *method, const std::string& key, const int64_t amount, const RGWRateLimitInfo* info) {
-      if (key.empty() || key.length() == 1 || !info->enabled)
+    void decrease_bytes(RGWRateLimitOp op, const std::string& key, const int64_t amount, const RGWRateLimitInfo* info) {
+      // Only RGWRateLimitOp::Read and RGWRateLimitOp::Write affect bytes
+      if ((op == RGWRateLimitOp::Read && info->max_read_bytes) ||
+          (op == RGWRateLimitOp::Write && info->max_write_bytes))
       {
-        return;
+        auto& it = find_or_create(key);
+        it.decrease_bytes(op, amount, info);
       }
-      OpType type = op_type(method, "", info);
-      // Only read and write ops affect bytes
-      if ((type == OpType::Read && !info->max_read_bytes) || (type == OpType::Write && !info->max_write_bytes))
+    }
+    void decrease_time(RGWRateLimitOp op, const std::string& key, const int64_t ms, const RGWRateLimitInfo* info) {
+      // Only RGWRateLimitOp::List affects time
+      if (op == RGWRateLimitOp::List && info->max_list_time)
       {
-        return;
+        auto& it = find_or_create(key);
+        it.decrease_time(op, ms, info);
       }
-      auto& it = find_or_create(key);
-      if (type == OpType::Read)
-        it.decrease_bytes(true, amount, info);
-      else if (type == OpType::Write)
-        it.decrease_bytes(false, amount, info);
-      // OpType::List does not affect bytes
     }
     void clear() {
       ratelimit_entries.clear();

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -760,10 +760,8 @@ int dump_body(req_state* const s,
   if(s->op_type == RGW_OP_GET_HEALTH_CHECK)
     healthcheck = true;
   if(len > 0 && !healthcheck) {
-    const char *method = s->info.method;
-    s->ratelimit_data->decrease_bytes(method, s->ratelimit_user_name, len, &s->user_ratelimit);
-    if(!rgw::sal::Bucket::empty(s->bucket.get()))
-      s->ratelimit_data->decrease_bytes(method, s->ratelimit_bucket_marker, len, &s->bucket_ratelimit);
+    s->ratelimit_data->decrease_bytes(s->ratelimit_user_op, s->ratelimit_user_name, len, &s->user_ratelimit);
+    s->ratelimit_data->decrease_bytes(s->ratelimit_bucket_op, s->ratelimit_bucket_marker, len, &s->bucket_ratelimit);
   }
   try {
     return RESTFUL_IO(s)->send_body(buf, len);
@@ -797,10 +795,8 @@ int recv_body(req_state* const s,
   if(s->op_type ==  RGW_OP_GET_HEALTH_CHECK)
     healthcheck = true;
   if(len > 0 && !healthcheck) {
-    const char *method = s->info.method;
-    s->ratelimit_data->decrease_bytes(method, s->ratelimit_user_name, len, &s->user_ratelimit);
-    if(!rgw::sal::Bucket::empty(s->bucket.get()))
-      s->ratelimit_data->decrease_bytes(method, s->ratelimit_bucket_marker, len, &s->bucket_ratelimit);
+    s->ratelimit_data->decrease_bytes(s->ratelimit_user_op, s->ratelimit_user_name, len, &s->user_ratelimit);
+    s->ratelimit_data->decrease_bytes(s->ratelimit_bucket_op, s->ratelimit_bucket_marker, len, &s->bucket_ratelimit);
   }
   return len;
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -382,6 +382,7 @@
      --max-write-bytes             specify max bytes per accumulation interval for WRITE ops per RGW (Not GET or HEAD request methods), 0 means unlimited
      --max-list-ops                specify max requests per accumulation interval for bucket listing requests per RGW, 0 means unlimited
      --max-delete-ops              specify max requests per accumulation interval for DELETE ops per RGW (DELETE request methods), 0 means unlimited
+     --max-list-time               specify max time consumption per accumulation interval for bucket listing requests per RGW, 0 means unlimited
      --ratelimit-scope             scope of rate limiting: bucket, user, anonymous
                                    anonymous can be configured only with global rate limit
   

--- a/src/test/rgw/bench_rgw_ratelimit.cc
+++ b/src/test/rgw/bench_rgw_ratelimit.cc
@@ -37,12 +37,13 @@ struct parameters {
 std::shared_ptr<std::vector<client_info>> ds = std::make_shared<std::vector<client_info>>(std::vector<client_info>());
 
 std::string method[2] = {"PUT", "GET"};
+RGWRateLimitOp limit[2] = {RGWRateLimitOp::Write, RGWRateLimitOp::Read};
 void simulate_transfer(client_info& it, const RGWRateLimitInfo* info, std::shared_ptr<RateLimiter> ratelimit, const parameters& params, boost::asio::yield_context& yield, boost::asio::io_context& ioctx)
 {
     auto dout = DoutPrefix(g_ceph_context, ceph_subsys_rgw, "rate limiter: ");
     boost::asio::steady_timer timer(ioctx);
-    int rw = 0; // will always use PUT method as there is no difference
-    std::string methodop(method[rw]);
+    int rw = 0; // will always use RGWRateLimitOp::Write as there is no difference
+    RGWRateLimitOp limitop = limit[rw];
     auto req_size = params.req_size;
     auto backend_bandwidth = params.backend_bandwidth;
 // the 4 * 1024 * 1024 is the RGW default we are sending in a typical environment
@@ -50,12 +51,12 @@ void simulate_transfer(client_info& it, const RGWRateLimitInfo* info, std::share
         if (req_size <= backend_bandwidth) {
             while (req_size > 0) {
                 if(req_size > 4*1024*1024) {
-                    ratelimit->decrease_bytes(methodop.c_str(),it.tenant, 4*1024*1024, info);
+                    ratelimit->decrease_bytes(limitop, it.tenant, 4*1024*1024, info);
                     it.bytes += 4*1024*1024;
                     req_size = req_size - 4*1024*1024;
                 }
                 else {
-                    ratelimit->decrease_bytes(methodop.c_str(),it.tenant, req_size, info);
+                    ratelimit->decrease_bytes(limitop, it.tenant, req_size, info);
                     req_size = 0;
                 }
             }
@@ -69,13 +70,13 @@ void simulate_transfer(client_info& it, const RGWRateLimitInfo* info, std::share
                         timer.async_wait(yield);
                         total_bytes = 0;
                     }
-                    ratelimit->decrease_bytes(methodop.c_str(),it.tenant, 4*1024*1024, info);
+                    ratelimit->decrease_bytes(limitop, it.tenant, 4*1024*1024, info);
                     it.bytes += 4*1024*1024;
                     req_size = req_size - 4*1024*1024;
                     total_bytes += 4*1024*1024;
                 }
                 else {
-                    ratelimit->decrease_bytes(methodop.c_str(),it.tenant, req_size, info);
+                    ratelimit->decrease_bytes(limitop, it.tenant, req_size, info);
                     it.bytes += req_size;
                     total_bytes += req_size;
                     req_size = 0;
@@ -91,7 +92,8 @@ bool simulate_request(client_info& it, const RGWRateLimitInfo& info, std::shared
     int rw = 0; // will always use PUT method as there is no different
     std::string methodop = method[rw];
     auto dout = DoutPrefix(g_ceph_context, ceph_subsys_rgw, "rate limiter: ");
-    bool to_fail = ratelimit->should_rate_limit(methodop.c_str(), it.tenant, time, &info, "");
+    RGWRateLimitOp op;
+    bool to_fail = ratelimit->should_rate_limit(methodop.c_str(), it.tenant, time, &info, "", op);
     if(to_fail)
     {
         it.rejected++;

--- a/src/test/rgw/bench_rgw_ratelimit_gc.cc
+++ b/src/test/rgw/bench_rgw_ratelimit_gc.cc
@@ -46,7 +46,8 @@ int main(int argc, char **argv)
     {
         std::string tenant = "uuser" + std::to_string(i);
         auto time = ceph::coarse_real_clock::now();
-        ratelimit->get_active()->should_rate_limit("PUT", tenant, time, &info, "");
+        RGWRateLimitOp op;
+        ratelimit->get_active()->should_rate_limit("PUT", tenant, time, &info, "", op);
     }
 
 }

--- a/src/test/rgw/test_rgw_ratelimit.cc
+++ b/src/test/rgw/test_rgw_ratelimit.cc
@@ -47,7 +47,9 @@ TEST(RGWRateLimit, op_limit_not_enabled)
   RGWRateLimitInfo info;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::None, op);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimit, reject_op_over_limit)
@@ -63,9 +65,11 @@ TEST(RGWRateLimit, reject_op_over_limit)
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(60, delay);
 }
 TEST(RGWRateLimit, accept_op_after_giveback)
@@ -79,10 +83,13 @@ TEST(RGWRateLimit, accept_op_after_giveback)
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
-  ratelimit.giveback_tokens("GET", key, "", &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
+  ratelimit.giveback_tokens(op, key, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimit, accept_op_after_refill)
@@ -96,9 +103,12 @@ TEST(RGWRateLimit, accept_op_after_refill)
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   time += 61s;
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimit, reject_bw_over_limit)
@@ -112,10 +122,13 @@ TEST(RGWRateLimit, reject_bw_over_limit)
   info.max_read_bytes = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
-  ratelimit.decrease_bytes("GET",key, 2, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
+  ratelimit.decrease_bytes(op, key, 2, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_GT(delay, 0);
 }
 TEST(RGWRateLimit, accept_bw)
@@ -129,10 +142,13 @@ TEST(RGWRateLimit, accept_bw)
   info.max_read_bytes = 2;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
-  ratelimit.decrease_bytes("GET",key, 1, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
+  ratelimit.decrease_bytes(op, key, 1, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimit, check_bw_debt_at_max_120secs)
@@ -146,10 +162,13 @@ TEST(RGWRateLimit, check_bw_debt_at_max_120secs)
   info.max_read_bytes = 2;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
-  ratelimit.decrease_bytes("GET",key, 100, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
+  ratelimit.decrease_bytes(op, key, 100, &info);
   time += 121s;
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimit, check_that_bw_limit_not_affect_ops)
@@ -164,10 +183,13 @@ TEST(RGWRateLimit, check_that_bw_limit_not_affect_ops)
   info.max_read_bytes = 100000000;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
-  ratelimit.decrease_bytes("GET",key, 10000, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
+  ratelimit.decrease_bytes(op, key, 10000, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_GT(delay, 0);
 }
 TEST(RGWRateLimit, read_limit_does_not_affect_writes)
@@ -182,10 +204,13 @@ TEST(RGWRateLimit, read_limit_does_not_affect_writes)
   info.max_read_bytes = 100000000;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
-  ratelimit.decrease_bytes("PUT",key, 10000, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Write, op);
+  ratelimit.decrease_bytes(op, key, 10000, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Write, op);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimit, write_limit_does_not_affect_reads)
@@ -200,10 +225,13 @@ TEST(RGWRateLimit, write_limit_does_not_affect_reads)
   info.max_write_bytes = 100000000;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
-  ratelimit.decrease_bytes("GET",key, 10000, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
+  ratelimit.decrease_bytes(RGWRateLimitOp::Write, key, 10000, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -217,7 +245,9 @@ TEST(RGWRateLimit, allow_unlimited_access)
   info.enabled = true;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -234,12 +264,16 @@ TEST(RGWRateLimit, unlimited_access_not_left_large_read_ops_budget)
 
   for (int i = 0; i < 10; i++)
   {
-    int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+    RGWRateLimitOp op;
+    int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+    EXPECT_EQ(RGWRateLimitOp::Read, op);
     EXPECT_EQ(0, delay);
   }
   time += 61s;
   info.max_read_ops = 1; // make read ops limited
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -256,12 +290,16 @@ TEST(RGWRateLimit, unlimited_access_not_left_large_write_ops_budget)
 
   for (int i = 0; i < 10; i++)
   {
-    int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+    RGWRateLimitOp op;
+    int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+    EXPECT_EQ(RGWRateLimitOp::Write, op);
     EXPECT_EQ(0, delay);
   }
   time += 61s;
   info.max_write_ops = 1; // make write ops limited
-  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Write, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -276,7 +314,8 @@ TEST(RGWRateLimitGC, NO_GC_AHEAD_OF_TIME)
   RGWRateLimitInfo info;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser123";
-  active->should_rate_limit("GET", key, time, &info, "");
+  RGWRateLimitOp op;
+  active->should_rate_limit("GET", key, time, &info, "", op);
   auto activegc = ratelimit->get_active();
   EXPECT_EQ(activegc, active);
 }
@@ -292,9 +331,10 @@ TEST(RGWRateLimiterGC, GC_IS_WORKING)
   info.enabled = true;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "-1";
+  RGWRateLimitOp op;
   for(int i = 0; i < 2000000; i++)
   {
-    active->should_rate_limit("GET", key, time, &info, "");
+    active->should_rate_limit("GET", key, time, &info, "", op);
     key = std::to_string(i);
   }
   auto activegc = ratelimit->get_active();
@@ -308,7 +348,7 @@ TEST(RGWRateLimitEntry, op_limit_not_enabled)
   RateLimiterEntry entry;
   RGWRateLimitInfo info;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimitEntry, reject_op_over_limit)
@@ -321,10 +361,10 @@ TEST(RGWRateLimitEntry, reject_op_over_limit)
   info.enabled = true;
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read, &info, time);
-  EXPECT_EQ(60, delay);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
+  EXPECT_GT(delay, 0);
 }
 TEST(RGWRateLimitEntry, accept_op_after_giveback)
 {
@@ -334,10 +374,10 @@ TEST(RGWRateLimitEntry, accept_op_after_giveback)
   info.enabled = true;
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read,  &info, time);
-  entry.giveback_tokens(OpType::Read);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read,  &info, time);
+  entry.giveback_tokens(RGWRateLimitOp::Read, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read,  &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read,  &info, time);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimitEntry, accept_op_after_refill)
@@ -348,9 +388,9 @@ TEST(RGWRateLimitEntry, accept_op_after_refill)
   info.enabled = true;
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read,  &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read,  &info, time);
   time += 61s;
-  delay = entry.should_rate_limit(OpType::Read,  &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read,  &info, time);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimitEntry, reject_bw_over_limit)
@@ -361,10 +401,10 @@ TEST(RGWRateLimitEntry, reject_bw_over_limit)
   info.enabled = true;
   info.max_read_bytes = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read,  &info, time);
-  entry.decrease_bytes(true, 2, &info);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read,  &info, time);
+  entry.decrease_bytes(RGWRateLimitOp::Read, 2, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read,  &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read,  &info, time);
   EXPECT_GT(delay, 0);
 }
 TEST(RGWRateLimitEntry, accept_bw)
@@ -375,10 +415,10 @@ TEST(RGWRateLimitEntry, accept_bw)
   info.enabled = true;
   info.max_read_bytes = 2;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
-  entry.decrease_bytes(true, 1, &info);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
+  entry.decrease_bytes(RGWRateLimitOp::Read, 1, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimitEntry, check_bw_debt_at_max_120secs)
@@ -389,10 +429,10 @@ TEST(RGWRateLimitEntry, check_bw_debt_at_max_120secs)
   info.enabled = true;
   info.max_read_bytes = 2;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
-  entry.decrease_bytes(true, 100, &info);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
+  entry.decrease_bytes(RGWRateLimitOp::Read, 100, &info);
   time += 121s;
-  delay = entry.should_rate_limit(OpType::Read, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimitEntry, check_that_bw_limit_not_affect_ops)
@@ -404,10 +444,10 @@ TEST(RGWRateLimitEntry, check_that_bw_limit_not_affect_ops)
   info.max_read_ops = 1;
   info.max_read_bytes = 100000000;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
-  entry.decrease_bytes(true, 10000, &info);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
+  entry.decrease_bytes(RGWRateLimitOp::Read, 10000, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_GT(delay, 0);
 }
 TEST(RGWRateLimitEntry, read_limit_does_not_affect_writes)
@@ -419,10 +459,10 @@ TEST(RGWRateLimitEntry, read_limit_does_not_affect_writes)
   info.max_read_ops = 1;
   info.max_read_bytes = 100000000;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Write, &info, time);
-  entry.decrease_bytes(false, 10000, &info);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Write, &info, time);
+  entry.decrease_bytes(RGWRateLimitOp::Write, 10000, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Write, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Write, &info, time);
   EXPECT_EQ(0, delay);
 }
 TEST(RGWRateLimitEntry, write_limit_does_not_affect_reads)
@@ -435,10 +475,10 @@ TEST(RGWRateLimitEntry, write_limit_does_not_affect_reads)
   info.max_write_bytes = 100000000;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
   std::string key = "uuser123";
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
-  entry.decrease_bytes(true, 10000, &info);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
+  entry.decrease_bytes(RGWRateLimitOp::Read, 10000, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -449,7 +489,7 @@ TEST(RGWRateLimitEntry, allow_unlimited_access)
   RGWRateLimitInfo info;
   info.enabled = true;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -471,9 +511,12 @@ TEST(RGWRateLimit, reject_list_op_over_limit)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_GT(delay, 0);
 }
 
@@ -488,10 +531,13 @@ TEST(RGWRateLimit, accept_list_op_after_giveback)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
-  ratelimit.giveback_tokens("GET", key, RES_LIST_TYPE_2, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  ratelimit.giveback_tokens(op, key, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -506,9 +552,90 @@ TEST(RGWRateLimit, accept_list_op_after_refill)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   time += 61s;
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_EQ(0, delay);
+}
+
+TEST(RGWRateLimit, reject_list_time_over_limit)
+{
+  // check that LIST op is being rejected because too much time used
+  std::atomic_bool replacing;
+  std::condition_variable cv;
+  RateLimiter ratelimit(g_ceph_context, replacing, cv);
+  RGWRateLimitInfo info;
+  info.enabled = true;
+  info.max_list_time = 10;
+  auto time = ceph::coarse_real_clock::now();
+  std::string key = "uuser_list";
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_EQ(0, delay);
+  ratelimit.decrease_time(op, key, 30000, &info);  // 20s debt
+  time = ceph::coarse_real_clock::now();
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_GT(delay, 0);
+  time += 61s;
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_GT(delay, 0);
+}
+
+TEST(RGWRateLimit, accept_list_time_after_refill)
+{
+  // check that use time is being filled properly for LIST ops
+  std::atomic_bool replacing;
+  std::condition_variable cv;
+  RateLimiter ratelimit(g_ceph_context, replacing, cv);
+  RGWRateLimitInfo info;
+  info.enabled = true;
+  info.max_list_time = 10;
+  auto time = ceph::coarse_real_clock::now();
+  std::string key = "uuser_list";
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_EQ(0, delay);
+  ratelimit.decrease_time(op, key, 15000, &info);  // 5s debt
+  time = ceph::coarse_real_clock::now();
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_GT(delay, 0);
+  time += 61s;
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_EQ(0, delay);
+}
+
+TEST(RGWRateLimit, check_list_time_debt_clip)
+{
+  // check that use time is clipped to 2 * max_list_time
+  std::atomic_bool replacing;
+  std::condition_variable cv;
+  RateLimiter ratelimit(g_ceph_context, replacing, cv);
+  RGWRateLimitInfo info;
+  info.enabled = true;
+  info.max_list_time = 10;
+  auto time = ceph::coarse_real_clock::now();
+  std::string key = "uuser_list";
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_EQ(0, delay);
+  ratelimit.decrease_time(op, key, 60000, &info);  // 50s debt clipped to 20s
+  time = ceph::coarse_real_clock::now();
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  EXPECT_GT(delay, 0);
+  time += 121s;
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -524,9 +651,12 @@ TEST(RGWRateLimit, list_limit_does_not_affect_reads)
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   // Should still be able to do a normal GET (read)
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -542,9 +672,12 @@ TEST(RGWRateLimit, read_limit_does_not_affect_lists)
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   // Should still be able to do a LIST op
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -560,9 +693,11 @@ TEST(RGWRateLimit, list_limit_does_not_affect_writes)
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
   // Should still be able to do a PUT (write)
-  delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Write, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -574,17 +709,22 @@ TEST(RGWRateLimit, unlimited_access_not_left_large_list_ops_budget)
   RateLimiter ratelimit(g_ceph_context, replacing, cv);
   RGWRateLimitInfo info;
   info.enabled = true;
+  info.max_list_time = 1000; // limit list by time but not by ops
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
 
   for (int i = 0; i < 10; i++)
   {
-    int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+    RGWRateLimitOp op;
+    int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+    EXPECT_EQ(RGWRateLimitOp::List, op);
     EXPECT_EQ(0, delay);
   }
   time += 61s;
   info.max_list_ops = 1; // make list ops limited
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -600,9 +740,12 @@ TEST(RGWRateLimit, write_limit_does_not_affect_lists)
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Write, op);
   // Should still be able to do a LIST op
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -618,9 +761,12 @@ TEST(RGWRateLimit, list_limit_does_not_affect_deletes)
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   // Should still be able to do a DELETE op
-  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -636,9 +782,12 @@ TEST(RGWRateLimit, delete_limit_does_not_affect_lists)
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   // Should still be able to do a LIST op
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_LIST_TYPE_2, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -654,9 +803,12 @@ TEST(RGWRateLimit, reject_delimiter_op_over_limit)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_GT(delay, 0);
 }
 
@@ -671,10 +823,13 @@ TEST(RGWRateLimit, accept_delimiter_op_after_giveback)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER);
-  ratelimit.giveback_tokens("GET", key, RES_DELIMITER, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  ratelimit.giveback_tokens(op, key, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -689,9 +844,12 @@ TEST(RGWRateLimit, accept_delimiter_op_after_refill)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   time += 61s;
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_DELIMITER, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -707,9 +865,12 @@ TEST(RGWRateLimit, reject_prefix_op_over_limit)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_GT(delay, 0);
 }
 
@@ -724,10 +885,13 @@ TEST(RGWRateLimit, accept_prefix_op_after_giveback)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX);
-  ratelimit.giveback_tokens("GET", key, RES_PREFIX, &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
+  ratelimit.giveback_tokens(op, key, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -742,9 +906,12 @@ TEST(RGWRateLimit, accept_prefix_op_after_refill)
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_list";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   time += 61s;
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX);
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, RES_PREFIX, op);
+  EXPECT_EQ(RGWRateLimitOp::List, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -757,9 +924,9 @@ TEST(RGWRateLimitEntry, reject_list_op_over_limit)
   info.enabled = true;
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::List, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::List, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   EXPECT_GT(delay, 0);
 }
 
@@ -771,10 +938,10 @@ TEST(RGWRateLimitEntry, accept_list_op_after_giveback)
   info.enabled = true;
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::List, &info, time);
-  entry.giveback_tokens(OpType::List);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
+  entry.giveback_tokens(RGWRateLimitOp::List, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::List, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -786,9 +953,9 @@ TEST(RGWRateLimitEntry, accept_list_op_after_refill)
   info.enabled = true;
   info.max_list_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::List, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   time += 61s;
-  delay = entry.should_rate_limit(OpType::List, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -801,9 +968,9 @@ TEST(RGWRateLimitEntry, list_limit_does_not_affect_reads)
   info.max_list_ops = 1;
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::List, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -816,9 +983,9 @@ TEST(RGWRateLimitEntry, read_limit_does_not_affect_lists)
   info.max_list_ops = 1;
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::List, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -831,9 +998,9 @@ TEST(RGWRateLimitEntry, list_limit_does_not_affect_writes)
   info.max_list_ops = 1;
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::List, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Write, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Write, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -846,9 +1013,9 @@ TEST(RGWRateLimitEntry, write_limit_does_not_affect_lists)
   info.max_list_ops = 1;
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Write, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Write, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::List, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -861,9 +1028,9 @@ TEST(RGWRateLimitEntry, list_limit_does_not_affect_deletes)
   info.max_list_ops = 1;
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::List, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -876,9 +1043,9 @@ TEST(RGWRateLimitEntry, delete_limit_does_not_affect_lists)
   info.max_list_ops = 1;
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::List, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::List, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -894,9 +1061,12 @@ TEST(RGWRateLimit, reject_delete_op_over_limit)
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_delete";
-  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   EXPECT_GT(delay, 0);
 }
 
@@ -911,10 +1081,13 @@ TEST(RGWRateLimit, accept_delete_op_after_giveback)
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_delete";
-  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
-  ratelimit.giveback_tokens("DELETE", key, "", &info);
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
+  ratelimit.giveback_tokens(op, key, &info);
   time = ceph::coarse_real_clock::now();
-  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -929,9 +1102,12 @@ TEST(RGWRateLimit, accept_delete_op_after_refill)
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_delete";
-  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   time += 61s;
-  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -947,9 +1123,12 @@ TEST(RGWRateLimit, delete_limit_does_not_affect_reads)
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_delete";
-  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   // Should still be able to do a normal GET (read)
-  delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -965,9 +1144,12 @@ TEST(RGWRateLimit, read_limit_does_not_affect_deletes)
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_delete";
-  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("GET", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Read, op);
   // Should still be able to do a DELETE op
-  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -983,9 +1165,12 @@ TEST(RGWRateLimit, write_limit_does_not_affect_deletes)
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_delete";
-  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Write, op);
   // Should still be able to do a DELETE op
-  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -1001,14 +1186,21 @@ TEST(RGWRateLimit, delete_limit_does_not_affect_writes)
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now();
   std::string key = "uuser_delete";
-  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   // Should still be able to do a PUT (write)
-  delay = ratelimit.should_rate_limit("PUT", key, time, &info, "");
+  delay = ratelimit.should_rate_limit("PUT", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Write, op);
   EXPECT_EQ(0, delay);
 }
 
 TEST(RGWRateLimit, unlimited_access_not_left_large_delete_ops_budget)
 {
+  // FIXME: this test does not do what it suggests, with
+  // info.max_delete_ops == 0 it's a RGWRateLimitOp::Write op and
+  // does not affect del.ops in RateLimiterEntry
+
   // 0 values in RGWRateLimitInfo should allow unlimited access
   std::atomic_bool replacing;
   std::condition_variable cv;
@@ -1020,12 +1212,16 @@ TEST(RGWRateLimit, unlimited_access_not_left_large_delete_ops_budget)
 
   for (int i = 0; i < 10; i++)
   {
-    int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+    RGWRateLimitOp op;
+    int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+    EXPECT_EQ(RGWRateLimitOp::Write, op);
     EXPECT_EQ(0, delay);
   }
   time += 61s;
   info.max_delete_ops = 1; // make delete ops limited
-  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "");
+  RGWRateLimitOp op;
+  int64_t delay = ratelimit.should_rate_limit("DELETE", key, time, &info, "", op);
+  EXPECT_EQ(RGWRateLimitOp::Delete, op);
   EXPECT_EQ(0, delay);
 }
 
@@ -1037,9 +1233,9 @@ TEST(RGWRateLimitEntry, reject_delete_op_over_limit)
   info.enabled = true;
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   EXPECT_GT(delay, 0);
 }
 
@@ -1051,10 +1247,10 @@ TEST(RGWRateLimitEntry, accept_delete_op_after_giveback)
   info.enabled = true;
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Delete, &info, time);
-  entry.giveback_tokens(OpType::Delete);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
+  entry.giveback_tokens(RGWRateLimitOp::Delete, &info);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -1066,9 +1262,9 @@ TEST(RGWRateLimitEntry, accept_delete_op_after_refill)
   info.enabled = true;
   info.max_delete_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   time += 61s;
-  delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -1081,9 +1277,9 @@ TEST(RGWRateLimitEntry, delete_limit_does_not_affect_reads)
   info.max_delete_ops = 1;
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Read, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -1096,9 +1292,9 @@ TEST(RGWRateLimitEntry, read_limit_does_not_affect_deletes)
   info.max_delete_ops = 1;
   info.max_read_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Read, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Read, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -1111,9 +1307,9 @@ TEST(RGWRateLimitEntry, write_limit_does_not_affect_deletes)
   info.max_delete_ops = 1;
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Write, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Write, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   EXPECT_EQ(0, delay);
 }
 
@@ -1126,9 +1322,9 @@ TEST(RGWRateLimitEntry, delete_limit_does_not_affect_writes)
   info.max_delete_ops = 1;
   info.max_write_ops = 1;
   auto time = ceph::coarse_real_clock::now().time_since_epoch();
-  int64_t delay = entry.should_rate_limit(OpType::Delete, &info, time);
+  int64_t delay = entry.should_rate_limit(RGWRateLimitOp::Delete, &info, time);
   time = ceph::coarse_real_clock::now().time_since_epoch();
-  delay = entry.should_rate_limit(OpType::Write, &info, time);
+  delay = entry.should_rate_limit(RGWRateLimitOp::Write, &info, time);
   EXPECT_EQ(0, delay);
 }
 


### PR DESCRIPTION
In addition to limiting the number of LIST requests, this change introduces a mechanism to limit the cumulative processing time they consume per accumulation interval.

LIST request vary significantly in their system impact: Linear LIST is easy and fast. But LIST with prefix and delimiter can be expensive and may require to collect objects names that are scattered accross the db and require a large number of db queries.

A limit by number seems not very helpful here, so a limit on the used processing time is added. This commit builds on the work for adding a limit to LIST done in https://github.com/ceph/ceph/pull/64762. It adds a limit for time very similar to the bandwith limits for READ and WRITE.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
