### PR TITLE
Add support for Swift Keystone Application Credential Access Rules

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,10 @@
+* RGW: Added support for Keystone application credential access rules for
+  Swift, letting RGW enforce the method/path restrictions defined on
+  restricted OpenStack application credential tokens. New config options
+  ``rgw_keystone_verify_access_rules`` (default: true) and
+  ``rgw_keystone_accepted_service_types`` (default: object-store, swift)
+  control enforcement behavior.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -30,6 +30,12 @@
   a few times in random workloads.  ``mds_dir_prefetch_backend_max`` (default 1)
   limits the number of concurrent background fetches.  This reduces latency in
   large directories while retaining cache warmth for hot directories.
+* RGW: Added support for Keystone application credential access rules for
+  Swift, letting RGW enforce the method/path restrictions defined on
+  restricted OpenStack application credential tokens. New config options
+  ``rgw_keystone_verify_access_rules`` (default: true) and
+  ``rgw_keystone_accepted_service_types`` (default: object-store, swift)
+  control enforcement behavior.
 
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1034,6 +1034,16 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_keystone_verify_access_rules
+  type: bool
+  level: advanced
+  default: true
+  help: Enable enforcement of Keystone application credential access rules.
+- name: rgw_keystone_accepted_service_types
+  type: str
+  level: advanced
+  default: object-store, swift
+  help: Comma-separated list of Keystone service types RGW identifies as.
 - name: rgw_keystone_implicit_tenants
   type: str
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -982,6 +982,16 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_keystone_verify_access_rules
+  type: bool
+  level: advanced
+  default: true
+  help: Enable enforcement of Keystone application credential access rules.
+- name: rgw_keystone_accepted_service_types
+  type: str
+  level: advanced
+  default: object-store, swift
+  help: Comma-separated list of Keystone service types RGW identifies as.
 - name: rgw_keystone_implicit_tenants
   type: str
   level: advanced

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -32,8 +32,6 @@ namespace rgw {
 namespace auth {
 namespace keystone {
 
-static constexpr const char* const SWIFT_SERVICE_TYPE = "object-store";
-
 static bool
 path_matches_pattern(const std::string& pattern, const std::string_view path)
 {
@@ -88,18 +86,35 @@ check_access_rules(
     const std::string_view method,
     const std::string_view path)
 {
+  // If no rules exist, Keystone implies unrestricted access for this credential
   if (rules.empty())
     return true;
+
+  // Access rules not enabled
+  if (!cct->_conf.get_val<bool>("rgw_keystone_verify_access_rules")) {
+    return true;
+  }
+
+  // Parse allowed services from config
+  std::string accepted_types = cct->_conf.get_val<std::string>("rgw_keystone_accepted_service_types");
+  std::vector<std::string> service_list;
+  get_str_vec(accepted_types, ",", service_list);
+
+  bool has_relevant_rule = false;
+
   for (const auto& rule : rules) {
-    if (rule.service != SWIFT_SERVICE_TYPE)
-      continue;
-    if (rule.method != method)
-      continue;
-    if (path_matches_pattern(rule.path, path)) {
-      ldpp_dout(dpp, 10) << "access rule matched: " << rule.path << dendl;
+    // Check if the rule service is in our accepted list
+    auto it = std::find(service_list.begin(), service_list.end(), rule.service);
+    if (it == service_list.end()) continue;
+
+    has_relevant_rule = true; // We found at least one rule for RGW
+
+    if (rule.method == method && path_matches_pattern(rule.path, path)) {
+      ldpp_dout(dpp, 10) << "Access rule matched: " << rule.method << " " << rule.path << dendl;
       return true;
     }
   }
+
   ldpp_dout(dpp, 5) << "no access rule matched" << dendl;
   return false;
 }

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -32,10 +32,8 @@ namespace rgw {
 namespace auth {
 namespace keystone {
 
-// Service type for access rules matching
 static constexpr const char* const SWIFT_SERVICE_TYPE = "object-store";
 
-// Match path against pattern with OpenStack glob support (* and **).
 static bool
 path_matches_pattern(const std::string& pattern, const std::string_view path)
 {
@@ -83,7 +81,6 @@ path_matches_pattern(const std::string& pattern, const std::string_view path)
   return pi == pattern.size();
 }
 
-// Check if request matches any access rule
 static bool
 check_access_rules(
     const DoutPrefixProvider* dpp,
@@ -471,8 +468,6 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
       ldpp_dout(dpp, 0) << "validated token: " << t->get_project_name()
                     << ":" << t->get_user_name()
                     << " expires: " << t->get_expires() << dendl;
-      // Check Application Credential Access Rules if present.
-      // If rules exist but none match, deny the request (403 Forbidden).
       if (!check_access_rules(dpp, t->get_access_rules(),
                               s->info.method, s->decoded_uri)) {
         ldpp_dout(dpp, 0) << "access rules check failed for method="

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -32,6 +32,81 @@ namespace rgw {
 namespace auth {
 namespace keystone {
 
+// Service type for access rules matching
+static constexpr const char* const SWIFT_SERVICE_TYPE = "object-store";
+
+// Match path against pattern with OpenStack glob support (* and **).
+static bool
+path_matches_pattern(const std::string& pattern, const std::string_view path)
+{
+  size_t pi = 0, si = 0;
+  size_t star_pi = std::string::npos, star_si = 0;
+  size_t dstar_pi = std::string::npos, dstar_si = 0;
+
+  while (si < path.size()) {
+    if (pi + 1 < pattern.size() && pattern[pi] == '*' &&
+        pattern[pi + 1] == '*') {
+      dstar_pi = pi;
+      dstar_si = si;
+      pi += 2;
+      if (pi < pattern.size() && pattern[pi] == '/')
+        pi++;
+      continue;
+    }
+    if (pi < pattern.size() && pattern[pi] == '*') {
+      star_pi = pi;
+      star_si = si;
+      pi++;
+      continue;
+    }
+    if (pi < pattern.size() && (pattern[pi] == path[si] || pattern[pi] == '?')) {
+      pi++;
+      si++;
+      continue;
+    }
+    if (dstar_pi != std::string::npos) {
+      pi = dstar_pi + 2;
+      if (pi < pattern.size() && pattern[pi] == '/')
+        pi++;
+      si = ++dstar_si;
+      continue;
+    }
+    if (star_pi != std::string::npos && path[star_si] != '/') {
+      pi = star_pi + 1;
+      si = ++star_si;
+      continue;
+    }
+    return false;
+  }
+  while (pi < pattern.size() && pattern[pi] == '*')
+    pi++;
+  return pi == pattern.size();
+}
+
+// Check if request matches any access rule
+static bool
+check_access_rules(
+    const DoutPrefixProvider* dpp,
+    const std::vector<rgw::keystone::TokenEnvelope::AccessRule>& rules,
+    const std::string_view method,
+    const std::string_view path)
+{
+  if (rules.empty())
+    return true;
+  for (const auto& rule : rules) {
+    if (rule.service != SWIFT_SERVICE_TYPE)
+      continue;
+    if (rule.method != method)
+      continue;
+    if (path_matches_pattern(rule.path, path)) {
+      ldpp_dout(dpp, 10) << "access rule matched: " << rule.path << dendl;
+      return true;
+    }
+  }
+  ldpp_dout(dpp, 5) << "no access rule matched" << dendl;
+  return false;
+}
+
 bool
 TokenEngine::is_applicable(const std::string& token) const noexcept
 {
@@ -70,6 +145,7 @@ admin_token_retry:
   }
 
   validate.append_header("X-Subject-Token", token);
+  validate.append_header("OpenStack-Identity-Access-Rules", "1.0");
 
   std::string admin_token;
   bool admin_token_cached = false;
@@ -395,6 +471,16 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
       ldpp_dout(dpp, 0) << "validated token: " << t->get_project_name()
                     << ":" << t->get_user_name()
                     << " expires: " << t->get_expires() << dendl;
+      // Check Application Credential Access Rules if present.
+      // If rules exist but none match, deny the request (403 Forbidden).
+      if (!check_access_rules(dpp, t->get_access_rules(),
+                              s->info.method, s->decoded_uri)) {
+        ldpp_dout(dpp, 0) << "access rules check failed for method="
+                          << s->info.method << " path=" << s->decoded_uri
+                          << dendl;
+        return result_t::deny(-EACCES);
+      }
+
       token_cache.add(token_id, *t);
       auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
                                                 get_creds_info(*t));

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
+#include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -88,22 +90,34 @@ path_matches_pattern(const std::string_view pattern, const std::string_view path
 }
 
 /* Build the set of accepted service types from config. Returns an empty set
- * when the option is unconfigured, which callers treat as "accept all". */
-static std::unordered_set<std::string>
+ * when the option is unconfigured, which callers treat as "accept all".
+ * Cached and only rebuilt when rgw_keystone_accepted_service_types changes,
+ * since re-splitting it on every request is wasted work. */
+static std::shared_ptr<const std::unordered_set<std::string>>
 build_accepted_service_types(CephContext* const cct)
 {
-  std::unordered_set<std::string> result;
+  static std::mutex m;
+  static std::string cached_raw;
+  static std::shared_ptr<const std::unordered_set<std::string>> cached;
+
   std::string accepted_types =
       cct->_conf.get_val<std::string>("rgw_keystone_accepted_service_types");
-  std::vector<std::string> parsed;
-  get_str_vec(accepted_types, ",", parsed);
-  for (auto& s : parsed) {
-    boost::algorithm::trim(s);
-    if (!s.empty()) {
-      result.insert(std::move(s));
+
+  std::lock_guard l{m};
+  if (!cached || accepted_types != cached_raw) {
+    auto result = std::make_shared<std::unordered_set<std::string>>();
+    std::vector<std::string> parsed;
+    get_str_vec(accepted_types, ",", parsed);
+    for (auto& s : parsed) {
+      boost::algorithm::trim(s);
+      if (!s.empty()) {
+        result->insert(std::move(s));
+      }
     }
+    cached = std::move(result);
+    cached_raw = std::move(accepted_types);
   }
-  return result;
+  return cached;
 }
 
 bool
@@ -133,20 +147,19 @@ check_access_rules(
 bool
 TokenEngine::is_applicable(const std::string& token) const noexcept
 {
-  return !token.empty() && !cct->_conf->rgw_keystone_url.empty();
+  return ! token.empty() && ! cct->_conf->rgw_keystone_url.empty();
 }
 
 boost::optional<TokenEngine::token_envelope_t>
-TokenEngine::get_from_keystone(
-    const DoutPrefixProvider* dpp,
-    const std::string& token,
-    bool allow_expired,
-    optional_yield y) const
+TokenEngine::get_from_keystone(const DoutPrefixProvider* dpp,
+                               const std::string& token,
+                               bool allow_expired,
+                               optional_yield y) const
 {
   /* Unfortunately, we can't use the short form of "using" here. It's because
    * we're aliasing a class' member, not namespace. */
-  using RGWValidateKeystoneToken =
-      rgw::keystone::Service::RGWValidateKeystoneToken;
+  using RGWValidateKeystoneToken = \
+    rgw::keystone::Service::RGWValidateKeystoneToken;
 
   bool admin_token_retried = false;
 
@@ -175,8 +188,8 @@ admin_token_retry:
 
   std::string admin_token;
   bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(
-      dpp, token_cache, config, y, admin_token, admin_token_cached);
+  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
+                                                    y, admin_token, admin_token_cached);
   if (ret < 0) {
     throw -EINVAL;
   }
@@ -203,9 +216,8 @@ admin_token_retry:
 
   /* If admin token is invalid we should expire it from the cache and
      try one last time without the cache. */
-  bool admin_token_unauthorized =
-      (validate.get_http_status() ==
-       RGWValidateKeystoneToken::HTTP_STATUS_UNAUTHORIZED);
+  bool admin_token_unauthorized = (validate.get_http_status() ==
+    RGWValidateKeystoneToken::HTTP_STATUS_UNAUTHORIZED);
 
   if (admin_token_unauthorized && admin_token_cached) {
     ldpp_dout(dpp, 20) << "invalidating admin_token cache due to 401" << dendl;
@@ -219,11 +231,10 @@ admin_token_retry:
   }
 
   /* If admin token is invalid or token supplied by client is non-existent. */
-  if (admin_token_unauthorized ||
-      validate.get_http_status() ==
-          RGWValidateKeystoneToken::HTTP_STATUS_NOTFOUND) {
+  if (admin_token_unauthorized || validate.get_http_status() ==
+        RGWValidateKeystoneToken::HTTP_STATUS_NOTFOUND) {
     ldpp_dout(dpp, 5) << "Failed keystone auth from " << url << " with "
-                      << validate.get_http_status() << dendl;
+                  << validate.get_http_status() << dendl;
     return boost::none;
   }
   // throw any other http or connection errors
@@ -231,9 +242,8 @@ admin_token_retry:
     throw ret;
   }
 
-  ldpp_dout(dpp, 20) << "received response status="
-                     << validate.get_http_status()
-                     << ", body=" << token_body_bl.c_str() << dendl;
+  ldpp_dout(dpp, 20) << "received response status=" << validate.get_http_status()
+                 << ", body=" << token_body_bl.c_str() << dendl;
 
   TokenEngine::token_envelope_t token_body;
   ret = token_body.parse(dpp, token, token_body_bl);
@@ -245,8 +255,8 @@ admin_token_retry:
 }
 
 TokenEngine::auth_info_t
-TokenEngine::get_creds_info(
-    const TokenEngine::token_envelope_t& token) const noexcept
+TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
+                           ) const noexcept
 {
   using acct_privilege_t = rgw::auth::RemoteApplier::AuthInfo::acct_privilege_t;
   std::vector<std::string> role_names;
@@ -263,12 +273,12 @@ TokenEngine::get_creds_info(
   /* Build keystone scope info if ops logging is enabled */
   auto keystone_scope = rgw::keystone::build_scope_info(cct, token);
 
-  return auth_info_t{
-      /* Suggested account name for the authenticated user. */
-      rgw_user(token.get_project_id()),
-      /* User's display name (aka real name). */
-      token.get_project_name(),
-      /* Keystone doesn't support RGW's subuser concept, so we cannot cut down
+  return auth_info_t {
+    /* Suggested account name for the authenticated user. */
+    rgw_user(token.get_project_id()),
+    /* User's display name (aka real name). */
+    token.get_project_name(),
+    /* Keystone doesn't support RGW's subuser concept, so we cannot cut down
      * the access rights through the perm_mask. At least at this layer. */
     RGW_PERM_FULL_CONTROL,
     level,
@@ -301,19 +311,18 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
 
   /* Construct all possible combinations including Swift's wildcards. */
   const std::array<std::string, 6> allowed_items = {
-      make_spec_item(tenant_uuid, user_uuid),
-      make_spec_item(tenant_name, user_name),
+    make_spec_item(tenant_uuid, user_uuid),
+    make_spec_item(tenant_name, user_name),
 
-      /* Wildcards. */
-      make_spec_item(tenant_uuid, "*"),
-      make_spec_item(tenant_name, "*"),
-      make_spec_item("*", user_uuid),
-      make_spec_item("*", user_name),
+    /* Wildcards. */
+    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_name, "*"),
+    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_name),
   };
 
   /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles = token.roles](
-             const rgw::auth::Identity::aclspec_t& aclspec) {
+  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
     uint32_t perm = 0;
 
     for (const auto& allowed_item : allowed_items) {
@@ -326,7 +335,7 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
 
     for (const auto& r : token_roles) {
       if (r.is_reader) {
-        if (r.is_admin) { /* system scope reader persona */
+        if (r.is_admin) {    /* system scope reader persona */
           /*
            * Because system reader defeats permissions,
            * we don't even look at the aclspec.
@@ -390,17 +399,16 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
   t = token_cache.find(token_id);
   if (t) {
     ldpp_dout(dpp, 20) << "cached token.project.id=" << t->get_project_id()
-                       << dendl;
-
+                   << dendl;
     if (dpp->get_cct()->_conf.get_val<bool>("rgw_keystone_verify_access_rules")) {
       const auto& raw_rules = t->get_access_rules();
       const auto accepted_svcs = build_accepted_service_types(dpp->get_cct());
       std::vector<token_envelope_t::AccessRule> rules_to_check;
-      if (accepted_svcs.empty()) {
+      if (accepted_svcs->empty()) {
         rules_to_check = raw_rules;
       } else {
         for (const auto& rule : raw_rules) {
-          if (accepted_svcs.count(rule.service)) {
+          if (accepted_svcs->count(rule.service)) {
             rules_to_check.push_back(rule);
           }
         }
@@ -412,8 +420,8 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
         return result_t::deny(-EACCES);
       }
     }
-    auto apl = apl_factory->create_apl_remote(
-        cct, s, get_acl_strategy(*t), get_creds_info(*t));
+    auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
+                                              get_creds_info(*t));
     return result_t::grant(std::move(apl));
   }
 
@@ -421,7 +429,7 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
    * token and if it's invalid the request is invalid. If it's valid
    * we allow an expired token to be used when doing lookup in Keystone.
    * We never get to this if the token is in the cache. */
-  if (g_conf()->rgw_keystone_service_token_enabled && !service_token.empty()) {
+  if (g_conf()->rgw_keystone_service_token_enabled && ! service_token.empty()) {
     boost::optional<TokenEngine::token_envelope_t> st;
 
     const auto& service_token_id = rgw_get_token_id(service_token);
@@ -430,30 +438,30 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
     /* Check cache for service token first. */
     st = token_cache.find_service(service_token_id);
     if (st) {
-      ldpp_dout(dpp, 20) << "cached service_token.project.id="
-                         << st->get_project_id() << dendl;
+      ldpp_dout(dpp, 20) << "cached service_token.project.id=" << st->get_project_id()
+                     << dendl;
 
       /* We found the service token in the cache so we allow using an expired
        * token for this request. */
       allow_expired = true;
       ldpp_dout(dpp, 20) << "allowing expired tokens because service_token_id="
-                         << service_token_id << " was found in cache" << dendl;
+                     << service_token_id
+                     << " was found in cache" << dendl;
     } else {
       /* Service token was not found in cache. Go to Keystone for validating
        * the token. The allow_expired here must always be false. */
       ceph_assert(allow_expired == false);
       st = get_from_keystone(dpp, service_token, allow_expired, y);
 
-      if (!st) {
+      if (! st) {
         return result_t::deny(-EACCES);
       }
 
       /* Verify expiration of service token. */
       if (st->expired()) {
-        ldpp_dout(dpp, 0) << "got expired service token: "
-                          << st->get_project_name() << ":"
-                          << st->get_user_name() << " expired "
-                          << st->get_expires() << dendl;
+        ldpp_dout(dpp, 0) << "got expired service token: " << st->get_project_name()
+                       << ":" << st->get_user_name()
+                       << " expired " << st->get_expires() << dendl;
         return result_t::deny(-EPERM);
       }
 
@@ -462,9 +470,10 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
         if (st->has_role(role) == true) {
           /* Service token is valid so we allow using an expired token for
            * this request. */
-          ldpp_dout(dpp, 20)
-              << "allowing expired tokens because service_token_id="
-              << service_token_id << " is valid, role: " << role << dendl;
+          ldpp_dout(dpp, 20) << "allowing expired tokens because service_token_id="
+                         << service_token_id
+                         << " is valid, role: "
+                         << role << dendl;
           allow_expired = true;
           token_cache.add_service(service_token_id, *st);
           break;
@@ -472,10 +481,8 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
       }
 
       if (!allow_expired) {
-        ldpp_dout(dpp, 0) << "service token user does not hold a matching "
-                             "role; required roles: "
-                          << g_conf()->rgw_keystone_service_token_accepted_roles
-                          << dendl;
+        ldpp_dout(dpp, 0) << "service token user does not hold a matching role; required roles: "
+                  << g_conf()->rgw_keystone_service_token_accepted_roles << dendl;
         return result_t::deny(-EPERM);
       }
     }
@@ -494,13 +501,13 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
   if (t->expired()) {
     if (allow_expired) {
       ldpp_dout(dpp, 20) << "allowing expired token: " << t->get_project_name()
-                         << ":" << t->get_user_name()
-                         << " expired: " << t->get_expires()
-                         << " because of valid service token" << dendl;
+                    << ":" << t->get_user_name()
+                    << " expired: " << t->get_expires()
+                    << " because of valid service token" << dendl;
     } else {
-      ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name() << ":"
-                        << t->get_user_name()
-                        << " expired: " << t->get_expires() << dendl;
+      ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name()
+                    << ":" << t->get_user_name()
+                    << " expired: " << t->get_expires() << dendl;
       return result_t::deny(-EPERM);
     }
   }
@@ -512,27 +519,26 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
        * service token we need to update the expiration before we cache it. */
       if (allow_expired) {
         time_t now = ceph_clock_now().sec();
-        time_t new_expires =
-            now + g_conf()->rgw_keystone_expired_token_cache_expiration;
-        ldpp_dout(dpp, 20)
-            << "updating expiration of allowed expired token"
-            << " from old " << t->get_expires() << " to now " << now << " + "
-            << g_conf()->rgw_keystone_expired_token_cache_expiration
-            << " secs = " << new_expires << dendl;
+        time_t new_expires = now + g_conf()->rgw_keystone_expired_token_cache_expiration;
+        ldpp_dout(dpp, 20) << "updating expiration of allowed expired token"
+                           << " from old " << t->get_expires() << " to now " << now << " + "
+                           << g_conf()->rgw_keystone_expired_token_cache_expiration
+                           << " secs = "
+                           << new_expires << dendl;
         t->set_expires(new_expires);
       }
-      ldpp_dout(dpp, 0) << "validated token: " << t->get_project_name() << ":"
-                        << t->get_user_name()
-                        << " expires: " << t->get_expires() << dendl;
+      ldpp_dout(dpp, 0) << "validated token: " << t->get_project_name()
+                    << ":" << t->get_user_name()
+                    << " expires: " << t->get_expires() << dendl;
       if (dpp->get_cct()->_conf.get_val<bool>("rgw_keystone_verify_access_rules")) {
         const auto& raw_rules = t->get_access_rules();
         const auto accepted_svcs = build_accepted_service_types(dpp->get_cct());
         std::vector<token_envelope_t::AccessRule> rules_to_check;
-        if (accepted_svcs.empty()) {
+        if (accepted_svcs->empty()) {
           rules_to_check = raw_rules;
         } else {
           for (const auto& rule : raw_rules) {
-            if (accepted_svcs.count(rule.service)) {
+            if (accepted_svcs->count(rule.service)) {
               rules_to_check.push_back(rule);
             }
           }
@@ -544,30 +550,28 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
           return result_t::deny(-EACCES);
         }
       }
-
       token_cache.add(token_id, *t);
-      auto apl = apl_factory->create_apl_remote(
-          cct, s, get_acl_strategy(*t), get_creds_info(*t));
+      auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
+                                                get_creds_info(*t));
       return result_t::grant(std::move(apl));
     }
   }
 
   ldpp_dout(dpp, 0) << "user does not hold a matching role; required roles: "
-                    << g_conf()->rgw_keystone_accepted_roles << dendl;
+                << g_conf()->rgw_keystone_accepted_roles << dendl;
 
   return result_t::deny(-EPERM);
 }
+
 
 /*
  * Try to validate S3 auth against keystone s3token interface
  */
 std::pair<boost::optional<rgw::keystone::TokenEnvelope>, int>
-EC2Engine::get_from_keystone(
-    const DoutPrefixProvider* dpp,
-    const std::string_view& access_key_id,
-    const std::string& string_to_sign,
-    const std::string_view& signature,
-    optional_yield y) const
+EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_view& access_key_id,
+                             const std::string& string_to_sign,
+                             const std::string_view& signature,
+                             optional_yield y) const
 {
   /* prepare keystone url */
   std::string keystone_url = config.get_endpoint_url();
@@ -580,16 +584,16 @@ EC2Engine::get_from_keystone(
   /* get authentication token for Keystone. */
   std::string admin_token;
   bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(
-      dpp, token_cache, config, y, admin_token, admin_token_cached);
+  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
+                                                    y, admin_token, admin_token_cached);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: cannot get token for keystone access"
-                      << dendl;
+                  << dendl;
     throw ret;
   }
 
-  using RGWValidateKeystoneToken =
-      rgw::keystone::Service::RGWValidateKeystoneToken;
+  using RGWValidateKeystoneToken
+    = rgw::keystone::Service::RGWValidateKeystoneToken;
 
   /* The container for plain response obtained from Keystone. It will be
    * parsed token_envelope_t::parse method. */
@@ -623,16 +627,16 @@ EC2Engine::get_from_keystone(
 
   /* if the supplied signature is wrong, we will get 401 from Keystone */
   if (validate.get_http_status() ==
-      decltype(validate)::HTTP_STATUS_UNAUTHORIZED) {
+          decltype(validate)::HTTP_STATUS_UNAUTHORIZED) {
     return std::make_pair(boost::none, -ERR_SIGNATURE_NO_MATCH);
-  } else if (
-      validate.get_http_status() == decltype(validate)::HTTP_STATUS_NOTFOUND) {
+  } else if (validate.get_http_status() ==
+          decltype(validate)::HTTP_STATUS_NOTFOUND) {
     return std::make_pair(boost::none, -ERR_INVALID_ACCESS_KEY);
   }
   // throw any other http or connection errors
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: token validation ERROR: "
-                      << token_body_bl.c_str() << dendl;
+                  << token_body_bl.c_str() << dendl;
     throw ret;
   }
 
@@ -641,19 +645,18 @@ EC2Engine::get_from_keystone(
   ret = token_envelope.parse(dpp, std::string(), token_body_bl);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: token parsing failed, ret=0" << ret
-                      << dendl;
+                  << dendl;
     throw ret;
   }
 
   return std::make_pair(std::move(token_envelope), 0);
 }
 
-auto
-EC2Engine::get_secret_from_keystone(
-    const DoutPrefixProvider* dpp,
-    const std::string& user_id,
-    const std::string_view& access_key_id,
-    optional_yield y) const -> std::pair<boost::optional<std::string>, int>
+auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
+                                         const std::string& user_id,
+                                         const std::string_view& access_key_id,
+                                         optional_yield y) const
+    -> std::pair<boost::optional<std::string>, int>
 {
   /*  Fetch from /users/{USER_ID}/credentials/OS-EC2/{ACCESS_KEY_ID} */
   /* Should return json with response key "credential" which contains entry "secret"*/
@@ -673,15 +676,16 @@ EC2Engine::get_secret_from_keystone(
   /* get authentication token for Keystone. */
   std::string admin_token;
   bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(
-      dpp, token_cache, config, y, admin_token, admin_token_cached);
+  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
+                                                    y, admin_token, admin_token_cached);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: cannot get token for keystone access"
-                      << dendl;
+                  << dendl;
     return make_pair(boost::none, ret);
   }
 
-  using RGWGetAccessSecret = rgw::keystone::Service::RGWKeystoneHTTPTransceiver;
+  using RGWGetAccessSecret
+    = rgw::keystone::Service::RGWKeystoneHTTPTransceiver;
 
   /* The container for plain response obtained from Keystone.*/
   ceph::bufferlist token_body_bl;
@@ -697,22 +701,22 @@ EC2Engine::get_secret_from_keystone(
   ret = secret.process(dpp, y);
 
   /* if the supplied access key isn't found, we will get 404 from Keystone */
-  if (secret.get_http_status() == decltype(secret)::HTTP_STATUS_NOTFOUND) {
+  if (secret.get_http_status() ==
+          decltype(secret)::HTTP_STATUS_NOTFOUND) {
     return make_pair(boost::none, -ERR_INVALID_ACCESS_KEY);
   }
   // return any other http or connection errors
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: secret fetching error: "
-                      << token_body_bl.c_str() << dendl;
+                  << token_body_bl.c_str() << dendl;
     return make_pair(boost::none, ret);
   }
 
   /* now parse response */
 
   JSONParser parser;
-  if (!parser.parse(token_body_bl.c_str(), token_body_bl.length())) {
-    ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed json"
-                      << dendl;
+  if (! parser.parse(token_body_bl.c_str(), token_body_bl.length())) {
+    ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed json" << dendl;
     return make_pair(boost::none, -EINVAL);
   }
 
@@ -723,13 +727,11 @@ EC2Engine::get_secret_from_keystone(
     if (!credential_iter.end()) {
       JSONDecoder::decode_json("secret", secret_string, *credential_iter, true);
     } else {
-      ldpp_dout(dpp, 0)
-          << "Keystone credential not present in return from server" << dendl;
+      ldpp_dout(dpp, 0) << "Keystone credential not present in return from server" << dendl;
       return make_pair(boost::none, -EINVAL);
     }
   } catch (const JSONDecoder::err& err) {
-    ldpp_dout(dpp, 0) << "Keystone credential parse error: " << err.what()
-                      << dendl;
+    ldpp_dout(dpp, 0) << "Keystone credential parse error: " << err.what() << dendl;
     return make_pair(boost::none, -EINVAL);
   }
 
@@ -739,15 +741,14 @@ EC2Engine::get_secret_from_keystone(
 /*
  * Try to get a token for S3 authentication, using a secret cache if available
  */
-auto
-EC2Engine::get_access_token(
-    const DoutPrefixProvider* dpp,
-    const std::string_view& access_key_id,
-    const std::string& string_to_sign,
-    const std::string_view& signature,
-    const signature_factory_t& signature_factory,
-    bool ignore_signature,
-    optional_yield y) const -> access_token_result
+auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
+                                 const std::string_view& access_key_id,
+                                 const std::string& string_to_sign,
+                                 const std::string_view& signature,
+                                 const signature_factory_t& signature_factory,
+                                 bool ignore_signature,
+                                 optional_yield y) const
+    -> access_token_result
 {
   using server_signature_t = VersionAbstractor::server_signature_t;
   boost::optional<rgw::keystone::TokenEnvelope> token;
@@ -755,8 +756,8 @@ EC2Engine::get_access_token(
   int failure_reason;
 
   /* Get a token from the cache if one has already been stored */
-  boost::optional<boost::tuple<rgw::keystone::TokenEnvelope, std::string>> t =
-      secret_cache.find(std::string(access_key_id));
+  boost::optional<boost::tuple<rgw::keystone::TokenEnvelope, std::string>>
+    t = secret_cache.find(std::string(access_key_id));
 
   /* Check that credentials can correctly be used to sign data */
   if (t) {
@@ -767,14 +768,11 @@ EC2Engine::get_access_token(
       return {t->get<0>(), t->get<1>(), 0};
     } else {
       std::string sig(signature);
-      server_signature_t server_signature =
-          signature_factory(cct, t->get<1>(), string_to_sign);
+      server_signature_t server_signature = signature_factory(cct, t->get<1>(), string_to_sign);
       if (sig.compare(server_signature) == 0) {
         return {t->get<0>(), t->get<1>(), 0};
       } else {
-        ldpp_dout(dpp, 0)
-            << "Secret string does not correctly sign payload, cache miss"
-            << dendl;
+        ldpp_dout(dpp, 0) << "Secret string does not correctly sign payload, cache miss" << dendl;
       }
     }
   } else {
@@ -808,12 +806,13 @@ EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t&) const
 }
 
 EC2Engine::auth_info_t
-EC2Engine::get_creds_info(
-    const EC2Engine::token_envelope_t& token,
-    const std::vector<std::string>& admin_roles,
-    const std::string& access_key_id) const noexcept
+EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
+                          const std::vector<std::string>& admin_roles,
+                          const std::string& access_key_id
+                         ) const noexcept
 {
-  using acct_privilege_t = rgw::auth::RemoteApplier::AuthInfo::acct_privilege_t;
+  using acct_privilege_t = \
+    rgw::auth::RemoteApplier::AuthInfo::acct_privilege_t;
 
   /* Check whether the user has an admin status. */
   acct_privilege_t level = acct_privilege_t::IS_PLAIN_ACCT;
@@ -851,23 +850,21 @@ EC2Engine::get_creds_info(
   };
 }
 
-rgw::auth::Engine::result_t
-EC2Engine::authenticate(
-    const DoutPrefixProvider* dpp,
-    const std::string_view& access_key_id,
-    const std::string_view& signature,
-    const std::string_view& session_token,
-    const string_to_sign_t& string_to_sign,
-    const signature_factory_t& signature_factory,
-    const completer_factory_t& completer_factory,
-    const req_state* s,
-    optional_yield y) const
+rgw::auth::Engine::result_t EC2Engine::authenticate(
+  const DoutPrefixProvider* dpp,
+  const std::string_view& access_key_id,
+  const std::string_view& signature,
+  const std::string_view& session_token,
+  const string_to_sign_t& string_to_sign,
+  const signature_factory_t& signature_factory,
+  const completer_factory_t& completer_factory,
+  const req_state* s,
+  optional_yield y) const
 {
   /* This will be initialized on the first call to this method. In C++11 it's
    * also thread-safe. */
   static const struct RolesCacher {
-    explicit RolesCacher(CephContext* const cct)
-    {
+    explicit RolesCacher(CephContext* const cct) {
       get_str_vec(cct->_conf->rgw_keystone_accepted_roles, plain);
       get_str_vec(cct->_conf->rgw_keystone_accepted_admin_roles, admin);
 
@@ -882,10 +879,10 @@ EC2Engine::authenticate(
   /* When we handle a HTTP OPTIONS call we must ignore the signature */
   bool ignore_signature = (s->op_type == RGW_OP_OPTIONS_CORS);
 
-  auto [t, secret_key, failure_reason] = get_access_token(
-      dpp, access_key_id, string_to_sign, signature, signature_factory,
-      ignore_signature, y);
-  if (!t) {
+  auto [t, secret_key, failure_reason] =
+    get_access_token(dpp, access_key_id, string_to_sign,
+                     signature, signature_factory, ignore_signature, y);
+  if (! t) {
     if (failure_reason == -ERR_SIGNATURE_NO_MATCH) {
       // we looked up a secret but it didn't generate the same signature as
       // the client. since we found this access key in keystone, we should
@@ -897,9 +894,9 @@ EC2Engine::authenticate(
 
   /* Verify expiration. */
   if (t->expired()) {
-    ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name() << ":"
-                      << t->get_user_name() << " expired: " << t->get_expires()
-                      << dendl;
+    ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name()
+                  << ":" << t->get_user_name()
+                  << " expired: " << t->get_expires() << dendl;
     return result_t::deny();
   }
 
@@ -912,29 +909,26 @@ EC2Engine::authenticate(
     }
   }
 
-  if (!found) {
+  if (! found) {
     ldpp_dout(dpp, 5) << "s3 keystone: user does not hold a matching role;"
-                         " required roles: "
-                      << cct->_conf->rgw_keystone_accepted_roles << dendl;
+                     " required roles: "
+                  << cct->_conf->rgw_keystone_accepted_roles << dendl;
     return result_t::deny();
   } else {
     /* everything seems fine, continue with this user */
-    ldpp_dout(dpp, 5) << "s3 keystone: validated token: "
-                      << t->get_project_name() << ":" << t->get_user_name()
-                      << " expires: " << t->get_expires() << dendl;
+    ldpp_dout(dpp, 5) << "s3 keystone: validated token: " << t->get_project_name()
+                  << ":" << t->get_user_name()
+                  << " expires: " << t->get_expires() << dendl;
 
-    auto apl = apl_factory->create_apl_remote(
-        cct, s, get_acl_strategy(*t),
-        get_creds_info(*t, accepted_roles.admin, std::string(access_key_id)));
+    auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
+                                              get_creds_info(*t, accepted_roles.admin, std::string(access_key_id)));
     return result_t::grant(std::move(apl), completer_factory(secret_key));
   }
 }
 
-bool
-SecretCache::find(
-    const std::string& token_id,
-    SecretCache::token_envelope_t& token,
-    std::string& secret)
+bool SecretCache::find(const std::string& token_id,
+                       SecretCache::token_envelope_t& token,
+		       std::string &secret)
 {
   std::lock_guard<std::mutex> l(lock);
 
@@ -960,11 +954,9 @@ SecretCache::find(
   return true;
 }
 
-void
-SecretCache::add(
-    const std::string& token_id,
-    const SecretCache::token_envelope_t& token,
-    const std::string& secret)
+void SecretCache::add(const std::string& token_id,
+                      const SecretCache::token_envelope_t& token,
+		      const std::string& secret)
 {
   std::lock_guard<std::mutex> l(lock);
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <errno.h>
@@ -32,8 +33,8 @@ namespace rgw {
 namespace auth {
 namespace keystone {
 
-static bool
-path_matches_pattern(const std::string& pattern, const std::string_view path)
+bool
+path_matches_pattern(const std::string_view pattern, const std::string_view path)
 {
   size_t pi = 0, si = 0;
   size_t star_pi = std::string::npos, star_si = 0;
@@ -55,11 +56,13 @@ path_matches_pattern(const std::string& pattern, const std::string_view path)
       pi++;
       continue;
     }
-    if (pi < pattern.size() && (pattern[pi] == path[si] || pattern[pi] == '?')) {
+
+    if (pi < pattern.size() && pattern[pi] == path[si]) {
       pi++;
       si++;
       continue;
     }
+    
     if (dstar_pi != std::string::npos) {
       pi = dstar_pi + 2;
       if (pi < pattern.size() && pattern[pi] == '/')
@@ -67,7 +70,12 @@ path_matches_pattern(const std::string& pattern, const std::string_view path)
       si = ++dstar_si;
       continue;
     }
-    if (star_pi != std::string::npos && path[star_si] != '/') {
+    // single * only refuses to cross '/' when it's between slashes in pattern
+    bool star_between_slashes = star_pi != std::string::npos &&
+        (star_pi > 0 && pattern[star_pi - 1] == '/') &&
+        (star_pi + 1 < pattern.size() && pattern[star_pi + 1] == '/');
+    if (star_pi != std::string::npos &&
+        (!star_between_slashes || path[star_si] != '/')) {
       pi = star_pi + 1;
       si = ++star_si;
       continue;
@@ -79,62 +87,66 @@ path_matches_pattern(const std::string& pattern, const std::string_view path)
   return pi == pattern.size();
 }
 
-static bool
+/* Build the set of accepted service types from config. Returns an empty set
+ * when the option is unconfigured, which callers treat as "accept all". */
+static std::unordered_set<std::string>
+build_accepted_service_types(CephContext* const cct)
+{
+  std::unordered_set<std::string> result;
+  std::string accepted_types =
+      cct->_conf.get_val<std::string>("rgw_keystone_accepted_service_types");
+  std::vector<std::string> parsed;
+  get_str_vec(accepted_types, ",", parsed);
+  for (auto& s : parsed) {
+    boost::algorithm::trim(s);
+    if (!s.empty()) {
+      result.insert(std::move(s));
+    }
+  }
+  return result;
+}
+
+bool
 check_access_rules(
     const DoutPrefixProvider* dpp,
     const std::vector<rgw::keystone::TokenEnvelope::AccessRule>& rules,
-    const std::string_view method,
-    const std::string_view path)
+    std::string_view method,
+    std::string_view path)
 {
-  // If no rules exist, Keystone implies unrestricted access for this credential
-  if (rules.empty())
-    return true;
-
-  // Access rules not enabled
-  if (!cct->_conf.get_val<bool>("rgw_keystone_verify_access_rules")) {
+  if (rules.empty()) {
     return true;
   }
 
-  // Parse allowed services from config
-  std::string accepted_types = cct->_conf.get_val<std::string>("rgw_keystone_accepted_service_types");
-  std::vector<std::string> service_list;
-  get_str_vec(accepted_types, ",", service_list);
-
-  bool has_relevant_rule = false;
-
   for (const auto& rule : rules) {
-    // Check if the rule service is in our accepted list
-    auto it = std::find(service_list.begin(), service_list.end(), rule.service);
-    if (it == service_list.end()) continue;
-
-    has_relevant_rule = true; // We found at least one rule for RGW
-
     if (rule.method == method && path_matches_pattern(rule.path, path)) {
-      ldpp_dout(dpp, 10) << "Access rule matched: " << rule.method << " " << rule.path << dendl;
+      ldpp_dout(dpp, 10) << "Access rule matched: " << rule.method << " "
+                         << rule.path << dendl;
       return true;
     }
   }
 
-  ldpp_dout(dpp, 5) << "no access rule matched" << dendl;
+  ldpp_dout(dpp, 5) << "No access rule matched for method=" << method
+                    << " path=" << path << dendl;
   return false;
 }
 
 bool
 TokenEngine::is_applicable(const std::string& token) const noexcept
 {
-  return ! token.empty() && ! cct->_conf->rgw_keystone_url.empty();
+  return !token.empty() && !cct->_conf->rgw_keystone_url.empty();
 }
 
 boost::optional<TokenEngine::token_envelope_t>
-TokenEngine::get_from_keystone(const DoutPrefixProvider* dpp,
-                               const std::string& token,
-                               bool allow_expired,
-                               optional_yield y) const
+TokenEngine::get_from_keystone(
+    const DoutPrefixProvider* dpp,
+    const std::string& token,
+    bool allow_expired,
+    optional_yield y) const
 {
   /* Unfortunately, we can't use the short form of "using" here. It's because
    * we're aliasing a class' member, not namespace. */
-  using RGWValidateKeystoneToken = \
-    rgw::keystone::Service::RGWValidateKeystoneToken;
+  using RGWValidateKeystoneToken =
+      rgw::keystone::Service::RGWValidateKeystoneToken;
 
   bool admin_token_retried = false;
 
@@ -157,12 +169,14 @@ admin_token_retry:
   }
 
   validate.append_header("X-Subject-Token", token);
-  validate.append_header("OpenStack-Identity-Access-Rules", "1.0");
+  if (dpp->get_cct()->_conf.get_val<bool>("rgw_keystone_verify_access_rules")) {
+    validate.append_header("OpenStack-Identity-Access-Rules", "1.0");
+  }
 
   std::string admin_token;
   bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
-                                                    y, admin_token, admin_token_cached);
+  int ret = rgw::keystone::Service::get_admin_token(
+      dpp, token_cache, config, y, admin_token, admin_token_cached);
   if (ret < 0) {
     throw -EINVAL;
   }
@@ -189,8 +203,9 @@ admin_token_retry:
 
   /* If admin token is invalid we should expire it from the cache and
      try one last time without the cache. */
-  bool admin_token_unauthorized = (validate.get_http_status() ==
-    RGWValidateKeystoneToken::HTTP_STATUS_UNAUTHORIZED);
+  bool admin_token_unauthorized =
+      (validate.get_http_status() ==
+       RGWValidateKeystoneToken::HTTP_STATUS_UNAUTHORIZED);
 
   if (admin_token_unauthorized && admin_token_cached) {
     ldpp_dout(dpp, 20) << "invalidating admin_token cache due to 401" << dendl;
@@ -204,10 +219,11 @@ admin_token_retry:
   }
 
   /* If admin token is invalid or token supplied by client is non-existent. */
-  if (admin_token_unauthorized || validate.get_http_status() ==
-        RGWValidateKeystoneToken::HTTP_STATUS_NOTFOUND) {
+  if (admin_token_unauthorized ||
+      validate.get_http_status() ==
+          RGWValidateKeystoneToken::HTTP_STATUS_NOTFOUND) {
     ldpp_dout(dpp, 5) << "Failed keystone auth from " << url << " with "
-                  << validate.get_http_status() << dendl;
+                      << validate.get_http_status() << dendl;
     return boost::none;
   }
   // throw any other http or connection errors
@@ -215,8 +231,9 @@ admin_token_retry:
     throw ret;
   }
 
-  ldpp_dout(dpp, 20) << "received response status=" << validate.get_http_status()
-                 << ", body=" << token_body_bl.c_str() << dendl;
+  ldpp_dout(dpp, 20) << "received response status="
+                     << validate.get_http_status()
+                     << ", body=" << token_body_bl.c_str() << dendl;
 
   TokenEngine::token_envelope_t token_body;
   ret = token_body.parse(dpp, token, token_body_bl);
@@ -228,8 +245,8 @@ admin_token_retry:
 }
 
 TokenEngine::auth_info_t
-TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
-                           ) const noexcept
+TokenEngine::get_creds_info(
+    const TokenEngine::token_envelope_t& token) const noexcept
 {
   using acct_privilege_t = rgw::auth::RemoteApplier::AuthInfo::acct_privilege_t;
   std::vector<std::string> role_names;
@@ -246,12 +263,12 @@ TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
   /* Build keystone scope info if ops logging is enabled */
   auto keystone_scope = rgw::keystone::build_scope_info(cct, token);
 
-  return auth_info_t {
-    /* Suggested account name for the authenticated user. */
-    rgw_user(token.get_project_id()),
-    /* User's display name (aka real name). */
-    token.get_project_name(),
-    /* Keystone doesn't support RGW's subuser concept, so we cannot cut down
+  return auth_info_t{
+      /* Suggested account name for the authenticated user. */
+      rgw_user(token.get_project_id()),
+      /* User's display name (aka real name). */
+      token.get_project_name(),
+      /* Keystone doesn't support RGW's subuser concept, so we cannot cut down
      * the access rights through the perm_mask. At least at this layer. */
     RGW_PERM_FULL_CONTROL,
     level,
@@ -284,18 +301,19 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
 
   /* Construct all possible combinations including Swift's wildcards. */
   const std::array<std::string, 6> allowed_items = {
-    make_spec_item(tenant_uuid, user_uuid),
-    make_spec_item(tenant_name, user_name),
+      make_spec_item(tenant_uuid, user_uuid),
+      make_spec_item(tenant_name, user_name),
 
-    /* Wildcards. */
-    make_spec_item(tenant_uuid, "*"),
-    make_spec_item(tenant_name, "*"),
-    make_spec_item("*", user_uuid),
-    make_spec_item("*", user_name),
+      /* Wildcards. */
+      make_spec_item(tenant_uuid, "*"),
+      make_spec_item(tenant_name, "*"),
+      make_spec_item("*", user_uuid),
+      make_spec_item("*", user_name),
   };
 
   /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+  return [allowed_items, token_roles = token.roles](
+             const rgw::auth::Identity::aclspec_t& aclspec) {
     uint32_t perm = 0;
 
     for (const auto& allowed_item : allowed_items) {
@@ -308,7 +326,7 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
 
     for (const auto& r : token_roles) {
       if (r.is_reader) {
-        if (r.is_admin) {    /* system scope reader persona */
+        if (r.is_admin) { /* system scope reader persona */
           /*
            * Because system reader defeats permissions,
            * we don't even look at the aclspec.
@@ -372,9 +390,30 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
   t = token_cache.find(token_id);
   if (t) {
     ldpp_dout(dpp, 20) << "cached token.project.id=" << t->get_project_id()
-                   << dendl;
-    auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
-                                              get_creds_info(*t));
+                       << dendl;
+
+    if (dpp->get_cct()->_conf.get_val<bool>("rgw_keystone_verify_access_rules")) {
+      const auto& raw_rules = t->get_access_rules();
+      const auto accepted_svcs = build_accepted_service_types(dpp->get_cct());
+      std::vector<token_envelope_t::AccessRule> rules_to_check;
+      if (accepted_svcs.empty()) {
+        rules_to_check = raw_rules;
+      } else {
+        for (const auto& rule : raw_rules) {
+          if (accepted_svcs.count(rule.service)) {
+            rules_to_check.push_back(rule);
+          }
+        }
+      }
+      if (!check_access_rules(dpp, rules_to_check, s->info.method, s->decoded_uri)) {
+        ldpp_dout(dpp, 0) << "access rules check failed for cached token, method="
+                          << s->info.method << " path=" << s->decoded_uri
+                          << dendl;
+        return result_t::deny(-EACCES);
+      }
+    }
+    auto apl = apl_factory->create_apl_remote(
+        cct, s, get_acl_strategy(*t), get_creds_info(*t));
     return result_t::grant(std::move(apl));
   }
 
@@ -382,7 +421,7 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
    * token and if it's invalid the request is invalid. If it's valid
    * we allow an expired token to be used when doing lookup in Keystone.
    * We never get to this if the token is in the cache. */
-  if (g_conf()->rgw_keystone_service_token_enabled && ! service_token.empty()) {
+  if (g_conf()->rgw_keystone_service_token_enabled && !service_token.empty()) {
     boost::optional<TokenEngine::token_envelope_t> st;
 
     const auto& service_token_id = rgw_get_token_id(service_token);
@@ -391,30 +430,30 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
     /* Check cache for service token first. */
     st = token_cache.find_service(service_token_id);
     if (st) {
-      ldpp_dout(dpp, 20) << "cached service_token.project.id=" << st->get_project_id()
-                     << dendl;
+      ldpp_dout(dpp, 20) << "cached service_token.project.id="
+                         << st->get_project_id() << dendl;
 
       /* We found the service token in the cache so we allow using an expired
        * token for this request. */
       allow_expired = true;
       ldpp_dout(dpp, 20) << "allowing expired tokens because service_token_id="
-                     << service_token_id
-                     << " was found in cache" << dendl;
+                         << service_token_id << " was found in cache" << dendl;
     } else {
       /* Service token was not found in cache. Go to Keystone for validating
        * the token. The allow_expired here must always be false. */
       ceph_assert(allow_expired == false);
       st = get_from_keystone(dpp, service_token, allow_expired, y);
 
-      if (! st) {
+      if (!st) {
         return result_t::deny(-EACCES);
       }
 
       /* Verify expiration of service token. */
       if (st->expired()) {
-        ldpp_dout(dpp, 0) << "got expired service token: " << st->get_project_name()
-                       << ":" << st->get_user_name()
-                       << " expired " << st->get_expires() << dendl;
+        ldpp_dout(dpp, 0) << "got expired service token: "
+                          << st->get_project_name() << ":"
+                          << st->get_user_name() << " expired "
+                          << st->get_expires() << dendl;
         return result_t::deny(-EPERM);
       }
 
@@ -423,10 +462,9 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
         if (st->has_role(role) == true) {
           /* Service token is valid so we allow using an expired token for
            * this request. */
-          ldpp_dout(dpp, 20) << "allowing expired tokens because service_token_id="
-                         << service_token_id
-                         << " is valid, role: "
-                         << role << dendl;
+          ldpp_dout(dpp, 20)
+              << "allowing expired tokens because service_token_id="
+              << service_token_id << " is valid, role: " << role << dendl;
           allow_expired = true;
           token_cache.add_service(service_token_id, *st);
           break;
@@ -434,8 +472,10 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
       }
 
       if (!allow_expired) {
-        ldpp_dout(dpp, 0) << "service token user does not hold a matching role; required roles: "
-                  << g_conf()->rgw_keystone_service_token_accepted_roles << dendl;
+        ldpp_dout(dpp, 0) << "service token user does not hold a matching "
+                             "role; required roles: "
+                          << g_conf()->rgw_keystone_service_token_accepted_roles
+                          << dendl;
         return result_t::deny(-EPERM);
       }
     }
@@ -454,13 +494,13 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
   if (t->expired()) {
     if (allow_expired) {
       ldpp_dout(dpp, 20) << "allowing expired token: " << t->get_project_name()
-                    << ":" << t->get_user_name()
-                    << " expired: " << t->get_expires()
-                    << " because of valid service token" << dendl;
+                         << ":" << t->get_user_name()
+                         << " expired: " << t->get_expires()
+                         << " because of valid service token" << dendl;
     } else {
-      ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name()
-                    << ":" << t->get_user_name()
-                    << " expired: " << t->get_expires() << dendl;
+      ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name() << ":"
+                        << t->get_user_name()
+                        << " expired: " << t->get_expires() << dendl;
       return result_t::deny(-EPERM);
     }
   }
@@ -472,47 +512,62 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
        * service token we need to update the expiration before we cache it. */
       if (allow_expired) {
         time_t now = ceph_clock_now().sec();
-        time_t new_expires = now + g_conf()->rgw_keystone_expired_token_cache_expiration;
-        ldpp_dout(dpp, 20) << "updating expiration of allowed expired token"
-                           << " from old " << t->get_expires() << " to now " << now << " + "
-                           << g_conf()->rgw_keystone_expired_token_cache_expiration
-                           << " secs = "
-                           << new_expires << dendl;
+        time_t new_expires =
+            now + g_conf()->rgw_keystone_expired_token_cache_expiration;
+        ldpp_dout(dpp, 20)
+            << "updating expiration of allowed expired token"
+            << " from old " << t->get_expires() << " to now " << now << " + "
+            << g_conf()->rgw_keystone_expired_token_cache_expiration
+            << " secs = " << new_expires << dendl;
         t->set_expires(new_expires);
       }
-      ldpp_dout(dpp, 0) << "validated token: " << t->get_project_name()
-                    << ":" << t->get_user_name()
-                    << " expires: " << t->get_expires() << dendl;
-      if (!check_access_rules(dpp, t->get_access_rules(),
-                              s->info.method, s->decoded_uri)) {
-        ldpp_dout(dpp, 0) << "access rules check failed for method="
-                          << s->info.method << " path=" << s->decoded_uri
-                          << dendl;
-        return result_t::deny(-EACCES);
+      ldpp_dout(dpp, 0) << "validated token: " << t->get_project_name() << ":"
+                        << t->get_user_name()
+                        << " expires: " << t->get_expires() << dendl;
+      if (dpp->get_cct()->_conf.get_val<bool>("rgw_keystone_verify_access_rules")) {
+        const auto& raw_rules = t->get_access_rules();
+        const auto accepted_svcs = build_accepted_service_types(dpp->get_cct());
+        std::vector<token_envelope_t::AccessRule> rules_to_check;
+        if (accepted_svcs.empty()) {
+          rules_to_check = raw_rules;
+        } else {
+          for (const auto& rule : raw_rules) {
+            if (accepted_svcs.count(rule.service)) {
+              rules_to_check.push_back(rule);
+            }
+          }
+        }
+        if (!check_access_rules(dpp, rules_to_check, s->info.method, s->decoded_uri)) {
+          ldpp_dout(dpp, 0) << "access rules check failed for method="
+                            << s->info.method << " path=" << s->decoded_uri
+                            << dendl;
+          return result_t::deny(-EACCES);
+        }
       }
 
       token_cache.add(token_id, *t);
-      auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
-                                                get_creds_info(*t));
+      auto apl = apl_factory->create_apl_remote(
+          cct, s, get_acl_strategy(*t), get_creds_info(*t));
       return result_t::grant(std::move(apl));
     }
   }
 
   ldpp_dout(dpp, 0) << "user does not hold a matching role; required roles: "
-                << g_conf()->rgw_keystone_accepted_roles << dendl;
+                    << g_conf()->rgw_keystone_accepted_roles << dendl;
 
   return result_t::deny(-EPERM);
 }
-
 
 /*
  * Try to validate S3 auth against keystone s3token interface
  */
 std::pair<boost::optional<rgw::keystone::TokenEnvelope>, int>
-EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_view& access_key_id,
-                             const std::string& string_to_sign,
-                             const std::string_view& signature,
-                             optional_yield y) const
+EC2Engine::get_from_keystone(
+    const DoutPrefixProvider* dpp,
+    const std::string_view& access_key_id,
+    const std::string& string_to_sign,
+    const std::string_view& signature,
+    optional_yield y) const
 {
   /* prepare keystone url */
   std::string keystone_url = config.get_endpoint_url();
@@ -525,16 +580,16 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
   /* get authentication token for Keystone. */
   std::string admin_token;
   bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
-                                                    y, admin_token, admin_token_cached);
+  int ret = rgw::keystone::Service::get_admin_token(
+      dpp, token_cache, config, y, admin_token, admin_token_cached);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: cannot get token for keystone access"
-                  << dendl;
+                      << dendl;
     throw ret;
   }
 
-  using RGWValidateKeystoneToken
-    = rgw::keystone::Service::RGWValidateKeystoneToken;
+  using RGWValidateKeystoneToken =
+      rgw::keystone::Service::RGWValidateKeystoneToken;
 
   /* The container for plain response obtained from Keystone. It will be
    * parsed token_envelope_t::parse method. */
@@ -568,16 +623,16 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
 
   /* if the supplied signature is wrong, we will get 401 from Keystone */
   if (validate.get_http_status() ==
-          decltype(validate)::HTTP_STATUS_UNAUTHORIZED) {
+      decltype(validate)::HTTP_STATUS_UNAUTHORIZED) {
     return std::make_pair(boost::none, -ERR_SIGNATURE_NO_MATCH);
-  } else if (validate.get_http_status() ==
-          decltype(validate)::HTTP_STATUS_NOTFOUND) {
+  } else if (
+      validate.get_http_status() == decltype(validate)::HTTP_STATUS_NOTFOUND) {
     return std::make_pair(boost::none, -ERR_INVALID_ACCESS_KEY);
   }
   // throw any other http or connection errors
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: token validation ERROR: "
-                  << token_body_bl.c_str() << dendl;
+                      << token_body_bl.c_str() << dendl;
     throw ret;
   }
 
@@ -586,18 +641,19 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
   ret = token_envelope.parse(dpp, std::string(), token_body_bl);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: token parsing failed, ret=0" << ret
-                  << dendl;
+                      << dendl;
     throw ret;
   }
 
   return std::make_pair(std::move(token_envelope), 0);
 }
 
-auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
-                                         const std::string& user_id,
-                                         const std::string_view& access_key_id,
-                                         optional_yield y) const
-    -> std::pair<boost::optional<std::string>, int>
+auto
+EC2Engine::get_secret_from_keystone(
+    const DoutPrefixProvider* dpp,
+    const std::string& user_id,
+    const std::string_view& access_key_id,
+    optional_yield y) const -> std::pair<boost::optional<std::string>, int>
 {
   /*  Fetch from /users/{USER_ID}/credentials/OS-EC2/{ACCESS_KEY_ID} */
   /* Should return json with response key "credential" which contains entry "secret"*/
@@ -617,16 +673,15 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   /* get authentication token for Keystone. */
   std::string admin_token;
   bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
-                                                    y, admin_token, admin_token_cached);
+  int ret = rgw::keystone::Service::get_admin_token(
+      dpp, token_cache, config, y, admin_token, admin_token_cached);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: cannot get token for keystone access"
-                  << dendl;
+                      << dendl;
     return make_pair(boost::none, ret);
   }
 
-  using RGWGetAccessSecret
-    = rgw::keystone::Service::RGWKeystoneHTTPTransceiver;
+  using RGWGetAccessSecret = rgw::keystone::Service::RGWKeystoneHTTPTransceiver;
 
   /* The container for plain response obtained from Keystone.*/
   ceph::bufferlist token_body_bl;
@@ -642,22 +697,22 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   ret = secret.process(dpp, y);
 
   /* if the supplied access key isn't found, we will get 404 from Keystone */
-  if (secret.get_http_status() ==
-          decltype(secret)::HTTP_STATUS_NOTFOUND) {
+  if (secret.get_http_status() == decltype(secret)::HTTP_STATUS_NOTFOUND) {
     return make_pair(boost::none, -ERR_INVALID_ACCESS_KEY);
   }
   // return any other http or connection errors
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: secret fetching error: "
-                  << token_body_bl.c_str() << dendl;
+                      << token_body_bl.c_str() << dendl;
     return make_pair(boost::none, ret);
   }
 
   /* now parse response */
 
   JSONParser parser;
-  if (! parser.parse(token_body_bl.c_str(), token_body_bl.length())) {
-    ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed json" << dendl;
+  if (!parser.parse(token_body_bl.c_str(), token_body_bl.length())) {
+    ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed json"
+                      << dendl;
     return make_pair(boost::none, -EINVAL);
   }
 
@@ -668,11 +723,13 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
     if (!credential_iter.end()) {
       JSONDecoder::decode_json("secret", secret_string, *credential_iter, true);
     } else {
-      ldpp_dout(dpp, 0) << "Keystone credential not present in return from server" << dendl;
+      ldpp_dout(dpp, 0)
+          << "Keystone credential not present in return from server" << dendl;
       return make_pair(boost::none, -EINVAL);
     }
   } catch (const JSONDecoder::err& err) {
-    ldpp_dout(dpp, 0) << "Keystone credential parse error: " << err.what() << dendl;
+    ldpp_dout(dpp, 0) << "Keystone credential parse error: " << err.what()
+                      << dendl;
     return make_pair(boost::none, -EINVAL);
   }
 
@@ -682,14 +739,15 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
 /*
  * Try to get a token for S3 authentication, using a secret cache if available
  */
-auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
-                                 const std::string_view& access_key_id,
-                                 const std::string& string_to_sign,
-                                 const std::string_view& signature,
-                                 const signature_factory_t& signature_factory,
-                                 bool ignore_signature,
-                                 optional_yield y) const
-    -> access_token_result
+auto
+EC2Engine::get_access_token(
+    const DoutPrefixProvider* dpp,
+    const std::string_view& access_key_id,
+    const std::string& string_to_sign,
+    const std::string_view& signature,
+    const signature_factory_t& signature_factory,
+    bool ignore_signature,
+    optional_yield y) const -> access_token_result
 {
   using server_signature_t = VersionAbstractor::server_signature_t;
   boost::optional<rgw::keystone::TokenEnvelope> token;
@@ -697,8 +755,8 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
   int failure_reason;
 
   /* Get a token from the cache if one has already been stored */
-  boost::optional<boost::tuple<rgw::keystone::TokenEnvelope, std::string>>
-    t = secret_cache.find(std::string(access_key_id));
+  boost::optional<boost::tuple<rgw::keystone::TokenEnvelope, std::string>> t =
+      secret_cache.find(std::string(access_key_id));
 
   /* Check that credentials can correctly be used to sign data */
   if (t) {
@@ -709,11 +767,14 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
       return {t->get<0>(), t->get<1>(), 0};
     } else {
       std::string sig(signature);
-      server_signature_t server_signature = signature_factory(cct, t->get<1>(), string_to_sign);
+      server_signature_t server_signature =
+          signature_factory(cct, t->get<1>(), string_to_sign);
       if (sig.compare(server_signature) == 0) {
         return {t->get<0>(), t->get<1>(), 0};
       } else {
-        ldpp_dout(dpp, 0) << "Secret string does not correctly sign payload, cache miss" << dendl;
+        ldpp_dout(dpp, 0)
+            << "Secret string does not correctly sign payload, cache miss"
+            << dendl;
       }
     }
   } else {
@@ -747,13 +808,12 @@ EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t&) const
 }
 
 EC2Engine::auth_info_t
-EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
-                          const std::vector<std::string>& admin_roles,
-                          const std::string& access_key_id
-                         ) const noexcept
+EC2Engine::get_creds_info(
+    const EC2Engine::token_envelope_t& token,
+    const std::vector<std::string>& admin_roles,
+    const std::string& access_key_id) const noexcept
 {
-  using acct_privilege_t = \
-    rgw::auth::RemoteApplier::AuthInfo::acct_privilege_t;
+  using acct_privilege_t = rgw::auth::RemoteApplier::AuthInfo::acct_privilege_t;
 
   /* Check whether the user has an admin status. */
   acct_privilege_t level = acct_privilege_t::IS_PLAIN_ACCT;
@@ -791,21 +851,23 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
   };
 }
 
-rgw::auth::Engine::result_t EC2Engine::authenticate(
-  const DoutPrefixProvider* dpp,
-  const std::string_view& access_key_id,
-  const std::string_view& signature,
-  const std::string_view& session_token,
-  const string_to_sign_t& string_to_sign,
-  const signature_factory_t& signature_factory,
-  const completer_factory_t& completer_factory,
-  const req_state* s,
-  optional_yield y) const
+rgw::auth::Engine::result_t
+EC2Engine::authenticate(
+    const DoutPrefixProvider* dpp,
+    const std::string_view& access_key_id,
+    const std::string_view& signature,
+    const std::string_view& session_token,
+    const string_to_sign_t& string_to_sign,
+    const signature_factory_t& signature_factory,
+    const completer_factory_t& completer_factory,
+    const req_state* s,
+    optional_yield y) const
 {
   /* This will be initialized on the first call to this method. In C++11 it's
    * also thread-safe. */
   static const struct RolesCacher {
-    explicit RolesCacher(CephContext* const cct) {
+    explicit RolesCacher(CephContext* const cct)
+    {
       get_str_vec(cct->_conf->rgw_keystone_accepted_roles, plain);
       get_str_vec(cct->_conf->rgw_keystone_accepted_admin_roles, admin);
 
@@ -820,10 +882,10 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
   /* When we handle a HTTP OPTIONS call we must ignore the signature */
   bool ignore_signature = (s->op_type == RGW_OP_OPTIONS_CORS);
 
-  auto [t, secret_key, failure_reason] =
-    get_access_token(dpp, access_key_id, string_to_sign,
-                     signature, signature_factory, ignore_signature, y);
-  if (! t) {
+  auto [t, secret_key, failure_reason] = get_access_token(
+      dpp, access_key_id, string_to_sign, signature, signature_factory,
+      ignore_signature, y);
+  if (!t) {
     if (failure_reason == -ERR_SIGNATURE_NO_MATCH) {
       // we looked up a secret but it didn't generate the same signature as
       // the client. since we found this access key in keystone, we should
@@ -835,9 +897,9 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
 
   /* Verify expiration. */
   if (t->expired()) {
-    ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name()
-                  << ":" << t->get_user_name()
-                  << " expired: " << t->get_expires() << dendl;
+    ldpp_dout(dpp, 0) << "got expired token: " << t->get_project_name() << ":"
+                      << t->get_user_name() << " expired: " << t->get_expires()
+                      << dendl;
     return result_t::deny();
   }
 
@@ -850,26 +912,29 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
     }
   }
 
-  if (! found) {
+  if (!found) {
     ldpp_dout(dpp, 5) << "s3 keystone: user does not hold a matching role;"
-                     " required roles: "
-                  << cct->_conf->rgw_keystone_accepted_roles << dendl;
+                         " required roles: "
+                      << cct->_conf->rgw_keystone_accepted_roles << dendl;
     return result_t::deny();
   } else {
     /* everything seems fine, continue with this user */
-    ldpp_dout(dpp, 5) << "s3 keystone: validated token: " << t->get_project_name()
-                  << ":" << t->get_user_name()
-                  << " expires: " << t->get_expires() << dendl;
+    ldpp_dout(dpp, 5) << "s3 keystone: validated token: "
+                      << t->get_project_name() << ":" << t->get_user_name()
+                      << " expires: " << t->get_expires() << dendl;
 
-    auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
-                                              get_creds_info(*t, accepted_roles.admin, std::string(access_key_id)));
+    auto apl = apl_factory->create_apl_remote(
+        cct, s, get_acl_strategy(*t),
+        get_creds_info(*t, accepted_roles.admin, std::string(access_key_id)));
     return result_t::grant(std::move(apl), completer_factory(secret_key));
   }
 }
 
-bool SecretCache::find(const std::string& token_id,
-                       SecretCache::token_envelope_t& token,
-		       std::string &secret)
+bool
+SecretCache::find(
+    const std::string& token_id,
+    SecretCache::token_envelope_t& token,
+    std::string& secret)
 {
   std::lock_guard<std::mutex> l(lock);
 
@@ -895,9 +960,11 @@ bool SecretCache::find(const std::string& token_id,
   return true;
 }
 
-void SecretCache::add(const std::string& token_id,
-                      const SecretCache::token_envelope_t& token,
-		      const std::string& secret)
+void
+SecretCache::add(
+    const std::string& token_id,
+    const SecretCache::token_envelope_t& token,
+    const std::string& secret)
 {
   std::lock_guard<std::mutex> l(lock);
 

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -77,6 +77,12 @@ public:
   }
 }; /* class TokenEngine */
 
+class Identity : public rgw::auth::Identity {
+public:
+  // Virtual getter to access the token from the Swift handler
+  virtual const rgw::keystone::TokenEnvelope& get_token_envelope() const = 0;
+};
+
 class SecretCache {
   using token_envelope_t = rgw::keystone::TokenEnvelope;
 

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -77,11 +77,12 @@ public:
   }
 }; /* class TokenEngine */
 
-class Identity : public rgw::auth::Identity {
-public:
-  // Virtual getter to access the token from the Swift handler
-  virtual const rgw::keystone::TokenEnvelope& get_token_envelope() const = 0;
-};
+bool path_matches_pattern(std::string_view pattern, std::string_view path);
+
+bool check_access_rules(const DoutPrefixProvider* dpp,
+                        const std::vector<rgw::keystone::TokenEnvelope::AccessRule>& rules,
+                        std::string_view method,
+                        std::string_view path);
 
 class SecretCache {
   using token_envelope_t = rgw::keystone::TokenEnvelope;

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -466,6 +466,13 @@ void rgw::keystone::TokenEnvelope::Role::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("name", name, obj, true);
 }
 
+void rgw::keystone::TokenEnvelope::AccessRule::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("service", service, obj);
+  JSONDecoder::decode_json("method", method, obj);
+  JSONDecoder::decode_json("path", path, obj);
+}
+
 void rgw::keystone::TokenEnvelope::Domain::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("id", id, obj, true);
@@ -506,6 +513,10 @@ void rgw::keystone::TokenEnvelope::decode(JSONObj* const root_obj)
   ApplicationCredential tmp_app_cred;
   if (JSONDecoder::decode_json("application_credential", tmp_app_cred, root_obj, false)) {
     app_cred = std::move(tmp_app_cred);
+  // Parse application_credential.access_rules if present
+  JSONObjIter app_cred_iter = root_obj->find_first("application_credential");
+  if (!app_cred_iter.end()) {
+    JSONDecoder::decode_json("access_rules", access_rules, *app_cred_iter);
   }
 
   struct tm t;

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -513,10 +513,10 @@ void rgw::keystone::TokenEnvelope::decode(JSONObj* const root_obj)
   ApplicationCredential tmp_app_cred;
   if (JSONDecoder::decode_json("application_credential", tmp_app_cred, root_obj, false)) {
     app_cred = std::move(tmp_app_cred);
-  // Parse application_credential.access_rules if present
-  JSONObjIter app_cred_iter = root_obj->find_first("application_credential");
-  if (!app_cred_iter.end()) {
-    JSONDecoder::decode_json("access_rules", access_rules, *app_cred_iter);
+    JSONObjIter app_cred_iter = root_obj->find_first("application_credential");
+    if (!app_cred_iter.end()) {
+      JSONDecoder::decode_json("access_rules", access_rules, *app_cred_iter);
+    }
   }
 
   struct tm t;

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -498,6 +498,10 @@ void rgw::keystone::TokenEnvelope::ApplicationCredential::decode_json(JSONObj *o
   JSONDecoder::decode_json("id", id, obj, true);
   JSONDecoder::decode_json("name", name, obj, true);
   JSONDecoder::decode_json("restricted", restricted, obj, true);
+  // access_rules is nested under application_credential in the Keystone
+  // response, and only present when the OpenStack-Identity-Access-Rules
+  // request header was sent.
+  JSONDecoder::decode_json("access_rules", access_rules, obj, false);
 }
 
 void rgw::keystone::TokenEnvelope::decode(JSONObj* const root_obj)
@@ -513,10 +517,6 @@ void rgw::keystone::TokenEnvelope::decode(JSONObj* const root_obj)
   ApplicationCredential tmp_app_cred;
   if (JSONDecoder::decode_json("application_credential", tmp_app_cred, root_obj, false)) {
     app_cred = std::move(tmp_app_cred);
-    JSONObjIter app_cred_iter = root_obj->find_first("application_credential");
-    if (!app_cred_iter.end()) {
-      JSONDecoder::decode_json("access_rules", access_rules, *app_cred_iter);
-    }
   }
 
   struct tm t;

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -163,6 +163,15 @@ public:
     bool is_admin;
     bool is_reader;
     void decode_json(JSONObj *obj);
+
+  // OpenStack Application Credential Access Rule (for access rule filtering).
+  class AccessRule {
+  public:
+    std::string service;  // e.g., "object-store"
+    std::string method;   // HTTP method: GET, PUT, POST, DELETE, HEAD
+    std::string path;     // URL path pattern with glob support
+    void decode_json(JSONObj *obj);
+  };
   };
 
   class User {
@@ -187,6 +196,7 @@ public:
   User user;
   std::list<Role> roles;
   std::optional<ApplicationCredential> app_cred;
+  std::vector<AccessRule> access_rules;
 
   void decode(JSONObj* obj);
 
@@ -203,6 +213,8 @@ public:
   const std::string& get_user_id() const {return user.id;};
   const std::string& get_user_name() const {return user.name;};
   bool has_role(const std::string& r) const;
+  const std::vector<AccessRule>& get_access_rules() const { return access_rules; }
+  bool has_access_rules() const { return !access_rules.empty(); }
   bool expired() const {
     const uint64_t now = ceph_clock_now().sec();
     return std::cmp_greater_equal(now, get_expires());

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -164,12 +164,11 @@ public:
     bool is_reader;
     void decode_json(JSONObj *obj);
 
-  // OpenStack Application Credential Access Rule (for access rule filtering).
   class AccessRule {
   public:
-    std::string service;  // e.g., "object-store"
-    std::string method;   // HTTP method: GET, PUT, POST, DELETE, HEAD
-    std::string path;     // URL path pattern with glob support
+    std::string service;
+    std::string method;
+    std::string path;
     void decode_json(JSONObj *obj);
   };
   };

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -163,14 +163,14 @@ public:
     bool is_admin;
     bool is_reader;
     void decode_json(JSONObj *obj);
-
+  };
+  
   class AccessRule {
   public:
     std::string service;
     std::string method;
     std::string path;
     void decode_json(JSONObj *obj);
-  };
   };
 
   class User {
@@ -213,7 +213,6 @@ public:
   const std::string& get_user_name() const {return user.name;};
   bool has_role(const std::string& r) const;
   const std::vector<AccessRule>& get_access_rules() const { return access_rules; }
-  bool has_access_rules() const { return !access_rules.empty(); }
   bool expired() const {
     const uint64_t now = ceph_clock_now().sec();
     return std::cmp_greater_equal(now, get_expires());

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -187,6 +187,7 @@ public:
     std::string id;
     std::string name;
     bool restricted;
+    std::vector<AccessRule> access_rules;
     void decode_json(JSONObj *obj);
   };
 
@@ -195,7 +196,6 @@ public:
   User user;
   std::list<Role> roles;
   std::optional<ApplicationCredential> app_cred;
-  std::vector<AccessRule> access_rules;
 
   void decode(JSONObj* obj);
 
@@ -212,7 +212,10 @@ public:
   const std::string& get_user_id() const {return user.id;};
   const std::string& get_user_name() const {return user.name;};
   bool has_role(const std::string& r) const;
-  const std::vector<AccessRule>& get_access_rules() const { return access_rules; }
+  const std::vector<AccessRule>& get_access_rules() const {
+    static const std::vector<AccessRule> empty;
+    return app_cred ? app_cred->access_rules : empty;
+  }
   bool expired() const {
     const uint64_t now = ceph_clock_now().sec();
     return std::cmp_greater_equal(now, get_expires());

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2939,28 +2939,7 @@ int RGWHandler_REST_SWIFT::authorize(const DoutPrefixProvider *dpp, optional_yie
   if (ret < 0) {
     return ret;
   }
-  // Check for Keystone Application Credentials Access Rules
-  auto keystone_identity = dynamic_cast<rgw::auth::keystone::Identity*>(s->auth.identity.get());
-  if (keystone_identity) {
-    const auto& token = keystone_identity->get_token_envelope();
-    // Only enforce if the token actually has access rules (is a restricted app cred)
-    if (token.has_access_rules()) {
-      //match path and remove query params
-      std::string_view path = s->decoded_uri;
-      size_t pos = path.find('?');
-      if (pos != std::string_view::npos) {
-        path = path.substr(0, pos);
-      }
-      // Enforce access rules
-      if (!rgw::auth::keystone::check_access_rules(dpp, s->cct, 
-                                                   token.get_access_rules(), 
-                                                   s->info.method, path)) {
-        ldpp_dout(dpp, 0) << "Keystone Access Rules: request denied for method=" 
-                          << s->info.method << " path=" << path << dendl;
-        return -EACCES; // Returns 403 Forbidden
-      }
-    }
-  }
+  /* Keystone Application Credentials Access Rules already enforced in TokenEngine */
 
   return 0;
 }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2932,10 +2932,37 @@ RGWOp *RGWHandler_REST_Obj_SWIFT::op_options()
   return new RGWOptionsCORS_ObjStore_SWIFT;
 }
 
-
 int RGWHandler_REST_SWIFT::authorize(const DoutPrefixProvider *dpp, optional_yield y)
 {
-  return rgw::auth::Strategy::apply(dpp, auth_strategy, s, y);
+
+  int ret = rgw::auth::Strategy::apply(dpp, auth_strategy, s, y);
+  if (ret < 0) {
+    return ret;
+  }
+  // Check for Keystone Application Credentials Access Rules
+  auto keystone_identity = dynamic_cast<rgw::auth::keystone::Identity*>(s->auth.identity.get());
+  if (keystone_identity) {
+    const auto& token = keystone_identity->get_token_envelope();
+    // Only enforce if the token actually has access rules (is a restricted app cred)
+    if (token.has_access_rules()) {
+      //match path and remove query params
+      std::string_view path = s->decoded_uri;
+      size_t pos = path.find('?');
+      if (pos != std::string_view::npos) {
+        path = path.substr(0, pos);
+      }
+      // Enforce access rules
+      if (!rgw::auth::keystone::check_access_rules(dpp, s->cct, 
+                                                   token.get_access_rules(), 
+                                                   s->info.method, path)) {
+        ldpp_dout(dpp, 0) << "Keystone Access Rules: request denied for method=" 
+                          << s->info.method << " path=" << path << dendl;
+        return -EACCES; // Returns 403 Forbidden
+      }
+    }
+  }
+
+  return 0;
 }
 
 int RGWHandler_REST_SWIFT::postauth_init(optional_yield y)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -342,6 +342,13 @@ target_include_directories(unittest_rgw_kms_cache
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_kms_cache ${rgw_libs})
 
+# unittest_rgw_keystone
+add_executable(unittest_rgw_keystone test_rgw_auth_keystone.cc)
+add_ceph_unittest(unittest_rgw_keystone)
+target_include_directories(unittest_rgw_keystone
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_keystone ${rgw_libs})
+
 # unittest_rgw_url
 add_executable(unittest_rgw_url test_rgw_url.cc)
 add_ceph_unittest(unittest_rgw_url)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -387,6 +387,13 @@ target_include_directories(unittest_rgw_kms_cache
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_kms_cache ${rgw_libs})
 
+# unittest_rgw_keystone
+add_executable(unittest_rgw_keystone test_rgw_auth_keystone.cc)
+add_ceph_unittest(unittest_rgw_keystone)
+target_include_directories(unittest_rgw_keystone
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_keystone ${rgw_libs})
+
 # unittest_rgw_url
 add_executable(unittest_rgw_url test_rgw_url.cc)
 add_ceph_unittest(unittest_rgw_url)

--- a/src/test/rgw/test_rgw_auth_keystone.cc
+++ b/src/test/rgw/test_rgw_auth_keystone.cc
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+#include "rgw/rgw_keystone.h"
+#include "rgw/rgw_auth_keystone.h"
+
+using rgw::keystone::TokenEnvelope;
+
+namespace rgw::auth::keystone {
+
+TEST(RGWKeystoneAuth, PathMatchesPattern)
+{
+  struct Case {
+    std::string pattern;
+    std::string path;
+    bool expected;
+  };
+
+  const std::vector<Case> cases = {
+    {"/v1/a/c", "/v1/a/c", true},
+    {"/v1/a/c", "/v1/a/d", false},
+    {"/v1/*/c", "/v1/a/c", true},
+    {"/v1/*/c", "/v1/a/d", false},
+    /* single * must not cross a / */
+    {"/v1/*/c", "/v1/a/b/c", false},
+    {"/v1/**", "/v1/a/c", true},
+    {"/v1/**", "/v1/a/b/c", true},
+    {"/v1/**", "/v2/a/b/c", false},
+    /* trailing slash in pattern */
+    {"/v1/**/", "/v1/a/b", true},
+    {"*", "/anything", true},
+    /* empty pattern / path edge cases */
+    {"", "", true},
+    {"/v1", "/v1", true},
+    {"/v1", "/v1/extra", false},
+  };
+
+  for (const auto& tc : cases) {
+    SCOPED_TRACE(tc.pattern + " vs " + tc.path);
+    ASSERT_EQ(tc.expected, path_matches_pattern(tc.pattern, tc.path));
+  }
+}
+
+TEST(RGWKeystoneAuth, CheckAccessRules)
+{
+  std::vector<TokenEnvelope::AccessRule> rules;
+  rules.push_back({"object-store", "GET", "/v1/*"});
+  rules.push_back({"compute", "GET", "/v1/*"});
+
+  ASSERT_TRUE(check_access_rules(nullptr, rules, "GET", "/v1/a"));
+  ASSERT_FALSE(check_access_rules(nullptr, rules, "PUT", "/v1/a"));
+  ASSERT_FALSE(check_access_rules(nullptr, rules, "GET", "/v2/a"));
+
+  /* empty rules = no restriction (regular token, not app cred) */
+  std::vector<TokenEnvelope::AccessRule> empty_rules;
+  ASSERT_TRUE(check_access_rules(nullptr, empty_rules, "GET", "/v1/a"));
+  ASSERT_TRUE(check_access_rules(nullptr, empty_rules, "DELETE", "/anything"));
+}
+
+} // namespace rgw::auth::keystone


### PR DESCRIPTION


This PR adds support for Keystone Application Credential Access Rules. It allows RGW to respect and enforce the method/path restrictions defined on restricted OpenStack tokens.

Key Changes
Enforcement: Added check_access_rules in rgw_auth_keystone.cc to validate the request method and path against the token’s rules. It supports wildcard matching (* and **).

Swift Support: Updated the Swift REST handler to trigger these checks during authorization.

Keystone Integration: RGW now sends the OpenStack-Identity-Access-Rules: 1.0 header during token validation and handles the access_rules JSON in the response.

New Configs:

rgw_keystone_verify_access_rules: Toggle enforcement (default: true).

rgw_keystone_accepted_service_types: Filter rules by service type (default: object-store, swift).

fixes: https://tracker.ceph.com/issues/69948
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
