### PR TITLE
rgw/notification: notification Event is not printing the correct  x_amz_request_id.

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -9,6 +9,8 @@
     Configuration file syntax follows the OpenSSL standard (see https://github.com/openssl/openssl/blob/master/doc/man5/config.pod).
     If the default provider is required when also using custom providers,
     it must be explicitly loaded in the configuration file or code (see https://github.com/openssl/openssl/blob/master/README-PROVIDERS.md).
+* RGW: Fixed bucket notification events so the 'x_amz_request_id' in NotificationEvent now matches the 'x_amz_request_id' returned by the corresponding S3 operation.
+
 
 * DASHBOARD: Removed the older landing page which was deprecated in Quincy.
   Admins can no longer enable the older, deprecated landing page layout by

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -38,14 +38,15 @@ static inline std::ostream& operator<<(std::ostream& out,
   std::string user;
   std::string password;
   parse_url_authority(e.push_endpoint, host, user, password);
-  return out << "notification id: '" << e.event.configurationId
-             << "', topic: '" << e.arn_topic
-             << "', endpoint: '" << host
-             << "', endpoint_user: '" << user
-             << "', bucket_owner: '" << e.event.bucket_ownerIdentity
-             << "', bucket: '" << e.event.bucket_name
-             << "', object: '" << e.event.object_key
-             << "', event type: '" << e.event.eventName << "'";
+  return out << "notification id=" << e.event.configurationId
+             << " topic=" << e.arn_topic << " endpoint=" << host
+             << " endpoint_user=" << user
+             << " bucket_owner=" << e.event.bucket_ownerIdentity
+             << " bucket=" << e.event.bucket_name
+             << " object=" << e.event.object_key
+             << " object_versionId=" << e.event.object_versionId
+             << " x_amz_request_id=" << e.event.x_amz_request_id
+             << " event type=" << e.event.eventName;
 }
 
 struct persistency_tracker {
@@ -258,13 +259,14 @@ private:
     ret = push_endpoint->send(this, event_entry.event, yield);
     if (ret < 0) {
       ldpp_dout(this, 5) << "WARNING: push entry marker: " << entry.marker
-                         << " failed. error: " << ret
+                         << " failed."
                          << " (will retry) for event with " << event_entry
-                         << dendl;
+                         << " ret=" << ret << dendl;
       return EntryProcessingResult::Failure;
     }
     ldpp_dout(this, 5) << "INFO: push entry marker: " << entry.marker
-                       << " ok for event with " << event_entry << dendl;
+                       << " ok for event with " << event_entry << " ret=" << ret
+                       << dendl;
     if (perfcounter)
       perfcounter->inc(l_rgw_pubsub_push_ok);
     return EntryProcessingResult::Successful;
@@ -1394,7 +1396,7 @@ reservation_t::reservation_t(const DoutPrefixProvider* _dpp,
   metadata_fetched_from_attributes(false),
   user_id(to_string(_s->owner.id)),
   user_tenant(_s->user->get_id().tenant),
-  req_id(_s->req_id),
+  req_id(_s->trans_id),
   yield(y)
 {
   filter_amz_meta(x_meta_map, _s->info.x_meta_map);

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -391,7 +391,7 @@ class RGWPSCreateTopicOp : public RGWOp {
     encode_xml("TopicArn", topic_arn.to_string(), f);
     f->close_section(); // CreateTopicResult
     f->open_object_section("ResponseMetadata");
-    encode_xml("RequestId", s->req_id, f); 
+    encode_xml("RequestId", s->trans_id, f);
     f->close_section(); // ResponseMetadata
     f->close_section(); // CreateTopicResponse
     rgw_flush_formatter_and_reset(s, f);
@@ -501,7 +501,7 @@ public:
     encode_xml("Topics", result, f); 
     f->close_section(); // ListTopicsResult
     f->open_object_section("ResponseMetadata");
-    encode_xml("RequestId", s->req_id, f); 
+    encode_xml("RequestId", s->trans_id, f);
     f->close_section(); // ResponseMetadata
     if (!next_token.empty()) {
       encode_xml("NextToken", next_token, f);
@@ -626,7 +626,7 @@ class RGWPSGetTopicOp : public RGWOp {
     encode_xml("Topic", result, f); 
     f->close_section();
     f->open_object_section("ResponseMetadata");
-    encode_xml("RequestId", s->req_id, f); 
+    encode_xml("RequestId", s->trans_id, f);
     f->close_section();
     f->close_section();
     rgw_flush_formatter_and_reset(s, f);
@@ -712,7 +712,7 @@ class RGWPSGetTopicAttributesOp : public RGWOp {
     result.dump_xml_as_attributes(f);
     f->close_section(); // GetTopicAttributesResult
     f->open_object_section("ResponseMetadata");
-    encode_xml("RequestId", s->req_id, f); 
+    encode_xml("RequestId", s->trans_id, f);
     f->close_section(); // ResponseMetadata
     f->close_section(); // GetTopicAttributesResponse
     rgw_flush_formatter_and_reset(s, f);
@@ -877,7 +877,7 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
     const auto f = s->formatter;
     f->open_object_section_in_ns("SetTopicAttributesResponse", RGW_REST_SNS_XMLNS);
     f->open_object_section("ResponseMetadata");
-    encode_xml("RequestId", s->req_id, f);
+    encode_xml("RequestId", s->trans_id, f);
     f->close_section();  // ResponseMetadata
     f->close_section();  // SetTopicAttributesResponse
     rgw_flush_formatter_and_reset(s, f);
@@ -1032,7 +1032,7 @@ class RGWPSDeleteTopicOp : public RGWOp {
     const auto f = s->formatter;
     f->open_object_section_in_ns("DeleteTopicResponse", RGW_REST_SNS_XMLNS);
     f->open_object_section("ResponseMetadata");
-    encode_xml("RequestId", s->req_id, f); 
+    encode_xml("RequestId", s->trans_id, f);
     f->close_section(); // ResponseMetadata
     f->close_section(); // DeleteTopicResponse
     rgw_flush_formatter_and_reset(s, f);

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -5843,3 +5843,91 @@ def test_persistent_sharded_topic_config_change_kafka():
     new_num_shards = random.randint(2, 10)
     default_num_shards = 11
     persistent_notification_shard_config_change('kafka', conn, new_num_shards, default_num_shards)
+
+
+@pytest.mark.basic_test
+def test_ps_s3_x_amz_request_id_on_master():
+    """ test that the x-amz-request-id in the notification event matches
+    the x-amz-request-id returned in the S3 put_object and delete_object responses.
+    Uses a persistent topic with a wrong endpoint so events stay in the queue,
+    then uses 'topic dump' to inspect the event entries. """
+    conn = connection()
+    zonegroup = get_config_zonegroup()
+
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = conn.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+
+    # create s3 topic with a wrong endpoint so events are queued and not delivered
+    endpoint_address = 'http://WrongHost:1234'
+    endpoint_args = 'push-endpoint=' + endpoint_address + '&persistent=true'
+    topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
+
+    # create s3 notification for creation and deletion events
+    notification_name = bucket_name + NOTIFICATION_SUFFIX
+    topic_conf_list = [{
+        'Id': notification_name,
+        'TopicArn': topic_arn,
+        'Events': ['s3:ObjectCreated:*', 's3:ObjectRemoved:*']
+    }]
+    s3_notification_conf = PSNotificationS3(conn, bucket_name, topic_conf_list)
+    _, status = s3_notification_conf.set_config()
+    assert status // 100 == 2
+
+    # use boto3 client for S3 operations to capture x-amz-request-id from responses
+    client = boto3.client(
+        's3',
+        endpoint_url='http://' + conn.host + ':' + str(conn.port),
+        aws_access_key_id=conn.aws_access_key_id,
+        aws_secret_access_key=conn.aws_secret_access_key,
+    )
+
+    # put object and capture x-amz-request-id from the response
+    key_name = 'test_request_id_key'
+    put_response = client.put_object(Bucket=bucket_name, Key=key_name, Body=b'hello world')
+    put_request_id = put_response['ResponseMetadata']['HTTPHeaders'].get('x-amz-request-id', '')
+    assert put_request_id, "put_object response missing x-amz-request-id"
+
+    # delete object and capture x-amz-request-id from the response
+    delete_response = client.delete_object(Bucket=bucket_name, Key=key_name)
+    delete_request_id = delete_response['ResponseMetadata']['HTTPHeaders'].get('x-amz-request-id', '')
+    assert delete_request_id, "delete_object response missing x-amz-request-id"
+
+    # the put and delete request ids should be different
+    assert put_request_id != delete_request_id
+
+    # wait for events to be queued
+    time.sleep(5)
+
+    # dump the persistent topic entries and verify x-amz-request-id
+    result = admin(['topic', 'dump', '--topic', topic_name], get_config_cluster())
+    assert result[1] == 0
+    parsed_result = json.loads(result[0])
+    assert len(parsed_result) == 2
+
+    # find creation and deletion events from the dump
+    # note: topic dump eventName does not have the 's3:' prefix
+    creation_event = None
+    deletion_event = None
+    for entry in parsed_result:
+        event = entry['entry']['event']
+        if event['eventName'].startswith('ObjectCreated'):
+            creation_event = event
+        elif event['eventName'].startswith('ObjectRemoved'):
+            deletion_event = event
+
+    assert creation_event is not None, "creation event not found in topic dump"
+    assert deletion_event is not None, "deletion event not found in topic dump"
+
+    # verify creation event x-amz-request-id matches the put_object response
+    assert creation_event['responseElements']['x-amz-request-id'] == put_request_id
+
+    # verify deletion event x-amz-request-id matches the delete_object response
+    assert deletion_event['responseElements']['x-amz-request-id'] == delete_request_id
+
+    # cleanup
+    s3_notification_conf.del_config()
+    topic_conf.del_config()
+    conn.delete_bucket(bucket_name)


### PR DESCRIPTION

 Fixes: https://tracker.ceph.com/issues/75412
Fixes: https://tracker.ceph.com/issues/75417

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
