### PR TITLE
mgr/dashboard: Fix flaky teuthology test failure

### DIFF
--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -30,22 +30,43 @@ class MgrModuleTestCase(DashboardTestCase):
                 if self._resp.status_code == 200:
                     return True
             except (MaxRetryError, requests.ConnectionError):
-                pass
+                return False
             return False
 
-        self.wait_until_true(_check_connection, timeout=30)
+        self.wait_until_true(_check_connection, timeout=30, period=2)
+
+    def wait_until_mgr_module_state(self, module_name, enabled, timeout=60):
+        """
+        Wait until the mgr CLI reports the requested module state.
+        """
+
+        def _check():
+            try:
+                data = self._ceph_cmd(['mgr', 'module', 'ls'])
+                logger.info("mgr module ls returned: %s", data)
+
+                enabled_modules = data.get('enabled_modules', [])
+                disabled_modules = data.get('disabled_modules', [])
+
+                if enabled:
+                    return module_name in enabled_modules
+
+                return module_name in disabled_modules or module_name not in enabled_modules
+            except Exception as ex:  # pylint: disable=broad-except
+                logger.warning("Error checking mgr module state for %s: %s",
+                               module_name, ex)
+                return False
+
+        self.wait_until_true(_check, timeout=timeout, period=2)
 
 
 class MgrModuleTest(MgrModuleTestCase):
 
     def test_list_disabled_module(self):
         self._ceph_cmd(['mgr', 'module', 'disable', 'iostat'], wait=3)
-        data = self._get(
-            '/api/mgr/module',
-            retries=1,
-            wait_func=lambda:  # pylint: disable=unnecessary-lambda
-            self.wait_until_rest_api_accessible()
-        )
+        self.wait_until_mgr_module_state('iostat', False, timeout=90)
+        self.wait_until_rest_api_accessible()
+        data = self._get('/api/mgr/module', retries=3)
         self.assertStatus(200)
         self.assertSchema(
             data,
@@ -62,12 +83,9 @@ class MgrModuleTest(MgrModuleTestCase):
 
     def test_list_enabled_module(self):
         self._ceph_cmd(['mgr', 'module', 'enable', 'iostat'], wait=3)
-        data = self._get(
-            '/api/mgr/module',
-            retries=1,
-            wait_func=lambda:  # pylint: disable=unnecessary-lambda
-            self.wait_until_rest_api_accessible()
-        )
+        self.wait_until_mgr_module_state('iostat', True, timeout=90)
+        self.wait_until_rest_api_accessible()
+        data = self._get('/api/mgr/module', retries=3)
         self.assertStatus(200)
         self.assertSchema(
             data,


### PR DESCRIPTION
this issue happens when iostat module enabled -> mgr respawned -> dashboard restart (attempts to bind to 8443) -> Port 8443 unavailable -> and API cant access.

This appears to be a mgr/dashboard restart readiness flake triggered by module enable/disable. I’d first increase the readiness timeout and wait for the API/module state to converge.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
