### PR TITLE
 rgw: Policy evalaution logging

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -36,6 +36,8 @@
   - The `rgw default data log backing` option is removed and it is no longer
     possible to create clusters with an omap based datalog.
   - `radosgw-admin datalog type` will only accept `--log_type=fifo`.
+* RGW: iam:RemoveClientIdFromOIDCProvider is now a recognized action for
+  policy, corrected from a typo of iam:RemoveCientIdFromOIDCProvider
 
 * MGR: The default values of ``mon_target_pg_per_osd`` and ``mon_max_pg_per_osd``
   have been increased from 100 and 250 to 200 and 500, respectively. These values

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2620,8 +2620,10 @@ fi
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
 %{_bindir}/rgw-policy-check
+%{_bindir}/rgw-policy-test
 %{_mandir}/man8/radosgw.8*
 %{_mandir}/man8/rgw-policy-check.8*
+%{_mandir}/man8/rgw-policy-test.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -23,6 +23,7 @@ usr/bin/rgw-gap-list
 usr/bin/rgw-gap-list-comparator
 usr/bin/rgw-orphan-list
 usr/bin/rgw-policy-check
+usr/bin/rgw-policy-test
 usr/bin/rgw-restore-bucket-index
 usr/bin/rbd
 usr/bin/rbdmap
@@ -44,6 +45,7 @@ usr/share/man/man8/mount.ceph.8
 usr/share/man/man8/rados.8
 usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/rgw-policy-check.8
+usr/share/man/man8/rgw-policy-test.8
 usr/share/man/man8/rgw-gap-list.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8

--- a/doc/man/8/CMakeLists.txt
+++ b/doc/man/8/CMakeLists.txt
@@ -61,6 +61,7 @@ if(WITH_RADOSGW)
 	rgw-orphan-list.rst
 	rgw-gap-list.rst
 	rgw-policy-check.rst
+	rgw-policy-test.rst
 	ceph-diff-sorted.rst
 	rgw-restore-bucket-index.rst)
 endif()

--- a/doc/man/8/rgw-policy-test.rst
+++ b/doc/man/8/rgw-policy-test.rst
@@ -1,0 +1,65 @@
+:orphan:
+
+===================================================
+rgw-policy-test -- test evaluation of bucket policy
+===================================================
+
+.. program:: rgw-policy-test
+
+Synopsis
+========
+
+| **rgw-policy-test**
+   [-e *key*=*value*]... [-t *tenant*] [-R resource] [-I identity] *action* *filename* 
+
+
+Description
+===========
+
+This utility reads a policy from a file or stdin and evaluates it
+against the supplied identity, resource, action, and request context
+(the key/value pairs evaluated by conditions.) The utility will print
+a trace of evaluating the policy and the effect of its evaluation.
+
+On error it will print a message and return non-zero.
+
+Options
+=======
+
+.. option:: -t *tenant*, --tenant *tenant*
+
+   Specify *tenant* as the tenant. If not provided, the default
+   (empty) tenant is used.
+
+.. option:: -e *key*=*value*, --environment *key*=*value*
+
+   Add (*key*, *value*) to the environment for evaluation. May be
+   specified multiple times.
+
+.. option:: -I *SCHEMA:STRING*, --identity *SCHEMA:STRING*
+
+   Specify *identity* as the identity whose access is to be checked.
+
+.. option:: -R *ARN*, --resource *ARN*
+
+   Specify *ARN* as the resource for which to check access.
+
+.. option:: *action*
+
+   Use *action* as the action to check.
+
+.. option:: *filename*
+
+   Read the policy from *filename*, or - for standard input.
+
+Availability
+============
+
+**rgw-policy-test** is part of Ceph, a massively scalable, open-source,
+distributed storage system.  Please refer to the Ceph documentation at
+https://docs.ceph.com/ for more information.
+
+See also
+========
+
+:doc:`radosgw <radosgw>`\(8)

--- a/doc/man_index.rst
+++ b/doc/man_index.rst
@@ -48,4 +48,5 @@
    man/8/ceph-immutable-object-cache
    man/8/ceph-diff-sorted
    man/8/rgw-policy-check
+   man/8/rgw-policy-test
    man/8/rgw-restore-bucket-index

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4851,6 +4851,7 @@ options:
   default: 11
   services: 
     - rgw
+
 - name: rgw_usage_log_key_transition
   type: bool
   level: advanced
@@ -4891,3 +4892,14 @@ options:
   desc: When not empty, this value is returned as a response header Access-Control-Expose-Headers.
   services:
   - rgw
+
+- name: rgw_copious_policy_logging
+  type: bool
+  level: advanced
+  desc: Log the details of each policy evaluation in extreme verbosity
+  default: false
+  services:
+  - rgw
+  flags:
+  - runtime
+  with_legacy: true

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -114,6 +114,8 @@ template<class A, class B, class Hash, class KeyEqual>
 inline std::ostream& operator<<(std::ostream& out, const std::unordered_map<A,B,Hash, KeyEqual>& m);
 template<class A, class B, class Comp, class Alloc>
 inline std::ostream& operator<<(std::ostream& out, const std::multimap<A,B,Comp,Alloc>& m);
+template <class Key, class T, class Hash, class KeyEqual, class Alloc>
+inline std::ostream& operator<<(std::ostream& out, const std::unordered_multimap<Key, T, Hash, KeyEqual, Alloc>& m);
 }
 
 namespace boost {
@@ -293,6 +295,22 @@ inline std::ostream& operator<<(std::ostream& out, const std::multimap<A,B,Comp,
   return out;
 }
 
+template<class Key, class T, class Hash, class KeyEqual, class Alloc>
+inline std::ostream&
+operator<<(
+  std::ostream& out,
+  const std::unordered_multimap<Key, T, Hash, KeyEqual, Alloc>& m)
+{
+  out << "{{";
+  for (auto it = m.begin();
+       it != m.end();
+       ++it) {
+    if (it != m.begin()) out << ",";
+    out << it->first << "=" << it->second;
+  }
+  out << "}}";
+  return out;
+}
 } // namespace std
 
 namespace boost {

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -117,6 +117,32 @@ private:
   boost::container::small_vector<char, 1024> str;
 };
 
+class StringEntry : public Entry {
+public:
+  StringEntry() = delete;
+  StringEntry(short pr, short sub, std::string_view prefix)
+      : Entry(pr, sub), str(prefix.begin(), prefix.end()) {}
+  ~StringEntry() override = default;
+
+  StringEntry(const StringEntry&) = default;
+  StringEntry& operator=(const StringEntry&) = default;
+  StringEntry(StringEntry&&) = default;
+  StringEntry& operator=(StringEntry&&) = default;
+
+  std::string_view strv() const override {
+    return std::string_view(str.data(), str.size());
+  }
+  std::size_t size() const override {
+    return str.size();
+  }
+
+  auto get_inserter() {
+    return std::back_inserter(str);
+  }
+
+private:
+  boost::container::small_vector<char, 1024> str;
+};
 }
 }
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -668,6 +668,12 @@ add_executable(rgw-policy-check ${radosgw_polparser_srcs})
 target_link_libraries(rgw-policy-check ${rgw_libs})
 install(TARGETS rgw-policy-check DESTINATION bin)
 
+set(radosgw_poltester_srcs
+  rgw_poltester.cc)
+add_executable(rgw-policy-test ${radosgw_poltester_srcs})
+target_link_libraries(rgw-policy-test ${rgw_libs})
+install(TARGETS rgw-policy-test DESTINATION bin)
+
 set(librgw_srcs
   librgw.cc)
 add_library(rgw SHARED ${librgw_srcs})

--- a/src/rgw/rgw_arn.h
+++ b/src/rgw/rgw_arn.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <boost/optional.hpp>
 
+#include <fmt/ostream.h>
+
 class rgw_obj;
 class rgw_bucket;
 
@@ -119,3 +121,4 @@ struct hash<::rgw::Service> {
 };
 } // namespace std
 
+template <> struct fmt::formatter<rgw::ARN> : ostream_formatter {};

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -365,7 +365,6 @@ auto transform_old_authinfo(const DoutPrefixProvider* dpp,
   }
   return transform_old_authinfo(info, std::move(account), std::move(policies), driver);
 }
-
 } /* namespace auth */
 } /* namespace rgw */
 
@@ -1384,3 +1383,168 @@ rgw::auth::AnonymousEngine::authenticate(const DoutPrefixProvider* dpp, const re
     return result_t::grant(std::move(apl));
   }
 }
+
+namespace rgw::auth {
+ACLOwner
+PrincipalIdentity::get_aclowner() const
+{
+  ceph_abort();
+  return {};
+}
+
+uint32_t
+PrincipalIdentity::get_perms_from_aclspec(
+    const DoutPrefixProvider* dpp,
+    const aclspec_t& aclspec) const
+{
+  ceph_abort();
+  return 0;
+}
+
+bool
+PrincipalIdentity::is_admin() const
+{
+  ceph_abort();
+  return false;
+}
+
+bool
+PrincipalIdentity::is_owner_of(const rgw_owner& owner) const
+{
+  ceph_abort();
+  return false;
+}
+
+bool
+PrincipalIdentity::is_root() const
+{
+  ceph_abort();
+  return false;
+}
+
+uint32_t
+PrincipalIdentity::get_perm_mask() const
+{
+  ceph_abort();
+  return 0;
+}
+
+std::string
+PrincipalIdentity::get_acct_name() const
+{
+  ceph_abort();
+  return {};
+}
+
+std::string
+PrincipalIdentity::get_subuser() const
+{
+  ceph_abort();
+  return {};
+}
+
+const std::string&
+PrincipalIdentity::get_tenant() const
+{
+  ceph_abort();
+  static std::string empty;
+  return empty;
+}
+
+const std::optional<RGWAccountInfo>&
+PrincipalIdentity::get_account() const
+{
+  ceph_abort();
+  static std::optional<RGWAccountInfo> empty;
+  return empty;
+}
+
+void
+PrincipalIdentity::to_str(std::ostream& out) const
+{
+  out << id;
+}
+
+bool
+PrincipalIdentity::is_identity(const Principal& p) const
+{
+  // Wildcard on either side always matches.
+  if (p.is_wildcard() || id.is_wildcard()) {
+    return true;
+  } else if (p.is_account()) {
+    // Compare account to account, since we're matching principal to principal
+    return (id.get_account() == p.get_account());
+  } else if (p.is_user() || p.is_role()) {
+    // Parse out id/path/subuser to pass to match_principal
+    std::string_view name;
+    std::string path; // We need actual storage to prepend a `/`.
+    std::string_view subuser;
+    std::string_view res{id.get_id()};
+    if (id.is_user() || id.is_role()) {
+      auto pos = res.rfind('/');
+      if (pos != res.npos) {
+        path.push_back('/');
+        path.append(res, 0, pos + 1);
+        res = res.substr(pos + 1);
+      }
+    }
+    if (p.is_user()) {
+      if (!id.is_user()) {
+        return false;
+      }
+      auto pos = res.find(':');
+      if (pos != res.npos) {
+        subuser = res.substr(pos + 1, res.npos);
+        res = res.substr(0, pos);
+      }
+      name = res;
+    } else if (p.is_role()) {
+      if (!(id.is_role() || id.is_assumed_role())) {
+        return false;
+      }
+      if (id.is_assumed_role()) {
+        auto pos = res.rfind('/');
+        name = res.substr(0, pos);
+      } else {
+        name = res;
+      }
+    }
+    return ((id.get_account() == p.get_account()) &&
+            match_principal(path, name, subuser, p.get_id()));
+  } else if (p.is_assumed_role()) {
+    // Match role/session to role/session
+    auto role_session = id.get_role_session();
+    if (auto pos = role_session.rfind('/');
+        (pos != role_session.npos) && (pos != 0)) {
+      if (pos = role_session.rfind('/', pos - 1); pos != role_session.npos) {
+        role_session = role_session.substr(pos + 1);
+      }
+    }
+    return (id.is_assumed_role() && (id.get_account() == p.get_account()) &&
+            (role_session == p.get_role_session()));
+  } else if (p.is_oidc_provider()) {
+    return id.is_oidc_provider() && id.get_idp_url() == p.get_idp_url();
+  } else if (p.is_service()) {
+    return id.is_service() && id.get_service() == p.get_service();
+  }
+  return false;
+}
+
+uint32_t
+PrincipalIdentity::get_identity_type() const
+{
+  if (id.is_role() || id.is_assumed_role()) {
+    return TYPE_ROLE;
+  } else if (id.is_oidc_provider()) {
+    return TYPE_WEB;
+  } else {
+    return TYPE_RGW;
+  }
+}
+
+std::optional<rgw::ARN>
+PrincipalIdentity::get_caller_identity() const
+{
+  return std::nullopt;
+}
+} // namespace rgw::auth

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -10,6 +10,8 @@
 #include <system_error>
 #include <utility>
 
+#include <fmt/ostream.h>
+
 #include "include/expected.hpp"
 #include "include/function2.hpp"
 
@@ -989,6 +991,7 @@ protected:
 } /* namespace auth */
 } /* namespace rgw */
 
+template <> struct fmt::formatter<rgw::auth::Identity> : ostream_formatter {};
 
 uint32_t rgw_perms_from_aclspec_default_strategy(
   const std::string& uid,

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -988,6 +988,43 @@ protected:
   }
 };
 
+// A Principal-only identity disconnected from any backends for use in
+// testing and utilities.
+class PrincipalIdentity : public Identity {
+  const Principal id;
+public:
+
+  explicit PrincipalIdentity(Principal&& id) : id(std::move(id)) {}
+
+  // These exist to meet the interface requirement but are
+  // unimplemented and will `abort()`.
+  ACLOwner get_aclowner() const override;
+  uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override;
+  bool is_admin() const override;
+  bool is_owner_of(const rgw_owner& owner) const override;
+  bool is_root() const override;
+  uint32_t get_perm_mask() const override;
+  std::string get_acct_name() const override;
+  std::string get_subuser() const override;
+  const std::string& get_tenant() const override;
+  const std::optional<RGWAccountInfo>& get_account() const override;
+  void to_str(std::ostream& out) const override;
+
+  // Predict whether the server would consider this identity to match a
+  // policy principal `p`, mirroring the structural matching in
+  // rgw::auth::LocalApplier::is_identity (users) and
+  // RoleApplier::is_identity (roles and assumed-role sessions) as far as
+  // the tool's Principal-only identity model allows.
+  bool is_identity(const Principal& p) const override;
+
+  // A role or an assumed-role session evaluates trust policies
+  // through the TYPE_ROLE branch of Statement::eval_principal;
+  // reflect that so rather than always reporting TYPE_RGW.
+  uint32_t get_identity_type() const override;
+  std::optional<rgw::ARN> get_caller_identity() const override;
+};
+
+
 } /* namespace auth */
 } /* namespace rgw */
 

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -220,27 +220,27 @@ public:
     return t == Service;
   }
 
-  const std::string& get_account() const {
+  std::string_view get_account() const {
     return u.tenant;
   }
 
-  const std::string& get_id() const {
+  std::string_view get_id() const {
     return u.id;
   }
 
-  const std::string& get_idp_url() const {
+  std::string_view get_idp_url() const {
     return idp_url;
   }
 
-  const std::string& get_role_session() const {
+  std::string_view get_role_session() const {
     return u.id;
   }
 
-  const std::string& get_role() const {
+  std::string_view get_role() const {
     return u.id;
   }
 
-  const std::string& get_service() const {
+  std::string_view get_service() const {
     return service_id;
   }
 

--- a/src/rgw/rgw_bucket_logging.cc
+++ b/src/rgw/rgw_bucket_logging.cc
@@ -1102,7 +1102,7 @@ int verify_target_bucket_policy(const DoutPrefixProvider* dpp,
     rgw::IAM::Environment env;
     const auto arn_it = env.emplace("aws:SourceArn", std::move(source_bucket_arn));
     const auto acct_it = env.emplace("aws:SourceAccount", std::move(source_account));
-    if (policy.eval(env, ident, rgw::IAM::s3PutObject, target_resource_arn) != rgw::IAM::Effect::Allow) {
+    if (policy.eval(dpp, env, ident, rgw::IAM::s3PutObject, target_resource_arn) != rgw::IAM::Effect::Allow) {
       ldpp_dout(dpp, 1) << "ERROR: logging bucket: '" << target_bucket_id <<
         "' must have a bucket policy that allows logging service principal to put objects in the following resource ARN: '" <<
         target_resource_arn.to_string() << "' from source bucket ARN: '" << arn_it->second <<

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1152,10 +1152,11 @@ Effect eval_or_pass(const DoutPrefixProvider* dpp,
                     const uint64_t op,
                     const ARN& resource,
                     boost::optional<rgw::IAM::PolicyPrincipal&> princ_type=boost::none) {
-  if (!policy)
+  if (!policy) {
     return Effect::Pass;
-  else
-    return policy->eval(env, id, op, resource, princ_type);
+  } else {
+    return policy->eval(dpp, env, id, op, resource, princ_type);
+  }
 }
 
 Effect eval_identity_or_session_policies(const DoutPrefixProvider* dpp,
@@ -1376,7 +1377,7 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
   // If RestrictPublicBuckets is enabled and the bucket policy allows public access,
   // deny the request if the requester is not in the bucket owner account
   if (s->public_access_block.RestrictPublicBuckets &&
-      bucket_policy && rgw::IAM::is_public(*bucket_policy) &&
+      bucket_policy && rgw::IAM::is_public(dpp, *bucket_policy) &&
       !s->identity->is_owner_of(s->bucket_info.owner)) {
     ldpp_dout(dpp, 10) << __func__ << ": public policies are blocked by the RestrictPublicBuckets block public access setting" << dendl;
     return false;
@@ -1543,7 +1544,7 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, struct perm_state_b
   // If RestrictPublicBuckets is enabled and the bucket policy allows public access,
   // deny the request if the requester is not in the bucket owner account
   if (ps->public_access_block.RestrictPublicBuckets &&
-      bucket_policy && rgw::IAM::is_public(*bucket_policy) &&
+      bucket_policy && rgw::IAM::is_public(dpp, *bucket_policy) &&
       !ps->identity->is_owner_of(ps->bucket_info.owner)) {
     ldpp_dout(dpp, 10) << __func__ << ": public policies are blocked by the RestrictPublicBuckets block public access setting" << dendl;
     return false;

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -170,7 +170,7 @@ static const actpair actpairs[] =
  { "iam:GetOIDCProvider", iamGetOIDCProvider},
  { "iam:ListOIDCProviders", iamListOIDCProviders},
  { "iam:AddClientIdToOIDCProvider", iamAddClientIdToOIDCProvider},
- { "iam:RemoveCientIdFromOIDCProvider", iamRemoveClientIdFromOIDCProvider},
+ { "iam:RemoveClientIdFromOIDCProvider", iamRemoveClientIdFromOIDCProvider},
  { "iam:UpdateOIDCProviderThumbprint", iamUpdateOIDCProviderThumbprint},
  { "iam:TagRole", iamTagRole},
  { "iam:ListRoleTags", iamListRoleTags},

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -10,6 +10,7 @@
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 
+
 #include <arpa/inet.h>
 
 #include <experimental/iterator>
@@ -344,6 +345,79 @@ const Keyword top[1]{{"<Top>", TokenKind::pseudo, TokenID::Top, 0, false,
 const Keyword cond_key[1]{{"<Condition Key>", TokenKind::cond_key,
 			     TokenID::CondKey, 0, true, false}};
 
+namespace {
+boost::optional<Principal>
+parse_principal_(const struct Keyword* w, std::string&& s,
+                 string* errmsg) {
+  if ((w->id == TokenID::AWS) && (s == "*")) {
+    // Wildcard!
+    return Principal::wildcard();
+  } else if (w->id == TokenID::CanonicalUser) {
+    // Do nothing for now.
+    if (errmsg)
+      *errmsg = "RGW does not support canonical users.";
+    return boost::none;
+  } else if (w->id == TokenID::AWS || w->id == TokenID::Federated) {
+    // AWS and Federated ARNs
+    if (auto a = ARN::parse(s)) {
+      if (a->resource == "root") {
+	return Principal::account(std::move(a->account));
+      }
+
+      static const char rx_str[] = "([^/]*)/(.*)";
+      static const regex rx(rx_str, sizeof(rx_str) - 1,
+			    std::regex_constants::ECMAScript |
+			    std::regex_constants::optimize);
+      smatch match;
+      if (regex_match(a->resource, match, rx) && match.size() == 3) {
+	if (match[1] == "user") {
+	  return Principal::user(std::move(a->account),
+				 match[2]);
+	}
+
+	if (match[1] == "role") {
+	  return Principal::role(std::move(a->account),
+				 match[2]);
+	}
+
+        if (match[1] == "oidc-provider") {
+                return Principal::oidc_provider(std::move(match[2]));
+        }
+	if (match[1] == "assumed-role") {
+	  return Principal::assumed_role(std::move(a->account), match[2]);
+	}
+      }
+    } else if (std::none_of(s.begin(), s.end(),
+		       [](const char& c) {
+			 return (c == ':') || (c == '/');
+		       })) {
+      // Since tenants are simply prefixes, there's no really good
+      // way to see if one exists or not. So we return the thing and
+      // let them try to match against it.
+      return Principal::account(std::move(s));
+    }
+    if (errmsg)
+      *errmsg =
+	fmt::format(
+	  "`{}` is not a supported AWS or Federated ARN. Supported ARNs are "
+	  "forms like: "
+	  "`arn:aws:iam::tenant:root` or a bare tenant name for a tenant, "
+	  "`arn:aws:iam::tenant:role/role-name` for a role, "
+	  "`arn:aws:sts::tenant:assumed-role/role-name/role-session-name` "
+	  "for an assumed role, "
+	  "`arn:aws:iam::tenant:user/user-name` for a user, "
+	  "`arn:aws:iam::tenant:oidc-provider/idp-url` for OIDC.", s);
+  } else if (w->id == TokenID::Service) {
+      return Principal::service(std::move(s));
+  }
+
+  if (errmsg)
+    *errmsg = fmt::format("RGW does not support principals of type `{}`.",
+			  w->name);
+  return boost::none;
+}
+}
+
 struct ParseState {
   PolicyParser* pp;
   const Keyword* w;
@@ -643,72 +717,7 @@ bool ParseState::key(const char* s, size_t l) {
 // which will make all of this ever so much nicer.
 boost::optional<Principal> ParseState::parse_principal(string&& s,
 						       string* errmsg) {
-  if ((w->id == TokenID::AWS) && (s == "*")) {
-    // Wildcard!
-    return Principal::wildcard();
-  } else if (w->id == TokenID::CanonicalUser) {
-    // Do nothing for now.
-    if (errmsg)
-      *errmsg = "RGW does not support canonical users.";
-    return boost::none;
-  } else if (w->id == TokenID::AWS || w->id == TokenID::Federated) {
-    // AWS and Federated ARNs
-    if (auto a = ARN::parse(s)) {
-      if (a->resource == "root") {
-	return Principal::account(std::move(a->account));
-      }
-
-      static const char rx_str[] = "([^/]*)/(.*)";
-      static const regex rx(rx_str, sizeof(rx_str) - 1,
-			    std::regex_constants::ECMAScript |
-			    std::regex_constants::optimize);
-      smatch match;
-      if (regex_match(a->resource, match, rx) && match.size() == 3) {
-	if (match[1] == "user") {
-	  return Principal::user(std::move(a->account),
-				 match[2]);
-	}
-
-	if (match[1] == "role") {
-	  return Principal::role(std::move(a->account),
-				 match[2]);
-	}
-
-        if (match[1] == "oidc-provider") {
-                return Principal::oidc_provider(std::move(match[2]));
-        }
-	if (match[1] == "assumed-role") {
-	  return Principal::assumed_role(std::move(a->account), match[2]);
-	}
-      }
-    } else if (std::none_of(s.begin(), s.end(),
-		       [](const char& c) {
-			 return (c == ':') || (c == '/');
-		       })) {
-      // Since tenants are simply prefixes, there's no really good
-      // way to see if one exists or not. So we return the thing and
-      // let them try to match against it.
-      return Principal::account(std::move(s));
-    }
-    if (errmsg)
-      *errmsg =
-	fmt::format(
-	  "`{}` is not a supported AWS or Federated ARN. Supported ARNs are "
-	  "forms like: "
-	  "`arn:aws:iam::tenant:root` or a bare tenant name for a tenant, "
-	  "`arn:aws:iam::tenant:role/role-name` for a role, "
-	  "`arn:aws:sts::tenant:assumed-role/role-name/role-session-name` "
-	  "for an assumed role, "
-	  "`arn:aws:iam::tenant:user/user-name` for a user, "
-	  "`arn:aws:iam::tenant:oidc-provider/idp-url` for OIDC.", s);
-  } else if (w->id == TokenID::Service) {
-      return Principal::service(std::move(s));
-  }
-
-  if (errmsg)
-    *errmsg = fmt::format("RGW does not support principals of type `{}`.",
-			  w->name);
-  return boost::none;
+  return ::rgw::IAM::parse_principal_(w, std::move(s), errmsg);
 }
 
 bool ParseState::do_string(CephContext* cct, const char* s, size_t l) {
@@ -2143,6 +2152,40 @@ bool is_public(const Policy& p, const LogOut& eval_log)
 {
   return std::any_of(p.statements.begin(), p.statements.end(),
                      IsPublicStatement(eval_log));
+}
+
+boost::optional<Principal> parse_principal(std::string&& s, string* errmsg) {
+  keyword_hash tokens;
+  auto colon = s.find(':') ;
+  if (colon == s.npos) {
+    if (errmsg) {
+      *errmsg = "Identities are of the form SCHEMA:STRING";
+    }
+    return boost::none;
+  }
+  const auto w = tokens.lookup(s.data(), colon);
+  if (!w || w->kind != TokenKind::princ_type) {
+    if (errmsg) {
+      *errmsg = fmt::format("`{}` is not a valid identity schema",
+                            std::string_view{s.data(), colon});
+    }
+    return boost::none;
+  }
+  s.erase(0, colon + 1);
+  return parse_principal_(w, std::move(s), errmsg);
+}
+
+// This function is only use from the policy testing tool, so it makes
+// no sense for it to handle wildcards.
+boost::optional<action_t>
+parse_action(std::string_view s)
+{
+  for (const auto& [key, n] : actpairs) {
+    if (boost::iequals(key, s)) {
+      return rgw::IAM::action_t(n);
+    }
+  }
+  return boost::none;
 }
 } // namespace IAM
 } // namespace rgw

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1291,7 +1291,7 @@ Effect Statement::eval_conditions(const Environment& e) const {
   return Effect::Deny;
 }
 
-const char* action_bit_string(uint64_t action) {
+const char* action_bit_string(action_t action) {
   switch (action) {
   case s3GetObject:
     return "s3:GetObject";
@@ -1419,8 +1419,8 @@ const char* action_bit_string(uint64_t action) {
   case s3PutBucketLogging:
     return "s3:PutBucketLogging";
 
-    case s3PostBucketLogging:
-      return "s3:PostBucketLogging";
+  case s3PostBucketLogging:
+    return "s3:PostBucketLogging";
 
   case s3GetBucketTagging:
     return "s3:GetBucketTagging";
@@ -1490,6 +1490,27 @@ const char* action_bit_string(uint64_t action) {
 
   case s3BypassGovernanceRetention:
     return "s3:BypassGovernanceRetention";
+
+  case s3GetBucketPolicyStatus:
+    return "s3:GetBucketPolicyStatus";
+
+  case s3PutPublicAccessBlock:
+    return "s3:PutPublicAccessBlock";
+
+  case s3GetPublicAccessBlock:
+    return "s3:GetPublicAccessBlock";
+
+  case s3DeletePublicAccessBlock:
+    return "s3:DeletePublicAccessBlock";
+
+  case s3PutBucketPublicAccessBlock:
+    return "s3:PutBucketPublicAccessBlock";
+
+  case s3GetBucketPublicAccessBlock:
+    return "s3:GetBucketPublicAccessBlock";
+
+  case s3DeleteBucketPublicAccessBlock:
+    return "s3:DeleteBucketPublicAccessBlock";
 
   case s3GetObjectAttributes:
     return "s3:GetObjectAttributes";
@@ -1760,22 +1781,31 @@ const char* action_bit_string(uint64_t action) {
 
   case organizationsListTargetsForPolicy:
     return "organizations:ListTargetsForPolicy";
+
+  case s3All:
+  case s3objectlambdaAll:
+  case iamAll:
+  case stsAll:
+  case snsAll:
+  case organizationsAll:
+  case allCount:
+    return "{invalidSentinel}";
   }
-  return "s3Invalid";
+  return "{invalidUnknown}";
 }
 
 namespace {
 ostream& print_actions(ostream& m, const Action_t a) {
   bool begun = false;
   m << "[ ";
-  for (auto i = 0U; i < allCount; ++i) {
+  for (std::underlying_type_t<action_t> i = 0; i < allCount; ++i) {
     if (a[i] == 1) {
       if (begun) {
         m << ", ";
       } else {
         begun = true;
       }
-      m << action_bit_string(i);
+      m << action_bit_string(action_t(i));
     }
   }
   if (begun) {

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1,13 +1,14 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
-
 #include <cstring>
 #include <iostream>
 #include <regex>
 #include <sstream>
-#include <stack>
 #include <utility>
+
+#include <fmt/ranges.h>
+#include <fmt/std.h>
 
 #include <arpa/inet.h>
 
@@ -15,15 +16,11 @@
 
 #include "rapidjson/reader.h"
 
-#include "include/expected.hpp"
-
 #include "rgw_auth.h"
 #include "rgw_iam_policy.h"
 
 
-namespace {
-constexpr int dout_subsys = ceph_subsys_rgw;
-}
+inline constexpr int dout_subsys = ceph_subsys_rgw;
 
 using std::dec;
 using std::hex;
@@ -50,6 +47,19 @@ using rapidjson::StringStream;
 
 using rgw::auth::Principal;
 
+using namespace std::literals;
+
+template<typename T>
+struct fmt::formatter<boost::optional<const T&>> : fmt::formatter<T> {
+  template<typename FormatContext>
+  auto format(const boost::optional<const T&>& opt, FormatContext& ctx) const {
+    if (opt) {
+      return fmt::formatter<T>::format(*opt, ctx);
+    }
+    return fmt::format_to(ctx.out(), "--");
+  }
+};
+
 namespace rgw {
 namespace IAM {
 #include "rgw_iam_policy_keywords.frag.cc"
@@ -58,8 +68,6 @@ struct actpair {
   const char* name;
   const uint64_t bit;
 };
-
-
 
 static const actpair actpairs[] =
 {{ "s3:AbortMultipartUpload", s3AbortMultipartUpload },
@@ -226,6 +234,108 @@ static const actpair actpairs[] =
  { "organizations:ListPolicies", organizationsListPolicies},
  { "organizations:ListTargetsForPolicy", organizationsListTargetsForPolicy},
 };
+
+namespace {
+const char* condop_string(const TokenID t) {
+  switch (t) {
+  case TokenID::StringEquals:
+    return "StringEquals";
+
+  case TokenID::StringNotEquals:
+    return "StringNotEquals";
+
+  case TokenID::StringEqualsIgnoreCase:
+    return "StringEqualsIgnoreCase";
+
+  case TokenID::StringNotEqualsIgnoreCase:
+    return "StringNotEqualsIgnoreCase";
+
+  case TokenID::StringLike:
+    return "StringLike";
+
+  case TokenID::StringNotLike:
+    return "StringNotLike";
+
+  // Numeric!
+  case TokenID::NumericEquals:
+    return "NumericEquals";
+
+  case TokenID::NumericNotEquals:
+    return "NumericNotEquals";
+
+  case TokenID::NumericLessThan:
+    return "NumericLessThan";
+
+  case TokenID::NumericLessThanEquals:
+    return "NumericLessThanEquals";
+
+  case TokenID::NumericGreaterThan:
+    return "NumericGreaterThan";
+
+  case TokenID::NumericGreaterThanEquals:
+    return "NumericGreaterThanEquals";
+
+  case TokenID::DateEquals:
+    return "DateEquals";
+
+  case TokenID::DateNotEquals:
+    return "DateNotEquals";
+
+  case TokenID::DateLessThan:
+    return "DateLessThan";
+
+  case TokenID::DateLessThanEquals:
+    return "DateLessThanEquals";
+
+  case TokenID::DateGreaterThan:
+    return "DateGreaterThan";
+
+  case TokenID::DateGreaterThanEquals:
+    return "DateGreaterThanEquals";
+
+  case TokenID::Bool:
+    return "Bool";
+
+  case TokenID::BinaryEquals:
+    return "BinaryEquals";
+
+  case TokenID::IpAddress:
+    return "IpAddress";
+
+  case TokenID::NotIpAddress:
+    return "NotIpAddress";
+
+  case TokenID::ArnEquals:
+    return "ArnEquals";
+
+  case TokenID::ArnNotEquals:
+    return "ArnNotEquals";
+
+  case TokenID::ArnLike:
+    return "ArnLike";
+
+  case TokenID::ArnNotLike:
+    return "ArnNotLike";
+
+  case TokenID::Null:
+    return "Null";
+
+  default:
+    return "InvalidConditionOperator";
+  }
+}
+}
+
+template <typename T>
+inline std::ostream&
+operator<<(std::ostream& out, const boost::optional<T>& t)
+{
+  if (!t)
+    out << "--";
+  else
+    out << ' ' << *t;
+  return out;
+}
 
 struct PolicyParser;
 
@@ -873,20 +983,28 @@ static bool arn_like(const std::string& input, const std::string& pattern)
   return match_policy(pattern, input, MATCH_POLICY_ARN);
 }
 
-bool Condition::eval(const Environment& env) const {
+bool Condition::eval(const Environment& env, const LogOut& eval_log) const {
   std::vector<std::string> runtime_vals;
   auto i = env.find(key);
   if (op == TokenID::Null) {
     const std::string value = (i == env.end() ? "true" : "false");
-    return typed_any(std::equal_to<bool>{}, as_bool, value, vals);
+    eval_log.format("Null check. key `{}` {}.", key,
+                    i == env.end() ? "is not present"sv :
+                                     "is present"sv);
+    return typed_any(std::equal_to<bool>{}, as_bool, value, vals, eval_log);
   }
 
   if (i == env.end()) {
     if (op == TokenID::ForAllValuesStringEquals ||
         op == TokenID::ForAllValuesStringEqualsIgnoreCase ||
         op == TokenID::ForAllValuesStringLike) {
+      eval_log.format(
+          "Evaluating `{}` when key `{}` is not present. Vacuously true.",
+          condop_string(op), key);
       return true;
     } else {
+      eval_log.format("Evaluating `{}` when key `{}` is not present. Returning {}.",
+                      condop_string(op), key, ifexists ? "true" : "false");
       return ifexists;
     }
   }
@@ -901,113 +1019,131 @@ bool Condition::eval(const Environment& env) const {
     }
   }
   const auto& s = i->second;
-
-  const auto& itr = env.equal_range(key);
-
+  const auto itr = env.equal_range(key);
+  // Printable range because for fmt::format.
+  const std::ranges::subrange prange(itr.first, itr.second);
+  eval_log.format("Evaluating `{}` for `[{}]` against `[{}]`",
+                  condop_string(op), fmt::join(prange, ","),
+                  fmt::join(isruntime ? runtime_vals : vals, ","));
   switch (op) {
     // String!
   case TokenID::ForAnyValueStringEquals:
   case TokenID::StringEquals:
-    return multimap_any(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::equal_to<std::string>(), itr,
+                        isruntime ? runtime_vals : vals,
+                        eval_log);
 
   case TokenID::StringNotEquals:
-    return multimap_none(std::equal_to<std::string>(),
-     itr, isruntime? runtime_vals : vals);
+    return multimap_none(std::equal_to<std::string>(), itr,
+                         isruntime ? runtime_vals : vals, eval_log);
 
   case TokenID::ForAnyValueStringEqualsIgnoreCase:
   case TokenID::StringEqualsIgnoreCase:
-    return multimap_any(ci_equal_to(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(ci_equal_to(), itr, isruntime ? runtime_vals : vals,
+                        eval_log);
 
   case TokenID::StringNotEqualsIgnoreCase:
-    return multimap_none(ci_equal_to(), itr, isruntime? runtime_vals : vals);
+    return multimap_none(ci_equal_to(), itr, isruntime ? runtime_vals : vals,
+                         eval_log);
 
   case TokenID::ForAnyValueStringLike:
   case TokenID::StringLike:
-    return multimap_any(string_like(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(string_like(), itr, isruntime ? runtime_vals : vals,
+                        eval_log);
 
   case TokenID::StringNotLike:
-    return multimap_none(string_like(), itr, isruntime? runtime_vals : vals);
+    return multimap_none(string_like(), itr, isruntime ? runtime_vals : vals,
+                         eval_log);
 
   case TokenID::ForAllValuesStringEquals:
-    return multimap_all(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(std::equal_to<std::string>(), itr,
+                        isruntime ? runtime_vals : vals,
+                        eval_log);
 
   case TokenID::ForAllValuesStringLike:
-    return multimap_all(string_like(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(string_like(), itr, isruntime ? runtime_vals : vals,
+                        eval_log);
 
   case TokenID::ForAllValuesStringEqualsIgnoreCase:
-    return multimap_all(ci_equal_to(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(ci_equal_to(), itr, isruntime ? runtime_vals : vals,
+                        eval_log);
 
     // Numeric
   case TokenID::NumericEquals:
-    return typed_any(std::equal_to<double>(), as_number, s, vals);
+    return typed_any(std::equal_to<double>(), as_number, s, vals, eval_log);
 
   case TokenID::NumericNotEquals:
-    return typed_none(std::equal_to<double>(),
-       as_number, s, vals);
+    return typed_none(std::equal_to<double>(), as_number, s, vals, eval_log);
 
 
   case TokenID::NumericLessThan:
-    return typed_any(std::less<double>(), as_number, s, vals);
+    return typed_any(std::less<double>(), as_number, s, vals, eval_log);
 
 
   case TokenID::NumericLessThanEquals:
-    return typed_any(std::less_equal<double>(), as_number, s, vals);
+    return typed_any(std::less_equal<double>(), as_number, s, vals, eval_log);
 
   case TokenID::NumericGreaterThan:
-    return typed_any(std::greater<double>(), as_number, s, vals);
+    return typed_any(std::greater<double>(), as_number, s, vals, eval_log);
 
   case TokenID::NumericGreaterThanEquals:
-    return typed_any(std::greater_equal<double>(), as_number, s,
-       vals);
+    return typed_any(std::greater_equal<double>(), as_number, s, vals,
+                     eval_log);
 
     // Date!
   case TokenID::DateEquals:
-    return typed_any(std::equal_to<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::equal_to<ceph::real_time>(), as_date, s, vals,
+                     eval_log);
 
   case TokenID::DateNotEquals:
     return typed_none(std::equal_to<ceph::real_time>(),
-       as_date, s, vals);
+                      as_date, s, vals, eval_log);
   case TokenID::DateLessThan:
-    return typed_any(std::less<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::less<ceph::real_time>(), as_date, s, vals, eval_log);
 
 
   case TokenID::DateLessThanEquals:
-    return typed_any(std::less_equal<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::less_equal<ceph::real_time>(), as_date, s, vals,
+                     eval_log);
 
   case TokenID::DateGreaterThan:
-    return typed_any(std::greater<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::greater<ceph::real_time>(), as_date, s, vals,
+                     eval_log);
 
   case TokenID::DateGreaterThanEquals:
     return typed_any(std::greater_equal<ceph::real_time>(), as_date, s,
-		     vals);
+		     vals, eval_log);
 
     // Bool!
   case TokenID::Bool:
-    return typed_any(std::equal_to<bool>(), as_bool, s, vals);
+    return typed_any(std::equal_to<bool>(), as_bool, s, vals, eval_log);
 
     // Binary!
   case TokenID::BinaryEquals:
     return typed_any(std::equal_to<ceph::bufferlist>(), as_binary, s,
-		     vals);
+		     vals, eval_log);
 
     // IP Address!
   case TokenID::IpAddress:
-    return typed_any(std::equal_to<MaskedIP>(), as_network, s, vals);
+    return typed_any(std::equal_to<MaskedIP>(), as_network, s, vals, eval_log);
 
   case TokenID::NotIpAddress:
     return typed_none(std::equal_to<MaskedIP>(),
-      as_network, s, vals);
+                      as_network, s, vals, eval_log);
 
     // Amazon Resource Names!
     // The ArnEquals and ArnLike condition operators behave identically.
   case TokenID::ArnEquals:
   case TokenID::ArnLike:
-    return multimap_any(arn_like, itr, isruntime? runtime_vals : vals);
+    return multimap_any(arn_like, itr, isruntime ? runtime_vals : vals,
+                        eval_log);
   case TokenID::ArnNotEquals:
   case TokenID::ArnNotLike:
-    return multimap_none(arn_like, itr, isruntime? runtime_vals : vals);
+    return multimap_none(arn_like, itr, isruntime ? runtime_vals : vals,
+                         eval_log);
 
   default:
+    eval_log.format("Unknown operation: Returning false.");
     return false;
   }
 }
@@ -1074,96 +1210,6 @@ boost::optional<MaskedIP> Condition::as_network(const string& s) {
   return m;
 }
 
-namespace {
-const char* condop_string(const TokenID t) {
-  switch (t) {
-  case TokenID::StringEquals:
-    return "StringEquals";
-
-  case TokenID::StringNotEquals:
-    return "StringNotEquals";
-
-  case TokenID::StringEqualsIgnoreCase:
-    return "StringEqualsIgnoreCase";
-
-  case TokenID::StringNotEqualsIgnoreCase:
-    return "StringNotEqualsIgnoreCase";
-
-  case TokenID::StringLike:
-    return "StringLike";
-
-  case TokenID::StringNotLike:
-    return "StringNotLike";
-
-  // Numeric!
-  case TokenID::NumericEquals:
-    return "NumericEquals";
-
-  case TokenID::NumericNotEquals:
-    return "NumericNotEquals";
-
-  case TokenID::NumericLessThan:
-    return "NumericLessThan";
-
-  case TokenID::NumericLessThanEquals:
-    return "NumericLessThanEquals";
-
-  case TokenID::NumericGreaterThan:
-    return "NumericGreaterThan";
-
-  case TokenID::NumericGreaterThanEquals:
-    return "NumericGreaterThanEquals";
-
-  case TokenID::DateEquals:
-    return "DateEquals";
-
-  case TokenID::DateNotEquals:
-    return "DateNotEquals";
-
-  case TokenID::DateLessThan:
-    return "DateLessThan";
-
-  case TokenID::DateLessThanEquals:
-    return "DateLessThanEquals";
-
-  case TokenID::DateGreaterThan:
-    return "DateGreaterThan";
-
-  case TokenID::DateGreaterThanEquals:
-    return "DateGreaterThanEquals";
-
-  case TokenID::Bool:
-    return "Bool";
-
-  case TokenID::BinaryEquals:
-    return "BinaryEquals";
-
-  case TokenID::IpAddress:
-    return "case TokenID::IpAddress";
-
-  case TokenID::NotIpAddress:
-    return "NotIpAddress";
-
-  case TokenID::ArnEquals:
-    return "ArnEquals";
-
-  case TokenID::ArnNotEquals:
-    return "ArnNotEquals";
-
-  case TokenID::ArnLike:
-    return "ArnLike";
-
-  case TokenID::ArnNotLike:
-    return "ArnNotLike";
-
-  case TokenID::Null:
-    return "Null";
-
-  default:
-    return "InvalidConditionOperator";
-  }
-}
-
 template<typename Iterator>
 ostream& print_array(ostream& m, Iterator begin, Iterator end) {
   if (begin == end) {
@@ -1184,8 +1230,6 @@ ostream& print_dict(ostream& m, Iterator begin, Iterator end) {
   return m;
 }
 
-}
-
 ostream& operator <<(ostream& m, const Condition& c) {
   m << condop_string(c.op);
   if (c.ifexists) {
@@ -1196,46 +1240,82 @@ ostream& operator <<(ostream& m, const Condition& c) {
   return m << " }";
 }
 
-Effect Statement::eval(const Environment& e,
-		       boost::optional<const rgw::auth::Identity&> ida,
-		       uint64_t act, boost::optional<const ARN&> res, boost::optional<PolicyPrincipal&> princ_type) const {
+Effect
+Statement::eval(
+    const Environment& e,
+    boost::optional<const rgw::auth::Identity&> ida,
+    uint64_t act,
+    boost::optional<const ARN&> res,
+    const LogOut& eval_log,
+    boost::optional<PolicyPrincipal&> princ_type) const {
 
-  if (eval_principal(e, ida, princ_type) == Effect::Deny) {
+  if (eval_principal(e, ida, eval_log, princ_type) == Effect::Deny) {
+    eval_log.format("Passing.");
     return Effect::Pass;
   }
 
   if (res && resource.empty() && notresource.empty()) {
+    eval_log.format("A resource was specified but both Resource and NotResource "
+                    "were empty. Passing.");
     return Effect::Pass;
   }
   if (!res && (!resource.empty() || !notresource.empty())) {
+    eval_log.format("No resource was specified, but Resource or "
+                    "NotResource was non-empty. Passing.");
     return Effect::Pass;
   }
   if (!resource.empty() && res) {
-    if (!std::any_of(resource.begin(), resource.end(),
-          [&res](const ARN& pattern) {
-            return pattern.match(*res);
-          })) {
+    eval_log.format("Checking Resource for {}:", res);
+    if (!std::any_of(
+            resource.begin(), resource.end(),
+            [&res, &eval_log](const ARN& pattern) {
+              if (pattern.match(*res)) {
+                eval_log.format("Matched `{}`.", pattern);
+                return true;
+              }
+              return false;
+            })) {
+      eval_log.format("No match in Resource. Passing.");
       return Effect::Pass;
     }
   } else if (!notresource.empty() && res) {
-    if (std::any_of(notresource.begin(), notresource.end(),
-          [&res](const ARN& pattern) {
-            return pattern.match(*res);
+    eval_log.format("Checking NotResource for {}:", res);
+    if (std::any_of(
+          notresource.begin(), notresource.end(),
+          [&res, &eval_log](const ARN& pattern) {
+            if (pattern.match(*res)) {
+              eval_log.format("Matched `{}`.", pattern);
+              return true;
+            }
+            return false;
           })) {
+      eval_log.format("Match found in NotResource. Passing.");
       return Effect::Pass;
     }
   }
 
-  if (!(action[act] == 1) || (notaction[act] == 1)) {
+  if (!(action[act] == 1)) {
+    eval_log.format("{} not found in Action. Passing.",
+                    action_bit_string(action_t(act)));
     return Effect::Pass;
   }
 
-  if (std::all_of(conditions.begin(),
-		  conditions.end(),
-		  [&e](const Condition& c) { return c.eval(e);})) {
+  if (notaction[act] == 1) {
+    eval_log.format("{} found in NotAction. Passing.",
+                    action_bit_string(action_t(act)));
+    return Effect::Pass;
+  }
+
+  eval_log.format("Evaluating conditions:");
+  if (std::all_of(conditions.begin(), conditions.end(),
+                  [&e, &eval_log](const Condition& c) {
+                    return c.eval(e, eval_log);
+                  })) {
+    eval_log.format("Returning {}.", effect);
     return effect;
   }
 
+  eval_log.format("Passing.");
   return Effect::Pass;
 }
 
@@ -1248,50 +1328,76 @@ static bool is_identity(const auth::Identity& ida,
       });
 }
 
-Effect Statement::eval_principal(const Environment& e,
-		       boost::optional<const rgw::auth::Identity&> ida, boost::optional<PolicyPrincipal&> princ_type) const {
+Effect
+Statement::eval_principal(
+    const Environment& e,
+    boost::optional<const rgw::auth::Identity&> ida,
+    const LogOut& eval_log,
+    boost::optional<PolicyPrincipal&> princ_type) const {
   if (princ_type) {
     *princ_type = PolicyPrincipal::Other;
   }
+  eval_log.format("Evaluating identity `{}`:", ida);
   if (ida) {
     if (princ.empty() && noprinc.empty()) {
+      eval_log.format("Principal empty and NotPrincipal empty: Denying.");
       return Effect::Deny;
     }
-    if (ida->get_identity_type() != TYPE_ROLE && !princ.empty() && !is_identity(*ida, princ)) {
+    if (ida->get_identity_type() != TYPE_ROLE &&
+        !princ.empty() && !is_identity(*ida, princ)) {
+      eval_log.format("Identity is not role, Principal is not empty, and "
+                      "the identity is not in Principal.");
       return Effect::Deny;
     }
+    eval_log.format("Checking type of Principal match.");
     if (ida->get_identity_type() == TYPE_ROLE && !princ.empty()) {
       bool princ_matched = false;
-      for (auto p : princ) { // Check each principal to determine the type of the one that has matched
+      // Check each principal to determine the type of the one that has matched
+      for (auto p : princ) {
         if (ida->is_identity(p)) {
           if (p.is_assumed_role() || p.is_user()) {
-            if (princ_type) *princ_type = PolicyPrincipal::Session;
+            if (princ_type) {
+              eval_log.format("Setting principal type to Session.");
+              *princ_type = PolicyPrincipal::Session;
+            }
           } else {
-            if (princ_type) *princ_type = PolicyPrincipal::Role;
+            if (princ_type) {
+              eval_log.format("Setting principal type to Role.");
+              *princ_type = PolicyPrincipal::Role;
+            }
           }
           princ_matched = true;
         }
       }
       if (!princ_matched) {
+        eval_log.format("No match in Principal, Denying.");
         return Effect::Deny;
       }
     } else if (!noprinc.empty() && is_identity(*ida, noprinc)) {
+      eval_log.format("Match in NotPrincipal, Denying.");
       return Effect::Deny;
     }
   }
   return Effect::Allow;
 }
 
-Effect Statement::eval_conditions(const Environment& e) const {
-  if (std::all_of(conditions.begin(),
-		  conditions.end(),
-		  [&e](const Condition& c) { return c.eval(e);})) {
-    return Effect::Allow;
-  }
+Effect Statement::eval_conditions(const Environment& e,
+                                  const LogOut& eval_log) const {
+  if (std::all_of(
+        conditions.begin(), conditions.end(),
+        [&e, &eval_log](const Condition& c) {
+          eval_log.format("Evaluating condition `{}`:", c);
+          return c.eval(e, eval_log);
+        })) {
+      eval_log.format("Returning Allow.");
+      return Effect::Allow;
+    }
+
+  eval_log.format("Returning Deny.");
   return Effect::Deny;
 }
 
-const char* action_bit_string(action_t action) {
+std::string_view action_bit_string(action_t action) {
   switch (action) {
   case s3GetObject:
     return "s3:GetObject";
@@ -1783,11 +1889,23 @@ const char* action_bit_string(action_t action) {
     return "organizations:ListTargetsForPolicy";
 
   case s3All:
+    return "s3:*";
+
   case s3objectlambdaAll:
+    return "s3-object-lambda:*";
+
   case iamAll:
+    return "iam:*";
+
   case stsAll:
+    return "sts:*";
+
   case snsAll:
+    return "sns:*";
+
   case organizationsAll:
+    return "organizations:*";
+
   case allCount:
     return "{invalidSentinel}";
   }
@@ -1903,45 +2021,70 @@ Policy::Policy(CephContext* cct, const string* tenant,
 }
 
 Effect Policy::eval(const Environment& e,
-		    boost::optional<const rgw::auth::Identity&> ida,
-		    std::uint64_t action, boost::optional<const ARN&> resource,
-        boost::optional<PolicyPrincipal&> princ_type) const {
+                    boost::optional<const rgw::auth::Identity&> ida,
+                    std::uint64_t action,
+                    boost::optional<const ARN&> resource,
+                    const LogOut& eval_log,
+                    boost::optional<PolicyPrincipal&> princ_type) const
+{
   auto allowed = false;
+  eval_log.format("Evaluating policy:\n```\n{}\n```\n"
+                  "Environment: {}\n"
+                  "Principal: {}\n"
+                  "Action: {}\n"
+                  "Resource: {}",
+                  text, e, ida, action_bit_string(action_t(action)),
+                  resource);
+
   for (auto& s : statements) {
-    auto g = s.eval(e, ida, action, resource, princ_type);
+    eval_log.format("Evaluating statement `{}`:", s);
+    auto g = s.eval(e, ida, action, resource, eval_log, princ_type);
     if (g == Effect::Deny) {
+      eval_log.format("Denying.");
       return g;
     } else if (g == Effect::Allow) {
       allowed = true;
     }
   }
+  eval_log.format("{}", allowed ? "Allowing." : "Passing.");
   return allowed ? Effect::Allow : Effect::Pass;
 }
 
-Effect Policy::eval_principal(const Environment& e,
-		    boost::optional<const rgw::auth::Identity&> ida, boost::optional<PolicyPrincipal&> princ_type) const {
+Effect
+Policy::eval_principal(
+    const Environment& e,
+    boost::optional<const rgw::auth::Identity&> ida,
+    const LogOut& eval_log,
+    boost::optional<PolicyPrincipal&> princ_type) const {
   auto allowed = false;
   for (auto& s : statements) {
-    auto g = s.eval_principal(e, ida, princ_type);
+    eval_log.format("Evaluating identity `{}` in statement `{}`:", ida, s);
+    auto g = s.eval_principal(e, ida, eval_log, princ_type);
     if (g == Effect::Deny) {
+      eval_log.format("Denying.");
       return g;
     } else if (g == Effect::Allow) {
       allowed = true;
     }
   }
+  eval_log.format("{}", allowed ? "Allowing." : "Denying.");
   return allowed ? Effect::Allow : Effect::Deny;
 }
 
-Effect Policy::eval_conditions(const Environment& e) const {
+Effect Policy::eval_conditions(const Environment& e,
+                               const LogOut& eval_log) const {
   auto allowed = false;
   for (auto& s : statements) {
-    auto g = s.eval_conditions(e);
+    eval_log.format("Evaluating conditions in statement `{}`", s);
+    auto g = s.eval_conditions(e, eval_log);
     if (g == Effect::Deny) {
+      eval_log.format("Denying.");
       return g;
     } else if (g == Effect::Allow) {
       allowed = true;
     }
   }
+  eval_log.format("{}", allowed ? "Allowing." : "Denying.");
   return allowed ? Effect::Allow : Effect::Deny;
 }
 
@@ -1976,11 +2119,18 @@ static const Environment iam_all_env = {
 
 struct IsPublicStatement
 {
-  bool operator() (const Statement &s) const {
+  const LogOut& eval_log;
+
+  IsPublicStatement(const LogOut& eval_log) :
+    eval_log(eval_log)
+  {}
+
+  bool operator()(const Statement& s) const {
     if (s.effect == Effect::Allow) {
       for (const auto& p : s.princ) {
         if (p.is_wildcard()) {
-          return s.eval_conditions(iam_all_env) == Effect::Allow;
+          eval_log.format("Evaluating conditions in statement `{}`:", s);
+          return s.eval_conditions(iam_all_env, eval_log) == Effect::Allow;
         }
       }
     }
@@ -1989,10 +2139,10 @@ struct IsPublicStatement
 };
 
 
-bool is_public(const Policy& p)
+bool is_public(const Policy& p, const LogOut& eval_log)
 {
-  return std::any_of(p.statements.begin(), p.statements.end(), IsPublicStatement());
+  return std::any_of(p.statements.begin(), p.statements.end(),
+                     IsPublicStatement(eval_log));
 }
-
 } // namespace IAM
 } // namespace rgw

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -222,6 +222,9 @@ enum action_t {
   allCount
 };
 
+boost::optional<rgw::auth::Principal>
+parse_principal(std::string&& s, std::string* errmsg);
+
 using Action_t = std::bitset<allCount>;
 using NotAction_t = Action_t;
 
@@ -840,6 +843,8 @@ inline bool is_public(const DoutPrefixProvider* dpp, const Policy& p)
   }
   return b;
 }
+
+boost::optional<action_t> parse_action(std::string_view s);
 }
 }
 

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -40,7 +40,7 @@ class Identity;
 namespace rgw {
 namespace IAM {
 
-enum {
+enum action_t {
   s3GetObject,
   s3GetObjectVersion,
   s3PutObject,
@@ -339,7 +339,7 @@ inline int op_to_perm(std::uint64_t op) {
 }
 }
 
-const char* action_bit_string(uint64_t action);
+const char* action_bit_string(action_t action);
 
 enum class PolicyPrincipal {
   Role,

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -7,8 +7,10 @@
 #include <chrono>
 #include <cstdint>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <string_view>
+#include <variant>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/container/flat_map.hpp>
@@ -18,6 +20,7 @@
 #include <boost/variant.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "common/ceph_time.h"
 #include "common/iso_8601.h"
@@ -339,7 +342,7 @@ inline int op_to_perm(std::uint64_t op) {
 }
 }
 
-const char* action_bit_string(action_t action);
+std::string_view action_bit_string(action_t action);
 
 enum class PolicyPrincipal {
   Role,
@@ -369,6 +372,61 @@ inline bool operator ==(const MaskedIP& l, const MaskedIP& r) {
   return (l.addr >> shift) == (r.addr >> shift);
 }
 
+class LogOut {
+  template <class... Ts>
+  struct overloaded : Ts... {
+    using Ts::operator()...;
+  };
+
+  mutable std::variant<std::monostate, std::ostream*, const DoutPrefixProvider*> log;
+  std::string prefix;
+
+public:
+  LogOut() : log(std::monostate{}) {}
+  LogOut(std::nullptr_t) : log(std::monostate{}) {}
+  LogOut(std::ostream& m) : log(&m) {}
+  LogOut(const DoutPrefixProvider* dpp)
+    : log(dpp) {
+    if (!dpp || !dpp->get_cct()->_conf->rgw_copious_policy_logging) {
+      log = std::monostate{};
+    } else {
+      std::ostringstream ostr;
+      dpp->gen_prefix(ostr);
+      prefix = std::move(ostr).str();
+    }
+  }
+
+  operator bool() const { return !std::holds_alternative<std::monostate>(log); };
+  void vformat(fmt::string_view fmt, fmt::format_args args) const {
+    std::visit(
+        overloaded{
+            [](std::monostate) {},
+            [&fmt, &args](std::ostream* o) {
+              assert(o); // We're constructing from a reference so `o` can't be null.
+              fmt::vprint(*o, fmt, args);
+              *o << std::endl;
+            },
+            [&fmt, &args, this](const DoutPrefixProvider* dpp) {
+              assert(dpp); // If we're given null, we switch to monostate
+
+              // The user has explicitly turned on policy logging, so
+              // we don't bother with the conditional logging
+              // business.
+              ceph::logging::StringEntry e(0, ceph_subsys_rgw, prefix);
+              fmt::vformat_to(e.get_inserter(), fmt, args);
+              dpp->get_cct()->_log->submit_entry(std::move(e));
+              return;
+            }
+            }, log);
+  }
+  template <typename... Args>
+  void format(fmt::format_string<Args...> fmt, Args&&... args) const
+  {
+    vformat(fmt, fmt::make_format_args(args...));
+  }
+};
+
+
 struct Condition {
   TokenID op;
   // Originally I was going to use a perfect hash table, but Marcus
@@ -387,8 +445,7 @@ struct Condition {
   Condition() = default;
   Condition(TokenID op, const char* s, std::size_t len, bool ifexists)
     : op(op), key(s, len), ifexists(ifexists) {}
-
-  bool eval(const Environment& e) const;
+  bool eval(const Environment& e, const LogOut& eval_log) const;
 
   static boost::optional<double> as_number(const std::string& s) {
     std::size_t p = 0;
@@ -485,89 +542,120 @@ struct Condition {
     }
   };
 
-  using unordered_multimap_it_pair = std::pair <std::unordered_multimap<std::string,std::string>::const_iterator, std::unordered_multimap<std::string,std::string>::const_iterator>;
+  using unordered_multimap_it_pair = std::pair<
+    std::unordered_multimap<std::string, std::string>::const_iterator,
+    std::unordered_multimap<std::string, std::string>::const_iterator>;
 
   template<typename F>
-  static bool multimap_all(F&& f, const unordered_multimap_it_pair& it,
-                           const std::vector<std::string>& v) {
+  static bool multimap_all(F&& f,
+                           const unordered_multimap_it_pair& it,
+                           const std::vector<std::string>& v,
+                           const LogOut& eval_log) {
     for (auto itr = it.first; itr != it.second; itr++) {
       bool matched = false;
+      std::string failmatch;
       for (const auto& d : v) {
         if (f(itr->second, d)) {
-	        matched = true;
+          matched = true;
+        } else if (eval_log && failmatch.empty()) {
+          failmatch = fmt::format("({}, {})", itr->second, d);
+        }
       }
-     }
-     if (!matched)
-      return false;
+      if (!matched) {
+        if (failmatch.empty()) {
+          eval_log.format("Values matched against were empty.");
+        } else {
+          eval_log.format("Predicate false for {}", failmatch);
+        }
+        return false;
+      }
     }
     return true;
   }
 
-  template<typename F>
-  static bool multimap_any(F&& f, const unordered_multimap_it_pair& it,
-                           const std::vector<std::string>& v) {
+  template <typename F>
+  static bool
+  multimap_any(F&& f,
+               const unordered_multimap_it_pair& it,
+               const std::vector<std::string>& v,
+               const LogOut& eval_log) {
     for (auto itr = it.first; itr != it.second; itr++) {
       for (const auto& d : v) {
         if (f(itr->second, d)) {
-	        return true;
+          eval_log.format("Predicate true for ({}, {})", itr->second, d);
+          return true;
+        }
       }
-     }
     }
+    eval_log.format("No predicate true. Returning false.");
     return false;
   }
 
   template<typename F>
   static bool multimap_none(F&& f, const unordered_multimap_it_pair& it,
-                            const std::vector<std::string>& v) {
+                            const std::vector<std::string>& v,
+                            const LogOut& eval_log) {
     for (auto itr = it.first; itr != it.second; itr++) {
       for (const auto& d : v) {
         if (f(itr->second, d)) {
+          eval_log.format("Predicate true for ({}, {})", itr->second, d);
           return false;
         }
       }
     }
+    eval_log.format("No predicate true. Returning true.");
     return true;
   }
 
   template<typename F, typename X>
   static bool typed_any(F&& f, X&& x, const std::string& c,
-                        const std::vector<std::string>& v) {
-    auto xc = std::forward<X>(x)(c);
+                        const std::vector<std::string>& v,
+                        const LogOut& eval_log) {
+    auto xc = x(c);
     if (!xc) {
+      eval_log.format("Failed to convert `{}`. Returning false.", c);
       return false;
     }
 
     for (const auto& d : v) {
       auto xd = x(d);
       if (!xd) {
+        eval_log.format("Failed to convert `{}`. Skipping.", d);
         continue;
       }
 
       if (f(*xc, *xd)) {
+        eval_log.format("Predicate true for ({}, {})", *xc, *xd);
         return true;
       }
     }
+    eval_log.format("No predicate true for `{}`. Returning false.", *xc);
     return false;
   }
 
   template<typename F, typename X>
   static bool typed_none(F&& f, X&& x, const std::string& c,
-                         const std::vector<std::string>& v) {
-    auto xc = std::forward<X>(x)(c);
+                         const std::vector<std::string>& v,
+                         const LogOut& eval_log) {
+    auto xc = x(c);
     if (!xc) {
+      eval_log.format("Failed to convert `{}`. Returning false.", c);
       return false;
     }
 
     for (const auto& d : v) {
       auto xd = x(d);
       if (!xd) {
+        eval_log.format("Failed to convert `{}`. Skipping.", d);
         continue;
       }
 
       if (f(*xc, *xd)) {
+        eval_log.format("Predicate true for ({}, {})", *xc, *xd);
         return false;
       }
     }
+    eval_log.format("No predicate true for `{}`. Returning true.", *xc);
     return true;
   }
 
@@ -607,13 +695,21 @@ struct Statement {
   std::vector<Condition> conditions;
 
   Effect eval(const Environment& e,
-	      boost::optional<const rgw::auth::Identity&> ida,
-	      std::uint64_t action, boost::optional<const ARN&> resource, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+              boost::optional<const rgw::auth::Identity&> ida,
+              std::uint64_t action,
+              boost::optional<const ARN&> resource,
+              const LogOut& eval_log,
+              boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
 
-  Effect eval_principal(const Environment& e,
-		       boost::optional<const rgw::auth::Identity&> ida, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+  Effect eval_principal(
+    const Environment& e,
+    boost::optional<const rgw::auth::Identity&> ida,
+    const LogOut& eval_log,
+    boost::optional<PolicyPrincipal&> princ_type = boost::none) const;
 
-  Effect eval_conditions(const Environment& e) const;
+  Effect
+  eval_conditions(const Environment& e,
+                  const LogOut& eval_log) const;
 };
 
 std::ostream& operator <<(std::ostream& m, const Statement& s);
@@ -652,14 +748,39 @@ struct Policy {
 	 std::string text,
 	 bool reject_invalid_principals);
 
+  Effect eval(std::ostream& out, const Environment& e,
+              boost::optional<const rgw::auth::Identity&> ida,
+              std::uint64_t action,
+              boost::optional<const ARN&> resource,
+              boost::optional<PolicyPrincipal&> princ_type = boost::none) const {
+    return eval(e, ida, action, resource, out, princ_type);
+  }
+
   Effect eval(const Environment& e,
-	      boost::optional<const rgw::auth::Identity&> ida,
-	      std::uint64_t action, boost::optional<const ARN&> resource, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+              boost::optional<const rgw::auth::Identity&> ida,
+              std::uint64_t action,
+              boost::optional<const ARN&> resource,
+              boost::optional<PolicyPrincipal&> princ_type = boost::none) const {
+    return eval(e, ida, action, resource, {}, princ_type);
+  }
 
-  Effect eval_principal(const Environment& e,
-	      boost::optional<const rgw::auth::Identity&> ida, boost::optional<PolicyPrincipal&> princ_type=boost::none) const;
+  Effect eval(const DoutPrefixProvider* dpp,
+              const Environment& e,
+              boost::optional<const rgw::auth::Identity&> ida,
+              std::uint64_t action,
+              boost::optional<const ARN&> resource,
+              boost::optional<PolicyPrincipal&> princ_type = boost::none) const {
+      return eval(e, ida, action, resource, dpp, princ_type);
+  }
 
-  Effect eval_conditions(const Environment& e) const;
+  Effect eval_principal(
+      const Environment& e,
+      boost::optional<const rgw::auth::Identity&> ida,
+      const LogOut& eval_log,
+      boost::optional<PolicyPrincipal&> princ_type = boost::none) const;
+
+  Effect eval_conditions(const Environment& e,
+                         const LogOut& eval_log) const;
 
   template <typename F>
   bool has_conditional(const std::string& conditional, F p) const {
@@ -693,10 +814,36 @@ struct Policy {
   bool has_partial_conditional_value(const std::string& c) const {
     return has_conditional_value(c, Condition::ci_starts_with());
   }
+
+private:
+
+  Effect eval(const Environment& e,
+              boost::optional<const rgw::auth::Identity&> ida,
+              std::uint64_t action,
+              boost::optional<const ARN&> resource,
+              const LogOut& eval_log,
+              boost::optional<PolicyPrincipal&> princ_type  =boost::none) const;
+
 };
 
 std::ostream& operator <<(std::ostream& m, const Policy& p);
-bool is_public(const Policy& p);
+bool is_public(const Policy& p, const LogOut& eval_log);
 
+inline bool is_public(const DoutPrefixProvider* dpp, const Policy& p)
+{
+  bool b = false;
+  if (dpp) {
+    bool copious_logging = dpp->get_cct()->_conf->rgw_copious_policy_logging;
+    b = is_public(p, {copious_logging ? dpp : nullptr});
+  } else {
+    b = is_public(p, nullptr);
+  }
+  return b;
 }
 }
+}
+
+template <> struct fmt::formatter<rgw::IAM::MaskedIP> : ostream_formatter {};
+template <> struct fmt::formatter<rgw::IAM::Condition> : ostream_formatter {};
+template <> struct fmt::formatter<rgw::IAM::Statement> : ostream_formatter {};
+template <> struct fmt::formatter<rgw::IAM::Policy> : ostream_formatter {};

--- a/src/rgw/rgw_iam_policy_keywords.h
+++ b/src/rgw/rgw_iam_policy_keywords.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
-namespace rgw {
-namespace IAM {
+#include <string_view>
+
+#include <fmt/format.h>
+
+namespace rgw::IAM {
 
 enum class TokenKind {
   pseudo, top, statement, cond_op, cond_key, version_key, effect_key,
@@ -127,6 +130,25 @@ enum class Effect {
   Pass
 };
 
+inline std::string_view to_string(Effect e)
+{
+  using enum Effect;
+  switch (e) {
+  case Allow:
+    return "Allow";
+  case Pass:
+    return "Pass";
+  case Deny:
+    return "Deny";
+  }
+  return "Unknown Effect";
+}
+
+inline std::ostream& operator <<(std::ostream& m, const Effect& e)
+{
+  return m << to_string(e);
+}
+
 enum class Type {
   string,
   number,
@@ -137,5 +159,13 @@ enum class Type {
   arn,
   null
 };
-}
-}
+} // namespace rgw::IAM
+
+template<>
+struct fmt::formatter<rgw::IAM::Effect> : formatter<std::string_view> {
+  template<typename FormatContext>
+  auto format(const rgw::IAM::Effect& e, FormatContext& ctx) const {
+    auto s = to_string(e);
+    return formatter<std::string_view>::format(s, ctx);
+  }
+};

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -9359,7 +9359,7 @@ void RGWPutBucketPolicy::execute(optional_yield y)
       s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
     rgw::sal::Attrs attrs(s->bucket_attrs);
     if (s->public_access_block.BlockPublicPolicy &&
-        rgw::IAM::is_public(p)) {
+        rgw::IAM::is_public(this, p)) {
       op_ret = -EACCES;
       return;
     }
@@ -9906,7 +9906,8 @@ int RGWGetBucketPolicyStatus::verify_permission(optional_yield y)
 
 void RGWGetBucketPolicyStatus::execute(optional_yield y)
 {
-  isPublic = (s->iam_policy && rgw::IAM::is_public(*s->iam_policy)) || s->bucket_acl.is_public(this);
+  isPublic = (s->iam_policy && rgw::IAM::is_public(this, *s->iam_policy)) ||
+             s->bucket_acl.is_public(this);
 }
 
 int RGWPutBucketPublicAccessBlock::verify_permission(optional_yield y)

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -453,7 +453,7 @@ protected:
   bool first_data;
   uint64_t cur_ofs;
   bufferlist waiting;
-  uint64_t action = 0;
+  rgw::IAM::action_t action{};
 
   bool get_retention;
   bool get_legal_hold;

--- a/src/rgw/rgw_poltester.cc
+++ b/src/rgw/rgw_poltester.cc
@@ -1,0 +1,167 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <boost/optional.hpp>
+
+#include "include/buffer.h"
+
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
+
+#include "global/global_init.h"
+
+#include "rgw/rgw_auth.h"
+#include "rgw/rgw_iam_policy.h"
+
+using namespace std::literals;
+
+namespace buffer = ceph::buffer;
+
+using rgw::auth::Identity;
+
+void
+evaluate(CephContext* cct, const std::string* tenant,
+         const std::string& fname, std::istream& in,
+         const std::unordered_multimap<std::string, std::string>& environment,
+         boost::optional<const rgw::auth::Identity&> ida, uint64_t action,
+         boost::optional<const rgw::ARN&> resource)
+{
+  buffer::list bl;
+  bl.append(in);
+  try {
+    auto p = rgw::IAM::Policy(
+      cct, tenant, bl.to_str(),
+      cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
+    auto effect = p.eval(std::cout, environment, ida, action, resource);
+    std::cout << effect << std::endl;
+  } catch (const rgw::IAM::PolicyParseException& e) {
+    std::cerr << fname << ": " << e.what() << std::endl;
+    throw;
+  } catch (const std::exception& e) {
+    std::cerr << fname << ": caught exception: " << e.what() << std::endl;
+    throw;
+  }
+}
+
+int helpful_exit(std::string_view cmdname)
+{
+  std::cerr << cmdname << " -h for usage" << std::endl;
+  return 1;
+}
+
+void usage(std::string_view cmdname)
+{
+  std::cout << "usage: " << cmdname << " [options...] ACTION POLICY" << std::endl;
+  std::cout << "options:" << std::endl;
+  std::cout <<
+    "  -t | --tenant=TENANT\ttenant owning the resource the policy governs\n";
+  std::cout <<
+    "  -e | --environment=KEY=VALUE\tPair to set in the environment\n";
+  std::cout << "  -I | --identity=IDENTITY\tIdentity against which to test\n";
+  std::cout << "  -R | --resource=ARN\tResource to test access to\n\n";
+  std::cout << "  ACTION\tAction to test against, e.g. s3:GetObject\n";
+  std::cout << "  POLICY\tFilename of the policy or - for standard input\n";
+  std::cout.flush();
+}
+
+// This has an uncaught exception. Even if the exception is caught, the program
+// would need to be terminated, so the warning is simply suppressed.
+// coverity[root_function:SUPPRESS]
+int main(int argc, const char* argv[])
+{
+  std::string_view cmdname = argv[0];
+  std::string tenant{}; // Explicitly defaulted to the empty tenant if none is provided.
+  std::unordered_multimap<std::string, std::string> environment;
+  boost::optional<rgw::auth::PrincipalIdentity> identity_;
+  boost::optional<const rgw::auth::Identity&> identity;
+  uint64_t action = 0;
+  boost::optional<rgw::ARN> resource_;
+  boost::optional<const rgw::ARN&> resource;
+
+  auto args = argv_to_vec(argc, argv);
+  if (ceph_argparse_need_usage(args)) {
+    usage(cmdname);
+    return 0;
+  }
+
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DAEMON_ACTIONS |
+			 CINIT_FLAG_NO_MON_CONFIG);
+  common_init_finish(cct.get());
+  std::string val;
+  for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
+    if (ceph_argparse_double_dash(args, i)) {
+      break;
+    } else if (ceph_argparse_witharg(args, i, &val, "--tenant", "-t",
+				     (char*)nullptr)) {
+      tenant = std::move(val);
+    } else if (ceph_argparse_witharg(args, i, &val, "--environment", "-e",
+				     (char*)nullptr)) {
+      auto equal = val.find('=');
+      if (equal == val.npos || equal == 0) {
+        return helpful_exit(cmdname);
+      }
+      std::string k{val.data(), equal};
+      std::string v{val.data() + equal + 1};
+      environment.insert({std::move(k), std::move(v)});
+    } else if (ceph_argparse_witharg(args, i, &val, "--resource", "-R",
+				     (char*)nullptr)) {
+      resource_ = rgw::ARN::parse(val);
+      if (!resource_) {
+        return helpful_exit(cmdname);
+      }
+      resource = *resource_;
+    } else if (ceph_argparse_witharg(args, i, &val, "--identity", "-I",
+				     (char*)nullptr)) {
+      std::string errmsg;
+      auto principal = rgw::IAM::parse_principal(std::move(val), &errmsg);
+      if (!principal) {
+        std::cerr << errmsg << std::endl;
+        return helpful_exit(cmdname);
+      }
+      identity_.emplace(std::move(*principal));
+      identity = *identity_;
+    } else {
+      ++i;
+    }
+  }
+
+  if (args.size() != 2) {
+    return helpful_exit(cmdname);
+  }
+
+  if (auto act = rgw::IAM::parse_action(args[0]); act) {
+    action = *act;
+  } else {
+    std::cerr << args[0] << " is not a valid action." << std::endl;
+    return helpful_exit(cmdname);
+  }
+
+  try {
+    if (args[1] == "-"s) {
+      evaluate(cct.get(), &tenant, "(stdin)", std::cin,
+               environment, identity, action, resource);
+    } else {
+      std::ifstream in;
+      in.open(args[1], std::ifstream::in);
+      if (!in.is_open()) {
+        std::cerr << "Can't read " << args[1] << std::endl;
+        return 1;
+      }
+      evaluate(cct.get(), &tenant, args[1], in, environment,
+               identity, action, resource);
+    }
+  } catch (const std::exception&) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -857,7 +857,7 @@ int RGWREST_STS::verify_permission(optional_yield y)
 
     const rgw::IAM::Policy p(s->cct, policy_tenant, policy, false);
     if (!s->principal_tags.empty()) {
-      auto res = p.eval(s->env, *s->auth.identity, rgw::IAM::stsTagSession, boost::none);
+      auto res = p.eval(this, s->env, *s->auth.identity, rgw::IAM::stsTagSession, boost::none);
       if (res != rgw::IAM::Effect::Allow) {
         ldout(s->cct, 0) << "evaluating policy for stsTagSession returned deny/pass" << dendl;
         return -EPERM;
@@ -870,7 +870,7 @@ int RGWREST_STS::verify_permission(optional_yield y)
       op = rgw::IAM::stsAssumeRole;
     }
 
-    auto res = p.eval(s->env, *s->auth.identity, op, boost::none);
+    auto res = p.eval(this, s->env, *s->auth.identity, op, boost::none);
     if (res != rgw::IAM::Effect::Allow) {
       ldout(s->cct, 0) << "evaluating policy for op: " << op << " returned deny/pass" << dendl;
       return -EPERM;

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -271,18 +271,15 @@ TEST_F(PolicyTest, Eval1) {
 
   ARN arn1(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn1),
-	    Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn1), Effect::Allow);
 
   ARN arn2(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "example_bucket");
-  EXPECT_EQ(p.eval(e, none, s3PutBucketAcl, arn2),
-	    Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, s3PutBucketAcl, arn2), Effect::Pass);
 
   ARN arn3(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "erroneous_bucket");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn3),
-	    Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn3), Effect::Pass);
 
 }
 
@@ -341,29 +338,22 @@ TEST_F(PolicyTest, Eval2) {
   for (auto i = 0ULL; i < s3All; ++i) {
     ARN arn1(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn1),
-	      Effect::Allow);
+    EXPECT_EQ(p.eval(e, trueacct, i, arn1), Effect::Allow);
     ARN arn2(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket/myobject");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn2),
-	      Effect::Allow);
+    EXPECT_EQ(p.eval(e, trueacct, i, arn2), Effect::Allow);
     ARN arn3(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket");
-    EXPECT_EQ(p.eval(e, notacct, i, arn3),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(e, notacct, i, arn3), Effect::Pass);
     ARN arn4(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "mybucket/myobject");
-    EXPECT_EQ(p.eval(e, notacct, i, arn4),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(e, notacct, i, arn4), Effect::Pass);
     ARN arn5(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "notyourbucket");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn5),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(e, trueacct, i, arn5), Effect::Pass);
     ARN arn6(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "notyourbucket/notyourobject");
-    EXPECT_EQ(p.eval(e, trueacct, i, arn6),
-	      Effect::Pass);
-
+    EXPECT_EQ(p.eval(e, trueacct, i, arn6), Effect::Pass);
   }
 }
 
@@ -535,13 +525,11 @@ TEST_F(PolicyTest, Eval3) {
 
   ARN arn1(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket");
-  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn1),
-	    Effect::Allow);
+  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn1), Effect::Allow);
 
   ARN arn2(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket");
-  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn2),
-	    Effect::Allow);
+  EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy, arn2), Effect::Allow);
 
 
   for (auto op = 0ULL; op < s3All; ++op) {
@@ -550,20 +538,16 @@ TEST_F(PolicyTest, Eval3) {
     }
     ARN arn3(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data");
-    EXPECT_EQ(p.eval(em, none, op, arn3),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(em, none, op, arn3), Effect::Pass);
     ARN arn4(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data");
-    EXPECT_EQ(p.eval(tr, none, op, arn4),
-	      s3allow[op] ? Effect::Allow : Effect::Pass);
+    EXPECT_EQ(p.eval(tr, none, op, arn4), s3allow[op] ? Effect::Allow : Effect::Pass);
     ARN arn5(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data");
-    EXPECT_EQ(p.eval(fa, none, op, arn5),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(fa, none, op, arn5), Effect::Pass);
     ARN arn6(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data/moo");
-    EXPECT_EQ(p.eval(em, none, op, arn6),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(em, none, op, arn6), Effect::Pass);
     ARN arn7(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "confidential-data/moo");
     EXPECT_EQ(p.eval(tr, none, op, arn7),
@@ -574,16 +558,13 @@ TEST_F(PolicyTest, Eval3) {
 	      Effect::Pass);
     ARN arn9(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "really-confidential-data");
-    EXPECT_EQ(p.eval(em, none, op, arn9),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(em, none, op, arn9), Effect::Pass);
     ARN arn10(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "really-confidential-data");
-    EXPECT_EQ(p.eval(tr, none, op, arn10),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(tr, none, op, arn10), Effect::Pass);
     ARN arn11(Partition::aws, Service::s3,
 			 "", arbitrary_tenant, "really-confidential-data");
-    EXPECT_EQ(p.eval(fa, none, op, arn11),
-	      Effect::Pass);
+    EXPECT_EQ(p.eval(fa, none, op, arn11), Effect::Pass);
     ARN arn12(Partition::aws, Service::s3,
 			 "", arbitrary_tenant,
 			 "really-confidential-data/moo");
@@ -596,7 +577,6 @@ TEST_F(PolicyTest, Eval3) {
 			 "", arbitrary_tenant,
 			 "really-confidential-data/moo");
     EXPECT_EQ(p.eval(fa, none, op, arn14), Effect::Pass);
-
   }
 }
 
@@ -636,13 +616,11 @@ TEST_F(PolicyTest, Eval4) {
 
   ARN arn1(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1),
-	    Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1), Effect::Allow);
 
   ARN arn2(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamDeleteRole, arn2),
-	    Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, iamDeleteRole, arn2), Effect::Pass);
 }
 
 TEST_F(PolicyTest, Parse5) {
@@ -681,18 +659,15 @@ TEST_F(PolicyTest, Eval5) {
 
   ARN arn1(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1),
-	    Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1), Effect::Allow);
 
   ARN arn2(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "role/example_role");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2),
-	    Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2), Effect::Pass);
 
   ARN arn3(Partition::aws, Service::iam,
 		       "", "", "role/example_role");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn3),
-	    Effect::Pass);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn3), Effect::Pass);
 }
 
 TEST_F(PolicyTest, Parse6) {
@@ -731,13 +706,11 @@ TEST_F(PolicyTest, Eval6) {
 
   ARN arn1(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "user/A");
-  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1),
-	    Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, iamCreateRole, arn1), Effect::Allow);
 
   ARN arn2(Partition::aws, Service::iam,
 		       "", arbitrary_tenant, "user/A");
-  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2),
-	    Effect::Allow);
+  EXPECT_EQ(p.eval(e, none, s3ListBucket, arn2), Effect::Allow);
 }
 
 TEST_F(PolicyTest, Parse7) {
@@ -786,18 +759,15 @@ TEST_F(PolicyTest, Eval7) {
 
   ARN arn1(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket/*");
-  EXPECT_EQ(p.eval(e, subacct, s3ListBucket, arn1),
-	    Effect::Allow);
-  
+  EXPECT_EQ(p.eval(e, subacct, s3ListBucket, arn1), Effect::Allow);
+
   ARN arn2(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket/*");
-  EXPECT_EQ(p.eval(e, parentacct, s3ListBucket, arn2),
-	    Effect::Pass);
+  EXPECT_EQ(p.eval(e, parentacct, s3ListBucket, arn2), Effect::Pass);
 
   ARN arn3(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket/*");
-  EXPECT_EQ(p.eval(e, sub2acct, s3ListBucket, arn3),
-	    Effect::Pass);
+  EXPECT_EQ(p.eval(e, sub2acct, s3ListBucket, arn3), Effect::Pass);
 }
 
 
@@ -1283,43 +1253,43 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
   ARN arn1(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket");
   EXPECT_EQ(allowp.eval(e, trueacct, s3ListBucket, arn1),
-	    Effect::Pass);
+            Effect::Pass);
   ARN arn2(Partition::aws, Service::s3,
       "", arbitrary_tenant, "example_bucket/myobject");
   EXPECT_EQ(fullp.eval(e, trueacct, s3ListBucket, arn2),
-	    Effect::Pass);
+            Effect::Pass);
 
   ARN arn3(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket");
   EXPECT_EQ(allowp.eval(allowedIP, trueacct, s3ListBucket, arn3),
-	    Effect::Allow);
+            Effect::Allow);
   ARN arn4(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket");
   EXPECT_EQ(allowp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn4),
-	    Effect::Pass);
+            Effect::Pass);
 
   ARN arn5(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
   EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket, arn5),
-	    Effect::Deny);
+            Effect::Deny);
   ARN arn6(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
   EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket, arn6),
-	    Effect::Deny);
+            Effect::Deny);
 
   ARN arn7(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
   EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket, arn7),
-	    Effect::Pass);
+            Effect::Pass);
   ARN arn8(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
   EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket, arn8),
-	    Effect::Pass);
+            Effect::Pass);
 
   ARN arn9(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket");
   EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn9),
-	    Effect::Pass);
+            Effect::Pass);
   ARN arn10(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject");
   EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket, arn10),
@@ -1555,20 +1525,20 @@ TEST(Condition, ArnLike)
     Condition ArnLike{TokenID::ArnLike, key.data(), key.size(), false};
     ArnLike.vals.push_back("arn:aws:s3:::bucket");
 
-    EXPECT_FALSE(ArnLike.eval({}));
-    EXPECT_TRUE(ArnLike.eval({{key, "arn:aws:s3:::bucket"}}));
-    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::BUCKET"}}));
-    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::user"}}));
+    EXPECT_FALSE(ArnLike.eval({}, nullptr));
+    EXPECT_TRUE(ArnLike.eval({{key, "arn:aws:s3:::bucket"}}, nullptr));
+    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::BUCKET"}}, nullptr));
+    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::user"}}, nullptr));
   }
   {
     Condition ArnLike{TokenID::ArnLike, key.data(), key.size(), false};
     ArnLike.vals.push_back("arn:aws:s3:::b*");
 
-    EXPECT_FALSE(ArnLike.eval({}));
-    EXPECT_TRUE(ArnLike.eval({{key, "arn:aws:s3:::b"}}));
-    EXPECT_TRUE(ArnLike.eval({{key, "arn:aws:s3:::bucket"}}));
-    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::BUCKET"}}));
-    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::user"}}));
+    EXPECT_FALSE(ArnLike.eval({}, nullptr));
+    EXPECT_TRUE(ArnLike.eval({{key, "arn:aws:s3:::b"}}, nullptr));
+    EXPECT_TRUE(ArnLike.eval({{key, "arn:aws:s3:::bucket"}}, nullptr));
+    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::BUCKET"}}, nullptr));
+    EXPECT_FALSE(ArnLike.eval({{key, "arn:aws:s3:::user"}}, nullptr));
   }
 }
 
@@ -1589,7 +1559,7 @@ protected:
 TEST_F(ConditionTest, StringNotEqualsLogic)
 {
   std::string key = "aws:UserName";
-  
+
   // Test case: value matches one of multiple condition values
   // Should return false because value equals at least one condition value
   {
@@ -1599,11 +1569,11 @@ TEST_F(ConditionTest, StringNotEqualsLogic)
     stringNotEquals.vals.push_back("charlie");
 
     // Input "bob" matches second condition value, should return false
-    EXPECT_FALSE(stringNotEquals.eval({{key, "bob"}}));
-    // Input "alice" matches first condition value, should return false  
-    EXPECT_FALSE(stringNotEquals.eval({{key, "alice"}}));
+    EXPECT_FALSE(stringNotEquals.eval({{key, "bob"}}, nullptr));
+    // Input "alice" matches first condition value, should return false
+    EXPECT_FALSE(stringNotEquals.eval({{key, "alice"}}, nullptr));
   }
-  
+
   // Test case: value doesn't match any condition values
   // Should return true because value differs from all condition values
   {
@@ -1613,7 +1583,7 @@ TEST_F(ConditionTest, StringNotEqualsLogic)
     stringNotEquals.vals.push_back("charlie");
 
     // Input "david" doesn't match any condition value, should return true
-    EXPECT_TRUE(stringNotEquals.eval({{key, "david"}}));
+    EXPECT_TRUE(stringNotEquals.eval({{key, "david"}}, nullptr));
   }
 }
 
@@ -1630,11 +1600,11 @@ TEST_F(ConditionTest, NumericNotEqualsLogic)
     numericNotEquals.vals.push_back("30");
 
     // Input "20" matches second condition value, should return false
-    EXPECT_FALSE(numericNotEquals.eval({{key, "20"}}));
+    EXPECT_FALSE(numericNotEquals.eval({{key, "20"}}, nullptr));
     // Input "10" matches first condition value, should return false
-    EXPECT_FALSE(numericNotEquals.eval({{key, "10"}}));
+    EXPECT_FALSE(numericNotEquals.eval({{key, "10"}}, nullptr));
   }
-  
+
   // Test case: value doesn't match any condition values
   // Should return true because value differs from all condition values
   {
@@ -1644,14 +1614,14 @@ TEST_F(ConditionTest, NumericNotEqualsLogic)
     numericNotEquals.vals.push_back("30");
 
     // Input "40" doesn't match any condition value, should return true
-    EXPECT_TRUE(numericNotEquals.eval({{key, "40"}}));
+    EXPECT_TRUE(numericNotEquals.eval({{key, "40"}}, nullptr));
   }
 }
 
 TEST_F(ConditionTest, DateNotEqualsLogic)
 {
   std::string key = "aws:CurrentTime";
-  
+
   // Test case: value matches one of multiple condition values
   // Should return false because value equals at least one condition value
   {
@@ -1661,9 +1631,9 @@ TEST_F(ConditionTest, DateNotEqualsLogic)
     dateNotEquals.vals.push_back("2023-12-01T00:00:00Z");
 
     // Input matches second condition value, should return false
-    EXPECT_FALSE(dateNotEquals.eval({{key, "2023-06-01T00:00:00Z"}}));
+    EXPECT_FALSE(dateNotEquals.eval({{key, "2023-06-01T00:00:00Z"}}, nullptr));
   }
-  
+
   // Test case: value doesn't match any condition values
   // Should return true because value differs from all condition values
   {
@@ -1673,14 +1643,14 @@ TEST_F(ConditionTest, DateNotEqualsLogic)
     dateNotEquals.vals.push_back("2023-12-01T00:00:00Z");
 
     // Input doesn't match any condition value, should return true
-    EXPECT_TRUE(dateNotEquals.eval({{key, "2024-01-01T00:00:00Z"}}));
+    EXPECT_TRUE(dateNotEquals.eval({{key, "2024-01-01T00:00:00Z"}}, nullptr));
   }
 }
 
 TEST_F(ConditionTest, NotIpAddressLogic)
 {
   std::string key = "aws:SourceIp";
-  
+
   // Test case: value matches one of multiple condition values
   // Should return false because value equals at least one condition value
   {
@@ -1690,11 +1660,11 @@ TEST_F(ConditionTest, NotIpAddressLogic)
     notIpAddress.vals.push_back("172.16.0.1");
 
     // Input matches second condition value, should return false
-    EXPECT_FALSE(notIpAddress.eval({{key, "10.0.0.1"}}));
+    EXPECT_FALSE(notIpAddress.eval({{key, "10.0.0.1"}}, nullptr));
     // Input matches first condition value, should return false
-    EXPECT_FALSE(notIpAddress.eval({{key, "192.168.1.1"}}));
+    EXPECT_FALSE(notIpAddress.eval({{key, "192.168.1.1"}}, nullptr));
   }
-  
+
   // Test case: value doesn't match any condition values
   // Should return true because value differs from all condition values
   {
@@ -1704,14 +1674,14 @@ TEST_F(ConditionTest, NotIpAddressLogic)
     notIpAddress.vals.push_back("172.16.0.1");
 
     // Input doesn't match any condition value, should return true
-    EXPECT_TRUE(notIpAddress.eval({{key, "8.8.8.8"}}));
+    EXPECT_TRUE(notIpAddress.eval({{key, "8.8.8.8"}}, nullptr));
   }
 }
 
 TEST_F(ConditionTest, ArnNotEqualsLogic)
 {
   std::string key = "aws:SourceArn";
-  
+
   // Test case: value matches one of multiple condition values
   // Should return false because value equals at least one condition value
   {
@@ -1721,9 +1691,9 @@ TEST_F(ConditionTest, ArnNotEqualsLogic)
     arnNotEquals.vals.push_back("arn:aws:s3:::bucket3");
 
     // Input matches second condition value, should return false
-    EXPECT_FALSE(arnNotEquals.eval({{key, "arn:aws:s3:::bucket2"}}));
+    EXPECT_FALSE(arnNotEquals.eval({{key, "arn:aws:s3:::bucket2"}}, nullptr));
   }
-  
+
   // Test case: value doesn't match any condition values
   // Should return true because value differs from all condition values
   {
@@ -1733,14 +1703,15 @@ TEST_F(ConditionTest, ArnNotEqualsLogic)
     arnNotEquals.vals.push_back("arn:aws:s3:::bucket3");
 
     // Input doesn't match any condition value, should return true
-    EXPECT_TRUE(arnNotEquals.eval({{key, "arn:aws:s3:::other-bucket"}}));
+    EXPECT_TRUE(arnNotEquals.eval({{key, "arn:aws:s3:::other-bucket"}},
+                                  nullptr));
   }
 }
 
 TEST_F(ConditionTest, StringNotLikeLogic)
 {
   std::string key = "s3:prefix";
-  
+
   // Test case: value matches one of multiple condition patterns
   // Should return false because value matches at least one condition pattern
   {
@@ -1750,11 +1721,11 @@ TEST_F(ConditionTest, StringNotLikeLogic)
     stringNotLike.vals.push_back("temp/*");
 
     // Input matches second condition pattern, should return false
-    EXPECT_FALSE(stringNotLike.eval({{key, "admin/config.txt"}}));
+    EXPECT_FALSE(stringNotLike.eval({{key, "admin/config.txt"}}, nullptr));
     // Input matches first condition pattern, should return false
-    EXPECT_FALSE(stringNotLike.eval({{key, "user/profile.jpg"}}));
+    EXPECT_FALSE(stringNotLike.eval({{key, "user/profile.jpg"}}, nullptr));
   }
-  
+
   // Test case: value doesn't match any condition patterns
   // Should return true because value differs from all condition patterns
   {
@@ -1764,7 +1735,7 @@ TEST_F(ConditionTest, StringNotLikeLogic)
     stringNotLike.vals.push_back("temp/*");
 
     // Input doesn't match any condition pattern, should return true
-    EXPECT_TRUE(stringNotLike.eval({{key, "public/document.pdf"}}));
+    EXPECT_TRUE(stringNotLike.eval({{key, "public/document.pdf"}}, nullptr));
   }
 }
 
@@ -1777,8 +1748,8 @@ TEST_F(ConditionTest, Null)
     Condition isNull{TokenID::Null, key.data(), key.size(), false};
     isNull.vals.push_back("true");
 
-    EXPECT_TRUE(isNull.eval({}));
-    EXPECT_FALSE(isNull.eval({{key, "admin/config.txt"}}));
+    EXPECT_TRUE(isNull.eval({}, nullptr));
+    EXPECT_FALSE(isNull.eval({{key, "admin/config.txt"}}, nullptr));
   }
 
   {
@@ -1786,8 +1757,8 @@ TEST_F(ConditionTest, Null)
     Condition notNull{TokenID::Null, key.data(), key.size(), false};
     notNull.vals.push_back("false");
 
-    EXPECT_FALSE(notNull.eval({}));
-    EXPECT_TRUE(notNull.eval({{key, "admin/config.txt"}}));
+    EXPECT_FALSE(notNull.eval({}, nullptr));
+    EXPECT_TRUE(notNull.eval({{key, "admin/config.txt"}}, nullptr));
   }
 }
 
@@ -1799,32 +1770,32 @@ TEST_F(ConditionTest, KeyStoneRoleStringEquals)
   cond.vals.push_back("testrole");
 
   // No roles
-  EXPECT_FALSE(cond.eval({}));
+  EXPECT_FALSE(cond.eval({}, nullptr));
 
   // Single matching role
-  EXPECT_TRUE(cond.eval({{key, "testrole"}}));
+  EXPECT_TRUE(cond.eval({{key, "testrole"}}, nullptr));
 
   // Single non-matching role
-  EXPECT_FALSE(cond.eval({{key, "member"}}));
+  EXPECT_FALSE(cond.eval({{key, "member"}}, nullptr));
 
   //Multiple roles in env,one matches
   Environment multi_env;
   multi_env.emplace(key, "member");
   multi_env.emplace(key, "testrole");
   multi_env.emplace(key, "reader");
-  EXPECT_TRUE(cond.eval(multi_env));
+  EXPECT_TRUE(cond.eval(multi_env, nullptr));
 
   //Multiple roles in env, no match
   Environment no_match_env;
   no_match_env.emplace(key, "member");
   no_match_env.emplace(key, "reader");
-  EXPECT_FALSE(cond.eval(no_match_env));
+  EXPECT_FALSE(cond.eval(no_match_env, nullptr));
 
   // Multiple identical roles (redundancy check)
   Environment duplicate_env;
   duplicate_env.emplace(key, "testrole");
   duplicate_env.emplace(key, "testrole");
-  EXPECT_TRUE(cond.eval(duplicate_env));
+  EXPECT_TRUE(cond.eval(duplicate_env, nullptr));
 }
 
 TEST_F(ConditionTest, KeyStoneRoleNotStringEquals)
@@ -1835,26 +1806,26 @@ TEST_F(ConditionTest, KeyStoneRoleNotStringEquals)
   cond.vals.push_back("admin");
 
   // No roles
-  EXPECT_FALSE(cond.eval({}));
+  EXPECT_FALSE(cond.eval({}, nullptr));
 
   // Role matches
-  EXPECT_FALSE(cond.eval({{key, "admin"}}));
+  EXPECT_FALSE(cond.eval({{key, "admin"}}, nullptr));
 
   // Role doesn't match
-  EXPECT_TRUE(cond.eval({{key, "member"}}));
+  EXPECT_TRUE(cond.eval({{key, "member"}}, nullptr));
 
   // Multiple roles in env, one matches -> false
   Environment multi_env;
   multi_env.emplace(key, "member");
   multi_env.emplace(key, "admin");
   EXPECT_FALSE(multi_env.count(key) == 0);
-  EXPECT_FALSE(cond.eval(multi_env));
+  EXPECT_FALSE(cond.eval(multi_env, nullptr));
 
   // Multiple roles, none match -> true
   Environment no_match_env;
   no_match_env.emplace(key, "member");
   no_match_env.emplace(key, "reader");
-  EXPECT_TRUE(cond.eval(no_match_env));
+  EXPECT_TRUE(cond.eval(no_match_env, nullptr));
 }
 
 TEST_F(ConditionTest, KeyStoneRolePolicyParsing)
@@ -1893,18 +1864,18 @@ TEST_F(ConditionTest, KeyStoneRolePolicyParsing)
   // Eval with matching role in environment
   Environment match_env;
   match_env.emplace("keystone:role", "testrole");
-  EXPECT_TRUE(p->statements[0].conditions[0].eval(match_env));
+  EXPECT_TRUE(p->statements[0].conditions[0].eval(match_env, nullptr));
 
   // Eval with non-matching role
   Environment nomatch_env;
   nomatch_env.emplace("keystone:role", "member");
-  EXPECT_FALSE(p->statements[0].conditions[0].eval(nomatch_env));
+  EXPECT_FALSE(p->statements[0].conditions[0].eval(nomatch_env, nullptr));
 
   // Eval with multiple roles, one matching
   Environment multi_env;
   multi_env.emplace("keystone:role", "member");
   multi_env.emplace("keystone:role", "testrole");
-  EXPECT_TRUE(p->statements[0].conditions[0].eval(multi_env));
+  EXPECT_TRUE(p->statements[0].conditions[0].eval(multi_env, nullptr));
 }
 
 TEST_F(ConditionTest, KeystoneUserIdStringEquals)
@@ -1913,7 +1884,7 @@ TEST_F(ConditionTest, KeystoneUserIdStringEquals)
   Condition cond{TokenID::StringEquals, key.data(), key.size(), false};
   cond.vals.push_back("user-123");
 
-  EXPECT_FALSE(cond.eval({}));
-  EXPECT_TRUE(cond.eval({{key, "user-123"}}));
-  EXPECT_FALSE(cond.eval({{key, "user-456"}}));
+  EXPECT_FALSE(cond.eval({}, nullptr));
+  EXPECT_TRUE(cond.eval({{key, "user-123"}}, nullptr));
+  EXPECT_FALSE(cond.eval({{key, "user-456"}}, nullptr));
 }

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -40,6 +40,7 @@ using boost::none;
 
 using rgw::auth::Identity;
 using rgw::auth::Principal;
+using rgw::auth::PrincipalIdentity;
 
 using rgw::ARN;
 using rgw::IAM::Effect;
@@ -142,81 +143,6 @@ using rgw::IAM::organizationsAllValue;
 using rgw::IAM::allValue;
 
 using rgw::IAM::get_managed_policy;
-
-class FakeIdentity : public Identity {
-  const Principal id;
-public:
-
-  explicit FakeIdentity(Principal&& id) : id(std::move(id)) {}
-
-  ACLOwner get_aclowner() const override {
-    ceph_abort();
-    return {};
-  }
-
-  uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
-    ceph_abort();
-    return 0;
-  };
-
-  bool is_admin() const override {
-    ceph_abort();
-    return false;
-  }
-
-  bool is_owner_of(const rgw_owner& owner) const override {
-    ceph_abort();
-    return false;
-  }
-
-  bool is_root() const override {
-    ceph_abort();
-    return false;
-  }
-
-  virtual uint32_t get_perm_mask() const override {
-    ceph_abort();
-    return 0;
-  }
-
-  string get_acct_name() const override {
-    abort();
-    return string{};
-  }
-
-  string get_subuser() const override {
-    abort();
-    return string{};
-  }
-
-  const std::string& get_tenant() const override {
-    ceph_abort();
-    static std::string empty;
-    return empty;
-  }
-
-  const std::optional<RGWAccountInfo>& get_account() const override {
-    ceph_abort();
-    static std::optional<RGWAccountInfo> empty;
-    return empty;
-  }
-
-  void to_str(std::ostream& out) const override {
-    out << id;
-  }
-
-  bool is_identity(const Principal& p) const override {
-    return id.is_wildcard() || p.is_wildcard() || p == id;
-  }
-
-  uint32_t get_identity_type() const override {
-    return TYPE_RGW;
-  }
-
-  std::optional<rgw::ARN> get_caller_identity() const override {
-    return std::nullopt;
-  }
-};
 
 class PolicyTest : public ::testing::Test {
 protected:
@@ -330,10 +256,10 @@ TEST_F(PolicyTest, Eval2) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example2, true);
   Environment e;
 
-  auto trueacct = FakeIdentity(
+  auto trueacct = PrincipalIdentity(
     Principal::account("ACCOUNT-ID-WITHOUT-HYPHENS"));
 
-  auto notacct = FakeIdentity(
+  auto notacct = PrincipalIdentity(
     Principal::account("some-other-account"));
   for (auto i = 0ULL; i < s3All; ++i) {
     ARN arn1(Partition::aws, Service::s3,
@@ -750,11 +676,11 @@ TEST_F(PolicyTest, Eval7) {
   auto p  = Policy(cct.get(), &arbitrary_tenant, example7, true);
   Environment e;
 
-  auto subacct = FakeIdentity(
+  auto subacct = PrincipalIdentity(
     Principal::user(std::move(""), "A:subA"));
-  auto parentacct = FakeIdentity(
+  auto parentacct = PrincipalIdentity(
     Principal::user(std::move(""), "A"));
-  auto sub2acct = FakeIdentity(
+  auto sub2acct = PrincipalIdentity(
     Principal::user(std::move(""), "A:sub2A"));
 
   ARN arn1(Partition::aws, Service::s3,
@@ -1247,7 +1173,7 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
   blocklistedIP.emplace("aws:SourceIp", "192.168.1.1");
   blocklistedIPv6.emplace("aws:SourceIp", "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
 
-  auto trueacct = FakeIdentity(
+  auto trueacct = PrincipalIdentity(
     Principal::account("ACCOUNT-ID-WITHOUT-HYPHENS"));
   // Without an IP address in the environment then evaluation will always pass
   ARN arn1(Partition::aws, Service::s3,


### PR DESCRIPTION
Add option `rgw copious policy logging` to dump a trace of policy evaluation to the log. Also add `rgw-policy-test` to verbosely evaluate policies from the command line.

https://tracker.ceph.com/issues/77740


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
