### PR TITLE
cephadm: Refactor _check_daemons to allow service subclasses to choose the next action

### DIFF
--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -972,7 +972,7 @@ class CephadmAgentHelpers:
             return down
         try:
             spec = self.mgr.spec_store.active_specs.get(CephadmAgent.TYPE, None)
-            deps = self.mgr._calc_daemon_deps(spec, CephadmAgent.TYPE, agent.daemon_id)
+            deps = CephadmAgent.sorted_dependencies(self.mgr, spec, CephadmAgent.TYPE)
             last_deps, last_config = self.mgr.agent_cache.get_agent_last_config_deps(host)
             if not last_config or last_deps != deps:
                 # if root cert is the dep that changed, we must use ssh to reconfig

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3154,15 +3154,6 @@ Then run the following:
             previews_for_specs.update({host: osd_reports})
         return previews_for_specs
 
-    def _calc_daemon_deps(self,
-                          spec: Optional[ServiceSpec],
-                          daemon_type: str,
-                          daemon_id: str) -> List[str]:
-        svc_type = daemon_type_to_service(daemon_type)
-        svc_cls = service_registry.get_service(svc_type)
-        deps = svc_cls.get_dependencies(self, spec, daemon_type) if svc_cls else []
-        return sorted(deps)
-
     @forall_hosts
     def _remove_daemons(self, name: str, host: str) -> str:
         return CephadmServe(self)._remove_daemon(name, host)

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1208,11 +1208,6 @@ class CephadmServe:
                     REDEPLOY_TRIGGERS = ['secure_monitoring_stack', 'mgmt-gateway']
                     if any(svc in e for e in diff for svc in REDEPLOY_TRIGGERS):
                         action = 'redeploy'
-                elif dd.daemon_type == 'jaeger-agent':
-                    # changes to jaeger-agent deps affect the way the unit.run for
-                    # the daemon is written, which we rewrite on redeploy, but not
-                    # on reconfig.
-                    action = 'redeploy'
             elif dd.daemon_type == 'haproxy':
                 if spec and hasattr(spec, 'backend_service'):
                     backend_spec = self.mgr.spec_store[spec.backend_service].spec

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1181,7 +1181,7 @@ class CephadmServe:
                     backend_spec = self.mgr.spec_store[spec.backend_service].spec
                     if backend_spec.service_type == 'nfs':
                         svc = service_registry.get_service('ingress')
-                        if svc.has_placement_changed(deps, spec):
+                        if svc.has_placement_changed(last_deps, spec):
                             self.log.debug(f'Redeploy {spec.service_name()} as placement has changed')
                             action = 'redeploy'
             elif spec is not None and hasattr(spec, 'extra_container_args') and dd.extra_container_args != spec.extra_container_args:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1161,6 +1161,18 @@ class CephadmServe:
                 self.log.info('Reconfiguring %s (unknown last config time)...' % (
                     dd.name()))
                 action = 'reconfig'
+            elif spec is not None and hasattr(spec, 'extra_container_args') and dd.extra_container_args != spec.extra_container_args:
+                self.log.debug(
+                    f'{dd.name()} container cli args {dd.extra_container_args} -> {spec.extra_container_args}')
+                self.log.info(f'Redeploying {dd.name()}, (container cli args changed) . . .')
+                dd.extra_container_args = spec.extra_container_args
+                action = 'redeploy'
+            elif spec is not None and hasattr(spec, 'extra_entrypoint_args') and dd.extra_entrypoint_args != spec.extra_entrypoint_args:
+                self.log.info(f'Redeploying {dd.name()}, (entrypoint args changed) . . .')
+                self.log.debug(
+                    f'{dd.name()} daemon entrypoint args {dd.extra_entrypoint_args} -> {spec.extra_entrypoint_args}')
+                dd.extra_entrypoint_args = spec.extra_entrypoint_args
+                action = 'redeploy'
             elif last_deps != deps:
                 sym_diff = set(deps).symmetric_difference(last_deps)
                 self.log.info(f'Reconfiguring {dd.name()} deps {last_deps} -> {deps} (diff {sym_diff})')
@@ -1190,18 +1202,6 @@ class CephadmServe:
                         if svc.has_placement_changed(last_deps, spec):
                             self.log.debug(f'Redeploy {spec.service_name()} as placement has changed')
                             action = 'redeploy'
-            elif spec is not None and hasattr(spec, 'extra_container_args') and dd.extra_container_args != spec.extra_container_args:
-                self.log.debug(
-                    f'{dd.name()} container cli args {dd.extra_container_args} -> {spec.extra_container_args}')
-                self.log.info(f'Redeploying {dd.name()}, (container cli args changed) . . .')
-                dd.extra_container_args = spec.extra_container_args
-                action = 'redeploy'
-            elif spec is not None and hasattr(spec, 'extra_entrypoint_args') and dd.extra_entrypoint_args != spec.extra_entrypoint_args:
-                self.log.info(f'Redeploying {dd.name()}, (entrypoint args changed) . . .')
-                self.log.debug(
-                    f'{dd.name()} daemon entrypoint args {dd.extra_entrypoint_args} -> {spec.extra_entrypoint_args}')
-                dd.extra_entrypoint_args = spec.extra_entrypoint_args
-                action = 'redeploy'
             elif self.mgr.last_monmap and \
                     self.mgr.last_monmap > last_config and \
                     dd.daemon_type in CEPH_TYPES:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1201,13 +1201,6 @@ class CephadmServe:
                 sym_diff = set(deps).symmetric_difference(last_deps)
                 self.log.info(f'Reconfiguring {dd.name()} deps {last_deps} -> {deps} (diff {sym_diff})')
                 action = 'reconfig'
-                # we need only redeploy if secure_monitoring_stack or mgmt-gateway value has changed:
-                # TODO(redo): check if we should just go always with redeploy (it's fast enough)
-                if dd.daemon_type in ['prometheus', 'node-exporter', 'alertmanager', 'ceph-exporter']:
-                    diff = list(set(last_deps).symmetric_difference(set(deps)))
-                    REDEPLOY_TRIGGERS = ['secure_monitoring_stack', 'mgmt-gateway']
-                    if any(svc in e for e in diff for svc in REDEPLOY_TRIGGERS):
-                        action = 'redeploy'
             elif dd.daemon_type == 'haproxy':
                 if spec and hasattr(spec, 'backend_service'):
                     backend_spec = self.mgr.spec_store[spec.backend_service].spec

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1173,6 +1173,30 @@ class CephadmServe:
                     f'{dd.name()} daemon entrypoint args {dd.extra_entrypoint_args} -> {spec.extra_entrypoint_args}')
                 dd.extra_entrypoint_args = spec.extra_entrypoint_args
                 action = 'redeploy'
+            elif svc_obj.manages_own_next_action:
+                # method uses new action enum type
+                _scheduled_action = utils.Action.create(scheduled_action)
+                _action = svc_obj.choose_next_action(
+                    _scheduled_action,
+                    dd.daemon_type,
+                    spec,
+                    curr_deps=deps,
+                    last_deps=last_deps,
+                )
+                if _action is not _scheduled_action:
+                    self.log.info(
+                        (
+                            'Daemon %s chose new action %s (was %s)'
+                            ' (deps: %r, last_deps: %r)'
+                        ),
+                        dd.name(),
+                        _action,
+                        _scheduled_action,
+                        deps,
+                        last_deps,
+                    )
+                    # convert back to legacy str type
+                    action = str(_action)
             elif last_deps != deps:
                 sym_diff = set(deps).symmetric_difference(last_deps)
                 self.log.info(f'Reconfiguring {dd.name()} deps {last_deps} -> {deps} (diff {sym_diff})')

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1152,7 +1152,11 @@ class CephadmServe:
                 dd.hostname, dd.name())
             if last_deps is None:
                 last_deps = []
-            action = self.mgr.cache.get_scheduled_daemon_action(dd.hostname, dd.name())
+            action = scheduled_action = (
+                self.mgr.cache.get_scheduled_daemon_action(
+                    dd.hostname, dd.name()
+                )
+            )
             if not last_config:
                 self.log.info('Reconfiguring %s (unknown last config time)...' % (
                     dd.name()))
@@ -1209,8 +1213,7 @@ class CephadmServe:
                 action = 'reconfig'
 
             if action:
-                if self.mgr.cache.get_scheduled_daemon_action(dd.hostname, dd.name()) == 'redeploy' \
-                        and action == 'reconfig':
+                if scheduled_action == 'redeploy' and action == 'reconfig':
                     action = 'redeploy'
                 try:
                     daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(dd)

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1139,13 +1139,15 @@ class CephadmServe:
             if dd.daemon_type in REQUIRES_POST_ACTIONS:
                 daemons_post[dd.daemon_type].append(dd)
 
-            if service_registry.get_service(daemon_type_to_service(dd.daemon_type)).get_active_daemon(
+            svc_type = daemon_type_to_service(dd.daemon_type)
+            svc_obj = service_registry.get_service(svc_type)
+            if svc_obj.get_active_daemon(
                self.mgr.cache.get_daemons_by_service(dd.service_name())).daemon_id == dd.daemon_id:
                 dd.is_active = True
             else:
                 dd.is_active = False
 
-            deps = self.mgr._calc_daemon_deps(spec, dd.daemon_type, dd.daemon_id)
+            deps = svc_obj.sorted_dependencies(self.mgr, spec, dd.daemon_type)
             last_deps, last_config = self.mgr.cache.get_daemon_last_config_deps(
                 dd.hostname, dd.name())
             if last_deps is None:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1201,15 +1201,9 @@ class CephadmServe:
                 sym_diff = set(deps).symmetric_difference(last_deps)
                 self.log.info(f'Reconfiguring {dd.name()} deps {last_deps} -> {deps} (diff {sym_diff})')
                 action = 'reconfig'
-            elif self.mgr.last_monmap and \
-                    self.mgr.last_monmap > last_config and \
-                    dd.daemon_type in CEPH_TYPES:
-                self.log.info('Reconfiguring %s (monmap changed)...' % dd.name())
-                action = 'reconfig'
-            elif self.mgr.extra_ceph_conf_is_newer(last_config) and \
-                    dd.daemon_type in CEPH_TYPES:
-                self.log.info('Reconfiguring %s (extra config changed)...' % dd.name())
-                action = 'reconfig'
+            action = _ceph_service_next_action(
+                action, dd.daemon_type, dd.name(), self.mgr, last_config
+            )
 
             if action:
                 if scheduled_action == 'redeploy' and action == 'reconfig':
@@ -1893,3 +1887,26 @@ def _host_selector(svc: Any) -> Optional[HostSelector]:
     if hasattr(svc, 'filter_host_candidates'):
         return cast(HostSelector, svc)
     return None
+
+
+def _ceph_service_next_action(
+    action: Optional[str],
+    daemon_type: str,
+    name: str,
+    mgr: 'CephadmOrchestrator',
+    last_config: Optional[datetime.datetime],
+) -> Optional[str]:
+    if daemon_type not in CEPH_TYPES:
+        return action
+    if last_config is None:
+        return action
+    if action in ['reconfig', 'redeploy']:
+        return action
+
+    if mgr.last_monmap and mgr.last_monmap > last_config:
+        logger.info('Reconfiguring %s (monmap changed)...', name)
+        return 'reconfig'
+    if mgr.extra_ceph_conf_is_newer(last_config):
+        logger.info('Reconfiguring %s (extra config changed)...', name)
+        return 'reconfig'
+    return action

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1173,7 +1173,7 @@ class CephadmServe:
                     f'{dd.name()} daemon entrypoint args {dd.extra_entrypoint_args} -> {spec.extra_entrypoint_args}')
                 dd.extra_entrypoint_args = spec.extra_entrypoint_args
                 action = 'redeploy'
-            elif svc_obj.manages_own_next_action:
+            else:
                 # method uses new action enum type
                 _scheduled_action = utils.Action.create(scheduled_action)
                 _action = svc_obj.choose_next_action(
@@ -1197,10 +1197,6 @@ class CephadmServe:
                     )
                     # convert back to legacy str type
                     action = str(_action)
-            elif last_deps != deps:
-                sym_diff = set(deps).symmetric_difference(last_deps)
-                self.log.info(f'Reconfiguring {dd.name()} deps {last_deps} -> {deps} (diff {sym_diff})')
-                action = 'reconfig'
             action = _ceph_service_next_action(
                 action, dd.daemon_type, dd.name(), self.mgr, last_config
             )

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1201,14 +1201,6 @@ class CephadmServe:
                 sym_diff = set(deps).symmetric_difference(last_deps)
                 self.log.info(f'Reconfiguring {dd.name()} deps {last_deps} -> {deps} (diff {sym_diff})')
                 action = 'reconfig'
-            elif dd.daemon_type == 'haproxy':
-                if spec and hasattr(spec, 'backend_service'):
-                    backend_spec = self.mgr.spec_store[spec.backend_service].spec
-                    if backend_spec.service_type == 'nfs':
-                        svc = service_registry.get_service('ingress')
-                        if svc.has_placement_changed(last_deps, spec):
-                            self.log.debug(f'Redeploy {spec.service_name()} as placement has changed')
-                            action = 'redeploy'
             elif self.mgr.last_monmap and \
                     self.mgr.last_monmap > last_config and \
                     dd.daemon_type in CEPH_TYPES:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1213,11 +1213,6 @@ class CephadmServe:
                     # the daemon is written, which we rewrite on redeploy, but not
                     # on reconfig.
                     action = 'redeploy'
-                elif dd.daemon_type == 'nfs':
-                    # check what has changed, based on that decide action
-                    only_kmip_updated = all(s.startswith('kmip') for s in list(sym_diff))
-                    if not only_kmip_updated:
-                        action = 'redeploy'
             elif dd.daemon_type == 'haproxy':
                 if spec and hasattr(spec, 'backend_service'):
                     backend_spec = self.mgr.spec_store[spec.backend_service].spec

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -886,11 +886,6 @@ class CephadmService(metaclass=ABCMeta):
     def has_placement_changed(self, deps: List[str], spec: ServiceSpec) -> bool:
         return False
 
-    # manages_own_next_action allows the CephadmService subclasses
-    # to incrementally support using choose_next_action instead of
-    # "hard coded" blocks in the _check_daemons function.
-    manages_own_next_action = False
-
     def choose_next_action(
         self,
         scheduled_action: utils.Action,
@@ -1789,8 +1784,6 @@ class CephExporterService(CephService):
         daemon_spec.deps = self.get_dependencies(self.mgr)
 
         return daemon_spec
-
-    manages_own_next_action = True
 
     def choose_next_action(
         self,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1790,6 +1790,24 @@ class CephExporterService(CephService):
 
         return daemon_spec
 
+    manages_own_next_action = True
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        return next_action_for_mgmt_stack_service(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps
+        )
+
 
 @register_cephadm_service
 class CephfsMirrorService(CephService):
@@ -1887,3 +1905,51 @@ class CephadmAgent(CephService):
         return config, sorted([str(self.mgr.get_mgr_ip()), str(agent.server_port),
                                self.mgr.cert_mgr.get_root_ca(),
                                str(self.mgr.get_module_option('device_enhanced_scan'))])
+
+
+def next_action_for_mgmt_stack_service(
+    scheduled_action: utils.Action,
+    daemon_type: Optional[str],
+    spec: Optional[ServiceSpec],
+    curr_deps: List[str],
+    last_deps: List[str],
+) -> utils.Action:
+    """This function exists to help refactor existing code to use
+    choose_next_action instead of if-blocks inside serve.py.
+    It avoids the need to muck around with common base classes at the
+    cost of some duplication.
+    Call this from choose_next_action.
+    """
+    if curr_deps == last_deps:
+        return scheduled_action
+    sym_diff = set(curr_deps).symmetric_difference(last_deps)
+    logger.info(
+        'Reconfigure wanted %s: deps %r -> %r (diff %r)',
+        spec.service_name() if spec else daemon_type,
+        last_deps,
+        curr_deps,
+        sym_diff,
+    )
+    action = utils.Action.RECONFIG
+    # we need only redeploy if secure_monitoring_stack or mgmt-gateway value has changed:
+    # TODO(redo): check if we should just go always with redeploy (it's fast enough)
+    # TODO(jjm) remove this assert when refactoring process WRT
+    # choose_next_action is done.
+    assert daemon_type in [
+        'prometheus',
+        'node-exporter',
+        'alertmanager',
+        'ceph-exporter',
+    ]
+    REDEPLOY_TRIGGERS = ['secure_monitoring_stack', 'mgmt-gateway']
+    # [from: JJM, to: Redo] in different commits you added calls to
+    # symmetric_difference  for the same variables. I have removed this
+    # duplication but please let me know if I overlooked something WRT
+    # to that in case it was intentional.
+    # Also what is this line below trying to check? I struggle with nested
+    # inline comprehensions but its seems to me you just want to know if
+    # the service newly depends on one of these mgmt stack deps?
+    # If so we ought to be able to vastly simplify this...
+    if any(svc in e for e in sym_diff for svc in REDEPLOY_TRIGGERS):
+        action = utils.Action.REDEPLOY
+    return action

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -886,6 +886,35 @@ class CephadmService(metaclass=ABCMeta):
     def has_placement_changed(self, deps: List[str], spec: ServiceSpec) -> bool:
         return False
 
+    # manages_own_next_action allows the CephadmService subclasses
+    # to incrementally support using choose_next_action instead of
+    # "hard coded" blocks in the _check_daemons function.
+    manages_own_next_action = False
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        if curr_deps == last_deps:
+            return scheduled_action
+        sym_diff = set(curr_deps).symmetric_difference(last_deps)
+        logger.info(
+            'Reconfigure wanted %s: deps %r -> %r (diff %r)',
+            spec.service_name() if spec else daemon_type,
+            last_deps,
+            curr_deps,
+            sym_diff,
+        )
+        return utils.Action.RECONFIG
+
 
 class CephService(CephadmService):
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -325,6 +325,18 @@ class CephadmService(metaclass=ABCMeta):
     ) -> List[str]:
         return []
 
+    @classmethod
+    def sorted_dependencies(
+        cls,
+        mgr: "CephadmOrchestrator",
+        spec: Optional[ServiceSpec] = None,
+        daemon_type: Optional[str] = None,
+    ) -> List[str]:
+        """A version of get_dependencies that guarantees that the returned
+        list is in sorted order.
+        """
+        return sorted(cls.get_dependencies(mgr, spec, daemon_type))
+
     def __init__(self, mgr: "CephadmOrchestrator"):
         self.mgr: "CephadmOrchestrator" = mgr
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -317,9 +317,12 @@ class CephadmService(metaclass=ABCMeta):
         pass
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+    def get_dependencies(
+        cls,
+        mgr: "CephadmOrchestrator",
+        spec: Optional[ServiceSpec] = None,
+        daemon_type: Optional[str] = None,
+    ) -> List[str]:
         return []
 
     def __init__(self, mgr: "CephadmOrchestrator"):

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -549,8 +549,6 @@ class IngressService(CephService):
             return True
         return False
 
-    manages_own_next_action = True
-
     def choose_next_action(
         self,
         scheduled_action: utils.Action,

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -548,3 +548,38 @@ class IngressService(CephService):
             logger.debug(f'Placement has changed for {spec.service_name()} from {hosts} -> {current_hosts}')
             return True
         return False
+
+    manages_own_next_action = True
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        action = super().choose_next_action(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps
+        )
+        if (
+            action is not utils.Action.REDEPLOY
+            and daemon_type == 'haproxy'
+            and spec
+            and hasattr(spec, 'backend_service')
+        ):
+            backend_spec = self.mgr.spec_store[spec.backend_service].spec
+            if (
+                backend_spec.service_type == 'nfs'
+                and self.has_placement_changed(last_deps, spec)
+            ):
+                logger.debug(
+                    'Redeploy wanted %s: placement has changed',
+                    spec.service_name(),
+                )
+                action = utils.Action.REDEPLOY
+        return action

--- a/src/pybind/mgr/cephadm/services/jaeger.py
+++ b/src/pybind/mgr/cephadm/services/jaeger.py
@@ -50,8 +50,6 @@ class JaegerAgentService(CephadmService):
         daemon_spec.deps = self.get_dependencies(self.mgr)
         return daemon_spec
 
-    manages_own_next_action = True
-
     def choose_next_action(
         self,
         scheduled_action: utils.Action,

--- a/src/pybind/mgr/cephadm/services/jaeger.py
+++ b/src/pybind/mgr/cephadm/services/jaeger.py
@@ -3,6 +3,7 @@ from cephadm.services.cephadmservice import CephadmService, CephadmDaemonDeployS
 from ceph.deployment.service_spec import TracingSpec, ServiceSpec
 from .service_registry import register_cephadm_service
 from mgr_util import build_url
+from cephadm import utils
 
 if TYPE_CHECKING:
     from ..module import CephadmOrchestrator
@@ -48,6 +49,30 @@ class JaegerAgentService(CephadmService):
         daemon_spec.final_config = {'collector_nodes': ",".join(collectors)}
         daemon_spec.deps = self.get_dependencies(self.mgr)
         return daemon_spec
+
+    manages_own_next_action = True
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        action = super().choose_next_action(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps
+        )
+        # changes to jaeger-agent deps affect the way the unit.run for
+        # the daemon is written, which we rewrite on redeploy, but not
+        # on reconfig.
+        if action is utils.Action.RECONFIG:
+            action = utils.Action.REDEPLOY
+        return action
 
 
 @register_cephadm_service

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -477,8 +477,6 @@ class AlertmanagerService(CephadmService):
             return HandleCommandResult(-errno.EBUSY, '', warn_message)
         return HandleCommandResult(0, warn_message, '')
 
-    manages_own_next_action = True
-
     def choose_next_action(
         self,
         scheduled_action: utils.Action,
@@ -780,8 +778,6 @@ class PrometheusService(CephadmService):
                 return '/federate'
         return '/prometheus/federate'
 
-    manages_own_next_action = True
-
     def choose_next_action(
         self,
         scheduled_action: utils.Action,
@@ -848,8 +844,6 @@ class NodeExporterService(CephadmService):
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
         out = f'It is presumed safe to stop {names}'
         return HandleCommandResult(0, out, '')
-
-    manages_own_next_action = True
 
     def choose_next_action(
         self,

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -14,7 +14,12 @@ from cephadm.tlsobject_types import TLSCredentials
 from orchestrator import DaemonDescription
 from ceph.deployment.service_spec import AlertManagerSpec, GrafanaSpec, ServiceSpec, \
     SNMPGatewaySpec, PrometheusSpec, MgmtGatewaySpec
-from cephadm.services.cephadmservice import CephadmService, CephadmDaemonDeploySpec, get_dashboard_urls
+from cephadm.services.cephadmservice import (
+    CephadmDaemonDeploySpec,
+    CephadmService,
+    get_dashboard_urls,
+    next_action_for_mgmt_stack_service,
+)
 from mgr_util import build_url, password_hash
 from ceph.deployment.utils import wrap_ipv6
 from .. import utils
@@ -472,6 +477,24 @@ class AlertmanagerService(CephadmService):
             return HandleCommandResult(-errno.EBUSY, '', warn_message)
         return HandleCommandResult(0, warn_message, '')
 
+    manages_own_next_action = True
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        return next_action_for_mgmt_stack_service(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps
+        )
+
 
 @register_cephadm_service
 class PrometheusService(CephadmService):
@@ -757,6 +780,24 @@ class PrometheusService(CephadmService):
                 return '/federate'
         return '/prometheus/federate'
 
+    manages_own_next_action = True
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        return next_action_for_mgmt_stack_service(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps
+        )
+
 
 @register_cephadm_service
 class NodeExporterService(CephadmService):
@@ -807,6 +848,24 @@ class NodeExporterService(CephadmService):
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
         out = f'It is presumed safe to stop {names}'
         return HandleCommandResult(0, out, '')
+
+    manages_own_next_action = True
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        return next_action_for_mgmt_stack_service(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps
+        )
 
 
 @register_cephadm_service

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -436,8 +436,6 @@ class NFSService(CephService):
                 logger.debug(f"No IP address found in the network {spec.monitoring_networks} on host {host}.")
         return monitoring_addr, monitoring_port
 
-    manages_own_next_action = True
-
     def choose_next_action(
         self,
         scheduled_action: utils.Action,

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -435,3 +435,34 @@ class NFSService(CephService):
             if not monitoring_addr:
                 logger.debug(f"No IP address found in the network {spec.monitoring_networks} on host {host}.")
         return monitoring_addr, monitoring_port
+
+    manages_own_next_action = True
+
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+    ) -> utils.Action:
+        """Given the scheduled_action, service spec, daemon_type, and
+        current and previous dependency lists return the next action that
+        this service would prefer cephadm take.
+        """
+        if curr_deps == last_deps:
+            return scheduled_action
+        sym_diff = set(curr_deps).symmetric_difference(last_deps)
+        logger.info(
+            'Reconfigure wanted %s: deps %r -> %r (diff %r)',
+            spec.service_name() if spec else daemon_type,
+            last_deps,
+            curr_deps,
+            sym_diff,
+        )
+        action = utils.Action.RECONFIG
+        # check what has changed, based on that decide action
+        only_kmip_updated = all(s.startswith('kmip') for s in sym_diff)
+        if not only_kmip_updated:
+            action = utils.Action.REDEPLOY
+        return action

--- a/src/pybind/mgr/cephadm/tests/conftest.py
+++ b/src/pybind/mgr/cephadm/tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
 from cephadm.services.osd import RemoveUtil, OSD
-from mock import mock
-from .fixtures import with_cephadm_module
+from unittest import mock
+from .fixtures import with_cephadm_module, async_side_effect
 from cephadm import CephadmOrchestrator
 from typing import Generator
 
@@ -26,3 +26,22 @@ def osd_obj():
     with mock.patch("cephadm.services.osd.RemoveUtil"):
         o = OSD(0, mock.MagicMock())
         yield o
+
+
+@pytest.fixture()
+def mock_cephadm(monkeypatch):
+    import cephadm.module
+    import cephadm.serve
+
+    mm = mock.MagicMock()
+    mm._run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+    monkeypatch.setattr(
+        cephadm.serve.CephadmServe, '_run_cephadm', mm._run_cephadm
+    )
+    monkeypatch.setattr(
+        cephadm.module.CephadmOrchestrator,
+        '_daemon_action',
+        mm._daemon_action,
+    )
+    mm.serve = cephadm.serve.CephadmServe
+    return mm

--- a/src/pybind/mgr/cephadm/tests/services/test_custom_container.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_custom_container.py
@@ -1,5 +1,8 @@
+import contextlib
 import json
-from unittest.mock import patch
+from unittest.mock import patch, ANY
+
+import pytest
 
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import CustomContainerSpec
@@ -150,3 +153,47 @@ class TestCustomContainer:
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+
+@pytest.mark.parametrize(
+    'newargs',
+    [
+        {'cargs': ['--secret=foo,target=/etc/foo.x']},
+        {'eargs': ['flip flop']},
+        {'eargs': ['flip flop'], "cargs": None},
+    ],
+)
+def test_custom_cont_choose_next_action(
+    cephadm_module, mock_cephadm, newargs
+):
+    cargs1 = cargs2 = ['--secret=foo,type=env']
+    eargs1 = eargs2 = ['flim flam']
+    if 'cargs' in newargs:
+        cargs2 = newargs['cargs']
+    if 'eargs' in newargs:
+        eargs2 = newargs['eargs']
+    spec = CustomContainerSpec(
+        service_id='tsettinu',
+        image='quay.io/foobar/barbaz:latest',
+        entrypoint='/usr/local/bin/blat.sh',
+        ports=[9090],
+        extra_container_args=cargs1,
+        extra_entrypoint_args=eargs1,
+    )
+    # use a second spec to avoid messing around with ArgumentSpec types
+    spec2 = CustomContainerSpec(
+        service_id='tsettinu',
+        image='quay.io/foobar/barbaz:latest',
+        entrypoint='/usr/local/bin/blat.sh',
+        ports=[9090],
+        extra_container_args=cargs2,
+        extra_entrypoint_args=eargs2,
+    )
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(with_host(cephadm_module, 'test'))
+        stack.enter_context(with_service(cephadm_module, spec))
+        cephadm_module.apply([spec2])
+        # manually invoke _check_daemons to trigger a call to
+        # _daemon_action so we can check what action was chosen
+        mock_cephadm.serve(cephadm_module)._check_daemons()
+        mock_cephadm._daemon_action.assert_called_with(ANY, action='redeploy')

--- a/src/pybind/mgr/cephadm/tests/services/test_jaeger.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_jaeger.py
@@ -1,5 +1,6 @@
+import contextlib
 import json
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import TracingSpec
@@ -185,3 +186,18 @@ class TestJaeger:
                         error_ok=True,
                         use_current_daemon_image=False,
                     )
+
+
+def test_jaeger_agent_choose_next_action(cephadm_module, mock_cephadm):
+    jaeger_spec = TracingSpec(service_type="jaeger-agent")
+    coll_spec = TracingSpec(service_type="jaeger-collector")
+    es_spec = TracingSpec(service_type="elasticsearch")
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(with_host(cephadm_module, "test"))
+        stack.enter_context(with_service(cephadm_module, jaeger_spec))
+        stack.enter_context(with_service(cephadm_module, es_spec))
+        stack.enter_context(with_service(cephadm_module, coll_spec))
+        # manually invoke _check_daemons to trigger a call to
+        # _daemon_action so we can check what action was chosen
+        mock_cephadm.serve(cephadm_module)._check_daemons()
+        mock_cephadm._daemon_action.assert_called_with(ANY, action="redeploy")

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -504,3 +504,52 @@ def test_nfs_choose_next_action(cephadm_module, mock_cephadm):
         # NB: it appears that the code is designed to redeploy unless all
         # dependencies are prefixed with 'kmip' but I can't find any code
         # that would produce any dependencies prefixed with 'kmip'!
+
+
+@patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+@patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+@patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+def test_ingress_for_nfs_choose_next_action(cephadm_module, mock_cephadm):
+    nfs_spec = NFSServiceSpec(
+        service_id="foo",
+        placement=PlacementSpec(hosts=['test']),
+    )
+    ingress_spec = IngressSpec(
+        service_id='bar',
+        backend_service='nfs.foo',
+        frontend_port=2468,
+        monitor_port=8642,
+        virtual_ip='1.2.3.0/24',
+        placement=PlacementSpec(hosts=['test']),
+    )
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(with_host(cephadm_module, "test"))
+        stack.enter_context(with_host(cephadm_module, "test2"))
+        cephadm_module.cache.update_host_networks(
+            'test',
+            {
+                '1.2.3.0/24': {
+                    'if0': [
+                        '1.2.3.4',  # simulate already assigned VIP
+                        '1.2.3.1',  # simulate interface IP
+                    ]
+                }
+            },
+        )
+        stack.enter_context(with_service(cephadm_module, nfs_spec))
+        # For whatever reason this mocked out version of the nfs deamon
+        # doesn't get assigned ports and ingress needs them. So we
+        # manually help it along here.
+        nfs_dds = cephadm_module.cache.get_daemons_by_service(
+            ingress_spec.backend_service
+        )
+        nfs_dd = nfs_dds[0]
+        nfs_dd.ports = [8765]
+        mock_cephadm.serve(cephadm_module)._check_daemons()
+        stack.enter_context(with_service(cephadm_module, ingress_spec))
+        ingress_spec.placement = PlacementSpec(hosts=['test', 'test2'])
+        cephadm_module.apply([ingress_spec])
+        # manually invoke _check_daemons to trigger a call to
+        # _daemon_action so we can check what action was chosen
+        mock_cephadm.serve(cephadm_module)._check_daemons()
+        mock_cephadm._daemon_action.assert_called_with(ANY, action="redeploy")

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+import contextlib
+from unittest.mock import MagicMock, patch, ANY
 
 from cephadm.services.service_registry import service_registry
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
@@ -476,3 +477,30 @@ class TestNFS:
                     '}\n'
                 )
                 assert expected_tls_block in ganesha_conf
+
+
+@patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+@patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+@patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+def test_nfs_choose_next_action(cephadm_module, mock_cephadm):
+    nfs_spec = NFSServiceSpec(
+        service_id="foo",
+        placement=PlacementSpec(hosts=['test']),
+        ssl=True,
+        ssl_cert=ceph_generated_cert,
+        ssl_key=ceph_generated_key,
+        ssl_ca_cert=cephadm_root_ca,
+        certificate_source='inline',
+    )
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(with_host(cephadm_module, "test"))
+        stack.enter_context(with_service(cephadm_module, nfs_spec))
+        nfs_spec.tls_ktls = True
+        cephadm_module.apply([nfs_spec])
+        # manually invoke _check_daemons to trigger a call to
+        # _daemon_action so we can check what action was chosen
+        mock_cephadm.serve(cephadm_module)._check_daemons()
+        mock_cephadm._daemon_action.assert_called_with(ANY, action="redeploy")
+        # NB: it appears that the code is designed to redeploy unless all
+        # dependencies are prefixed with 'kmip' but I can't find any code
+        # that would produce any dependencies prefixed with 'kmip'!

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -3,7 +3,17 @@ import json
 import socket
 from enum import Enum
 from functools import wraps
-from typing import Optional, Callable, TypeVar, List, NewType, TYPE_CHECKING, Any, NamedTuple
+from typing import (
+    Any,
+    Callable,
+    List,
+    NamedTuple,
+    NewType,
+    Optional,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
 from orchestrator import OrchestratorError
 import hashlib
 
@@ -58,6 +68,25 @@ class SpecialHostLabels(str, Enum):
 
     def to_json(self) -> str:
         return self.value
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class Action(str, Enum):
+    NO_ACTION = ''
+    RECONFIG = 'reconfig'
+    REDEPLOY = 'redeploy'
+    RESTART = 'restart'
+    ROTATE_KEY = 'rotate-key'
+    START = 'start'
+    STOP = 'stop'
+
+    @classmethod
+    def create(cls, action: Union[str, 'Action', None]) -> 'Action':
+        if not action:
+            return cls.NO_ACTION
+        return cls(action)
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
The _check_daemons function in serve.py contains a loop that uses dependencies, spec fields and other metadata to determine if a service needs to be reconfigured, redeployed, etc instead of the default action.

There are are number of special cases for services including jaeger agent, ingress, nfs, etc. that are gated on a number of if-clauses. Try to move away from customization via cascading if statements and add a new `choose_next_action` method to the CephadmService ABC. Service classes that want extra special handling to determine the next action (instead of just inheriting from the base) can override `choose_next_action` and implement custom behavior.

Update the existing classes to support `choose_next_action` and replace the existing if-statement blocks.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
