### PR TITLE
tentacle: cmake: update C standard from C99 to C11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -237,7 +237,7 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 11)
 # we use `asm()` to inline assembly, so enable the GNU extension
 set(CMAKE_C_EXTENSIONS ON)
 set(C_STANDARD_REQUIRED ON)


### PR DESCRIPTION
userspace-rcu-devel v0.15 adds a check for C11 that causes a failure due to -std=gnu99 compiler option.

Backport of https://github.com/ceph/ceph/pull/66079 by @edwinzrodriguez 
Original tracker: https://tracker.ceph.com/issues/73660
Backport tracker: https://tracker.ceph.com/issues/75456

(cherry picked from commit 2ccaa2f5515f866dfbabe9c1dac640f574e4db3b)

