### PR TITLE
mon: improve mon ping loggings

### DIFF
--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -152,10 +152,12 @@ void ElectionLogic::start()
 void ElectionLogic::defer(int who)
 {
   if (strategy == CLASSIC) {
-      ldout(cct, 5) << "defer to " << who << dendl;
+      ldout(cct, 5) << fmt::format("defer to {} (mon.{})",
+        who, elector->get_rank_name(who)) << dendl;
       ceph_assert(who < elector->get_my_rank());
   } else {
-    ldout(cct, 5) << "defer to " << who << ", disallowed_leaders=" << elector->get_disallowed_leaders() << dendl;
+    ldout(cct, 5) << fmt::format("defer to {} (mon.{}), disallowed_leaders=",
+      who, elector->get_rank_name(who)) << elector->get_disallowed_leaders() << dendl;
     ceph_assert(!elector->get_disallowed_leaders().count(who));
   }
 
@@ -229,7 +231,7 @@ bool ElectionLogic::propose_classic_prefix(int from, epoch_t mepoch)
 void ElectionLogic::receive_propose(int from, epoch_t mepoch,
 				    const ConnectionTracker *ct)
 {
-  ldout(cct, 20) << __func__ << " from " << from << dendl;
+  ldout(cct, 20) << __func__ << " from " << from << " (mon." << elector->get_rank_name(from) << ")" << dendl;
   if (from == elector->get_my_rank()) {
     lderr(cct) << "I got a propose from my own rank, hopefully this is startup weirdness,dropping" << dendl;
     return;
@@ -455,7 +457,7 @@ void ElectionLogic::propose_connectivity_handler(int from, epoch_t mepoch,
 				     &leader_leader_liveness);
 	if ((from < leader_acked && leader_from_score >= leader_leader_score) ||
 	    (leader_from_score > leader_leader_score)) {
-    ldout(cct, 10) << "defering to " << from << dendl;
+    ldout(cct, 10) << "defering to " << from << " (mon." << elector->get_rank_name(from) << ")" << dendl;
 	  defer(from);
 	  leader_peer_tracker.reset(new ConnectionTracker(*ct));
 	} else { // we can't defer to them *this* round even though they should win...
@@ -466,24 +468,24 @@ void ElectionLogic::propose_connectivity_handler(int from, epoch_t mepoch,
 	  if ((from < leader_acked && cur_from_score >= cur_leader_score) ||
 	      (cur_from_score > cur_leader_score)) {
 	    ldout(cct, 5) << "Bumping epoch and starting new election; acked "
-			  << leader_acked << " should defer to " << from
-			  << " but there is score disagreement!" << dendl;
+			  << leader_acked << " (mon." << elector->get_rank_name(leader_acked) << ") should defer to " << from
+			  << " (mon." << elector->get_rank_name(from) << ") but there is score disagreement!" << dendl;
 	    bump_epoch(epoch+1);
 	    start();
 	  } else {
 	    ldout(cct, 5) << "no, we already acked " << leader_acked
-			  << " and it won't defer to " << from
-			  << " despite better round scores" << dendl;
+			  << " (mon." << elector->get_rank_name(leader_acked) << ") and it won't defer to " << from
+			  << " (mon." << elector->get_rank_name(from) << ") despite better round scores" << dendl;
 	  }
 	}
       } else {
-  ldout(cct, 10) << "defering to " << from << dendl;
+  ldout(cct, 10) << "defering to " << from << " (mon." << elector->get_rank_name(from) << ")" << dendl;
 	defer(from);
 	leader_peer_tracker.reset(new ConnectionTracker(*ct));
       }
     } else {
       // ignore them!
-      ldout(cct, 5) << "no, we already acked " << leader_acked << " with score >=" << from_score << dendl;
+      ldout(cct, 5) << "no, we already acked " << leader_acked << " (mon." << elector->get_rank_name(leader_acked) << ") with score >=" << from_score << dendl;
     }
   }
 }

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -142,6 +142,12 @@ public:
    * @returns true if the rank is in our current quorum, false otherwise.
    */
   virtual bool is_current_member(int rank) const = 0;
+  /**
+   * Get the monitor name for the given rank.
+   * @param rank the monitor rank whose name we want
+   * @returns the monitor name for the given rank
+   */
+  virtual std::string get_rank_name(int rank) const = 0;
   virtual ~ElectionOwner() {}
 };
 

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -111,6 +111,11 @@ bool Elector::is_current_member(int rank) const
   return mon->quorum.count(rank);
 }
 
+std::string Elector::get_rank_name(int rank) const
+{
+  return mon->monmap->get_name(rank);
+}
+
 void Elector::trigger_new_election()
 {
   mon->start_election();
@@ -453,7 +458,8 @@ void Elector::handle_nak(MonOpRequestRef op)
 
 void Elector::begin_peer_ping(int peer)
 {
-  dout(20) << __func__ << " with " << peer << dendl;
+  dout(20) << __func__ << " with " << peer 
+    << ((peer >= 0 && peer < ssize(mon->monmap->ranks)) ? " (mon." + mon->monmap->get_name(peer) + ")" : "") << dendl;
   if (peer < 0) {
     dout(20) << __func__ << " ignoring negative peer " << peer << dendl;
     return;
@@ -462,7 +468,7 @@ void Elector::begin_peer_ping(int peer)
     // This peer is already being pinged
     // so we don't need to schedule another ping_check
     // against it, ping_check will call itself because it is self-sustaining.
-    dout(20) << peer << " is already being pinged ... return " << dendl;
+    dout(20) << peer << " (mon." << mon->monmap->get_name(peer) << ") is already being pinged ... return " << dendl;
     return;
   }
   // Check if quorum feature is not set and we are in
@@ -491,7 +497,7 @@ void Elector::begin_peer_ping(int peer)
     return;
   }
   dout(30) << "schedule ping_check against peer: "
-    << peer << " every " << ping_timeout / PING_DIVISOR << "s" << dendl;
+    << peer << " (mon." << mon->monmap->get_name(peer) << ") every " << ping_timeout / PING_DIVISOR << "s" << dendl;
   mon->timer.add_event_after(ping_timeout / PING_DIVISOR,
 			     new C_MonContext{mon, [this, peer](int) {
 				 ping_check(peer);
@@ -500,7 +506,8 @@ void Elector::begin_peer_ping(int peer)
 
 bool Elector::send_peer_ping(int peer, const utime_t *n)
 {
-  dout(10) << __func__ << " to peer " << peer << dendl;
+  dout(10) << __func__ << " to peer " << peer 
+    << (peer >= 0 && peer < ssize(mon->monmap->ranks) ? " (mon." + mon->monmap->get_name(peer) + ")" : "") << dendl;
   if (peer < 0 || peer >= ssize(mon->monmap->ranks)) {
     // Monitor no longer exists in the monmap,
     // therefore, we shouldn't ping this monitor
@@ -520,7 +527,7 @@ bool Elector::send_peer_ping(int peer, const utime_t *n)
   MMonPing *ping = new MMonPing(MMonPing::PING, now, peer_tracker.get_encoded_bl());
   mon->messenger->send_to_mon(ping, mon->monmap->get_addrs(peer));
   peer_sent_ping[peer] = now;
-  dout(20) << " sent ping to peer: " << peer << " at " << now << dendl;
+  dout(20) << " sent ping to peer: " << peer << " (mon." << mon->monmap->get_name(peer) << ") at " << now << dendl;
   return true;
 }
 
@@ -538,18 +545,18 @@ void Elector::process_pending_pings()
 
 void Elector::ping_check(int peer)
 {
-  dout(20) << __func__ << "ing peer " << peer << dendl;
+  dout(20) << __func__ << "ing peer " << peer << " (mon." << mon->monmap->get_name(peer) << ")" << dendl;
 
   if (!live_pinging.count(peer) &&
       !dead_pinging.count(peer)) {
-    dout(20) << peer << " is no longer marked for pinging ... return" << dendl;
+    dout(20) << peer << " (mon." << mon->monmap->get_name(peer) << ") is no longer marked for pinging ... return" << dendl;
     return;
   }
   utime_t now = ceph_clock_now();
   utime_t& acked_ping = peer_acked_ping[peer];
   utime_t& newest_ping = peer_sent_ping[peer];
   if (!acked_ping.is_zero() && acked_ping < now - ping_timeout) {
-    dout(20) << "peer " << peer << " has not acked a ping in "
+    dout(20) << "peer " << peer << " (mon." << mon->monmap->get_name(peer) << ") has not acked a ping in "
        << now - acked_ping << " seconds" << dendl;
     peer_tracker.report_dead_connection(peer, now - acked_ping);
     acked_ping = now;
@@ -558,7 +565,7 @@ void Elector::ping_check(int peer)
   }
 
   if (acked_ping == newest_ping) {
-    dout(20) << "peer " << peer 
+    dout(20) << "peer " << peer << " (mon." << mon->monmap->get_name(peer) << ")"
       << " has not acked the newest ping"
       << " .. sending another ping" << dendl;
     if (!send_peer_ping(peer, &now)) {
@@ -569,7 +576,7 @@ void Elector::ping_check(int peer)
   }
 
   dout(30) << "Scheduling next ping_check for peer "
-    << peer << " in " << ping_timeout / PING_DIVISOR
+    << peer << " (mon." << mon->monmap->get_name(peer) << ") in " << ping_timeout / PING_DIVISOR
     << "s (recursively call ping_check until connection state changes)" << dendl;
   mon->timer.add_event_after(ping_timeout / PING_DIVISOR,
 			     new C_MonContext{mon, [this, peer](int) {
@@ -579,15 +586,15 @@ void Elector::ping_check(int peer)
 
 void Elector::begin_dead_ping(int peer)
 {
-  dout(20) << __func__ << " to peer " << peer << dendl;  
+  dout(20) << __func__ << " to peer " << peer << " (mon." << mon->monmap->get_name(peer) << ")" << dendl;  
   if (dead_pinging.count(peer)) {
-    dout(20) << peer << " already in dead_pinging ... return" << dendl;
+    dout(20) << peer << " (mon." << mon->monmap->get_name(peer) << ") already in dead_pinging ... return" << dendl;
     return;
   }
   
   live_pinging.erase(peer);
   dead_pinging.insert(peer);
-  dout(30) << "schedule dead_ping against peer: " << peer << dendl;
+  dout(30) << "schedule dead_ping against peer: " << peer << " (mon." << mon->monmap->get_name(peer) << ")" << dendl;
   mon->timer.add_event_after(ping_timeout,
 			     new C_MonContext{mon, [this, peer](int) {
 				 dead_ping(peer);
@@ -596,9 +603,9 @@ void Elector::begin_dead_ping(int peer)
 
 void Elector::dead_ping(int peer)
 {
-  dout(20) << __func__ << " to peer " << peer << dendl;
+  dout(20) << __func__ << " to peer " << peer << " (mon." << mon->monmap->get_name(peer) << ")" << dendl;
   if (!dead_pinging.count(peer)) {
-    dout(20) << __func__ << peer << " is no longer marked for dead pinging" << dendl;
+    dout(20) << __func__ << peer << " (mon." << mon->monmap->get_name(peer) << ") is no longer marked for dead pinging" << dendl;
     return;
   }
   ceph_assert(!live_pinging.count(peer));
@@ -608,7 +615,7 @@ void Elector::dead_ping(int peer)
 
   peer_tracker.report_dead_connection(peer, now - acked_ping);
   acked_ping = now;
-  dout(30) << "schedule " << __func__ << " against peer: " << peer << dendl;
+  dout(30) << "schedule " << __func__ << " against peer: " << peer << " (mon." << mon->monmap->get_name(peer) << ")" << dendl;
   mon->timer.add_event_after(ping_timeout,
 			       new C_MonContext{mon, [this, peer](int) {
 				   dead_ping(peer);
@@ -619,7 +626,8 @@ void Elector::handle_ping(MonOpRequestRef op)
 {
   MMonPing *m = static_cast<MMonPing*>(op->get_req());
   int prank = mon->monmap->get_rank(m->get_source_addr());
-  dout(20) << __func__ << " from: " << prank << dendl;
+  dout(20) << __func__ << " from: " << prank 
+    << (prank >= 0 ? " (mon." + mon->monmap->get_name(prank) + ")" : "") << dendl;
   if (prank < 0) {
     dout(5) << __func__ << " from unknown addr " << m->get_source_addr()
            << " mapped to rank " << prank << " (likely removed monitor) - dropping message" << dendl;
@@ -631,14 +639,14 @@ void Elector::handle_ping(MonOpRequestRef op)
   case MMonPing::PING:
     {
       dout(30) << "recieved PING from "
-        << prank << ", sending PING_REPLY back!" << dendl;
+        << prank << " (mon." << mon->monmap->get_name(prank) << "), sending PING_REPLY back!" << dendl;
       MMonPing *reply = new MMonPing(MMonPing::PING_REPLY, m->stamp, peer_tracker.get_encoded_bl());
       m->get_connection()->send_message(reply);
     }
     break;
 
   case MMonPing::PING_REPLY:
-    dout(30) << "recieved PING_REPLY from " << prank << dendl;
+    dout(30) << "recieved PING_REPLY from " << prank << " (mon." << mon->monmap->get_name(prank) << ")" << dendl;
     const utime_t& previous_acked = peer_acked_ping[prank];
     const utime_t& newest = peer_sent_ping[prank];
 
@@ -658,7 +666,7 @@ void Elector::handle_ping(MonOpRequestRef op)
     }
     utime_t now = ceph_clock_now();
     if (now - m->stamp > ping_timeout / PING_DIVISOR) {
-      dout(30) << "peer " << prank << " has not acked a ping in "
+      dout(30) << "peer " << prank << " (mon." << mon->monmap->get_name(prank) << ") has not acked a ping in "
         << now - m->stamp << " seconds, which is more than the "
         << ping_timeout / PING_DIVISOR << " seconds limit." 
         << " Sending another ping ..." << dendl;

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -287,6 +287,8 @@ class Elector : public ElectionOwner, RankProvider {
   void message_victory(const std::set<int>& quorum);
   /* Check if rank is in mon->quorum */
   bool is_current_member(int rank) const;
+  /* Get monitor name for a given rank */
+  std::string get_rank_name(int rank) const;
   /*
    * @}
    */

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2365,7 +2365,8 @@ void Monitor::lose_election(epoch_t epoch, set<int> &q, int l,
   quorum_con_features = features;
   quorum_mon_features = mon_features;
   quorum_min_mon_release = min_mon_release;
-  dout(10) << "lose_election, epoch " << epoch << " leader is mon" << leader
+  dout(10) << "lose_election, epoch " << epoch << " leader is mon." << leader
+	   << " (mon." << monmap->get_name(leader) << ")"
 	   << " quorum is " << quorum << " features are " << quorum_con_features
            << " mon_features are " << quorum_mon_features
 	   << " min_mon_release " << min_mon_release
@@ -4409,8 +4410,8 @@ void Monitor::resend_routed_requests()
       PaxosServiceMessage *req =
 	(PaxosServiceMessage *)decode_message(cct, 0, q);
       rr->op->mark_event("resend forwarded message to leader");
-      dout(10) << " resend to mon." << mon << " tid " << rr->tid << " " << *req
-	       << dendl;
+      dout(10) << " resend to mon." << mon << " (mon." << monmap->get_name(mon) << ")"
+	       << " tid " << rr->tid << " " << *req << dendl;
       MForward *forward = new MForward(rr->tid,
 				       req,
 				       rr->con_features,
@@ -5106,7 +5107,7 @@ void Monitor::timecheck_report()
       }
     }
     do_output = false;
-    dout(10) << __func__ << " send report to mon." << *q << dendl;
+    dout(10) << __func__ << " send report to mon." << *q << " (mon." << monmap->get_name(*q) << ")" << dendl;
     send_mon_message(m, *q);
   }
 }
@@ -5139,7 +5140,7 @@ void Monitor::timecheck()
     MTimeCheck2 *m = new MTimeCheck2(MTimeCheck2::OP_PING);
     m->epoch = get_epoch();
     m->round = timecheck_round;
-    dout(10) << __func__ << " send " << *m << " to mon." << *it << dendl;
+    dout(10) << __func__ << " send " << *m << " to mon." << *it << " (mon." << monmap->get_name(*it) << ")" << dendl;
     send_mon_message(m, *it);
   }
 }

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -524,7 +524,7 @@ void Paxos::handle_last(MonOpRequestRef op)
     }
     if (p->second < last_committed) {
       // share committed values
-      dout(10) << " sending commit to mon." << p->first << dendl;
+      dout(10) << " sending commit to mon." << p->first << " (mon." << mon.monmap->get_name(p->first) << ")" << dendl;
       MMonPaxos *commit = new MMonPaxos(mon.get_epoch(),
 					MMonPaxos::OP_COMMIT,
 					ceph_clock_now());
@@ -694,7 +694,7 @@ void Paxos::begin(bufferlist& v)
        ++p) {
     if (*p == mon.rank) continue;
     
-    dout(10) << " sending begin to mon." << *p << dendl;
+    dout(10) << " sending begin to mon." << *p << " (mon." << mon.monmap->get_name(*p) << ")" << dendl;
     MMonPaxos *begin = new MMonPaxos(mon.get_epoch(), MMonPaxos::OP_BEGIN,
 				     ceph_clock_now());
     begin->values[last_committed+1] = new_value;
@@ -920,7 +920,7 @@ void Paxos::commit_finish()
        ++p) {
     if (*p == mon.rank) continue;
 
-    dout(10) << " sending commit to mon." << *p << dendl;
+    dout(10) << " sending commit to mon." << *p << " (mon." << mon.monmap->get_name(*p) << ")" << dendl;
     MMonPaxos *commit = new MMonPaxos(mon.get_epoch(), MMonPaxos::OP_COMMIT,
 				      ceph_clock_now());
     commit->values[last_committed] = new_value;

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -308,6 +308,20 @@ struct Owner : public ElectionOwner, RankProvider {
     return prefix_str.c_str();
   }
   int timestep_count() const { return parent->timesteps_run; }
+  std::string get_rank_name(int rank) const {
+    // Note that actual monitor names are not simply "mon." + rank, 
+    // but this is sufficient for our testing purposes since we don't
+    // test any logic that depends on the actual names of the monitors yet.
+    // Cache common ranks to avoid repeated string allocations
+    static const std::string cached_names[] = {
+      "mon.0", "mon.1", "mon.2", "mon.3", "mon.4",
+      "mon.5", "mon.6", "mon.7", "mon.8", "mon.9"
+    };
+    if (rank >= 0 && rank < 10) {
+      return cached_names[rank];
+    }
+    return "mon." + std::to_string(rank);
+  }
 };
 
 Election::Election(int c, ElectionLogic::election_strategy es, int pingi,


### PR DESCRIPTION
Problem:
I've got tired of mapping monitor ranks with their names when trying to figure out which monitor pinged which.

Solution:
Why not have both?

Fixes: No Tracker

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
