### PR TITLE
rgw: Inject keystone roles into IAM policy

### DIFF
--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -126,6 +126,7 @@ For all requests, condition keys we support are:
 Request that authenticate with Keystone also include:
 
 - keystone:role
+- keystone:userid
 
 We support certain S3 condition keys for bucket and object requests.
 

--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -123,6 +123,10 @@ For all requests, condition keys we support are:
 - aws:UserAgent
 - aws:username
 
+Request that authenticate with Keystone also include:
+
+- keystone:role
+
 We support certain S3 condition keys for bucket and object requests.
 
 *Support for the following bucket-related operations was added in the Mimic

--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -181,6 +181,12 @@ S3 API (with AWS-like access and secret keys), if the ``rgw s3 auth
 use keystone`` option is set. For details, see
 :doc:`s3/authentication`.
 
+Requests authenticated via Keystone expose the Keystone role names in the
+IAM policy environment as the condition key ``keystone:role``. It can be
+used in bucket policies and idenitity policies to allow or deny access by
+role (e.g. ``StringEquals`` on ``keystone:role``).
+See :doc:`bucketpolicy` for list of supported condition keys.
+
 Service Token Support
 ---------------------
 

--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -181,10 +181,17 @@ S3 API (with AWS-like access and secret keys), if the ``rgw s3 auth
 use keystone`` option is set. For details, see
 :doc:`s3/authentication`.
 
-Requests authenticated via Keystone expose the Keystone role names in the
-IAM policy environment as the condition key ``keystone:role``. It can be
-used in bucket policies and idenitity policies to allow or deny access by
-role (e.g. ``StringEquals`` on ``keystone:role``).
+Requests authenticated via Keystone (Swift tokens or S3 with Keystone-managed
+credentials) expose the Keystone idenitity in the IAM policy environment
+as the condition keys: ``keystone:role`` (role names) and
+``keystone:userid`` (user UUID). These conditions can be used in bucket
+policies and idenitity policies with ``StringEquals``, ``StringNotEquals`` etc.
+
+- **keystone:role** - Allow or deny by *role* (e.g only users with role
+  ``reader`` get read access). Use for RBAC.
+- **keystone:userid** - Restrict to specific *user*. Use when policy
+  depends on a specific user, not just their role.
+
 See :doc:`bucketpolicy` for list of supported condition keys.
 
 Service Token Support

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -1052,6 +1052,9 @@ void rgw::auth::RemoteApplier::modify_request_state(const DoutPrefixProvider* dp
     s->env.emplace("keystone:role", std::move(role));
   }
 
+  if (!info.keystone_user_id.empty()) {
+    s->env.emplace("keystone:userid", info.keystone_user_id);
+  }
 }
 
 std::optional<rgw::ARN> rgw::auth::RemoteApplier::get_caller_identity() const 

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -1043,6 +1043,15 @@ void rgw::auth::RemoteApplier::modify_request_state(const DoutPrefixProvider* dp
   // copy our identity policies into req_state
   s->iam_identity_policies.insert(s->iam_identity_policies.end(),
                                   policies.begin(), policies.end());
+
+  for (auto role : this->info.keystone_roles) {
+    // Keystone roles are case-insensitive. Normalize the roles to
+    // lowercase before placing them into the environment.
+    std::transform(role.begin(), role.end(), role.begin(),
+      [](unsigned char c){ return std::tolower(c); });
+    s->env.emplace("keystone:role", std::move(role));
+  }
+
 }
 
 std::optional<rgw::ARN> rgw::auth::RemoteApplier::get_caller_identity() const 

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -600,6 +600,7 @@ public:
     const std::string subuser;
     const std::string keystone_user;
     const std::optional<rgw::keystone::ScopeInfo> keystone_scope;
+    const std::vector<std::string> keystone_roles;
 
   public:
     enum class acct_privilege_t {
@@ -619,7 +620,8 @@ public:
              const std::string subuser,
              const std::string keystone_user,
              const uint32_t acct_type=TYPE_NONE,
-             std::optional<rgw::keystone::ScopeInfo> keystone_scope=std::nullopt)
+             std::optional<rgw::keystone::ScopeInfo> keystone_scope=std::nullopt,
+             std::vector<std::string> keystone_roles = {})
     : acct_user(acct_user),
       acct_name(acct_name),
       perm_mask(perm_mask),
@@ -628,7 +630,8 @@ public:
       access_key_id(access_key_id),
       subuser(subuser),
       keystone_user(keystone_user),
-      keystone_scope(std::move(keystone_scope)) {
+      keystone_scope(std::move(keystone_scope)),
+      keystone_roles(std::move(keystone_roles)) {
     }
   };
 

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -601,6 +601,7 @@ public:
     const std::string keystone_user;
     const std::optional<rgw::keystone::ScopeInfo> keystone_scope;
     const std::vector<std::string> keystone_roles;
+    const std::string keystone_user_id;
 
   public:
     enum class acct_privilege_t {
@@ -621,7 +622,9 @@ public:
              const std::string keystone_user,
              const uint32_t acct_type=TYPE_NONE,
              std::optional<rgw::keystone::ScopeInfo> keystone_scope=std::nullopt,
-             std::vector<std::string> keystone_roles = {})
+             std::vector<std::string> keystone_roles = {},
+             const std::string keystone_user_id = {}
+            )
     : acct_user(acct_user),
       acct_name(acct_name),
       perm_mask(perm_mask),
@@ -631,7 +634,8 @@ public:
       subuser(subuser),
       keystone_user(keystone_user),
       keystone_scope(std::move(keystone_scope)),
-      keystone_roles(std::move(keystone_roles)) {
+      keystone_roles(std::move(keystone_roles)),
+      keystone_user_id(keystone_user_id) {
     }
   };
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -172,7 +172,8 @@ TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
     token.get_user_name(),
     TYPE_KEYSTONE,
     std::move(keystone_scope),
-    std::move(role_names)
+    std::move(role_names),
+    token.get_user_id()
   };
 }
 
@@ -689,7 +690,8 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
     token.get_user_name(),
     TYPE_KEYSTONE,
     std::move(keystone_scope),
-    std::move(role_names)
+    std::move(role_names),
+    token.get_user_id()
   };
 }
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -144,13 +144,14 @@ TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
                            ) const noexcept
 {
   using acct_privilege_t = rgw::auth::RemoteApplier::AuthInfo::acct_privilege_t;
+  std::vector<std::string> role_names;
 
   /* Check whether the user has an admin status. */
   acct_privilege_t level = acct_privilege_t::IS_PLAIN_ACCT;
   for (const auto& role : token.roles) {
+    role_names.push_back(role.name);
     if (role.is_admin && !role.is_reader) {
       level = acct_privilege_t::IS_ADMIN_ACCT;
-      break;
     }
   }
 
@@ -170,8 +171,9 @@ TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token
     rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
     token.get_user_name(),
     TYPE_KEYSTONE,
-    std::move(keystone_scope)
-};
+    std::move(keystone_scope),
+    std::move(role_names)
+  };
 }
 
 static inline const std::string
@@ -668,6 +670,11 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
   /* Build keystone scope info if ops logging is enabled */
   auto keystone_scope = rgw::keystone::build_scope_info(cct, token);
 
+  std::vector<std::string> role_names;
+  for (const auto& role : token.roles) {
+    role_names.push_back(role.name);
+  }
+
   return auth_info_t {
     /* Suggested account name for the authenticated user. */
     rgw_user(token.get_project_id()),
@@ -681,7 +688,8 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
     rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
     token.get_user_name(),
     TYPE_KEYSTONE,
-    std::move(keystone_scope)
+    std::move(keystone_scope),
+    std::move(role_names)
   };
 }
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -1786,3 +1786,119 @@ TEST_F(ConditionTest, Null)
     EXPECT_TRUE(notNull.eval({{key, "admin/config.txt"}}));
   }
 }
+
+TEST_F(ConditionTest, KeyStoneRoleStringEquals)
+{
+  std::string key = "keystone:role";
+
+  Condition cond{TokenID::StringEquals, key.data(), key.size(), false};
+  cond.vals.push_back("testrole");
+
+  // No roles
+  EXPECT_FALSE(cond.eval({}));
+
+  // Single matching role
+  EXPECT_TRUE(cond.eval({{key, "testrole"}}));
+
+  // Single non-matching role
+  EXPECT_FALSE(cond.eval({{key, "member"}}));
+
+  //Multiple roles in env,one matches
+  Environment multi_env;
+  multi_env.emplace(key, "member");
+  multi_env.emplace(key, "testrole");
+  multi_env.emplace(key, "reader");
+  EXPECT_TRUE(cond.eval(multi_env));
+
+  //Multiple roles in env, no match
+  Environment no_match_env;
+  no_match_env.emplace(key, "member");
+  no_match_env.emplace(key, "reader");
+  EXPECT_FALSE(cond.eval(no_match_env));
+
+  // Multiple identical roles (redundancy check)
+  Environment duplicate_env;
+  duplicate_env.emplace(key, "testrole");
+  duplicate_env.emplace(key, "testrole");
+  EXPECT_TRUE(cond.eval(duplicate_env));
+}
+
+TEST_F(ConditionTest, KeyStoneRoleNotStringEquals)
+{
+  std::string key = "keystone:role";
+
+  Condition cond{TokenID::StringNotEquals, key.data(), key.size(), false};
+  cond.vals.push_back("admin");
+
+  // No roles
+  EXPECT_FALSE(cond.eval({}));
+
+  // Role matches
+  EXPECT_FALSE(cond.eval({{key, "admin"}}));
+
+  // Role doesn't match
+  EXPECT_TRUE(cond.eval({{key, "member"}}));
+
+  // Multiple roles in env, one matches -> false
+  Environment multi_env;
+  multi_env.emplace(key, "member");
+  multi_env.emplace(key, "admin");
+  EXPECT_FALSE(multi_env.count(key) == 0);
+  EXPECT_FALSE(cond.eval(multi_env));
+
+  // Multiple roles, none match -> true
+  Environment no_match_env;
+  no_match_env.emplace(key, "member");
+  no_match_env.emplace(key, "reader");
+  EXPECT_TRUE(cond.eval(no_match_env));
+}
+
+TEST_F(ConditionTest, KeyStoneRolePolicyParsing)
+{
+  string keystone_role_policy = R"(
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect" : "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::example_bucket/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "keystone:role": "testrole"
+        }
+      }
+    }]
+  }
+  )";
+
+  string tenant = "arbitrary_tenant";
+  boost::optional<Policy> p;
+
+  ASSERT_NO_THROW(
+    p = Policy(cct.get(), &tenant, keystone_role_policy, true));
+  ASSERT_TRUE(p);
+  EXPECT_EQ(p->statements.size(), 1U);
+  EXPECT_EQ(p->statements[0].conditions.size(), 1U);
+  EXPECT_EQ(p->statements[0].conditions[0].key, "keystone:role");
+  EXPECT_EQ(p->statements[0].conditions[0].vals.size(), 1U);
+  EXPECT_EQ(p->statements[0].conditions[0].vals[0], "testrole");
+
+  // Eval with matching role in environment
+  Environment match_env;
+  match_env.emplace("keystone:role", "testrole");
+  EXPECT_TRUE(p->statements[0].conditions[0].eval(match_env));
+
+  // Eval with non-matching role
+  Environment nomatch_env;
+  nomatch_env.emplace("keystone:role", "member");
+  EXPECT_FALSE(p->statements[0].conditions[0].eval(nomatch_env));
+
+  // Eval with multiple roles, one matching
+  Environment multi_env;
+  multi_env.emplace("keystone:role", "member");
+  multi_env.emplace("keystone:role", "testrole");
+  EXPECT_TRUE(p->statements[0].conditions[0].eval(multi_env));
+}

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -1902,3 +1902,14 @@ TEST_F(ConditionTest, KeyStoneRolePolicyParsing)
   multi_env.emplace("keystone:role", "testrole");
   EXPECT_TRUE(p->statements[0].conditions[0].eval(multi_env));
 }
+
+TEST_F(ConditionTest, KeystoneUserIdStringEquals)
+{
+  const std::string key = "keystone:userid";
+  Condition cond{TokenID::StringEquals, key.data(), key.size(), false};
+  cond.vals.push_back("user-123");
+
+  EXPECT_FALSE(cond.eval({}));
+  EXPECT_TRUE(cond.eval({{key, "user-123"}}));
+  EXPECT_FALSE(cond.eval({{key, "user-456"}}));
+}


### PR DESCRIPTION
Keystone roles are injected into the IAM policy evaluation environment as "keystone:role" condition keys. This enables bucket policies to grant or deny access based on Keystone roles. It bridges the gap between Openstack RBAC and S3 IAM policy.



On-behalf-of: SAP <supriti.singh@clyso.com>
On-behalf-of: SAP <marcel.lauhoff@sap.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
