### PR TITLE
rgw/d4n: add liburing io_uring and boost.asio io_uring backends for SSDDriver I/O

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -349,10 +349,42 @@ below.
 .. confval:: rgw_d4n_l1_datacache_disk_reserve
 .. confval:: rgw_d4n_l1_evict_cache_on_start
 .. confval:: rgw_d4n_l1_fadvise
-.. confval:: rgw_d4n_libaio_aio_threads
-.. confval:: rgw_d4n_libaio_aio_num
 .. confval:: rgw_lfuda_sync_frequency
 .. confval:: rgw_d4n_l1_datacache_address
+
+D4N Asynchronous I/O Backend Settings
+--------------------------------------
+
+D4N supports two asynchronous I/O backends for cache read/write
+operations: ``libaio`` (POSIX AIO, the default) and ``liburing`` (io_uring).
+The active backend is selected at startup via :confval:`rgw_d4n_io_backend_type`.
+
+.. confval:: rgw_d4n_io_backend_type
+
+If the ``liburing`` backend is selected but liburing is unavailable or
+initialization fails, the gateway automatically falls back to ``libaio``.
+The ``liburing`` backend requires Linux kernel 5.1 or later.
+
+.. note:: The ``liburing`` backend and all ``rgw_d4n_io_uring_*`` options are *experimental*.
+
+liburing Settings
+~~~~~~~~~~~~~~~~~
+
+The following options apply only when :confval:`rgw_d4n_io_backend_type` is set to ``liburing``.
+
+.. confval:: rgw_d4n_io_uring_queue_depth
+.. confval:: rgw_d4n_io_uring_direct_io
+.. confval:: rgw_d4n_io_uring_sqpoll
+.. confval:: rgw_d4n_io_uring_sq_thread_idle_ms
+.. confval:: rgw_d4n_io_uring_iopoll
+
+libaio Settings
+~~~~~~~~~~~~~~~~~
+
+The following options apply only when :confval:`rgw_d4n_io_backend_type` is set to ``libaio``.
+
+.. confval:: rgw_d4n_libaio_aio_threads
+.. confval:: rgw_d4n_libaio_aio_num
 
 Topic Persistency Settings
 ==========================

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4242,6 +4242,99 @@ options:
   see_also:
   - rgw_thread_pool_size
   with_legacy: true
+- name: rgw_d4n_io_backend_type
+  type: str
+  level: advanced
+  desc: Specify the asynchronous I/O library for RGW D4N cache operations.
+  long_desc: The RGW D4N cache backend can use either libaio (POSIX AIO) or liburing (io_uring)
+    for asynchronous I/O operations. io_uring provides better performance on modern Linux
+    kernels but requires kernel 5.1+ and liburing. If liburing is not available or
+    initialization fails, the backend will automatically fall back to libaio.
+  default: libaio
+  services:
+  - rgw
+  enum_values:
+  - libaio
+  - liburing
+  flags:
+  - startup
+  with_legacy: true
+- name: rgw_d4n_io_uring_queue_depth
+  type: int
+  level: advanced
+  desc: io_uring submission queue depth for D4N cache operations.
+  long_desc: Specifies the number of entries in the io_uring submission queue. A larger
+    queue allows more concurrent I/O operations but consumes more kernel memory. This
+    option only applies when rgw_d4n_io_backend_type is set to liburing.
+  default: 2048
+  min: 4
+  max: 8192
+  services:
+  - rgw
+  flags:
+  - startup
+  with_legacy: true
+- name: rgw_d4n_io_uring_direct_io
+  type: bool
+  level: advanced
+  desc: Enable O_DIRECT for io_uring cache I/O operations.
+  long_desc: When enabled, io_uring will use O_DIRECT for bypassing the kernel page cache.
+    This can improve performance for large sequential I/O but requires 512-byte aligned
+    buffers. The io_uring backend automatically handles buffer alignment when this is
+    enabled. This option only applies when rgw_d4n_io_backend_type is set to liburing.
+  default: false
+  services:
+  - rgw
+  flags:
+  - startup
+  with_legacy: true
+- name: rgw_d4n_io_uring_sqpoll
+  type: bool
+  level: advanced
+  desc: Enable SQPOLL mode for kernel-side submission polling.
+  long_desc: When enabled, the kernel will poll the submission queue, eliminating the
+    need for syscalls to submit I/O operations. This can significantly reduce latency
+    but requires elevated privileges (CAP_SYS_NICE or root). If initialization fails,
+    the driver will fall back to normal mode. This option only applies when
+    rgw_d4n_io_backend_type is set to liburing.
+  default: false
+  services:
+  - rgw
+  flags:
+  - startup
+  with_legacy: true
+- name: rgw_d4n_io_uring_sq_thread_idle_ms
+  type: int
+  level: advanced
+  desc: SQPOLL thread idle timeout in milliseconds before sleeping.
+  long_desc: When SQPOLL mode is enabled, this sets how long the kernel polling thread
+    will spin before going to sleep when there are no submissions. Lower values save
+    CPU but may increase latency when new operations arrive. This option only applies
+    when rgw_d4n_io_uring_sqpoll is enabled.
+  default: 1000
+  min: 100
+  max: 60000
+  services:
+  - rgw
+  flags:
+  - startup
+  with_legacy: true
+- name: rgw_d4n_io_uring_iopoll
+  type: bool
+  level: advanced
+  desc: Enable IOPOLL mode for polling-based I/O completion.
+  long_desc: When enabled, io_uring will use polling for I/O completion instead of
+    interrupts. This can significantly reduce latency for NVMe devices that support
+    polling mode. IOPOLL requires O_DIRECT; if rgw_d4n_io_uring_direct_io is disabled,
+    O_DIRECT is forced automatically. Works best with high-performance NVMe storage.
+    Note that IOPOLL is incompatible with SQPOLL mode - if both are enabled, IOPOLL
+    takes precedence.
+  default: false
+  services:
+  - rgw
+  flags:
+  - startup
+  with_legacy: true
 - name: rgw_lfuda_sync_frequency
   type: int
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -541,6 +541,10 @@ if(WITH_RADOSGW_STANDALONE)
   endif()
 endif()
 
+if(WITH_RADOSGW_D4N AND WITH_LIBURING)
+  target_link_libraries(rgw_common PUBLIC uring::uring)
+endif()
+
 set(rgw_a_srcs
   rgw_appmain.cc
   rgw_asio_client.cc

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8951,7 +8951,7 @@ void RGWBulkUploadOp::execute(optional_yield y)
 
   auto status = rgw::tar::StatusIndicator::create();
   do {
-    op_ret = stream->get_exactly(rgw::tar::BLOCK_SIZE, buffer);
+    op_ret = stream->get_exactly(rgw::tar::TAR_BLOCK_SIZE, buffer);
     if (op_ret < 0) {
       ldpp_dout(this, 2) << "cannot read header" << dendl;
       return;
@@ -8979,7 +8979,7 @@ void RGWBulkUploadOp::execute(optional_yield y)
 	  else
 	    filename = file_prefix + std::string(header->get_filename());
 	  auto body = AlignedStreamGetter(0, header->get_filesize(),
-                                          rgw::tar::BLOCK_SIZE, *stream);
+                                          rgw::tar::TAR_BLOCK_SIZE, *stream);
           op_ret = handle_file(filename,
                                header->get_filesize(),
                                body, y);

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
 #include <boost/asio/system_executor.hpp>
 
 #include <boost/container/small_vector.hpp>
@@ -6,12 +9,20 @@
 #include "common/errno.h"
 #include "common/async/blocked_completion.h"
 #include "rgw_ssd_driver.h"
+
+#if defined(HAVE_LIBURING)
+#include <liburing.h>
+#include <sys/eventfd.h>
+#include <thread>
+#endif
+
 #if defined(__linux__)
 #include <features.h>
 #include <sys/xattr.h>
 #endif
 
 #include <filesystem>
+#include <fstream>
 #include <errno.h>
 namespace efs = std::filesystem;
 
@@ -19,6 +30,142 @@ namespace rgw { namespace cache {
 
 static std::atomic<uint64_t> index{0};
 static std::atomic<uint64_t> dir_index{0};
+
+#if defined(HAVE_LIBURING)
+namespace {  // anonymous namespace
+
+// Type-erased CQE dispatch entry.  Stored as io_uring SQE user_data.
+// The reaper thread recovers this pointer from each CQE and calls handler().
+struct IoUringSqeData {
+  using Handler = void(*)(struct io_uring_cqe* cqe, void* arg);
+  Handler handler;   // type-specific CQE handler (e.g. IoUringAsyncReadOp::handle_cqe)
+  void*   arg;       // raw Completion* pointer (ownership transferred)
+};
+
+struct ThreadIoUringState {
+  io_uring ring{};
+  bool initialized = false;
+  int event_fd = -1;
+  std::thread reaper_thread;
+  std::atomic<bool> shutdown{false};
+
+  int init(const DoutPrefixProvider* dpp, unsigned queue_depth, unsigned flags,
+           unsigned sq_thread_idle_ms) {
+    if (initialized) {
+      return 0;
+    }
+    ldpp_dout(dpp, 30) << "URING: ThreadIoUringState::init():" << dendl;
+    // SINGLE_ISSUER: only the owning thread submits to this ring.
+    // CQ access (reaping) from the reaper thread is still allowed.
+#ifdef IORING_SETUP_SINGLE_ISSUER
+    flags |= IORING_SETUP_SINGLE_ISSUER;
+#endif
+    // Note: COOP_TASKRUN and DEFER_TASKRUN are intentionally NOT used.
+    // They require the submitting thread to call io_uring_enter to flush
+    // completions, which conflicts with the eventfd-based reaper model
+    // where CQEs must be posted by the kernel autonomously.
+
+    auto queue_init = [&](unsigned f) {
+      struct io_uring_params params{};
+      params.flags = f;
+      if (f & IORING_SETUP_SQPOLL) {
+        params.sq_thread_idle = sq_thread_idle_ms;
+      }
+      return io_uring_queue_init_params(queue_depth, &ring, &params);
+    };
+
+    int ret = queue_init(flags);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: URING: ThreadIoUringState::init(): io_uring_queue_init_params() failed"
+                        << " flags=0x" << std::hex << flags
+                        << std::dec << ": " << cpp_strerror(-ret) << dendl;
+      // If init failed due to unsupported flags, retry with only basic flags
+      if (ret != -EINVAL) {
+        return ret;
+      }
+      // disable all flags except IORING_SETUP_IOPOLL and IORING_SETUP_SQPOLL and retry  (disables IORING_SETUP_SINGLE_ISSUER and IORING_SETUP_*POLL)
+      unsigned basic_flags = flags & (IORING_SETUP_IOPOLL | IORING_SETUP_SQPOLL);
+      ret = queue_init(basic_flags);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: URING: ThreadIoUringState::init(): io_uring_queue_init_params() retry failed"
+                          << " flags=0x" << std::hex << basic_flags
+                          << std::dec << ": " << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
+      flags = basic_flags;
+    }
+
+    // Create eventfd for CQE notifications to the reaper thread
+    event_fd = ::eventfd(0, EFD_CLOEXEC);
+    if (event_fd < 0) {
+      int err = errno;
+      ldpp_dout(dpp, 0) << "ERROR: URING: eventfd() failed: " << cpp_strerror(err) << dendl;
+      io_uring_queue_exit(&ring);
+      return -err;
+    }
+
+    ret = io_uring_register_eventfd(&ring, event_fd);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: URING: io_uring_register_eventfd() failed: " << cpp_strerror(-ret) << dendl;
+      ::close(event_fd);
+      event_fd = -1;
+      io_uring_queue_exit(&ring);
+      return ret;
+    }
+
+    // Start the reaper thread that processes CQEs asynchronously
+    shutdown.store(false, std::memory_order_relaxed);
+    reaper_thread = std::thread([this]() { reap_loop(); });
+
+    initialized = true;
+    ldpp_dout(dpp, 10) << "URING: ThreadIoUringState::init(): flags=0x" << std::hex << flags << std::dec << " ready" << dendl;
+    return 0;
+  }
+
+  void reap_loop() {
+    while (true) {
+      uint64_t val = 0;
+      ssize_t n = ::read(event_fd, &val, sizeof(val));
+      if (n < 0) {
+        if (errno == EINTR) continue;
+        break;  // eventfd closed or error
+      }
+      // Reap all available CQEs
+      struct io_uring_cqe* cqe;
+      while (io_uring_peek_cqe(&ring, &cqe) == 0) {
+        auto* sqe_data = static_cast<IoUringSqeData*>(io_uring_cqe_get_data(cqe));
+        if (sqe_data) {
+          sqe_data->handler(cqe, sqe_data->arg);
+          delete sqe_data;
+        }
+        io_uring_cqe_seen(&ring, cqe);
+      }
+      if (shutdown.load(std::memory_order_relaxed)) break;
+    }
+  }
+
+  ~ThreadIoUringState() {
+    if (initialized) {
+      shutdown.store(true, std::memory_order_relaxed);
+      if (event_fd >= 0) {
+        // Wake the reaper so it can exit
+        uint64_t val = 1;
+        [[maybe_unused]] auto _ = ::write(event_fd, &val, sizeof(val));
+      }
+      if (reaper_thread.joinable()) {
+        reaper_thread.join();
+      }
+      io_uring_queue_exit(&ring);
+      if (event_fd >= 0) {
+        ::close(event_fd);
+      }
+    }
+  }
+};
+
+thread_local ThreadIoUringState thread_uring_state;
+}  // anonymous namespace
+#endif // HAVE_LIBURING
 
 static std::vector<std::string> tokenize_key(std::string_view key)
 {
@@ -114,6 +261,61 @@ static std::string create_dirs_get_filepath_from_key(const DoutPrefixProvider* d
 
 }
 
+#if defined(HAVE_LIBURING)
+int SSDDriver::init_per_thread_uring(const DoutPrefixProvider* dpp, struct io_uring** ring_out) const
+{
+    // Fast path: ring already initialized for this thread
+    ldpp_dout(dpp, 30) << "URING: SSDDriver::init_per_thread_uring: ring_out=0x" << std::hex << ring_out << std::dec << dendl;
+    if (thread_uring_state.initialized) {
+        if (ring_out) {
+            *ring_out = &thread_uring_state.ring;
+        }
+        return 0;
+    }
+
+    unsigned flags = 0;
+    std::string enabled_features;
+
+    if (dpp->get_cct()->_conf->rgw_d4n_io_uring_iopoll) {
+        flags |= IORING_SETUP_IOPOLL;
+        enabled_features += "IOPOLL ";
+    }
+    unsigned sq_thread_idle_ms = 0;
+    if (dpp->get_cct()->_conf->rgw_d4n_io_uring_sqpoll) {
+        flags |= IORING_SETUP_SQPOLL;
+        sq_thread_idle_ms = dpp->get_cct()->_conf.get_val<int64_t>("rgw_d4n_io_uring_sq_thread_idle_ms");
+        enabled_features += "SQPOLL ";
+    }
+    // IOPOLL requires O_DIRECT file descriptors
+    if (dpp->get_cct()->_conf->rgw_d4n_io_uring_direct_io ||
+        dpp->get_cct()->_conf->rgw_d4n_io_uring_iopoll) {
+        enabled_features += "O_DIRECT ";
+    }
+
+    int ret = thread_uring_state.init(dpp, IoUringQueueDepth, flags, sq_thread_idle_ms);
+    if (ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: URING: Failed to initialize io_uring with flags=0x" << std::hex << flags << std::dec
+                          << ", queue_depth=" << IoUringQueueDepth << ": " << cpp_strerror(-ret) << dendl;
+        return ret;
+    }
+
+    if (flags & IORING_SETUP_SQPOLL) {
+        ldpp_dout(dpp, 10) << "URING: SSDDriver: io_uring initialized: " << enabled_features
+                           << ", queue_depth=" << IoUringQueueDepth
+                           << ", sq_thread_idle_ms=" << sq_thread_idle_ms << dendl;
+    } else {
+        ldpp_dout(dpp, 10) << "URING: SSDDriver: io_uring initialized: " << enabled_features
+                           << ", queue_depth=" << IoUringQueueDepth << dendl;
+    }
+
+    if (ring_out) {
+        *ring_out = &thread_uring_state.ring;
+    }
+
+    return 0;
+}
+#endif // HAVE_LIBURING
+
 int SSDDriver::initialize(const DoutPrefixProvider* dpp)
 {
     if(partition_info.location.back() != '/') {
@@ -177,14 +379,84 @@ int SSDDriver::initialize(const DoutPrefixProvider* dpp)
       }
     }
 
-    #if defined(HAVE_LIBAIO) && defined(__GLIBC__)
-    // libaio setup
-    struct aioinit ainit{0};
-    ainit.aio_threads = dpp->get_cct()->_conf.get_val<int64_t>("rgw_d4n_libaio_aio_threads");
-    ainit.aio_num = dpp->get_cct()->_conf.get_val<int64_t>("rgw_d4n_libaio_aio_num");
-    ainit.aio_idle_time = 120;
-    aio_init(&ainit);
-    #endif
+    // Determine which I/O backend to use based on config
+    std::string backend_type = dpp->get_cct()->_conf.get_val<std::string>("rgw_d4n_io_backend_type");
+    ldpp_dout(dpp, 5) << "SSDDriver: requested I/O backend type: " << backend_type << dendl;
+
+#if defined(HAVE_LIBURING)
+    if (backend_type == "liburing") {
+        // Check if io_uring is disabled in sysctl
+        std::ifstream sysctl_file("/proc/sys/kernel/io_uring_disabled");
+        if (sysctl_file.is_open()) {
+            int io_uring_disabled_val = -1;
+            if (sysctl_file >> io_uring_disabled_val) {
+                ldpp_dout(dpp, 20) << "SSDDriver: URING: sysctl kernel.io_uring_disabled="
+                                   << io_uring_disabled_val << dendl;
+                if (io_uring_disabled_val > 0) {
+                    ldpp_dout(dpp, 0) << "WARNING: URING: sysctl kernel.io_uring_disabled="
+                                      << io_uring_disabled_val
+                                      << ", falling back to libaio" << dendl;
+                    use_io_uring = false;
+                    goto skip_uring_init;
+                }
+            } else {
+                ldpp_dout(dpp, 0) << "WARNING: URING: failed to read value from /proc/sys/kernel/io_uring_disabled"
+                                  << ", falling back to libaio" << dendl;
+                use_io_uring = false;
+                goto skip_uring_init;
+            }
+        }
+
+        // Try to initialize io_uring
+        IoUringQueueDepth = dpp->get_cct()->_conf.get_val<int64_t>("rgw_d4n_io_uring_queue_depth");
+
+        // IOPOLL requires O_DIRECT; force it when the admin left direct_io disabled
+        if (dpp->get_cct()->_conf->rgw_d4n_io_uring_iopoll &&
+            !dpp->get_cct()->_conf->rgw_d4n_io_uring_direct_io) {
+            ldpp_dout(dpp, 0) << "WARNING: URING: IOPOLL requires O_DIRECT; forcing O_DIRECT for liburing I/O"
+                              << dendl;
+        }
+
+        // Warm up the thread-local io_uring instance / detect any initialization issues early
+        int uring_ret = init_per_thread_uring(dpp, nullptr);
+        if (uring_ret < 0) {
+            ldpp_dout(dpp, 0) << "WARNING: URING: io_uring initialization failed: " << cpp_strerror(-uring_ret)
+                              << ", falling back to libaio" << dendl;
+            use_io_uring = false;
+        } else {
+            ldpp_dout(dpp, 5) << "SSDDriver: URING: configured to use 'liburing' backend" << dendl;
+            use_io_uring = true;
+        }
+    } else {
+        ldpp_dout(dpp, 5) << "SSDDriver: URING: configured to use 'libaio' backend" << dendl;
+        use_io_uring = false;
+    }
+#else
+    if (backend_type == "liburing") {
+        ldpp_dout(dpp, 0) << "ERROR: URING: io_uring backend requested but liburing not compiled in, falling back to using libaio" << dendl;
+    }
+    use_io_uring = false;
+#endif
+
+    skip_uring_init:
+
+    // Initialize libaio if that's what we're using
+    if (!use_io_uring) {
+#if defined(HAVE_LIBAIO) && defined(__GLIBC__)
+      // libaio setup
+      struct aioinit ainit{0};
+      ainit.aio_threads = dpp->get_cct()->_conf.get_val<int64_t>("rgw_d4n_libaio_aio_threads");
+      ainit.aio_num = dpp->get_cct()->_conf.get_val<int64_t>("rgw_d4n_libaio_aio_num");
+      ainit.aio_idle_time = 120;
+      aio_init(&ainit);
+      ldpp_dout(dpp, 5) << "SSDDriver: libaio backend initialized" << dendl;
+#else
+      ldpp_dout(dpp, 0) << "SSDDriver: ERROR: libaio backend is not available on this platform" << dendl;
+      return -ENOSYS;
+#endif
+    }
+
+    ldpp_dout(dpp, 5) << "SSDDriver: using " << (use_io_uring ? "io_uring" : "libaio") << " I/O backend" << dendl;
 
     efs::space_info space = efs::space(partition_info.location);
     //currently partition_info.size is unused
@@ -318,7 +590,7 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 					    }
 
 					    if (attrs.find(RGW_CACHE_ATTR_DELETE_MARKER) != attrs.end()) {
-						std::string deleteMarkerStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
+                                                std::string deleteMarkerStr = attrs[RGW_CACHE_ATTR_DELETE_MARKER].to_str();
 						deleteMarker = (deleteMarkerStr == "1") ? true : false;
 						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): deleteMarker: " << deleteMarker << dendl;
 					    }
@@ -479,25 +751,44 @@ int SSDDriver::append_data(const DoutPrefixProvider* dpp, const::std::string& ke
     return 0;
 }
 
+// Template create functions for async operations
 template <typename Executor1, typename CompletionHandler>
-auto SSDDriver::AsyncReadOp::create(const Executor1& ex1, CompletionHandler&& handler)
+auto SSDDriver::LibaioAsyncReadOp::create(const Executor1& ex1, CompletionHandler&& handler)
 {
     auto p = Completion::create(ex1, std::move(handler));
     return p;
 }
 
 template <typename Executor1, typename CompletionHandler>
-auto SSDDriver::AsyncWriteRequest::create(const Executor1& ex1, CompletionHandler&& handler)
+auto SSDDriver::LibaioAsyncWriteRequest::create(const Executor1& ex1, CompletionHandler&& handler)
 {
     auto p = Completion::create(ex1, std::move(handler));
     return p;
 }
+
+#if defined(HAVE_LIBURING)
+template <typename Executor1, typename CompletionHandler>
+auto SSDDriver::IoUringAsyncReadOp::create(const Executor1& ex1, CompletionHandler&& handler)
+{
+    auto p = Completion::create(ex1, std::move(handler));
+    return p;
+}
+
+template <typename Executor1, typename CompletionHandler>
+auto SSDDriver::IoUringAsyncWriteRequest::create(const Executor1& ex1, CompletionHandler&& handler)
+{
+    auto p = Completion::create(ex1, std::move(handler));
+    return p;
+}
+#endif
+
+// libaio implementation (always available)
 
 template <typename Executor, typename CompletionToken>
-auto SSDDriver::get_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+auto SSDDriver::get_async_libaio(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
                 off_t read_ofs, off_t read_len, CompletionToken&& token)
 {
-  using Op = AsyncReadOp;
+  using Op = LibaioAsyncReadOp;
   using Signature = typename Op::Signature;
   return boost::asio::async_initiate<CompletionToken, Signature>(
       [this] (auto handler, const DoutPrefixProvider *dpp,
@@ -525,10 +816,10 @@ auto SSDDriver::get_async(const DoutPrefixProvider *dpp, const Executor& ex, con
 }
 
 template <typename Executor, typename CompletionToken>
-void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+void SSDDriver::put_async_libaio(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
                 const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token)
 {
-  using Op = AsyncWriteRequest;
+  using Op = LibaioAsyncWriteRequest;
   using Signature = typename Op::Signature;
   return boost::asio::async_initiate<CompletionToken, Signature>(
       [this] (auto handler, const DoutPrefixProvider *dpp,
@@ -547,13 +838,14 @@ void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, con
     bufferlist src = bl;
     r = op.prepare_libaio_write_op(dpp, src, len, op.temp_file_path);
     op.cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
-    op.cb->aio_sigevent.sigev_notify_function = SSDDriver::AsyncWriteRequest::libaio_write_cb;
+    op.cb->aio_sigevent.sigev_notify_function = SSDDriver::LibaioAsyncWriteRequest::libaio_write_cb;
     op.cb->aio_sigevent.sigev_notify_attributes = nullptr;
     op.cb->aio_sigevent.sigev_value.sival_ptr = (void*)p.get();
     op.dpp = dpp;
     op.priv_data = this;
     op.attrs = std::move(attrs);
-    if (r >= 0) {
+    bool prepare_succeeded = (r >= 0);
+    if (prepare_succeeded) {
         r = ::aio_write(op.cb.get());
     } else {
         ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): ::prepare_libaio_write_op(), r=" << r << dendl;
@@ -561,6 +853,12 @@ void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, con
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): ::aio_write(), r=" << r << dendl;
     if(r < 0) {
+        // If prepare succeeded but aio_write failed, we need to free the data buffer
+        // (libaio_aiocb_deleter will close the fd, but doesn't free the data)
+        if (prepare_succeeded && op.data) {
+            ::free(op.data);
+            op.data = nullptr;
+        }
         auto ec = boost::system::error_code{-r, boost::system::system_category()};
         ceph::async::dispatch(std::move(p), ec);
     } else {
@@ -568,6 +866,159 @@ void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, con
     }
   }, token, dpp, ex, key, bl, len, attrs);
 }
+
+// Dispatcher functions that select the appropriate backend based on use_io_uring flag
+
+template <typename Executor, typename CompletionToken>
+auto SSDDriver::get_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 off_t read_ofs, off_t read_len, CompletionToken&& token)
+{
+#if defined(HAVE_LIBURING)
+    if (use_io_uring) {
+        return get_async_uring(dpp, ex, key, read_ofs, read_len, std::forward<CompletionToken>(token));
+    }
+#endif
+    return get_async_libaio(dpp, ex, key, read_ofs, read_len, std::forward<CompletionToken>(token));
+}
+
+template <typename Executor, typename CompletionToken>
+void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token)
+{
+#if defined(HAVE_LIBURING)
+    if (use_io_uring) {
+        put_async_uring(dpp, ex, key, bl, len, attrs, std::forward<CompletionToken>(token));
+        return;
+    }
+#endif
+    put_async_libaio(dpp, ex, key, bl, len, attrs, std::forward<CompletionToken>(token));
+}
+
+#if defined(HAVE_LIBURING)
+// io_uring implementation
+
+template <typename Executor, typename CompletionToken>
+auto SSDDriver::get_async_uring(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                off_t read_ofs, off_t read_len, CompletionToken&& token)
+{
+  using Op = IoUringAsyncReadOp;
+  using Signature = typename Op::Signature;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [this] (auto handler, const DoutPrefixProvider *dpp,
+              const Executor& ex, const std::string& key,
+              off_t read_ofs, off_t read_len) {
+    auto p = Op::create(ex, handler);
+    auto& op = p->user_data;
+
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    ldpp_dout(dpp, 20) << "SSDCache: URING: " << __func__ << "(): location=" << location << dendl;
+
+    io_uring* ring = nullptr;
+    int ring_ret = init_per_thread_uring(dpp, &ring);
+    if (ring_ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: URING: get_async_uring: init_per_thread_uring failed: " << ring_ret << dendl;
+        auto ec = boost::system::error_code{-ring_ret, boost::system::system_category()};
+        ceph::async::post(std::move(p), ec, bufferlist{});
+        return;
+    }
+
+    // Allocate the type-erased CQE handler; the reaper thread will own it
+    auto* sqe_data = new IoUringSqeData{&Op::handle_cqe, p.get()};
+
+    int ret = op.prepare_io_uring_read_op(dpp, location, read_ofs, read_len, sqe_data, ring);
+    if (ret < 0) {
+        delete sqe_data;
+        ldpp_dout(dpp, 0) << "ERROR: URING: get_async_uring: prepare failed: " << cpp_strerror(-ret) << dendl;
+        auto ec = boost::system::error_code{-ret, boost::system::system_category()};
+        ceph::async::post(std::move(p), ec, bufferlist{});
+        return;
+    }
+
+    // Non-blocking submit — the SQE is now in the ring
+    int submitted = io_uring_submit(ring);
+    if (submitted < 0) {
+        // SQE was prepared but submit failed; clean up resources
+        delete sqe_data;
+        if (op.fd >= 0) { ::close(op.fd); op.fd = -1; }
+        if (op.buffer) { ::free(op.buffer); op.buffer = nullptr; }
+        ldpp_dout(dpp, 0) << "ERROR: URING: get_async_uring: io_uring_submit failed: " << cpp_strerror(-submitted) << dendl;
+        auto ec = boost::system::error_code{-submitted, boost::system::system_category()};
+        ceph::async::post(std::move(p), ec, bufferlist{});
+        return;
+    }
+
+    // Release ownership — the reaper thread will reconstruct the
+    // unique_ptr<Completion> from sqe_data->arg when the CQE arrives.
+    // The coroutine suspends here (async_initiate returns).
+    (void)p.release();
+  }, token, dpp, ex, key, read_ofs, read_len);
+}
+
+template <typename Executor, typename CompletionToken>
+void SSDDriver::put_async_uring(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token)
+{
+  using Op = IoUringAsyncWriteRequest;
+  using Signature = typename Op::Signature;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [this] (auto handler, const DoutPrefixProvider *dpp,
+              const Executor& ex, const std::string& key, const bufferlist& bl,
+              uint64_t len, const rgw::sal::Attrs& attrs) {
+    auto p = Op::create(ex, handler);
+    auto& op = p->user_data;
+
+    op.file_path = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    ldpp_dout(dpp, 20) << "SSDCache: URING: " << __func__ << "(): op.file_path=" << op.file_path << dendl;
+
+    op.temp_file_path = create_dirs_get_filepath_from_key(dpp, partition_info.location, key, true);
+    ldpp_dout(dpp, 20) << "SSDCache: URING: " << __func__ << "(): op.temp_file_path=" << op.temp_file_path << dendl;
+
+    io_uring* ring = nullptr;
+    int ring_ret = init_per_thread_uring(dpp, &ring);
+    if (ring_ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: URING: put_async_uring: init_per_thread_uring failed: " << ring_ret << dendl;
+        auto ec = boost::system::error_code{-ring_ret, boost::system::system_category()};
+        ceph::async::dispatch(std::move(p), ec);
+        return;
+    }
+
+    // Set up op fields needed by the write completion handler
+    op.dpp = dpp;
+    op.priv_data = this;
+    op.attrs = std::move(attrs);
+
+    // Allocate the type-erased CQE handler; the reaper thread will own it
+    auto* sqe_data = new IoUringSqeData{&Op::handle_cqe, p.get()};
+
+    bufferlist src = bl;
+    int r = op.prepare_io_uring_write_op(dpp, src, len, op.temp_file_path, sqe_data, ring);
+    if (r < 0) {
+        delete sqe_data;
+        ldpp_dout(dpp, 0) << "ERROR: URING: put_async_uring: prepare failed: " << cpp_strerror(-r) << dendl;
+        auto ec = boost::system::error_code{-r, boost::system::system_category()};
+        ceph::async::dispatch(std::move(p), ec);
+        return;
+    }
+
+    // Non-blocking submit
+    int submitted = io_uring_submit(ring);
+    if (submitted < 0) {
+        delete sqe_data;
+        if (op.fd >= 0) { ::close(op.fd); op.fd = -1; }
+        if (op.data) { ::free(op.data); op.data = nullptr; }
+        ldpp_dout(dpp, 0) << "ERROR: URING: put_async_uring: io_uring_submit failed: " << cpp_strerror(-submitted) << dendl;
+        auto ec = boost::system::error_code{-submitted, boost::system::system_category()};
+        ceph::async::dispatch(std::move(p), ec);
+        return;
+    }
+
+    // Release ownership — the reaper thread will reconstruct the
+    // unique_ptr<Completion> from sqe_data->arg when the CQE arrives.
+    // The coroutine suspends here (async_initiate returns).
+    (void)p.release();
+  }, token, dpp, ex, key, bl, len, attrs);
+}
+#endif // HAVE_LIBURING
 
 rgw::Aio::OpFunc SSDDriver::ssd_cache_read_op(const DoutPrefixProvider *dpp, optional_yield y, rgw::cache::CacheDriver* cache_driver,
                                 off_t read_ofs, off_t read_len, const std::string& key) {
@@ -669,7 +1120,7 @@ int SSDDriver::rename(const DoutPrefixProvider* dpp, const::std::string& oldKey,
 }
 
 
-int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path)
+int SSDDriver::LibaioAsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path)
 {
     int r = 0;
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Write To Cache, location=" << file_path << dendl;
@@ -686,15 +1137,15 @@ int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvid
             if (pos != std::string::npos) {
                 dir_path.erase(pos, (dir_path.length() - pos));
             }
-            ldpp_dout(dpp, 20) << "INFO: AsyncWriteRequest::prepare_libaio_write_op: dir_path for creating directories=" << dir_path << dendl;
+            ldpp_dout(dpp, 20) << "INFO: LibaioAsyncWriteRequest::prepare_libaio_write_op: dir_path for creating directories=" << dir_path << dendl;
             create_directories(dpp, dir_path);
             r = fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | dpp->get_cct()->_conf->rgw_d4n_l1_write_open_flags, mode));
             if (fd < 0) {
-                ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
+                ldpp_dout(dpp, 0) << "ERROR: LibaioAsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
                 return r;
             }
         } else {
-            ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
+            ldpp_dout(dpp, 0) << "ERROR: LibaioAsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
             return r;
         }
     }
@@ -704,7 +1155,7 @@ int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvid
 
     data = malloc(len);
     if (!data) {
-        ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: memory allocation failed" << dendl;
+        ldpp_dout(dpp, 0) << "ERROR: LibaioAsyncWriteRequest::prepare_libaio_write_op: memory allocation failed" << dendl;
         ::close(fd);
         return r;
     }
@@ -714,14 +1165,20 @@ int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvid
     return r;
 }
 
-void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
+
+void SSDDriver::LibaioAsyncWriteRequest::libaio_write_cb(sigval sigval) {
     auto p = std::unique_ptr<Completion>{static_cast<Completion*>(sigval.sival_ptr)};
     auto op = std::move(p->user_data);
-    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_cb: key: " << op.file_path << dendl;
+    ldpp_dout(op.dpp, 20) << "INFO: LibaioAsyncWriteRequest::libaio_write_cb: key: " << op.file_path << dendl;
     int ret = -aio_error(op.cb.get());
     boost::system::error_code ec;
     if (ret < 0) {
         ec.assign(-ret, boost::system::system_category());
+        // Free the data buffer before returning
+        if (op.data) {
+            ::free(op.data);
+            op.data = nullptr;
+        }
         ceph::async::dispatch(std::move(p), ec);
         return;
     }
@@ -731,8 +1188,13 @@ void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
         optional_yield y{null_yield};
         attr_ret = op.priv_data->set_attrs(op.dpp, op.temp_file_path, op.attrs, y);
         if (attr_ret < 0) {
-            ldpp_dout(op.dpp, 0) << "ERROR: AsyncWriteRequest::libaio_write_yield_cb::set_attrs: failed to set attrs, ret = " << attr_ret << dendl;
+            ldpp_dout(op.dpp, 0) << "ERROR: LibaioAsyncWriteRequest::libaio_write_cb::set_attrs: failed to set attrs, ret = " << attr_ret << dendl;
             ec.assign(-ret, boost::system::system_category());
+            // Free the data buffer before returning
+            if (op.data) {
+                ::free(op.data);
+                op.data = nullptr;
+            }
             ceph::async::dispatch(std::move(p), ec);
             return;
         }
@@ -742,8 +1204,8 @@ void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
     efs::space_info space = efs::space(partition_info.location);
     op.priv_data->set_free_space(op.dpp, space.available);
 
-    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_yield_cb: new_path: " << op.file_path << dendl;
-    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_yield_cb: old_path: " << op.temp_file_path << dendl;
+    ldpp_dout(op.dpp, 20) << "INFO: LibaioAsyncWriteRequest::libaio_write_cb: new_path: " << op.file_path << dendl;
+    ldpp_dout(op.dpp, 20) << "INFO: LibaioAsyncWriteRequest::libaio_write_cb: old_path: " << op.temp_file_path << dendl;
 
     ret = std::rename(op.temp_file_path.c_str(), op.file_path.c_str());
     if (ret < 0) {
@@ -751,10 +1213,15 @@ void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
         ldpp_dout(op.dpp, 0) << "ERROR: put::rename: failed to rename file: " << ret << dendl;
         ec.assign(-ret, boost::system::system_category());
     }
+    // Free the data buffer before returning
+    if (op.data) {
+        ::free(op.data);
+        op.data = nullptr;
+    }
     ceph::async::dispatch(std::move(p), ec);
 }
 
-int SSDDriver::AsyncReadOp::prepare_libaio_read_op(const DoutPrefixProvider *dpp, const std::string& file_path, off_t read_ofs, off_t read_len, void* arg)
+int SSDDriver::LibaioAsyncReadOp::prepare_libaio_read_op(const DoutPrefixProvider *dpp, const std::string& file_path, off_t read_ofs, off_t read_len, void* arg)
 {
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): file_path=" << file_path << dendl;
     aio_cb.reset(new struct aiocb);
@@ -783,7 +1250,7 @@ int SSDDriver::AsyncReadOp::prepare_libaio_read_op(const DoutPrefixProvider *dpp
     return 0;
 }
 
-void SSDDriver::AsyncReadOp::libaio_cb_aio_dispatch(sigval sigval)
+void SSDDriver::LibaioAsyncReadOp::libaio_cb_aio_dispatch(sigval sigval)
 {
     auto p = std::unique_ptr<Completion>{static_cast<Completion*>(sigval.sival_ptr)};
     auto op = std::move(p->user_data);
@@ -994,7 +1461,15 @@ int SSDDriver::set_attr(const DoutPrefixProvider* dpp, const std::string& key, c
         ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): set_attr: key: " << attr_name << " val: " << policy_json << dendl;
       }
     } else {
-      ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): set_attr: key: " << attr_name << " val: " << attr_val << dendl;
+      if (attr_val.find('\0') != std::string::npos) {
+        bufferlist bl;
+        bl.append(attr_val);
+        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): set_attr: key: " << attr_name << " val(hex, " << attr_val.size() << "B): ";
+        bl.hexdump(*_dout);
+        *_dout << dendl;
+      } else {
+        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): set_attr: key: " << attr_name << " val: " << attr_val << dendl;
+      }
     }
 
     auto ret = setxattr(location.c_str(), attr_name.c_str(), attr_val.c_str(), attr_val.size(), 0);
@@ -1025,5 +1500,277 @@ int SSDDriver::delete_attr(const DoutPrefixProvider* dpp, const std::string& key
 
     return 0;
 }
+
+#if defined(HAVE_LIBURING)
+// io_uring read completion handler
+void SSDDriver::IoUringAsyncReadOp::io_uring_read_completion(struct io_uring_cqe* cqe, IoUringAsyncReadOp* op)
+{
+    ldpp_dout(op->dpp, 20) << "SSDCache: URING: " << __func__ << "():" << dendl;
+
+    int ret = cqe->res;
+    if (ret < 0) {
+        ldpp_dout(op->dpp, 0) << "ERROR: URING: IoUringAsyncReadOp::io_uring_read_completion: read failed with ret=" << -ret << dendl;
+    }
+    if (ret > 0 && op->buffer) {
+        if (op->direct_io) {
+            // With O_DIRECT, we read from an aligned offset/length.
+            // Trim the result to the originally requested range.
+            size_t ofs_adjustment = op->offset & (IO_BUFFER_ALIGNMENT - 1);
+            size_t available = (static_cast<size_t>(ret) > ofs_adjustment)
+                               ? static_cast<size_t>(ret) - ofs_adjustment : 0;
+            size_t copy_len = std::min(op->length, available);
+            if (copy_len > 0) {
+                op->result.append(static_cast<const char*>(op->buffer) + ofs_adjustment, copy_len);
+            }
+        } else {
+            op->result.append(static_cast<const char*>(op->buffer), ret);
+        }
+    }
+    if (op->fd >= 0) {
+        ::close(op->fd);
+        op->fd = -1;
+    }
+    if (op->buffer) {
+        ::free(op->buffer);
+        op->buffer = nullptr;
+    }
+}
+
+// Called by the reaper thread to dispatch a read CQE back to the coroutine
+void SSDDriver::IoUringAsyncReadOp::handle_cqe(struct io_uring_cqe* cqe, void* arg)
+{
+    auto p = std::unique_ptr<Completion>{static_cast<Completion*>(arg)};
+    auto& op = p->user_data;
+
+    int cqe_res = cqe->res;
+    io_uring_read_completion(cqe, &op);
+
+    boost::system::error_code ec;
+    if (cqe_res < 0) {
+        ec.assign(-cqe_res, boost::system::system_category());
+        ldpp_dout(op.dpp, 0) << "ERROR: URING: read CQE failed: " << cpp_strerror(-cqe_res) << dendl;
+    }
+    // Post to the handler's executor — this resumes the coroutine
+    ceph::async::post(std::move(p), ec, std::move(op.result));
+}
+
+// Prepare an io_uring read operation
+int SSDDriver::IoUringAsyncReadOp::prepare_io_uring_read_op(
+    const DoutPrefixProvider *dpp,
+    const std::string& file_path,
+    off_t read_ofs,
+    size_t read_len,
+    void* sqe_user_data,
+    struct io_uring* ring)
+{
+    ldpp_dout(dpp, 20) << "SSDCache: URING: IoUringAsyncReadOp::prepare_io_uring_read_op(): file_path=" << file_path << dendl;
+
+    // IOPOLL rings only accept O_DIRECT fds; force direct I/O when IOPOLL is enabled
+    bool iopoll = dpp->get_cct()->_conf->rgw_d4n_io_uring_iopoll;
+    bool want_direct = dpp->get_cct()->_conf->rgw_d4n_io_uring_direct_io || iopoll;
+    int open_flags = O_RDONLY;
+    if (want_direct) {
+        open_flags |= O_DIRECT;
+    }
+
+    fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), open_flags));
+    if (fd < 0) {
+        if ((open_flags & O_DIRECT) && errno == EINVAL && !iopoll) {
+            // O_DIRECT not supported on this filesystem, fall back (not with IOPOLL)
+            want_direct = false;
+            fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), O_RDONLY));
+        }
+        if (fd < 0) {
+            ldpp_dout(dpp, 0) << "ERROR: URING: IoUringAsyncReadOp::prepare_io_uring_read_op: open file failed, errno=" << errno << ", location='" << file_path << "'" << dendl;
+            return -errno;
+        }
+    }
+    // posix_fadvise is meaningless with O_DIRECT (page cache is bypassed)
+    if (!want_direct && dpp->get_cct()->_conf->rgw_d4n_l1_fadvise != POSIX_FADV_NORMAL)
+        posix_fadvise(fd, 0, 0, dpp->get_cct()->_conf->rgw_d4n_l1_fadvise);
+
+    this->dpp = dpp;
+    this->direct_io = want_direct;
+    offset = read_ofs;
+    length = read_len;
+
+    // For O_DIRECT, offset and length must be aligned to IO_BUFFER_ALIGNMENT
+    off_t aligned_ofs = want_direct ? (read_ofs & ~(off_t)(IO_BUFFER_ALIGNMENT - 1)) : read_ofs;
+    size_t ofs_adjustment = read_ofs - aligned_ofs;
+    size_t aligned_len = want_direct ? iouring_align_size(read_len + ofs_adjustment) : read_len;
+
+    if (posix_memalign(&buffer, IO_BUFFER_ALIGNMENT, aligned_len) != 0) {
+        ldpp_dout(dpp, 0) << "ERROR: URING: IoUringAsyncReadOp::prepare_io_uring_read_op: memory allocation failed" << dendl;
+        ::close(fd);
+        return -ENOMEM;
+    }
+
+    struct io_uring_sqe* sqe = io_uring_get_sqe(ring);
+    if (!sqe) {
+        ldpp_dout(dpp, 0) << "ERROR: URING: IoUringAsyncReadOp::prepare_io_uring_read_op: failed to get sqe" << dendl;
+        ::close(fd);
+        free(buffer);
+        return -EAGAIN;
+    }
+    io_uring_prep_read(sqe, fd, buffer, aligned_len, aligned_ofs);
+    io_uring_sqe_set_data(sqe, sqe_user_data);
+    return 0;
+}
+
+// io_uring write completion handler.
+// Returns 0 on success, negative errno on failure. Does not publish on short write.
+int SSDDriver::IoUringAsyncWriteRequest::io_uring_write_completion(struct io_uring_cqe* cqe, IoUringAsyncWriteRequest* op)
+{
+    ldpp_dout(op->dpp, 20) << "SSDCache: URING: " << __func__ << "():" << dendl;
+
+    int result = 0;
+    int ret = cqe->res;
+    if (ret < 0) {
+        ldpp_dout(op->dpp, 0) << "ERROR: URING: io_uring_write_completion: I/O write failed, ret=" << -ret << dendl;
+        result = ret;
+    } else if (static_cast<size_t>(ret) != op->submitted_len) {
+        // Short write: do not ftruncate/rename — that would publish a partial cache object.
+        ldpp_dout(op->dpp, 0) << "ERROR: URING: io_uring_write_completion: short write, wrote=" << ret
+                              << " expected=" << op->submitted_len << dendl;
+        result = -EIO;
+    } else {
+        // With O_DIRECT, we wrote an aligned (padded) length.
+        // Truncate the file to the real data size.
+        if (op->direct_io && op->fd >= 0) {
+            int tr = ::ftruncate(op->fd, op->length);
+            if (tr < 0) {
+                result = -errno;
+                ldpp_dout(op->dpp, 0) << "ERROR: URING: io_uring_write_completion: ftruncate failed, errno="
+                                      << errno << dendl;
+            }
+        }
+        if (result == 0 && op->attrs.size() > 0) {
+            optional_yield y{null_yield};
+            int attr_ret = op->priv_data->set_attrs(op->dpp, op->temp_file_path, op->attrs, y);
+            if (attr_ret < 0) {
+                result = attr_ret;
+                ldpp_dout(op->dpp, 0) << "ERROR: URING: io_uring_write_completion::set_attrs: failed to set attrs, ret = "
+                                      << attr_ret << dendl;
+            }
+        }
+        if (result == 0) {
+            Partition partition_info = op->priv_data->get_current_partition_info(op->dpp);
+            efs::space_info space = efs::space(partition_info.location);
+            op->priv_data->set_free_space(op->dpp, space.available);
+            ldpp_dout(op->dpp, 20) << "SSDCache: URING: io_uring_write_completion: new_path: " << op->file_path << dendl;
+            ldpp_dout(op->dpp, 20) << "SSDCache: URING: io_uring_write_completion: old_path: " << op->temp_file_path << dendl;
+            ret = std::rename(op->temp_file_path.c_str(), op->file_path.c_str());
+            if (ret < 0) {
+                result = -errno;
+                ldpp_dout(op->dpp, 0) << "ERROR: URING: put::rename: failed to rename file: ret=" << result << dendl;
+            }
+        }
+    }
+
+    if (op->fd >= 0) {
+        ::close(op->fd);
+        op->fd = -1;
+    }
+    if (op->data) {
+        ::free(op->data);
+        op->data = nullptr;
+    }
+    return result;
+}
+
+// Called by the reaper thread to dispatch a write CQE back to the coroutine
+void SSDDriver::IoUringAsyncWriteRequest::handle_cqe(struct io_uring_cqe* cqe, void* arg)
+{
+    auto p = std::unique_ptr<Completion>{static_cast<Completion*>(arg)};
+    auto& op = p->user_data;
+
+    int result = io_uring_write_completion(cqe, &op);
+
+    boost::system::error_code ec;
+    if (result < 0) {
+        ec.assign(-result, boost::system::system_category());
+        ldpp_dout(op.dpp, 0) << "ERROR: URING: write CQE failed: " << cpp_strerror(-result) << dendl;
+    }
+    // Post to the handler's executor — this resumes the coroutine
+    ceph::async::post(std::move(p), ec);
+}
+
+// Prepare an io_uring write operation
+int SSDDriver::IoUringAsyncWriteRequest::prepare_io_uring_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path, void* sqe_user_data, struct io_uring* ring)
+{
+    ldpp_dout(dpp, 20) << "SSDCache: URING: IoUringAsyncWriteRequest::prepare_io_uring_write_op(): Write To Cache, file_path=" << file_path << dendl;
+    mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+
+    // IOPOLL rings only accept O_DIRECT fds; force direct I/O when IOPOLL is enabled
+    bool iopoll = dpp->get_cct()->_conf->rgw_d4n_io_uring_iopoll;
+    bool want_direct = dpp->get_cct()->_conf->rgw_d4n_io_uring_direct_io || iopoll;
+    int open_flags = O_WRONLY | O_CREAT | O_TRUNC | dpp->get_cct()->_conf->rgw_d4n_l1_write_open_flags;
+    if (want_direct) {
+        open_flags |= O_DIRECT;
+    }
+
+    fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), open_flags, mode));
+    if (fd < 0) {
+        int saved_errno = errno;
+        if ((open_flags & O_DIRECT) && saved_errno == EINVAL && !iopoll) {
+            // O_DIRECT not supported on this filesystem, fall back (not with IOPOLL)
+            open_flags &= ~O_DIRECT;
+            want_direct = false;
+            fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), open_flags, mode));
+        }
+        // directories might have been deleted by a parallel delete of the last version of an object
+        if (fd < 0 && errno == ENOENT) {
+            // retry after creating directories
+            std::string dir_path = file_path;
+            auto pos = dir_path.find_last_of('/');
+            if (pos != std::string::npos) {
+                dir_path.erase(pos, (dir_path.length() - pos));
+            }
+            ldpp_dout(dpp, 20) << "SSDCache: URING: IoUringAsyncWriteRequest::prepare_io_uring_write_op: dir_path for creating directories=" << dir_path << dendl;
+            create_directories(dpp, dir_path);
+            fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), open_flags, mode));
+            if (fd < 0) {
+                ldpp_dout(dpp, 0) << "ERROR: URING: IoUringAsyncWriteRequest::prepare_io_uring_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
+                return -errno;
+            }
+        } else if (fd < 0) {
+            ldpp_dout(dpp, 0) << "ERROR: URING: IoUringAsyncWriteRequest::prepare_io_uring_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
+            return -errno;
+        }
+    }
+    // posix_fadvise is meaningless with O_DIRECT (page cache is bypassed)
+    if (!want_direct && dpp->get_cct()->_conf->rgw_d4n_l1_fadvise != POSIX_FADV_NORMAL)
+        posix_fadvise(fd, 0, 0, dpp->get_cct()->_conf->rgw_d4n_l1_fadvise);
+
+    // For O_DIRECT, length must be aligned; allocate aligned buffer and zero-pad
+    size_t aligned_len = want_direct ? iouring_align_size(len) : len;
+    if (posix_memalign(&data, IO_BUFFER_ALIGNMENT, aligned_len) != 0) {
+        ldpp_dout(dpp, 0) << "ERROR: URING: IoUringAsyncWriteRequest::prepare_io_uring_write_op: memory allocation failed" << dendl;
+        if (fd >= 0) {
+            ::close(fd);
+        }
+        return -ENOMEM;
+    }
+    memcpy(data, bl.c_str(), len);
+    // Zero-pad beyond actual data for O_DIRECT alignment
+    if (aligned_len > len) {
+        memset(static_cast<char*>(data) + len, 0, aligned_len - len);
+    }
+    length = len;
+    submitted_len = aligned_len;
+    direct_io = want_direct;
+
+    struct io_uring_sqe* sqe = io_uring_get_sqe(ring);
+    if (!sqe) {
+        ldpp_dout(dpp, 0) << "ERROR: prepare_io_uring_write_op: failed to get sqe" << dendl;
+        ::close(fd);
+        free(data);
+        return -EAGAIN;
+    }
+    io_uring_prep_write(sqe, fd, data, submitted_len, 0);
+    io_uring_sqe_set_data(sqe, sqe_user_data);
+    return 0;
+}
+#endif // HAVE_LIBURING
 
 } } // namespace rgw::cache

--- a/src/rgw/rgw_ssd_driver.h
+++ b/src/rgw/rgw_ssd_driver.h
@@ -1,8 +1,31 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
 #pragma once
 
 #include <aio.h>
 #include "rgw_common.h"
 #include "rgw_cache_driver.h"
+
+#if defined(HAVE_LIBURING)
+// Forward decls only; <liburing.h> stays in rgw_ssd_driver.cc. Bundled
+// liburing includes are only available to targets that link uring::uring
+// (rgw_common), not rgw_common_standalone which also includes this header.
+struct io_uring;
+struct io_uring_cqe;
+
+namespace rgw { namespace cache {
+
+// Alignment for O_DIRECT I/O (typically 512 or 4096 bytes for modern devices)
+constexpr size_t IO_BUFFER_ALIGNMENT = 4096;
+
+// Round up size to alignment boundary
+inline size_t iouring_align_size(size_t size, size_t alignment = IO_BUFFER_ALIGNMENT) {
+  return (size + alignment - 1) & ~(alignment - 1);
+}
+
+} } // namespace rgw::cache
+#endif // HAVE_LIBURING
 
 namespace rgw { namespace cache {
 
@@ -41,6 +64,15 @@ private:
   std::mutex cache_lock;
   bool admin;
 
+  // io backend selection - true = io_uring, false = libaio
+  bool use_io_uring = false;
+
+#if defined(HAVE_LIBURING)
+  int64_t IoUringQueueDepth;  // set from ceph.conf in SSDDriver::initialize()
+
+  int init_per_thread_uring(const DoutPrefixProvider* dpp, struct io_uring** ring_out) const;
+#endif
+
   struct libaio_read_handler {
     rgw::Aio* throttle = nullptr;
     rgw::AioResult& r;
@@ -62,6 +94,60 @@ private:
     }
   };
 
+#if defined(HAVE_LIBURING)
+
+  // async read operation using io_uring
+  struct IoUringAsyncReadOp {
+    const DoutPrefixProvider* dpp = nullptr;
+    bufferlist result;
+    int fd = -1;
+    off_t offset = 0;       // original requested offset
+    size_t length = 0;      // original requested length
+    void* buffer = nullptr;
+    bool direct_io = false;  // whether O_DIRECT was used (needs result trimming)
+    using Signature = void(boost::system::error_code, bufferlist);
+    using Completion = ceph::async::Completion<Signature, IoUringAsyncReadOp>;
+
+    int prepare_io_uring_read_op(const DoutPrefixProvider *dpp, const std::string& file_path, off_t read_ofs, size_t read_len, void* sqe_user_data, struct io_uring* ring);
+    static void io_uring_read_completion(struct io_uring_cqe* cqe, IoUringAsyncReadOp* op);
+    // CQE reaper callback: processes CQE and dispatches the async completion
+    static void handle_cqe(struct io_uring_cqe* cqe, void* arg);
+
+    template <typename Executor1, typename CompletionHandler>
+    static auto create(const Executor1& ex1, CompletionHandler&& handler);
+  };
+
+  // async write operation using io_uring
+  class IoUringAsyncWriteRequest {
+  public:
+    const DoutPrefixProvider* dpp;
+    std::string file_path;
+    std::string temp_file_path;
+    void* data;
+    int fd;
+    size_t length;          // original (unaligned) data length
+    size_t submitted_len = 0; // bytes submitted to io_uring (may be aligned)
+    bool direct_io = false; // whether O_DIRECT was used (needs ftruncate)
+    SSDDriver *priv_data;
+    rgw::sal::Attrs attrs;
+
+    using Signature = void(boost::system::error_code);
+    using Completion = ceph::async::Completion<Signature, IoUringAsyncWriteRequest>;
+
+    int prepare_io_uring_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path, void* sqe_user_data, struct io_uring* ring);
+    // Returns 0 on success, negative errno on failure. Must not publish on short write.
+    static int io_uring_write_completion(struct io_uring_cqe* cqe, IoUringAsyncWriteRequest* op);
+    // CQE reaper callback: processes CQE and dispatches the async completion
+    static void handle_cqe(struct io_uring_cqe* cqe, void* arg);
+
+    template <typename Executor1, typename CompletionHandler>
+    static auto create(const Executor1& ex1, CompletionHandler&& handler);
+
+    IoUringAsyncWriteRequest() : dpp(nullptr), data(nullptr), fd(-1), length(0), priv_data(nullptr) {}
+    ~IoUringAsyncWriteRequest() = default;
+  };
+#endif // HAVE_LIBURING
+
   // unique_ptr with custom deleter for struct aiocb
   struct libaio_aiocb_deleter {
     void operator()(struct aiocb* c) {
@@ -73,27 +159,13 @@ private:
     }
   };
 
-  template <typename Executor, typename CompletionToken>
-    auto get_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
-		    off_t read_ofs, off_t read_len, CompletionToken&& token);
-  
-  template <typename Executor, typename CompletionToken>
-  void put_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
-                  const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token);
-  
-  rgw::Aio::OpFunc ssd_cache_read_op(const DoutPrefixProvider *dpp, optional_yield y, rgw::cache::CacheDriver* cache_driver,
-				  off_t read_ofs, off_t read_len, const std::string& key);
-
-  rgw::Aio::OpFunc ssd_cache_write_op(const DoutPrefixProvider *dpp, optional_yield y, rgw::cache::CacheDriver* cache_driver,
-                                const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, const std::string& key);
-
   using unique_aio_cb_ptr = std::unique_ptr<struct aiocb, libaio_aiocb_deleter>;
 
-  struct AsyncReadOp {
+  struct LibaioAsyncReadOp {
     bufferlist result;
     unique_aio_cb_ptr aio_cb;
     using Signature = void(boost::system::error_code, bufferlist);
-    using Completion = ceph::async::Completion<Signature, AsyncReadOp>;
+    using Completion = ceph::async::Completion<Signature, LibaioAsyncReadOp>;
 
     int prepare_libaio_read_op(const DoutPrefixProvider *dpp, const std::string& file_path, off_t read_ofs, off_t read_len, void* arg);
     static void libaio_cb_aio_dispatch(sigval sigval);
@@ -102,26 +174,60 @@ private:
     static auto create(const Executor1& ex1, CompletionHandler&& handler);
   };
 
-  struct AsyncWriteRequest {
+  struct LibaioAsyncWriteRequest {
     const DoutPrefixProvider* dpp;
-	  std::string file_path;
+    std::string file_path;
     std::string temp_file_path;
-	  void *data;
-	  int fd;
-	  unique_aio_cb_ptr cb;
+    void *data;
+    int fd;
+    unique_aio_cb_ptr cb;
     SSDDriver *priv_data;
     rgw::sal::Attrs attrs;
 
     using Signature = void(boost::system::error_code);
-    using Completion = ceph::async::Completion<Signature, AsyncWriteRequest>;
+    using Completion = ceph::async::Completion<Signature, LibaioAsyncWriteRequest>;
 
-	  int prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path);
+    int prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path);
     static void libaio_write_cb(sigval sigval);
 
     template <typename Executor1, typename CompletionHandler>
     static auto create(const Executor1& ex1, CompletionHandler&& handler);
   };
+
+#if defined(HAVE_LIBURING)
+  // io_uring async operations
+  template <typename Executor, typename CompletionToken>
+  auto get_async_uring(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 off_t read_ofs, off_t read_len, CompletionToken&& token);
+
+  template <typename Executor, typename CompletionToken>
+  void put_async_uring(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token);
+#endif
+
+  // libaio async operations
+  template <typename Executor, typename CompletionToken>
+  auto get_async_libaio(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 off_t read_ofs, off_t read_len, CompletionToken&& token);
+
+  template <typename Executor, typename CompletionToken>
+  void put_async_libaio(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token);
+
+  // Dispatch to appropriate backend based on use_io_uring flag
+  template <typename Executor, typename CompletionToken>
+  auto get_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 off_t read_ofs, off_t read_len, CompletionToken&& token);
+
+  template <typename Executor, typename CompletionToken>
+  void put_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
+                 const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token);
+
+  rgw::Aio::OpFunc ssd_cache_read_op(const DoutPrefixProvider *dpp, optional_yield y, rgw::cache::CacheDriver* cache_driver,
+                                     off_t read_ofs, off_t read_len, const std::string& key);
+
+  rgw::Aio::OpFunc ssd_cache_write_op(const DoutPrefixProvider *dpp, optional_yield y, rgw::cache::CacheDriver* cache_driver,
+                                      const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, const std::string& key);
 };
 
 } } // namespace rgw::cache
-

--- a/src/rgw/rgw_tar.h
+++ b/src/rgw/rgw_tar.h
@@ -16,7 +16,7 @@
 namespace rgw {
 namespace tar {
 
-static constexpr size_t BLOCK_SIZE = 512;
+static constexpr size_t TAR_BLOCK_SIZE = 512;
 
 
 static inline std::pair<class StatusIndicator,
@@ -82,8 +82,8 @@ protected:
     char __padding[355];
   } *header;
 
-  static_assert(sizeof(*header) == BLOCK_SIZE,
-                "The TAR header must be exactly BLOCK_SIZE length");
+  static_assert(sizeof(*header) == TAR_BLOCK_SIZE,
+                "The TAR header must be exactly TAR_BLOCK_SIZE length");
 
   /* The label is far more important from what the code really does. */
   static size_t pos2len(const size_t pos) {
@@ -91,7 +91,7 @@ protected:
   }
 
 public:
-  explicit HeaderView(const char (&header)[BLOCK_SIZE])
+  explicit HeaderView(const char (&header)[TAR_BLOCK_SIZE])
     : header(reinterpret_cast<const header_t*>(header)) {
   }
 
@@ -138,11 +138,11 @@ public:
 static inline std::pair<StatusIndicator,
                         boost::optional<HeaderView>>
 interpret_block(const StatusIndicator& status, ceph::bufferlist& bl) {
-  static constexpr std::array<char, BLOCK_SIZE> zero_block = {0, };
-  const char (&block)[BLOCK_SIZE] = \
-    reinterpret_cast<const char (&)[BLOCK_SIZE]>(*bl.c_str());
+  static constexpr std::array<char, TAR_BLOCK_SIZE> zero_block = {0, };
+  const char (&block)[TAR_BLOCK_SIZE] = \
+    reinterpret_cast<const char (&)[TAR_BLOCK_SIZE]>(*bl.c_str());
 
-  if (std::memcmp(zero_block.data(), block, BLOCK_SIZE) == 0) {
+  if (std::memcmp(zero_block.data(), block, TAR_BLOCK_SIZE) == 0) {
     return std::make_pair(StatusIndicator(status, true), boost::none);
   } else {
     return std::make_pair(StatusIndicator(status, false), HeaderView(block));


### PR DESCRIPTION
Introduce two new io_uring nased SSD cache backends for RGWs D4N I/O, liburing and boost::asio/io_uring (in addition to the existing libaio backend)

The boost io_uring work is based on @cbodley PR #50635 and guidance (that PR's commits cherry-picked to this PR)

Performance comparison of the 3 backends:
```
## WORKLOAD: 3 iterations of hsbench small object PUT runs:

echo ${RANDOM} ; time (nice numactl -N 1 -m 1 -- env GOMAXPROCS=$(( $(numactl -N 0 -- nproc) / 2 )) ~/go/bin/hsbench -a b2345678901234567890 -s b234567890123456789012345678901234567890 -u http://127.0.0.1:8000 -z 4K -d -1 -t $(( $(numactl -N 0 -- nproc) * 2 )) -b $(( $(numactl -N 0 -- nproc) * 4 )) -n 100000 -m cxip -bp "b01b--${RANDOM}-" -op 'folder01/stage01_')
```

results - note the `IO/s:` column:
```
## -o rgw_d4n_io_backend_type=libaio
--------------------------------------------------------------------------------------------vvvvvvvvvv
2026/03/12 03:17:14 Loop: 0, Int: TOTAL, Dur(s): 16.2, Mode: PUT, Ops: 100000, MB/s: 24.05, IO/s: 6157, Lat(ms): [ min: 9.0, avg: 20.8, 99%: 35.4, max: 63.9 ]
2026/03/12 03:20:59 Loop: 0, Int: TOTAL, Dur(s): 16.4, Mode: PUT, Ops: 100000, MB/s: 23.83, IO/s: 6101, Lat(ms): [ min: 6.0, avg: 21.0, 99%: 35.3, max: 84.0 ]
2026/03/12 03:21:52 Loop: 0, Int: TOTAL, Dur(s): 16.3, Mode: PUT, Ops: 100000, MB/s: 23.93, IO/s: 6126, Lat(ms): [ min: 8.9, avg: 20.9, 99%: 34.0, max: 59.3 ]

## -o rgw_d4n_io_backend_type=liburing
-------------------------------------------------------------------------------------------vvvvvvvvvvv
2026/03/12 03:28:40 Loop: 0, Int: TOTAL, Dur(s): 7.6, Mode: PUT, Ops: 100000, MB/s: 51.41, IO/s: 13161, Lat(ms): [ min: 2.3, avg: 9.7, 99%: 19.0, max: 49.8 ]
2026/03/12 03:30:05 Loop: 0, Int: TOTAL, Dur(s): 7.7, Mode: PUT, Ops: 100000, MB/s: 50.61, IO/s: 12956, Lat(ms): [ min: 2.4, avg: 9.9, 99%: 18.8, max: 69.8 ]
2026/03/12 03:30:42 Loop: 0, Int: TOTAL, Dur(s): 7.6, Mode: PUT, Ops: 100000, MB/s: 51.63, IO/s: 13217, Lat(ms): [ min: 2.0, avg: 9.7, 99%: 17.9, max: 53.9 ]

## -o rgw_d4n_io_backend_type=boosturing
-------------------------------------------------------------------------------------------vvvvvvvvvvv
2026/03/12 03:34:49 Loop: 0, Int: TOTAL, Dur(s): 8.0, Mode: PUT, Ops: 100000, MB/s: 48.74, IO/s: 12478, Lat(ms): [ min: 2.3, avg: 10.2, 99%: 19.9, max: 49.9 ]
2026/03/12 03:35:26 Loop: 0, Int: TOTAL, Dur(s): 8.0, Mode: PUT, Ops: 100000, MB/s: 49.02, IO/s: 12550, Lat(ms): [ min: 2.7, avg: 10.2, 99%: 19.1, max: 74.1 ]
2026/03/12 03:36:05 Loop: 0, Int: TOTAL, Dur(s): 7.8, Mode: PUT, Ops: 100000, MB/s: 50.07, IO/s: 12819, Lat(ms): [ min: 1.5, avg: 10.0, 99%: 18.5, max: 44.4 ]
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
