### PR TITLE
squid: qa/tasks/keystone: upgrade keystone to 2025.2

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -8,7 +8,7 @@ overrides:
         rgw keystone barbican password: rgwcrypt-pass
         rgw keystone barbican domain: Default
         rgw keystone api version: 3
-        rgw keystone accepted roles: admin,Member,creator
+        rgw keystone accepted roles: admin,member,creator
         rgw keystone implicit tenants: true
         rgw keystone accepted admin roles: admin
         rgw swift enforce content length: true
@@ -55,9 +55,9 @@ tasks:
           password: s3-pass
           project: s3
           domain: default
-      roles: [ name: Member, name: creator ]
+      roles: [ name: member, name: creator ]
       role-mappings:
-        - name: Member
+        - name: member
           user: rgwcrypt-user
           project: rgwcrypt
         - name: admin

--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -27,7 +27,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      force-branch: stable/2024.2
+      force-branch: stable/2025.2
       services:
         - name: swift
           type: object-store
@@ -68,7 +68,7 @@ tasks:
           project: s3
 - barbican:
     client.0:
-      force-branch: stable/2024.2
+      force-branch: stable/2025.2
       use-keystone-role: client.0
       keystone_authtoken:
         auth_plugin: password

--- a/qa/suites/rgw/tempest/0-install.yaml
+++ b/qa/suites/rgw/tempest/0-install.yaml
@@ -4,7 +4,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      force-branch: stable/2024.2
+      force-branch: stable/2025.2
       services:
         - name: swift
           type: object-store

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -173,7 +173,9 @@ def create_barbican_conf(ctx, cclient):
 
     run_in_barbican_dir(ctx, cclient,
                         ['bash', '-c',
-                         'echo -n -e "[DEFAULT]\nhost_href=' + barbican_url + '\n" ' + \
+                         'echo -n -e "[DEFAULT]\nhost_href = ' + barbican_url + \
+                         '\n[simple_crypto_plugin]\n' + \
+                         'kek =  UGxlYXNlIG1ha2UgYmFyYmljYW4gZ3JlYXQgYWdhaW4=\n" ' + \
                          '>barbican.conf'])
 
     log.info("run barbican db upgrade")

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -46,7 +46,7 @@ def run_in_keystone_venv(ctx, client, args, **kwargs):
 
 def get_keystone_venved_cmd(ctx, cmd, args, env=[]):
     kbindir = get_keystone_dir(ctx) + '/.tox/venv/bin/'
-    return env + [ kbindir + 'python', kbindir + cmd ] + args
+    return env + [ kbindir + cmd ] + args
 
 @contextlib.contextmanager
 def download(ctx, config):
@@ -196,9 +196,8 @@ def setup_venv(ctx, config):
 
         run_in_keystone_venv(ctx, client,
             [   'pip', 'install',
-                'python-openstackclient==5.2.1',
-                'osc-lib==2.0.0'
-             ])
+                'python-openstackclient', 'uwsgi',
+            ])
     try:
         yield
     finally:
@@ -277,8 +276,10 @@ def run_keystone(ctx, config):
         client_public_with_id = 'keystone.public' + '.' + client_id
 
         public_host, public_port = ctx.keystone.public_endpoints[client]
-        run_cmd = get_keystone_venved_cmd(ctx, 'keystone-wsgi-public',
-            [   '--host', public_host, '--port', str(public_port),
+        run_cmd = get_keystone_venved_cmd(ctx, 'uwsgi',
+            [
+                '--http-socket', f"{public_host}:{public_port}",
+                '--module', 'keystone.wsgi.api:application',
                 # Let's put the Keystone in background, wait for EOF
                 # and after receiving it, send SIGTERM to the daemon.
                 # This crazy hack is because Keystone, in contrast to


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75470

---

backport of https://github.com/ceph/ceph/pull/67660
parent tracker: https://tracker.ceph.com/issues/75041

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh