### PR TITLE
kv/rocksdb: Give option to mute rocksdb initial output

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3493,6 +3493,33 @@ options:
   level: advanced
   default: true
   with_legacy: true
+- name: rocksdb_startuplog_print
+  type: bool
+  level: advanced
+  default: false
+  flags:
+  - startup
+  with_legacy: true
+  desc: Print rocksdb initialization log to ceph log
+  long_desc: On each start rocksdb prints a lot of information about its configuration
+    and column family options. True to see it in ceph log, false to omit it from the log.
+    Only affects initial rocksdb output.
+  see_also:
+  - rocksdb_startuplog_save
+- name: rocksdb_startuplog_save
+  type: bool
+  level: advanced
+  default: true
+  flags:
+  - startup
+  with_legacy: true
+  desc: Store rocksdb initialization log for later
+  long_desc: On each start rocksdb prints a lot of information about its configuration
+    and column family options. It is often important to inspect the value later.
+    When true, admin socket command "rocksdb initlog" is created.
+    Only affects initial rocksdb output.
+  see_also:
+    - rocksdb_startuplog_print
 - name: rocksdb_cache_size
   type: size
   level: advanced

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -34,7 +34,7 @@
 #include "include/utime.h"
 #include "KeyValueDB.h"
 #include "RocksDBStore.h"
-
+#include "common/admin_socket.h"
 #include "common/debug.h"
 
 #ifdef WITH_CRIMSON
@@ -189,13 +189,24 @@ int RocksDBStore::set_merge_operator(
   return 0;
 }
 
-class CephRocksdbLogger : public rocksdb::Logger {
+class CephRocksdbLogger : public rocksdb::Logger, public AdminSocketHook {
   CephContext *cct;
+  std::stringstream saved_init;
 public:
   explicit CephRocksdbLogger(CephContext *c) : cct(c) {
     cct->get();
+    if (cct->_conf->rocksdb_startuplog_save) {
+      AdminSocket *admin_socket = cct->get_admin_socket();
+      if (admin_socket) {
+        admin_socket->register_command("rocksdb initlog", this, "print rocksdb log captured on start");
+      }
+    }
   }
   ~CephRocksdbLogger() override {
+    AdminSocket *admin_socket = cct->get_admin_socket();
+    if (admin_socket) {
+      admin_socket->unregister_commands(this);
+    }
     cct->put();
   }
 
@@ -203,7 +214,16 @@ public:
   void Logv(const char* format, va_list ap) override {
     Logv(rocksdb::INFO_LEVEL, format, ap);
   }
-
+  void LogHeader(const char* format, va_list ap) override {
+    if (cct->_conf->rocksdb_startuplog_save) {
+      char buf[65536];
+      vsnprintf(buf, sizeof(buf), format, ap);
+      saved_init << buf << std::endl;
+    }
+    if (cct->_conf->rocksdb_startuplog_print) {
+      Logv(rocksdb::INFO_LEVEL, format, ap);
+    }
+  }
   // Write an entry to the log file with the specified log level
   // and format.  Any log with level under the internal log level
   // of *this (see @SetInfoLogLevel and @GetInfoLogLevel) will not be
@@ -215,6 +235,19 @@ public:
     char buf[65536];
     vsnprintf(buf, sizeof(buf), format, ap);
     *_dout << buf << dendl;
+
+  }
+  int call(
+    std::string_view command,
+    const cmdmap_t& cmdmap,
+    const bufferlist& inbl,
+    Formatter *f,
+    std::ostream& ss,
+    bufferlist& out) override
+  {
+    // the only command is "rocksdb initlog", so just print
+    out.append(saved_init.str());
+    return 0;
   }
 };
 


### PR DESCRIPTION
During initialization rocksdb prints a lot of information about its column families.
Its rarely useful, unless for some later debugging. Created 2 new config options:
- rocksdb_startuplog_print (default: false) When true print all lines as before.
- rocksdb_startuplog_save (default: true) Capture rocksdb log traffic. Create admin command "rocksdb initlog" that prints the content.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
