### PR TITLE
mgr/rbd_support: fix perf iostat pool-spec to filter by data pool

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -610,6 +610,21 @@ Commands
   Rebuild an invalid object map for the specified image. An image snapshot can be
   specified to rebuild an invalid object map for a snapshot.
 
+:command:`perf image iostat` [-p | --pool *pool-name*] [--namespace *namespace*] [--iterations *iterations*] [--sort-by *sort-by*] [--format *format*] [--pretty-format] [*pool-spec*]
+  Display image IO statistics. The output shows per-image write/read
+  operations, bytes, and latency.
+
+  The pool/pool-spec refers to the pool where image data is stored (the data
+  pool for images created with ``--data-pool``, otherwise the pool where the
+  image is defined).
+
+:command:`perf image iotop` [-p | --pool *pool-name*] [--namespace *namespace*] [*pool-spec*]
+  Display a top-like IO monitor.
+  
+  The pool/pool-spec refers to the pool where image data is stored (the data
+  pool for images created with ``--data-pool``, otherwise the pool where the
+  image is defined).
+
 :command:`pool init` [*pool-name*] [--force]
   Initialize pool for use by RBD. Newly created pools must be initialized
   prior to use.

--- a/src/pybind/mgr/rbd_support/perf.py
+++ b/src/pybind/mgr/rbd_support/perf.py
@@ -165,15 +165,23 @@ class PerfHandler:
         for query_id in query[QUERY_IDS]:
             res = self.module.get_osd_perf_counters(query_id)
             for counter in res['counters']:
-                # replace pool id from object name if it exists
                 k = counter['k']
-                pool_id = int(k[2][0]) if k[2][0] else int(k[0][0])
+                data_pool_id = int(k[0][0])
                 namespace = k[1][0]
                 image_id = k[2][1]
+                # The metadata pool id is encoded in the object name
+                # for images with a separate data pool (e.g. EC).
+                pool_id = int(k[2][0]) if k[2][0] else data_pool_id
 
-                # ignore metrics from non-matching pools/namespaces
-                if pool_id not in pool_id_map:
+                # Filter by data pool (where I/O takes place)
+                if data_pool_id not in pool_id_map:
                     continue
+
+                # Ensure metadata pool is in pool_id_map for display
+                # and image name resolution
+                if pool_id not in pool_id_map:
+                    pool_id_map[pool_id] = self.module.rados.pool_reverse_lookup(
+                        pool_id)
                 if pool_key[1] is not None and pool_key[1] != namespace:
                     continue
 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -2165,6 +2165,10 @@
                                plain]
     --pretty-format            pretty formatting (json and xml)
   
+  The pool/pool-spec refers to the pool where image data is stored (the data
+  pool for images created with --data-pool, otherwise the pool where the
+  image is defined).
+  
   rbd help perf image iotop
   usage: rbd perf image iotop [--pool <pool>] [--namespace <namespace>] 
                               <pool-spec> 
@@ -2178,6 +2182,10 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --namespace arg      namespace name
+  
+  The pool/pool-spec refers to the pool where image data is stored (the data
+  pool for images created with --data-pool, otherwise the pool where the
+  image is defined).
   
   rbd help persistent-cache flush
   usage: rbd persistent-cache flush [--pool <pool>] [--namespace <namespace>] 

--- a/src/tools/rbd/action/Perf.cc
+++ b/src/tools/rbd/action/Perf.cc
@@ -262,7 +262,8 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   throw po::validation_error(po::validation_error::invalid_option_value);
 }
 
-void format(const ImageStats& image_stats, Formatter* f, bool global_search) {
+void format(const ImageStats& image_stats, Formatter* f,
+            const std::string& pool_filter) {
   TextTable tbl;
   if (f) {
     f->open_array_section("images");
@@ -310,7 +311,7 @@ void format(const ImageStats& image_stats, Formatter* f, bool global_search) {
       f->close_section();
     } else {
       std::string name;
-      if (global_search) {
+      if (pool_filter.empty() || image_stat.pool_name != pool_filter) {
         name += image_stat.pool_name + "/";
         if (!image_stat.pool_namespace.empty()) {
           name += image_stat.pool_namespace + "/";
@@ -648,7 +649,7 @@ int execute_iostat(const po::variables_map &vm,
         printed_notice = true;
       }
     } else {
-      iostat::format(image_stats, f, pool_spec.empty());
+      iostat::format(image_stats, f, pool);
       if (f != nullptr) {
         break;
       }
@@ -704,13 +705,19 @@ int execute_iotop(const po::variables_map &vm,
 }
 
 Shell::Action top_action(
-  {"perf", "image", "iotop"}, {}, "Display a top-like IO monitor.", "",
+  {"perf", "image", "iotop"}, {}, "Display a top-like IO monitor.",
+  "The pool/pool-spec refers to the pool where image data is stored (the data\n"
+  "pool for images created with --data-pool, otherwise the pool where the\n"
+  "image is defined).\n",
   &get_arguments_iotop, &execute_iotop);
 
 #endif // HAVE_CURSES
 
 Shell::Action stat_action(
-  {"perf", "image", "iostat"}, {}, "Display image IO statistics.", "",
+  {"perf", "image", "iostat"}, {}, "Display image IO statistics.",
+  "The pool/pool-spec refers to the pool where image data is stored (the data\n"
+  "pool for images created with --data-pool, otherwise the pool where the\n"
+  "image is defined).\n",
   &get_arguments_iostat, &execute_iostat);
 } // namespace perf
 } // namespace action


### PR DESCRIPTION
When running rbd perf image iostat <pool_name> on a pool containing RBD images that use an erasure-coded (EC) data pool, the EC images are missing from the output. The command works correctly without a pool filter (global mode), but specifying the metadata pool name produces empty results for EC images.
The reason is the perf queries sent to the OSD only matched the metadata pool, hence I/O on EC data pool objects was not captured. 

Fixes: https://tracker.ceph.com/issues/75480

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
