### PR TITLE
tentacle: mgr/dashboard: Initiator add shows success but host is not added/displayed in Subsystem Initiators table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.html
@@ -1,104 +1,26 @@
-<cd-modal [pageURL]="pageURL">
-  <span class="modal-title"
-        i18n>{{ action | titlecase }} {{ resource | upperFirst }}</span>
-  <ng-container class="modal-content">
-    <form name="initiatorForm"
-          #formDir="ngForm"
-          [formGroup]="initiatorForm"
-          novalidate>
-      <div class="modal-body">
-        <!-- Hosts -->
-        <div class="form-group row">
-          <label class="cd-col-form-label required"
-                 i18n>Hosts
-          </label>
-          <div class="cd-col-form-input">
-            <!-- Add host -->
-            <div class="custom-control custom-checkbox"
-                 formGroupName="addHost">
-              <input type="checkbox"
-                     class="custom-control-input"
-                     id="addHostCheck"
-                     name="addHostCheck"
-                     formControlName="addHostCheck"
-                     (change)="setAddHostCheck()"/>
-              <label class="custom-control-label mb-0"
-                     for="addHostCheck"
-                     i18n>Add host</label>
-              <cd-help-text>
-                <span i18n>Allow specific hosts to run NVMe/TCP commands to the NVMe subsystem.</span>
-              </cd-help-text>
-              <div formArrayName="addedHosts"
-                   *ngIf="initiatorForm.get('addHost.addHostCheck').value"  >
-                <div *ngFor="let host of addedHosts.controls; let hi = index"
-                     class="input-group cd-mb my-1">
-                  <input class="cd-form-control"
-                         type="text"
-                         i18n-placeholder
-                         placeholder="Add host nqn"
-                         [required]="!initiatorForm.getValue('allowAnyHost')"
-                         [formControlName]="hi"/>
-                  <button class="btn btn-light"
-                          type="button"
-                          id="add-button-{{hi}}"
-                          [disabled]="initiatorForm.get('addHost.addedHosts').controls[hi].invalid
-                          || initiatorForm.get('addHost.addedHosts').errors?.duplicate
-                          || initiatorForm.get('addHost.addedHosts').controls.length === 32
-                          || (initiatorForm.get('addHost.addedHosts').controls.length !== 1 && initiatorForm.get('addHost.addedHosts').controls.length !== hi+1)"
-                          (click)="addHost()">
-                    <i class="fa fa-plus"></i>
-                  </button>
-                  <button class="btn btn-light"
-                          type="button"
-                          id="delete-button-{{hi}}"
-                          [disabled]="addedHosts.controls.length === 1"
-                          (click)="removeHost(hi)">
-                    <i class="fa fa-trash-o"></i>
-                  </button>
-                  <ng-container *ngIf="initiatorForm.get('addHost.addedHosts').controls[hi].invalid
-                                && (initiatorForm.get('addHost.addedHosts').controls[hi].dirty
-                                || initiatorForm.get('addHost.addedHosts').controls[hi].touched)">
-                    <span class="invalid-feedback"
-                          *ngIf="initiatorForm.get('addHost.addedHosts').controls[hi].errors?.required"
-                          i18n>This field is required.</span>
-                    <span class="invalid-feedback"
-                          *ngIf="initiatorForm.get('addHost.addedHosts').controls[hi].errors?.pattern"
-                          i18n>Expected NQN format<br/>&lt;<code>nqn.$year-$month.$reverseDomainName:$utf8-string</code>".&gt; or <br/>&lt;<code>nqn.2014-08.org.nvmexpress:uuid:$UUID-string</code>".&gt;</span>
-                    <span class="invalid-feedback"
-                          *ngIf="initiatorForm.get('addHost.addedHosts').controls[hi].errors?.maxLength"
-                          i18n>An NQN may not be more than 223 bytes in length.</span>
-                  </ng-container>
-                </div>
-                <span class="invalid-feedback"
-                      *ngIf="initiatorForm.get('addHost.addedHosts').errors?.duplicate"
-                      i18n>Duplicate entry detected. Enter a unique value.</span>
-              </div>
-            </div>
-            <!-- Allow any host -->
-            <div class="custom-control custom-checkbox pt-0">
-              <input type="checkbox"
-                     class="custom-control-input"
-                     id="allowAnyHost"
-                     name="allowAnyHost"
-                     formControlName="allowAnyHost"/>
-              <label class="custom-control-label"
-                     for="allowAnyHost"
-                     i18n>Allow any host</label>
-              <cd-alert-panel *ngIf="initiatorForm.getValue('allowAnyHost')"
-                              [showTitle]="false"
-                              type="warning">Allowing any host to connect to the NVMe/TCP gateway may pose security risks.
-              </cd-alert-panel>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <div class="text-right">
-          <cd-form-button-panel (submitActionEvent)="onSubmit()"
-                                [form]="initiatorForm"
-                                [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
-        </div>
-      </div>
-    </form>
-  </ng-container>
-</cd-modal>
+<cd-tearsheet
+  [steps]="steps"
+  [title]="title"
+  [description]="description"
+  (submitRequested)="onSubmit($event)"
+  (stepChanged)="onStepChanged()"
+  [isSubmitLoading]="isSubmitLoading"
+  submitButtonLabel="Add"
+  i18n-submitButtonLabel>
+
+  <cd-tearsheet-step>
+    <cd-nvmeof-subsystem-step-two
+      #tearsheetStep
+               modal-primary-focus
+      [group]="group"
+      [existingHosts]="existingHosts"></cd-nvmeof-subsystem-step-two>
+  </cd-tearsheet-step>
+  @if(showAuthStep) {
+  <cd-tearsheet-step>
+    <cd-nvmeof-subsystem-step-three
+      #tearsheetStep
+      [stepTwoValue]="stepTwoValue"
+      [group]="group"></cd-nvmeof-subsystem-step-three>
+  </cd-tearsheet-step>
+  }
+</cd-tearsheet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
@@ -43,6 +43,19 @@ describe('NvmeofInitiatorsFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should initialize with two steps (Host access control + Authentication optional)', () => {
+    expect(component.steps.length).toBe(2);
+    expect(component.steps[0].label).toBe('Host access control');
+    expect(component.steps[1].label).toBe('Authentication (optional)');
+  });
+
+  it('should hide Authentication step when showAuthStep is false', () => {
+    component.showAuthStep = false;
+    component.rebuildSteps();
+    expect(component.steps.length).toBe(1);
+    expect(component.steps[0].label).toBe('Host access control');
+  });
+
   describe('should test form', () => {
     beforeEach(() => {
       nvmeofService = TestBed.inject(NvmeofService);
@@ -55,6 +68,25 @@ describe('NvmeofInitiatorsFormComponent', () => {
       component.onSubmit();
       expect(nvmeofService.addInitiators).toHaveBeenCalledWith(subsystemNQN, {
         host_nqn: ''
+      });
+    });
+
+    it('should build hosts from addedHosts when hostDchapKeyList is absent', () => {
+      const subsystemNQN = 'nqn.test';
+      component.subsystemNQN = subsystemNQN;
+      component.group = 'test-group';
+
+      const payload: any = {
+        hostType: HOST_TYPE.SPECIFIC,
+        addedHosts: ['host2'],
+        gw_group: 'test-group'
+      };
+
+      component.onSubmit(payload);
+      expect(nvmeofService.addSubsystemInitiators).toHaveBeenCalledWith(subsystemNQN, {
+        allow_all: false,
+        gw_group: 'test-group',
+        hosts: [{ dhchap_key: '', host_nqn: 'host2' }]
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
@@ -1,139 +1,147 @@
-import { Component, OnInit } from '@angular/core';
-import { UntypedFormArray, UntypedFormControl, Validators } from '@angular/forms';
-
-import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
-import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
-import { CdValidators } from '~/app/shared/forms/cd-validators';
-import { Permission } from '~/app/shared/models/permissions';
-import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
-import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { Step } from 'carbon-components-angular';
+import { NvmeofService, SubsystemInitiatorRequest } from '~/app/shared/api/nvmeof.service';
 import { FinishedTask } from '~/app/shared/models/finished-task';
+import {
+  AuthStepType,
+  HOST_TYPE,
+  HostStepType,
+  NvmeofSubsystemInitiator
+} from '~/app/shared/models/nvmeof';
+import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { InitiatorRequest, NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
+
+type InitiatorsFormPayload = Pick<HostStepType, 'hostType' | 'addedHosts'> &
+  Partial<Pick<AuthStepType, 'hostDchapKeyList'>>;
+
+const STEP_LABELS = {
+  HOSTS: $localize`Host access control`,
+  AUTH: $localize`Authentication (optional)`
+} as const;
 
 @Component({
   selector: 'cd-nvmeof-initiators-form',
   templateUrl: './nvmeof-initiators-form.component.html',
-  styleUrls: ['./nvmeof-initiators-form.component.scss']
+  styleUrls: ['./nvmeof-initiators-form.component.scss'],
+  standalone: false
 })
 export class NvmeofInitiatorsFormComponent implements OnInit {
-  permission: Permission;
-  initiatorForm: CdFormGroup;
-  action: string;
-  resource: string;
-  pageURL: string;
-  remove: boolean = false;
-  subsystemNQN: string;
-  removeHosts: { name: string; value: boolean; id: number }[] = [];
-  group: string;
+  group!: string;
+  subsystemNQN!: string;
+  isSubmitLoading = false;
+  existingHosts: string[] = [];
+  showAuthStep = true;
+  stepTwoValue: HostStepType = null;
+
+  @ViewChild(TearsheetComponent) tearsheet!: TearsheetComponent;
+
+  steps: Step[] = [];
+
+  title = $localize`Add Initiator`;
+  description = $localize`Allow specific hosts to run NVMe/TCP commands to the NVMe subsystem.`;
+  pageURL = 'block/nvmeof/subsystems';
 
   constructor(
-    private authStorageService: AuthStorageService,
-    public actionLabels: ActionLabelsI18n,
     private nvmeofService: NvmeofService,
     private taskWrapperService: TaskWrapperService,
     private router: Router,
-    private route: ActivatedRoute,
-    private formBuilder: CdFormBuilder
-  ) {
-    this.permission = this.authStorageService.getPermissions().nvmeof;
-    this.resource = $localize`Initiator`;
-    this.pageURL = 'block/nvmeof/subsystems';
-  }
-
-  NQN_REGEX = /^nqn\.(19|20)\d\d-(0[1-9]|1[0-2])\.\D{2,3}(\.[A-Za-z0-9-]+)+(:[A-Za-z0-9-\.]+(:[A-Za-z0-9-\.]+)*)$/;
-  NQN_REGEX_UUID = /^nqn\.2014-08\.org\.nvmexpress:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-  ALLOW_ALL_HOST = '*';
-
-  customNQNValidator = CdValidators.custom(
-    'pattern',
-    (nqnInput: string) =>
-      !!nqnInput && !(this.NQN_REGEX.test(nqnInput) || this.NQN_REGEX_UUID.test(nqnInput))
-  );
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit() {
     this.route.queryParams.subscribe((params) => {
       this.group = params?.['group'];
     });
-    this.createForm();
-    this.action = this.actionLabels.ADD;
-    this.route.params.subscribe((params: { subsystem_nqn: string }) => {
-      this.subsystemNQN = params.subsystem_nqn;
-    });
-  }
-
-  createForm() {
-    this.initiatorForm = new CdFormGroup({
-      allowAnyHost: new UntypedFormControl(false),
-      addHost: new CdFormGroup({
-        addHostCheck: new UntypedFormControl(false),
-        addedHosts: this.formBuilder.array(
-          [],
-          [
-            CdValidators.custom(
-              'duplicate',
-              (hosts: string[]) => !!hosts.length && new Set(hosts)?.size !== hosts.length
-            )
-          ]
-        )
-      })
-    });
-  }
-
-  get addedHosts(): UntypedFormArray {
-    return this.initiatorForm.get('addHost.addedHosts') as UntypedFormArray;
-  }
-
-  addHost() {
-    let newHostFormGroup;
-    newHostFormGroup = this.formBuilder.control('', [this.customNQNValidator, Validators.required]);
-    this.addedHosts.push(newHostFormGroup);
-  }
-
-  removeHost(index: number) {
-    this.addedHosts.removeAt(index);
-  }
-
-  setAddHostCheck() {
-    const addHostCheck = this.initiatorForm.get('addHost.addHostCheck').value;
-    if (!addHostCheck) {
-      while (this.addedHosts.length !== 0) {
-        this.addedHosts.removeAt(0);
+    this.route.parent.params.subscribe((params: any) => {
+      if (params.subsystem_nqn) {
+        this.subsystemNQN = params.subsystem_nqn;
       }
-    } else {
-      this.addHost();
+    });
+    this.route.params.subscribe((params: any) => {
+      if (!this.subsystemNQN && params.subsystem_nqn) {
+        this.subsystemNQN = params.subsystem_nqn;
+      }
+      this.fetchExistingHosts();
+    });
+    this.rebuildSteps();
+  }
+
+  rebuildSteps() {
+    const steps: Step[] = [{ label: STEP_LABELS.HOSTS, invalid: false }];
+
+    if (this.showAuthStep) {
+      steps.push({ label: STEP_LABELS.AUTH, invalid: false });
+    }
+
+    this.steps = steps;
+
+    if (this.tearsheet?.currentStep >= steps.length) {
+      this.tearsheet.currentStep = steps.length - 1;
     }
   }
 
-  onSubmit() {
-    const component = this;
-    const allowAnyHost: boolean = this.initiatorForm.getValue('allowAnyHost');
-    const hosts: string[] = this.addedHosts.value;
-    let taskUrl = `nvmeof/initiator/${URLVerbs.ADD}`;
+  onStepChanged() {
+    if (!this.tearsheet) return;
 
-    const request: InitiatorRequest = {
-      host_nqn: hosts.join(','),
+    const hostStep = this.tearsheet.getStepValueByLabel<HostStepType>(STEP_LABELS.HOSTS);
+
+    if (hostStep) {
+      this.stepTwoValue = hostStep;
+    }
+
+    const nextShowAuth = (hostStep?.hostType ?? HOST_TYPE.SPECIFIC) === HOST_TYPE.SPECIFIC;
+
+    if (nextShowAuth !== this.showAuthStep) {
+      this.showAuthStep = nextShowAuth;
+      this.rebuildSteps();
+    }
+  }
+
+  fetchExistingHosts() {
+    if (!this.subsystemNQN || !this.group) return;
+    this.nvmeofService
+      .getInitiators(this.subsystemNQN, this.group)
+      .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
+        const initiators = Array.isArray(response) ? response : response?.hosts || [];
+        this.existingHosts = initiators.map((i) => i.nqn);
+      });
+  }
+
+  onSubmit(payload: InitiatorsFormPayload) {
+    this.isSubmitLoading = true;
+    const taskUrl = `nvmeof/initiator/add`;
+    const hostKeyList = payload.hostDchapKeyList || [];
+    const addedHosts = payload.addedHosts || [];
+    const hosts =
+      payload.hostType === HOST_TYPE.SPECIFIC
+        ? hostKeyList.length
+          ? hostKeyList
+          : addedHosts.map((host_nqn: string) => ({ host_nqn, dhchap_key: '' }))
+        : [];
+
+    const request: SubsystemInitiatorRequest = {
+      allow_all: payload.hostType === HOST_TYPE.ALL,
+      hosts,
       gw_group: this.group
     };
-
-    if (allowAnyHost) {
-      hosts.push('*');
-      request['host_nqn'] = hosts.join(',');
-    }
     this.taskWrapperService
       .wrapTaskAroundCall({
         task: new FinishedTask(taskUrl, {
           nqn: this.subsystemNQN
         }),
-        call: this.nvmeofService.addInitiators(this.subsystemNQN, request)
+        call: this.nvmeofService.addSubsystemInitiators(this.subsystemNQN, request)
       })
       .subscribe({
-        error() {
-          component.initiatorForm.setErrors({ cdSubmitButton: true });
+        error: () => {
+          this.isSubmitLoading = false;
         },
         complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
+          this.isSubmitLoading = false;
+          this.router.navigate([{ outlets: { modal: null } }], {
+            relativeTo: this.route.parent,
+            queryParamsHandling: 'preserve'
+          });
         }
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
@@ -88,7 +88,8 @@ export class NvmeofInitiatorsListComponent implements OnInit {
   listInitiators() {
     this.nvmeofService
       .getInitiators(this.subsystemNQN, this.group)
-      .subscribe((initiators: NvmeofSubsystemInitiator[]) => {
+      .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
+        const initiators = Array.isArray(response) ? response : response?.hosts || [];
         this.initiators = initiators;
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.html
@@ -1,0 +1,123 @@
+
+<form [formGroup]="formGroup"
+      novalidate>
+  <div cdsGrid
+       [useCssGrid]="true"
+       [narrow]="true"
+       [fullWidth]="true">
+    <div cdsCol
+         [columnNumbers]="{sm: 10, md: 10, lg: 12}">
+      <div cdsRow
+           class="form-heading">
+        <h3 class="cds--type-heading-03"
+            i18n>Authentication</h3>
+        <p
+          class="cds--type-label-02"
+          i18n>Configure authentication to verify the identity of connecting hosts and protect the subsystem from unauthorized access.</p>
+      </div>
+      <div cdsRow
+           class="form-item">
+        <cds-radio-group
+          formControlName="authType"
+          legend="Authentication type"
+          i18n-legend>
+          <cds-radio
+            [value]="AUTHENTICATION.Unidirectional">
+            <div class="auth-radio">
+              <span>Unidirectional</span>
+              <span class="cds--form__helper-text"
+                    i18n>Each host can provide an optional DH-HMAC-CHAP key. The subsystem does not require its own key.</span>
+            </div>
+          </cds-radio>
+          <cds-radio
+            [value]="AUTHENTICATION.Bidirectional">
+            <div class="auth-radio">
+              <div cdsStack="horizontal">
+                <span i18n>Bidirectional</span>
+                <cds-tag
+                  type="blue"
+                  size="sm"
+                  i18n>
+                  Requires keys on both sides
+                </cds-tag>
+              </div>
+              <span class="cds--form__helper-text"
+                    i18n>Both subsystem and hosts must provide DH-HMAC-CHAP keys. All connections will be verified in both directions.</span>
+            </div>
+          </cds-radio>
+        </cds-radio-group>
+      </div>
+      @if(formGroup.get('authType').value === AUTHENTICATION.Bidirectional) {
+      <div cdsRow
+           class="form-item step-3-form-item">
+        <div class="step-3-heading">
+          <h1
+            class="cds--type-heading-compact-01"
+            i18n>Subsystem authentication detail</h1>
+          <p class="cds--type-label-01 text-helper"
+             i18n>Mandatory field.</p>
+        </div>
+        <cds-text-label
+          i18n
+          helperText="A secret key for the subsystem to authenticate itself to hosts."
+          i18n-helperText
+          [invalid]="subDK.isInvalid"
+          [invalidText]="
+            formGroup.get('subsystemDchapKey')?.errors?.invalidBase64
+              ? INVALID_TEXTS['invalidBase64']
+              : INVALID_TEXTS['required']
+          ">
+          Subsystem DH-HMAC-CHAP key
+          <input cdsPassword
+                 cdValidate
+                 #subDK="cdValidate"
+                 [invalid]="subDK.isInvalid"
+                 formControlName="subsystemDchapKey"
+                 type="password"
+                 class="step-3-form-item"
+                 placeholder="Enter subsystem DH-HMAC-CHAP key"
+                 i18n-placeholder
+                 autocomplete>
+        </cds-text-label>
+      </div>
+      }
+      <div cdsRow
+           class="form-item step-3-form-item"
+           formArrayName="hostDchapKeyList">
+        <div class="step-3-heading">
+          <h1
+            class="cds--type-heading-compact-01"
+            i18n>Host authentication details</h1>
+          <p class="cds--type-label-01 text-helper"
+             i18n>{{formGroup.get('authType').value === AUTHENTICATION.Bidirectional ? 'All fields are required.' : 'Optional fields.'}}</p>
+        </div>
+        @for (hostDchapKeyItem of hostDchapKeyList.controls; track hostDchapKeyItem.get('host_nqn')?.value; let i = $index) {
+        <div [formGroupName]="i">
+          <cds-text-label
+            class="cds-mb-3"
+            [invalid]="hostKey.isInvalid"
+            [invalidText]="
+              hostDhchapKeyCtrl(i)?.errors?.invalidBase64
+                ? INVALID_TEXTS['invalidBase64']
+                : INVALID_TEXTS['required']
+            ">
+            <span
+              class="cds-mb-3"
+              i18n>DHCHAP Key | {{hostDchapKeyItem.get('host_nqn')?.value }}</span>
+            <input cdsPassword
+                   cdValidate
+                   #hostKey="cdValidate"
+                   formControlName="dhchap_key"
+                   type="password"
+                   placeholder="Enter DHCHAP key"
+                   class="step-3-form-item"
+                   i18n-placeholder
+                   autocomplete
+                   [invalid]="hostKey.isInvalid">
+          </cds-text-label>
+        </div>
+        }
+      </div>
+    </div>
+  </div>
+</form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.spec.ts
@@ -1,0 +1,95 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ToastrModule } from 'ngx-toastr';
+
+import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { SharedModule } from '~/app/shared/shared.module';
+import { NvmeofSubsystemsStepThreeComponent } from './nvmeof-subsystem-step-3.component';
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { GridModule, InputModule, RadioModule, TagModule } from 'carbon-components-angular';
+import { AUTHENTICATION } from '~/app/shared/models/nvmeof';
+
+describe('NvmeofSubsystemsStepThreeComponent', () => {
+  let component: NvmeofSubsystemsStepThreeComponent;
+  let fixture: ComponentFixture<NvmeofSubsystemsStepThreeComponent>;
+  let nvmeofService: NvmeofService;
+  let form: CdFormGroup;
+  const mockGroupName = 'default';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NvmeofSubsystemsStepThreeComponent],
+      providers: [NgbActiveModal],
+      imports: [
+        HttpClientTestingModule,
+        NgbTypeaheadModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        SharedModule,
+        GridModule,
+        RadioModule,
+        TagModule,
+        InputModule,
+        ToastrModule.forRoot()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NvmeofSubsystemsStepThreeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    form = component.formGroup;
+    component.group = mockGroupName;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('should test form', () => {
+    beforeEach(() => {
+      nvmeofService = TestBed.inject(NvmeofService);
+      spyOn(nvmeofService, 'createSubsystem').and.stub();
+    });
+
+    describe('form initialization', () => {
+      it('should initialize form with default values', () => {
+        expect(form).toBeTruthy();
+        expect(form.get('authType')?.value).toBe(AUTHENTICATION.Unidirectional);
+        expect(form.get('subsystemDchapKey')?.value).toBe(null);
+      });
+
+      it('should keep host key optional in unidirectional mode', () => {
+        const hostKeyCtrl = (form.get('hostDchapKeyList') as any).at(0).get('dhchap_key');
+        hostKeyCtrl.setValue('');
+        hostKeyCtrl.markAsTouched();
+        hostKeyCtrl.updateValueAndValidity();
+
+        expect(hostKeyCtrl.hasError('required')).toBeFalsy();
+      });
+
+      it('should require host key in bidirectional mode', () => {
+        form.get('authType')?.setValue(AUTHENTICATION.Bidirectional);
+        const hostKeyCtrl = (form.get('hostDchapKeyList') as any).at(0).get('dhchap_key');
+        hostKeyCtrl.setValue('');
+        hostKeyCtrl.markAsTouched();
+        hostKeyCtrl.updateValueAndValidity();
+
+        expect(hostKeyCtrl.hasError('required')).toBeTruthy();
+      });
+
+      it('should validate host key base64 format when provided', () => {
+        const hostKeyCtrl = (form.get('hostDchapKeyList') as any).at(0).get('dhchap_key');
+        hostKeyCtrl.setValue('not-valid-key');
+        hostKeyCtrl.markAsTouched();
+        hostKeyCtrl.updateValueAndValidity();
+
+        expect(hostKeyCtrl.hasError('invalidBase64')).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.ts
@@ -1,0 +1,111 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormArray, UntypedFormControl } from '@angular/forms';
+
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { CdValidators } from '~/app/shared/forms/cd-validators';
+import { AUTHENTICATION, HostStepType } from '~/app/shared/models/nvmeof';
+import { TearsheetStep } from '~/app/shared/models/tearsheet-step';
+
+@Component({
+  selector: 'cd-nvmeof-subsystem-step-three',
+  templateUrl: './nvmeof-subsystem-step-3.component.html',
+  styleUrls: ['./nvmeof-subsystem-step-3.component.scss'],
+  standalone: false
+})
+export class NvmeofSubsystemsStepThreeComponent implements OnInit, TearsheetStep {
+  @Input() group!: string;
+  @Input() set stepTwoValue(value: HostStepType | null) {
+    this._addedHosts = value?.addedHosts ?? [];
+    if (this.formGroup) {
+      this.syncHostList();
+    }
+  }
+
+  formGroup: CdFormGroup;
+  action: string;
+  pageURL: string;
+  INVALID_TEXTS = {
+    required: $localize`This field is required`,
+    invalidBase64: $localize`Invalid key format. Use Base64 or DHHC-1:XX:base64:`
+  };
+  AUTHENTICATION = AUTHENTICATION;
+
+  _addedHosts: Array<string> = [];
+
+  constructor(public actionLabels: ActionLabelsI18n) {}
+
+  private syncHostList() {
+    const currentList = this.hostDchapKeyList;
+
+    // save existing dhchap keys by host_nqn
+    const existing = new Map<string, string | null>();
+    currentList.getRawValue().forEach((x: any) => existing.set(x.host_nqn, x.dhchap_key));
+
+    currentList.clear();
+
+    const hosts = this._addedHosts;
+
+    if (hosts.length) {
+      hosts.forEach((nqn) => {
+        currentList.push(this.createHostDhchapKeyFormGroup(nqn, existing.get(nqn) ?? null));
+      });
+    } else {
+      currentList.push(this.createHostDhchapKeyFormGroup('', null));
+    }
+  }
+
+  private createForm() {
+    this.formGroup = new CdFormGroup({
+      authType: new UntypedFormControl(AUTHENTICATION.Unidirectional),
+      subsystemDchapKey: new UntypedFormControl(null, [
+        CdValidators.base64(),
+        CdValidators.requiredIf({
+          authType: AUTHENTICATION.Bidirectional
+        })
+      ]),
+      hostDchapKeyList: new FormArray([])
+    });
+
+    this.syncHostList();
+    this.formGroup.get('authType')?.valueChanges.subscribe(() => {
+      this.refreshHostKeyValidation();
+    });
+  }
+
+  private createHostDhchapKeyFormGroup(hostNQN: string = '', key: string | null = null) {
+    return new CdFormGroup({
+      dhchap_key: new UntypedFormControl(key, {
+        validators: [
+          CdValidators.base64(),
+          CdValidators.custom(
+            'required',
+            (value: string) =>
+              this.formGroup?.get('authType')?.value === AUTHENTICATION.Bidirectional && !value
+          )
+        ]
+      }),
+      host_nqn: new UntypedFormControl(hostNQN)
+    });
+  }
+
+  private refreshHostKeyValidation() {
+    this.hostDchapKeyList.controls.forEach((control) => {
+      control.get('dhchap_key')?.updateValueAndValidity({ emitEvent: false });
+    });
+  }
+
+  ngOnInit() {
+    this.createForm();
+  }
+
+  get hostDchapKeyList() {
+    return this.formGroup.get('hostDchapKeyList') as FormArray;
+  }
+
+  hostDhchapKeyCtrl(i: number) {
+    return (this.hostDchapKeyList.at(i) as CdFormGroup).get('dhchap_key');
+  }
+
+  trackByIndex = (i: number) => i;
+}


### PR DESCRIPTION
…layed in Subsystem Initiators table

Fixes: https://tracker.ceph.com/issues/75402

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>
(cherry picked from commit e32e8d251c5506c5a214477d7ba09f2717bf1066)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.html
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.html
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.spec.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.ts





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
