### PR TITLE
fifo-based bucket index log

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -183,6 +183,11 @@
   This restriction does not apply to operator-initiated scrubs, nor to repair scrubs.
   It can be disabled by setting ``osd_scrub_queued_snaptrims_limit`` to 0.
 * RGW: Add SSE-KMS secrets cache
+* RGW: New buckets now default to the FIFO bilog backend instead of the
+  older InIndex (omap-based) backend, controlled by the new
+  ``rgw_default_bucket_bilog_type`` configuration option (default:
+  ``fifo``). Existing InIndex buckets are unaffected until their next
+  reshard, at which point they are automatically migrated to FIFO.
 
 >=21.0.0
 

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1925,6 +1925,10 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
 
   // op.olh_epoch is provided (> 0) in the case when a remote epoch is coming in as the result of multisite sync;
   uint64_t candidate_epoch = op.olh_epoch ? op.olh_epoch : now_epoch;
+
+  encode(candidate_epoch, *out);
+  CLS_LOG(20, "%s: key=%s olh_epoch=%lu candidate_epoch=%lu",
+          __func__, op.key.to_string().c_str(), op.olh_epoch, candidate_epoch);
   if (olh.start_modify(candidate_epoch)) {
     // promote this version to current if it's a newer epoch, or if it matches the
     // current epoch and sorts after the current instance
@@ -2101,6 +2105,10 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
 
   uint64_t now_epoch = duration_cast<std::chrono::nanoseconds>(real_clock::now().time_since_epoch()).count();
   uint64_t candidate_epoch = op.olh_epoch ? op.olh_epoch : now_epoch;
+
+  encode(candidate_epoch, *out);
+  CLS_LOG(20, "%s: key=%s olh_epoch=%lu candidate_epoch=%lu",
+          __func__, op.key.to_string().c_str(), op.olh_epoch, candidate_epoch);
 
   if (!olh_found) {
     bool instance_only = false;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1171,7 +1171,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
 	       __func__,
 	       modify_op_str(op.op).c_str(), op.key.to_string().c_str(),
 	       (unsigned long)op.ver.pool, (unsigned long long)op.ver.epoch,
-	       op.tag.c_str());
+	       op.op_tag.c_str());
 
   rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
@@ -1209,21 +1209,21 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
    * marker */
   entry.flags &= rgw_bucket_dir_entry::FLAG_VER;
 
-  if (op.tag.size()) {
-    auto pinter = entry.pending_map.find(op.tag);
+  if (op.op_tag.size()) {
+    auto pinter = entry.pending_map.find(op.op_tag);
     if (pinter == entry.pending_map.end()) {
       CLS_LOG_BITX(bitx_inst, 1,
 		   "ERROR: %s: couldn't find tag for pending operation with tag %s",
-		   __func__, op.tag.c_str());
+		   __func__, op.op_tag.c_str());
       return -EINVAL;
     }
     CLS_LOG_BITX(bitx_inst, 20,
 		 "INFO: %s: removing tag %s from pending map",
-		   __func__, op.tag.c_str());
+		   __func__, op.op_tag.c_str());
     entry.pending_map.erase(pinter);
   }
 
-  if (op.tag.size() && op.op == CLS_RGW_OP_CANCEL) {
+  if (op.op_tag.size() && op.op == CLS_RGW_OP_CANCEL) {
     CLS_LOG_BITX(bitx_inst, 20, "INFO: %s: op is cancel", __func__);
   } else if (op.ver.pool == entry.ver.pool &&
              op.ver.epoch && op.ver.epoch <= entry.ver.epoch) {
@@ -1240,7 +1240,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   entry.ver = op.ver;
   if (op.op == CLS_RGW_OP_CANCEL) {
     log_op = false; // don't log cancelation
-    if (op.tag.size()) {
+    if (op.op_tag.size()) {
       if (!entry.exists && entry.pending_map.empty()) {
         // a racing delete succeeded, and we canceled the last pending op
         CLS_LOG_BITX(bitx_inst, 20,

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1321,7 +1321,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     entry.meta = meta;
     entry.key = op.key;
     entry.exists = true;
-    entry.tag = op.tag;
+    entry.tag = op.op_tag;
     // account for new entry
     stats.num_entries++;
     stats.total_size += meta.accounted_size;
@@ -1340,7 +1340,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   } // CLS_RGW_OP_ADD
 
   if (log_op) {
-    rc = log_index_operation(hctx, op.key, op.op, op.tag, entry.meta.mtime,
+    rc = log_index_operation(hctx, op.key, op.op, op.op_tag, entry.meta.mtime,
 			     entry.ver, CLS_RGW_STATE_COMPLETE, header.ver,
 			     header.max_marker, op.bilog_flags, NULL, NULL,
 			     &op.zones_trace);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1925,6 +1925,10 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
 
   // op.olh_epoch is provided (> 0) in the case when a remote epoch is coming in as the result of multisite sync;
   uint64_t candidate_epoch = op.olh_epoch ? op.olh_epoch : now_epoch;
+
+  encode(candidate_epoch, *out);
+  CLS_LOG(20, "%s: key=%s olh_epoch=%lu candidate_epoch=%lu",
+          __func__, op.key.to_string().c_str(), op.olh_epoch, candidate_epoch);
   if (olh.start_modify(candidate_epoch)) {
     // promote this version to current if it's a newer epoch, or if it matches the
     // current epoch and sorts after the current instance
@@ -2168,6 +2172,10 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
 
   uint64_t now_epoch = duration_cast<std::chrono::nanoseconds>(real_clock::now().time_since_epoch()).count();
   uint64_t candidate_epoch = op.olh_epoch ? op.olh_epoch : now_epoch;
+
+  encode(candidate_epoch, *out);
+  CLS_LOG(20, "%s: key=%s olh_epoch=%lu candidate_epoch=%lu",
+          __func__, op.key.to_string().c_str(), op.olh_epoch, candidate_epoch);
 
   if (!olh_found) {
     bool instance_only = false;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -144,17 +144,20 @@ void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& o,
                                   const rgw_bucket_dir_entry_meta* meta,
                                   uint64_t olh_epoch,
                                   ceph::real_time unmod_since,
-                                  bool high_precision_time) const {
+                                  bool high_precision_time,
+                                  ceph::bufferlist* epoch_out_bl) const {
   cls_rgw_bucket_link_olh(o, key, olh_tag, delete_marker, op_tag, meta,
                           olh_epoch, unmod_since, high_precision_time,
-                          log_op, zones_trace);
+                          log_op, zones_trace, epoch_out_bl);
 }
 
 void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& o,
                                            const std::string& olh_tag,
-                                           uint64_t olh_epoch) const {
+                                           uint64_t olh_epoch,
+                                           ceph::bufferlist* epoch_out_bl) const {
   cls_rgw_bucket_unlink_instance(o, key, op_tag, olh_tag, olh_epoch,
-                                 log_op, bilog_flags, zones_trace);
+                                 log_op, bilog_flags, zones_trace,
+                                 epoch_out_bl);
 }
 
 void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
@@ -331,9 +334,10 @@ int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const string& oid,
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& key,
                             const bufferlist& olh_tag, bool delete_marker,
                             const string& op_tag, const rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace)
+                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace,
+                            bufferlist* epoch_out_bl)
 {
-  bufferlist in, out;
+  bufferlist in;
   rgw_cls_link_olh_op call;
   call.key = key;
   call.olh_tag = olh_tag.to_str();
@@ -348,7 +352,11 @@ void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_o
   call.high_precision_time = high_precision_time;
   call.zones_trace = zones_trace;
   encode(call, in);
-  op.exec(method::bucket_link_olh, in);
+  if (epoch_out_bl) {
+    op.exec(method::bucket_link_olh, in, epoch_out_bl, nullptr);
+  } else {
+    op.exec(method::bucket_link_olh, in);
+  }
 }
 
 int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const string& oid,
@@ -368,9 +376,10 @@ int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const string& oid,
 void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
                                    const cls_rgw_obj_key& key, const string& op_tag,
                                    const string& olh_tag, uint64_t olh_epoch, bool log_op,
-                                   uint16_t bilog_flags, const rgw_zone_set& zones_trace)
+                                   uint16_t bilog_flags, const rgw_zone_set& zones_trace,
+                                   bufferlist* epoch_out_bl)
 {
-  bufferlist in, out;
+  bufferlist in;
   rgw_cls_unlink_instance_op call;
   call.key = key;
   call.op_tag = op_tag;
@@ -380,7 +389,11 @@ void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
   call.zones_trace = zones_trace;
   call.bilog_flags = bilog_flags;
   encode(call, in);
-  op.exec(method::bucket_unlink_instance, in);
+  if (epoch_out_bl) {
+    op.exec(method::bucket_unlink_instance, in, epoch_out_bl, nullptr);
+  } else {
+    op.exec(method::bucket_unlink_instance, in);
+  }
 }
 
 void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret)

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -112,7 +112,7 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, const s
   bufferlist in;
   rgw_cls_obj_complete_op call;
   call.op = op;
-  call.tag = tag;
+  call.op_tag = tag;
   call.key = key;
   call.ver = ver;
   call.locator = obj_locator;
@@ -126,6 +126,35 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, const s
   }
   encode(call, in);
   o.exec(method::bucket_complete_op, in);
+}
+
+void CLSRGWCompleteModifyOpBase::complete_op(librados::ObjectWriteOperation& o,
+                                             const rgw_bucket_entry_ver& ver,
+                                             const rgw_bucket_dir_entry_meta& dir_meta,
+                                             const std::list<cls_rgw_obj_key>* remove_objs,
+                                             const std::string& locator) const {
+  cls_rgw_bucket_complete_op(o, op, op_tag, ver, key, dir_meta,
+                             remove_objs, log_op, bilog_flags,
+                             &zones_trace, locator);
+}
+
+void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& o,
+                                  const ceph::bufferlist& olh_tag,
+                                  bool delete_marker,
+                                  const rgw_bucket_dir_entry_meta* meta,
+                                  uint64_t olh_epoch,
+                                  ceph::real_time unmod_since,
+                                  bool high_precision_time) const {
+  cls_rgw_bucket_link_olh(o, key, olh_tag, delete_marker, op_tag, meta,
+                          olh_epoch, unmod_since, high_precision_time,
+                          log_op, zones_trace);
+}
+
+void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& o,
+                                           const std::string& olh_tag,
+                                           uint64_t olh_epoch) const {
+  cls_rgw_bucket_unlink_instance(o, key, op_tag, olh_tag, olh_epoch,
+                                 log_op, bilog_flags, zones_trace);
 }
 
 void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -144,17 +144,20 @@ void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& o,
                                   const rgw_bucket_dir_entry_meta* meta,
                                   uint64_t olh_epoch,
                                   ceph::real_time unmod_since,
-                                  bool high_precision_time) const {
+                                  bool high_precision_time,
+                                  ceph::bufferlist* epoch_out_bl) const {
   cls_rgw_bucket_link_olh(o, key, olh_tag, delete_marker, op_tag, meta,
                           olh_epoch, unmod_since, high_precision_time,
-                          log_op, zones_trace);
+                          log_op, zones_trace, epoch_out_bl);
 }
 
 void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& o,
                                            const std::string& olh_tag,
-                                           uint64_t olh_epoch) const {
+                                           uint64_t olh_epoch,
+                                           ceph::bufferlist* epoch_out_bl) const {
   cls_rgw_bucket_unlink_instance(o, key, op_tag, olh_tag, olh_epoch,
-                                 log_op, bilog_flags, zones_trace);
+                                 log_op, bilog_flags, zones_trace,
+                                 epoch_out_bl);
 }
 
 void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
@@ -331,9 +334,10 @@ int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const string& oid,
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& key,
                             const bufferlist& olh_tag, bool delete_marker,
                             const string& op_tag, const rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace)
+                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace,
+                            bufferlist* epoch_out_bl)
 {
-  bufferlist in, out;
+  bufferlist in;
   rgw_cls_link_olh_op call;
   call.key = key;
   call.olh_tag = olh_tag.to_str();
@@ -348,7 +352,11 @@ void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_o
   call.high_precision_time = high_precision_time;
   call.zones_trace = zones_trace;
   encode(call, in);
-  op.exec(method::bucket_link_olh, in);
+  if (epoch_out_bl) {
+    op.exec(method::bucket_link_olh, in, epoch_out_bl, nullptr);
+  } else {
+    op.exec(method::bucket_link_olh, in);
+  }
 }
 
 void cls_rgw_bucket_refresh_instance(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& key)
@@ -377,9 +385,10 @@ int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const string& oid,
 void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
                                    const cls_rgw_obj_key& key, const string& op_tag,
                                    const string& olh_tag, uint64_t olh_epoch, bool log_op,
-                                   uint16_t bilog_flags, const rgw_zone_set& zones_trace)
+                                   uint16_t bilog_flags, const rgw_zone_set& zones_trace,
+                                   bufferlist* epoch_out_bl)
 {
-  bufferlist in, out;
+  bufferlist in;
   rgw_cls_unlink_instance_op call;
   call.key = key;
   call.op_tag = op_tag;
@@ -389,7 +398,11 @@ void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
   call.zones_trace = zones_trace;
   call.bilog_flags = bilog_flags;
   encode(call, in);
-  op.exec(method::bucket_unlink_instance, in);
+  if (epoch_out_bl) {
+    op.exec(method::bucket_unlink_instance, in, epoch_out_bl, nullptr);
+  } else {
+    op.exec(method::bucket_unlink_instance, in);
+  }
 }
 
 void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret)

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -171,10 +171,12 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
                             const cls_rgw_obj_key& key, const ceph::buffer::list& olh_tag,
                             bool delete_marker, const std::string& op_tag, const rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace);
+                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace,
+                            ceph::buffer::list* epoch_out_bl = nullptr);
 void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
                                    const cls_rgw_obj_key& key, const std::string& op_tag,
-                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, uint16_t bilog_flags, const rgw_zone_set& zones_trace);
+                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, uint16_t bilog_flags, const rgw_zone_set& zones_trace,
+                                   ceph::buffer::list* epoch_out_bl = nullptr);
 void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const std::string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret);
 void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const std::string& olh_tag);
 void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, const std::string& olh_tag);

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -152,7 +152,7 @@ list<rgw_cls_obj_complete_op> rgw_cls_obj_complete_op::generate_test_instances()
   op.locator = "locator";
   op.ver.pool = 2;
   op.ver.epoch = 100;
-  op.tag = "tag";
+  op.op_tag = "tag";
 
   list<rgw_bucket_dir_entry_meta> l = rgw_bucket_dir_entry_meta::generate_test_instances();
   auto iter = l.begin();
@@ -175,7 +175,7 @@ void rgw_cls_obj_complete_op::dump(Formatter *f) const
   f->open_object_section("meta");
   meta.dump(f);
   f->close_section();
-  f->dump_string("tag", tag);
+  f->dump_string("tag", op_tag);
   f->dump_bool("log_op", log_op);
   f->dump_int("bilog_flags", bilog_flags);
   encode_json("zones_trace", zones_trace, f);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "cls/rgw/cls_rgw_types.h"
+#include "include/rados/librados_fwd.hpp"
 
 struct rgw_cls_tag_timeout_op
 {
@@ -79,21 +80,27 @@ struct rgw_cls_obj_prepare_op
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_prepare_op)
 
-struct rgw_cls_obj_complete_op
-{
-  RGWModifyOp op;
+// common bilog-related fields shared across bucket index write operations.
+// wire structs (rgw_cls_obj_complete_op, rgw_cls_link_olh_op,
+// rgw_cls_unlink_instance_op) inherit from this to provide a uniform
+// interface for both InIndex (cls_rgw CLS) and FIFO bilog writing.
+struct cls_rgw_bi_log_related_op {
+  bool log_op{false};
   cls_rgw_obj_key key;
+  std::string op_tag;
+  rgw_zone_set zones_trace;
+  uint16_t bilog_flags{0};
+  RGWModifyOp op{CLS_RGW_OP_UNKNOWN};
+};
+
+struct rgw_cls_obj_complete_op : cls_rgw_bi_log_related_op
+{
   std::string locator;
   rgw_bucket_entry_ver ver;
   rgw_bucket_dir_entry_meta meta;
-  std::string tag;
-  bool log_op;
-  uint16_t bilog_flags;
-
   std::list<cls_rgw_obj_key> remove_objs;
-  rgw_zone_set zones_trace;
 
-  rgw_cls_obj_complete_op() : op(CLS_RGW_OP_ADD), log_op(false), bilog_flags(0) {}
+  rgw_cls_obj_complete_op() { op = CLS_RGW_OP_ADD; }
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(9, 7, bl);
@@ -101,7 +108,7 @@ struct rgw_cls_obj_complete_op
     encode(c, bl);
     encode(ver.epoch, bl);
     encode(meta, bl);
-    encode(tag, bl);
+    encode(op_tag, bl);
     encode(locator, bl);
     encode(remove_objs, bl);
     encode(ver, bl);
@@ -110,7 +117,7 @@ struct rgw_cls_obj_complete_op
     encode(bilog_flags, bl);
     encode(zones_trace, bl);
     ENCODE_FINISH(bl);
- }
+  }
   void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(9, 3, 3, bl);
     uint8_t c;
@@ -121,7 +128,7 @@ struct rgw_cls_obj_complete_op
     }
     decode(ver.epoch, bl);
     decode(meta, bl);
-    decode(tag, bl);
+    decode(op_tag, bl);
     if (struct_v >= 2) {
       decode(locator, bl);
     }
@@ -162,20 +169,15 @@ struct rgw_cls_obj_complete_op
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_complete_op)
 
-struct rgw_cls_link_olh_op {
-  cls_rgw_obj_key key;
+struct rgw_cls_link_olh_op : cls_rgw_bi_log_related_op {
   std::string olh_tag;
-  bool delete_marker;
-  std::string op_tag;
+  bool delete_marker{false};
   rgw_bucket_dir_entry_meta meta;
-  uint64_t olh_epoch;
-  bool log_op;
-  uint16_t bilog_flags;
-  ceph::real_time unmod_since; /* only create delete marker if newer then this */
-  bool high_precision_time;
-  rgw_zone_set zones_trace;
+  uint64_t olh_epoch{0};
+  ceph::real_time unmod_since; /* only create delete marker if newer than this */
+  bool high_precision_time{false};
 
-  rgw_cls_link_olh_op() : delete_marker(false), olh_epoch(0), log_op(false), bilog_flags(0), high_precision_time(false) {}
+  rgw_cls_link_olh_op() {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(5, 1, bl);
@@ -229,13 +231,9 @@ struct rgw_cls_link_olh_op {
 };
 WRITE_CLASS_ENCODER(rgw_cls_link_olh_op)
 
-struct rgw_cls_unlink_instance_op {
-  cls_rgw_obj_key key;
-  std::string op_tag;
+struct rgw_cls_unlink_instance_op : cls_rgw_bi_log_related_op {
   // this represents a remote epoch during multisite sync
-  uint64_t olh_epoch;
-  bool log_op;
-  uint16_t bilog_flags;
+  uint64_t olh_epoch{0};
   // cls ops include olh_tag so the OLH class code can guard sensitive updates—only proceed if op.olh_tag equals
   // the OLH’s stored tag. If it doesn’t, the op fails and the caller refreshes state/retries.
   // for context: in real clusters, out‑of‑order replication or topology changes can recreate/move an OLH
@@ -243,9 +241,8 @@ struct rgw_cls_unlink_instance_op {
   // writers carrying the old tag get refused instead of overwriting the new state. A concrete example of failures
   // tied to OLH attributes shows how wrong attributes/tags cause bad GET behavior, which is why the guard exists.
   std::string olh_tag;
-  rgw_zone_set zones_trace;
 
-  rgw_cls_unlink_instance_op() : olh_epoch(0), log_op(false), bilog_flags(0) {}
+  rgw_cls_unlink_instance_op() { op = CLS_RGW_OP_UNLINK_INSTANCE; }
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(3, 1, bl);
@@ -1795,6 +1792,94 @@ struct cls_rgw_get_bucket_resharding_ret  {
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)
 
+// OpIssuer types: carry bilog metadata and issue the CLS bucket index op.
+// used by with_bilog<CLSRGWOpType>() in rgw_rados.cc to dispatch both the
+// in-index CLS operation and (for FIFO buckets) the bilog FIFO write.
+
+// base for CLSRGWCompleteModifyOp — holds all bilog fields and issues the
+// cls_rgw_bucket_complete_op() call.
+struct CLSRGWCompleteModifyOpBase : cls_rgw_bi_log_related_op {
+  CLSRGWCompleteModifyOpBase(bool log_data, cls_rgw_obj_key key_,
+                             std::string tag_, const rgw_zone_set* zones_trace_,
+                             uint16_t bilog_flags_,
+                             RGWModifyOp op_ = CLS_RGW_OP_UNKNOWN) {
+    log_op = log_data;
+    key = std::move(key_);
+    op_tag = std::move(tag_);
+    if (zones_trace_) zones_trace = *zones_trace_;
+    bilog_flags = bilog_flags_;
+    op = op_;
+  }
+  void complete_op(librados::ObjectWriteOperation& o,
+                   const rgw_bucket_entry_ver& ver,
+                   const rgw_bucket_dir_entry_meta& dir_meta,
+                   const std::list<cls_rgw_obj_key>* remove_objs,
+                   const std::string& locator) const;
+};
+
+// typed complete-op issuer.
+template <RGWModifyOp OpType>
+struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
+  template <class... Args>
+  explicit CLSRGWCompleteModifyOp(Args&&... args)
+    : CLSRGWCompleteModifyOpBase(std::forward<Args>(args)...) { op = OpType; }
+};
+
+// base for CLSRGWLinkOLH
+struct CLSRGWLinkOLHBase : private cls_rgw_bi_log_related_op {
+  CLSRGWLinkOLHBase(bool log_data, cls_rgw_obj_key key_,
+                    std::string tag_, const rgw_zone_set* zones_trace_,
+                    uint16_t bilog_flags_) {
+    log_op = log_data;
+    key = std::move(key_);
+    op_tag = std::move(tag_);
+    if (zones_trace_) zones_trace = *zones_trace_;
+    bilog_flags = bilog_flags_;
+  }
+  static RGWModifyOp get_bilog_op_type(bool delete_marker) {
+    return delete_marker ? CLS_RGW_OP_LINK_OLH_DM : CLS_RGW_OP_LINK_OLH;
+  }
+  std::string& get_op_tag_ref() { return op_tag; }
+  const cls_rgw_bi_log_related_op& get_bilog_op() const { return *this; }
+
+  void link_olh(librados::ObjectWriteOperation& o,
+                const ceph::bufferlist& olh_tag,
+                bool delete_marker,
+                const rgw_bucket_dir_entry_meta* meta,
+                uint64_t olh_epoch,
+                ceph::real_time unmod_since,
+                bool high_precision_time) const;
+};
+
+// typed OLH-link issuer. DeleteMarkerV selects LINK_OLH vs LINK_OLH_DM.
+template <bool DeleteMarkerV>
+struct CLSRGWLinkOLH : CLSRGWLinkOLHBase {
+  using CLSRGWLinkOLHBase::CLSRGWLinkOLHBase;
+  static constexpr RGWModifyOp get_bilog_op_type() {
+    return DeleteMarkerV ? CLS_RGW_OP_LINK_OLH_DM : CLS_RGW_OP_LINK_OLH;
+  }
+};
+
+// issuer for unlink-instance ops. always carries CLS_RGW_OP_UNLINK_INSTANCE.
+struct CLSRGWUnlinkInstance : cls_rgw_bi_log_related_op {
+  CLSRGWUnlinkInstance(bool log_data, cls_rgw_obj_key key_,
+                       std::string tag_, const rgw_zone_set* zones_trace_,
+                       uint16_t bilog_flags_) {
+    log_op = log_data;
+    key = std::move(key_);
+    op_tag = std::move(tag_);
+    if (zones_trace_) zones_trace = *zones_trace_;
+    bilog_flags = bilog_flags_;
+    op = CLS_RGW_OP_UNLINK_INSTANCE;
+  }
+  static constexpr RGWModifyOp get_bilog_op_type() {
+    return CLS_RGW_OP_UNLINK_INSTANCE;
+  }
+  void unlink_instance(librados::ObjectWriteOperation& o,
+                       const std::string& olh_tag,
+                       uint64_t olh_epoch) const;
+};
+
 namespace cls::rgw {
 struct ClassId {
   static constexpr auto name = "rgw";
@@ -1871,3 +1956,4 @@ constexpr auto guard_bucket_resharding = ClsMethod<RdTag, ClassId>(RGW_GUARD_BUC
 constexpr auto get_bucket_resharding = ClsMethod<RdTag, ClassId>(RGW_GET_BUCKET_RESHARDING);
 }
 }
+

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1848,7 +1848,8 @@ struct CLSRGWLinkOLHBase : private cls_rgw_bi_log_related_op {
                 const rgw_bucket_dir_entry_meta* meta,
                 uint64_t olh_epoch,
                 ceph::real_time unmod_since,
-                bool high_precision_time) const;
+                bool high_precision_time,
+                ceph::bufferlist* epoch_out_bl = nullptr) const;
 };
 
 // typed OLH-link issuer. DeleteMarkerV selects LINK_OLH vs LINK_OLH_DM.
@@ -1877,7 +1878,8 @@ struct CLSRGWUnlinkInstance : cls_rgw_bi_log_related_op {
   }
   void unlink_instance(librados::ObjectWriteOperation& o,
                        const std::string& olh_tag,
-                       uint64_t olh_epoch) const;
+                       uint64_t olh_epoch,
+                       ceph::bufferlist* epoch_out_bl = nullptr) const;
 };
 
 namespace cls::rgw {

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1870,7 +1870,8 @@ struct CLSRGWLinkOLHBase : private cls_rgw_bi_log_related_op {
                 const rgw_bucket_dir_entry_meta* meta,
                 uint64_t olh_epoch,
                 ceph::real_time unmod_since,
-                bool high_precision_time) const;
+                bool high_precision_time,
+                ceph::bufferlist* epoch_out_bl = nullptr) const;
 };
 
 // typed OLH-link issuer. DeleteMarkerV selects LINK_OLH vs LINK_OLH_DM.
@@ -1899,7 +1900,8 @@ struct CLSRGWUnlinkInstance : cls_rgw_bi_log_related_op {
   }
   void unlink_instance(librados::ObjectWriteOperation& o,
                        const std::string& olh_tag,
-                       uint64_t olh_epoch) const;
+                       uint64_t olh_epoch,
+                       ceph::bufferlist* epoch_out_bl = nullptr) const;
 };
 
 namespace cls::rgw {

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "cls/rgw/cls_rgw_types.h"
+#include "include/rados/librados_fwd.hpp"
 
 struct rgw_cls_tag_timeout_op
 {
@@ -79,21 +80,27 @@ struct rgw_cls_obj_prepare_op
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_prepare_op)
 
-struct rgw_cls_obj_complete_op
-{
-  RGWModifyOp op;
+// common bilog-related fields shared across bucket index write operations.
+// wire structs (rgw_cls_obj_complete_op, rgw_cls_link_olh_op,
+// rgw_cls_unlink_instance_op) inherit from this to provide a uniform
+// interface for both InIndex (cls_rgw CLS) and FIFO bilog writing.
+struct cls_rgw_bi_log_related_op {
+  bool log_op{false};
   cls_rgw_obj_key key;
+  std::string op_tag;
+  rgw_zone_set zones_trace;
+  uint16_t bilog_flags{0};
+  RGWModifyOp op{CLS_RGW_OP_UNKNOWN};
+};
+
+struct rgw_cls_obj_complete_op : cls_rgw_bi_log_related_op
+{
   std::string locator;
   rgw_bucket_entry_ver ver;
   rgw_bucket_dir_entry_meta meta;
-  std::string tag;
-  bool log_op;
-  uint16_t bilog_flags;
-
   std::list<cls_rgw_obj_key> remove_objs;
-  rgw_zone_set zones_trace;
 
-  rgw_cls_obj_complete_op() : op(CLS_RGW_OP_ADD), log_op(false), bilog_flags(0) {}
+  rgw_cls_obj_complete_op() { op = CLS_RGW_OP_ADD; }
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(9, 7, bl);
@@ -101,7 +108,7 @@ struct rgw_cls_obj_complete_op
     encode(c, bl);
     encode(ver.epoch, bl);
     encode(meta, bl);
-    encode(tag, bl);
+    encode(op_tag, bl);
     encode(locator, bl);
     encode(remove_objs, bl);
     encode(ver, bl);
@@ -110,7 +117,7 @@ struct rgw_cls_obj_complete_op
     encode(bilog_flags, bl);
     encode(zones_trace, bl);
     ENCODE_FINISH(bl);
- }
+  }
   void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(9, 3, 3, bl);
     uint8_t c;
@@ -121,7 +128,7 @@ struct rgw_cls_obj_complete_op
     }
     decode(ver.epoch, bl);
     decode(meta, bl);
-    decode(tag, bl);
+    decode(op_tag, bl);
     if (struct_v >= 2) {
       decode(locator, bl);
     }
@@ -162,20 +169,15 @@ struct rgw_cls_obj_complete_op
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_complete_op)
 
-struct rgw_cls_link_olh_op {
-  cls_rgw_obj_key key;
+struct rgw_cls_link_olh_op : cls_rgw_bi_log_related_op {
   std::string olh_tag;
-  bool delete_marker;
-  std::string op_tag;
+  bool delete_marker{false};
   rgw_bucket_dir_entry_meta meta;
-  uint64_t olh_epoch;
-  bool log_op;
-  uint16_t bilog_flags;
-  ceph::real_time unmod_since; /* only create delete marker if newer then this */
-  bool high_precision_time;
-  rgw_zone_set zones_trace;
+  uint64_t olh_epoch{0};
+  ceph::real_time unmod_since; /* only create delete marker if newer than this */
+  bool high_precision_time{false};
 
-  rgw_cls_link_olh_op() : delete_marker(false), olh_epoch(0), log_op(false), bilog_flags(0), high_precision_time(false) {}
+  rgw_cls_link_olh_op() {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(5, 1, bl);
@@ -251,13 +253,9 @@ struct rgw_cls_refresh_instance_op {
 };
 WRITE_CLASS_ENCODER(rgw_cls_refresh_instance_op)
 
-struct rgw_cls_unlink_instance_op {
-  cls_rgw_obj_key key;
-  std::string op_tag;
+struct rgw_cls_unlink_instance_op : cls_rgw_bi_log_related_op {
   // this represents a remote epoch during multisite sync
-  uint64_t olh_epoch;
-  bool log_op;
-  uint16_t bilog_flags;
+  uint64_t olh_epoch{0};
   // cls ops include olh_tag so the OLH class code can guard sensitive updates—only proceed if op.olh_tag equals
   // the OLH’s stored tag. If it doesn’t, the op fails and the caller refreshes state/retries.
   // for context: in real clusters, out‑of‑order replication or topology changes can recreate/move an OLH
@@ -265,9 +263,8 @@ struct rgw_cls_unlink_instance_op {
   // writers carrying the old tag get refused instead of overwriting the new state. A concrete example of failures
   // tied to OLH attributes shows how wrong attributes/tags cause bad GET behavior, which is why the guard exists.
   std::string olh_tag;
-  rgw_zone_set zones_trace;
 
-  rgw_cls_unlink_instance_op() : olh_epoch(0), log_op(false), bilog_flags(0) {}
+  rgw_cls_unlink_instance_op() { op = CLS_RGW_OP_UNLINK_INSTANCE; }
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(3, 1, bl);
@@ -1817,6 +1814,94 @@ struct cls_rgw_get_bucket_resharding_ret  {
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)
 
+// OpIssuer types: carry bilog metadata and issue the CLS bucket index op.
+// used by with_bilog<CLSRGWOpType>() in rgw_rados.cc to dispatch both the
+// in-index CLS operation and (for FIFO buckets) the bilog FIFO write.
+
+// base for CLSRGWCompleteModifyOp — holds all bilog fields and issues the
+// cls_rgw_bucket_complete_op() call.
+struct CLSRGWCompleteModifyOpBase : cls_rgw_bi_log_related_op {
+  CLSRGWCompleteModifyOpBase(bool log_data, cls_rgw_obj_key key_,
+                             std::string tag_, const rgw_zone_set* zones_trace_,
+                             uint16_t bilog_flags_,
+                             RGWModifyOp op_ = CLS_RGW_OP_UNKNOWN) {
+    log_op = log_data;
+    key = std::move(key_);
+    op_tag = std::move(tag_);
+    if (zones_trace_) zones_trace = *zones_trace_;
+    bilog_flags = bilog_flags_;
+    op = op_;
+  }
+  void complete_op(librados::ObjectWriteOperation& o,
+                   const rgw_bucket_entry_ver& ver,
+                   const rgw_bucket_dir_entry_meta& dir_meta,
+                   const std::list<cls_rgw_obj_key>* remove_objs,
+                   const std::string& locator) const;
+};
+
+// typed complete-op issuer.
+template <RGWModifyOp OpType>
+struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
+  template <class... Args>
+  explicit CLSRGWCompleteModifyOp(Args&&... args)
+    : CLSRGWCompleteModifyOpBase(std::forward<Args>(args)...) { op = OpType; }
+};
+
+// base for CLSRGWLinkOLH
+struct CLSRGWLinkOLHBase : private cls_rgw_bi_log_related_op {
+  CLSRGWLinkOLHBase(bool log_data, cls_rgw_obj_key key_,
+                    std::string tag_, const rgw_zone_set* zones_trace_,
+                    uint16_t bilog_flags_) {
+    log_op = log_data;
+    key = std::move(key_);
+    op_tag = std::move(tag_);
+    if (zones_trace_) zones_trace = *zones_trace_;
+    bilog_flags = bilog_flags_;
+  }
+  static RGWModifyOp get_bilog_op_type(bool delete_marker) {
+    return delete_marker ? CLS_RGW_OP_LINK_OLH_DM : CLS_RGW_OP_LINK_OLH;
+  }
+  std::string& get_op_tag_ref() { return op_tag; }
+  const cls_rgw_bi_log_related_op& get_bilog_op() const { return *this; }
+
+  void link_olh(librados::ObjectWriteOperation& o,
+                const ceph::bufferlist& olh_tag,
+                bool delete_marker,
+                const rgw_bucket_dir_entry_meta* meta,
+                uint64_t olh_epoch,
+                ceph::real_time unmod_since,
+                bool high_precision_time) const;
+};
+
+// typed OLH-link issuer. DeleteMarkerV selects LINK_OLH vs LINK_OLH_DM.
+template <bool DeleteMarkerV>
+struct CLSRGWLinkOLH : CLSRGWLinkOLHBase {
+  using CLSRGWLinkOLHBase::CLSRGWLinkOLHBase;
+  static constexpr RGWModifyOp get_bilog_op_type() {
+    return DeleteMarkerV ? CLS_RGW_OP_LINK_OLH_DM : CLS_RGW_OP_LINK_OLH;
+  }
+};
+
+// issuer for unlink-instance ops. always carries CLS_RGW_OP_UNLINK_INSTANCE.
+struct CLSRGWUnlinkInstance : cls_rgw_bi_log_related_op {
+  CLSRGWUnlinkInstance(bool log_data, cls_rgw_obj_key key_,
+                       std::string tag_, const rgw_zone_set* zones_trace_,
+                       uint16_t bilog_flags_) {
+    log_op = log_data;
+    key = std::move(key_);
+    op_tag = std::move(tag_);
+    if (zones_trace_) zones_trace = *zones_trace_;
+    bilog_flags = bilog_flags_;
+    op = CLS_RGW_OP_UNLINK_INSTANCE;
+  }
+  static constexpr RGWModifyOp get_bilog_op_type() {
+    return CLS_RGW_OP_UNLINK_INSTANCE;
+  }
+  void unlink_instance(librados::ObjectWriteOperation& o,
+                       const std::string& olh_tag,
+                       uint64_t olh_epoch) const;
+};
+
 namespace cls::rgw {
 struct ClassId {
   static constexpr auto name = "rgw";
@@ -1894,3 +1979,4 @@ constexpr auto guard_bucket_resharding = ClsMethod<RdTag, ClassId>(RGW_GUARD_BUC
 constexpr auto get_bucket_resharding = ClsMethod<RdTag, ClassId>(RGW_GET_BUCKET_RESHARDING);
 }
 }
+

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4085,6 +4085,32 @@ options:
   see_also:
   - rgw_dmclock_metadata_res
   - rgw_dmclock_metadata_wgt
+- name: rgw_default_data_log_backing
+  type: str
+  level: advanced
+  desc: Default backing store for the RGW data sync log
+  long_desc: Whether to use the older OMAP backing store or the high performance FIFO
+    based backing store by default. This only covers the creation of the log on startup
+    if none exists.
+  default: fifo
+  services:
+  - rgw
+  enum_values:
+  - fifo
+  - omap
+- name: rgw_default_bucket_bilog_type
+  type: str
+  level: advanced
+  desc: Default bilog backend for newly created buckets
+  long_desc: Whether new buckets use the InIndex (omap-based, stored in bucket index
+    objects) or FIFO bilog backend. Set to 'fifo' to have new buckets start on FIFO
+    directly. Existing buckets are unaffected until migrated.
+  default: inindex
+  services:
+  - rgw
+  enum_values:
+  - inindex
+  - fifo
 - name: rgw_d3n_l1_local_datacache_enabled
   type: bool
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4103,9 +4103,9 @@ options:
   level: advanced
   desc: Default bilog backend for newly created buckets
   long_desc: Whether new buckets use the InIndex (omap-based, stored in bucket index
-    objects) or FIFO bilog backend. Set to 'fifo' to have new buckets start on FIFO
-    directly. Existing buckets are unaffected until migrated.
-  default: inindex
+    objects) or FIFO bilog backend. Defaults to 'fifo'. Existing InIndex buckets are
+    migrated to FIFO automatically on their next reshard.
+  default: fifo
   services:
   - rgw
   enum_values:

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4099,9 +4099,9 @@ options:
   level: advanced
   desc: Default bilog backend for newly created buckets
   long_desc: Whether new buckets use the InIndex (omap-based, stored in bucket index
-    objects) or FIFO bilog backend. Set to 'fifo' to have new buckets start on FIFO
-    directly. Existing buckets are unaffected until migrated.
-  default: inindex
+    objects) or FIFO bilog backend. Defaults to 'fifo'. Existing InIndex buckets are
+    migrated to FIFO automatically on their next reshard.
+  default: fifo
   services:
   - rgw
   enum_values:

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4081,6 +4081,32 @@ options:
   see_also:
   - rgw_dmclock_metadata_res
   - rgw_dmclock_metadata_wgt
+- name: rgw_default_data_log_backing
+  type: str
+  level: advanced
+  desc: Default backing store for the RGW data sync log
+  long_desc: Whether to use the older OMAP backing store or the high performance FIFO
+    based backing store by default. This only covers the creation of the log on startup
+    if none exists.
+  default: fifo
+  services:
+  - rgw
+  enum_values:
+  - fifo
+  - omap
+- name: rgw_default_bucket_bilog_type
+  type: str
+  level: advanced
+  desc: Default bilog backend for newly created buckets
+  long_desc: Whether new buckets use the InIndex (omap-based, stored in bucket index
+    objects) or FIFO bilog backend. Set to 'fifo' to have new buckets start on FIFO
+    directly. Existing buckets are unaffected until migrated.
+  default: inindex
+  services:
+  - rgw
+  enum_values:
+  - inindex
+  - fifo
 - name: rgw_d3n_l1_local_datacache_enabled
   type: bool
   level: advanced

--- a/src/doc/rgw/bilog-fifo.md
+++ b/src/doc/rgw/bilog-fifo.md
@@ -1,0 +1,138 @@
+
+Introduce a FIFO-backed bilog backend as an alternative to the
+existing InIndex backend. Each bucket index shard gets a dedicated FIFO object
+(`<shard_oid>.bilog`) for its bilog. Selection is per-bucket and recorded in
+`bucket_info.layout.logs`.
+
+The FIFO backend uses `neorados::cls::fifo::FIFO` (the same implementation
+used by the datalog). Bilog push, list, trim, and marker cursor semantics
+are modelled after the datalog pattern.
+
+Design:
+
+### 1. Backend selection
+
+Backends are selected at bucket-creation time via the config option
+`rgw_default_bucket_bilog_type` (`inindex` / `fifo`. default is `inindex`).
+The chosen type is stored as a `BucketLogType` in `bucket_info.layout.logs[0]`.
+Once written, the bucket uses that backend for its lifetime until explicitly migrated.
+
+### 2. Per-shard FIFO objects
+
+One FIFO object per bucket index shard, with OID `<shard_oid>.bilog`. This
+matches the sharding of the index itself and avoids a single-FIFO bottleneck
+per bucket. Shard routing for writes uses `RGWSI_BucketIndex_RADOS::
+bucket_shard_index(key, num_shards)`.
+
+### 3. CLS layer bypass
+
+For FIFO buckets the CLS-level bilog write is suppressed by setting
+`log_op = false` in the op struct. The FIFO push is performed by the RGW
+layer before the CLS op completes.
+
+### 4. Ordering for crash-safety
+
+The FIFO entry is pushed **before** the CLS bucket index op. This prevents the
+worst-case scenario: a crash after the CLS op but before the FIFO push would
+leave the secondary permanently unable to see the change.
+
+**Object Write Op**
+This is weaker than InIndex, where `write_entry` and `log_index_operation` are
+both called inside the same CLS method (e.g. `cls_rgw_bucket_complete_op`).
+A crash rolls back the entire transaction. With FIFO, a crash between the push and the
+CLS op leaves a bilog entry that claims an object was added, but the bucket
+index has no corresponding entry.
+When the secondary zone processes such an entry it calls `HeadObject`
+on the source, which returns 404. Sync process treats `-ENOENT` as a non-fatal
+ignorable error (`ignore_sync_error()` in `rgw_data_sync.cc`) - it silently skips
+the entry and advances the sync marker. No data is lost on the secondary.
+
+**OLH operations (`LINK_OLH`, `UNLINK_INSTANCE`)**
+The FIFO entry carries the `olh_epoch`. On the secondary the
+`cls_rgw_bucket_link_olh` handler calls `start_modify(candidate_epoch)`, which
+discards the op silently if `candidate_epoch < olh.epoch`.
+If RGW crashes after the FIFO push (epoch=N, `LINK_OLH` for `foo#v1`)
+but before the `link_olh` op, and the client never retries, the primary's
+OLH pointer stays at the previous version while the secondary advances to `foo#v1`.
+Epoch comparison cannot detect this: epoch=N is the highest epoch the secondary
+has seen for this object, so `start_modify(N)` applies correctly from its perspective.
+
+So, FIFO-first means the secondary can be *ahead* of the primary with a
+diverged OLH pointer that epoch comparison has no mechanism to reverse.
+We issue `link_olh` / `unlink_instance` before the FIFO push. This is safer. 
+They will eventually converge upon a retry or a new FIFO push on secondary.
+
+
+### 5. Dispatch: `with_bilog<>`
+
+A central template method `RGWRados::with_bilog<OpType>()` selects the
+appropriate handler at the call site:
+
+```
+is_inindex && log_data   → OpIssuer(log_data=true)  + BILogNopHandler
+is_inindex && !log_data  → OpIssuer(log_data=false) + BILogNopHandler
+is_fifo   && log_data    → OpIssuer(log_data=false) + RGWBILogUpdateBatch
+is_fifo   && !log_data   → OpIssuer(log_data=false) + BILogNopHandler
+```
+
+`BILogNopHandler` is a NOP with the same interface as
+`RGWBILogUpdateBatch`.
+
+### 6. Write batching (current state)
+
+Each operation flushes one entry to the FIFO immediately. This adds one OSD
+round-trip per bucket write. Batching multiple writes is deferred for now.
+
+### 7. Marker and cursor format
+FIFO list markers are raw strings (e.g. `"00000001"`). For multi-shard
+buckets, the service layer builds markers of the form
+`<shard_id>#<raw_marker>` using `build_bucket_index_marker()`, matching the
+InIndex format.
+
+Multi-generation markers use the format
+`G{gen:020}@{inner_marker}` from `rgw_log_backing.h`.
+
+---
+
+## Implementation Status
+
+- `BucketLogType::FIFO` - new enum value in `rgw_bucket_layout.h`
+- `LazyFIFO` - per-shard FIFO wrapper with lazy init in `rgw_log_backing.h`
+- `RGWBILogFIFO` - multiple shard FIFO push/list/trim in `rgw_bilog.h/.cc`
+- `RGWBILogUpdateBatch` - per-request write helper with shard routing and async flush
+- `RGWSI_BILog_RADOS` - service layer changes (InIndex + FIFO) in `svc_bilog_rados.h/.cc`
+- `BILogNopHandler` - NOP handler for InIndex and disabled-log paths
+- `with_bilog<>` - dispatch template in `RGWRados`
+- `cls_rgw_bi_log_related_op` - base struct for CLS ops with typed OpIssuer classes
+- `cls_obj_complete_op` - template calls `with_bilog<>` internally
+- `bucket_index_link_olh` - rewritten with `with_bilog<CLSRGWLinkOLH<>>`
+- `bucket_index_unlink_instance` - rewritten with `with_bilog<CLSRGWUnlinkInstance>`
+- `apply_olh_log` - FIFO entry pushed via `with_bilog<void>` at `need_to_link` condition
+- `check_disk_state` - FIFO entry pushed via `with_bilog<void>`. `suggest_flag` split
+- FIFO batch cache - `shared_ptr<RGWBILogFIFO>` cached in `RGWRados` by `(bucket_id, gen)`
+- New bucket FIFO start with `init_default_bucket_layout()` with configurable `rgw_default_bucket_bilog_type`
+- `commit_target_layout` preserves FIFO backend type through reshard
+- basic `CORO_TEST_F` tests in `test/rgw/test_bilog.cc`
+
+## Remaining Work
+
+### Error propagation:
+Currently `do_flush(y)` and `co_flush()` log the error and continue and `flush(optional_yield y)` returns `void`. need to return error codes as appropriate.
+
+### InIndex → FIFO migration
+Existing buckets created before `rgw_default_bucket_bilog_type = fifo` remain
+on InIndex indefinitely. Migration requires something similar to multi-generation
+ `log_list` cursor that walks [InIndex, FIFO] in order using cursorgen used
+ by datalog.
+
+### Write batching
+
+Currently one FIFO push per bucket operation, Batching multiple entries into a single `fifo_push` call could be beneficial at high write rates.
+
+###  Functional testing
+
+- multisite sync verification with FIFO-backed buckets
+- sync catch-up after zone outage
+- reshard of FIFO bucket with sync veriification
+- radosgw-admin bilog commands (`list`, `trim`, `status`)
+- upgrade path: InIndex bucket continues working after upgrade

--- a/src/doc/rgw/bilog-fifo.md
+++ b/src/doc/rgw/bilog-fifo.md
@@ -116,9 +116,6 @@ Multi-generation markers use the format
 
 ## Remaining Work
 
-### Error propagation:
-Currently `do_flush(y)` and `co_flush()` log the error and continue and `flush(optional_yield y)` returns `void`. need to return error codes as appropriate.
-
 ### InIndex → FIFO migration
 Existing buckets created before `rgw_default_bucket_bilog_type = fifo` remain
 on InIndex indefinitely. Migration requires something similar to multi-generation
@@ -127,7 +124,8 @@ on InIndex indefinitely. Migration requires something similar to multi-generatio
 
 ### Write batching
 
-Currently one FIFO push per bucket operation, Batching multiple entries into a single `fifo_push` call could be beneficial at high write rates.
+Currently one FIFO push per bucket operation, Batching multiple entries into a single `fifo_push` call could be beneficial at high write rates. can it be
+made crash-consistent?
 
 ###  Functional testing
 

--- a/src/doc/rgw/bilog-fifo.md
+++ b/src/doc/rgw/bilog-fifo.md
@@ -13,7 +13,7 @@ Design:
 ### 1. Backend selection
 
 Backends are selected at bucket-creation time via the config option
-`rgw_default_bucket_bilog_type` (`inindex` / `fifo`. default is `inindex`).
+`rgw_default_bucket_bilog_type` (`inindex` / `fifo`. default is `fifo`).
 The chosen type is stored as a `BucketLogType` in `bucket_info.layout.logs[0]`.
 Once written, the bucket uses that backend for its lifetime until explicitly migrated.
 
@@ -69,11 +69,15 @@ A central template method `RGWRados::with_bilog<OpType>()` selects the
 appropriate handler at the call site:
 
 ```
-is_inindex && log_data   → OpIssuer(log_data=true)  + BILogNopHandler
-is_inindex && !log_data  → OpIssuer(log_data=false) + BILogNopHandler
-is_fifo   && log_data    → OpIssuer(log_data=false) + RGWBILogUpdateBatch
-is_fifo   && !log_data   → OpIssuer(log_data=false) + BILogNopHandler
+is_inindex && log_data                     → OpIssuer(log_data=true)  + BILogNopHandler
+is_inindex && !log_data                    → OpIssuer(log_data=false) + BILogNopHandler
+is_fifo   && log_data && fifo_sync_enabled → OpIssuer(log_data=false) + RGWBILogUpdateBatch
+is_fifo   && (!log_data || !fifo_sync_enabled) → OpIssuer(log_data=false) + BILogNopHandler
 ```
+
+`fifo_sync_enabled` reflects `bucket_info.datasync_flag_enabled()`: a FIFO
+bucket with sync disabled falls through to the NOP handler even when
+`log_data` is set, since there's nothing to sync.
 
 `BILogNopHandler` is a NOP with the same interface as
 `RGWBILogUpdateBatch`.
@@ -90,7 +94,7 @@ buckets, the service layer builds markers of the form
 InIndex format.
 
 Multi-generation markers use the format
-`G{gen:020}@{inner_marker}` from `rgw_log_backing.h`.
+`("G{:0>20}@{}", gen_id, cursor)` from `rgw_log_backing.h`.
 
 ---
 
@@ -112,25 +116,14 @@ Multi-generation markers use the format
 - FIFO batch cache - `shared_ptr<RGWBILogFIFO>` cached in `RGWRados` by `(bucket_id, gen)`
 - New bucket FIFO start with `init_default_bucket_layout()` with configurable `rgw_default_bucket_bilog_type`
 - `commit_target_layout` preserves FIFO backend type through reshard
+- InIndex → FIFO migration on reshard - `commit_target_layout` upgrades an
+  InIndex bucket's next log generation to FIFO when
+  `rgw_default_bucket_bilog_type = fifo`, unless the zone doesn't need to log
+  data (`need_to_log_data()`). Buckets stay on InIndex until their next reshard.
 - basic `CORO_TEST_F` tests in `test/rgw/test_bilog.cc`
 
 ## Remaining Work
 
-### InIndex → FIFO migration
-Existing buckets created before `rgw_default_bucket_bilog_type = fifo` remain
-on InIndex indefinitely. Migration requires something similar to multi-generation
- `log_list` cursor that walks [InIndex, FIFO] in order using cursorgen used
- by datalog.
-
 ### Write batching
 
-Currently one FIFO push per bucket operation, Batching multiple entries into a single `fifo_push` call could be beneficial at high write rates. can it be
-made crash-consistent?
-
-###  Functional testing
-
-- multisite sync verification with FIFO-backed buckets
-- sync catch-up after zone outage
-- reshard of FIFO bucket with sync veriification
-- radosgw-admin bilog commands (`list`, `trim`, `status`)
-- upgrade path: InIndex bucket continues working after upgrade
+Currently one FIFO push per bucket operation, Batching multiple entries into a single `fifo_push` call could be beneficial at high write rates. It's scoped for later enhancement.

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -182,6 +182,7 @@ if(WITH_RADOSGW_RADOS)
           driver/rados/rgw_bl_rados.cc
           driver/rados/rgw_cr_rados.cc
           driver/rados/rgw_cr_tools.cc
+          driver/rados/rgw_bilog.cc
           driver/rados/rgw_d3n_datacache.cc
           driver/rados/rgw_datalog.cc
           driver/rados/rgw_datalog_notify.cc

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -203,6 +203,7 @@ list(APPEND librgw_rados_srcs
   driver/rados/rgw_bl_rados.cc
   driver/rados/rgw_cr_rados.cc
   driver/rados/rgw_cr_tools.cc
+  driver/rados/rgw_bilog.cc
   driver/rados/rgw_d3n_datacache.cc
   driver/rados/rgw_datalog.cc
   driver/rados/rgw_datalog_notify.cc

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -6,6 +6,8 @@
 #include <span>
 #include <string>
 
+#include <boost/system/system_error.hpp>
+
 #include "common/async/blocked_completion.h"
 #include "common/dout.h"
 #include "rgw_asio_thread.h"
@@ -173,7 +175,14 @@ void RGWBILogUpdateBatch::do_flush(asio::yield_context y)
   for (auto& [shard, entry] : pending) {
     ceph::buffer::list bl;
     encode(entry, bl);
-    fifo_->push(dpp, shard, std::move(bl), y);
+    try {
+      fifo_->push(dpp, shard, std::move(bl), y);
+    } catch (const boost::system::system_error& e) {
+      ldpp_dout(dpp, 5) << __func__ << ": failed to push bilog entry for "
+                       << entry.object << "/" << entry.instance
+                       << " shard=" << shard
+                       << ": " << e.what() << dendl;
+    }
   }
   pending.clear();
 }

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -199,10 +199,14 @@ void RGWBILogUpdateBatch::do_flush()
               ceph::async::use_blocked);
 }
 
-void RGWBILogUpdateBatch::flush(asio::yield_context y)
+void RGWBILogUpdateBatch::flush(optional_yield y)
 {
   if (!pending.empty()) {
-    do_flush(y);
+    if (y) {
+      do_flush(y.get_yield_context());
+    } else {
+      do_flush();
+    }
   }
 }
 

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -206,6 +206,30 @@ void RGWBILogUpdateBatch::flush(asio::yield_context y)
   }
 }
 
+asio::awaitable<void> RGWBILogUpdateBatch::co_flush()
+{
+  if (pending.empty()) {
+    co_return;
+  }
+  if (!fifo_) {
+    pending.clear();
+    co_return;
+  }
+  for (auto& [shard, entry] : pending) {
+    ceph::buffer::list bl;
+    encode(entry, bl);
+    try {
+      co_await fifo_->push(dpp, shard, std::move(bl));
+    } catch (const boost::system::system_error& e) {
+      ldpp_dout(dpp, 5) << __func__ << ": failed to push bilog entry for "
+                       << entry.object << "/" << entry.instance
+                       << " shard=" << shard
+                       << ": " << e.what() << dendl;
+    }
+  }
+  pending.clear();
+}
+
 void RGWBILogUpdateBatch::flush()
 {
   if (!pending.empty()) {

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -10,6 +10,7 @@
 
 #include "common/async/blocked_completion.h"
 #include "common/dout.h"
+#include "common/errno.h"
 #include "rgw_asio_thread.h"
 #include "services/svc_bi_rados.h"
 
@@ -166,11 +167,11 @@ void RGWBILogUpdateBatch::add_maybe_flush(RGWModifyOp op,
   stage(shard_of(list_state.key), std::move(entry));
 }
 
-void RGWBILogUpdateBatch::do_flush(asio::yield_context y)
+int RGWBILogUpdateBatch::do_flush(asio::yield_context y)
 {
   if (!fifo_) {
-    pending.clear(); 
-    return;
+    pending.clear();
+    return 0;
   }
   for (auto& [shard, entry] : pending) {
     ceph::buffer::list bl;
@@ -178,46 +179,52 @@ void RGWBILogUpdateBatch::do_flush(asio::yield_context y)
     try {
       fifo_->push(dpp, shard, std::move(bl), y);
     } catch (const boost::system::system_error& e) {
-      ldpp_dout(dpp, 5) << __func__ << ": failed to push bilog entry for "
+      ldpp_dout(dpp, 1) << __func__ << ": failed to push bilog entry for "
                        << entry.object << "/" << entry.instance
                        << " shard=" << shard
                        << ": " << e.what() << dendl;
+      pending.clear();
+      return -e.code().value();
     }
   }
   pending.clear();
+  return 0;
 }
 
-void RGWBILogUpdateBatch::do_flush()
+int RGWBILogUpdateBatch::do_flush()
 {
   if (!fifo_) {
     pending.clear();
-    return;
+    return 0;
   }
   maybe_warn_about_blocking(dpp);
+  int ret = 0;
   asio::spawn(rados_.get_executor(),
-              [this](asio::yield_context y) { do_flush(y); },
+              [this, &ret](asio::yield_context y) { ret = do_flush(y); },
               ceph::async::use_blocked);
+  return ret;
 }
 
-void RGWBILogUpdateBatch::flush(optional_yield y)
+int RGWBILogUpdateBatch::flush(optional_yield y)
 {
   if (!pending.empty()) {
     if (y) {
-      do_flush(y.get_yield_context());
+      return do_flush(y.get_yield_context());
     } else {
-      do_flush();
+      return do_flush();
     }
   }
+  return 0;
 }
 
-asio::awaitable<void> RGWBILogUpdateBatch::co_flush()
+asio::awaitable<int> RGWBILogUpdateBatch::co_flush()
 {
   if (pending.empty()) {
-    co_return;
+    co_return 0;
   }
   if (!fifo_) {
     pending.clear();
-    co_return;
+    co_return 0;
   }
   for (auto& [shard, entry] : pending) {
     ceph::buffer::list bl;
@@ -225,31 +232,34 @@ asio::awaitable<void> RGWBILogUpdateBatch::co_flush()
     try {
       co_await fifo_->push(dpp, shard, std::move(bl));
     } catch (const boost::system::system_error& e) {
-      ldpp_dout(dpp, 5) << __func__ << ": failed to push bilog entry for "
+      ldpp_dout(dpp, 1) << __func__ << ": failed to push bilog entry for "
                        << entry.object << "/" << entry.instance
                        << " shard=" << shard
                        << ": " << e.what() << dendl;
+      pending.clear();
+      co_return -e.code().value();
     }
   }
   pending.clear();
+  co_return 0;
 }
 
-void RGWBILogUpdateBatch::flush()
+int RGWBILogUpdateBatch::flush()
 {
   if (!pending.empty()) {
-    do_flush();
+    return do_flush();
   }
+  return 0;
 }
 
 RGWBILogUpdateBatch::~RGWBILogUpdateBatch()
 {
   if (!pending.empty()) {
-    try {
-      do_flush();
-    } catch (const std::exception& e) {
+    int r = do_flush();
+    if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: " << __func__
                         << ": failed to flush pending bilog entries: "
-                        << e.what() << dendl;
+                        << cpp_strerror(r) << dendl;
     }
   }
 }

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -6,7 +6,10 @@
 #include <span>
 #include <string>
 
+#include "common/async/blocked_completion.h"
 #include "common/dout.h"
+#include "rgw_asio_thread.h"
+#include "services/svc_bi_rados.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -78,4 +81,134 @@ std::string_view RGWBILogFIFO::max_marker()
 {
   static const std::string s = fifo::FIFO::max_marker();
   return std::string_view(s);
+}
+
+
+RGWBILogUpdateBatch::RGWBILogUpdateBatch(const DoutPrefixProvider* dpp,
+                                         neorados::RADOS r,
+                                         neorados::IOContext loc,
+                                         std::span<const std::string> shard_oids)
+  : dpp(dpp),
+    rados_(r),
+    fifos(shard_oids.size(),
+          [&r, &loc, &shard_oids](std::size_t i, auto emplacer) {
+            emplacer.emplace(r, bilog_fifo_oid(shard_oids[i]), loc);
+          }),
+    num_shards(static_cast<int>(shard_oids.size()))
+{}
+
+int RGWBILogUpdateBatch::shard_of(const cls_rgw_obj_key& key) const
+{
+  if (num_shards <= 1) {
+    return 0;
+  }
+  return RGWSI_BucketIndex_RADOS::bucket_shard_index(key, num_shards);
+}
+
+void RGWBILogUpdateBatch::stage(int shard, rgw_bi_log_entry entry)
+{
+  pending.push_back(Pending{shard, std::move(entry)});
+}
+
+void RGWBILogUpdateBatch::add_maybe_flush(uint64_t olh_epoch,
+                                          ceph::real_time mtime,
+                                          const cls_rgw_bi_log_related_op& op_info)
+{
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << op_info.key
+                     << " op=" << (int)op_info.op << dendl;
+  rgw_bi_log_entry entry;
+  entry.object = op_info.key.name;
+  entry.instance = op_info.key.instance;
+  entry.timestamp = mtime;
+  entry.op = op_info.op;
+  entry.state = CLS_RGW_STATE_COMPLETE;
+  entry.tag = op_info.op_tag;
+  entry.bilog_flags = op_info.bilog_flags;
+  entry.zones_trace = op_info.zones_trace;
+  entry.ver.epoch = olh_epoch;
+  stage(shard_of(op_info.key), std::move(entry));
+}
+
+void RGWBILogUpdateBatch::add_maybe_flush(uint64_t olh_epoch,
+                                          const cls_rgw_obj_key& key,
+                                          const std::string& op_tag,
+                                          bool delete_marker,
+                                          ceph::real_time mtime,
+                                          const rgw_zone_set& zones_trace)
+{
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << key
+                     << " delete_marker=" << delete_marker << dendl;
+  rgw_bi_log_entry entry;
+  entry.object = key.name;
+  entry.instance = key.instance;
+  entry.timestamp = mtime;
+  entry.op = delete_marker ? CLS_RGW_OP_LINK_OLH_DM : CLS_RGW_OP_LINK_OLH;
+  entry.state = CLS_RGW_STATE_COMPLETE;
+  entry.tag = op_tag;
+  entry.bilog_flags = RGW_BILOG_FLAG_VERSIONED_OP;
+  entry.zones_trace = zones_trace;
+  entry.ver.epoch = olh_epoch;
+  stage(shard_of(key), std::move(entry));
+}
+
+void RGWBILogUpdateBatch::add_maybe_flush(RGWModifyOp op,
+                                          const rgw_bucket_dir_entry& list_state,
+                                          rgw_zone_set zones_trace)
+{
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << list_state.key
+                     << " op=" << (int)op << dendl;
+  rgw_bi_log_entry entry;
+  entry.object = list_state.key.name;
+  entry.instance = list_state.key.instance;
+  entry.timestamp = list_state.meta.mtime;
+  entry.op = op;
+  entry.state = CLS_RGW_STATE_COMPLETE;
+  entry.tag = list_state.tag;
+  entry.zones_trace = std::move(zones_trace);
+  stage(shard_of(list_state.key), std::move(entry));
+}
+
+void RGWBILogUpdateBatch::do_flush(asio::yield_context y)
+{
+  for (auto& [shard, entry] : pending) {
+    ceph::buffer::list bl;
+    encode(entry, bl);
+    fifos[shard].push(dpp, std::move(bl), y);
+  }
+  pending.clear();
+}
+
+void RGWBILogUpdateBatch::do_flush()
+{
+  maybe_warn_about_blocking(dpp);
+  asio::spawn(rados_.get_executor(),
+              [this](asio::yield_context y) { do_flush(y); },
+              ceph::async::use_blocked);
+}
+
+void RGWBILogUpdateBatch::flush(asio::yield_context y)
+{
+  if (!pending.empty()) {
+    do_flush(y);
+  }
+}
+
+void RGWBILogUpdateBatch::flush()
+{
+  if (!pending.empty()) {
+    do_flush();
+  }
+}
+
+RGWBILogUpdateBatch::~RGWBILogUpdateBatch()
+{
+  if (!pending.empty()) {
+    try {
+      do_flush();
+    } catch (const std::exception& e) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                        << ": failed to flush pending bilog entries: "
+                        << e.what() << dendl;
+    }
+  }
 }

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_bilog.h"
+
+#include <span>
+#include <string>
+
+#include "common/dout.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+using ceph::containers::tiny_vector;
+
+RGWBILogFIFO::RGWBILogFIFO(neorados::RADOS rados,
+                             const neorados::IOContext& loc,
+                             std::span<const std::string> shard_oids)
+  : fifos(shard_oids.size(),
+          [&rados, &loc, &shard_oids](std::size_t i, auto emplacer) {
+            emplacer.emplace(rados, bilog_fifo_oid(shard_oids[i]), loc);
+          })
+{}
+
+asio::awaitable<void>
+RGWBILogFIFO::push(const DoutPrefixProvider* dpp,
+                   int shard_id,
+                   ceph::buffer::list entry)
+{
+  co_return co_await fifos[shard_id].push(dpp, std::move(entry));
+}
+
+void RGWBILogFIFO::push(const DoutPrefixProvider* dpp,
+                   int shard_id,
+                   ceph::buffer::list entry,
+                   asio::yield_context y)
+{
+  fifos[shard_id].push(dpp, std::move(entry), y);
+}
+
+asio::awaitable<std::tuple<std::span<fifo::entry>, std::optional<std::string>>>
+RGWBILogFIFO::list(const DoutPrefixProvider* dpp,
+                   int shard_id,
+                   std::string marker,
+                   std::span<fifo::entry> entries)
+{
+  co_return co_await fifos[shard_id].list(dpp, std::move(marker), entries);
+}
+
+std::tuple<std::span<fifo::entry>, std::optional<std::string>>
+RGWBILogFIFO::list(const DoutPrefixProvider* dpp,
+                   int shard_id,
+                   std::string marker,
+                   std::span<fifo::entry> entries,
+                   asio::yield_context y)
+{
+  return fifos[shard_id].list(dpp, std::move(marker), entries, y);
+}
+
+asio::awaitable<void>
+RGWBILogFIFO::trim(const DoutPrefixProvider* dpp,
+                   int shard_id,
+                   std::string marker,
+                   bool exclusive)
+{
+  co_return co_await fifos[shard_id].trim(dpp, std::move(marker), exclusive);
+}
+
+void RGWBILogFIFO::trim(const DoutPrefixProvider* dpp,
+                   int shard_id,
+                   std::string marker,
+                   bool exclusive,
+                   asio::yield_context y)
+{
+  fifos[shard_id].trim(dpp, std::move(marker), exclusive, y);
+}
+
+std::string_view RGWBILogFIFO::max_marker()
+{
+  static const std::string s = fifo::FIFO::max_marker();
+  return std::string_view(s);
+}

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -86,23 +86,19 @@ std::string_view RGWBILogFIFO::max_marker()
 
 RGWBILogUpdateBatch::RGWBILogUpdateBatch(const DoutPrefixProvider* dpp,
                                          neorados::RADOS r,
-                                         neorados::IOContext loc,
-                                         std::span<const std::string> shard_oids)
+                                         std::shared_ptr<RGWBILogFIFO> fifo)
   : dpp(dpp),
-    rados_(r),
-    fifos(shard_oids.size(),
-          [&r, &loc, &shard_oids](std::size_t i, auto emplacer) {
-            emplacer.emplace(r, bilog_fifo_oid(shard_oids[i]), loc);
-          }),
-    num_shards(static_cast<int>(shard_oids.size()))
+    rados_(std::move(r)),
+    fifo_(std::move(fifo))
 {}
 
 int RGWBILogUpdateBatch::shard_of(const cls_rgw_obj_key& key) const
 {
-  if (num_shards <= 1) {
+  const int n = fifo_ ? fifo_->num_shards() : 0;
+  if (n <= 1) {
     return 0;
   }
-  return RGWSI_BucketIndex_RADOS::bucket_shard_index(key, num_shards);
+  return RGWSI_BucketIndex_RADOS::bucket_shard_index(key, n);
 }
 
 void RGWBILogUpdateBatch::stage(int shard, rgw_bi_log_entry entry)
@@ -170,16 +166,24 @@ void RGWBILogUpdateBatch::add_maybe_flush(RGWModifyOp op,
 
 void RGWBILogUpdateBatch::do_flush(asio::yield_context y)
 {
+  if (!fifo_) {
+    pending.clear(); 
+    return;
+  }
   for (auto& [shard, entry] : pending) {
     ceph::buffer::list bl;
     encode(entry, bl);
-    fifos[shard].push(dpp, std::move(bl), y);
+    fifo_->push(dpp, shard, std::move(bl), y);
   }
   pending.clear();
 }
 
 void RGWBILogUpdateBatch::do_flush()
 {
+  if (!fifo_) {
+    pending.clear();
+    return;
+  }
   maybe_warn_about_blocking(dpp);
   asio::spawn(rados_.get_executor(),
               [this](asio::yield_context y) { do_flush(y); },

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -165,6 +165,7 @@ void RGWBILogUpdateBatch::add_maybe_flush(RGWModifyOp op,
   entry.object = list_state.key.name;
   entry.instance = list_state.key.instance;
   entry.timestamp = list_state.meta.mtime;
+  entry.ver = list_state.ver;
   entry.op = op;
   entry.state = CLS_RGW_STATE_COMPLETE;
   entry.tag = list_state.tag;

--- a/src/rgw/driver/rados/rgw_bilog.cc
+++ b/src/rgw/driver/rados/rgw_bilog.cc
@@ -19,11 +19,16 @@
 using ceph::containers::tiny_vector;
 
 RGWBILogFIFO::RGWBILogFIFO(neorados::RADOS rados,
-                             const neorados::IOContext& loc,
-                             std::span<const std::string> shard_oids)
-  : fifos(shard_oids.size(),
-          [&rados, &loc, &shard_oids](std::size_t i, auto emplacer) {
-            emplacer.emplace(rados, bilog_fifo_oid(shard_oids[i]), loc);
+                             const neorados::IOContext& log_pool,
+                             std::string_view bucket_id,
+                             uint64_t log_gen,
+                             uint32_t num_shards)
+  : fifos(num_shards,
+          [&rados, &log_pool, bucket_id, log_gen](std::size_t i, auto emplacer) {
+            emplacer.emplace(rados,
+                             bilog_fifo_oid(bucket_id, log_gen,
+                             static_cast<int>(i)),
+                             log_pool);
           })
 {}
 

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -115,8 +115,8 @@ class RGWBILogUpdateBatch {
   // append an entry to the pending list.
   void stage(int shard, rgw_bi_log_entry entry);
   // encode and push all pending entries to their respective FIFO shards.
-  void do_flush(asio::yield_context y);
-  void do_flush();
+  int do_flush(asio::yield_context y);
+  int do_flush();
 
 public:
   // fifo may be null (error-path batch — silently drops all entries).
@@ -142,10 +142,10 @@ public:
                        const rgw_bucket_dir_entry& list_state,
                        rgw_zone_set zones_trace);
 
-  void flush(optional_yield y);
-  void flush();
+  int flush(optional_yield y);
+  int flush();
   // awaitable variant — use from coroutine contexts (avoids use_blocked).
-  asio::awaitable<void> co_flush();
+  asio::awaitable<int> co_flush();
 
   ~RGWBILogUpdateBatch();
 };

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -144,6 +144,8 @@ public:
 
   void flush(asio::yield_context y);
   void flush();
+  // awaitable variant — use from coroutine contexts (avoids use_blocked).
+  asio::awaitable<void> co_flush();
 
   ~RGWBILogUpdateBatch();
 };

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -30,24 +30,24 @@ namespace asio = boost::asio;
 namespace fifo = neorados::cls::fifo;
 using ceph::containers::tiny_vector;
 
-/// FIFO OID for a given index shard OID "<shard_oid>.bilog"
-/// e.g. ".dir.{bucket_id}.{gen}.{shard_id}.bilog"
+// FIFO OID for a given index shard OID "<shard_oid>.bilog"
+// e.g. ".dir.{bucket_id}.{gen}.{shard_id}.bilog"
 inline std::string bilog_fifo_oid(std::string_view shard_oid)
 {
   return std::string{shard_oid} + ".bilog";
 }
 
-/// per-bucket FIFO bilog: one LazyFIFO per index shard, stored in the same
-/// RADOS pool as the bucket index, with OID = <shard_oid>.bilog.
-///
-/// callers obtain shard_oids from open_bucket_index() and pass them to the
-/// constructor. The shard count and gen are recorded in bucket_log_layout
-/// (field 'in_index') so that trim/list can reconstruct the OIDs later.
+// per-bucket FIFO bilog: one LazyFIFO per index shard, stored in the same
+// RADOS pool as the bucket index, with OID = <shard_oid>.bilog.
+//
+// callers obtain shard_oids from open_bucket_index() and pass them to the
+// constructor. The shard count and gen are recorded in bucket_log_layout
+// (field 'in_index') so that trim/list can reconstruct the OIDs later.
 class RGWBILogFIFO {
   tiny_vector<LazyFIFO> fifos;
 
 public:
-  /// fifos[i] will use OID bilog_fifo_oid(shard_oids[i]).
+  // fifos[i] will use OID bilog_fifo_oid(shard_oids[i]).
   RGWBILogFIFO(neorados::RADOS rados,
                const neorados::IOContext& loc,
                std::span<const std::string> shard_oids);
@@ -56,18 +56,18 @@ public:
     return static_cast<int>(fifos.size());
   }
 
-  /// append a single bilog entry to shard_id (awaitable).
+  // append a single bilog entry to shard_id (awaitable).
   asio::awaitable<void> push(const DoutPrefixProvider* dpp,
                              int shard_id,
                              ceph::buffer::list entry);
 
-  /// append a single bilog entry to shard_id (yield_context).
+  // append a single bilog entry to shard_id (yield_context).
   void push(const DoutPrefixProvider* dpp,
             int shard_id,
             ceph::buffer::list entry,
             asio::yield_context y);
 
-  /// list up to entries.size() entries from shard_id starting after marker.
+  // list up to entries.size() entries from shard_id starting after marker.
   asio::awaitable<std::tuple<std::span<fifo::entry>, std::optional<std::string>>>
   list(const DoutPrefixProvider* dpp,
        int shard_id,
@@ -81,8 +81,8 @@ public:
        std::span<fifo::entry> entries,
        asio::yield_context y);
 
-  /// trim shard_id up to and including marker.
-  /// exclusive=true leaves the entry at marker; exclusive=false removes it.
+  // trim shard_id up to and including marker.
+  // exclusive=true leaves the entry at marker; exclusive=false removes it.
   asio::awaitable<void> trim(const DoutPrefixProvider* dpp,
                              int shard_id,
                              std::string marker,
@@ -97,9 +97,9 @@ public:
   static std::string_view max_marker();
 };
 
-/// per-shard FIFO bilog batch writer for FIFO-backed buckets.
-/// entries are staged internally and flushed to each shard's LazyFIFO either
-/// via an explicit flush() call or on destruction.
+// per-shard FIFO bilog batch writer for FIFO-backed buckets.
+// entries are staged internally and flushed to each shard's LazyFIFO either
+// via an explicit flush() call or on destruction.
 class RGWBILogUpdateBatch {
   const DoutPrefixProvider* dpp;
   neorados::RADOS rados_;
@@ -110,26 +110,26 @@ class RGWBILogUpdateBatch {
   };
   std::vector<Pending> pending;
 
-  /// returns the shard index for 'key' using the same hash as the bucket index.
+  // returns the shard index for 'key' using the same hash as the bucket index.
   int shard_of(const cls_rgw_obj_key& key) const;
-  /// append an entry to the pending list.
+  // append an entry to the pending list.
   void stage(int shard, rgw_bi_log_entry entry);
-  /// encode and push all pending entries to their respective FIFO shards.
+  // encode and push all pending entries to their respective FIFO shards.
   void do_flush(asio::yield_context y);
   void do_flush();
 
 public:
-  /// fifo may be null (error-path batch — silently drops all entries).
+  // fifo may be null (error-path batch — silently drops all entries).
   RGWBILogUpdateBatch(const DoutPrefixProvider* dpp,
                       neorados::RADOS r,
                       std::shared_ptr<RGWBILogFIFO> fifo);
 
-  /// generic complete/cancel/add/del ops — built from an OpIssuer's base fields.
+  // generic complete/cancel/add/del ops — built from an OpIssuer's base fields.
   void add_maybe_flush(uint64_t olh_epoch,
                        ceph::real_time mtime,
                        const cls_rgw_bi_log_related_op& op_info);
 
-  /// OLH link entry — built during apply_olh_log replay (no OpIssuer available).
+  // OLH link entry — built during apply_olh_log replay (no OpIssuer available).
   void add_maybe_flush(uint64_t olh_epoch,
                        const cls_rgw_obj_key& key,
                        const std::string& op_tag,
@@ -137,7 +137,7 @@ public:
                        ceph::real_time mtime,
                        const rgw_zone_set& zones_trace);
 
-  /// disk-state correction entry — built during check_disk_state reconciliation.
+  // disk-state correction entry — built during check_disk_state reconciliation.
   void add_maybe_flush(RGWModifyOp op,
                        const rgw_bucket_dir_entry& list_state,
                        rgw_zone_set zones_trace);

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -7,6 +7,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/spawn.hpp>
@@ -17,9 +18,13 @@
 #include "common/async/yield_context.h"
 #include "common/containers.h"
 
+#include "cls/rgw/cls_rgw_ops.h"
+
 #include "neorados/cls/fifo.h"
 
 #include "rgw_log_backing.h"
+
+class RGWSI_BucketIndex_RADOS;
 
 namespace asio = boost::asio;
 namespace fifo = neorados::cls::fifo;
@@ -76,7 +81,7 @@ public:
        std::span<fifo::entry> entries,
        asio::yield_context y);
 
-  /// trim shard_id up to and including marker?
+  /// trim shard_id up to and including marker.
   /// exclusive=true leaves the entry at marker; exclusive=false removes it.
   asio::awaitable<void> trim(const DoutPrefixProvider* dpp,
                              int shard_id,
@@ -89,6 +94,59 @@ public:
             bool exclusive,
             asio::yield_context y);
 
-  /// returns the absolute maximum marker string for the FIFO implementation
   static std::string_view max_marker();
+};
+
+/// per-shard FIFO bilog batch writer for FIFO-backed buckets.
+/// entries are staged internally and flushed to each shard's LazyFIFO either
+/// when the batch reaches max_batch_size or via an explicit flush() call.
+/// the destructor flushes any remaining staged entries.
+class RGWBILogUpdateBatch {
+  const DoutPrefixProvider* dpp;
+  neorados::RADOS rados_;
+  tiny_vector<LazyFIFO> fifos;   // one per index shard
+  int num_shards;
+  struct Pending {
+    int shard;
+    rgw_bi_log_entry entry;
+  };
+  std::vector<Pending> pending;
+
+  /// returns the shard index for 'key' using the same hash as the bucket index.
+  int shard_of(const cls_rgw_obj_key& key) const;
+  /// append an entry to the pending list.
+  void stage(int shard, rgw_bi_log_entry entry);
+  /// encode and push all pending entries to their respective FIFO shards.
+  void do_flush(asio::yield_context y);
+  void do_flush();
+
+public:
+  /// shard_oids must be ordered by shard ID (as returned by open_bucket_index).
+  RGWBILogUpdateBatch(const DoutPrefixProvider* dpp,
+                      neorados::RADOS r,
+                      neorados::IOContext loc,
+                      std::span<const std::string> shard_oids);
+
+  /// generic complete/cancel/add/del ops — built from an OpIssuer's base fields.
+  void add_maybe_flush(uint64_t olh_epoch,
+                       ceph::real_time mtime,
+                       const cls_rgw_bi_log_related_op& op_info);
+
+  /// OLH link entry — built during apply_olh_log replay (no OpIssuer available).
+  void add_maybe_flush(uint64_t olh_epoch,
+                       const cls_rgw_obj_key& key,
+                       const std::string& op_tag,
+                       bool delete_marker,
+                       ceph::real_time mtime,
+                       const rgw_zone_set& zones_trace);
+
+  /// disk-state correction entry — built during check_disk_state reconciliation.
+  void add_maybe_flush(RGWModifyOp op,
+                       const rgw_bucket_dir_entry& list_state,
+                       rgw_zone_set zones_trace);
+
+  void flush(asio::yield_context y);
+  void flush();
+
+  ~RGWBILogUpdateBatch();
 };

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -1,0 +1,94 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#pragma once
+
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/spawn.hpp>
+
+#include "include/neorados/RADOS.hpp"
+#include "include/buffer.h"
+
+#include "common/async/yield_context.h"
+#include "common/containers.h"
+
+#include "neorados/cls/fifo.h"
+
+#include "rgw_log_backing.h"
+
+namespace asio = boost::asio;
+namespace fifo = neorados::cls::fifo;
+using ceph::containers::tiny_vector;
+
+/// FIFO OID for a given index shard OID "<shard_oid>.bilog"
+/// e.g. ".dir.{bucket_id}.{gen}.{shard_id}.bilog"
+inline std::string bilog_fifo_oid(std::string_view shard_oid)
+{
+  return std::string{shard_oid} + ".bilog";
+}
+
+/// per-bucket FIFO bilog: one LazyFIFO per index shard, stored in the same
+/// RADOS pool as the bucket index, with OID = <shard_oid>.bilog.
+///
+/// callers obtain shard_oids from open_bucket_index() and pass them to the
+/// constructor. The shard count and gen are recorded in bucket_log_layout
+/// (field 'in_index') so that trim/list can reconstruct the OIDs later.
+class RGWBILogFIFO {
+  tiny_vector<LazyFIFO> fifos;
+
+public:
+  /// fifos[i] will use OID bilog_fifo_oid(shard_oids[i]).
+  RGWBILogFIFO(neorados::RADOS rados,
+               const neorados::IOContext& loc,
+               std::span<const std::string> shard_oids);
+
+  int num_shards() const {
+    return static_cast<int>(fifos.size());
+  }
+
+  /// append a single bilog entry to shard_id (awaitable).
+  asio::awaitable<void> push(const DoutPrefixProvider* dpp,
+                             int shard_id,
+                             ceph::buffer::list entry);
+
+  /// append a single bilog entry to shard_id (yield_context).
+  void push(const DoutPrefixProvider* dpp,
+            int shard_id,
+            ceph::buffer::list entry,
+            asio::yield_context y);
+
+  /// list up to entries.size() entries from shard_id starting after marker.
+  asio::awaitable<std::tuple<std::span<fifo::entry>, std::optional<std::string>>>
+  list(const DoutPrefixProvider* dpp,
+       int shard_id,
+       std::string marker,
+       std::span<fifo::entry> entries);
+
+  std::tuple<std::span<fifo::entry>, std::optional<std::string>>
+  list(const DoutPrefixProvider* dpp,
+       int shard_id,
+       std::string marker,
+       std::span<fifo::entry> entries,
+       asio::yield_context y);
+
+  /// trim shard_id up to and including marker?
+  /// exclusive=true leaves the entry at marker; exclusive=false removes it.
+  asio::awaitable<void> trim(const DoutPrefixProvider* dpp,
+                             int shard_id,
+                             std::string marker,
+                             bool exclusive);
+
+  void trim(const DoutPrefixProvider* dpp,
+            int shard_id,
+            std::string marker,
+            bool exclusive,
+            asio::yield_context y);
+
+  /// returns the absolute maximum marker string for the FIFO implementation
+  static std::string_view max_marker();
+};

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -142,7 +142,7 @@ public:
                        const rgw_bucket_dir_entry& list_state,
                        rgw_zone_set zones_trace);
 
-  void flush(asio::yield_context y);
+  void flush(optional_yield y);
   void flush();
   // awaitable variant — use from coroutine contexts (avoids use_blocked).
   asio::awaitable<void> co_flush();

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -99,13 +99,11 @@ public:
 
 /// per-shard FIFO bilog batch writer for FIFO-backed buckets.
 /// entries are staged internally and flushed to each shard's LazyFIFO either
-/// when the batch reaches max_batch_size or via an explicit flush() call.
-/// the destructor flushes any remaining staged entries.
+/// via an explicit flush() call or on destruction.
 class RGWBILogUpdateBatch {
   const DoutPrefixProvider* dpp;
   neorados::RADOS rados_;
-  tiny_vector<LazyFIFO> fifos;   // one per index shard
-  int num_shards;
+  std::shared_ptr<RGWBILogFIFO> fifo_;
   struct Pending {
     int shard;
     rgw_bi_log_entry entry;
@@ -121,11 +119,10 @@ class RGWBILogUpdateBatch {
   void do_flush();
 
 public:
-  /// shard_oids must be ordered by shard ID (as returned by open_bucket_index).
+  /// fifo may be null (error-path batch — silently drops all entries).
   RGWBILogUpdateBatch(const DoutPrefixProvider* dpp,
                       neorados::RADOS r,
-                      neorados::IOContext loc,
-                      std::span<const std::string> shard_oids);
+                      std::shared_ptr<RGWBILogFIFO> fifo);
 
   /// generic complete/cancel/add/del ops — built from an OpIssuer's base fields.
   void add_maybe_flush(uint64_t olh_epoch,

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -9,6 +9,9 @@
 #include <string_view>
 #include <vector>
 
+#include <algorithm>
+#include <cmath>
+
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/spawn.hpp>
 
@@ -23,6 +26,7 @@
 #include "neorados/cls/fifo.h"
 
 #include "rgw_log_backing.h"
+#include "rgw_bucket_layout.h"
 
 class RGWSI_BucketIndex_RADOS;
 
@@ -30,27 +34,47 @@ namespace asio = boost::asio;
 namespace fifo = neorados::cls::fifo;
 using ceph::containers::tiny_vector;
 
-// FIFO OID for a given index shard OID "<shard_oid>.bilog"
-// e.g. ".dir.{bucket_id}.{gen}.{shard_id}.bilog"
-inline std::string bilog_fifo_oid(std::string_view shard_oid)
+// build a bilog FIFO OID with format: "{bucket_id}.{log_gen}.{shard_id}.bilog".
+inline std::string bilog_fifo_oid(std::string_view bucket_id,
+                                   uint64_t log_gen,
+                                   int shard_id)
 {
-  return std::string{shard_oid} + ".bilog";
+  return std::string{bucket_id} + '.' +
+         std::to_string(log_gen) + '.' +
+         std::to_string(shard_id) + ".bilog";
 }
 
-// per-bucket FIFO bilog: one LazyFIFO per index shard, stored in the same
-// RADOS pool as the bucket index, with OID = <shard_oid>.bilog.
-//
-// callers obtain shard_oids from open_bucket_index() and pass them to the
-// constructor. The shard count and gen are recorded in bucket_log_layout
-// (field 'in_index') so that trim/list can reconstruct the OIDs later.
+// compute an appropriate number of bilog shards for a given index shard count
+// upon reshard. uses logarithmic formula to keep the bilog shard count much lower,
+// growing slowly every time index shards double, bilog gets 2 more shards.
+// typically ranges from 7 to 21 across the default index max shards 11 to 1999 shards.
+inline uint32_t bilog_shards_for_index(uint32_t index_shards,
+                                       uint32_t min_shards = 7,
+                                       uint32_t max_shards = 0)
+{
+  if (index_shards == 0) {
+    return min_shards;
+  }
+  auto v = static_cast<uint32_t>(std::log2(index_shards) * 2.0);
+  v = std::max(v, min_shards);
+  if (max_shards > 0) {
+    v = std::min(v, max_shards);
+  }
+  return v;
+}
+
+// per-bucket FIFO bilog: one LazyFIFO per bilog shard, stored in the log pool.
+
+// shard count is recorded in bucket_log_layout_generation::layout::fifo::num_shards.
 class RGWBILogFIFO {
   tiny_vector<LazyFIFO> fifos;
 
 public:
-  // fifos[i] will use OID bilog_fifo_oid(shard_oids[i]).
   RGWBILogFIFO(neorados::RADOS rados,
-               const neorados::IOContext& loc,
-               std::span<const std::string> shard_oids);
+               const neorados::IOContext& log_pool,
+               std::string_view bucket_id,
+               uint64_t log_gen,
+               uint32_t num_shards);
 
   int num_shards() const {
     return static_cast<int>(fifos.size());

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -63,8 +63,18 @@ inline uint32_t bilog_shards_for_index(uint32_t index_shards,
   return v;
 }
 
-// per-bucket FIFO bilog: one LazyFIFO per bilog shard, stored in the log pool.
+inline rgw::bucket_log_layout_generation fifo_log_layout_from_index(
+    uint64_t gen, const rgw::bucket_index_layout_generation& index)
+{
+  rgw::bucket_log_layout_generation log;
+  log.gen = gen;
+  log.layout.type = rgw::BucketLogType::FIFO;
+  log.layout.in_index = {index.gen, index.layout.normal};
+  log.layout.fifo.num_shards = bilog_shards_for_index(index.layout.normal.num_shards);
+  return log;
+}
 
+// per-bucket FIFO bilog: one LazyFIFO per bilog shard, stored in the log pool.
 // shard count is recorded in bucket_log_layout_generation::layout::fifo::num_shards.
 class RGWBILogFIFO {
   tiny_vector<LazyFIFO> fifos;

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -15,6 +15,8 @@
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/spawn.hpp>
 
+#include <fmt/format.h>
+
 #include "include/neorados/RADOS.hpp"
 #include "include/buffer.h"
 
@@ -39,9 +41,7 @@ inline std::string bilog_fifo_oid(std::string_view bucket_id,
                                    uint64_t log_gen,
                                    int shard_id)
 {
-  return std::string{bucket_id} + '.' +
-         std::to_string(log_gen) + '.' +
-         std::to_string(shard_id) + ".bilog";
+  return fmt::format("{}.{}.{}.bilog", bucket_id, log_gen, shard_id);
 }
 
 // per-bucket FIFO bilog: one LazyFIFO per bilog shard, stored in the log pool.

--- a/src/rgw/driver/rados/rgw_bilog.h
+++ b/src/rgw/driver/rados/rgw_bilog.h
@@ -44,36 +44,6 @@ inline std::string bilog_fifo_oid(std::string_view bucket_id,
          std::to_string(shard_id) + ".bilog";
 }
 
-// compute an appropriate number of bilog shards for a given index shard count
-// upon reshard. uses logarithmic formula to keep the bilog shard count much lower,
-// growing slowly every time index shards double, bilog gets 2 more shards.
-// typically ranges from 7 to 21 across the default index max shards 11 to 1999 shards.
-inline uint32_t bilog_shards_for_index(uint32_t index_shards,
-                                       uint32_t min_shards = 7,
-                                       uint32_t max_shards = 0)
-{
-  if (index_shards == 0) {
-    return min_shards;
-  }
-  auto v = static_cast<uint32_t>(std::log2(index_shards) * 2.0);
-  v = std::max(v, min_shards);
-  if (max_shards > 0) {
-    v = std::min(v, max_shards);
-  }
-  return v;
-}
-
-inline rgw::bucket_log_layout_generation fifo_log_layout_from_index(
-    uint64_t gen, const rgw::bucket_index_layout_generation& index)
-{
-  rgw::bucket_log_layout_generation log;
-  log.gen = gen;
-  log.layout.type = rgw::BucketLogType::FIFO;
-  log.layout.in_index = {index.gen, index.layout.normal};
-  log.layout.fifo.num_shards = bilog_shards_for_index(index.layout.normal.num_shards);
-  return log;
-}
-
 // per-bucket FIFO bilog: one LazyFIFO per bilog shard, stored in the log pool.
 // shard count is recorded in bucket_log_layout_generation::layout::fifo::num_shards.
 class RGWBILogFIFO {

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3027,7 +3027,18 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
   }
 
   if (layout.current_index.layout.type == rgw::BucketIndexType::Normal) {
-    layout.logs.push_back(log_layout_from_index(0, layout.current_index));
+    const bool use_fifo =
+      (cct->_conf.get_val<std::string>("rgw_default_bucket_bilog_type") == "fifo");
+    if (use_fifo) {
+      rgw::bucket_log_layout_generation fifo_log;
+      fifo_log.gen = 0;
+      fifo_log.layout.type = rgw::BucketLogType::FIFO;
+      fifo_log.layout.in_index = {layout.current_index.gen,
+                                  layout.current_index.layout.normal};
+      layout.logs.push_back(fifo_log);
+    } else {
+      layout.logs.push_back(log_layout_from_index(0, layout.current_index));
+    }
   }
 }
 

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3009,6 +3009,7 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
 				const RGWZone& zone,
 				std::optional<rgw::BucketIndexType> type,
 				std::optional<uint32_t> shards) {
+
   layout.current_index.gen = 0;
   layout.current_index.layout.normal.hash_type = rgw::BucketHashType::Mod;
 
@@ -3030,12 +3031,7 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
     const bool use_fifo =
       (cct->_conf.get_val<std::string>("rgw_default_bucket_bilog_type") == "fifo");
     if (use_fifo) {
-      rgw::bucket_log_layout_generation fifo_log;
-      fifo_log.gen = 0;
-      fifo_log.layout.type = rgw::BucketLogType::FIFO;
-      fifo_log.layout.in_index = {layout.current_index.gen,
-                                  layout.current_index.layout.normal};
-      layout.logs.push_back(fifo_log);
+      layout.logs.push_back(fifo_log_layout_from_index(0, layout.current_index));
     } else {
       layout.logs.push_back(log_layout_from_index(0, layout.current_index));
     }

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3058,6 +3058,7 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
 				const RGWZone& zone,
 				std::optional<rgw::BucketIndexType> type,
 				std::optional<uint32_t> shards) {
+
   layout.current_index.gen = 0;
   layout.current_index.layout.normal.hash_type = rgw::BucketHashType::Mod;
 
@@ -3079,12 +3080,7 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
     const bool use_fifo =
       (cct->_conf.get_val<std::string>("rgw_default_bucket_bilog_type") == "fifo");
     if (use_fifo) {
-      rgw::bucket_log_layout_generation fifo_log;
-      fifo_log.gen = 0;
-      fifo_log.layout.type = rgw::BucketLogType::FIFO;
-      fifo_log.layout.in_index = {layout.current_index.gen,
-                                  layout.current_index.layout.normal};
-      layout.logs.push_back(fifo_log);
+      layout.logs.push_back(fifo_log_layout_from_index(0, layout.current_index));
     } else {
       layout.logs.push_back(log_layout_from_index(0, layout.current_index));
     }

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3076,7 +3076,18 @@ void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
   }
 
   if (layout.current_index.layout.type == rgw::BucketIndexType::Normal) {
-    layout.logs.push_back(log_layout_from_index(0, layout.current_index));
+    const bool use_fifo =
+      (cct->_conf.get_val<std::string>("rgw_default_bucket_bilog_type") == "fifo");
+    if (use_fifo) {
+      rgw::bucket_log_layout_generation fifo_log;
+      fifo_log.gen = 0;
+      fifo_log.layout.type = rgw::BucketLogType::FIFO;
+      fifo_log.layout.in_index = {layout.current_index.gen,
+                                  layout.current_index.layout.normal};
+      layout.logs.push_back(fifo_log);
+    } else {
+      layout.logs.push_back(log_layout_from_index(0, layout.current_index));
+    }
   }
 }
 

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3139,7 +3139,7 @@ int RGWBucketInstanceMetadataHandler::put_prepare(
     const auto& log = bci.info.layout.logs.back();
     if (bci.info.bucket_deleted() && log.layout.type != rgw::BucketLogType::Deleted) {
       const auto index_log = bci.info.layout.logs.back();
-      const int shards_num = rgw::num_shards(index_log.layout.in_index);
+      const int shards_num = rgw::num_shards(index_log);
       bci.info.layout.logs.push_back({log.gen+1, {rgw::BucketLogType::Deleted}});
       ldpp_dout(dpp, 10) << "store log layout type: " <<  bci.info.layout.logs.back().layout.type << dendl;
       for (int i = 0; i < shards_num; ++i) {

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -3776,7 +3776,10 @@ public:
 	    no_zero = true;
 	  } else if (auto& log = source_info.layout.logs.front();
                      log.layout.type != rgw::BucketLogType::InIndex) {
-	    ldpp_dout(dpp, 20) << "unrecognized log layout type when checking compatibility " << log.layout.type << dendl;
+      // The InIndex backward-compatibility check only applies to InIndex logs.
+	    ldpp_dout(dpp, 20) << "log gen=0 backend is " << log.layout.type
+			    << "; skipping InIndex backward-compatibility check"
+			    << dendl;
 	    no_zero = true;
 	  }
 	  if (!no_zero) {

--- a/src/rgw/driver/rados/rgw_log_backing.cc
+++ b/src/rgw/driver/rados/rgw_log_backing.cc
@@ -170,7 +170,7 @@ asio::awaitable<void> log_remove(
   neorados::RADOS rados,
   const neorados::IOContext& loc,
   int shards,
-  const fu2::unique_function<std::string(int) const>& get_oid,
+  fu2::unique_function<std::string(int) const> get_oid,
   bool leave_zero)
 {
   sys::error_code ec;

--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -305,19 +305,37 @@ public:
   LazyFIFO(neorados::RADOS r,  std::string oid, neorados::IOContext loc)
     : r(r), oid(std::move(oid)), loc(std::move(loc)) {}
 
+  // push a batch of entries (awaitable)
   asio::awaitable<void> push(const DoutPrefixProvider *dpp,
 			     std::deque<ceph::buffer::list> entries) {
     co_await lazy_init(dpp);
     co_return co_await fifo->push(dpp, std::move(entries), asio::use_awaitable);
   }
 
+  // push a single entry (awaitable)
+  asio::awaitable<void> push(const DoutPrefixProvider *dpp,
+			     ceph::buffer::list entry) {
+    co_await lazy_init(dpp);
+    co_return co_await fifo->push(dpp, std::move(entry), asio::use_awaitable);
+  }
+
+  // push a single entry (yield_context)
   void push(const DoutPrefixProvider *dpp,
-			     ceph::buffer::list entry,
-			     asio::yield_context y) {
+	    ceph::buffer::list entry,
+	    asio::yield_context y) {
     lazy_init(dpp, y);
     fifo->push(dpp, std::move(entry), y);
   }
 
+  // push a batch of entries (yield_context)
+  void push(const DoutPrefixProvider *dpp,
+	    std::deque<ceph::buffer::list> entries,
+	    asio::yield_context y) {
+    lazy_init(dpp, y);
+    fifo->push(dpp, std::move(entries), y);
+  }
+
+  // list entries (awaitable)
   asio::awaitable<std::tuple<std::span<fifo::entry>, std::optional<std::string>>>
   list(const DoutPrefixProvider *dpp, std::string markstr,
        std::span<fifo::entry> entries) {
@@ -325,10 +343,27 @@ public:
     co_return co_await fifo->list(dpp, markstr, entries, asio::use_awaitable);
   }
 
+  // list entries (yield_context)
+  std::tuple<std::span<fifo::entry>, std::optional<std::string>>
+  list(const DoutPrefixProvider *dpp, std::string markstr,
+       std::span<fifo::entry> entries, asio::yield_context y) {
+    lazy_init(dpp, y);
+    return fifo->list(dpp, markstr, entries, y);
+  }
+
+  // trim up to markstr (awaitable)
   asio::awaitable<void> trim(const DoutPrefixProvider *dpp,
 			     std::string markstr, bool exclusive) {
     co_await lazy_init(dpp);
     co_return co_await fifo->trim(dpp, markstr, exclusive, asio::use_awaitable);
+  }
+
+  // trim up to markstr (yield_context)
+  void trim(const DoutPrefixProvider *dpp,
+	    std::string markstr, bool exclusive,
+	    asio::yield_context y) {
+    lazy_init(dpp, y);
+    fifo->trim(dpp, markstr, exclusive, y);
   }
 
   asio::awaitable<std::tuple<std::string, ceph::real_time>>

--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -371,4 +371,10 @@ public:
     co_await lazy_init(dpp);
     co_return co_await fifo->last_entry_info(dpp, asio::use_awaitable);
   }
+
+  std::tuple<std::string, ceph::real_time>
+  last_entry_info(const DoutPrefixProvider *dpp, asio::yield_context y) {
+    lazy_init(dpp, y);
+    return fifo->last_entry_info(dpp, y);
+  }
 };

--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -305,7 +305,6 @@ public:
   LazyFIFO(neorados::RADOS r,  std::string oid, neorados::IOContext loc)
     : r(r), oid(std::move(oid)), loc(std::move(loc)) {}
 
-  // push a batch of entries (awaitable)
   asio::awaitable<void> push(const DoutPrefixProvider *dpp,
 			     std::deque<ceph::buffer::list> entries) {
     co_await lazy_init(dpp);
@@ -340,7 +339,11 @@ public:
   list(const DoutPrefixProvider *dpp, std::string markstr,
        std::span<fifo::entry> entries) {
     co_await lazy_init(dpp);
-    co_return co_await fifo->list(dpp, markstr, entries, asio::use_awaitable);
+    auto [cur, next] = co_await fifo->list(dpp, markstr, entries,
+                                           asio::use_awaitable);
+    co_return std::tuple{cur, next.empty()
+                              ? std::nullopt
+                              : std::optional<std::string>{std::move(next)}};
   }
 
   // list entries (yield_context)
@@ -348,7 +351,10 @@ public:
   list(const DoutPrefixProvider *dpp, std::string markstr,
        std::span<fifo::entry> entries, asio::yield_context y) {
     lazy_init(dpp, y);
-    return fifo->list(dpp, markstr, entries, y);
+    auto [cur, next] = fifo->list(dpp, markstr, entries, y);
+    return {cur, next.empty()
+                 ? std::nullopt
+                 : std::optional<std::string>{std::move(next)}};
   }
 
   // trim up to markstr (awaitable)

--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -86,7 +86,7 @@ asio::awaitable<void> log_remove(
   neorados::RADOS rados,
   const neorados::IOContext& loc,
   int shards,
-  const fu2::unique_function<std::string(int) const>& get_oid,
+  fu2::unique_function<std::string(int) const> get_oid,
   bool leave_zero);
 
 struct logback_generation {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9403,7 +9403,7 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
                        << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
     bilog.add_maybe_flush(committed_epoch, key, op_tag, delete_marker,
-                          meta ? meta->mtime : ceph::real_time{}, zones_trace);
+                          meta ? meta->mtime : ceph::real_clock::now(), zones_trace);
     int r = bilog.flush(y);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9500,7 +9500,7 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
         }
         ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
                            << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
-        bilog.add_maybe_flush(committed_epoch, ceph::real_time{}, op_issuer);
+        bilog.add_maybe_flush(committed_epoch, ceph::real_clock::now(), op_issuer);
         int r = bilog.flush(y);
         if (r < 0) {
           ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9862,28 +9862,6 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": could not apply olh update to oid \"" << ref.obj.oid << "\", r=" << r << dendl;
     }
     return r;
-  }
-
-  // OLH xattr update committed. now record the FIFO bilog entry.
-  if (need_to_link) {
-    rgw_zone_set zt;
-    if (zones_trace) {
-      zt = *zones_trace;
-    }
-    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
-    int bilog_r = 0;
-    // with_bilog<void> always returns 0; capture the flush error via bilog_r.
-    with_bilog<void>(dpp, [&](auto& bilog_handler) {
-      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
-                                    delete_marker, state.mtime, zt);
-      bilog_r = bilog_handler.flush(y);
-    }, bucket_info, log_op);
-    if (bilog_r < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: " << __func__
-                        << ": failed to flush bilog entry for " << key
-                        << ": " << cpp_strerror(bilog_r) << dendl;
-      return bilog_r;
-    }
   }
 
   if (need_to_remove) {
@@ -11087,9 +11065,16 @@ int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
     dpp,
     [&](auto& op_issuer, auto& bilog_handler) {
       // Record the bilog entry (into FIFO, or NOP for InIndex) before the CLS op.
+      rgw_bucket_dir_entry bilog_ent = ent;
+      bilog_ent.ver = ver;
       bilog_handler.add_maybe_flush(
-        epoch, ent.meta.mtime,
-        static_cast<const cls_rgw_bi_log_related_op&>(op_issuer));
+        op_issuer.op, bilog_ent, zones_trace);
+      int flush_r = bilog_handler.flush(null_yield);
+      if (flush_r < 0) {
+        ldout_bitx_c(bitx, cct, 0) << "ERROR: " << __func__
+            << ": failed to flush bilog entry: " << cpp_strerror(flush_r) << dendl_bitx;
+        return flush_r;
+      }
 
       ObjectWriteOperation o;
       o.assert_exists(); // bucket index shard must exist

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9355,24 +9355,41 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     // issue the cls op first. only push to the FIFO on success so that a
     // crash between the cls op and the FIFO push leaves the secondary behind
     // rather than ahead with a diverged OLH pointer
+    //
+    // CLS returns the epoch it committed in the output bufferlist. use that
+    // to record the same epoch in the FIFO bilog entry
+    bufferlist epoch_out_bl;
     int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
 	              [&](BucketShard *bs) -> int {
 	                auto& ref = bs->bucket_obj;
 	                librados::ObjectWriteOperation op;
 	                op.assert_exists(); // bucket index shard must exist
 	                cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+	                epoch_out_bl.clear();
 	                op_issuer.link_olh(op, olh_state.olh_tag, delete_marker,
 	                                   meta, olh_epoch, unmod_since,
-	                                   high_precision_time);
+	                                   high_precision_time, &epoch_out_bl);
 	                return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
-	                                        std::move(op), y);
+	                                        std::move(op), y,
+	                                        librados::OPERATION_RETURNVEC);
 	              }, y);
     if (ret < 0) {
       ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
       return ret;
     }
-    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
-                          ceph::real_time{}, zones_trace);
+
+    uint64_t committed_epoch = olh_epoch;
+    try {
+      auto iter = epoch_out_bl.cbegin();
+      decode(committed_epoch, iter);
+    } catch (const ceph::buffer::error&) {
+      ldpp_dout(dpp, 0) << "WARNING: " << __func__
+                        << ": failed to decode committed epoch from link_olh response" << dendl;
+    }
+    ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
+                       << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
+    bilog.add_maybe_flush(committed_epoch, key, op_tag, delete_marker,
+                          meta ? meta->mtime : ceph::real_time{}, zones_trace);
     int r = bilog.flush(y);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9439,22 +9456,36 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
       [&](auto& op_issuer, auto& bilog) -> int {
         // cls op first, FIFO push on success only (same as
         // bucket_index_link_olh to avoid secondary OLH pointer divergence).
+        bufferlist epoch_out_bl;
         int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
               [&](BucketShard *bs) -> int {
                 auto& ref = bs->bucket_obj;
                 librados::ObjectWriteOperation op;
                 op.assert_exists(); // bucket index shard must exist
                 cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-                op_issuer.unlink_instance(op, olh_tag, olh_epoch);
+                epoch_out_bl.clear();
+                op_issuer.unlink_instance(op, olh_tag, olh_epoch, &epoch_out_bl);
                 return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
-                                        std::move(op), y);
+                                        std::move(op), y,
+                                        librados::OPERATION_RETURNVEC);
               }, y);
         if (ret < 0) {
           ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
           return ret;
         }
 
-        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        uint64_t committed_epoch = olh_epoch;
+        try {
+          auto iter = epoch_out_bl.cbegin();
+          decode(committed_epoch, iter);
+        } catch (const ceph::buffer::error&) {
+          ldpp_dout(dpp, 0) << "WARNING: " << __func__
+                            << ": failed to decode committed epoch from unlink_instance response"
+                            << dendl;
+        }
+        ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
+                           << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
+        bilog.add_maybe_flush(committed_epoch, ceph::real_time{}, op_issuer);
         int r = bilog.flush(y);
         if (r < 0) {
           ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9753,6 +9784,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
           need_to_link = true;
           need_to_remove = false;
           key = entry.key;
+          link_epoch = entry.epoch;
           delete_marker = entry.delete_marker;
           link_op_tag = entry.op_tag;
         } else {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -831,13 +831,22 @@ int RGWRados::get_max_chunk_size(const rgw_placement_rule& placement_rule, const
 [[nodiscard]] int add_datalog_entry(const DoutPrefixProvider* dpp,
 				    RGWDataChangesLog* datalog,
 				    const RGWBucketInfo& bucket_info,
+				    const std::string& hash_key,
 				    uint32_t shard_id, optional_yield y)
 {
   const auto& logs = bucket_info.layout.logs;
   if (logs.empty()) {
     return 0;
   }
-  int r = datalog->add_entry(dpp, bucket_info, logs.back(), shard_id, y);
+  const auto& log = logs.back();
+  int effective_shard;
+  if (log.layout.type == rgw::BucketLogType::FIFO) {
+    effective_shard = RGWSI_BucketIndex_RADOS::bucket_shard_index(
+        hash_key, log.layout.fifo.num_shards);
+  } else {
+    effective_shard = shard_id;
+  }
+  int r = datalog->add_entry(dpp, bucket_info, log, effective_shard, y);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
   }
@@ -1024,8 +1033,8 @@ void RGWIndexCompletionManager::process()
         /* this null_yield can stay for now since we're in our own
          * thread */
         std::ignore = add_datalog_entry(&dpp, store->svc.datalog_rados,
-                                        bucket_info, bs.shard_id,
-                                        null_yield);
+                                        bucket_info, c->obj.get_hash_object(),
+                                        bs.shard_id, null_yield);
         /* if there is an error we can ignore it, as a) there's
          * nothing we can do and b) it's already logged in
          * add_datalog_entry */
@@ -6913,7 +6922,9 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y,
 
     if (add_log) {
       r = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->get_bucket_info(), bs->shard_id, y);
+			    target->get_bucket_info(),
+			    target->get_obj().get_hash_object(),
+			    bs->shard_id, y);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "failed to write datalog for object: r=" << r << dendl;
         return r;
@@ -8443,7 +8454,8 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, obj.get_hash_object(),
+			    bs->shard_id, y);
   }
 
   return ret;
@@ -8476,7 +8488,8 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, obj.get_hash_object(),
+			    bs->shard_id, y);
   }
 
   return ret;
@@ -8510,7 +8523,8 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
      * have no way to tell that they're all caught up
      */
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, obj.get_hash_object(),
+			    bs->shard_id, y);
   }
 
   return ret;
@@ -9416,7 +9430,8 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
   }
 
   if (log_data_change) {
-    r = add_datalog_entry(dpp, svc.datalog_rados, bucket_info, bs.shard_id, y);
+    r = add_datalog_entry(dpp, svc.datalog_rados, bucket_info,
+                          obj_instance.get_hash_object(), bs.shard_id, y);
   }
 
   return r;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -8450,7 +8450,7 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
 
   ret = store->cls_obj_complete_add(dpp, target->bucket_info, *bs, obj, optag,
                                     poolid, epoch, ent, category,
-                                    remove_objs, bilog_flags, zones_trace,
+                                    remove_objs, bilog_flags, y, zones_trace,
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
@@ -8484,7 +8484,7 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
 
   ret = store->cls_obj_complete_del(dpp, target->bucket_info, *bs, optag,
                                     poolid, epoch, obj, removed_mtime,
-                                    remove_objs, bilog_flags, zones_trace,
+                                    remove_objs, bilog_flags, y, zones_trace,
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
@@ -8512,7 +8512,7 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
   int ret = guard_reshard(dpp, obj, &bs, [&](BucketShard *bs) -> int {
 				 return store->cls_obj_complete_cancel(dpp, target->bucket_info,
 				                                       *bs, optag, obj, remove_objs,
-				                                       bilog_flags, zones_trace,
+				                                       bilog_flags, y, zones_trace,
 				                                       log_op);
 			       }, y);
 
@@ -11037,7 +11037,7 @@ int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
                                   int64_t pool, uint64_t epoch,
                                   rgw_bucket_dir_entry& ent, RGWObjCategory category,
                                   list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
-                                  rgw_zone_set* _zones_trace, bool log_op)
+                                  optional_yield y, rgw_zone_set* _zones_trace, bool log_op)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
   ldout_bitx_c(bitx, cct, 10) << "ENTERING " << __func__ << ": bucket-shard=" << bs <<
@@ -11069,7 +11069,7 @@ int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
       bilog_ent.ver = ver;
       bilog_handler.add_maybe_flush(
         op_issuer.op, bilog_ent, zones_trace);
-      int flush_r = bilog_handler.flush(null_yield);
+      int flush_r = bilog_handler.flush(y);
       if (flush_r < 0) {
         ldout_bitx_c(bitx, cct, 0) << "ERROR: " << __func__
             << ": failed to flush bilog entry: " << cpp_strerror(flush_r) << dendl_bitx;
@@ -11104,17 +11104,17 @@ template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD
     const DoutPrefixProvider*, const RGWBucketInfo&,
     BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
     rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
-    uint16_t, rgw_zone_set*, bool);
+    uint16_t, optional_yield, rgw_zone_set*, bool);
 template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
     const DoutPrefixProvider*, const RGWBucketInfo&,
     BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
     rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
-    uint16_t, rgw_zone_set*, bool);
+    uint16_t, optional_yield, rgw_zone_set*, bool);
 template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
     const DoutPrefixProvider*, const RGWBucketInfo&,
     BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
     rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
-    uint16_t, rgw_zone_set*, bool);
+    uint16_t, optional_yield, rgw_zone_set*, bool);
 
 int RGWRados::cls_obj_complete_add(const DoutPrefixProvider* dpp,
                                    const RGWBucketInfo& bucket_info,
@@ -11122,11 +11122,11 @@ int RGWRados::cls_obj_complete_add(const DoutPrefixProvider* dpp,
                                    int64_t pool, uint64_t epoch,
                                    rgw_bucket_dir_entry& ent, RGWObjCategory category,
                                    list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
-                                   rgw_zone_set* zones_trace, bool log_op)
+                                   optional_yield y, rgw_zone_set* zones_trace, bool log_op)
 {
   return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>>(
     dpp, bucket_info, bs, obj, tag, pool, epoch,
-    ent, category, remove_objs, bilog_flags, zones_trace, log_op);
+    ent, category, remove_objs, bilog_flags, y, zones_trace, log_op);
 }
 
 int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
@@ -11136,7 +11136,7 @@ int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
                                    rgw_obj& obj,
                                    real_time& removed_mtime,
                                    list<rgw_obj_index_key>* remove_objs,
-                                   uint16_t bilog_flags,
+                                   uint16_t bilog_flags, optional_yield y,
                                    rgw_zone_set* zones_trace,
                                    bool log_op)
 {
@@ -11145,14 +11145,14 @@ int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
   obj.key.get_index_key(&ent.key);
   return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
     dpp, bucket_info, bs, obj, tag, pool, epoch,
-    ent, RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
+    ent, RGWObjCategory::None, remove_objs, bilog_flags, y, zones_trace, log_op);
 }
 
 int RGWRados::cls_obj_complete_cancel(const DoutPrefixProvider* dpp,
                                       const RGWBucketInfo& bucket_info,
                                       BucketShard& bs, string& tag, rgw_obj& obj,
                                       list<rgw_obj_index_key>* remove_objs,
-                                      uint16_t bilog_flags,
+                                      uint16_t bilog_flags, optional_yield y,
                                       rgw_zone_set* zones_trace, bool log_op)
 {
   rgw_bucket_dir_entry ent;
@@ -11160,7 +11160,7 @@ int RGWRados::cls_obj_complete_cancel(const DoutPrefixProvider* dpp,
   return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
     dpp, bucket_info, bs, obj, tag,
     -1 /* pool id */, 0, ent,
-    RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
+    RGWObjCategory::None, remove_objs, bilog_flags, y, zones_trace, log_op);
 }
 
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -98,6 +98,7 @@
 #include "services/svc_sys_obj_cache.h"
 #include "services/svc_bucket.h"
 #include "services/svc_mdlog.h"
+#include "services/svc_bilog_rados.h"
 
 #include "compressor/Compressor.h"
 
@@ -10867,6 +10868,48 @@ int RGWRados::cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs,
   int ret = bs.bucket_obj.operate(dpp, std::move(o), y);
   ldout_bitx(bitx, dpp, 10) << "EXITING " << __func__ << ": ret=" << ret << dendl_bitx;
   return ret;
+}
+
+// bilog batch factory
+RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
+    const DoutPrefixProvider* dpp,
+    const RGWBucketInfo& bucket_info)
+{
+  ceph_assert(!bucket_info.layout.logs.empty());
+  const auto& log_layout = bucket_info.layout.logs.back();
+  ceph_assert(log_layout.layout.type == rgw::BucketLogType::FIFO);
+
+  const auto& index_layout = rgw::log_to_index_layout(log_layout);
+
+  librados::IoCtx index_pool;
+  std::map<int, std::string> bucket_objs;
+  int r = svc.bi_rados->open_bucket_index(
+      dpp, bucket_info, std::nullopt, index_layout,
+      &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                      << ": open_bucket_index failed for "
+                      << bucket_info.bucket << ": " << cpp_strerror(r) << dendl;
+    // TODO: The proper fix is to change
+    // with_bilog<> to check for failure before invoking the lambda, but that
+    // requires reworking the template signature.  For now, return a zero-shard
+    // batch: callers can call add_maybe_flush/flush safely (pending stays
+    // empty), but any bilog entries for this operation will be silently
+    // dropped.  The ERROR log above ensures this is always visible.
+    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+                               neorados::IOContext{}, {});
+  }
+
+  // conversion to ordered vector.
+  std::vector<std::string> shard_oids;
+  shard_oids.reserve(bucket_objs.size());
+  for (auto& [/*shard_id*/_, oid] : bucket_objs) {
+    shard_oids.push_back(oid);
+  }
+
+  neorados::IOContext neo_loc(index_pool.get_id());
+  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+                             std::move(neo_loc), shard_oids);
 }
 
 int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, string& tag,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -8435,9 +8435,12 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
   ent.meta.restore_status = restore_status;
   ent.meta.restore_expiry_date = restore_expiry_date;
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  const bool add_log = log_op && store->svc.zone->need_to_log_data();
 
-  ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace, add_log);
+  ret = store->cls_obj_complete_add(dpp, target->bucket_info, *bs, obj, optag,
+                                    poolid, epoch, ent, category,
+                                    remove_objs, bilog_flags, zones_trace,
+                                    log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
 			    target->bucket_info, bs->shard_id, y);
@@ -8465,10 +8468,12 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  const bool add_log = log_op && store->svc.zone->need_to_log_data();
 
-  ret = store->cls_obj_complete_del(*bs, optag, poolid, epoch, obj, removed_mtime, remove_objs, bilog_flags, zones_trace, add_log);
-
+  ret = store->cls_obj_complete_del(dpp, target->bucket_info, *bs, optag,
+                                    poolid, epoch, obj, removed_mtime,
+                                    remove_objs, bilog_flags, zones_trace,
+                                    log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
 			    target->bucket_info, bs->shard_id, y);
@@ -8489,10 +8494,13 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
   RGWRados *store = target->get_store();
   BucketShard *bs;
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  const bool add_log = log_op && store->svc.zone->need_to_log_data();
 
   int ret = guard_reshard(dpp, obj, &bs, [&](BucketShard *bs) -> int {
-				 return store->cls_obj_complete_cancel(*bs, optag, obj, remove_objs, bilog_flags, zones_trace, add_log);
+				 return store->cls_obj_complete_cancel(dpp, target->bucket_info,
+				                                       *bs, optag, obj, remove_objs,
+				                                       bilog_flags, zones_trace,
+				                                       log_op);
 			       }, y);
 
   if (add_log) {
@@ -9340,22 +9348,43 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
   zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
 
   BucketShard bs(this);
+  cls_rgw_obj_key key(obj_instance.key.get_index_key_name(),
+                      obj_instance.key.instance);
 
-  r = guard_reshard(dpp, &bs, obj_instance, bucket_info,
-		    [&](BucketShard *bs) -> int {
-		      cls_rgw_obj_key key(obj_instance.key.get_index_key_name(), obj_instance.key.instance);
-		      auto& ref = bs->bucket_obj;
-		      librados::ObjectWriteOperation op;
-		      op.assert_exists(); // bucket index shard must exist
-		      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-		      cls_rgw_bucket_link_olh(op, key, olh_state.olh_tag,
-                                              delete_marker, op_tag, meta, olh_epoch,
-					      unmod_since, high_precision_time,
-					      log_data_change, zones_trace);
-                      return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), y);
-                    }, y);
+  auto do_op = [&](auto& op_issuer, auto& bilog) -> int {
+    int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
+	              [&](BucketShard *bs) -> int {
+	                auto& ref = bs->bucket_obj;
+	                librados::ObjectWriteOperation op;
+	                op.assert_exists(); // bucket index shard must exist
+	                cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+	                op_issuer.link_olh(op, olh_state.olh_tag, delete_marker,
+	                                   meta, olh_epoch, unmod_since,
+	                                   high_precision_time);
+	                return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
+	                                        std::move(op), y);
+	              }, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
+      return ret;
+    }
+    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
+                          ceph::real_time{}, zones_trace);
+    return 0;
+  };
+
+  if (delete_marker) {
+    r = with_bilog<CLSRGWLinkOLH<true>>(dpp, do_op, bucket_info,
+                                        log_data_change,
+                                        key, op_tag, &zones_trace,
+                                        static_cast<uint16_t>(RGW_BILOG_FLAG_VERSIONED_OP));
+  } else {
+    r = with_bilog<CLSRGWLinkOLH<false>>(dpp, do_op, bucket_info,
+                                         log_data_change,
+                                         key, op_tag, &zones_trace,
+                                         static_cast<uint16_t>(RGW_BILOG_FLAG_VERSIONED_OP));
+  }
   if (r < 0) {
-    ldpp_dout(dpp, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_olh() returned r=" << r << dendl;
     return r;
   }
 
@@ -9394,19 +9423,32 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
 
   BucketShard bs(this);
 
-  cls_rgw_obj_key key(obj_instance.key.get_index_key_name(), obj_instance.key.instance);
-  r = guard_reshard(dpp, &bs, obj_instance, bucket_info,
-		    [&](BucketShard *bs) -> int {
-		      auto& ref = bs->bucket_obj;
-		      librados::ObjectWriteOperation op;
-		      op.assert_exists(); // bucket index shard must exist
-		      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-		      cls_rgw_bucket_unlink_instance(op, key, op_tag,
-						     olh_tag, olh_epoch, log_op, bilog_flags, zones_trace);
-                      return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), y);
-                    }, y);
+  cls_rgw_obj_key key(obj_instance.key.get_index_key_name(),
+                        obj_instance.key.instance);
+  r = with_bilog<CLSRGWUnlinkInstance>(dpp,
+      [&](auto& op_issuer, auto& bilog) -> int {
+        int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
+              [&](BucketShard *bs) -> int {
+                auto& ref = bs->bucket_obj;
+                librados::ObjectWriteOperation op;
+                op.assert_exists(); // bucket index shard must exist
+                cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+                op_issuer.unlink_instance(op, olh_tag, olh_epoch);
+                return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
+                                        std::move(op), y);
+              }, y);
+        if (ret < 0) {
+          ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
+          return ret;
+        }
+        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        return 0;
+      },
+      bucket_info,
+      log_op,
+      key, op_tag, &zones_trace, bilog_flags);
   if (r < 0) {
-    ldpp_dout(dpp, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_instance() returned r=" << r << dendl;
+    ldpp_dout(dpp, 20) << "rgw_rados_operate() after unlink_instance() returned r=" << r << dendl;
     return r;
   }
 
@@ -10896,7 +10938,7 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     // batch: callers can call add_maybe_flush/flush safely (pending stays
     // empty), but any bilog entries for this operation will be silently
     // dropped.  The ERROR log above ensures this is always visible.
-    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+    return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
                                neorados::IOContext{}, {});
   }
 
@@ -10908,25 +10950,25 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   }
 
   neorados::IOContext neo_loc(index_pool.get_id());
-  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+  return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
                              std::move(neo_loc), shard_oids);
 }
 
-int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, string& tag,
+template <class CLSRGWBucketModifyOpT>
+int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
+                                  const RGWBucketInfo& bucket_info,
+                                  BucketShard& bs, const rgw_obj& obj, string& tag,
                                   int64_t pool, uint64_t epoch,
                                   rgw_bucket_dir_entry& ent, RGWObjCategory category,
-                                  list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                                  rgw_zone_set *_zones_trace, bool log_op)
+                                  list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
+                                  rgw_zone_set* _zones_trace, bool log_op)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
   ldout_bitx_c(bitx, cct, 10) << "ENTERING " << __func__ << ": bucket-shard=" << bs <<
-    " obj=" << obj << " tag=" << tag << " op=" << op <<
+    " obj=" << obj << " tag=" << tag <<
     ", remove_objs=" << (remove_objs ? *remove_objs : std::list<rgw_obj_index_key>()) <<
     ", log_op=" << log_op << dendl_bitx;
   ldout_bitx_c(bitx, cct, 25) << "BACKTRACE: " << __func__ << ": " << ClibBackTrace(0) << dendl_bitx;
-
-  ObjectWriteOperation o;
-  o.assert_exists(); // bucket index shard must exist
 
   rgw_bucket_dir_entry_meta dir_meta;
   dir_meta = ent.meta;
@@ -10942,58 +10984,100 @@ int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModify
   ver.pool = pool;
   ver.epoch = epoch;
   cls_rgw_obj_key key(ent.key.name, ent.key.instance);
-  cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-  cls_rgw_bucket_complete_op(o, op, tag, ver, key, dir_meta, remove_objs,
-                             log_op, bilog_flags, &zones_trace, obj.key.get_loc());
-  complete_op_data *arg;
-  index_completion_manager->create_completion(obj, op, tag, ver, key, dir_meta, remove_objs,
-                                              log_op, bilog_flags, &zones_trace, &arg);
-  librados::AioCompletion *completion = arg->rados_completion;
-  int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
-  completion->release(); /* can't reference arg here, as it might have already been released */
 
-  ldout_bitx_c(bitx, cct, 10) << "EXITING " << __func__ << ": ret=" << ret << dendl_bitx;
-  return ret;
+  return with_bilog<CLSRGWBucketModifyOpT>(
+    dpp,
+    [&](auto& op_issuer, auto& bilog_handler) {
+      // Record the bilog entry (into FIFO, or NOP for InIndex) before the CLS op.
+      bilog_handler.add_maybe_flush(
+        epoch, ent.meta.mtime,
+        static_cast<const cls_rgw_bi_log_related_op&>(op_issuer));
+
+      ObjectWriteOperation o;
+      o.assert_exists(); // bucket index shard must exist
+      cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
+      // op_issuer.log_op is true for InIndex (writes in-index bilog),
+      // false for FIFO (suppressed — FIFO batch handles it above).
+      op_issuer.complete_op(o, ver, dir_meta, remove_objs, obj.key.get_loc());
+
+      complete_op_data *arg;
+      index_completion_manager->create_completion(
+        obj, op_issuer.op, tag, ver, key, dir_meta, remove_objs,
+        op_issuer.log_op, bilog_flags, &zones_trace, &arg);
+      librados::AioCompletion *completion = arg->rados_completion;
+      int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
+      completion->release(); /* can't reference arg here, as it might have already been released */
+
+      ldout_bitx_c(bitx, cct, 10) << "EXITING " << __func__ << ": ret=" << ret << dendl_bitx;
+      return ret;
+    },
+    bucket_info,
+    log_op,
+    key, tag, &zones_trace, bilog_flags);
 }
 
-int RGWRados::cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, string& tag,
+// explicit instantiations for the three complete-op types
+template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>>(
+    const DoutPrefixProvider*, const RGWBucketInfo&,
+    BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
+    rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
+    uint16_t, rgw_zone_set*, bool);
+template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
+    const DoutPrefixProvider*, const RGWBucketInfo&,
+    BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
+    rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
+    uint16_t, rgw_zone_set*, bool);
+template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
+    const DoutPrefixProvider*, const RGWBucketInfo&,
+    BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
+    rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
+    uint16_t, rgw_zone_set*, bool);
+
+int RGWRados::cls_obj_complete_add(const DoutPrefixProvider* dpp,
+                                   const RGWBucketInfo& bucket_info,
+                                   BucketShard& bs, const rgw_obj& obj, string& tag,
                                    int64_t pool, uint64_t epoch,
                                    rgw_bucket_dir_entry& ent, RGWObjCategory category,
-                                   list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                                   rgw_zone_set *zones_trace, bool log_op)
+                                   list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
+                                   rgw_zone_set* zones_trace, bool log_op)
 {
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_ADD, tag, pool, epoch,
-                             ent, category, remove_objs, bilog_flags,
-                             zones_trace, log_op);
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>>(
+    dpp, bucket_info, bs, obj, tag, pool, epoch,
+    ent, category, remove_objs, bilog_flags, zones_trace, log_op);
 }
 
-int RGWRados::cls_obj_complete_del(BucketShard& bs, string& tag,
+int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
+                                   const RGWBucketInfo& bucket_info,
+                                   BucketShard& bs, string& tag,
                                    int64_t pool, uint64_t epoch,
                                    rgw_obj& obj,
                                    real_time& removed_mtime,
-                                   list<rgw_obj_index_key> *remove_objs,
+                                   list<rgw_obj_index_key>* remove_objs,
                                    uint16_t bilog_flags,
-                                   rgw_zone_set *zones_trace,
+                                   rgw_zone_set* zones_trace,
                                    bool log_op)
 {
   rgw_bucket_dir_entry ent;
   ent.meta.mtime = removed_mtime;
   obj.key.get_index_key(&ent.key);
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_DEL, tag, pool, epoch,
-			     ent, RGWObjCategory::None, remove_objs,
-			     bilog_flags, zones_trace, log_op);
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
+    dpp, bucket_info, bs, obj, tag, pool, epoch,
+    ent, RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
 }
 
-int RGWRados::cls_obj_complete_cancel(BucketShard& bs, string& tag, rgw_obj& obj,
-                                      list<rgw_obj_index_key> *remove_objs,
-                                      uint16_t bilog_flags, rgw_zone_set *zones_trace, bool log_op)
+int RGWRados::cls_obj_complete_cancel(const DoutPrefixProvider* dpp,
+                                      const RGWBucketInfo& bucket_info,
+                                      BucketShard& bs, string& tag, rgw_obj& obj,
+                                      list<rgw_obj_index_key>* remove_objs,
+                                      uint16_t bilog_flags,
+                                      rgw_zone_set* zones_trace, bool log_op)
 {
   rgw_bucket_dir_entry ent;
   obj.key.get_index_key(&ent.key);
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_CANCEL, tag,
-			     -1 /* pool id */, 0, ent,
-			     RGWObjCategory::None, remove_objs, bilog_flags,
-			     zones_trace, log_op);
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
+    dpp, bucket_info, bs, obj, tag,
+    -1 /* pool id */, 0, ent,
+    RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
 }
 
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10976,29 +10976,23 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     }
   }
 
-  const auto& index_layout = rgw::log_to_index_layout(log_layout);
-  librados::IoCtx index_pool;
-  std::map<int, std::string> bucket_objs;
-  int r = svc.bi_rados->open_bucket_index(
-      dpp, bucket_info, std::nullopt, index_layout,
-      &index_pool, &bucket_objs, nullptr);
+  librados::IoCtx log_ioctx;
+  int r = rgw_init_ioctx(dpp, get_rados_handle(),
+                         svc.zone->get_zone_params().log_pool,
+                         log_ioctx, true, false);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__
-                      << ": open_bucket_index failed for "
-                      << bucket_info.bucket << ": " << cpp_strerror(r) << dendl;
-    // return a null fifo batch: callers can still call add_maybe_flush/flush safely
+                      << ": failed to open log pool: " << cpp_strerror(r) << dendl;
     return RGWBILogUpdateBatch(dpp, neo, nullptr);
   }
 
-  // build ordered shard OID vector.
-  std::vector<std::string> shard_oids;
-  shard_oids.reserve(bucket_objs.size());
-  for (auto& [/*shard_id*/_, oid] : bucket_objs) {
-    shard_oids.push_back(oid);
-  }
-
-  neorados::IOContext neo_loc(index_pool.get_id());
-  auto fifo = std::make_shared<RGWBILogFIFO>(neo, neo_loc, shard_oids);
+  neorados::IOContext neo_loc(log_ioctx.get_id());
+  const auto& fifo_layout = log_layout.layout.fifo;
+  auto fifo = std::make_shared<RGWBILogFIFO>(
+      neo, neo_loc,
+      bucket_info.bucket.bucket_id,
+      log_layout.gen,
+      fifo_layout.num_shards);
 
   {
     std::unique_lock wl(fifo_bilog_cache_lock_);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10938,8 +10938,18 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   const auto& log_layout = bucket_info.layout.logs.back();
   ceph_assert(log_layout.layout.type == rgw::BucketLogType::FIFO);
 
-  const auto& index_layout = rgw::log_to_index_layout(log_layout);
+  auto neo = svc.bilog_rados->get_rados_neo();
+  const auto key = std::make_pair(bucket_info.bucket.bucket_id, log_layout.gen);
 
+  // cached path
+  {
+    std::shared_lock rl(fifo_bilog_cache_lock_);
+    if (auto it = fifo_bilog_cache_.find(key); it != fifo_bilog_cache_.end()) {
+      return RGWBILogUpdateBatch(dpp, neo, it->second);
+    }
+  }
+
+  const auto& index_layout = rgw::log_to_index_layout(log_layout);
   librados::IoCtx index_pool;
   std::map<int, std::string> bucket_objs;
   int r = svc.bi_rados->open_bucket_index(
@@ -10949,17 +10959,11 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     ldpp_dout(dpp, 0) << "ERROR: " << __func__
                       << ": open_bucket_index failed for "
                       << bucket_info.bucket << ": " << cpp_strerror(r) << dendl;
-    // TODO: The proper fix is to change
-    // with_bilog<> to check for failure before invoking the lambda, but that
-    // requires reworking the template signature.  For now, return a zero-shard
-    // batch: callers can call add_maybe_flush/flush safely (pending stays
-    // empty), but any bilog entries for this operation will be silently
-    // dropped.  The ERROR log above ensures this is always visible.
-    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
-                               neorados::IOContext{}, {});
+    // return a null fifo batch: callers can still call add_maybe_flush/flush safely
+    return RGWBILogUpdateBatch(dpp, neo, nullptr);
   }
 
-  // conversion to ordered vector.
+  // build ordered shard OID vector.
   std::vector<std::string> shard_oids;
   shard_oids.reserve(bucket_objs.size());
   for (auto& [/*shard_id*/_, oid] : bucket_objs) {
@@ -10967,8 +10971,17 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   }
 
   neorados::IOContext neo_loc(index_pool.get_id());
-  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
-                             std::move(neo_loc), shard_oids);
+  auto fifo = std::make_shared<RGWBILogFIFO>(neo, neo_loc, shard_oids);
+
+  {
+    std::unique_lock wl(fifo_bilog_cache_lock_);
+    auto [it, inserted] = fifo_bilog_cache_.emplace(key, fifo);
+    if (!inserted) { // check for racing insertion
+      fifo = it->second;
+    }
+  }
+
+  return RGWBILogUpdateBatch(dpp, neo, std::move(fifo));
 }
 
 template <class CLSRGWBucketModifyOpT>

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9352,11 +9352,9 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
                       obj_instance.key.instance);
 
   auto do_op = [&](auto& op_issuer, auto& bilog) -> int {
-    // stage and flush the FIFO bilog entry before the cls op so that a
-    // crash after the FIFO push but before link_olh
-    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
-                          ceph::real_time{}, zones_trace);
-    bilog.flush(y);
+    // issue the cls op first. only push to the FIFO on success so that a
+    // crash between the cls op and the FIFO push leaves the secondary behind
+    // rather than ahead with a diverged OLH pointer
     int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
 	              [&](BucketShard *bs) -> int {
 	                auto& ref = bs->bucket_obj;
@@ -9373,6 +9371,9 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
       ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
       return ret;
     }
+    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
+                          ceph::real_time{}, zones_trace);
+    bilog.flush(y);
     return 0;
   };
 
@@ -9430,8 +9431,8 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
                         obj_instance.key.instance);
   r = with_bilog<CLSRGWUnlinkInstance>(dpp,
       [&](auto& op_issuer, auto& bilog) -> int {
-        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
-        bilog.flush(y);
+        // cls op first, FIFO push on success only (same as
+        // bucket_index_link_olh to avoid secondary OLH pointer divergence).
         int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
               [&](BucketShard *bs) -> int {
                 auto& ref = bs->bucket_obj;
@@ -9446,6 +9447,9 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
           ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
           return ret;
         }
+
+        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        bilog.flush(y);
         return 0;
       },
       bucket_info,
@@ -9766,21 +9770,6 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
     return r;
   }
 
-  // for FIFO-backed buckets write the OLH-link bilog entry before the
-  // OLH xattr update so a crash after the FIFO push but before the
-  // rados op produces a safe, re-replayable state.
-  if (need_to_link) {
-    rgw_zone_set zt;
-    if (zones_trace) {
-      zt = *zones_trace;
-    }
-    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
-    with_bilog<void>(dpp, [&](auto& bilog_handler) {
-      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
-                                    delete_marker, state.mtime, zt);
-    }, bucket_info, log_op);
-  }
-
   const rgw_bucket& bucket = obj.bucket;
 
   if (need_to_link) {
@@ -9814,6 +9803,19 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": could not apply olh update to oid \"" << ref.obj.oid << "\", r=" << r << dendl;
     }
     return r;
+  }
+
+  // OLH xattr update committed. now record the FIFO bilog entry.
+  if (need_to_link) {
+    rgw_zone_set zt;
+    if (zones_trace) {
+      zt = *zones_trace;
+    }
+    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
+    with_bilog<void>(dpp, [&](auto& bilog_handler) {
+      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
+                                    delete_marker, state.mtime, zt);
+    }, bucket_info, log_op);
   }
 
   if (need_to_remove) {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9352,6 +9352,11 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
                       obj_instance.key.instance);
 
   auto do_op = [&](auto& op_issuer, auto& bilog) -> int {
+    // stage and flush the FIFO bilog entry before the cls op so that a
+    // crash after the FIFO push but before link_olh
+    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
+                          ceph::real_time{}, zones_trace);
+    bilog.flush(y);
     int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
 	              [&](BucketShard *bs) -> int {
 	                auto& ref = bs->bucket_obj;
@@ -9368,8 +9373,6 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
       ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
       return ret;
     }
-    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
-                          ceph::real_time{}, zones_trace);
     return 0;
   };
 
@@ -9427,6 +9430,8 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
                         obj_instance.key.instance);
   r = with_bilog<CLSRGWUnlinkInstance>(dpp,
       [&](auto& op_issuer, auto& bilog) -> int {
+        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        bilog.flush(y);
         int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
               [&](BucketShard *bs) -> int {
                 auto& ref = bs->bucket_obj;
@@ -9441,7 +9446,6 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
           ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
           return ret;
         }
-        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
         return 0;
       },
       bucket_info,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9679,6 +9679,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
   uint64_t link_epoch = 0;
   cls_rgw_obj_key key;
   bool delete_marker = false;
+  std::string link_op_tag;  // op_tag of the LINK_OLH entry
   set<cls_rgw_obj_key> remove_instances;
   bool need_to_remove = false;
 
@@ -9733,6 +9734,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
           need_to_remove = false;
           key = entry.key;
           delete_marker = entry.delete_marker;
+          link_op_tag = entry.op_tag;
         } else {
           ldpp_dout(dpp, 20) << "apply_olh skipping key=" << entry.key<< " epoch=" << iter->first << " delete_marker=" << entry.delete_marker
               << " before current=" << key << " epoch=" << link_epoch << " delete_marker=" << delete_marker << dendl;
@@ -9758,6 +9760,21 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
   int r = get_obj_head_ref(dpp, bucket_info, obj, &ref);
   if (r < 0) {
     return r;
+  }
+
+  // for FIFO-backed buckets write the OLH-link bilog entry before the
+  // OLH xattr update so a crash after the FIFO push but before the
+  // rados op produces a safe, re-replayable state.
+  if (need_to_link) {
+    rgw_zone_set zt;
+    if (zones_trace) {
+      zt = *zones_trace;
+    }
+    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
+    with_bilog<void>(dpp, [&](auto& bilog_handler) {
+      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
+                                    delete_marker, state.mtime, zt);
+    }, bucket_info, log_op);
   }
 
   const rgw_bucket& bucket = obj.bucket;
@@ -11871,13 +11888,20 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
                                rgw_bucket_dir_entry& list_state,
                                rgw_bucket_dir_entry& object,
                                bufferlist& suggested_updates,
-                               optional_yield y)
+                               optional_yield y,
+                               bool log_op)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
   ldout_bitx(bitx, dpp, 10) << "ENTERING " << __func__ << ": bucket=" <<
     bucket_info.bucket << " dir_entry=" << list_state.key << dendl_bitx;
 
-  uint8_t suggest_flag = (svc.zone->need_to_log_data() ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);
+  // for InIndex buckets, CLS writes the bilog entry when
+  // processing the suggestion (CEPH_RGW_DIR_SUGGEST_LOG_OP flag).
+  // for FIFO buckets we suppress that flag and write the entry ourselves.
+  const bool is_inindex =
+    bucket_info.layout.logs.empty() ||
+    bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
+  uint8_t suggest_flag = (is_inindex && svc.zone->need_to_log_data() ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);
 
   std::string loc;
 
@@ -11918,6 +11942,10 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
     list_state.ver = index_ver;
     ldout_bitx(bitx, dpp, 10) << "INFO: " << __func__ << ": encoding remove of " << list_state.key << " on suggested_updates" << dendl_bitx;
     cls_rgw_encode_suggestion(CEPH_RGW_REMOVE | suggest_flag, list_state, suggested_updates);
+    // FIFO: write the DEL bilog entry from the client side (CLS won't do it).
+    with_bilog<void>(dpp, [&](auto& bilog_handler) {
+      bilog_handler.add_maybe_flush(CLS_RGW_OP_DEL, list_state, rgw_zone_set{});
+    }, bucket_info, log_op);
     return -ENOENT;
   }
 
@@ -12014,6 +12042,10 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   ldout_bitx(bitx, dpp, 10) << "INFO: " << __func__ <<
     ": encoding update of " << list_state.key << " on suggested_updates" << dendl_bitx;
   cls_rgw_encode_suggestion(CEPH_RGW_UPDATE | suggest_flag, list_state, suggested_updates);
+  // FIFO: write the ADD bilog entry from the client side (CLS won't do it).
+  with_bilog<void>(dpp, [&](auto& bilog_handler) {
+    bilog_handler.add_maybe_flush(CLS_RGW_OP_ADD, list_state, rgw_zone_set{});
+  }, bucket_info, log_op);
 
   ldout_bitx(bitx, dpp, 10) << "EXITING " << __func__ << dendl_bitx;
   return 0;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9373,7 +9373,13 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     }
     bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
                           ceph::real_time{}, zones_trace);
-    bilog.flush(y);
+    int r = bilog.flush(y);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                        << ": failed to flush bilog entry for " << key
+                        << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
     return 0;
   };
 
@@ -9449,7 +9455,13 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
         }
 
         bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
-        bilog.flush(y);
+        int r = bilog.flush(y);
+        if (r < 0) {
+          ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                            << ": failed to flush bilog entry for " << key
+                            << ": " << cpp_strerror(r) << dendl;
+          return r;
+        }
         return 0;
       },
       bucket_info,
@@ -9812,10 +9824,19 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
       zt = *zones_trace;
     }
     zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
+    int bilog_r = 0;
+    // with_bilog<void> always returns 0; capture the flush error via bilog_r.
     with_bilog<void>(dpp, [&](auto& bilog_handler) {
       bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
                                     delete_marker, state.mtime, zt);
+      bilog_r = bilog_handler.flush(y);
     }, bucket_info, log_op);
+    if (bilog_r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                        << ": failed to flush bilog entry for " << key
+                        << ": " << cpp_strerror(bilog_r) << dendl;
+      return bilog_r;
+    }
   }
 
   if (need_to_remove) {
@@ -11964,6 +11985,13 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
     // FIFO: write the DEL bilog entry from the client side (CLS won't do it).
     with_bilog<void>(dpp, [&](auto& bilog_handler) {
       bilog_handler.add_maybe_flush(CLS_RGW_OP_DEL, list_state, rgw_zone_set{});
+      int r = bilog_handler.flush(y);
+      if (r < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                          << ": failed to flush DEL bilog entry for "
+                          << list_state.key << ": " << cpp_strerror(r) << dendl;
+        // continue: the index correction is more important than the bilog entry
+      }
     }, bucket_info, log_op);
     return -ENOENT;
   }
@@ -12064,6 +12092,13 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   // FIFO: write the ADD bilog entry from the client side (CLS won't do it).
   with_bilog<void>(dpp, [&](auto& bilog_handler) {
     bilog_handler.add_maybe_flush(CLS_RGW_OP_ADD, list_state, rgw_zone_set{});
+    int r = bilog_handler.flush(y);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                        << ": failed to flush ADD bilog entry for "
+                        << list_state.key << ": " << cpp_strerror(r) << dendl;
+      // continue: the index correction is more important than the bilog entry
+    }
   }, bucket_info, log_op);
 
   ldout_bitx(bitx, dpp, 10) << "EXITING " << __func__ << dendl_bitx;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10955,7 +10955,7 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     // batch: callers can call add_maybe_flush/flush safely (pending stays
     // empty), but any bilog entries for this operation will be silently
     // dropped.  The ERROR log above ensures this is always visible.
-    return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
+    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
                                neorados::IOContext{}, {});
   }
 
@@ -10967,7 +10967,7 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   }
 
   neorados::IOContext neo_loc(index_pool.get_id());
-  return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
+  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
                              std::move(neo_loc), shard_oids);
 }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9417,7 +9417,13 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     }
     bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
                           ceph::real_time{}, zones_trace);
-    bilog.flush(y);
+    int r = bilog.flush(y);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                        << ": failed to flush bilog entry for " << key
+                        << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
     return 0;
   };
 
@@ -9518,7 +9524,13 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
         }
 
         bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
-        bilog.flush(y);
+        int r = bilog.flush(y);
+        if (r < 0) {
+          ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                            << ": failed to flush bilog entry for " << key
+                            << ": " << cpp_strerror(r) << dendl;
+          return r;
+        }
         return 0;
       },
       bucket_info,
@@ -9881,10 +9893,19 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
       zt = *zones_trace;
     }
     zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
+    int bilog_r = 0;
+    // with_bilog<void> always returns 0; capture the flush error via bilog_r.
     with_bilog<void>(dpp, [&](auto& bilog_handler) {
       bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
                                     delete_marker, state.mtime, zt);
+      bilog_r = bilog_handler.flush(y);
     }, bucket_info, log_op);
+    if (bilog_r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                        << ": failed to flush bilog entry for " << key
+                        << ": " << cpp_strerror(bilog_r) << dendl;
+      return bilog_r;
+    }
   }
 
   if (need_to_remove) {
@@ -12033,6 +12054,13 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
     // FIFO: write the DEL bilog entry from the client side (CLS won't do it).
     with_bilog<void>(dpp, [&](auto& bilog_handler) {
       bilog_handler.add_maybe_flush(CLS_RGW_OP_DEL, list_state, rgw_zone_set{});
+      int r = bilog_handler.flush(y);
+      if (r < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                          << ": failed to flush DEL bilog entry for "
+                          << list_state.key << ": " << cpp_strerror(r) << dendl;
+        // continue: the index correction is more important than the bilog entry
+      }
     }, bucket_info, log_op);
     return -ENOENT;
   }
@@ -12133,6 +12161,13 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   // FIFO: write the ADD bilog entry from the client side (CLS won't do it).
   with_bilog<void>(dpp, [&](auto& bilog_handler) {
     bilog_handler.add_maybe_flush(CLS_RGW_OP_ADD, list_state, rgw_zone_set{});
+    int r = bilog_handler.flush(y);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                        << ": failed to flush ADD bilog entry for "
+                        << list_state.key << ": " << cpp_strerror(r) << dendl;
+      // continue: the index correction is more important than the bilog entry
+    }
   }, bucket_info, log_op);
 
   ldout_bitx(bitx, dpp, 10) << "EXITING " << __func__ << dendl_bitx;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -98,6 +98,7 @@
 #include "services/svc_sys_obj_cache.h"
 #include "services/svc_bucket.h"
 #include "services/svc_mdlog.h"
+#include "services/svc_bilog_rados.h"
 
 #include "compressor/Compressor.h"
 
@@ -10936,6 +10937,48 @@ int RGWRados::cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs,
   int ret = bs.bucket_obj.operate(dpp, std::move(o), y);
   ldout_bitx(bitx, dpp, 10) << "EXITING " << __func__ << ": ret=" << ret << dendl_bitx;
   return ret;
+}
+
+// bilog batch factory
+RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
+    const DoutPrefixProvider* dpp,
+    const RGWBucketInfo& bucket_info)
+{
+  ceph_assert(!bucket_info.layout.logs.empty());
+  const auto& log_layout = bucket_info.layout.logs.back();
+  ceph_assert(log_layout.layout.type == rgw::BucketLogType::FIFO);
+
+  const auto& index_layout = rgw::log_to_index_layout(log_layout);
+
+  librados::IoCtx index_pool;
+  std::map<int, std::string> bucket_objs;
+  int r = svc.bi_rados->open_bucket_index(
+      dpp, bucket_info, std::nullopt, index_layout,
+      &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__
+                      << ": open_bucket_index failed for "
+                      << bucket_info.bucket << ": " << cpp_strerror(r) << dendl;
+    // TODO: The proper fix is to change
+    // with_bilog<> to check for failure before invoking the lambda, but that
+    // requires reworking the template signature.  For now, return a zero-shard
+    // batch: callers can call add_maybe_flush/flush safely (pending stays
+    // empty), but any bilog entries for this operation will be silently
+    // dropped.  The ERROR log above ensures this is always visible.
+    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+                               neorados::IOContext{}, {});
+  }
+
+  // conversion to ordered vector.
+  std::vector<std::string> shard_oids;
+  shard_oids.reserve(bucket_objs.size());
+  for (auto& [/*shard_id*/_, oid] : bucket_objs) {
+    shard_oids.push_back(oid);
+  }
+
+  neorados::IOContext neo_loc(index_pool.get_id());
+  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+                             std::move(neo_loc), shard_oids);
 }
 
 int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, string& tag,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9396,6 +9396,11 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
                       obj_instance.key.instance);
 
   auto do_op = [&](auto& op_issuer, auto& bilog) -> int {
+    // stage and flush the FIFO bilog entry before the cls op so that a
+    // crash after the FIFO push but before link_olh
+    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
+                          ceph::real_time{}, zones_trace);
+    bilog.flush(y);
     int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
 	              [&](BucketShard *bs) -> int {
 	                auto& ref = bs->bucket_obj;
@@ -9412,8 +9417,6 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
       ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
       return ret;
     }
-    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
-                          ceph::real_time{}, zones_trace);
     return 0;
   };
 
@@ -9496,6 +9499,8 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
                         obj_instance.key.instance);
   r = with_bilog<CLSRGWUnlinkInstance>(dpp,
       [&](auto& op_issuer, auto& bilog) -> int {
+        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        bilog.flush(y);
         int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
               [&](BucketShard *bs) -> int {
                 auto& ref = bs->bucket_obj;
@@ -9510,7 +9515,6 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
           ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
           return ret;
         }
-        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
         return 0;
       },
       bucket_info,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9748,6 +9748,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
   uint64_t link_epoch = 0;
   cls_rgw_obj_key key;
   bool delete_marker = false;
+  std::string link_op_tag;  // op_tag of the LINK_OLH entry
   set<cls_rgw_obj_key> remove_instances;
   bool need_to_remove = false;
 
@@ -9802,6 +9803,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
           need_to_remove = false;
           key = entry.key;
           delete_marker = entry.delete_marker;
+          link_op_tag = entry.op_tag;
         } else {
           ldpp_dout(dpp, 20) << "apply_olh skipping key=" << entry.key<< " epoch=" << iter->first << " delete_marker=" << entry.delete_marker
               << " before current=" << key << " epoch=" << link_epoch << " delete_marker=" << delete_marker << dendl;
@@ -9827,6 +9829,21 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
   int r = get_obj_head_ref(dpp, bucket_info, obj, &ref);
   if (r < 0) {
     return r;
+  }
+
+  // for FIFO-backed buckets write the OLH-link bilog entry before the
+  // OLH xattr update so a crash after the FIFO push but before the
+  // rados op produces a safe, re-replayable state.
+  if (need_to_link) {
+    rgw_zone_set zt;
+    if (zones_trace) {
+      zt = *zones_trace;
+    }
+    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
+    with_bilog<void>(dpp, [&](auto& bilog_handler) {
+      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
+                                    delete_marker, state.mtime, zt);
+    }, bucket_info, log_op);
   }
 
   const rgw_bucket& bucket = obj.bucket;
@@ -11940,13 +11957,20 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
                                rgw_bucket_dir_entry& list_state,
                                rgw_bucket_dir_entry& object,
                                bufferlist& suggested_updates,
-                               optional_yield y)
+                               optional_yield y,
+                               bool log_op)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
   ldout_bitx(bitx, dpp, 10) << "ENTERING " << __func__ << ": bucket=" <<
     bucket_info.bucket << " dir_entry=" << list_state.key << dendl_bitx;
 
-  uint8_t suggest_flag = (svc.zone->need_to_log_data() ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);
+  // for InIndex buckets, CLS writes the bilog entry when
+  // processing the suggestion (CEPH_RGW_DIR_SUGGEST_LOG_OP flag).
+  // for FIFO buckets we suppress that flag and write the entry ourselves.
+  const bool is_inindex =
+    bucket_info.layout.logs.empty() ||
+    bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
+  uint8_t suggest_flag = (is_inindex && svc.zone->need_to_log_data() ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);
 
   std::string loc;
 
@@ -11987,6 +12011,10 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
     list_state.ver = index_ver;
     ldout_bitx(bitx, dpp, 10) << "INFO: " << __func__ << ": encoding remove of " << list_state.key << " on suggested_updates" << dendl_bitx;
     cls_rgw_encode_suggestion(CEPH_RGW_REMOVE | suggest_flag, list_state, suggested_updates);
+    // FIFO: write the DEL bilog entry from the client side (CLS won't do it).
+    with_bilog<void>(dpp, [&](auto& bilog_handler) {
+      bilog_handler.add_maybe_flush(CLS_RGW_OP_DEL, list_state, rgw_zone_set{});
+    }, bucket_info, log_op);
     return -ENOENT;
   }
 
@@ -12083,6 +12111,10 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   ldout_bitx(bitx, dpp, 10) << "INFO: " << __func__ <<
     ": encoding update of " << list_state.key << " on suggested_updates" << dendl_bitx;
   cls_rgw_encode_suggestion(CEPH_RGW_UPDATE | suggest_flag, list_state, suggested_updates);
+  // FIFO: write the ADD bilog entry from the client side (CLS won't do it).
+  with_bilog<void>(dpp, [&](auto& bilog_handler) {
+    bilog_handler.add_maybe_flush(CLS_RGW_OP_ADD, list_state, rgw_zone_set{});
+  }, bucket_info, log_op);
 
   ldout_bitx(bitx, dpp, 10) << "EXITING " << __func__ << dendl_bitx;
   return 0;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -831,13 +831,22 @@ int RGWRados::get_max_chunk_size(const rgw_placement_rule& placement_rule, const
 [[nodiscard]] int add_datalog_entry(const DoutPrefixProvider* dpp,
 				    RGWDataChangesLog* datalog,
 				    const RGWBucketInfo& bucket_info,
+				    const std::string& hash_key,
 				    uint32_t shard_id, optional_yield y)
 {
   const auto& logs = bucket_info.layout.logs;
   if (logs.empty()) {
     return 0;
   }
-  int r = datalog->add_entry(dpp, bucket_info, logs.back(), shard_id, y);
+  const auto& log = logs.back();
+  int effective_shard;
+  if (log.layout.type == rgw::BucketLogType::FIFO) {
+    effective_shard = RGWSI_BucketIndex_RADOS::bucket_shard_index(
+        hash_key, log.layout.fifo.num_shards);
+  } else {
+    effective_shard = shard_id;
+  }
+  int r = datalog->add_entry(dpp, bucket_info, log, effective_shard, y);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
   }
@@ -1024,8 +1033,8 @@ void RGWIndexCompletionManager::process()
         /* this null_yield can stay for now since we're in our own
          * thread */
         std::ignore = add_datalog_entry(&dpp, store->svc.datalog_rados,
-                                        bucket_info, bs.shard_id,
-                                        null_yield);
+                                        bucket_info, c->obj.get_hash_object(),
+                                        bs.shard_id, null_yield);
         /* if there is an error we can ignore it, as a) there's
          * nothing we can do and b) it's already logged in
          * add_datalog_entry */
@@ -6957,7 +6966,9 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y,
 
     if (add_log) {
       r = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->get_bucket_info(), bs->shard_id, y);
+			    target->get_bucket_info(),
+			    target->get_obj().get_hash_object(),
+			    bs->shard_id, y);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "failed to write datalog for object: r=" << r << dendl;
         return r;
@@ -8487,7 +8498,8 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, obj.get_hash_object(),
+			    bs->shard_id, y);
   }
 
   return ret;
@@ -8520,7 +8532,8 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, obj.get_hash_object(),
+			    bs->shard_id, y);
   }
 
   return ret;
@@ -8554,7 +8567,8 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
      * have no way to tell that they're all caught up
      */
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, obj.get_hash_object(),
+			    bs->shard_id, y);
   }
 
   return ret;
@@ -9460,7 +9474,8 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
   }
 
   if (log_data_change) {
-    r = add_datalog_entry(dpp, svc.datalog_rados, bucket_info, bs.shard_id, y);
+    r = add_datalog_entry(dpp, svc.datalog_rados, bucket_info,
+                          obj_instance.get_hash_object(), bs.shard_id, y);
   }
 
   return r;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9399,24 +9399,41 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     // issue the cls op first. only push to the FIFO on success so that a
     // crash between the cls op and the FIFO push leaves the secondary behind
     // rather than ahead with a diverged OLH pointer
+    //
+    // CLS returns the epoch it committed in the output bufferlist. use that
+    // to record the same epoch in the FIFO bilog entry
+    bufferlist epoch_out_bl;
     int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
 	              [&](BucketShard *bs) -> int {
 	                auto& ref = bs->bucket_obj;
 	                librados::ObjectWriteOperation op;
 	                op.assert_exists(); // bucket index shard must exist
 	                cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+	                epoch_out_bl.clear();
 	                op_issuer.link_olh(op, olh_state.olh_tag, delete_marker,
 	                                   meta, olh_epoch, unmod_since,
-	                                   high_precision_time);
+	                                   high_precision_time, &epoch_out_bl);
 	                return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
-	                                        std::move(op), y);
+	                                        std::move(op), y,
+	                                        librados::OPERATION_RETURNVEC);
 	              }, y);
     if (ret < 0) {
       ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
       return ret;
     }
-    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
-                          ceph::real_time{}, zones_trace);
+
+    uint64_t committed_epoch = olh_epoch;
+    try {
+      auto iter = epoch_out_bl.cbegin();
+      decode(committed_epoch, iter);
+    } catch (const ceph::buffer::error&) {
+      ldpp_dout(dpp, 0) << "WARNING: " << __func__
+                        << ": failed to decode committed epoch from link_olh response" << dendl;
+    }
+    ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
+                       << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
+    bilog.add_maybe_flush(committed_epoch, key, op_tag, delete_marker,
+                          meta ? meta->mtime : ceph::real_time{}, zones_trace);
     int r = bilog.flush(y);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9508,22 +9525,36 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
       [&](auto& op_issuer, auto& bilog) -> int {
         // cls op first, FIFO push on success only (same as
         // bucket_index_link_olh to avoid secondary OLH pointer divergence).
+        bufferlist epoch_out_bl;
         int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
               [&](BucketShard *bs) -> int {
                 auto& ref = bs->bucket_obj;
                 librados::ObjectWriteOperation op;
                 op.assert_exists(); // bucket index shard must exist
                 cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-                op_issuer.unlink_instance(op, olh_tag, olh_epoch);
+                epoch_out_bl.clear();
+                op_issuer.unlink_instance(op, olh_tag, olh_epoch, &epoch_out_bl);
                 return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
-                                        std::move(op), y);
+                                        std::move(op), y,
+                                        librados::OPERATION_RETURNVEC);
               }, y);
         if (ret < 0) {
           ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
           return ret;
         }
 
-        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        uint64_t committed_epoch = olh_epoch;
+        try {
+          auto iter = epoch_out_bl.cbegin();
+          decode(committed_epoch, iter);
+        } catch (const ceph::buffer::error&) {
+          ldpp_dout(dpp, 0) << "WARNING: " << __func__
+                            << ": failed to decode committed epoch from unlink_instance response"
+                            << dendl;
+        }
+        ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
+                           << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
+        bilog.add_maybe_flush(committed_epoch, ceph::real_time{}, op_issuer);
         int r = bilog.flush(y);
         if (r < 0) {
           ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9822,6 +9853,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
           need_to_link = true;
           need_to_remove = false;
           key = entry.key;
+          link_epoch = entry.epoch;
           delete_marker = entry.delete_marker;
           link_op_tag = entry.op_tag;
         } else {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11024,7 +11024,7 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     // batch: callers can call add_maybe_flush/flush safely (pending stays
     // empty), but any bilog entries for this operation will be silently
     // dropped.  The ERROR log above ensures this is always visible.
-    return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
+    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
                                neorados::IOContext{}, {});
   }
 
@@ -11036,7 +11036,7 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   }
 
   neorados::IOContext neo_loc(index_pool.get_id());
-  return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
+  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
                              std::move(neo_loc), shard_oids);
 }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11007,8 +11007,18 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   const auto& log_layout = bucket_info.layout.logs.back();
   ceph_assert(log_layout.layout.type == rgw::BucketLogType::FIFO);
 
-  const auto& index_layout = rgw::log_to_index_layout(log_layout);
+  auto neo = svc.bilog_rados->get_rados_neo();
+  const auto key = std::make_pair(bucket_info.bucket.bucket_id, log_layout.gen);
 
+  // cached path
+  {
+    std::shared_lock rl(fifo_bilog_cache_lock_);
+    if (auto it = fifo_bilog_cache_.find(key); it != fifo_bilog_cache_.end()) {
+      return RGWBILogUpdateBatch(dpp, neo, it->second);
+    }
+  }
+
+  const auto& index_layout = rgw::log_to_index_layout(log_layout);
   librados::IoCtx index_pool;
   std::map<int, std::string> bucket_objs;
   int r = svc.bi_rados->open_bucket_index(
@@ -11018,17 +11028,11 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     ldpp_dout(dpp, 0) << "ERROR: " << __func__
                       << ": open_bucket_index failed for "
                       << bucket_info.bucket << ": " << cpp_strerror(r) << dendl;
-    // TODO: The proper fix is to change
-    // with_bilog<> to check for failure before invoking the lambda, but that
-    // requires reworking the template signature.  For now, return a zero-shard
-    // batch: callers can call add_maybe_flush/flush safely (pending stays
-    // empty), but any bilog entries for this operation will be silently
-    // dropped.  The ERROR log above ensures this is always visible.
-    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
-                               neorados::IOContext{}, {});
+    // return a null fifo batch: callers can still call add_maybe_flush/flush safely
+    return RGWBILogUpdateBatch(dpp, neo, nullptr);
   }
 
-  // conversion to ordered vector.
+  // build ordered shard OID vector.
   std::vector<std::string> shard_oids;
   shard_oids.reserve(bucket_objs.size());
   for (auto& [/*shard_id*/_, oid] : bucket_objs) {
@@ -11036,8 +11040,17 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   }
 
   neorados::IOContext neo_loc(index_pool.get_id());
-  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->get_rados_neo(),
-                             std::move(neo_loc), shard_oids);
+  auto fifo = std::make_shared<RGWBILogFIFO>(neo, neo_loc, shard_oids);
+
+  {
+    std::unique_lock wl(fifo_bilog_cache_lock_);
+    auto [it, inserted] = fifo_bilog_cache_.emplace(key, fifo);
+    if (!inserted) { // check for racing insertion
+      fifo = it->second;
+    }
+  }
+
+  return RGWBILogUpdateBatch(dpp, neo, std::move(fifo));
 }
 
 template <class CLSRGWBucketModifyOpT>

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9447,7 +9447,7 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
                        << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
     bilog.add_maybe_flush(committed_epoch, key, op_tag, delete_marker,
-                          meta ? meta->mtime : ceph::real_time{}, zones_trace);
+                          meta ? meta->mtime : ceph::real_clock::now(), zones_trace);
     int r = bilog.flush(y);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9569,7 +9569,7 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
         }
         ldpp_dout(dpp, 20) << __func__ << ": committed_epoch=" << committed_epoch
                            << " olh_epoch=" << olh_epoch << " key=" << key << dendl;
-        bilog.add_maybe_flush(committed_epoch, ceph::real_time{}, op_issuer);
+        bilog.add_maybe_flush(committed_epoch, ceph::real_clock::now(), op_issuer);
         int r = bilog.flush(y);
         if (r < 0) {
           ldpp_dout(dpp, 0) << "ERROR: " << __func__
@@ -9931,28 +9931,6 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": could not apply olh update to oid \"" << ref.obj.oid << "\", r=" << r << dendl;
     }
     return r;
-  }
-
-  // OLH xattr update committed. now record the FIFO bilog entry.
-  if (need_to_link) {
-    rgw_zone_set zt;
-    if (zones_trace) {
-      zt = *zones_trace;
-    }
-    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
-    int bilog_r = 0;
-    // with_bilog<void> always returns 0; capture the flush error via bilog_r.
-    with_bilog<void>(dpp, [&](auto& bilog_handler) {
-      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
-                                    delete_marker, state.mtime, zt);
-      bilog_r = bilog_handler.flush(y);
-    }, bucket_info, log_op);
-    if (bilog_r < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: " << __func__
-                        << ": failed to flush bilog entry for " << key
-                        << ": " << cpp_strerror(bilog_r) << dendl;
-      return bilog_r;
-    }
   }
 
   if (need_to_remove) {
@@ -11156,9 +11134,16 @@ int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
     dpp,
     [&](auto& op_issuer, auto& bilog_handler) {
       // Record the bilog entry (into FIFO, or NOP for InIndex) before the CLS op.
+      rgw_bucket_dir_entry bilog_ent = ent;
+      bilog_ent.ver = ver;
       bilog_handler.add_maybe_flush(
-        epoch, ent.meta.mtime,
-        static_cast<const cls_rgw_bi_log_related_op&>(op_issuer));
+        op_issuer.op, bilog_ent, zones_trace);
+      int flush_r = bilog_handler.flush(null_yield);
+      if (flush_r < 0) {
+        ldout_bitx_c(bitx, cct, 0) << "ERROR: " << __func__
+            << ": failed to flush bilog entry: " << cpp_strerror(flush_r) << dendl_bitx;
+        return flush_r;
+      }
 
       ObjectWriteOperation o;
       o.assert_exists(); // bucket index shard must exist

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11045,29 +11045,23 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     }
   }
 
-  const auto& index_layout = rgw::log_to_index_layout(log_layout);
-  librados::IoCtx index_pool;
-  std::map<int, std::string> bucket_objs;
-  int r = svc.bi_rados->open_bucket_index(
-      dpp, bucket_info, std::nullopt, index_layout,
-      &index_pool, &bucket_objs, nullptr);
+  librados::IoCtx log_ioctx;
+  int r = rgw_init_ioctx(dpp, get_rados_handle(),
+                         svc.zone->get_zone_params().log_pool,
+                         log_ioctx, true, false);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__
-                      << ": open_bucket_index failed for "
-                      << bucket_info.bucket << ": " << cpp_strerror(r) << dendl;
-    // return a null fifo batch: callers can still call add_maybe_flush/flush safely
+                      << ": failed to open log pool: " << cpp_strerror(r) << dendl;
     return RGWBILogUpdateBatch(dpp, neo, nullptr);
   }
 
-  // build ordered shard OID vector.
-  std::vector<std::string> shard_oids;
-  shard_oids.reserve(bucket_objs.size());
-  for (auto& [/*shard_id*/_, oid] : bucket_objs) {
-    shard_oids.push_back(oid);
-  }
-
-  neorados::IOContext neo_loc(index_pool.get_id());
-  auto fifo = std::make_shared<RGWBILogFIFO>(neo, neo_loc, shard_oids);
+  neorados::IOContext neo_loc(log_ioctx.get_id());
+  const auto& fifo_layout = log_layout.layout.fifo;
+  auto fifo = std::make_shared<RGWBILogFIFO>(
+      neo, neo_loc,
+      bucket_info.bucket.bucket_id,
+      log_layout.gen,
+      fifo_layout.num_shards);
 
   {
     std::unique_lock wl(fifo_bilog_cache_lock_);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -8494,7 +8494,7 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
 
   ret = store->cls_obj_complete_add(dpp, target->bucket_info, *bs, obj, optag,
                                     poolid, epoch, ent, category,
-                                    remove_objs, bilog_flags, zones_trace,
+                                    remove_objs, bilog_flags, y, zones_trace,
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
@@ -8528,7 +8528,7 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
 
   ret = store->cls_obj_complete_del(dpp, target->bucket_info, *bs, optag,
                                     poolid, epoch, obj, removed_mtime,
-                                    remove_objs, bilog_flags, zones_trace,
+                                    remove_objs, bilog_flags, y, zones_trace,
                                     log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
@@ -8556,7 +8556,7 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
   int ret = guard_reshard(dpp, obj, &bs, [&](BucketShard *bs) -> int {
 				 return store->cls_obj_complete_cancel(dpp, target->bucket_info,
 				                                       *bs, optag, obj, remove_objs,
-				                                       bilog_flags, zones_trace,
+				                                       bilog_flags, y, zones_trace,
 				                                       log_op);
 			       }, y);
 
@@ -11106,7 +11106,7 @@ int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
                                   int64_t pool, uint64_t epoch,
                                   rgw_bucket_dir_entry& ent, RGWObjCategory category,
                                   list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
-                                  rgw_zone_set* _zones_trace, bool log_op)
+                                  optional_yield y, rgw_zone_set* _zones_trace, bool log_op)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
   ldout_bitx_c(bitx, cct, 10) << "ENTERING " << __func__ << ": bucket-shard=" << bs <<
@@ -11138,7 +11138,7 @@ int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
       bilog_ent.ver = ver;
       bilog_handler.add_maybe_flush(
         op_issuer.op, bilog_ent, zones_trace);
-      int flush_r = bilog_handler.flush(null_yield);
+      int flush_r = bilog_handler.flush(y);
       if (flush_r < 0) {
         ldout_bitx_c(bitx, cct, 0) << "ERROR: " << __func__
             << ": failed to flush bilog entry: " << cpp_strerror(flush_r) << dendl_bitx;
@@ -11173,17 +11173,17 @@ template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD
     const DoutPrefixProvider*, const RGWBucketInfo&,
     BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
     rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
-    uint16_t, rgw_zone_set*, bool);
+    uint16_t, optional_yield, rgw_zone_set*, bool);
 template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
     const DoutPrefixProvider*, const RGWBucketInfo&,
     BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
     rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
-    uint16_t, rgw_zone_set*, bool);
+    uint16_t, optional_yield, rgw_zone_set*, bool);
 template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
     const DoutPrefixProvider*, const RGWBucketInfo&,
     BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
     rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
-    uint16_t, rgw_zone_set*, bool);
+    uint16_t, optional_yield, rgw_zone_set*, bool);
 
 int RGWRados::cls_obj_complete_add(const DoutPrefixProvider* dpp,
                                    const RGWBucketInfo& bucket_info,
@@ -11191,11 +11191,11 @@ int RGWRados::cls_obj_complete_add(const DoutPrefixProvider* dpp,
                                    int64_t pool, uint64_t epoch,
                                    rgw_bucket_dir_entry& ent, RGWObjCategory category,
                                    list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
-                                   rgw_zone_set* zones_trace, bool log_op)
+                                   optional_yield y, rgw_zone_set* zones_trace, bool log_op)
 {
   return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>>(
     dpp, bucket_info, bs, obj, tag, pool, epoch,
-    ent, category, remove_objs, bilog_flags, zones_trace, log_op);
+    ent, category, remove_objs, bilog_flags, y, zones_trace, log_op);
 }
 
 int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
@@ -11205,7 +11205,7 @@ int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
                                    rgw_obj& obj,
                                    real_time& removed_mtime,
                                    list<rgw_obj_index_key>* remove_objs,
-                                   uint16_t bilog_flags,
+                                   uint16_t bilog_flags, optional_yield y,
                                    rgw_zone_set* zones_trace,
                                    bool log_op)
 {
@@ -11214,14 +11214,14 @@ int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
   obj.key.get_index_key(&ent.key);
   return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
     dpp, bucket_info, bs, obj, tag, pool, epoch,
-    ent, RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
+    ent, RGWObjCategory::None, remove_objs, bilog_flags, y, zones_trace, log_op);
 }
 
 int RGWRados::cls_obj_complete_cancel(const DoutPrefixProvider* dpp,
                                       const RGWBucketInfo& bucket_info,
                                       BucketShard& bs, string& tag, rgw_obj& obj,
                                       list<rgw_obj_index_key>* remove_objs,
-                                      uint16_t bilog_flags,
+                                      uint16_t bilog_flags, optional_yield y,
                                       rgw_zone_set* zones_trace, bool log_op)
 {
   rgw_bucket_dir_entry ent;
@@ -11229,7 +11229,7 @@ int RGWRados::cls_obj_complete_cancel(const DoutPrefixProvider* dpp,
   return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
     dpp, bucket_info, bs, obj, tag,
     -1 /* pool id */, 0, ent,
-    RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
+    RGWObjCategory::None, remove_objs, bilog_flags, y, zones_trace, log_op);
 }
 
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -8479,9 +8479,12 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
   ent.meta.restore_status = restore_status;
   ent.meta.restore_expiry_date = restore_expiry_date;
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  const bool add_log = log_op && store->svc.zone->need_to_log_data();
 
-  ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace, add_log);
+  ret = store->cls_obj_complete_add(dpp, target->bucket_info, *bs, obj, optag,
+                                    poolid, epoch, ent, category,
+                                    remove_objs, bilog_flags, zones_trace,
+                                    log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
 			    target->bucket_info, bs->shard_id, y);
@@ -8509,10 +8512,12 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  const bool add_log = log_op && store->svc.zone->need_to_log_data();
 
-  ret = store->cls_obj_complete_del(*bs, optag, poolid, epoch, obj, removed_mtime, remove_objs, bilog_flags, zones_trace, add_log);
-
+  ret = store->cls_obj_complete_del(dpp, target->bucket_info, *bs, optag,
+                                    poolid, epoch, obj, removed_mtime,
+                                    remove_objs, bilog_flags, zones_trace,
+                                    log_op);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
 			    target->bucket_info, bs->shard_id, y);
@@ -8533,10 +8538,13 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
   RGWRados *store = target->get_store();
   BucketShard *bs;
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  const bool add_log = log_op && store->svc.zone->need_to_log_data();
 
   int ret = guard_reshard(dpp, obj, &bs, [&](BucketShard *bs) -> int {
-				 return store->cls_obj_complete_cancel(*bs, optag, obj, remove_objs, bilog_flags, zones_trace, add_log);
+				 return store->cls_obj_complete_cancel(dpp, target->bucket_info,
+				                                       *bs, optag, obj, remove_objs,
+				                                       bilog_flags, zones_trace,
+				                                       log_op);
 			       }, y);
 
   if (add_log) {
@@ -9384,22 +9392,43 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
   zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
 
   BucketShard bs(this);
+  cls_rgw_obj_key key(obj_instance.key.get_index_key_name(),
+                      obj_instance.key.instance);
 
-  r = guard_reshard(dpp, &bs, obj_instance, bucket_info,
-		    [&](BucketShard *bs) -> int {
-		      cls_rgw_obj_key key(obj_instance.key.get_index_key_name(), obj_instance.key.instance);
-		      auto& ref = bs->bucket_obj;
-		      librados::ObjectWriteOperation op;
-		      op.assert_exists(); // bucket index shard must exist
-		      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-		      cls_rgw_bucket_link_olh(op, key, olh_state.olh_tag,
-                                              delete_marker, op_tag, meta, olh_epoch,
-					      unmod_since, high_precision_time,
-					      log_data_change, zones_trace);
-                      return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), y);
-                    }, y);
+  auto do_op = [&](auto& op_issuer, auto& bilog) -> int {
+    int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
+	              [&](BucketShard *bs) -> int {
+	                auto& ref = bs->bucket_obj;
+	                librados::ObjectWriteOperation op;
+	                op.assert_exists(); // bucket index shard must exist
+	                cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+	                op_issuer.link_olh(op, olh_state.olh_tag, delete_marker,
+	                                   meta, olh_epoch, unmod_since,
+	                                   high_precision_time);
+	                return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
+	                                        std::move(op), y);
+	              }, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
+      return ret;
+    }
+    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
+                          ceph::real_time{}, zones_trace);
+    return 0;
+  };
+
+  if (delete_marker) {
+    r = with_bilog<CLSRGWLinkOLH<true>>(dpp, do_op, bucket_info,
+                                        log_data_change,
+                                        key, op_tag, &zones_trace,
+                                        static_cast<uint16_t>(RGW_BILOG_FLAG_VERSIONED_OP));
+  } else {
+    r = with_bilog<CLSRGWLinkOLH<false>>(dpp, do_op, bucket_info,
+                                         log_data_change,
+                                         key, op_tag, &zones_trace,
+                                         static_cast<uint16_t>(RGW_BILOG_FLAG_VERSIONED_OP));
+  }
   if (r < 0) {
-    ldpp_dout(dpp, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_olh() returned r=" << r << dendl;
     return r;
   }
 
@@ -9463,19 +9492,32 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
 
   BucketShard bs(this);
 
-  cls_rgw_obj_key key(obj_instance.key.get_index_key_name(), obj_instance.key.instance);
-  r = guard_reshard(dpp, &bs, obj_instance, bucket_info,
-		    [&](BucketShard *bs) -> int {
-		      auto& ref = bs->bucket_obj;
-		      librados::ObjectWriteOperation op;
-		      op.assert_exists(); // bucket index shard must exist
-		      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-		      cls_rgw_bucket_unlink_instance(op, key, op_tag,
-						     olh_tag, olh_epoch, log_op, bilog_flags, zones_trace);
-                      return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), y);
-                    }, y);
+  cls_rgw_obj_key key(obj_instance.key.get_index_key_name(),
+                        obj_instance.key.instance);
+  r = with_bilog<CLSRGWUnlinkInstance>(dpp,
+      [&](auto& op_issuer, auto& bilog) -> int {
+        int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
+              [&](BucketShard *bs) -> int {
+                auto& ref = bs->bucket_obj;
+                librados::ObjectWriteOperation op;
+                op.assert_exists(); // bucket index shard must exist
+                cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+                op_issuer.unlink_instance(op, olh_tag, olh_epoch);
+                return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid,
+                                        std::move(op), y);
+              }, y);
+        if (ret < 0) {
+          ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
+          return ret;
+        }
+        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        return 0;
+      },
+      bucket_info,
+      log_op,
+      key, op_tag, &zones_trace, bilog_flags);
   if (r < 0) {
-    ldpp_dout(dpp, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_instance() returned r=" << r << dendl;
+    ldpp_dout(dpp, 20) << "rgw_rados_operate() after unlink_instance() returned r=" << r << dendl;
     return r;
   }
 
@@ -10965,7 +11007,7 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
     // batch: callers can call add_maybe_flush/flush safely (pending stays
     // empty), but any bilog entries for this operation will be silently
     // dropped.  The ERROR log above ensures this is always visible.
-    return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+    return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
                                neorados::IOContext{}, {});
   }
 
@@ -10977,25 +11019,25 @@ RGWBILogUpdateBatch RGWRados::get_or_create_fifo_bilog_batch(
   }
 
   neorados::IOContext neo_loc(index_pool.get_id());
-  return RGWBILogUpdateBatch(dpp, svc.bilog_rados->rados_neo,
+  return RGWBILogUpdateBatch(dpp, *svc.bilog_rados->rados_neo,
                              std::move(neo_loc), shard_oids);
 }
 
-int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, string& tag,
+template <class CLSRGWBucketModifyOpT>
+int RGWRados::cls_obj_complete_op(const DoutPrefixProvider* dpp,
+                                  const RGWBucketInfo& bucket_info,
+                                  BucketShard& bs, const rgw_obj& obj, string& tag,
                                   int64_t pool, uint64_t epoch,
                                   rgw_bucket_dir_entry& ent, RGWObjCategory category,
-                                  list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                                  rgw_zone_set *_zones_trace, bool log_op)
+                                  list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
+                                  rgw_zone_set* _zones_trace, bool log_op)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
   ldout_bitx_c(bitx, cct, 10) << "ENTERING " << __func__ << ": bucket-shard=" << bs <<
-    " obj=" << obj << " tag=" << tag << " op=" << op <<
+    " obj=" << obj << " tag=" << tag <<
     ", remove_objs=" << (remove_objs ? *remove_objs : std::list<rgw_obj_index_key>()) <<
     ", log_op=" << log_op << dendl_bitx;
   ldout_bitx_c(bitx, cct, 25) << "BACKTRACE: " << __func__ << ": " << ClibBackTrace(0) << dendl_bitx;
-
-  ObjectWriteOperation o;
-  o.assert_exists(); // bucket index shard must exist
 
   rgw_bucket_dir_entry_meta dir_meta;
   dir_meta = ent.meta;
@@ -11011,58 +11053,100 @@ int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModify
   ver.pool = pool;
   ver.epoch = epoch;
   cls_rgw_obj_key key(ent.key.name, ent.key.instance);
-  cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-  cls_rgw_bucket_complete_op(o, op, tag, ver, key, dir_meta, remove_objs,
-                             log_op, bilog_flags, &zones_trace, obj.key.get_loc());
-  complete_op_data *arg;
-  index_completion_manager->create_completion(obj, op, tag, ver, key, dir_meta, remove_objs,
-                                              log_op, bilog_flags, &zones_trace, &arg);
-  librados::AioCompletion *completion = arg->rados_completion;
-  int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
-  completion->release(); /* can't reference arg here, as it might have already been released */
 
-  ldout_bitx_c(bitx, cct, 10) << "EXITING " << __func__ << ": ret=" << ret << dendl_bitx;
-  return ret;
+  return with_bilog<CLSRGWBucketModifyOpT>(
+    dpp,
+    [&](auto& op_issuer, auto& bilog_handler) {
+      // Record the bilog entry (into FIFO, or NOP for InIndex) before the CLS op.
+      bilog_handler.add_maybe_flush(
+        epoch, ent.meta.mtime,
+        static_cast<const cls_rgw_bi_log_related_op&>(op_issuer));
+
+      ObjectWriteOperation o;
+      o.assert_exists(); // bucket index shard must exist
+      cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
+      // op_issuer.log_op is true for InIndex (writes in-index bilog),
+      // false for FIFO (suppressed — FIFO batch handles it above).
+      op_issuer.complete_op(o, ver, dir_meta, remove_objs, obj.key.get_loc());
+
+      complete_op_data *arg;
+      index_completion_manager->create_completion(
+        obj, op_issuer.op, tag, ver, key, dir_meta, remove_objs,
+        op_issuer.log_op, bilog_flags, &zones_trace, &arg);
+      librados::AioCompletion *completion = arg->rados_completion;
+      int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
+      completion->release(); /* can't reference arg here, as it might have already been released */
+
+      ldout_bitx_c(bitx, cct, 10) << "EXITING " << __func__ << ": ret=" << ret << dendl_bitx;
+      return ret;
+    },
+    bucket_info,
+    log_op,
+    key, tag, &zones_trace, bilog_flags);
 }
 
-int RGWRados::cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, string& tag,
+// explicit instantiations for the three complete-op types
+template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>>(
+    const DoutPrefixProvider*, const RGWBucketInfo&,
+    BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
+    rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
+    uint16_t, rgw_zone_set*, bool);
+template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
+    const DoutPrefixProvider*, const RGWBucketInfo&,
+    BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
+    rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
+    uint16_t, rgw_zone_set*, bool);
+template int RGWRados::cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
+    const DoutPrefixProvider*, const RGWBucketInfo&,
+    BucketShard&, const rgw_obj&, string&, int64_t, uint64_t,
+    rgw_bucket_dir_entry&, RGWObjCategory, list<rgw_obj_index_key>*,
+    uint16_t, rgw_zone_set*, bool);
+
+int RGWRados::cls_obj_complete_add(const DoutPrefixProvider* dpp,
+                                   const RGWBucketInfo& bucket_info,
+                                   BucketShard& bs, const rgw_obj& obj, string& tag,
                                    int64_t pool, uint64_t epoch,
                                    rgw_bucket_dir_entry& ent, RGWObjCategory category,
-                                   list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                                   rgw_zone_set *zones_trace, bool log_op)
+                                   list<rgw_obj_index_key>* remove_objs, uint16_t bilog_flags,
+                                   rgw_zone_set* zones_trace, bool log_op)
 {
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_ADD, tag, pool, epoch,
-                             ent, category, remove_objs, bilog_flags,
-                             zones_trace, log_op);
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>>(
+    dpp, bucket_info, bs, obj, tag, pool, epoch,
+    ent, category, remove_objs, bilog_flags, zones_trace, log_op);
 }
 
-int RGWRados::cls_obj_complete_del(BucketShard& bs, string& tag,
+int RGWRados::cls_obj_complete_del(const DoutPrefixProvider* dpp,
+                                   const RGWBucketInfo& bucket_info,
+                                   BucketShard& bs, string& tag,
                                    int64_t pool, uint64_t epoch,
                                    rgw_obj& obj,
                                    real_time& removed_mtime,
-                                   list<rgw_obj_index_key> *remove_objs,
+                                   list<rgw_obj_index_key>* remove_objs,
                                    uint16_t bilog_flags,
-                                   rgw_zone_set *zones_trace,
+                                   rgw_zone_set* zones_trace,
                                    bool log_op)
 {
   rgw_bucket_dir_entry ent;
   ent.meta.mtime = removed_mtime;
   obj.key.get_index_key(&ent.key);
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_DEL, tag, pool, epoch,
-			     ent, RGWObjCategory::None, remove_objs,
-			     bilog_flags, zones_trace, log_op);
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(
+    dpp, bucket_info, bs, obj, tag, pool, epoch,
+    ent, RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
 }
 
-int RGWRados::cls_obj_complete_cancel(BucketShard& bs, string& tag, rgw_obj& obj,
-                                      list<rgw_obj_index_key> *remove_objs,
-                                      uint16_t bilog_flags, rgw_zone_set *zones_trace, bool log_op)
+int RGWRados::cls_obj_complete_cancel(const DoutPrefixProvider* dpp,
+                                      const RGWBucketInfo& bucket_info,
+                                      BucketShard& bs, string& tag, rgw_obj& obj,
+                                      list<rgw_obj_index_key>* remove_objs,
+                                      uint16_t bilog_flags,
+                                      rgw_zone_set* zones_trace, bool log_op)
 {
   rgw_bucket_dir_entry ent;
   obj.key.get_index_key(&ent.key);
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_CANCEL, tag,
-			     -1 /* pool id */, 0, ent,
-			     RGWObjCategory::None, remove_objs, bilog_flags,
-			     zones_trace, log_op);
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(
+    dpp, bucket_info, bs, obj, tag,
+    -1 /* pool id */, 0, ent,
+    RGWObjCategory::None, remove_objs, bilog_flags, zones_trace, log_op);
 }
 
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9396,11 +9396,9 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
                       obj_instance.key.instance);
 
   auto do_op = [&](auto& op_issuer, auto& bilog) -> int {
-    // stage and flush the FIFO bilog entry before the cls op so that a
-    // crash after the FIFO push but before link_olh
-    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
-                          ceph::real_time{}, zones_trace);
-    bilog.flush(y);
+    // issue the cls op first. only push to the FIFO on success so that a
+    // crash between the cls op and the FIFO push leaves the secondary behind
+    // rather than ahead with a diverged OLH pointer
     int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
 	              [&](BucketShard *bs) -> int {
 	                auto& ref = bs->bucket_obj;
@@ -9417,6 +9415,9 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
       ldpp_dout(dpp, 20) << "link_olh() returned r=" << ret << dendl;
       return ret;
     }
+    bilog.add_maybe_flush(olh_epoch, key, op_tag, delete_marker,
+                          ceph::real_time{}, zones_trace);
+    bilog.flush(y);
     return 0;
   };
 
@@ -9499,8 +9500,8 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
                         obj_instance.key.instance);
   r = with_bilog<CLSRGWUnlinkInstance>(dpp,
       [&](auto& op_issuer, auto& bilog) -> int {
-        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
-        bilog.flush(y);
+        // cls op first, FIFO push on success only (same as
+        // bucket_index_link_olh to avoid secondary OLH pointer divergence).
         int ret = guard_reshard(dpp, &bs, obj_instance, bucket_info,
               [&](BucketShard *bs) -> int {
                 auto& ref = bs->bucket_obj;
@@ -9515,6 +9516,9 @@ int RGWRados::bucket_index_unlink_instance(const DoutPrefixProvider *dpp,
           ldpp_dout(dpp, 20) << "unlink_instance() returned r=" << ret << dendl;
           return ret;
         }
+
+        bilog.add_maybe_flush(olh_epoch, ceph::real_time{}, op_issuer);
+        bilog.flush(y);
         return 0;
       },
       bucket_info,
@@ -9835,21 +9839,6 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
     return r;
   }
 
-  // for FIFO-backed buckets write the OLH-link bilog entry before the
-  // OLH xattr update so a crash after the FIFO push but before the
-  // rados op produces a safe, re-replayable state.
-  if (need_to_link) {
-    rgw_zone_set zt;
-    if (zones_trace) {
-      zt = *zones_trace;
-    }
-    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
-    with_bilog<void>(dpp, [&](auto& bilog_handler) {
-      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
-                                    delete_marker, state.mtime, zt);
-    }, bucket_info, log_op);
-  }
-
   const rgw_bucket& bucket = obj.bucket;
 
   if (need_to_link) {
@@ -9883,6 +9872,19 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": could not apply olh update to oid \"" << ref.obj.oid << "\", r=" << r << dendl;
     }
     return r;
+  }
+
+  // OLH xattr update committed. now record the FIFO bilog entry.
+  if (need_to_link) {
+    rgw_zone_set zt;
+    if (zones_trace) {
+      zt = *zones_trace;
+    }
+    zt.insert(svc.zone->get_zone().id, obj.bucket.get_key());
+    with_bilog<void>(dpp, [&](auto& bilog_handler) {
+      bilog_handler.add_maybe_flush(link_epoch, key, link_op_tag,
+                                    delete_marker, state.mtime, zt);
+    }, bucket_info, log_op);
   }
 
   if (need_to_remove) {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6207,7 +6207,7 @@ int RGWRados::store_delete_bucket_info_flag(RGWBucketInfo& bucket_info, std::map
   do {
     bucket_info.flags |= BUCKET_DELETED;
     index_log = bucket_info.layout.logs.back();
-    shards_num = rgw::num_shards(index_log.layout.in_index);
+    shards_num = rgw::num_shards(index_log);
     const auto& log = bucket_info.layout.logs.back();
     bucket_info.layout.logs.push_back({log.gen+1, {rgw::BucketLogType::Deleted}});
     r = ctl.bucket->store_bucket_instance_info(bucket, bucket_info, y, dpp, RGWBucketCtl::BucketInstance::PutParams()

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -338,8 +338,8 @@ struct BILogNopHandler {
   void add_maybe_flush(RGWModifyOp op,
                        const rgw_bucket_dir_entry& list_state,
                        rgw_zone_set zones_trace) {}
-  void flush(optional_yield) {}
-  void flush() {}
+  int flush(optional_yield) { return 0; }
+  int flush() { return 0; }
 };
 
 class RGWRados

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -408,7 +408,15 @@ class RGWRados
 
   ceph::mutex bucket_id_lock{ceph::make_mutex("rados_bucket_id")};
 
-  // This field represents the number of bucket index object shards
+  /// write-path FIFO bilog cache
+  /// shared_ptr<RGWBILogFIFO> is reused across all operations for the same
+  /// (bucket_id, gen) so that LazyFIFO::lazy_init()/FIFO::create() runs at
+  /// most once per shard per generation.
+  mutable ceph::shared_mutex fifo_bilog_cache_lock_ =
+      ceph::make_shared_mutex("RGWRados::fifo_bilog_cache");
+  std::map<std::pair<std::string, uint64_t>,
+           std::shared_ptr<RGWBILogFIFO>> fifo_bilog_cache_;
+
   uint32_t bucket_index_max_shards{0};
 
   std::string get_cluster_fsid(const DoutPrefixProvider *dpp, optional_yield y);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -338,7 +338,7 @@ struct BILogNopHandler {
   void add_maybe_flush(RGWModifyOp op,
                        const rgw_bucket_dir_entry& list_state,
                        rgw_zone_set zones_trace) {}
-  void flush(asio::yield_context y) {}
+  void flush(optional_yield) {}
   void flush() {}
 };
 

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1634,10 +1634,14 @@ public:
     const bool is_inindex =
       bucket_info.layout.logs.empty() ||
       bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
+    // suppress fifo bilog entries when sync is disabled.
+    // datasync_flag_enabled() reflects the bucket-info flag set by
+    // "bucket sync disable".
+    const bool fifo_sync_enabled = bucket_info.datasync_flag_enabled();
 
     if constexpr (std::is_same_v<CLSRGWBucketModifyOpT, void>) {
       // bilog-only variant: lambda receives only a bilog handler.
-      if (log_data && !is_inindex) {
+      if (log_data && !is_inindex && fifo_sync_enabled) {
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
         std::forward<F>(func)(batch);
       } else {
@@ -1652,13 +1656,15 @@ public:
         CLSRGWBucketModifyOpT op_issuer{log_data, std::forward<Args>(args)...};
         BILogNopHandler nop;
         return std::forward<F>(func)(op_issuer, nop);
-      } else if (log_data) {
-        // FIFO log: OpIssuer must not write in-index bilog. FIFO batch does it.
+      } else if (log_data && fifo_sync_enabled) {
+        // fifo log, sync enabled. OpIssuer must not write in-index bilog.
         CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
         return std::forward<F>(func)(op_issuer, batch);
       } else {
-        // logging disabled entirely.
+        // fifo log with logging disabled, or sync disabled: CLS op proceeds
+        // normally but no fifo entry is written.  op_issuer always gets
+        // log_op=false for fifo so the OSD never writes omap bilog entries.
         CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
         BILogNopHandler nop;
         return std::forward<F>(func)(op_issuer, nop);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1559,18 +1559,32 @@ public:
 
   int cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs, RGWModifyOp op, std::string& tag, rgw_obj& obj,
                          optional_yield y);
-  int cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, std::string& tag, int64_t pool, uint64_t epoch,
-                          rgw_bucket_dir_entry& ent, RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs,
-                          uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, std::string& tag, int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
-                           RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                           rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_del(BucketShard& bs, std::string& tag, int64_t pool, uint64_t epoch, rgw_obj& obj,
-                           ceph::real_time& removed_mtime, std::list<rgw_obj_index_key> *remove_objs,
-                           uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,
-                              std::list<rgw_obj_index_key> *remove_objs,
-                              uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
+  template <class CLSRGWBucketModifyOpT>
+  int cls_obj_complete_op(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                          BucketShard& bs, const rgw_obj& obj, std::string& tag,
+                          int64_t pool, uint64_t epoch,
+                          rgw_bucket_dir_entry& ent, RGWObjCategory category,
+                          std::list<rgw_obj_index_key>* remove_objs,
+                          uint16_t bilog_flags,
+                          rgw_zone_set* zones_trace = nullptr, bool log_op = true);
+  int cls_obj_complete_add(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                           BucketShard& bs, const rgw_obj& obj, std::string& tag,
+                           int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
+                           RGWObjCategory category, std::list<rgw_obj_index_key>* remove_objs,
+                           uint16_t bilog_flags,
+                           rgw_zone_set* zones_trace = nullptr, bool log_op = true);
+  int cls_obj_complete_del(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                           BucketShard& bs, std::string& tag,
+                           int64_t pool, uint64_t epoch, rgw_obj& obj,
+                           ceph::real_time& removed_mtime,
+                           std::list<rgw_obj_index_key>* remove_objs,
+                           uint16_t bilog_flags,
+                           rgw_zone_set* zones_trace = nullptr, bool log_op = true);
+  int cls_obj_complete_cancel(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                              BucketShard& bs, std::string& tag, rgw_obj& obj,
+                              std::list<rgw_obj_index_key>* remove_objs,
+                              uint16_t bilog_flags,
+                              rgw_zone_set* zones_trace = nullptr, bool log_op = true);
 
   /// create a FIFO bilog batch writer for the active log generation of
   /// bucket_info.  The shard OIDs are derived from the current FIFO log
@@ -1599,13 +1613,15 @@ public:
   int with_bilog(const DoutPrefixProvider* dpp,
                  F&& func,
                  const RGWBucketInfo& bucket_info,
+                 bool log_op,
                  Args&&... args)
   {
     ldpp_dout(dpp, 20) << __func__
-                       << ": zone.log_data="
-                       << svc.zone->get_zone().log_data << dendl;
+                       << ": log_op=" << log_op
+                       << " need_to_log_data=" << svc.zone->need_to_log_data()
+                       << dendl;
 
-    const bool log_data = svc.zone->get_zone().log_data;
+    const bool log_data = log_op && svc.zone->need_to_log_data();
     const bool is_inindex =
       bucket_info.layout.logs.empty() ||
       bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
@@ -1622,21 +1638,20 @@ public:
     } else {
       // full variant: lambda receives (op_issuer, bilog_handler).
       if (is_inindex) {
-        // InIndex or no-log: OpIssuer writes its own bilog; FIFO is NOP.
-        return std::forward<F>(func)(
-            CLSRGWBucketModifyOpT{log_data, std::forward<Args>(args)...},
-            BILogNopHandler{});
+        // InIndex or no-log: OpIssuer writes its own bilog. FIFO is NOP.
+        CLSRGWBucketModifyOpT op_issuer{log_data, std::forward<Args>(args)...};
+        BILogNopHandler nop;
+        return std::forward<F>(func)(op_issuer, nop);
       } else if (log_data) {
-        // FIFO log: OpIssuer must not write in-index bilog; FIFO batch does it.
+        // FIFO log: OpIssuer must not write in-index bilog. FIFO batch does it.
+        CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
-        return std::forward<F>(func)(
-            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
-            batch);
+        return std::forward<F>(func)(op_issuer, batch);
       } else {
         // logging disabled entirely.
-        return std::forward<F>(func)(
-            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
-            BILogNopHandler{});
+        CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
+        BILogNopHandler nop;
+        return std::forward<F>(func)(op_issuer, nop);
       }
     }
   }

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <functional>
+#include <type_traits>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
 
@@ -29,6 +30,7 @@
 #include "rgw_obj_manifest.h"
 #include "rgw_sync_module.h"
 #include "rgw_trim_bilog.h"
+#include "rgw_bilog.h"
 #include "rgw_service.h"
 #include "rgw_sal_store.h"
 #include "rgw_aio.h"
@@ -319,6 +321,25 @@ class lru_map;
 using tombstone_cache_t = lru_map<rgw_obj, tombstone_entry>;
 
 class RGWIndexCompletionManager;
+
+// no-op bilog handler
+// used when bilog recording is disabled or handled in-index (InIndex layout).
+struct BILogNopHandler {
+  void add_maybe_flush(uint64_t /*olh_epoch*/,
+                       ceph::real_time /*mtime*/,
+                       const cls_rgw_bi_log_related_op& /*op_info*/) {}
+  void add_maybe_flush(uint64_t /*olh_epoch*/,
+                       const cls_rgw_obj_key& /*key*/,
+                       const std::string& /*op_tag*/,
+                       bool /*delete_marker*/,
+                       ceph::real_time /*mtime*/,
+                       const rgw_zone_set& /*zones_trace*/) {}
+  void add_maybe_flush(RGWModifyOp /*op*/,
+                       const rgw_bucket_dir_entry& /*list_state*/,
+                       rgw_zone_set /*zones_trace*/) {}
+  void flush(asio::yield_context /*y*/) {}
+  void flush() {}
+};
 
 class RGWRados
 {
@@ -1550,6 +1571,75 @@ public:
   int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,
                               std::list<rgw_obj_index_key> *remove_objs,
                               uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
+
+  /// create a FIFO bilog batch writer for the active log generation of
+  /// bucket_info.  The shard OIDs are derived from the current FIFO log
+  /// layout stored in bucket_info.layout.logs.
+  RGWBILogUpdateBatch get_or_create_fifo_bilog_batch(
+      const DoutPrefixProvider* dpp,
+      const RGWBucketInfo& bucket_info);
+
+  /// dispatch bilog recording + optional bucket-index op for a single request.
+  ///
+  /// CLSRGWBucketModifyOpT == void:
+  ///   is called as func(bilog_handler)
+  ///   — used when only a bilog entry needs to be written without a CLS op
+  ///     (e.g. apply_olh_log replay, check_disk_state reconciliation).
+  ///
+  /// CLSRGWBucketModifyOpT != void:
+  ///   is called as func(op_issuer, bilog_handler)
+  ///   — used for normal bucket-index write operations; args are forwarded
+  ///     to the OpIssuer constructor.
+  ///
+  /// backend selection:
+  ///   InIndex log (or no log) + log_data=true  → OpIssuer(log_data=true)  + BILogNopHandler
+  ///   FIFO log               + log_data=true  → OpIssuer(log_data=false) + RGWBILogUpdateBatch
+  ///   any                    + log_data=false → OpIssuer(log_data=false) + BILogNopHandler
+  template <class CLSRGWBucketModifyOpT, class F, class... Args>
+  int with_bilog(const DoutPrefixProvider* dpp,
+                 F&& func,
+                 const RGWBucketInfo& bucket_info,
+                 Args&&... args)
+  {
+    ldpp_dout(dpp, 20) << __func__
+                       << ": zone.log_data="
+                       << svc.zone->get_zone().log_data << dendl;
+
+    const bool log_data = svc.zone->get_zone().log_data;
+    const bool is_inindex =
+      bucket_info.layout.logs.empty() ||
+      bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
+
+    if constexpr (std::is_same_v<CLSRGWBucketModifyOpT, void>) {
+      // bilog-only variant: lambda receives only a bilog handler.
+      if (log_data && !is_inindex) {
+        auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
+        return std::forward<F>(func)(batch);
+      } else {
+        BILogNopHandler nop;
+        return std::forward<F>(func)(nop);
+      }
+    } else {
+      // full variant: lambda receives (op_issuer, bilog_handler).
+      if (is_inindex) {
+        // InIndex or no-log: OpIssuer writes its own bilog; FIFO is NOP.
+        return std::forward<F>(func)(
+            CLSRGWBucketModifyOpT{log_data, std::forward<Args>(args)...},
+            BILogNopHandler{});
+      } else if (log_data) {
+        // FIFO log: OpIssuer must not write in-index bilog; FIFO batch does it.
+        auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
+        return std::forward<F>(func)(
+            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
+            batch);
+      } else {
+        // logging disabled entirely.
+        return std::forward<F>(func)(
+            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
+            BILogNopHandler{});
+      }
+    }
+  }
 
   using ent_map_t =
     boost::container::flat_map<std::string, rgw_bucket_dir_entry>;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1574,25 +1574,25 @@ public:
                           int64_t pool, uint64_t epoch,
                           rgw_bucket_dir_entry& ent, RGWObjCategory category,
                           std::list<rgw_obj_index_key>* remove_objs,
-                          uint16_t bilog_flags,
+                          uint16_t bilog_flags, optional_yield y,
                           rgw_zone_set* zones_trace = nullptr, bool log_op = true);
   int cls_obj_complete_add(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
                            BucketShard& bs, const rgw_obj& obj, std::string& tag,
                            int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
                            RGWObjCategory category, std::list<rgw_obj_index_key>* remove_objs,
-                           uint16_t bilog_flags,
+                           uint16_t bilog_flags, optional_yield y,
                            rgw_zone_set* zones_trace = nullptr, bool log_op = true);
   int cls_obj_complete_del(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
                            BucketShard& bs, std::string& tag,
                            int64_t pool, uint64_t epoch, rgw_obj& obj,
                            ceph::real_time& removed_mtime,
                            std::list<rgw_obj_index_key>* remove_objs,
-                           uint16_t bilog_flags,
+                           uint16_t bilog_flags, optional_yield y,
                            rgw_zone_set* zones_trace = nullptr, bool log_op = true);
   int cls_obj_complete_cancel(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
                               BucketShard& bs, std::string& tag, rgw_obj& obj,
                               std::list<rgw_obj_index_key>* remove_objs,
-                              uint16_t bilog_flags,
+                              uint16_t bilog_flags, optional_yield y,
                               rgw_zone_set* zones_trace = nullptr, bool log_op = true);
 
   // create a FIFO bilog batch writer for the active log generation of

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -37,6 +37,7 @@
 #include "rgw_d3n_cacherequest.h"
 
 #include "services/svc_bi_rados.h"
+#include "services/svc_zone.h"
 #include "common/Throttle.h"
 #include "common/ceph_mutex.h"
 #include "rgw_cache.h"
@@ -1630,11 +1631,12 @@ public:
       // bilog-only variant: lambda receives only a bilog handler.
       if (log_data && !is_inindex) {
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
-        return std::forward<F>(func)(batch);
+        std::forward<F>(func)(batch);
       } else {
         BILogNopHandler nop;
-        return std::forward<F>(func)(nop);
+        std::forward<F>(func)(nop);
       }
+      return 0;
     } else {
       // full variant: lambda receives (op_issuer, bilog_handler).
       if (is_inindex) {

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1816,7 +1816,8 @@ public:
                        rgw_bucket_dir_entry& list_state,
                        rgw_bucket_dir_entry& object,
                        bufferlist& suggested_updates,
-                       optional_yield y);
+                       optional_yield y,
+                       bool log_op = true);
 
   /**
    * Init pool iteration

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -326,19 +326,19 @@ class RGWIndexCompletionManager;
 // no-op bilog handler
 // used when bilog recording is disabled or handled in-index (InIndex layout).
 struct BILogNopHandler {
-  void add_maybe_flush(uint64_t /*olh_epoch*/,
-                       ceph::real_time /*mtime*/,
-                       const cls_rgw_bi_log_related_op& /*op_info*/) {}
-  void add_maybe_flush(uint64_t /*olh_epoch*/,
-                       const cls_rgw_obj_key& /*key*/,
-                       const std::string& /*op_tag*/,
-                       bool /*delete_marker*/,
-                       ceph::real_time /*mtime*/,
-                       const rgw_zone_set& /*zones_trace*/) {}
-  void add_maybe_flush(RGWModifyOp /*op*/,
-                       const rgw_bucket_dir_entry& /*list_state*/,
-                       rgw_zone_set /*zones_trace*/) {}
-  void flush(asio::yield_context /*y*/) {}
+  void add_maybe_flush(uint64_t olh_epoch,
+                       ceph::real_time mtime,
+                       const cls_rgw_bi_log_related_op& op_info) {}
+  void add_maybe_flush(uint64_t olh_epoch,
+                       const cls_rgw_obj_key& key,
+                       const std::string& op_tag,
+                       bool delete_marker,
+                       ceph::real_time mtime,
+                       const rgw_zone_set& zones_trace) {}
+  void add_maybe_flush(RGWModifyOp op,
+                       const rgw_bucket_dir_entry& list_state,
+                       rgw_zone_set zones_trace) {}
+  void flush(asio::yield_context y) {}
   void flush() {}
 };
 
@@ -408,10 +408,10 @@ class RGWRados
 
   ceph::mutex bucket_id_lock{ceph::make_mutex("rados_bucket_id")};
 
-  /// write-path FIFO bilog cache
-  /// shared_ptr<RGWBILogFIFO> is reused across all operations for the same
-  /// (bucket_id, gen) so that LazyFIFO::lazy_init()/FIFO::create() runs at
-  /// most once per shard per generation.
+  // write-path FIFO bilog cache
+  // shared_ptr<RGWBILogFIFO> is reused across all operations for the same
+  // (bucket_id, gen) so that LazyFIFO::lazy_init()/FIFO::create() runs at
+  // most once per shard per generation.
   mutable ceph::shared_mutex fifo_bilog_cache_lock_ =
       ceph::make_shared_mutex("RGWRados::fifo_bilog_cache");
   std::map<std::pair<std::string, uint64_t>,
@@ -1595,29 +1595,29 @@ public:
                               uint16_t bilog_flags,
                               rgw_zone_set* zones_trace = nullptr, bool log_op = true);
 
-  /// create a FIFO bilog batch writer for the active log generation of
-  /// bucket_info.  The shard OIDs are derived from the current FIFO log
-  /// layout stored in bucket_info.layout.logs.
+  // create a FIFO bilog batch writer for the active log generation of
+  // bucket_info.  The shard OIDs are derived from the current FIFO log
+  // layout stored in bucket_info.layout.logs.
   RGWBILogUpdateBatch get_or_create_fifo_bilog_batch(
       const DoutPrefixProvider* dpp,
       const RGWBucketInfo& bucket_info);
 
-  /// dispatch bilog recording + optional bucket-index op for a single request.
-  ///
-  /// CLSRGWBucketModifyOpT == void:
-  ///   is called as func(bilog_handler)
-  ///   — used when only a bilog entry needs to be written without a CLS op
-  ///     (e.g. apply_olh_log replay, check_disk_state reconciliation).
-  ///
-  /// CLSRGWBucketModifyOpT != void:
-  ///   is called as func(op_issuer, bilog_handler)
-  ///   — used for normal bucket-index write operations; args are forwarded
-  ///     to the OpIssuer constructor.
-  ///
-  /// backend selection:
-  ///   InIndex log (or no log) + log_data=true  → OpIssuer(log_data=true)  + BILogNopHandler
-  ///   FIFO log               + log_data=true  → OpIssuer(log_data=false) + RGWBILogUpdateBatch
-  ///   any                    + log_data=false → OpIssuer(log_data=false) + BILogNopHandler
+  // dispatch bilog recording + optional bucket-index op for a single request.
+  //
+  // CLSRGWBucketModifyOpT == void:
+  //   is called as func(bilog_handler)
+  //   — used when only a bilog entry needs to be written without a CLS op
+  //     (e.g. apply_olh_log replay, check_disk_state reconciliation).
+  //
+  // CLSRGWBucketModifyOpT != void:
+  //   is called as func(op_issuer, bilog_handler)
+  //   — used for normal bucket-index write operations; args are forwarded
+  //     to the OpIssuer constructor.
+  //
+  // backend selection:
+  //   InIndex log (or no log) + log_data=true  → OpIssuer(log_data=true)  + BILogNopHandler
+  //   FIFO log               + log_data=true  → OpIssuer(log_data=false) + RGWBILogUpdateBatch
+  //   any                    + log_data=false → OpIssuer(log_data=false) + BILogNopHandler
   template <class CLSRGWBucketModifyOpT, class F, class... Args>
   int with_bilog(const DoutPrefixProvider* dpp,
                  F&& func,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -37,6 +37,7 @@
 #include "rgw_d3n_cacherequest.h"
 
 #include "services/svc_bi_rados.h"
+#include "services/svc_zone.h"
 #include "common/Throttle.h"
 #include "common/ceph_mutex.h"
 #include "rgw_cache.h"
@@ -1634,11 +1635,12 @@ public:
       // bilog-only variant: lambda receives only a bilog handler.
       if (log_data && !is_inindex) {
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
-        return std::forward<F>(func)(batch);
+        std::forward<F>(func)(batch);
       } else {
         BILogNopHandler nop;
-        return std::forward<F>(func)(nop);
+        std::forward<F>(func)(nop);
       }
+      return 0;
     } else {
       // full variant: lambda receives (op_issuer, bilog_handler).
       if (is_inindex) {

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1820,7 +1820,8 @@ public:
                        rgw_bucket_dir_entry& list_state,
                        rgw_bucket_dir_entry& object,
                        bufferlist& suggested_updates,
-                       optional_yield y);
+                       optional_yield y,
+                       bool log_op = true);
 
   /**
    * Init pool iteration

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -326,19 +326,19 @@ class RGWIndexCompletionManager;
 // no-op bilog handler
 // used when bilog recording is disabled or handled in-index (InIndex layout).
 struct BILogNopHandler {
-  void add_maybe_flush(uint64_t /*olh_epoch*/,
-                       ceph::real_time /*mtime*/,
-                       const cls_rgw_bi_log_related_op& /*op_info*/) {}
-  void add_maybe_flush(uint64_t /*olh_epoch*/,
-                       const cls_rgw_obj_key& /*key*/,
-                       const std::string& /*op_tag*/,
-                       bool /*delete_marker*/,
-                       ceph::real_time /*mtime*/,
-                       const rgw_zone_set& /*zones_trace*/) {}
-  void add_maybe_flush(RGWModifyOp /*op*/,
-                       const rgw_bucket_dir_entry& /*list_state*/,
-                       rgw_zone_set /*zones_trace*/) {}
-  void flush(asio::yield_context /*y*/) {}
+  void add_maybe_flush(uint64_t olh_epoch,
+                       ceph::real_time mtime,
+                       const cls_rgw_bi_log_related_op& op_info) {}
+  void add_maybe_flush(uint64_t olh_epoch,
+                       const cls_rgw_obj_key& key,
+                       const std::string& op_tag,
+                       bool delete_marker,
+                       ceph::real_time mtime,
+                       const rgw_zone_set& zones_trace) {}
+  void add_maybe_flush(RGWModifyOp op,
+                       const rgw_bucket_dir_entry& list_state,
+                       rgw_zone_set zones_trace) {}
+  void flush(asio::yield_context y) {}
   void flush() {}
 };
 
@@ -408,10 +408,10 @@ class RGWRados
 
   ceph::mutex bucket_id_lock{ceph::make_mutex("rados_bucket_id")};
 
-  /// write-path FIFO bilog cache
-  /// shared_ptr<RGWBILogFIFO> is reused across all operations for the same
-  /// (bucket_id, gen) so that LazyFIFO::lazy_init()/FIFO::create() runs at
-  /// most once per shard per generation.
+  // write-path FIFO bilog cache
+  // shared_ptr<RGWBILogFIFO> is reused across all operations for the same
+  // (bucket_id, gen) so that LazyFIFO::lazy_init()/FIFO::create() runs at
+  // most once per shard per generation.
   mutable ceph::shared_mutex fifo_bilog_cache_lock_ =
       ceph::make_shared_mutex("RGWRados::fifo_bilog_cache");
   std::map<std::pair<std::string, uint64_t>,
@@ -1599,29 +1599,29 @@ public:
                               uint16_t bilog_flags,
                               rgw_zone_set* zones_trace = nullptr, bool log_op = true);
 
-  /// create a FIFO bilog batch writer for the active log generation of
-  /// bucket_info.  The shard OIDs are derived from the current FIFO log
-  /// layout stored in bucket_info.layout.logs.
+  // create a FIFO bilog batch writer for the active log generation of
+  // bucket_info.  The shard OIDs are derived from the current FIFO log
+  // layout stored in bucket_info.layout.logs.
   RGWBILogUpdateBatch get_or_create_fifo_bilog_batch(
       const DoutPrefixProvider* dpp,
       const RGWBucketInfo& bucket_info);
 
-  /// dispatch bilog recording + optional bucket-index op for a single request.
-  ///
-  /// CLSRGWBucketModifyOpT == void:
-  ///   is called as func(bilog_handler)
-  ///   — used when only a bilog entry needs to be written without a CLS op
-  ///     (e.g. apply_olh_log replay, check_disk_state reconciliation).
-  ///
-  /// CLSRGWBucketModifyOpT != void:
-  ///   is called as func(op_issuer, bilog_handler)
-  ///   — used for normal bucket-index write operations; args are forwarded
-  ///     to the OpIssuer constructor.
-  ///
-  /// backend selection:
-  ///   InIndex log (or no log) + log_data=true  → OpIssuer(log_data=true)  + BILogNopHandler
-  ///   FIFO log               + log_data=true  → OpIssuer(log_data=false) + RGWBILogUpdateBatch
-  ///   any                    + log_data=false → OpIssuer(log_data=false) + BILogNopHandler
+  // dispatch bilog recording + optional bucket-index op for a single request.
+  //
+  // CLSRGWBucketModifyOpT == void:
+  //   is called as func(bilog_handler)
+  //   — used when only a bilog entry needs to be written without a CLS op
+  //     (e.g. apply_olh_log replay, check_disk_state reconciliation).
+  //
+  // CLSRGWBucketModifyOpT != void:
+  //   is called as func(op_issuer, bilog_handler)
+  //   — used for normal bucket-index write operations; args are forwarded
+  //     to the OpIssuer constructor.
+  //
+  // backend selection:
+  //   InIndex log (or no log) + log_data=true  → OpIssuer(log_data=true)  + BILogNopHandler
+  //   FIFO log               + log_data=true  → OpIssuer(log_data=false) + RGWBILogUpdateBatch
+  //   any                    + log_data=false → OpIssuer(log_data=false) + BILogNopHandler
   template <class CLSRGWBucketModifyOpT, class F, class... Args>
   int with_bilog(const DoutPrefixProvider* dpp,
                  F&& func,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <functional>
+#include <type_traits>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
 
@@ -29,6 +30,7 @@
 #include "rgw_obj_manifest.h"
 #include "rgw_sync_module.h"
 #include "rgw_trim_bilog.h"
+#include "rgw_bilog.h"
 #include "rgw_service.h"
 #include "rgw_sal_store.h"
 #include "rgw_aio.h"
@@ -319,6 +321,25 @@ class lru_map;
 using tombstone_cache_t = lru_map<rgw_obj, tombstone_entry>;
 
 class RGWIndexCompletionManager;
+
+// no-op bilog handler
+// used when bilog recording is disabled or handled in-index (InIndex layout).
+struct BILogNopHandler {
+  void add_maybe_flush(uint64_t /*olh_epoch*/,
+                       ceph::real_time /*mtime*/,
+                       const cls_rgw_bi_log_related_op& /*op_info*/) {}
+  void add_maybe_flush(uint64_t /*olh_epoch*/,
+                       const cls_rgw_obj_key& /*key*/,
+                       const std::string& /*op_tag*/,
+                       bool /*delete_marker*/,
+                       ceph::real_time /*mtime*/,
+                       const rgw_zone_set& /*zones_trace*/) {}
+  void add_maybe_flush(RGWModifyOp /*op*/,
+                       const rgw_bucket_dir_entry& /*list_state*/,
+                       rgw_zone_set /*zones_trace*/) {}
+  void flush(asio::yield_context /*y*/) {}
+  void flush() {}
+};
 
 class RGWRados
 {
@@ -1554,6 +1575,75 @@ public:
   int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,
                               std::list<rgw_obj_index_key> *remove_objs,
                               uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
+
+  /// create a FIFO bilog batch writer for the active log generation of
+  /// bucket_info.  The shard OIDs are derived from the current FIFO log
+  /// layout stored in bucket_info.layout.logs.
+  RGWBILogUpdateBatch get_or_create_fifo_bilog_batch(
+      const DoutPrefixProvider* dpp,
+      const RGWBucketInfo& bucket_info);
+
+  /// dispatch bilog recording + optional bucket-index op for a single request.
+  ///
+  /// CLSRGWBucketModifyOpT == void:
+  ///   is called as func(bilog_handler)
+  ///   — used when only a bilog entry needs to be written without a CLS op
+  ///     (e.g. apply_olh_log replay, check_disk_state reconciliation).
+  ///
+  /// CLSRGWBucketModifyOpT != void:
+  ///   is called as func(op_issuer, bilog_handler)
+  ///   — used for normal bucket-index write operations; args are forwarded
+  ///     to the OpIssuer constructor.
+  ///
+  /// backend selection:
+  ///   InIndex log (or no log) + log_data=true  → OpIssuer(log_data=true)  + BILogNopHandler
+  ///   FIFO log               + log_data=true  → OpIssuer(log_data=false) + RGWBILogUpdateBatch
+  ///   any                    + log_data=false → OpIssuer(log_data=false) + BILogNopHandler
+  template <class CLSRGWBucketModifyOpT, class F, class... Args>
+  int with_bilog(const DoutPrefixProvider* dpp,
+                 F&& func,
+                 const RGWBucketInfo& bucket_info,
+                 Args&&... args)
+  {
+    ldpp_dout(dpp, 20) << __func__
+                       << ": zone.log_data="
+                       << svc.zone->get_zone().log_data << dendl;
+
+    const bool log_data = svc.zone->get_zone().log_data;
+    const bool is_inindex =
+      bucket_info.layout.logs.empty() ||
+      bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
+
+    if constexpr (std::is_same_v<CLSRGWBucketModifyOpT, void>) {
+      // bilog-only variant: lambda receives only a bilog handler.
+      if (log_data && !is_inindex) {
+        auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
+        return std::forward<F>(func)(batch);
+      } else {
+        BILogNopHandler nop;
+        return std::forward<F>(func)(nop);
+      }
+    } else {
+      // full variant: lambda receives (op_issuer, bilog_handler).
+      if (is_inindex) {
+        // InIndex or no-log: OpIssuer writes its own bilog; FIFO is NOP.
+        return std::forward<F>(func)(
+            CLSRGWBucketModifyOpT{log_data, std::forward<Args>(args)...},
+            BILogNopHandler{});
+      } else if (log_data) {
+        // FIFO log: OpIssuer must not write in-index bilog; FIFO batch does it.
+        auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
+        return std::forward<F>(func)(
+            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
+            batch);
+      } else {
+        // logging disabled entirely.
+        return std::forward<F>(func)(
+            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
+            BILogNopHandler{});
+      }
+    }
+  }
 
   using ent_map_t =
     boost::container::flat_map<std::string, rgw_bucket_dir_entry>;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1578,25 +1578,25 @@ public:
                           int64_t pool, uint64_t epoch,
                           rgw_bucket_dir_entry& ent, RGWObjCategory category,
                           std::list<rgw_obj_index_key>* remove_objs,
-                          uint16_t bilog_flags,
+                          uint16_t bilog_flags, optional_yield y,
                           rgw_zone_set* zones_trace = nullptr, bool log_op = true);
   int cls_obj_complete_add(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
                            BucketShard& bs, const rgw_obj& obj, std::string& tag,
                            int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
                            RGWObjCategory category, std::list<rgw_obj_index_key>* remove_objs,
-                           uint16_t bilog_flags,
+                           uint16_t bilog_flags, optional_yield y,
                            rgw_zone_set* zones_trace = nullptr, bool log_op = true);
   int cls_obj_complete_del(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
                            BucketShard& bs, std::string& tag,
                            int64_t pool, uint64_t epoch, rgw_obj& obj,
                            ceph::real_time& removed_mtime,
                            std::list<rgw_obj_index_key>* remove_objs,
-                           uint16_t bilog_flags,
+                           uint16_t bilog_flags, optional_yield y,
                            rgw_zone_set* zones_trace = nullptr, bool log_op = true);
   int cls_obj_complete_cancel(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
                               BucketShard& bs, std::string& tag, rgw_obj& obj,
                               std::list<rgw_obj_index_key>* remove_objs,
-                              uint16_t bilog_flags,
+                              uint16_t bilog_flags, optional_yield y,
                               rgw_zone_set* zones_trace = nullptr, bool log_op = true);
 
   // create a FIFO bilog batch writer for the active log generation of

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1638,10 +1638,14 @@ public:
     const bool is_inindex =
       bucket_info.layout.logs.empty() ||
       bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
+    // suppress fifo bilog entries when sync is disabled.
+    // datasync_flag_enabled() reflects the bucket-info flag set by
+    // "bucket sync disable".
+    const bool fifo_sync_enabled = bucket_info.datasync_flag_enabled();
 
     if constexpr (std::is_same_v<CLSRGWBucketModifyOpT, void>) {
       // bilog-only variant: lambda receives only a bilog handler.
-      if (log_data && !is_inindex) {
+      if (log_data && !is_inindex && fifo_sync_enabled) {
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
         std::forward<F>(func)(batch);
       } else {
@@ -1656,13 +1660,15 @@ public:
         CLSRGWBucketModifyOpT op_issuer{log_data, std::forward<Args>(args)...};
         BILogNopHandler nop;
         return std::forward<F>(func)(op_issuer, nop);
-      } else if (log_data) {
-        // FIFO log: OpIssuer must not write in-index bilog. FIFO batch does it.
+      } else if (log_data && fifo_sync_enabled) {
+        // fifo log, sync enabled. OpIssuer must not write in-index bilog.
         CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
         return std::forward<F>(func)(op_issuer, batch);
       } else {
-        // logging disabled entirely.
+        // fifo log with logging disabled, or sync disabled: CLS op proceeds
+        // normally but no fifo entry is written.  op_issuer always gets
+        // log_op=false for fifo so the OSD never writes omap bilog entries.
         CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
         BILogNopHandler nop;
         return std::forward<F>(func)(op_issuer, nop);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1563,18 +1563,32 @@ public:
 
   int cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs, RGWModifyOp op, std::string& tag, rgw_obj& obj,
                          optional_yield y);
-  int cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, std::string& tag, int64_t pool, uint64_t epoch,
-                          rgw_bucket_dir_entry& ent, RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs,
-                          uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, std::string& tag, int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
-                           RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
-                           rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_del(BucketShard& bs, std::string& tag, int64_t pool, uint64_t epoch, rgw_obj& obj,
-                           ceph::real_time& removed_mtime, std::list<rgw_obj_index_key> *remove_objs,
-                           uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,
-                              std::list<rgw_obj_index_key> *remove_objs,
-                              uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
+  template <class CLSRGWBucketModifyOpT>
+  int cls_obj_complete_op(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                          BucketShard& bs, const rgw_obj& obj, std::string& tag,
+                          int64_t pool, uint64_t epoch,
+                          rgw_bucket_dir_entry& ent, RGWObjCategory category,
+                          std::list<rgw_obj_index_key>* remove_objs,
+                          uint16_t bilog_flags,
+                          rgw_zone_set* zones_trace = nullptr, bool log_op = true);
+  int cls_obj_complete_add(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                           BucketShard& bs, const rgw_obj& obj, std::string& tag,
+                           int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
+                           RGWObjCategory category, std::list<rgw_obj_index_key>* remove_objs,
+                           uint16_t bilog_flags,
+                           rgw_zone_set* zones_trace = nullptr, bool log_op = true);
+  int cls_obj_complete_del(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                           BucketShard& bs, std::string& tag,
+                           int64_t pool, uint64_t epoch, rgw_obj& obj,
+                           ceph::real_time& removed_mtime,
+                           std::list<rgw_obj_index_key>* remove_objs,
+                           uint16_t bilog_flags,
+                           rgw_zone_set* zones_trace = nullptr, bool log_op = true);
+  int cls_obj_complete_cancel(const DoutPrefixProvider* dpp, const RGWBucketInfo& bucket_info,
+                              BucketShard& bs, std::string& tag, rgw_obj& obj,
+                              std::list<rgw_obj_index_key>* remove_objs,
+                              uint16_t bilog_flags,
+                              rgw_zone_set* zones_trace = nullptr, bool log_op = true);
 
   /// create a FIFO bilog batch writer for the active log generation of
   /// bucket_info.  The shard OIDs are derived from the current FIFO log
@@ -1603,13 +1617,15 @@ public:
   int with_bilog(const DoutPrefixProvider* dpp,
                  F&& func,
                  const RGWBucketInfo& bucket_info,
+                 bool log_op,
                  Args&&... args)
   {
     ldpp_dout(dpp, 20) << __func__
-                       << ": zone.log_data="
-                       << svc.zone->get_zone().log_data << dendl;
+                       << ": log_op=" << log_op
+                       << " need_to_log_data=" << svc.zone->need_to_log_data()
+                       << dendl;
 
-    const bool log_data = svc.zone->get_zone().log_data;
+    const bool log_data = log_op && svc.zone->need_to_log_data();
     const bool is_inindex =
       bucket_info.layout.logs.empty() ||
       bucket_info.layout.logs.back().layout.type != rgw::BucketLogType::FIFO;
@@ -1626,21 +1642,20 @@ public:
     } else {
       // full variant: lambda receives (op_issuer, bilog_handler).
       if (is_inindex) {
-        // InIndex or no-log: OpIssuer writes its own bilog; FIFO is NOP.
-        return std::forward<F>(func)(
-            CLSRGWBucketModifyOpT{log_data, std::forward<Args>(args)...},
-            BILogNopHandler{});
+        // InIndex or no-log: OpIssuer writes its own bilog. FIFO is NOP.
+        CLSRGWBucketModifyOpT op_issuer{log_data, std::forward<Args>(args)...};
+        BILogNopHandler nop;
+        return std::forward<F>(func)(op_issuer, nop);
       } else if (log_data) {
-        // FIFO log: OpIssuer must not write in-index bilog; FIFO batch does it.
+        // FIFO log: OpIssuer must not write in-index bilog. FIFO batch does it.
+        CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
         auto batch = get_or_create_fifo_bilog_batch(dpp, bucket_info);
-        return std::forward<F>(func)(
-            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
-            batch);
+        return std::forward<F>(func)(op_issuer, batch);
       } else {
         // logging disabled entirely.
-        return std::forward<F>(func)(
-            CLSRGWBucketModifyOpT{false, std::forward<Args>(args)...},
-            BILogNopHandler{});
+        CLSRGWBucketModifyOpT op_issuer{false, std::forward<Args>(args)...};
+        BILogNopHandler nop;
+        return std::forward<F>(func)(op_issuer, nop);
       }
     }
   }

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -788,6 +788,10 @@ static int commit_target_layout(rgw::sal::RadosStore* store,
   auto& layout = bucket_info.layout;
   const auto next_log_gen = layout.logs.empty() ? 1 :
       layout.logs.back().gen + 1;
+  // capture the previous bilog backend type before any clear so we can
+  // preserve it on the new generation.
+  const bool is_fifo = !layout.logs.empty() &&
+      layout.logs.back().layout.type == rgw::BucketLogType::FIFO;
 
   if (!store->svc()->zone->need_to_log_data()) {
     // if we're not syncing data, we can drop any existing logs
@@ -799,8 +803,21 @@ static int commit_target_layout(rgw::sal::RadosStore* store,
   layout.current_index = std::move(*layout.target_index);
   layout.target_index = std::nullopt;
   layout.resharding = rgw::BucketReshardState::None;
-  // add the in-index log layout
-  layout.logs.push_back(log_layout_from_index(next_log_gen, layout.current_index));
+
+  // add the new log generation, preserving the bilog backend type.
+  // FIFO-backed buckets keep FIFO after reshard; the in_index field still
+  // records the new index generation so shard OIDs can be constructed
+  // via bilog_fifo_oid.
+  if (is_fifo) {
+    rgw::bucket_log_layout_generation fifo_log;
+    fifo_log.gen = next_log_gen;
+    fifo_log.layout.type = rgw::BucketLogType::FIFO;
+    fifo_log.layout.in_index = {layout.current_index.gen,
+                                layout.current_index.layout.normal};
+    layout.logs.push_back(fifo_log);
+  } else {
+    layout.logs.push_back(log_layout_from_index(next_log_gen, layout.current_index));
+  }
 
   int ret = fault.check("commit_target_layout");
   if (ret == 0) { // no fault injected, write the bucket instance metadata
@@ -877,8 +894,10 @@ static int commit_reshard(rgw::sal::RadosStore* store,
       prev.current_index.layout.type == rgw::BucketIndexType::Normal) {
     // write a datalog entry for each shard of the previous index. triggering
     // sync on the old shards will force them to detect the end-of-log for that
-    // generation, and eventually transition to the next
-    // TODO: use a log layout to support types other than BucketLogType::InIndex
+    // generation, and eventually transition to the next.
+    // this works for both InIndex and FIFO-backed buckets: the shard count
+    // comes from the index normal layout (same for both types), and
+    // datalog::add_entry only uses the log generation number.
     for (uint32_t shard_id = 0; shard_id < rgw::num_shards(prev.current_index.layout.normal); ++shard_id) {
       // This null_yield can stay, for now, since we're in our own thread
       ret = store->svc()->datalog_rados->add_entry(dpp, bucket_info, prev.logs.back(), shard_id,

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -804,10 +804,11 @@ static int commit_target_layout(rgw::sal::RadosStore* store,
   layout.target_index = std::nullopt;
   layout.resharding = rgw::BucketReshardState::None;
 
-  // add the new log generation, preserving the bilog backend type.
-  // FIFO-backed buckets keep FIFO after reshard; in_index records which
-  // index generation's writes this log generation covers.
-  if (is_fifo) {
+  // add the new log generation. InIndex buckets are upgraded to FIFO on reshard
+  // unless the config has been explicitly set to 'inindex' to opt out
+  const bool want_fifo =
+    (store->ctx()->_conf.get_val<std::string>("rgw_default_bucket_bilog_type") == "fifo");
+  if (is_fifo || (want_fifo && store->svc()->zone->need_to_log_data())) {
     layout.logs.push_back(fifo_log_layout_from_index(next_log_gen, layout.current_index));
   } else {
     layout.logs.push_back(log_layout_from_index(next_log_gen, layout.current_index));
@@ -888,10 +889,7 @@ static int commit_reshard(rgw::sal::RadosStore* store,
       prev.current_index.layout.type == rgw::BucketIndexType::Normal) {
     // write a datalog entry for each shard of the previous index. triggering
     // sync on the old shards will force them to detect the end-of-log for that
-    // generation, and eventually transition to the next.
-    // this works for both InIndex and FIFO-backed buckets: the shard count
-    // comes from the index normal layout (same for both types), and
-    // datalog::add_entry only uses the log generation number.
+    // generation, and eventually transition to the next
     for (uint32_t shard_id = 0; shard_id < rgw::num_shards(prev.current_index.layout.normal); ++shard_id) {
       // This null_yield can stay, for now, since we're in our own thread
       ret = store->svc()->datalog_rados->add_entry(dpp, bucket_info, prev.logs.back(), shard_id,

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -805,16 +805,10 @@ static int commit_target_layout(rgw::sal::RadosStore* store,
   layout.resharding = rgw::BucketReshardState::None;
 
   // add the new log generation, preserving the bilog backend type.
-  // FIFO-backed buckets keep FIFO after reshard; the in_index field still
-  // records the new index generation so shard OIDs can be constructed
-  // via bilog_fifo_oid.
+  // FIFO-backed buckets keep FIFO after reshard; in_index records which
+  // index generation's writes this log generation covers.
   if (is_fifo) {
-    rgw::bucket_log_layout_generation fifo_log;
-    fifo_log.gen = next_log_gen;
-    fifo_log.layout.type = rgw::BucketLogType::FIFO;
-    fifo_log.layout.in_index = {layout.current_index.gen,
-                                layout.current_index.layout.normal};
-    layout.logs.push_back(fifo_log);
+    layout.logs.push_back(fifo_log_layout_from_index(next_log_gen, layout.current_index));
   } else {
     layout.logs.push_back(log_layout_from_index(next_log_gen, layout.current_index));
   }

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -887,10 +887,12 @@ static int commit_reshard(rgw::sal::RadosStore* store,
 
   if (store->svc()->zone->need_to_log_data() && !prev.logs.empty() &&
       prev.current_index.layout.type == rgw::BucketIndexType::Normal) {
-    // write a datalog entry for each shard of the previous index. triggering
-    // sync on the old shards will force them to detect the end-of-log for that
-    // generation, and eventually transition to the next
-    for (uint32_t shard_id = 0; shard_id < rgw::num_shards(prev.current_index.layout.normal); ++shard_id) {
+    // write a datalog entry for each shard of the previous generation's bilog.
+    // triggering sync on the old shards will force them to detect the
+    // end-of-log for that generation, and eventually transition to the next.
+    // use the log layout's own shard count (not the index's): FIFO-backed
+    // logs use an independent shard count that can differ from the index.
+    for (uint32_t shard_id = 0; shard_id < rgw::num_shards(prev.logs.back()); ++shard_id) {
       // This null_yield can stay, for now, since we're in our own thread
       ret = store->svc()->datalog_rados->add_entry(dpp, bucket_info, prev.logs.back(), shard_id,
 						   null_yield);

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -560,15 +560,21 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
 
   map<RGWObjCategory, RGWStorageStats> stats;
   const auto& last_log = logs.back();
-  const auto& index = log_to_index_layout(last_log);
-
-  int ret = bucket->read_stats(s, y, index, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
-  if (ret < 0 && ret != -ENOENT) {
-    op_ret = ret;
-    return;
-  }
 
   if (last_log.layout.type == rgw::BucketLogType::FIFO) {
+    const auto& current_index = bucket->get_info().layout.current_index;
+    ldpp_dout(s, 20) << __func__ << ": FIFO bucket, reading stats from"
+                     << " current_index gen=" << current_index.gen
+                     << " num_shards=" << current_index.layout.normal.num_shards
+                     << dendl;
+    int ret = bucket->read_stats(s, y, current_index, shard_id,
+                                 &bucket_ver, &master_ver, stats,
+                                 &max_marker, &syncstopped);
+    if (ret < 0 && ret != -ENOENT) {
+      op_ret = ret;
+      return;
+    }
+
     auto rados_store = static_cast<rgw::sal::RadosStore*>(driver);
     std::map<int, std::string> fifo_markers;
     ret = rados_store->svc()->bilog_rados->get_log_status(
@@ -589,7 +595,21 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
       }
       mgr.to_string(&max_marker);
     }
+    // TODO: FIFO SYNCSTOP/START needs to be fixed
     syncstopped = false;
+  } else {
+    const auto& index = log_to_index_layout(last_log);
+    ldpp_dout(s, 20) << __func__ << ": InIndex bucket, reading stats from"
+                     << " index gen=" << index.gen
+                     << " num_shards=" << index.layout.normal.num_shards
+                     << dendl;
+    int ret = bucket->read_stats(s, y, index, shard_id,
+                                 &bucket_ver, &master_ver, stats,
+                                 &max_marker, &syncstopped);
+    if (ret < 0 && ret != -ENOENT) {
+      op_ret = ret;
+      return;
+    }
   }
 
   oldest_gen = logs.front().gen;

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -595,8 +595,8 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
       }
       mgr.to_string(&max_marker);
     }
-    // TODO: FIFO SYNCSTOP/START needs to be fixed
-    syncstopped = false;
+    // syncstopped reflects whether bucket sync disable is active.
+    syncstopped = !bucket->get_info().datasync_flag_enabled();
   } else {
     const auto& index = log_to_index_layout(last_log);
     ldpp_dout(s, 20) << __func__ << ": InIndex bucket, reading stats from"

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -508,7 +508,10 @@ void RGWOp_BILog_List::send_response_end() {
     if (next_log_layout) {
       s->formatter->open_object_section("next_log");
       encode_json("generation", next_log_layout->gen, s->formatter);
-      encode_json("num_shards", rgw::num_shards(next_log_layout->layout.in_index.layout), s->formatter);
+      uint32_t next_num = (next_log_layout->layout.type == rgw::BucketLogType::FIFO)
+          ? rgw::num_shards(next_log_layout->layout.fifo)
+          : rgw::num_shards(next_log_layout->layout.in_index.layout);
+      encode_json("num_shards", next_num, s->formatter);
       s->formatter->close_section(); // next_log
     }
 
@@ -556,20 +559,47 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
   }
 
   map<RGWObjCategory, RGWStorageStats> stats;
-  const auto& index = log_to_index_layout(logs.back());
+  const auto& last_log = logs.back();
+  const auto& index = log_to_index_layout(last_log);
 
-  int ret =  bucket->read_stats(s, y, index, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
+  int ret = bucket->read_stats(s, y, index, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
   if (ret < 0 && ret != -ENOENT) {
     op_ret = ret;
     return;
+  }
+
+  if (last_log.layout.type == rgw::BucketLogType::FIFO) {
+    auto rados_store = static_cast<rgw::sal::RadosStore*>(driver);
+    std::map<int, std::string> fifo_markers;
+    ret = rados_store->svc()->bilog_rados->get_log_status(
+        s, bucket->get_info(), last_log, shard_id, &fifo_markers, y);
+    if (ret < 0 && ret != -ENOENT) {
+      op_ret = ret;
+      return;
+    }
+    if (shard_id >= 0) {
+      auto it = fifo_markers.find(shard_id);
+      max_marker = (it != fifo_markers.end()) ? it->second : "";
+    } else {
+      BucketIndexShardsManager mgr;
+      const int n = rgw::num_shards(last_log.layout.fifo);
+      for (int sid = 0; sid < n; ++sid) {
+        auto it = fifo_markers.find(sid);
+        mgr.add(sid, it != fifo_markers.end() ? it->second : "");
+      }
+      mgr.to_string(&max_marker);
+    }
+    syncstopped = false;
   }
 
   oldest_gen = logs.front().gen;
   latest_gen = logs.back().gen;
 
   for (auto& log : logs) {
-      uint32_t num_shards = rgw::num_shards(log.layout.in_index.layout);
-      generations.push_back({log.gen, num_shards});
+    uint32_t num_shards = (log.layout.type == rgw::BucketLogType::FIFO)
+        ? rgw::num_shards(log.layout.fifo)
+        : rgw::num_shards(log.layout.in_index.layout);
+    generations.push_back({log.gen, num_shards});
   }
 }
 

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2748,7 +2748,7 @@ bool RadosObject::is_sync_completed(const DoutPrefixProvider* dpp,
   }
 
   const auto& log_layout = bucket_info.layout.logs.front();
-  const uint32_t shard_count = num_shards(log_to_index_layout(log_layout));
+  const uint32_t shard_count = num_shards(log_layout);
 
   std::string marker;
   bool truncated;

--- a/src/rgw/driver/rados/rgw_service.cc
+++ b/src/rgw/driver/rados/rgw_service.cc
@@ -60,7 +60,7 @@ int RGWServices_Def::init(CephContext *cct,
   bucket_sobj = std::make_unique<RGWSI_Bucket_SObj>(cct);
   bucket_sync_sobj = std::make_unique<RGWSI_Bucket_Sync_SObj>(cct);
   bi_rados = std::make_unique<RGWSI_BucketIndex_RADOS>(cct);
-  bilog_rados = std::make_unique<RGWSI_BILog_RADOS>(cct);
+  bilog_rados = std::make_unique<RGWSI_BILog_RADOS_BackendDispatcher>(cct);
   cls = std::make_unique<RGWSI_Cls>(cct);
   config_key_rados = std::make_unique<RGWSI_ConfigKey_RADOS>(cct);
   datalog_rados = std::make_unique<RGWDataChangesLog>(driver);

--- a/src/rgw/driver/rados/rgw_service.cc
+++ b/src/rgw/driver/rados/rgw_service.cc
@@ -85,7 +85,7 @@ int RGWServices_Def::init(CephContext *cct,
   async_processor->start();
   bi_rados->init(zone.get(), driver->getRados()->get_rados_handle(),
 		 bilog_rados.get(), datalog_rados.get());
-  bilog_rados->init(bi_rados.get());
+  bilog_rados->init(bi_rados.get(), driver->get_neorados());
   bucket_sobj->init(zone.get(), sysobj.get(), sysobj_cache.get(),
                     bi_rados.get(), mdlog.get(),
                     sync_modules.get(), bucket_sync_sobj.get());

--- a/src/rgw/driver/rados/rgw_trim_bilog.cc
+++ b/src/rgw/driver/rados/rgw_trim_bilog.cc
@@ -482,6 +482,31 @@ class RGWFIFOBILogTrimShardCR : public RGWSimpleCoroutine {
   }
 };
 
+// remove all cls_fifo head + part objects for a retired FIFO bilog generation
+class RGWFIFOBILogRemoveShardsCR : public RGWSimpleCoroutine {
+  rgw::sal::RadosStore *store;
+  const RGWBucketInfo bucket_info;
+  const rgw::bucket_log_layout_generation log_layout;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
+ public:
+  RGWFIFOBILogRemoveShardsCR(rgw::sal::RadosStore* store,
+                              const RGWBucketInfo& bucket_info,
+                              const rgw::bucket_log_layout_generation& log_layout)
+    : RGWSimpleCoroutine(store->ctx()), store(store),
+      bucket_info(bucket_info), log_layout(log_layout) {}
+
+  int send_request(const DoutPrefixProvider *dpp) override {
+    cn = stack->create_completion_notifier();
+    return store->svc()->bilog_rados->remove_log_shards(
+        dpp, bucket_info, log_layout, cn->completion());
+  }
+  int request_complete() override {
+    int r = cn->completion()->get_return_value();
+    set_status() << "FIFO bilog remove shards complete. ret=" << r;
+    return r;
+  }
+};
+
 struct StatusShards {
   uint64_t generation = 0;
   std::vector<rgw_bucket_shard_sync_info> shards;
@@ -1092,6 +1117,17 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
 	ldpp_dout(dpp, 0) << "failed to remove bucket-index shards for retired generation: "
 			  << cpp_strerror(retcode) << dendl;
 	return set_cr_error(retcode);
+      }
+
+      // -ENOENT is tolerated for idempotency on re-runs.
+      if (clean_info->second.layout.type == rgw::BucketLogType::FIFO) {
+	yield call(new RGWFIFOBILogRemoveShardsCR(store, clean_info->first,
+						  clean_info->second));
+	if (retcode < 0 && retcode != -ENOENT) {
+	  ldpp_dout(dpp, 0) << "failed to remove FIFO log shards for retired generation: "
+			    << cpp_strerror(retcode) << dendl;
+	  return set_cr_error(retcode);
+	}
       }
 
       while (clean_info && retries < MAX_RETRIES) {

--- a/src/rgw/driver/rados/rgw_trim_bilog.cc
+++ b/src/rgw/driver/rados/rgw_trim_bilog.cc
@@ -34,6 +34,7 @@
 
 #include "services/svc_zone.h"
 #include "services/svc_bilog_rados.h"
+#include "cls/rgw/cls_rgw_client.h"
 
 #include <boost/asio/yield.hpp>
 #include "include/ceph_assert.h"
@@ -448,6 +449,39 @@ class BucketCleanIndexCollectCR : public RGWShardCollectCR {
   }
 };
 
+// per-shard FIFO bilog trim coroutine.
+class RGWFIFOBILogTrimShardCR : public RGWSimpleCoroutine {
+  const DoutPrefixProvider *dpp;
+  rgw::sal::RadosStore *store;
+  const RGWBucketInfo& bucket_info;
+  const rgw::bucket_log_layout_generation log_layout;
+  const int shard_id;
+  const std::string marker;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
+ public:
+  RGWFIFOBILogTrimShardCR(const DoutPrefixProvider *dpp,
+                           rgw::sal::RadosStore* store,
+                           const RGWBucketInfo& bucket_info,
+                           const rgw::bucket_log_layout_generation& log_layout,
+                           int shard_id,
+                           std::string_view marker)
+    : RGWSimpleCoroutine(store->ctx()),
+      dpp(dpp), store(store), bucket_info(bucket_info),
+      log_layout(log_layout), shard_id(shard_id), marker(marker) {}
+
+  int send_request(const DoutPrefixProvider *dpp) override {
+    cn = stack->create_completion_notifier();
+    return store->svc()->bilog_rados->trim_shard(
+        dpp, bucket_info, log_layout, shard_id, marker, cn->completion());
+  }
+
+  int request_complete() override {
+    int r = cn->completion()->get_return_value();
+    set_status() << "FIFO bilog trim shard complete; ret=" << r;
+    return r;
+  }
+};
+
 struct StatusShards {
   uint64_t generation = 0;
   std::vector<rgw_bucket_shard_sync_info> shards;
@@ -628,7 +662,6 @@ class BucketTrimInstanceCR : public RGWCoroutine {
   int child_ret = 0;
   const DoutPrefixProvider *dpp;
   std::vector<StatusShards> peer_status; //< sync status for each peer
-  std::vector<std::string> min_markers; //< min marker per shard
 
   /// The log generation to trim
   rgw::bucket_log_layout_generation totrim;
@@ -803,6 +836,118 @@ inline int parse_decode_json<StatusShards>(
   return 0;
 }
 
+/// coroutine that trims all shards of an InIndex bilog generation.
+class TrimInIndexGenerationCR : public RGWCoroutine {
+  const DoutPrefixProvider *dpp;
+  rgw::sal::RadosStore* const store;
+  const RGWBucketInfo& bucket_info;
+  const rgw::bucket_log_layout_generation& totrim;
+  const std::vector<StatusShards>& peer_status;
+  std::vector<std::string> min_markers;
+
+ public:
+  TrimInIndexGenerationCR(const DoutPrefixProvider *dpp,
+                          rgw::sal::RadosStore* store,
+                          const RGWBucketInfo& bucket_info,
+                          const rgw::bucket_log_layout_generation& totrim,
+                          const std::vector<StatusShards>& peer_status)
+    : RGWCoroutine(store->ctx()), dpp(dpp), store(store),
+      bucket_info(bucket_info), totrim(totrim), peer_status(peer_status) {}
+
+  int operate(const DoutPrefixProvider *dpp) override {
+    reenter(this) {
+      min_markers.assign(std::max(1u, rgw::num_shards(totrim.layout.in_index)),
+                         RGWSyncLogTrimCR::max_marker);
+      retcode = take_min_status(cct, totrim.gen, peer_status.cbegin(),
+                                peer_status.cend(), &min_markers, dpp);
+      if (retcode < 0) {
+        ldpp_dout(dpp, 4) << "failed to correlate InIndex bucket sync status from peers" << dendl;
+        return set_cr_error(retcode);
+      }
+      ldpp_dout(dpp, 10) << "trimming InIndex bilogs for bucket=" << bucket_info.bucket
+                         << " markers=" << min_markers
+                         << ", shards=" << min_markers.size() << dendl;
+      yield call(new BucketTrimShardCollectCR(dpp, store, bucket_info,
+                                              totrim.layout.in_index, min_markers));
+      if (retcode == -ENOENT) {
+        retcode = 0; // not fatal: shard removed unexpectedly
+      }
+      if (retcode < 0) {
+        ldpp_dout(dpp, 4) << "failed to trim InIndex bilog shards: "
+                          << cpp_strerror(retcode) << dendl;
+        return set_cr_error(retcode);
+      }
+      return set_cr_done();
+    }
+    return 0;
+  }
+};
+
+class TrimFIFOGenerationCR : public RGWCoroutine {
+  const DoutPrefixProvider *dpp;
+  rgw::sal::RadosStore* const store;
+  const RGWBucketInfo& bucket_info;
+  const rgw::bucket_log_layout_generation& totrim;
+  const std::vector<StatusShards>& peer_status;
+  std::vector<std::string> min_markers;
+
+ public:
+  TrimFIFOGenerationCR(const DoutPrefixProvider *dpp,
+                       rgw::sal::RadosStore* store,
+                       const RGWBucketInfo& bucket_info,
+                       const rgw::bucket_log_layout_generation& totrim,
+                       const std::vector<StatusShards>& peer_status)
+    : RGWCoroutine(store->ctx()), dpp(dpp), store(store),
+      bucket_info(bucket_info), totrim(totrim), peer_status(peer_status) {}
+
+  int operate(const DoutPrefixProvider *dpp) override {
+    reenter(this) {
+      min_markers.assign(std::max(1u, rgw::num_shards(totrim.layout.fifo)),
+                         RGWSyncLogTrimCR::max_marker);
+      retcode = take_min_status(cct, totrim.gen, peer_status.cbegin(),
+                                peer_status.cend(), &min_markers, dpp);
+      if (retcode < 0) {
+        ldpp_dout(dpp, 4) << "failed to correlate FIFO bucket sync status from peers" << dendl;
+        return set_cr_error(retcode);
+      }
+      ldpp_dout(dpp, 10) << "trimming FIFO bilogs for bucket=" << bucket_info.bucket
+                         << " gen=" << totrim.gen
+                         << " markers=" << min_markers << dendl;
+      yield {
+        for (size_t i = 0; i < min_markers.size(); ++i) {
+          const auto& m = min_markers[i];
+          if (m.empty() || m == RGWSyncLogTrimCR::max_marker) {
+            continue;
+          }
+          ldpp_dout(dpp, 10) << "trimming FIFO bilog shard " << i
+              << " of " << bucket_info.bucket << " at marker " << m << dendl;
+          spawn(new RGWFIFOBILogTrimShardCR(dpp, store, bucket_info,
+                                             totrim, static_cast<int>(i), m),
+                false);
+        }
+      }
+      // -ENOENT means the shard was already trimmed/removed.
+      retcode = 0;
+      while (retcode == 0 && num_spawned() > 0) {
+        yield wait_for_child();
+        int r = 0;
+        collect_next(&r);
+        if (r < 0 && r != -ENOENT) {
+          retcode = r;
+        }
+      }
+      drain_all();
+      if (retcode < 0) {
+        ldpp_dout(dpp, 4) << "failed to trim FIFO bilog shards: "
+                          << cpp_strerror(retcode) << dendl;
+        return set_cr_error(retcode);
+      }
+      return set_cr_done();
+    }
+    return 0;
+  }
+};
+
 int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
@@ -934,20 +1079,21 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
     }
 
     if (clean_info) {
-      if (clean_info->second.layout.type != rgw::BucketLogType::InIndex) {
-	ldpp_dout(dpp, 0) << "Unable to convert log of unknown type "
-			  << clean_info->second.layout.type
-			  << " to rgw::bucket_index_layout_generation " << dendl;
+      if (clean_info->second.layout.type != rgw::BucketLogType::InIndex &&
+	  clean_info->second.layout.type != rgw::BucketLogType::FIFO) {
+	ldpp_dout(dpp, 0) << "Unable to clean log of unknown type "
+			  << clean_info->second.layout.type << dendl;
 	return set_cr_error(-EINVAL);
       }
 
       yield call(new BucketCleanIndexCollectCR(dpp, store, clean_info->first,
 					       clean_info->second.layout.in_index));
       if (retcode < 0) {
-	ldpp_dout(dpp, 0) << "failed to remove previous generation: "
+	ldpp_dout(dpp, 0) << "failed to remove bucket-index shards for retired generation: "
 			  << cpp_strerror(retcode) << dendl;
 	return set_cr_error(retcode);
       }
+
       while (clean_info && retries < MAX_RETRIES) {
 	yield call(new RGWPutBucketInstanceInfoCR(
 		     store->svc()->async_processor,
@@ -998,44 +1144,21 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
 	clean_info = std::nullopt;
       }
     } else {
-      if (totrim.layout.type != rgw::BucketLogType::InIndex) {
-       ldpp_dout(dpp, 0) << "Unable to convert log of unknown type "
-                         << totrim.layout.type
-                         << " to rgw::bucket_index_layout_generation " << dendl;
-       return set_cr_error(-EINVAL);
-      }
-      // To avoid hammering the OSD too hard, either trim old
-      // generations OR trim the current one.
-
-      // determine the minimum marker for each shard
-
-      // initialize each shard with the maximum marker, which is only used when
-      // there are no peers syncing from us
-      min_markers.assign(std::max(1u, rgw::num_shards(totrim.layout.in_index)),
-			 RGWSyncLogTrimCR::max_marker);
-
-      retcode = take_min_status(cct, totrim.gen, peer_status.cbegin(),
-				peer_status.cend(), &min_markers, dpp);
-      if (retcode < 0) {
-	ldpp_dout(dpp, 4) << "failed to correlate bucket sync status from peers" << dendl;
-	return set_cr_error(retcode);
-      }
-
-      // trim shards with a ShardCollectCR
-      ldpp_dout(dpp, 10) << "trimming bilogs for bucket=" << pbucket_info->bucket
-			 << " markers=" << min_markers << ", shards=" << min_markers.size() << dendl;
-      set_status("trimming bilog shards");
-      yield call(new BucketTrimShardCollectCR(dpp, store, *pbucket_info, totrim.layout.in_index,
-					      min_markers));
-      if (retcode == -ENOENT) {
-        // this is not a fatal error to retry, as the shard seems to not exist
-        // anymore. This can happen if the shard was removed unexpectedly.
-        // should be already logged by the BucketTrimShardCollectCR().
-        retcode = 0;
+      // no old generation to clean. trim the active generation instead.
+      if (totrim.layout.type == rgw::BucketLogType::InIndex) {
+	set_status("trimming InIndex bilog shards");
+	yield call(new TrimInIndexGenerationCR(dpp, store, *pbucket_info,
+					       totrim, peer_status));
+      } else if (totrim.layout.type == rgw::BucketLogType::FIFO) {
+	set_status("trimming FIFO bilog shards");
+	yield call(new TrimFIFOGenerationCR(dpp, store, *pbucket_info,
+					    totrim, peer_status));
+      } else {
+	ldpp_dout(dpp, 0) << "Unable to trim log of unknown type "
+			  << totrim.layout.type << dendl;
+	return set_cr_error(-EINVAL);
       }
       if (retcode < 0) {
-	ldpp_dout(dpp, 4) << "failed to trim bilog shards: "
-			  << cpp_strerror(retcode) << dendl;
 	return set_cr_error(retcode);
       }
     }

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -10917,11 +10917,8 @@ next:
 
       count += entries.size();
 
-      for (list<rgw_bi_log_entry>::iterator iter = entries.begin(); iter != entries.end(); ++iter) {
-        rgw_bi_log_entry& entry = *iter;
+      for (auto& entry : entries) {
         encode_json("entry", entry, formatter.get());
-
-        marker = entry.id;
       }
       formatter->flush(cout);
     } while (truncated && count < max_entries);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2920,12 +2920,17 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
       source_sync_info.status = "init: bucket sync has not started";
       return 0;
     }
-    if (log.layout.type != rgw::BucketLogType::InIndex) {
+    if (log.layout.type != rgw::BucketLogType::InIndex &&
+        log.layout.type != rgw::BucketLogType::FIFO) {
       source_sync_info.error = fmt::format("unrecognized log layout type {}", to_string(log.layout.type));
       return -EINVAL;
     }
     // use shard count from our log gen=0
-    shard_status.resize(rgw::num_shards(log.layout.in_index));
+    if (log.layout.type == rgw::BucketLogType::FIFO) {
+      shard_status.resize(rgw::num_shards(log.layout.fifo));
+    } else {
+      shard_status.resize(rgw::num_shards(log.layout.in_index));
+    }
   } else {
     source_sync_info.error = fmt::format("failed to read bucket full sync status: {}", cpp_strerror(r));
     return r;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2938,12 +2938,17 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
       source_sync_info.status = "init: bucket sync has not started";
       return 0;
     }
-    if (log.layout.type != rgw::BucketLogType::InIndex) {
+    if (log.layout.type != rgw::BucketLogType::InIndex &&
+        log.layout.type != rgw::BucketLogType::FIFO) {
       source_sync_info.error = fmt::format("unrecognized log layout type {}", to_string(log.layout.type));
       return -EINVAL;
     }
     // use shard count from our log gen=0
-    shard_status.resize(rgw::num_shards(log.layout.in_index));
+    if (log.layout.type == rgw::BucketLogType::FIFO) {
+      shard_status.resize(rgw::num_shards(log.layout.fifo));
+    } else {
+      shard_status.resize(rgw::num_shards(log.layout.in_index));
+    }
   } else {
     source_sync_info.error = fmt::format("failed to read bucket full sync status: {}", cpp_strerror(r));
     return r;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -11010,11 +11010,8 @@ next:
 
       count += entries.size();
 
-      for (list<rgw_bi_log_entry>::iterator iter = entries.begin(); iter != entries.end(); ++iter) {
-        rgw_bi_log_entry& entry = *iter;
+      for (auto& entry : entries) {
         encode_json("entry", entry, formatter.get());
-
-        marker = entry.id;
       }
       formatter->flush(cout);
     } while (truncated && count < max_entries);

--- a/src/rgw/rgw_bucket_layout.cc
+++ b/src/rgw/rgw_bucket_layout.cc
@@ -187,6 +187,7 @@ std::string_view to_string(const BucketLogType& t)
 {
   switch (t) {
   case BucketLogType::InIndex: return "InIndex";
+  case BucketLogType::FIFO: return "FIFO";
   case BucketLogType::Deleted: return "Deleted";
   default: return "Unknown";
   }
@@ -195,6 +196,10 @@ bool parse(std::string_view str, BucketLogType& t)
 {
   if (boost::iequals(str, "InIndex")) {
     t = BucketLogType::InIndex;
+    return true;
+  }
+  if (boost::iequals(str, "FIFO")) {
+    t = BucketLogType::FIFO;
     return true;
   }
   if (boost::iequals(str, "Deleted")) {
@@ -249,6 +254,8 @@ void encode(const bucket_log_layout& l, bufferlist& bl, uint64_t f)
   encode(l.type, bl);
   switch (l.type) {
   case BucketLogType::InIndex:
+  case BucketLogType::FIFO:
+    // both need gen + num_shards to locate the per-shard log objects
     encode(l.in_index, bl);
     break;
   case BucketLogType::Deleted:
@@ -262,6 +269,8 @@ void decode(bucket_log_layout& l, bufferlist::const_iterator& bl)
   decode(l.type, bl);
   switch (l.type) {
   case BucketLogType::InIndex:
+  case BucketLogType::FIFO:
+    // both need gen + num_shards to locate the per-shard log objects
     decode(l.in_index, bl);
     break;
   case BucketLogType::Deleted:
@@ -273,7 +282,8 @@ void encode_json_impl(const char *name, const bucket_log_layout& l, ceph::Format
 {
   f->open_object_section(name);
   encode_json("type", l.type, f);
-  if (l.type == BucketLogType::InIndex) {
+  if (l.type == BucketLogType::InIndex ||
+      l.type == BucketLogType::FIFO) {
     encode_json("in_index", l.in_index, f);
   }
   f->close_section();
@@ -281,7 +291,8 @@ void encode_json_impl(const char *name, const bucket_log_layout& l, ceph::Format
 void decode_json_obj(bucket_log_layout& l, JSONObj *obj)
 {
   JSONDecoder::decode_json("type", l.type, obj);
-  if (l.type == BucketLogType::InIndex) {
+  if (l.type == BucketLogType::InIndex ||
+      l.type == BucketLogType::FIFO) {
     JSONDecoder::decode_json("in_index", l.in_index, obj);
   }
 }

--- a/src/rgw/rgw_bucket_layout.cc
+++ b/src/rgw/rgw_bucket_layout.cc
@@ -247,6 +247,34 @@ void decode_json_obj(bucket_index_log_layout& l, JSONObj *obj)
   JSONDecoder::decode_json("layout", l.layout, obj);
 }
 
+// bucket_fifo_log_layout
+void encode(const bucket_fifo_log_layout& l, bufferlist& bl, uint64_t f)
+{
+  ENCODE_START(1, 1, bl);
+  encode(l.num_shards, bl);
+  encode(l.hash_type, bl);
+  ENCODE_FINISH(bl);
+}
+void decode(bucket_fifo_log_layout& l, bufferlist::const_iterator& bl)
+{
+  DECODE_START(1, bl);
+  decode(l.num_shards, bl);
+  decode(l.hash_type, bl);
+  DECODE_FINISH(bl);
+}
+void encode_json_impl(const char *name, const bucket_fifo_log_layout& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("num_shards", l.num_shards, f);
+  encode_json("hash_type", l.hash_type, f);
+  f->close_section();
+}
+void decode_json_obj(bucket_fifo_log_layout& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("num_shards", l.num_shards, obj);
+  JSONDecoder::decode_json("hash_type", l.hash_type, obj);
+}
+
 // bucket_log_layout
 void encode(const bucket_log_layout& l, bufferlist& bl, uint64_t f)
 {
@@ -254,46 +282,53 @@ void encode(const bucket_log_layout& l, bufferlist& bl, uint64_t f)
   encode(l.type, bl);
   switch (l.type) {
   case BucketLogType::InIndex:
-  case BucketLogType::FIFO:
-    // both need gen + num_shards to locate the per-shard log objects
     encode(l.in_index, bl);
+    break;
+  case BucketLogType::FIFO:
+    encode(l.fifo, bl);
     break;
   case BucketLogType::Deleted:
     break;
   }
   ENCODE_FINISH(bl);
 }
+
 void decode(bucket_log_layout& l, bufferlist::const_iterator& bl)
 {
   DECODE_START(1, bl);
   decode(l.type, bl);
   switch (l.type) {
   case BucketLogType::InIndex:
-  case BucketLogType::FIFO:
-    // both need gen + num_shards to locate the per-shard log objects
     decode(l.in_index, bl);
+    break;
+  case BucketLogType::FIFO:
+    decode(l.fifo, bl);
     break;
   case BucketLogType::Deleted:
     break;
   }
   DECODE_FINISH(bl);
 }
+
 void encode_json_impl(const char *name, const bucket_log_layout& l, ceph::Formatter *f)
 {
   f->open_object_section(name);
   encode_json("type", l.type, f);
-  if (l.type == BucketLogType::InIndex ||
-      l.type == BucketLogType::FIFO) {
+  if (l.type == BucketLogType::InIndex) {
     encode_json("in_index", l.in_index, f);
+  } else if (l.type == BucketLogType::FIFO) {
+    encode_json("fifo", l.fifo, f);
   }
   f->close_section();
 }
+
 void decode_json_obj(bucket_log_layout& l, JSONObj *obj)
 {
   JSONDecoder::decode_json("type", l.type, obj);
-  if (l.type == BucketLogType::InIndex ||
-      l.type == BucketLogType::FIFO) {
+  if (l.type == BucketLogType::InIndex) {
     JSONDecoder::decode_json("in_index", l.in_index, obj);
+  } else if (l.type == BucketLogType::FIFO) {
+    JSONDecoder::decode_json("fifo", l.fifo, obj);
   }
 }
 

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -135,8 +135,11 @@ void decode_json_obj(bucket_index_layout_generation& l, JSONObj *obj);
 
 enum class BucketLogType : uint8_t {
   // colocated with bucket index, so the log layout matches the index layout
-  InIndex,
-  Deleted
+  InIndex,  // 0
+  // log generation has been removed.
+  Deleted,  // 1
+  // independent FIFO objects. one per index shard, named "{shard_oid}.bilog"
+  FIFO,     // 2
 };
 
 std::string_view to_string(const BucketLogType& t);
@@ -149,6 +152,8 @@ inline std::ostream& operator<<(std::ostream& out, const BucketLogType &log_type
   switch (log_type) {
     case BucketLogType::InIndex:
       return out << "InIndex";
+    case BucketLogType::FIFO:
+      return out << "FIFO";
     case BucketLogType::Deleted:
       return out << "Deleted";
     default:

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -138,7 +138,7 @@ enum class BucketLogType : uint8_t {
   InIndex,  // 0
   // log generation has been removed.
   Deleted,  // 1
-  // independent FIFO objects. one per index shard, named "{shard_oid}.bilog"
+  // independent FIFO objects
   FIFO,     // 2
 };
 
@@ -178,13 +178,40 @@ void decode(bucket_index_log_layout& l, bufferlist::const_iterator& bl);
 void encode_json_impl(const char *name, const bucket_index_log_layout& l, ceph::Formatter *f);
 void decode_json_obj(bucket_index_log_layout& l, JSONObj *obj);
 
+// layout for FIFO-backed bilog
+struct bucket_fifo_log_layout {
+  uint32_t num_shards = 7;
+  BucketHashType hash_type = BucketHashType::Mod;
+};
+
+inline bool operator==(const bucket_fifo_log_layout& l,
+                       const bucket_fifo_log_layout& r) {
+  return l.num_shards == r.num_shards && l.hash_type == r.hash_type;
+}
+inline bool operator!=(const bucket_fifo_log_layout& l,
+                       const bucket_fifo_log_layout& r) {
+  return !(l == r);
+}
+
+void encode(const bucket_fifo_log_layout& l, bufferlist& bl, uint64_t f=0);
+void decode(bucket_fifo_log_layout& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_fifo_log_layout& l, ceph::Formatter *f);
+void decode_json_obj(bucket_fifo_log_layout& l, JSONObj *obj);
+
 struct bucket_log_layout {
   BucketLogType type = BucketLogType::InIndex;
 
   bucket_index_log_layout in_index;
+  bucket_fifo_log_layout  fifo;
 
   friend std::ostream& operator<<(std::ostream& out, const bucket_log_layout& l) {
     out << "type=" << to_string(l.type);
+    if (l.type == BucketLogType::InIndex) {
+      out << ", in_index.gen=" << l.in_index.gen
+          << ", in_index.num_shards=" << l.in_index.layout.num_shards;
+    } else if (l.type == BucketLogType::FIFO) {
+      out << ", fifo.num_shards=" << l.fifo.num_shards;
+    }
     return out;
   }
 };

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -318,6 +318,23 @@ inline uint32_t num_shards(const bucket_index_layout_generation& index) {
   return num_shards(index.layout);
 }
 
+inline uint32_t num_shards(const bucket_fifo_log_layout& fifo) {
+  return fifo.num_shards > 0 ? fifo.num_shards : 1;
+}
+inline uint32_t num_shards(const bucket_log_layout& log) {
+  switch (log.type) {
+  case BucketLogType::InIndex:
+    return num_shards(log.in_index.layout);
+  case BucketLogType::FIFO:
+    return num_shards(log.fifo);
+  default:
+    return 0;
+  }
+}
+inline uint32_t num_shards(const bucket_log_layout_generation& log) {
+  return num_shards(log.layout);
+}
+
 inline uint32_t current_num_shards(const BucketLayout& layout) {
   return num_shards(layout.current_index);
 }

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <optional>
 #include <string>
 #include "include/encoding.h"
@@ -241,6 +243,37 @@ inline bucket_log_layout_generation log_layout_from_index(
     uint64_t gen, const bucket_index_layout_generation& index)
 {
   return {gen, {BucketLogType::InIndex, {index.gen, index.layout.normal}}};
+}
+
+// compute an appropriate number of bilog shards for a given index shard count
+// upon reshard. uses logarithmic formula to keep the bilog shard count much lower,
+// growing slowly every time index shards double, bilog gets 2 more shards.
+// typically ranges from 7 to 21 across the default index max shards 11 to 1999 shards.
+inline uint32_t bilog_shards_for_index(uint32_t index_shards,
+                                       uint32_t min_shards = 7,
+                                       uint32_t max_shards = 0)
+{
+  if (index_shards == 0) {
+    return min_shards;
+  }
+  auto v = static_cast<uint32_t>(std::log2(index_shards) * 2.0);
+  v = std::max(v, min_shards);
+  if (max_shards > 0) {
+    v = std::min(v, max_shards);
+  }
+  return v;
+}
+
+// return a log layout backed by independent FIFO objects
+inline bucket_log_layout_generation fifo_log_layout_from_index(
+    uint64_t gen, const bucket_index_layout_generation& index)
+{
+  bucket_log_layout_generation log;
+  log.gen = gen;
+  log.layout.type = BucketLogType::FIFO;
+  log.layout.in_index = {index.gen, index.layout.normal};
+  log.layout.fifo.num_shards = bilog_shards_for_index(index.layout.normal.num_shards);
+  return log;
 }
 
 inline auto matches_gen(uint64_t gen)

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -1021,10 +1021,13 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
     return 0; // no bilog
   }
   const auto& bilog = info.layout.logs.back();
-  if (bilog.layout.type != rgw::BucketLogType::InIndex) {
+  if (bilog.layout.type != rgw::BucketLogType::InIndex &&
+      bilog.layout.type != rgw::BucketLogType::FIFO) {
     return -ENOTSUP;
   }
-  const int shards_num = rgw::num_shards(bilog.layout.in_index);
+  const int shards_num = (bilog.layout.type == rgw::BucketLogType::FIFO)
+      ? rgw::num_shards(bilog.layout.fifo)
+      : rgw::num_shards(bilog.layout.in_index);
 
   int ret;
   if (!new_sync_enabled) {

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -6,24 +6,19 @@
 
 #include "rgw_asio_thread.h"
 #include "driver/rados/shard_io.h"
+#include "driver/rados/rgw_bilog.h"
+#include "driver/rados/rgw_log_backing.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "common/async/blocked_completion.h"
+
+#include <boost/asio/spawn.hpp>
 
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
 using rgwrados::shard_io::Result;
-
-RGWSI_BILog_RADOS::RGWSI_BILog_RADOS(CephContext *cct) : RGWServiceInstance(cct)
-{
-}
-
-void RGWSI_BILog_RADOS::init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
-                             neorados::RADOS rados_neo_)
-{
-  svc.bi = bi_rados_svc;
-  rados_neo.emplace(std::move(rados_neo_));
-}
+namespace asio = boost::asio;
+namespace fifo = neorados::cls::fifo;
 
 struct TrimWriter : rgwrados::shard_io::RadosWriter {
   const BucketIndexShardsManager& start;
@@ -54,21 +49,61 @@ struct TrimWriter : rgwrados::shard_io::RadosWriter {
   }
 };
 
-int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp, optional_yield y,
-				const RGWBucketInfo& bucket_info,
-				const rgw::bucket_log_layout_generation& log_layout,
-				int shard_id,
-				std::string_view start_marker,
-				std::string_view end_marker)
+struct StartWriter : rgwrados::shard_io::RadosWriter {
+  StartWriter(const DoutPrefixProvider& dpp,
+              boost::asio::any_io_executor ex,
+              librados::IoCtx& ioctx)
+    : RadosWriter(dpp, std::move(ex), ioctx)
+  {}
+  void prepare_write(int /*shard*/,
+                     librados::ObjectWriteOperation& op) override {
+    cls_rgw_bilog_start(op);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "start bilog shards: ";
+  }
+};
+
+struct StopWriter : rgwrados::shard_io::RadosWriter {
+  StopWriter(const DoutPrefixProvider& dpp,
+             boost::asio::any_io_executor ex,
+             librados::IoCtx& ioctx)
+    : RadosWriter(dpp, std::move(ex), ioctx)
+  {}
+  void prepare_write(int /*shard*/,
+                     librados::ObjectWriteOperation& op) override {
+    cls_rgw_bilog_stop(op);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "stop bilog shards: ";
+  }
+};
+
+
+void RGWSI_BILog_RADOS_InIndex::init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
+                                     neorados::RADOS rados_neo_)
+{
+  svc.bi = bi_rados_svc;
+  // rados_neo stored on base for rgw_rados.cc access
+  rados_neo.emplace(std::move(rados_neo_));
+}
+
+int RGWSI_BILog_RADOS_InIndex::log_trim(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id,
+    std::string_view start_marker,
+    std::string_view end_marker)
 {
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
-
   BucketIndexShardsManager start_marker_mgr;
   BucketIndexShardsManager end_marker_mgr;
 
   const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = svc.bi->open_bucket_index(dpp, bucket_info, shard_id, current_index, &index_pool, &bucket_objs, nullptr);
+  int r = svc.bi->open_bucket_index(dpp, bucket_info, shard_id, current_index,
+                                    &index_pool, &bucket_objs, nullptr);
   if (r < 0) {
     return r;
   }
@@ -86,17 +121,13 @@ int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp, optional_yield y,
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
   if (y) {
-    // run on the coroutine's executor and suspend until completion
     auto yield = y.get_yield_context();
     auto ex = yield.get_executor();
     auto writer = TrimWriter{*dpp, ex, index_pool, start_marker_mgr, end_marker_mgr};
-
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
   } else {
-    // run a strand on the system executor and block on a condition variable
     auto ex = boost::asio::make_strand(boost::asio::system_executor{});
     auto writer = TrimWriter{*dpp, ex, index_pool, start_marker_mgr, end_marker_mgr};
-
     maybe_warn_about_blocking(dpp);
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
                                      ceph::async::use_blocked[ec]);
@@ -104,42 +135,31 @@ int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp, optional_yield y,
   return ceph::from_error_code(ec);
 }
 
-struct StartWriter : rgwrados::shard_io::RadosWriter {
-  using RadosWriter::RadosWriter;
-  void prepare_write(int, librados::ObjectWriteOperation& op) override {
-    cls_rgw_bilog_start(op);
-  }
-  void add_prefix(std::ostream& out) const override {
-    out << "restart bilog shards: ";
-  }
-};
-
-int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, optional_yield y,
-                                 const RGWBucketInfo& bucket_info,
-                                 const rgw::bucket_log_layout_generation& log_layout,
-                                 int shard_id)
+int RGWSI_BILog_RADOS_InIndex::log_start(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id)
 {
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
   const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = svc.bi->open_bucket_index(dpp, bucket_info, shard_id, current_index, &index_pool, &bucket_objs, nullptr);
-  if (r < 0)
+  int r = svc.bi->open_bucket_index(dpp, bucket_info, shard_id, current_index,
+                                    &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
     return r;
+  }
 
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
   if (y) {
-    // run on the coroutine's executor and suspend until completion
     auto yield = y.get_yield_context();
     auto ex = yield.get_executor();
     auto writer = StartWriter{*dpp, ex, index_pool};
-
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
   } else {
-    // run a strand on the system executor and block on a condition variable
     auto ex = boost::asio::make_strand(boost::asio::system_executor{});
     auto writer = StartWriter{*dpp, ex, index_pool};
-
     maybe_warn_about_blocking(dpp);
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
                                      ceph::async::use_blocked[ec]);
@@ -147,42 +167,31 @@ int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, optional_yield y
   return ceph::from_error_code(ec);
 }
 
-struct StopWriter : rgwrados::shard_io::RadosWriter {
-  using RadosWriter::RadosWriter;
-  void prepare_write(int, librados::ObjectWriteOperation& op) override {
-    cls_rgw_bilog_stop(op);
-  }
-  void add_prefix(std::ostream& out) const override {
-    out << "stop bilog shards: ";
-  }
-};
-
-int RGWSI_BILog_RADOS::log_stop(const DoutPrefixProvider *dpp, optional_yield y,
-                                const RGWBucketInfo& bucket_info,
-                                const rgw::bucket_log_layout_generation& log_layout,
-                                int shard_id)
+int RGWSI_BILog_RADOS_InIndex::log_stop(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id)
 {
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
   const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = svc.bi->open_bucket_index(dpp, bucket_info, shard_id, current_index, &index_pool, &bucket_objs, nullptr);
-  if (r < 0)
+  int r = svc.bi->open_bucket_index(dpp, bucket_info, shard_id, current_index,
+                                    &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
     return r;
+  }
 
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
   if (y) {
-    // run on the coroutine's executor and suspend until completion
     auto yield = y.get_yield_context();
     auto ex = yield.get_executor();
     auto writer = StopWriter{*dpp, ex, index_pool};
-
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
   } else {
-    // run a strand on the system executor and block on a condition variable
     auto ex = boost::asio::make_strand(boost::asio::system_executor{});
     auto writer = StopWriter{*dpp, ex, index_pool};
-
     maybe_warn_about_blocking(dpp);
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
                                      ceph::async::use_blocked[ec]);
@@ -232,8 +241,9 @@ static int bilog_list(const DoutPrefixProvider* dpp, optional_yield y,
   map<int, string> oids;
   const auto& current_index = rgw::log_to_index_layout(log_layout);
   int r = svc_bi->open_bucket_index(dpp, bucket_info, shard_id, current_index, &index_pool, &oids, nullptr);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   const size_t max_aio = dpp->get_cct()->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
@@ -256,74 +266,67 @@ static int bilog_list(const DoutPrefixProvider* dpp, optional_yield y,
   return ceph::from_error_code(ec);
 }
 
-int RGWSI_BILog_RADOS::log_list(const DoutPrefixProvider *dpp, optional_yield y,
-				const RGWBucketInfo& bucket_info,
-				const rgw::bucket_log_layout_generation& log_layout,
-				int shard_id, string& marker, uint32_t max,
-                                std::list<rgw_bi_log_entry>& result, bool *truncated)
+int RGWSI_BILog_RADOS_InIndex::log_list(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id, string& marker, uint32_t max,
+    std::list<rgw_bi_log_entry>& result, bool *truncated)
 {
-  ldpp_dout(dpp, 20) << __func__ << ": " << bucket_info.bucket << " marker " << marker << " shard_id=" << shard_id << " max " << max << dendl;
+  ldpp_dout(dpp, 20) << __func__ << ": " << bucket_info.bucket
+                     << " marker " << marker << " shard_id=" << shard_id
+                     << " max " << max << dendl;
   result.clear();
 
   BucketIndexShardsManager marker_mgr;
   const bool has_shards = (shard_id >= 0);
-  // If there are multiple shards for the bucket index object, the marker
-  // should have the pattern '{shard_id_1}#{shard_marker_1},{shard_id_2}#
-  // {shard_marker_2}...', if there is no sharding, the bi_log_list should
-  // only contain one record, and the key is the bucket instance id.
   int r = marker_mgr.from_string(marker, shard_id);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   std::map<int, cls_rgw_bi_log_list_ret> bi_log_lists;
   r = bilog_list(dpp, y, svc.bi, bucket_info, log_layout, marker_mgr,
                  shard_id, max, bi_log_lists);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   map<int, list<rgw_bi_log_entry>::iterator> vcurrents;
   map<int, list<rgw_bi_log_entry>::iterator> vends;
   if (truncated) {
     *truncated = false;
   }
-  map<int, cls_rgw_bi_log_list_ret>::iterator miter = bi_log_lists.begin();
-  for (; miter != bi_log_lists.end(); ++miter) {
-    int shard_id = miter->first;
-    vcurrents[shard_id] = miter->second.entries.begin();
-    vends[shard_id] = miter->second.entries.end();
+  for (auto& [sid, ret] : bi_log_lists) {
+    vcurrents[sid] = ret.entries.begin();
+    vends[sid] = ret.entries.end();
     if (truncated) {
-      *truncated = (*truncated || miter->second.truncated);
+      *truncated = (*truncated || ret.truncated);
     }
   }
 
   size_t total = 0;
   bool has_more = true;
-  map<int, list<rgw_bi_log_entry>::iterator>::iterator viter;
-  map<int, list<rgw_bi_log_entry>::iterator>::iterator eiter;
   while (total < max && has_more) {
     has_more = false;
-
-    viter = vcurrents.begin();
-    eiter = vends.begin();
-
+    auto viter = vcurrents.begin();
+    auto eiter = vends.begin();
     for (; total < max && viter != vcurrents.end(); ++viter, ++eiter) {
-      assert (eiter != vends.end());
-
-      int shard_id = viter->first;
-      list<rgw_bi_log_entry>::iterator& liter = viter->second;
-
-      if (liter == eiter->second){
+      assert(eiter != vends.end());
+      int sid = viter->first;
+      auto& liter = viter->second;
+      if (liter == eiter->second) {
         continue;
       }
-      rgw_bi_log_entry& entry = *(liter);
+      rgw_bi_log_entry& entry = *liter;
       if (has_shards) {
         char buf[16];
-        snprintf(buf, sizeof(buf), "%d", shard_id);
+        snprintf(buf, sizeof(buf), "%d", sid);
         string tmp_id;
         build_bucket_index_marker(buf, entry.id, &tmp_id);
         entry.id.swap(tmp_id);
       }
-      marker_mgr.add(shard_id, entry.id);
+      marker_mgr.add(sid, entry.id);
       result.push_back(entry);
       total++;
       has_more = true;
@@ -332,46 +335,44 @@ int RGWSI_BILog_RADOS::log_list(const DoutPrefixProvider *dpp, optional_yield y,
   }
 
   if (truncated) {
-    for (viter = vcurrents.begin(), eiter = vends.begin(); viter != vcurrents.end(); ++viter, ++eiter) {
-      assert (eiter != vends.end());
+    for (auto viter = vcurrents.begin(), eiter = vends.begin();
+         viter != vcurrents.end(); ++viter, ++eiter) {
+      assert(eiter != vends.end());
       *truncated = (*truncated || (viter->second != eiter->second));
     }
   }
 
-  // Refresh marker, if there are multiple shards, the output will look like
-  // '{shard_oid_1}#{shard_marker_1},{shard_oid_2}#{shard_marker_2}...',
-  // if there is no sharding, the simply marker (without oid) is returned
   if (has_shards) {
     marker_mgr.to_string(&marker);
-  } else {
-    if (!result.empty()) {
-      marker = result.rbegin()->id;
-    }
+  } else if (!result.empty()) {
+    marker = result.rbegin()->id;
   }
 
   return 0;
 }
 
-int RGWSI_BILog_RADOS::get_log_status(const DoutPrefixProvider *dpp,
-                                      const RGWBucketInfo& bucket_info,
-				      const rgw::bucket_log_layout_generation& log_layout, 
-                                      int shard_id,
-                                      map<int, string> *markers,
-				      optional_yield y)
+int RGWSI_BILog_RADOS_InIndex::get_log_status(
+    const DoutPrefixProvider *dpp,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id,
+    map<int, string> *markers,
+    optional_yield y)
 {
   vector<rgw_bucket_dir_header> headers;
   map<int, string> bucket_instance_ids;
   const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = svc.bi->cls_bucket_head(dpp, bucket_info, current_index, shard_id, &headers, &bucket_instance_ids, y);
-  if (r < 0)
+  int r = svc.bi->cls_bucket_head(dpp, bucket_info, current_index, shard_id,
+                                   &headers, &bucket_instance_ids, y);
+  if (r < 0) {
     return r;
+  }
 
   ceph_assert(headers.size() == bucket_instance_ids.size());
 
   auto iter = headers.begin();
-  map<int, string>::iterator viter = bucket_instance_ids.begin();
-
-  for(; iter != headers.end(); ++iter, ++viter) {
+  auto viter = bucket_instance_ids.begin();
+  for (; iter != headers.end(); ++iter, ++viter) {
     if (shard_id >= 0) {
       (*markers)[shard_id] = iter->max_marker;
     } else {
@@ -380,5 +381,373 @@ int RGWSI_BILog_RADOS::get_log_status(const DoutPrefixProvider *dpp,
   }
 
   return 0;
+}
+
+// FIFO backend
+// ------------
+// each bucket shard keeps its bilog in a dedicated FIFO object whose name is
+// derived from the shard index OID via bilog_fifo_oid().  FIFO objects are
+// created lazily on the first write. there is no explicit creation step at
+// bucket creation time.
+// callers just construct a LazyFIFO and call list/trim/etc.
+//
+// Marker format
+// -------------
+// raw FIFO markers are strings like "00000001".
+// when a bucket has multiple shards, callers of log_list expect
+// markers of the form "<shard_id>#<raw_marker>" (e.g. "3#00000001") — the
+// same format used by the InIndex backend. we build those in log_entry.id
+// via build_bucket_index_marker()
+
+void RGWSI_BILog_RADOS_FIFO::init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
+                                   neorados::RADOS rados_neo_)
+{
+  bi_ = bi_rados_svc;
+  rados_neo.emplace(std::move(rados_neo_));
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_start(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& /*bucket_info*/,
+    const rgw::bucket_log_layout_generation& /*log_layout*/,
+    int /*shard_id*/)
+{
+  return 0; // FIFO has no pause/resume state
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_stop(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& /*bucket_info*/,
+    const rgw::bucket_log_layout_generation& /*log_layout*/,
+    int /*shard_id*/)
+{
+  return 0; // FIFO has no explicit cleanup
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_trim(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id,
+    std::string_view start_marker,
+    std::string_view end_marker)
+{
+  // discard all FIFO entries up to (but not including) end_marker from every
+  // relevant shard.  start_marker is intentionally unused: FIFO trim always
+  // progresses from the tail and cls_fifo tracks what has already been
+  // trimmed internally, so there is no need to pass a lower bound.
+  //
+  // end_marker is a BucketIndexShardsManager composite string of the form
+  // "<sid>#<raw>,...".  We look up each shard's raw marker
+  // with end_marker_mgr.get(sid, "").  Shards absent from the composite
+  // string are skipped (their per-shard marker is empty).
+  //
+  // LazyFIFO::trim(inclusive=false) trims everything *before* the given
+  // marker, consistent with InIndex bilog semantics where the end marker
+  // itself is not removed.
+  if (end_marker.empty()) {
+    return 0;
+  }
+
+  librados::IoCtx index_pool;
+  std::map<int, std::string> shard_oids;
+  const auto& current_index = rgw::log_to_index_layout(log_layout);
+  int r = bi_->open_bucket_index(dpp, bucket_info, shard_id, current_index,
+                                 &index_pool, &shard_oids, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  neorados::IOContext neo_loc(index_pool.get_id());
+  BucketIndexShardsManager end_marker_mgr;
+  r = end_marker_mgr.from_string(end_marker, shard_id);
+  if (r < 0) {
+    return r;
+  }
+
+  for (auto& [sid, oid] : shard_oids) {
+    const std::string shard_end = end_marker_mgr.get(sid, "");
+    if (shard_end.empty()) {
+      continue;
+    }
+    // each bucket index shard OID maps to a FIFO object named
+    // <shard_oid>.bilog.fifo.  LazyFIFO opens (or creates) it on demand.
+    const std::string fifo_oid = bilog_fifo_oid(oid);
+    LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
+    try {
+      if (y) {
+        lf.trim(dpp, shard_end, false /* inclusive */, y.get_yield_context());
+      } else {
+        maybe_warn_about_blocking(dpp);
+        asio::spawn(
+            rados_neo->get_executor(),
+            [&](asio::yield_context inner_y) {
+              lf.trim(dpp, shard_end, false /* inclusive */, inner_y);
+            },
+            ceph::async::use_blocked);
+      }
+    } catch (const boost::system::system_error& e) {
+      ldpp_dout(dpp, 5) << __func__ << ": FIFO trim on " << fifo_oid
+                        << " failed: " << e.what() << dendl;
+      return ceph::from_error_code(e.code());
+    }
+  }
+  return 0;
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_list(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id, string& marker, uint32_t max,
+    std::list<rgw_bi_log_entry>& result, bool *truncated)
+{
+  // read up to `max` bilog entries across all relevant shards starting after
+  // `marker`. shards are visited in ascending shard-id order (shard_oids is a
+  // std::map). entries from each shard are appended consecutively
+  ldpp_dout(dpp, 20) << __func__ << ": " << bucket_info.bucket
+                     << " marker " << marker << " shard_id=" << shard_id
+                     << " max " << max << dendl;
+  result.clear();
+  if (truncated) {
+    *truncated = false;
+  }
+  if (max == 0) {
+    return 0;
+  }
+
+  librados::IoCtx index_pool;
+  std::map<int, std::string> shard_oids;
+  const auto& current_index = rgw::log_to_index_layout(log_layout);
+  int r = bi_->open_bucket_index(dpp, bucket_info, shard_id, current_index,
+                                 &index_pool, &shard_oids, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  neorados::IOContext neo_loc(index_pool.get_id());
+  BucketIndexShardsManager marker_mgr;
+  r = marker_mgr.from_string(marker, shard_id);
+  if (r < 0) {
+    return r;
+  }
+
+  uint32_t total = 0;
+  for (auto& [sid, oid] : shard_oids) {
+    if (total >= max) {
+      if (truncated) {
+        *truncated = true;
+      }
+      break;
+    }
+
+    static constexpr uint32_t FIFO_BATCH_SIZE = 128;
+    const uint32_t fetch = std::min<uint32_t>(max - total, FIFO_BATCH_SIZE);
+    std::vector<fifo::entry> entries_buf(fetch);
+    const std::string fifo_oid = bilog_fifo_oid(oid);
+    LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
+    // raw per-shard resume marker. empty string means from the beginning.
+    std::string shard_marker = marker_mgr.get(sid, "");
+    // next_marker is returned by LazyFIFO::list when more entries exist
+    // beyond the batch
+    std::optional<std::string> next_marker;
+    std::span<fifo::entry> got;
+
+    try {
+      if (y) {
+        std::tie(got, next_marker) =
+            lf.list(dpp, shard_marker, std::span{entries_buf},
+                    y.get_yield_context());
+      } else {
+        maybe_warn_about_blocking(dpp);
+        asio::spawn(
+            rados_neo->get_executor(),
+            [&](asio::yield_context inner_y) {
+              std::tie(got, next_marker) =
+                  lf.list(dpp, shard_marker, std::span{entries_buf}, inner_y);
+            },
+            ceph::async::use_blocked);
+      }
+    } catch (const boost::system::system_error& e) {
+      ldpp_dout(dpp, 5) << __func__ << ": FIFO list on " << fifo_oid
+                        << " failed: " << e.what() << dendl;
+      return ceph::from_error_code(e.code());
+    }
+
+    for (auto& entry : got) {
+      // each FIFO entry is an encoded rgw_bi_log_entry.
+      rgw_bi_log_entry log_entry;
+      try {
+        auto p = entry.data.cbegin();
+        decode(log_entry, p);
+      } catch (const ceph::buffer::error& e) {
+        ldpp_dout(dpp, 0) << __func__ << ": failed to decode bilog entry from "
+                          << fifo_oid << ": " << e.what() << dendl;
+        return -EIO;
+      }
+      // build the composite id returned to the caller. multi-shard queries
+      // require "<sid>#<raw>". single-shard queries use the raw marker directly.
+      if (shard_id >= 0) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%d", sid);
+        std::string prefixed;
+        build_bucket_index_marker(buf, entry.marker, &prefixed);
+        log_entry.id = std::move(prefixed);
+      } else {
+        log_entry.id = entry.marker;
+      }
+      // track the raw FIFO marker.
+      // marker_mgr.to_string() will prepend the shard prefix.
+      marker_mgr.add(sid, entry.marker);
+      result.push_back(std::move(log_entry));
+      ++total;
+    }
+    if (next_marker && truncated) {
+      *truncated = true;
+    }
+  }
+
+  if (shard_id >= 0) {
+    marker_mgr.to_string(&marker);
+  } else if (!result.empty()) {
+    marker = result.rbegin()->id;
+  }
+
+  return 0;
+}
+
+int RGWSI_BILog_RADOS_FIFO::get_log_status(
+    const DoutPrefixProvider *dpp,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id,
+    map<int, string> *markers,
+    optional_yield y)
+{
+  // returns the marker of the most recently pushed entry in each shard FIFO.
+  // callers (e.g. radosgw-admin bilog status, bilog trim logic) use this as
+  // the upper bound for a subsequent log_trim() call.
+  //
+  // LazyFIFO::last_entry_info() reads the FIFO tail pointer and returns a
+  // tuple<marker, timestamp>.
+
+  // if a FIFO object does not yet exist for a shard (new bucket with no
+  // operations logged), last_entry_info() returns an empty marker string.
+  // the caller should treat an empty marker as nothing to trim.
+  librados::IoCtx index_pool;
+  std::map<int, std::string> shard_oids;
+  const auto& current_index = rgw::log_to_index_layout(log_layout);
+  int r = bi_->open_bucket_index(dpp, bucket_info, shard_id, current_index,
+                                 &index_pool, &shard_oids, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  neorados::IOContext neo_loc(index_pool.get_id());
+  for (auto& [sid, oid] : shard_oids) {
+    const std::string fifo_oid = bilog_fifo_oid(oid);
+    LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
+    try {
+      auto get_info = [&]() -> std::tuple<std::string, ceph::real_time> {
+        if (y) {
+          return lf.last_entry_info(dpp, y.get_yield_context());
+        } else {
+          maybe_warn_about_blocking(dpp);
+          std::tuple<std::string, ceph::real_time> result;
+          asio::spawn(
+              rados_neo->get_executor(),
+              [&](asio::yield_context inner_y) {
+                result = lf.last_entry_info(dpp, inner_y);
+              },
+              ceph::async::use_blocked);
+          return result;
+        }
+      };
+      (*markers)[sid] = std::get<0>(get_info());
+    } catch (const boost::system::system_error& e) {
+      ldpp_dout(dpp, 5) << __func__ << ": FIFO last_entry_info on "
+                        << fifo_oid << " failed: " << e.what() << dendl;
+      return ceph::from_error_code(e.code());
+    }
+  }
+
+  return 0;
+}
+
+// ── BackendDispatcher ─────────────────────────────────────────────────────────
+
+RGWSI_BILog_RADOS_BackendDispatcher::RGWSI_BILog_RADOS_BackendDispatcher(
+    CephContext *cct)
+  : RGWSI_BILog_RADOS(cct),
+    backend_inindex(cct),
+    backend_fifo(cct)
+{
+}
+
+void RGWSI_BILog_RADOS_BackendDispatcher::init(
+    RGWSI_BucketIndex_RADOS *bi_rados_svc, neorados::RADOS rados_neo_)
+{
+  rados_neo.emplace(rados_neo_);
+  backend_inindex.init(bi_rados_svc, rados_neo_);
+  backend_fifo.init(bi_rados_svc, std::move(rados_neo_));
+}
+
+RGWSI_BILog_RADOS& RGWSI_BILog_RADOS_BackendDispatcher::get_backend(
+    const rgw::bucket_log_layout_generation& log_layout)
+{
+  if (log_layout.layout.type == rgw::BucketLogType::FIFO) {
+    return backend_fifo;
+  }
+  return backend_inindex;
+}
+
+int RGWSI_BILog_RADOS_BackendDispatcher::log_start(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout, int shard_id)
+{
+  return get_backend(log_layout).log_start(dpp, y, bucket_info, log_layout,
+                                           shard_id);
+}
+
+int RGWSI_BILog_RADOS_BackendDispatcher::log_stop(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout, int shard_id)
+{
+  return get_backend(log_layout).log_stop(dpp, y, bucket_info, log_layout,
+                                          shard_id);
+}
+
+int RGWSI_BILog_RADOS_BackendDispatcher::log_trim(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id, std::string_view start_marker, std::string_view end_marker)
+{
+  return get_backend(log_layout).log_trim(dpp, y, bucket_info, log_layout,
+                                          shard_id, start_marker, end_marker);
+}
+
+int RGWSI_BILog_RADOS_BackendDispatcher::log_list(
+    const DoutPrefixProvider *dpp, optional_yield y,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id, string& marker, uint32_t max,
+    std::list<rgw_bi_log_entry>& result, bool *truncated)
+{
+  return get_backend(log_layout).log_list(dpp, y, bucket_info, log_layout,
+                                          shard_id, marker, max, result,
+                                          truncated);
+}
+
+int RGWSI_BILog_RADOS_BackendDispatcher::get_log_status(
+    const DoutPrefixProvider *dpp,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id, map<int, string> *markers, optional_yield y)
+{
+  return get_backend(log_layout).get_log_status(dpp, bucket_info, log_layout,
+                                                 shard_id, markers, y);
 }
 

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -121,13 +121,16 @@ int RGWSI_BILog_RADOS_InIndex::log_trim(
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
   if (y) {
+    // run on the coroutine's executor and suspend until completion
     auto yield = y.get_yield_context();
     auto ex = yield.get_executor();
     auto writer = TrimWriter{*dpp, ex, index_pool, start_marker_mgr, end_marker_mgr};
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
   } else {
+    // run a strand on the system executor and block on a condition variable
     auto ex = boost::asio::make_strand(boost::asio::system_executor{});
     auto writer = TrimWriter{*dpp, ex, index_pool, start_marker_mgr, end_marker_mgr};
+
     maybe_warn_about_blocking(dpp);
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
                                      ceph::async::use_blocked[ec]);
@@ -153,13 +156,16 @@ int RGWSI_BILog_RADOS_InIndex::log_start(
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
   if (y) {
+    // run on the coroutine's executor and suspend until completion
     auto yield = y.get_yield_context();
     auto ex = yield.get_executor();
     auto writer = StartWriter{*dpp, ex, index_pool};
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
   } else {
+    // run a strand on the system executor and block on a condition variable
     auto ex = boost::asio::make_strand(boost::asio::system_executor{});
     auto writer = StartWriter{*dpp, ex, index_pool};
+
     maybe_warn_about_blocking(dpp);
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
                                      ceph::async::use_blocked[ec]);
@@ -185,13 +191,16 @@ int RGWSI_BILog_RADOS_InIndex::log_stop(
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
   if (y) {
+    // run on the coroutine's executor and suspend until completion
     auto yield = y.get_yield_context();
     auto ex = yield.get_executor();
     auto writer = StopWriter{*dpp, ex, index_pool};
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
   } else {
+    // run a strand on the system executor and block on a condition variable
     auto ex = boost::asio::make_strand(boost::asio::system_executor{});
     auto writer = StopWriter{*dpp, ex, index_pool};
+
     maybe_warn_about_blocking(dpp);
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
                                      ceph::async::use_blocked[ec]);
@@ -280,6 +289,10 @@ int RGWSI_BILog_RADOS_InIndex::log_list(
 
   BucketIndexShardsManager marker_mgr;
   const bool has_shards = (shard_id >= 0);
+  // If there are multiple shards for the bucket index object, the marker
+  // should have the pattern '{shard_id_1}#{shard_marker_1},{shard_id_2}#
+  // {shard_marker_2}...', if there is no sharding, the bi_log_list should
+  // only contain one record, and the key is the bucket instance id.
   int r = marker_mgr.from_string(marker, shard_id);
   if (r < 0) {
     return r;
@@ -297,11 +310,11 @@ int RGWSI_BILog_RADOS_InIndex::log_list(
   if (truncated) {
     *truncated = false;
   }
-  for (auto& [sid, ret] : bi_log_lists) {
-    vcurrents[sid] = ret.entries.begin();
-    vends[sid] = ret.entries.end();
+  for (auto& [sid, shard_result] : bi_log_lists) {
+    vcurrents[sid] = shard_result.entries.begin();
+    vends[sid] = shard_result.entries.end();
     if (truncated) {
-      *truncated = (*truncated || ret.truncated);
+      *truncated = (*truncated || shard_result.truncated);
     }
   }
 
@@ -342,6 +355,9 @@ int RGWSI_BILog_RADOS_InIndex::log_list(
     }
   }
 
+  // Refresh marker, if there are multiple shards, the output will look like
+  // '{shard_oid_1}#{shard_marker_1},{shard_oid_2}#{shard_marker_2}...',
+  // if there is no sharding, the simply marker (without oid) is returned
   if (has_shards) {
     marker_mgr.to_string(&marker);
   } else if (!result.empty()) {

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -408,18 +408,18 @@ void RGWSI_BILog_RADOS_FIFO::init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
 
 int RGWSI_BILog_RADOS_FIFO::log_start(
     const DoutPrefixProvider *dpp, optional_yield y,
-    const RGWBucketInfo& /*bucket_info*/,
-    const rgw::bucket_log_layout_generation& /*log_layout*/,
-    int /*shard_id*/)
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id)
 {
   return 0; // FIFO has no pause/resume state
 }
 
 int RGWSI_BILog_RADOS_FIFO::log_stop(
     const DoutPrefixProvider *dpp, optional_yield y,
-    const RGWBucketInfo& /*bucket_info*/,
-    const rgw::bucket_log_layout_generation& /*log_layout*/,
-    int /*shard_id*/)
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id)
 {
   return 0; // FIFO has no explicit cleanup
 }
@@ -465,6 +465,7 @@ int RGWSI_BILog_RADOS_FIFO::log_trim(
     return r;
   }
 
+  int ret = 0;
   for (auto& [sid, oid] : shard_oids) {
     const std::string shard_end = end_marker_mgr.get(sid, "");
     if (shard_end.empty()) {
@@ -487,12 +488,15 @@ int RGWSI_BILog_RADOS_FIFO::log_trim(
             ceph::async::use_blocked);
       }
     } catch (const boost::system::system_error& e) {
+      // log and continue trimming remaining shards; trim is best-effort and
+      // the trim cycle will retry any skipped shards on its next iteration.
       ldpp_dout(dpp, 5) << __func__ << ": FIFO trim on " << fifo_oid
-                        << " failed: " << e.what() << dendl;
-      return ceph::from_error_code(e.code());
+                        << " shard=" << sid << " failed: " << e.what()
+                        << " (continuing)" << dendl;
+      ret = ceph::from_error_code(e.code());
     }
   }
-  return 0;
+  return ret;
 }
 
 int RGWSI_BILog_RADOS_FIFO::log_list(

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -18,9 +18,11 @@ RGWSI_BILog_RADOS::RGWSI_BILog_RADOS(CephContext *cct) : RGWServiceInstance(cct)
 {
 }
 
-void RGWSI_BILog_RADOS::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
+void RGWSI_BILog_RADOS::init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
+                             neorados::RADOS rados_neo_)
 {
   svc.bi = bi_rados_svc;
+  rados_neo.emplace(std::move(rados_neo_));
 }
 
 struct TrimWriter : rgwrados::shard_io::RadosWriter {

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -357,7 +357,7 @@ int RGWSI_BILog_RADOS_InIndex::log_list(
 
   // Refresh marker, if there are multiple shards, the output will look like
   // '{shard_oid_1}#{shard_marker_1},{shard_oid_2}#{shard_marker_2}...',
-  // if there is no sharding, the simply marker (without oid) is returned
+  // if there is no sharding, then simply marker (without oid) is returned
   if (has_shards) {
     marker_mgr.to_string(&marker);
   } else if (!result.empty()) {
@@ -627,11 +627,11 @@ int RGWSI_BILog_RADOS_FIFO::log_list(
     }
   }
 
-  if (shard_id >= 0) {
-    marker_mgr.to_string(&marker);
-  } else if (!result.empty()) {
-    marker = result.rbegin()->id;
-  }
+  // always encode per-shard positions using the marker format
+  // ("0#<xxx>,1#<xxx>,..."). using a raw FIFO marker (no shard prefix) here
+  // would cause from_string() to assign it to shard 0 only, causing all other
+  // shards to restart from the beginning on the next paginated call.
+  marker_mgr.to_string(&marker);
 
   return 0;
 }

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -544,9 +544,10 @@ int RGWSI_BILog_RADOS_FIFO::trim_shard(
   auto lf = std::make_shared<LazyFIFO>(*rados_neo, fifo_oid, neo_loc);
   asio::co_spawn(
       rados_neo->get_executor(),
-      [lf, dpp, marker_str = std::string{marker}]() -> asio::awaitable<void> {
+      [](std::shared_ptr<LazyFIFO> lf, const DoutPrefixProvider* dpp,
+         std::string marker_str) -> asio::awaitable<void> {
         co_return co_await lf->trim(dpp, marker_str, false);
-      }(),
+      }(lf, dpp, std::string{marker}),
       c);
   return 0;
 }
@@ -568,16 +569,17 @@ int RGWSI_BILog_RADOS_FIFO::remove_log_shards(
   const int n = static_cast<int>(rgw::num_shards(log_layout.layout.fifo));
   asio::co_spawn(
       rados_neo->get_executor(),
-      [neo = *rados_neo, neo_loc, dpp,
-       bucket_id = bucket_info.bucket.bucket_id,
-       gen = log_layout.gen, n]() -> asio::awaitable<void> {
+      [](neorados::RADOS neo, neorados::IOContext neo_loc,
+         const DoutPrefixProvider* dpp,
+         std::string bucket_id, uint64_t gen, int n) -> asio::awaitable<void> {
         co_return co_await log_remove(
-            dpp, neo, neo_loc, n,
-            [bucket_id, gen](int shard_id) {
+            dpp, std::move(neo), neo_loc, n,
+            [bucket_id = std::move(bucket_id), gen](int shard_id) {
               return bilog_fifo_oid(bucket_id, gen, shard_id);
             },
             false);
-      }(),
+      }(*rados_neo, neo_loc, dpp,
+        std::string{bucket_info.bucket.bucket_id}, log_layout.gen, n),
       c);
   return 0;
 }

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -3,6 +3,7 @@
 
 #include "svc_bilog_rados.h"
 #include "svc_bi_rados.h"
+#include "svc_zone.h"
 
 #include "rgw_asio_thread.h"
 #include "driver/rados/shard_io.h"
@@ -401,11 +402,12 @@ int RGWSI_BILog_RADOS_InIndex::get_log_status(
 
 // FIFO backend
 // ------------
-// each bucket shard keeps its bilog in a dedicated FIFO object whose name is
-// derived from the shard index OID via bilog_fifo_oid().  FIFO objects are
-// created lazily on the first write. there is no explicit creation step at
-// bucket creation time.
-// callers just construct a LazyFIFO and call list/trim/etc.
+// FIFO bilog objects are stored in the log pool and the shard count for an active
+// generation is stored in log_layout.layout.fifo.num_shards and chosen at
+// bucket creation/reshard time via bilog_shards_for_index().
+//
+// FIFO objects are created lazily on the first write. callers just construct a
+// LazyFIFO and call list/trim/etc.
 //
 // Marker format
 // -------------
@@ -465,31 +467,35 @@ int RGWSI_BILog_RADOS_FIFO::log_trim(
     return 0;
   }
 
-  librados::IoCtx index_pool;
-  std::map<int, std::string> shard_oids;
-  const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = bi_->open_bucket_index(dpp, bucket_info, shard_id, current_index,
-                                 &index_pool, &shard_oids, nullptr);
+  librados::IoCtx log_ioctx;
+  const auto& zone_params = bi_->svc.zone->get_zone_params();
+  int r = rgw_init_ioctx(dpp, bi_->rados, zone_params.log_pool, log_ioctx,
+                         true, false);
   if (r < 0) {
     return r;
   }
+  neorados::IOContext neo_loc(log_ioctx.get_id());
 
-  neorados::IOContext neo_loc(index_pool.get_id());
+  const auto& fifo_layout = log_layout.layout.fifo;
+  const std::string& bucket_id = bucket_info.bucket.bucket_id;
+  const uint64_t log_gen = log_layout.gen;
+
   BucketIndexShardsManager end_marker_mgr;
   r = end_marker_mgr.from_string(end_marker, shard_id);
   if (r < 0) {
     return r;
   }
 
+  const int first = (shard_id >= 0) ? shard_id : 0;
+  const int last  = (shard_id >= 0) ? shard_id
+                                     : static_cast<int>(fifo_layout.num_shards) - 1;
   int ret = 0;
-  for (auto& [sid, oid] : shard_oids) {
+  for (int sid = first; sid <= last; ++sid) {
     const std::string shard_end = end_marker_mgr.get(sid, "");
     if (shard_end.empty()) {
       continue;
     }
-    // each bucket index shard OID maps to a FIFO object named
-    // <shard_oid>.bilog.fifo.  LazyFIFO opens (or creates) it on demand.
-    const std::string fifo_oid = bilog_fifo_oid(oid);
+    const std::string fifo_oid = bilog_fifo_oid(bucket_id, log_gen, sid);
     LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
     try {
       if (y) {
@@ -536,16 +542,30 @@ int RGWSI_BILog_RADOS_FIFO::log_list(
     return 0;
   }
 
-  librados::IoCtx index_pool;
-  std::map<int, std::string> shard_oids;
-  const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = bi_->open_bucket_index(dpp, bucket_info, shard_id, current_index,
-                                 &index_pool, &shard_oids, nullptr);
+  librados::IoCtx log_ioctx;
+  const auto& zone_params = bi_->svc.zone->get_zone_params();
+  int r = rgw_init_ioctx(dpp, bi_->rados, zone_params.log_pool, log_ioctx,
+                         true, false);
   if (r < 0) {
     return r;
   }
+  neorados::IOContext neo_loc(log_ioctx.get_id());
 
-  neorados::IOContext neo_loc(index_pool.get_id());
+  const auto& fifo_layout = log_layout.layout.fifo;
+  const std::string& bucket_id = bucket_info.bucket.bucket_id;
+  const uint64_t log_gen = log_layout.gen;
+
+  // build a shard_id → fifo_oid map directly from the bilog layout.
+  std::map<int, std::string> shard_oids;
+  {
+    const int first = (shard_id >= 0) ? shard_id : 0;
+    const int last  = (shard_id >= 0) ? shard_id
+                                       : static_cast<int>(fifo_layout.num_shards) - 1;
+    for (int sid = first; sid <= last; ++sid) {
+      shard_oids[sid] = bilog_fifo_oid(bucket_id, log_gen, sid);
+    }
+  }
+
   BucketIndexShardsManager marker_mgr;
   r = marker_mgr.from_string(marker, shard_id);
   if (r < 0) {
@@ -564,7 +584,7 @@ int RGWSI_BILog_RADOS_FIFO::log_list(
     static constexpr uint32_t FIFO_BATCH_SIZE = 128;
     const uint32_t fetch = std::min<uint32_t>(max - total, FIFO_BATCH_SIZE);
     std::vector<fifo::entry> entries_buf(fetch);
-    const std::string fifo_oid = bilog_fifo_oid(oid);
+    const std::string& fifo_oid = oid;  // oid is already bilog_fifo_oid(bucket_id, log_gen, sid)
     LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
     // raw per-shard resume marker. empty string means from the beginning.
     std::string shard_marker = marker_mgr.get(sid, "");
@@ -654,18 +674,32 @@ int RGWSI_BILog_RADOS_FIFO::get_log_status(
   // if a FIFO object does not yet exist for a shard (new bucket with no
   // operations logged), last_entry_info() returns an empty marker string.
   // the caller should treat an empty marker as nothing to trim.
-  librados::IoCtx index_pool;
-  std::map<int, std::string> shard_oids;
-  const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = bi_->open_bucket_index(dpp, bucket_info, shard_id, current_index,
-                                 &index_pool, &shard_oids, nullptr);
+
+  librados::IoCtx log_ioctx;
+  const auto& zone_params = bi_->svc.zone->get_zone_params();
+  int r = rgw_init_ioctx(dpp, bi_->rados, zone_params.log_pool, log_ioctx,
+                         true, false);
   if (r < 0) {
     return r;
   }
+  neorados::IOContext neo_loc(log_ioctx.get_id());
 
-  neorados::IOContext neo_loc(index_pool.get_id());
+  const auto& fifo_layout = log_layout.layout.fifo;
+  const std::string& bucket_id = bucket_info.bucket.bucket_id;
+  const uint64_t log_gen = log_layout.gen;
+
+  std::map<int, std::string> shard_oids;
+  {
+    const int first = (shard_id >= 0) ? shard_id : 0;
+    const int last  = (shard_id >= 0) ? shard_id
+                                       : static_cast<int>(fifo_layout.num_shards) - 1;
+    for (int sid = first; sid <= last; ++sid) {
+      shard_oids[sid] = bilog_fifo_oid(bucket_id, log_gen, sid);
+    }
+  }
+
   for (auto& [sid, oid] : shard_oids) {
-    const std::string fifo_oid = bilog_fifo_oid(oid);
+    const std::string& fifo_oid = oid;  // oid is already bilog_fifo_oid(bucket_id, log_gen, sid)
     LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
     try {
       auto get_info = [&]() -> std::tuple<std::string, ceph::real_time> {

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -432,7 +432,55 @@ int RGWSI_BILog_RADOS_FIFO::log_start(
     const rgw::bucket_log_layout_generation& log_layout,
     int shard_id)
 {
-  return 0; // FIFO has no pause/resume state
+  // push a CLS_RGW_OP_RESYNC entry to each shard to
+  // clear the syncstopped state and resume sync.
+  librados::IoCtx log_ioctx;
+  const auto& zone_params = bi_->svc.zone->get_zone_params();
+  int r = rgw_init_ioctx(dpp, bi_->rados, zone_params.log_pool, log_ioctx,
+                         true, false);
+  if (r < 0) {
+    return r;
+  }
+  neorados::IOContext neo_loc(log_ioctx.get_id());
+
+  const auto& fifo_layout = log_layout.layout.fifo;
+  const std::string& bucket_id = bucket_info.bucket.bucket_id;
+  const uint64_t log_gen = log_layout.gen;
+
+  const int first = (shard_id >= 0) ? shard_id : 0;
+  const int last  = (shard_id >= 0) ? shard_id
+                                     : static_cast<int>(fifo_layout.num_shards) - 1;
+
+  rgw_bi_log_entry entry;
+  entry.op = CLS_RGW_OP_RESYNC;
+  entry.state = CLS_RGW_STATE_COMPLETE;
+  entry.timestamp = ceph::real_clock::now();
+  ceph::buffer::list bl;
+  encode(entry, bl);
+
+  int ret = 0;
+  for (int sid = first; sid <= last; ++sid) {
+    const std::string fifo_oid = bilog_fifo_oid(bucket_id, log_gen, sid);
+    LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
+    try {
+      if (y) {
+        lf.push(dpp, bl, y.get_yield_context());
+      } else {
+        maybe_warn_about_blocking(dpp);
+        asio::spawn(
+            rados_neo->get_executor(),
+            [&](asio::yield_context inner_y) {
+              lf.push(dpp, bl, inner_y);
+            },
+            ceph::async::use_blocked);
+      }
+    } catch (const boost::system::system_error& e) {
+      ldpp_dout(dpp, 1) << __func__ << ": FIFO push RESYNC on " << fifo_oid
+                        << " shard=" << sid << " failed: " << e.what() << dendl;
+      ret = ceph::from_error_code(e.code());
+    }
+  }
+  return ret;
 }
 
 int RGWSI_BILog_RADOS_FIFO::log_stop(
@@ -441,7 +489,55 @@ int RGWSI_BILog_RADOS_FIFO::log_stop(
     const rgw::bucket_log_layout_generation& log_layout,
     int shard_id)
 {
-  return 0; // FIFO has no explicit cleanup
+  // push a CLS_RGW_OP_SYNCSTOP control entry to each shard
+  // to detect the stop and transition to StateStopped.
+  librados::IoCtx log_ioctx;
+  const auto& zone_params = bi_->svc.zone->get_zone_params();
+  int r = rgw_init_ioctx(dpp, bi_->rados, zone_params.log_pool, log_ioctx,
+                         true, false);
+  if (r < 0) {
+    return r;
+  }
+  neorados::IOContext neo_loc(log_ioctx.get_id());
+
+  const auto& fifo_layout = log_layout.layout.fifo;
+  const std::string& bucket_id = bucket_info.bucket.bucket_id;
+  const uint64_t log_gen = log_layout.gen;
+
+  const int first = (shard_id >= 0) ? shard_id : 0;
+  const int last  = (shard_id >= 0) ? shard_id
+                                     : static_cast<int>(fifo_layout.num_shards) - 1;
+
+  rgw_bi_log_entry entry;
+  entry.op = CLS_RGW_OP_SYNCSTOP;
+  entry.state = CLS_RGW_STATE_COMPLETE;
+  entry.timestamp = ceph::real_clock::now();
+  ceph::buffer::list bl;
+  encode(entry, bl);
+
+  int ret = 0;
+  for (int sid = first; sid <= last; ++sid) {
+    const std::string fifo_oid = bilog_fifo_oid(bucket_id, log_gen, sid);
+    LazyFIFO lf(*rados_neo, fifo_oid, neo_loc);
+    try {
+      if (y) {
+        lf.push(dpp, bl, y.get_yield_context());
+      } else {
+        maybe_warn_about_blocking(dpp);
+        asio::spawn(
+            rados_neo->get_executor(),
+            [&](asio::yield_context inner_y) {
+              lf.push(dpp, bl, inner_y);
+            },
+            ceph::async::use_blocked);
+      }
+    } catch (const boost::system::system_error& e) {
+      ldpp_dout(dpp, 1) << __func__ << ": FIFO push SYNCSTOP on " << fifo_oid
+                        << " shard=" << sid << " failed: " << e.what() << dendl;
+      ret = ceph::from_error_code(e.code());
+    }
+  }
+  return ret;
 }
 
 int RGWSI_BILog_RADOS_FIFO::log_trim(

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -551,6 +551,37 @@ int RGWSI_BILog_RADOS_FIFO::trim_shard(
   return 0;
 }
 
+int RGWSI_BILog_RADOS_FIFO::remove_log_shards(
+    const DoutPrefixProvider* dpp,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    librados::AioCompletion* c)
+{
+  librados::IoCtx log_ioctx;
+  const auto& zone_params = bi_->svc.zone->get_zone_params();
+  int r = rgw_init_ioctx(dpp, bi_->rados, zone_params.log_pool, log_ioctx,
+                         true, false);
+  if (r < 0) {
+    return r;
+  }
+  neorados::IOContext neo_loc(log_ioctx.get_id());
+  const int n = static_cast<int>(rgw::num_shards(log_layout.layout.fifo));
+  asio::co_spawn(
+      rados_neo->get_executor(),
+      [neo = *rados_neo, neo_loc, dpp,
+       bucket_id = bucket_info.bucket.bucket_id,
+       gen = log_layout.gen, n]() -> asio::awaitable<void> {
+        co_return co_await log_remove(
+            dpp, neo, neo_loc, n,
+            [bucket_id, gen](int shard_id) {
+              return bilog_fifo_oid(bucket_id, gen, shard_id);
+            },
+            false);
+      }(),
+      c);
+  return 0;
+}
+
 int RGWSI_BILog_RADOS_FIFO::log_list(
     const DoutPrefixProvider *dpp, optional_yield y,
     const RGWBucketInfo& bucket_info,
@@ -845,5 +876,14 @@ int RGWSI_BILog_RADOS_BackendDispatcher::trim_shard(
 {
   return backend_fifo.trim_shard(dpp, bucket_info, log_layout, shard_id,
                                  marker, c);
+}
+
+int RGWSI_BILog_RADOS_BackendDispatcher::remove_log_shards(
+    const DoutPrefixProvider* dpp,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    librados::AioCompletion* c)
+{
+  return backend_fifo.remove_log_shards(dpp, bucket_info, log_layout, c);
 }
 

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -11,8 +11,10 @@
 #include "driver/rados/rgw_log_backing.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "common/async/blocked_completion.h"
+#include "common/async/librados_completion.h"
 
 #include <boost/asio/spawn.hpp>
+#include <boost/asio/co_spawn.hpp>
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -521,6 +523,34 @@ int RGWSI_BILog_RADOS_FIFO::log_trim(
   return ret;
 }
 
+int RGWSI_BILog_RADOS_FIFO::trim_shard(
+    const DoutPrefixProvider* dpp,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id,
+    std::string_view marker,
+    librados::AioCompletion* c)
+{
+  librados::IoCtx log_ioctx;
+  const auto& zone_params = bi_->svc.zone->get_zone_params();
+  int r = rgw_init_ioctx(dpp, bi_->rados, zone_params.log_pool, log_ioctx,
+                         true, false);
+  if (r < 0) {
+    return r;
+  }
+  neorados::IOContext neo_loc(log_ioctx.get_id());
+  const std::string fifo_oid = bilog_fifo_oid(
+      bucket_info.bucket.bucket_id, log_layout.gen, shard_id);
+  auto lf = std::make_shared<LazyFIFO>(*rados_neo, fifo_oid, neo_loc);
+  asio::co_spawn(
+      rados_neo->get_executor(),
+      [lf, dpp, marker_str = std::string{marker}]() -> asio::awaitable<void> {
+        co_return co_await lf->trim(dpp, marker_str, false);
+      }(),
+      c);
+  return 0;
+}
+
 int RGWSI_BILog_RADOS_FIFO::log_list(
     const DoutPrefixProvider *dpp, optional_yield y,
     const RGWBucketInfo& bucket_info,
@@ -803,5 +833,17 @@ int RGWSI_BILog_RADOS_BackendDispatcher::get_log_status(
 {
   return get_backend(log_layout).get_log_status(dpp, bucket_info, log_layout,
                                                  shard_id, markers, y);
+}
+
+int RGWSI_BILog_RADOS_BackendDispatcher::trim_shard(
+    const DoutPrefixProvider* dpp,
+    const RGWBucketInfo& bucket_info,
+    const rgw::bucket_log_layout_generation& log_layout,
+    int shard_id,
+    std::string_view marker,
+    librados::AioCompletion* c)
+{
+  return backend_fifo.trim_shard(dpp, bucket_info, log_layout, shard_id,
+                                 marker, c);
 }
 

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <optional>
+
+#include "include/neorados/RADOS.hpp"
 #include "driver/rados/rgw_service.h"
 
 class RGWSI_BILog_RADOS : public RGWServiceInstance
@@ -25,9 +28,13 @@ public:
     RGWSI_BucketIndex_RADOS *bi{nullptr};
   } svc;
 
+  // neorados::RADOS handle used by FIFO bilog batch writers.
+  // set during init()
+  std::optional<neorados::RADOS> rados_neo;
+
   RGWSI_BILog_RADOS(CephContext *cct);
 
-  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc);
+  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc, neorados::RADOS rados_neo);
 
   int log_start(const DoutPrefixProvider *dpp, optional_yield y,
                 const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -16,41 +16,87 @@
 
 #pragma once
 
+#include <map>
 #include <optional>
+#include <string>
+#include <string_view>
 
 #include "include/neorados/RADOS.hpp"
 #include "driver/rados/rgw_service.h"
+#include "rgw_bucket_layout.h"
 
 class RGWSI_BILog_RADOS : public RGWServiceInstance
 {
+protected:
+  std::optional<neorados::RADOS> rados_neo;
+
 public:
+
+  explicit RGWSI_BILog_RADOS(CephContext *cct) : RGWServiceInstance(cct) {}
+  virtual ~RGWSI_BILog_RADOS() = default;
+
+  neorados::RADOS& get_rados_neo() { return *rados_neo; }
+
+  virtual void init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
+                    neorados::RADOS rados_neo) = 0;
+
+  virtual int log_start(const DoutPrefixProvider *dpp, optional_yield y,
+                        const RGWBucketInfo& bucket_info,
+                        const rgw::bucket_log_layout_generation& log_layout,
+                        int shard_id) = 0;
+  virtual int log_stop(const DoutPrefixProvider *dpp, optional_yield y,
+                       const RGWBucketInfo& bucket_info,
+                       const rgw::bucket_log_layout_generation& log_layout,
+                       int shard_id) = 0;
+  virtual int log_trim(const DoutPrefixProvider *dpp, optional_yield y,
+                       const RGWBucketInfo& bucket_info,
+                       const rgw::bucket_log_layout_generation& log_layout,
+                       int shard_id,
+                       std::string_view start_marker,
+                       std::string_view end_marker) = 0;
+  virtual int log_list(const DoutPrefixProvider *dpp, optional_yield y,
+                       const RGWBucketInfo& bucket_info,
+                       const rgw::bucket_log_layout_generation& log_layout,
+                       int shard_id,
+                       std::string& marker,
+                       uint32_t max,
+                       std::list<rgw_bi_log_entry>& result,
+                       bool *truncated) = 0;
+  virtual int get_log_status(const DoutPrefixProvider *dpp,
+                             const RGWBucketInfo& bucket_info,
+                             const rgw::bucket_log_layout_generation& log_layout,
+                             int shard_id,
+                             std::map<int, std::string> *markers,
+                             optional_yield y) = 0;
+};
+
+// In-index backend.
+class RGWSI_BILog_RADOS_InIndex : public RGWSI_BILog_RADOS
+{
   struct Svc {
     RGWSI_BucketIndex_RADOS *bi{nullptr};
   } svc;
 
-  // neorados::RADOS handle used by FIFO bilog batch writers.
-  // set during init()
-  std::optional<neorados::RADOS> rados_neo;
+public:
+  using RGWSI_BILog_RADOS::RGWSI_BILog_RADOS;
 
-  RGWSI_BILog_RADOS(CephContext *cct);
-
-  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc, neorados::RADOS rados_neo);
+  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
+            neorados::RADOS rados_neo) override;
 
   int log_start(const DoutPrefixProvider *dpp, optional_yield y,
                 const RGWBucketInfo& bucket_info,
                 const rgw::bucket_log_layout_generation& log_layout,
-                int shard_id);
+                int shard_id) override;
   int log_stop(const DoutPrefixProvider *dpp, optional_yield y,
                const RGWBucketInfo& bucket_info,
                const rgw::bucket_log_layout_generation& log_layout,
-               int shard_id);
-
+               int shard_id) override;
   int log_trim(const DoutPrefixProvider *dpp, optional_yield y,
                const RGWBucketInfo& bucket_info,
                const rgw::bucket_log_layout_generation& log_layout,
                int shard_id,
                std::string_view start_marker,
-               std::string_view end_marker);
+               std::string_view end_marker) override;
   int log_list(const DoutPrefixProvider *dpp, optional_yield y,
                const RGWBucketInfo& bucket_info,
                const rgw::bucket_log_layout_generation& log_layout,
@@ -58,12 +104,97 @@ public:
                std::string& marker,
                uint32_t max,
                std::list<rgw_bi_log_entry>& result,
-               bool *truncated);
-
+               bool *truncated) override;
   int get_log_status(const DoutPrefixProvider *dpp,
                      const RGWBucketInfo& bucket_info,
                      const rgw::bucket_log_layout_generation& log_layout,
                      int shard_id,
                      std::map<int, std::string> *markers,
-                     optional_yield y);
+                     optional_yield y) override;
+};
+
+// FIFO (cls_fifo) backend.
+class RGWSI_BILog_RADOS_FIFO : public RGWSI_BILog_RADOS
+{
+  RGWSI_BucketIndex_RADOS *bi_{nullptr};
+public:
+  using RGWSI_BILog_RADOS::RGWSI_BILog_RADOS;
+
+  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
+            neorados::RADOS rados_neo) override;
+
+  int log_start(const DoutPrefixProvider *dpp, optional_yield y,
+                const RGWBucketInfo& bucket_info,
+                const rgw::bucket_log_layout_generation& log_layout,
+                int shard_id) override;
+  int log_stop(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
+               const rgw::bucket_log_layout_generation& log_layout,
+               int shard_id) override;
+  int log_trim(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
+               const rgw::bucket_log_layout_generation& log_layout,
+               int shard_id,
+               std::string_view start_marker,
+               std::string_view end_marker) override;
+  int log_list(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
+               const rgw::bucket_log_layout_generation& log_layout,
+               int shard_id,
+               std::string& marker,
+               uint32_t max,
+               std::list<rgw_bi_log_entry>& result,
+               bool *truncated) override;
+  int get_log_status(const DoutPrefixProvider *dpp,
+                     const RGWBucketInfo& bucket_info,
+                     const rgw::bucket_log_layout_generation& log_layout,
+                     int shard_id,
+                     std::map<int, std::string> *markers,
+                     optional_yield y) override;
+};
+
+// BackendDispatcher: responsibility is to route calls to the correct
+// concrete backend based on log_layout.layout.type
+class RGWSI_BILog_RADOS_BackendDispatcher : public RGWSI_BILog_RADOS
+{
+  RGWSI_BILog_RADOS_InIndex backend_inindex;
+  RGWSI_BILog_RADOS_FIFO   backend_fifo;
+
+  RGWSI_BILog_RADOS& get_backend(
+      const rgw::bucket_log_layout_generation& log_layout);
+
+public:
+  explicit RGWSI_BILog_RADOS_BackendDispatcher(CephContext *cct);
+
+  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc,
+            neorados::RADOS rados_neo) override;
+
+  int log_start(const DoutPrefixProvider *dpp, optional_yield y,
+                const RGWBucketInfo& bucket_info,
+                const rgw::bucket_log_layout_generation& log_layout,
+                int shard_id) override;
+  int log_stop(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
+               const rgw::bucket_log_layout_generation& log_layout,
+               int shard_id) override;
+  int log_trim(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
+               const rgw::bucket_log_layout_generation& log_layout,
+               int shard_id,
+               std::string_view start_marker,
+               std::string_view end_marker) override;
+  int log_list(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
+               const rgw::bucket_log_layout_generation& log_layout,
+               int shard_id,
+               std::string& marker,
+               uint32_t max,
+               std::list<rgw_bi_log_entry>& result,
+               bool *truncated) override;
+  int get_log_status(const DoutPrefixProvider *dpp,
+                     const RGWBucketInfo& bucket_info,
+                     const rgw::bucket_log_layout_generation& log_layout,
+                     int shard_id,
+                     std::map<int, std::string> *markers,
+                     optional_yield y) override;
 };

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -77,6 +77,11 @@ public:
                          int shard_id,
                          std::string_view marker,
                          librados::AioCompletion* c) { return 0; }
+
+  virtual int remove_log_shards(const DoutPrefixProvider* dpp,
+                                const RGWBucketInfo& bucket_info,
+                                const rgw::bucket_log_layout_generation& log_layout,
+                                librados::AioCompletion* c) { return 0; }
 };
 
 // In-index backend.
@@ -167,6 +172,11 @@ public:
                  int shard_id,
                  std::string_view marker,
                  librados::AioCompletion* c) override;
+
+  int remove_log_shards(const DoutPrefixProvider* dpp,
+                        const RGWBucketInfo& bucket_info,
+                        const rgw::bucket_log_layout_generation& log_layout,
+                        librados::AioCompletion* c) override;
 };
 
 // BackendDispatcher: responsibility is to route calls to the correct
@@ -220,4 +230,9 @@ public:
                  int shard_id,
                  std::string_view marker,
                  librados::AioCompletion* c) override;
+
+  int remove_log_shards(const DoutPrefixProvider* dpp,
+                        const RGWBucketInfo& bucket_info,
+                        const rgw::bucket_log_layout_generation& log_layout,
+                        librados::AioCompletion* c) override;
 };

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -22,6 +22,7 @@
 #include <string_view>
 
 #include "include/neorados/RADOS.hpp"
+#include "include/rados/librados_fwd.hpp"
 #include "driver/rados/rgw_service.h"
 #include "rgw_bucket_layout.h"
 
@@ -68,6 +69,14 @@ public:
                              int shard_id,
                              std::map<int, std::string> *markers,
                              optional_yield y) = 0;
+
+  // async FIFO shard trim via AioCompletion.
+  virtual int trim_shard(const DoutPrefixProvider* dpp,
+                         const RGWBucketInfo& bucket_info,
+                         const rgw::bucket_log_layout_generation& log_layout,
+                         int shard_id,
+                         std::string_view marker,
+                         librados::AioCompletion* c) { return 0; }
 };
 
 // In-index backend.
@@ -151,6 +160,13 @@ public:
                      int shard_id,
                      std::map<int, std::string> *markers,
                      optional_yield y) override;
+
+  int trim_shard(const DoutPrefixProvider* dpp,
+                 const RGWBucketInfo& bucket_info,
+                 const rgw::bucket_log_layout_generation& log_layout,
+                 int shard_id,
+                 std::string_view marker,
+                 librados::AioCompletion* c) override;
 };
 
 // BackendDispatcher: responsibility is to route calls to the correct
@@ -197,4 +213,11 @@ public:
                      int shard_id,
                      std::map<int, std::string> *markers,
                      optional_yield y) override;
+
+  int trim_shard(const DoutPrefixProvider* dpp,
+                 const RGWBucketInfo& bucket_info,
+                 const rgw::bucket_log_layout_generation& log_layout,
+                 int shard_id,
+                 std::string_view marker,
+                 librados::AioCompletion* c) override;
 };

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -494,22 +494,6 @@ target_link_libraries(ceph_test_bilog
 install(TARGETS ceph_test_bilog DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
-#
-# Helper for adding RGW tests built with Catch2:
-# Note: to define a test that does not use Catch2::main(), use:
-#   add_catch2_test_rgw(my_test_name NO_CATCH2_MAIN)
-# ...your test should be in a file called "test_<my_test_name>.cc (ex. "test_foo.cc")
-# and the output will be called "unittest_my_test_name".
-#
-function(add_catch2_test_rgw test_name)
-add_catch2_test(${test_name}
- ${ARGV1}
- EXTRA_LIBS rgw_common ${rgw_libs}
- EXTRA_INCS "SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/src/rgw")
-endfunction()
-
-add_catch2_test_rgw(rgw_hex)
-
 add_executable(unittest_rgw_async_utils test_rgw_async_utils.cc)
 add_ceph_unittest(unittest_rgw_async_utils)
 target_link_libraries(unittest_rgw_async_utils ${rgw_libs} ${UNITTEST_LIBS})

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -480,6 +480,36 @@ target_link_libraries(ceph_test_datalog
 install(TARGETS ceph_test_datalog DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
+if(WITH_RADOSGW_RADOS)
+# ceph_test_bilog
+add_executable(ceph_test_bilog test_bilog.cc)
+target_include_directories(ceph_test_bilog
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/services")
+target_link_libraries(ceph_test_bilog
+  libneorados
+  neoradostest-support
+  ${UNITTEST_LIBS}
+  ${rgw_libs})
+install(TARGETS ceph_test_bilog DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+#
+# Helper for adding RGW tests built with Catch2:
+# Note: to define a test that does not use Catch2::main(), use:
+#   add_catch2_test_rgw(my_test_name NO_CATCH2_MAIN)
+# ...your test should be in a file called "test_<my_test_name>.cc (ex. "test_foo.cc")
+# and the output will be called "unittest_my_test_name".
+#
+function(add_catch2_test_rgw test_name)
+add_catch2_test(${test_name}
+ ${ARGV1}
+ EXTRA_LIBS rgw_common ${rgw_libs}
+ EXTRA_INCS "SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/src/rgw")
+endfunction()
+
+add_catch2_test_rgw(rgw_hex)
+
 add_executable(unittest_rgw_async_utils test_rgw_async_utils.cc)
 add_ceph_unittest(unittest_rgw_async_utils)
 target_link_libraries(unittest_rgw_async_utils ${rgw_libs} ${UNITTEST_LIBS})

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -495,6 +495,20 @@ target_link_libraries(ceph_test_datalog
 install(TARGETS ceph_test_datalog DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
+if(WITH_RADOSGW_RADOS)
+# ceph_test_bilog
+add_executable(ceph_test_bilog test_bilog.cc)
+target_include_directories(ceph_test_bilog
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/services")
+target_link_libraries(ceph_test_bilog
+  libneorados
+  neoradostest-support
+  ${UNITTEST_LIBS}
+  ${rgw_libs})
+install(TARGETS ceph_test_bilog DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
 add_executable(unittest_rgw_async_utils test_rgw_async_utils.cc)
 add_ceph_unittest(unittest_rgw_async_utils)
 target_link_libraries(unittest_rgw_async_utils ${rgw_libs} ${UNITTEST_LIBS})

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -2052,19 +2052,13 @@ def test_bucket_reshard_index_log_trim():
 
     zonegroup_bucket_checkpoint(zonegroup_conns, test_bucket.name)
 
-    bilog_autotrim(zone.zone)
-
-    # checking bucket layout after 1st bilog autotrim
-    json_obj_4 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_4['layout']['logs']) == 2)
-
-    bilog_autotrim(zone.zone)
-
-    # checking bucket layout after 2nd bilog autotrim
-    json_obj_5 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_5['layout']['logs']) == 1)
-
-    bilog_autotrim(zone.zone)
+    # trim until only the active generation remains
+    for _ in range(6):
+        bilog_autotrim(zone.zone)
+        time.sleep(config.checkpoint_delay)
+        if len(bucket_layout(zone.zone, test_bucket.name)['layout']['logs']) == 1:
+            break
+    assert len(bucket_layout(zone.zone, test_bucket.name)['layout']['logs']) == 1
 
     # upload more objects
     for objname in ('i', 'j', 'k', 'l'):

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -2075,19 +2075,13 @@ def test_bucket_reshard_index_log_trim():
 
     zonegroup_bucket_checkpoint(zonegroup_conns, test_bucket.name)
 
-    bilog_autotrim(zone.zone)
-
-    # checking bucket layout after 1st bilog autotrim
-    json_obj_4 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_4['layout']['logs']) == 2)
-
-    bilog_autotrim(zone.zone)
-
-    # checking bucket layout after 2nd bilog autotrim
-    json_obj_5 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_5['layout']['logs']) == 1)
-
-    bilog_autotrim(zone.zone)
+    # trim until only the active generation remains
+    for _ in range(6):
+        bilog_autotrim(zone.zone)
+        time.sleep(config.checkpoint_delay)
+        if len(bucket_layout(zone.zone, test_bucket.name)['layout']['logs']) == 1:
+            break
+    assert len(bucket_layout(zone.zone, test_bucket.name)['layout']['logs']) == 1
 
     # upload more objects
     for objname in ('i', 'j', 'k', 'l'):

--- a/src/test/rgw/test_bilog.cc
+++ b/src/test/rgw/test_bilog.cc
@@ -1,0 +1,295 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_bilog.h"
+
+#include <string>
+#include <vector>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <fmt/format.h>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "cls/rgw/cls_rgw_types.h"
+#include "cls/rgw/cls_rgw_ops.h"
+
+#include "test/neorados/common_tests.h"
+
+#include "gtest/gtest.h"
+
+namespace asio = boost::asio;
+namespace fifo = neorados::cls::fifo;
+
+namespace {
+
+// encode a bilog entry into a bufferlist, matching what RGWBILogUpdateBatch
+// does internally before calling fifo_->push().
+ceph::buffer::list encode_entry(const rgw_bi_log_entry& e)
+{
+  ceph::buffer::list bl;
+  encode(e, bl);
+  return bl;
+}
+
+// decode the raw FIFO payload back to a rgw_bi_log_entry.
+rgw_bi_log_entry decode_entry(const fifo::entry& raw)
+{
+  rgw_bi_log_entry e;
+  auto p = raw.data.cbegin();
+  decode(e, p);
+  return e;
+}
+
+}
+
+// these tests exercise the FIFO push/list/trim pipeline directly without
+// going through the batch helper.
+
+// single-shard push + list round-trip: object name, instance, op, state and tag
+// must survive encode-push-list-decode intact.
+CORO_TEST_F(BilogFIFO, PushListRoundtrip, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.rt.0"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  rgw_bi_log_entry entry;
+  entry.object   = "myobject";
+  entry.instance = "v1";
+  entry.op       = CLS_RGW_OP_ADD;
+  entry.state    = CLS_RGW_STATE_COMPLETE;
+  entry.tag      = "tag-rt";
+
+  co_await store->push(dpp(), 0, encode_entry(entry));
+
+  std::vector<fifo::entry> buf(10);
+  auto [got, next] = co_await store->list(dpp(), 0, {}, buf);
+
+  EXPECT_EQ(1u, got.size());
+  EXPECT_FALSE(next.has_value());
+
+  const auto d = decode_entry(got[0]);
+  EXPECT_EQ("myobject",            d.object);
+  EXPECT_EQ("v1",                  d.instance);
+  EXPECT_EQ(CLS_RGW_OP_ADD,        d.op);
+  EXPECT_EQ(CLS_RGW_STATE_COMPLETE, d.state);
+  EXPECT_EQ("tag-rt",              d.tag);
+}
+
+// two-shard push: entries pushed to distinct shards must not appear in each
+// other's shard.
+CORO_TEST_F(BilogFIFO, MultiShard, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.ms.0", "blt.ms.1"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  rgw_bi_log_entry e0, e1;
+  e0.object = "obj-s0";  e0.tag = "t0";  e0.op = CLS_RGW_OP_ADD;
+  e1.object = "obj-s1";  e1.tag = "t1";  e1.op = CLS_RGW_OP_DEL;
+
+  co_await store->push(dpp(), 0, encode_entry(e0));
+  co_await store->push(dpp(), 1, encode_entry(e1));
+
+  std::vector<fifo::entry> buf(10);
+
+  auto [got0, _0] = co_await store->list(dpp(), 0, {}, buf);
+  EXPECT_EQ(1u, got0.size());
+  EXPECT_EQ("obj-s0", decode_entry(got0[0]).object);
+
+  auto [got1, _1] = co_await store->list(dpp(), 1, {}, buf);
+  EXPECT_EQ(1u, got1.size());
+  EXPECT_EQ("obj-s1", decode_entry(got1[0]).object);
+}
+
+// trim (exclusive=false): push 3 entries, trim inclusive up to the 2nd entry's
+// marker, then verify only the 3rd entry survives.
+CORO_TEST_F(BilogFIFO, Trim, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.trim.0"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  for (int i = 0; i < 3; ++i) {
+    rgw_bi_log_entry e;
+    e.object = fmt::format("obj-{}", i);
+    e.op     = CLS_RGW_OP_ADD;
+    e.state  = CLS_RGW_STATE_COMPLETE;
+    co_await store->push(dpp(), 0, encode_entry(e));
+  }
+
+  std::vector<fifo::entry> buf(10);
+  auto [all, _a] = co_await store->list(dpp(), 0, {}, buf);
+  EXPECT_EQ(3u, all.size());
+
+  // exclusive=false trims everything up to *and including* marker[1].
+  co_await store->trim(dpp(), 0, all[1].marker, /*exclusive=*/false);
+
+  auto [after, _b] = co_await store->list(dpp(), 0, {}, buf);
+  EXPECT_EQ(1u, after.size());
+  EXPECT_EQ("obj-2", decode_entry(after[0]).object);
+}
+
+// list from marker: push 3 entries, list starting after the first entry's
+// marker; should yield exactly entries 2 and 3.
+CORO_TEST_F(BilogFIFO, ListFromMarker, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.lm.0"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  for (int i = 0; i < 3; ++i) {
+    rgw_bi_log_entry e;
+    e.object = fmt::format("obj-{}", i);
+    e.op     = CLS_RGW_OP_ADD;
+    co_await store->push(dpp(), 0, encode_entry(e));
+  }
+
+  std::vector<fifo::entry> buf(10);
+  auto [all, _a] = co_await store->list(dpp(), 0, {}, buf);
+  EXPECT_EQ(3u, all.size());
+
+  // resume listing after the first entry's marker (exclusive start).
+  auto [from, _b] = co_await store->list(dpp(), 0, all[0].marker, buf);
+  EXPECT_EQ(2u, from.size());
+  EXPECT_EQ("obj-1", decode_entry(from[0]).object);
+  EXPECT_EQ("obj-2", decode_entry(from[1]).object);
+}
+
+// trim exclusive=true: the entry at the trim marker should NOT be removed.
+CORO_TEST_F(BilogFIFO, TrimExclusive, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.trimex.0"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  for (int i = 0; i < 3; ++i) {
+    rgw_bi_log_entry e;
+    e.object = fmt::format("obj-{}", i);
+    e.op     = CLS_RGW_OP_ADD;
+    co_await store->push(dpp(), 0, encode_entry(e));
+  }
+
+  std::vector<fifo::entry> buf(10);
+  auto [all, _a] = co_await store->list(dpp(), 0, {}, buf);
+  EXPECT_EQ(3u, all.size());
+
+  // exclusive=true: trim everything *before* marker[1] — entry[1] must remain.
+  co_await store->trim(dpp(), 0, all[1].marker, /*exclusive=*/true);
+
+  auto [after, _b] = co_await store->list(dpp(), 0, {}, buf);
+  EXPECT_EQ(2u, after.size());
+  EXPECT_EQ("obj-1", decode_entry(after[0]).object);
+  EXPECT_EQ("obj-2", decode_entry(after[1]).object);
+}
+
+// these tests exercise the batch wrapper.  co_flush() is the awaitable variant
+// of flush.
+
+// round-trip through the awaitable flush path: stage one entry via
+// add_maybe_flush, flush it via co_flush(), then read back the raw FIFO entry
+// and verify all fields match.
+CORO_TEST_F(BilogBatch, RoundTripYield, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.batch.rt.0"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  {
+    RGWBILogUpdateBatch batch(dpp(), rados(), store);
+
+    cls_rgw_bi_log_related_op op_info;
+    op_info.key         = cls_rgw_obj_key{"roundtrip-obj", "inst-1"};
+    op_info.op_tag      = "op-tag-rt";
+    op_info.bilog_flags = RGW_BILOG_FLAG_VERSIONED_OP;
+    op_info.op          = CLS_RGW_OP_ADD;
+
+    batch.add_maybe_flush(7 /* olh_epoch */, ceph::real_clock::now(), op_info);
+
+    // co_flush() is the awaitable variant: suspends the coroutine until all
+    // pending shards have been pushed, without blocking the io_context thread.
+    co_await batch.co_flush();
+  }
+
+  std::vector<fifo::entry> buf(10);
+  auto [got, _] = co_await store->list(dpp(), 0, {}, buf);
+
+  EXPECT_EQ(1u, got.size());
+
+  const auto d = decode_entry(got[0]);
+  EXPECT_EQ("roundtrip-obj",       d.object);
+  EXPECT_EQ("inst-1",              d.instance);
+  EXPECT_EQ("op-tag-rt",           d.tag);
+  EXPECT_EQ(CLS_RGW_OP_ADD,        d.op);
+  EXPECT_EQ(CLS_RGW_STATE_COMPLETE, d.state);
+  EXPECT_EQ(7u,                    d.ver.epoch);
+  EXPECT_NE(0, d.bilog_flags & RGW_BILOG_FLAG_VERSIONED_OP);
+}
+
+// OLH link overload: add_maybe_flush(epoch, key, tag, delete_marker, time,
+// zones_trace) should produce a CLS_RGW_OP_LINK_OLH_DM entry when
+// delete_marker=true and CLS_RGW_OP_LINK_OLH otherwise.
+CORO_TEST_F(BilogBatch, OLHDeleteMarker, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.olh.dm.0"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  {
+    RGWBILogUpdateBatch batch(dpp(), rados(), store);
+
+    rgw_zone_set zones_trace;
+    batch.add_maybe_flush(5 /* epoch */,
+                          cls_rgw_obj_key{"olh-obj", "v2"},
+                          "olh-tag",
+                          /*delete_marker=*/true,
+                          ceph::real_clock::now(),
+                          zones_trace);
+
+    co_await batch.co_flush();
+  }
+
+  std::vector<fifo::entry> buf(10);
+  auto [got, _] = co_await store->list(dpp(), 0, {}, buf);
+
+  EXPECT_EQ(1u, got.size());
+  const auto d = decode_entry(got[0]);
+  EXPECT_EQ("olh-obj",              d.object);
+  EXPECT_EQ("v2",                   d.instance);
+  EXPECT_EQ(CLS_RGW_OP_LINK_OLH_DM, d.op);
+  EXPECT_EQ(CLS_RGW_STATE_COMPLETE,  d.state);
+  EXPECT_EQ(5u,                     d.ver.epoch);
+  // OLH link entries from the 2nd overload are always versioned.
+  EXPECT_NE(0, d.bilog_flags & RGW_BILOG_FLAG_VERSIONED_OP);
+}
+
+CORO_TEST_F(BilogBatch, OLHLink, NeoRadosTest)
+{
+  const std::vector<std::string> shard_oids{"blt.olh.lnk.0"};
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+
+  {
+    RGWBILogUpdateBatch batch(dpp(), rados(), store);
+
+    rgw_zone_set zones_trace;
+    batch.add_maybe_flush(3 /* epoch */,
+                          cls_rgw_obj_key{"link-obj", "v1"},
+                          "link-tag",
+                          /*delete_marker=*/false,
+                          ceph::real_clock::now(),
+                          zones_trace);
+
+    co_await batch.co_flush();
+  }
+
+  std::vector<fifo::entry> buf(10);
+  auto [got, _] = co_await store->list(dpp(), 0, {}, buf);
+
+  EXPECT_EQ(1u, got.size());
+  const auto d = decode_entry(got[0]);
+  EXPECT_EQ("link-obj",            d.object);
+  EXPECT_EQ(CLS_RGW_OP_LINK_OLH,  d.op);
+  EXPECT_EQ(CLS_RGW_STATE_COMPLETE, d.state);
+  EXPECT_EQ(3u,                    d.ver.epoch);
+}
+
+// NOTE: The destructor-flush path (pending entries flushed by ~RGWBILogUpdateBatch)
+// is not tested here. it calls do_flush() which internally uses use_blocked,
+// which blocks the calling thread. In a CORO_TEST_F, the io_context runs on a
+// single thread.

--- a/src/test/rgw/test_bilog.cc
+++ b/src/test/rgw/test_bilog.cc
@@ -52,8 +52,7 @@ rgw_bi_log_entry decode_entry(const fifo::entry& raw)
 // must survive encode-push-list-decode intact.
 CORO_TEST_F(BilogFIFO, PushListRoundtrip, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.rt.0"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-rt", 0, 1);
 
   rgw_bi_log_entry entry;
   entry.object   = "myobject";
@@ -82,8 +81,7 @@ CORO_TEST_F(BilogFIFO, PushListRoundtrip, NeoRadosTest)
 // other's shard.
 CORO_TEST_F(BilogFIFO, MultiShard, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.ms.0", "blt.ms.1"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-ms", 0, 2);
 
   rgw_bi_log_entry e0, e1;
   e0.object = "obj-s0";  e0.tag = "t0";  e0.op = CLS_RGW_OP_ADD;
@@ -107,8 +105,7 @@ CORO_TEST_F(BilogFIFO, MultiShard, NeoRadosTest)
 // marker, then verify only the 3rd entry survives.
 CORO_TEST_F(BilogFIFO, Trim, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.trim.0"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-trim", 0, 1);
 
   for (int i = 0; i < 3; ++i) {
     rgw_bi_log_entry e;
@@ -134,8 +131,7 @@ CORO_TEST_F(BilogFIFO, Trim, NeoRadosTest)
 // marker; should yield exactly entries 2 and 3.
 CORO_TEST_F(BilogFIFO, ListFromMarker, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.lm.0"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-lm", 0, 1);
 
   for (int i = 0; i < 3; ++i) {
     rgw_bi_log_entry e;
@@ -158,8 +154,7 @@ CORO_TEST_F(BilogFIFO, ListFromMarker, NeoRadosTest)
 // trim exclusive=true: the entry at the trim marker should NOT be removed.
 CORO_TEST_F(BilogFIFO, TrimExclusive, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.trimex.0"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-trimex", 0, 1);
 
   for (int i = 0; i < 3; ++i) {
     rgw_bi_log_entry e;
@@ -189,8 +184,7 @@ CORO_TEST_F(BilogFIFO, TrimExclusive, NeoRadosTest)
 // and verify all fields match.
 CORO_TEST_F(BilogBatch, RoundTripYield, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.batch.rt.0"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-batch-rt", 0, 1);
 
   {
     RGWBILogUpdateBatch batch(dpp(), rados(), store);
@@ -228,8 +222,7 @@ CORO_TEST_F(BilogBatch, RoundTripYield, NeoRadosTest)
 // delete_marker=true and CLS_RGW_OP_LINK_OLH otherwise.
 CORO_TEST_F(BilogBatch, OLHDeleteMarker, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.olh.dm.0"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-olh-dm", 0, 1);
 
   {
     RGWBILogUpdateBatch batch(dpp(), rados(), store);
@@ -261,8 +254,7 @@ CORO_TEST_F(BilogBatch, OLHDeleteMarker, NeoRadosTest)
 
 CORO_TEST_F(BilogBatch, OLHLink, NeoRadosTest)
 {
-  const std::vector<std::string> shard_oids{"blt.olh.lnk.0"};
-  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), shard_oids);
+  auto store = std::make_shared<RGWBILogFIFO>(rados(), pool(), "blt-olh-lnk", 0, 1);
 
   {
     RGWBILogUpdateBatch batch(dpp(), rados(), store);

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -51,6 +51,12 @@ std::string get_oid(uint64_t gen_id, int i) {
 	  fmt::format("shard.{}", i));
 }
 
+// This is a bug in Boost. It's fixed in 1.87 and these pragmata can
+// be removed then.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-new-delete"
 asio::awaitable<void> make_omap(neorados::RADOS& rados,
 				const neorados::IOContext& loc) {
   for (int i = 0; i < SHARDS; ++i) {
@@ -64,7 +70,13 @@ asio::awaitable<void> make_omap(neorados::RADOS& rados,
   }
   co_return;
 }
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-new-delete"
 asio::awaitable<void> make_fifo(const DoutPrefixProvider* dpp,
 				neorados::RADOS& rados,
                                 const neorados::IOContext& loc) {
@@ -74,6 +86,8 @@ asio::awaitable<void> make_fifo(const DoutPrefixProvider* dpp,
     EXPECT_TRUE(fifo);
   }
 }
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 }
 
 CORO_TEST_F(LogBacking, TestOmap, NeoRadosTest)


### PR DESCRIPTION

replaces https://github.com/ceph/ceph/pull/66074 and the original PR https://github.com/ceph/ceph/pull/38185

design: https://gist.github.com/smanjara/c311d2ea14aed094cd69ea416e04d16a


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
