### PR TITLE
doc: clarify radosgw-admin sync-stats and reset-stats constraints

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -823,7 +823,18 @@ Options
 .. option:: --sync-stats
 
     Option for the 'user stats' command. When specified, it will update user stats with
-    the current stats reported by the user's buckets indexes.
+    the current stats reported by the user's buckets indexes. This option encompasses
+    the functionality of :option:`--reset-stats`. Note that you cannot specify both
+    --sync-stats and --reset-stats at the same time.
+
+.. option:: --reset-stats
+
+    Option for the 'user stats' command. When specified, it resets the user's
+    stats.
+
+    .. note::
+       This option is only applicable at the user level and cannot be used in
+       conjunction with the --bucket option.
 
 .. option:: --show-config
 


### PR DESCRIPTION
This PR addresses documentation mismatches in radosgw-admin.rst regarding --sync-stats, --reset-stats, and --bucket constraints, as discussed with @yuvalif.

 Changes:
- Updated the description of --sync-stats to clarify that it encompasses the functionality of --reset-stats and noted that they are mutually exclusive.
- Added a .. note:: to --reset-stats clarifying that it is a user-level option and cannot be combined with the --bucket option.

These updates align the manual with the existing logic in radosgw-admin.cc.