### PR TITLE
dashboard: align notifications footer to bottom when body has fewer items

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
@@ -85,6 +85,10 @@
   align-items: flex-start;
   position: relative;
 
+  > cd-icon {
+    margin-top: -$spacing-03;
+  }
+
   .notification-close {
     position: absolute;
     right: 0;

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-footer/notification-footer.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-footer/notification-footer.component.scss
@@ -3,13 +3,14 @@
 
 .notification-footer {
   position: sticky;
+  bottom: 0;
+  width: 100%;
   z-index: 2;
   display: flex;
   align-items: center;
   background-color: theme.$layer-01;
   block-size: 2.5rem;
   border-block-start: 1px solid theme.$border-subtle-01;
-  inset-block-end: 0;
   min-block-size: 2.5rem;
   cursor: pointer;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel/notification-panel.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel/notification-panel.component.scss
@@ -11,7 +11,6 @@ $inline-min-size: 20rem;
   position: fixed;
   z-index: 2;
   overflow-y: auto;
-  overflow-x: hidden;
   background-color: var(--cds-layer-01);
   border-block-end: 1px solid var(--cds-border-subtle-02);
   border-inline-start: 1px solid var(--cds-border-subtle-02);


### PR DESCRIPTION
dashboard: align notifications footer to bottom when body has fewer items

When the notifications list contains only a few items, the footer
appears above empty space instead of staying at the bottom of the
notification panel.

This change adjusts the notification panel layout to ensure the
footer remains anchored at the bottom.

Fixes: https://tracker.ceph.com/issues/74599
Signed-off-by: Shashiranjan Singh <singhshashiranjan34@gmail.com>

---

### Before

<img width="449" height="756" alt="Screenshot 2026-03-14 021032" src="https://github.com/user-attachments/assets/17abb43c-83fb-4e2d-8ce6-26aea024ec6d" />

### After

<img width="434" height="767" alt="image" src="https://github.com/user-attachments/assets/da20c71a-f360-4103-94fc-166fa0a0cac1" />

---

## Contribution Guidelines

- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

---

## Checklist

### Tracker (select at least one)
- [x] References tracker ticket
- [ ] Very recent bug; references commit where it was introduced
- [ ] New feature (ticket optional)
- [ ] Doc update (no ticket needed)
- [ ] Code cleanup (no ticket needed)

### Component impact
- [x] Affects Dashboard, opened tracker ticket
- [ ] Affects Orchestrator, opened tracker ticket
- [ ] No impact that needs to be tracked

### Documentation (select at least one)
- [ ] Updates relevant documentation
- [x] No doc update is appropriate

### Tests (select at least one)
- [ ] Includes unit test(s)
- [ ] Includes integration test(s)
- [x] Includes bug reproducer (see screenshots in PR description)
- [ ] No tests