### PR TITLE
tentacle: mgr/dashboard: Add secure and verify-host-name to "listener add" on NVMeoF CLI

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -348,6 +348,11 @@ else:
                 "trsvcid": Param(int, "NVMeoF transport service port", True, 4420),
                 "adrfam": Param(int, "NVMeoF address family (0 - IPv4, 1 - IPv6)", True, 0),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "secure": Param(bool, "Use a secure channel", True, False),
+                "verify_host_name": Param(bool,
+                                          "Fail if the host name doesn't match the "
+                                          "gateway's host name",
+                                          True, False),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -359,7 +364,9 @@ else:
             traddr: str,
             trsvcid: int = 4420,
             adrfam: int = 0,  # IPv4,
-            gw_group: Optional[str] = None
+            gw_group: Optional[str] = None,
+            secure: Optional[bool] = False,
+            verify_host_name: Optional[bool] = False,
         ):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_listener(
                 NVMeoFClient.pb2.create_listener_req(
@@ -368,6 +375,8 @@ else:
                     traddr=traddr,
                     trsvcid=int(trsvcid),
                     adrfam=int(adrfam),
+                    secure=str_to_bool(secure),
+                    verify_host_name=str_to_bool(verify_host_name),
                 )
             )
 

--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -183,11 +183,12 @@ class NamespaceIOStats(NamedTuple):
 class Listener(NamedTuple):
     host_name: Annotated[str, CliHeader("Host")]
     trtype: Annotated[str, CliHeader("Transport")]
-    traddr: Annotated[str, CliHeader("Target Address")]
+    adrfam: Annotated[int, CliHeader("Address Family")]  # 0: IPv4, 1: IPv6
+    traddr: Annotated[str, CliHeader("Address")]
+    trsvcid: Annotated[int, CliHeader("Port")]
     secure: Optional[bool]
     active: Optional[bool]
-    adrfam: Annotated[int, CliHeader("Address Family")] = 0  # 0: IPv4, 1: IPv6
-    trsvcid: Annotated[int, CliHeader("Target Port")] = 4420
+    manual: Optional[bool]
 
 
 class ListenerList(NamedTuple):

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -10030,6 +10030,10 @@ paths:
                 host_name:
                   description: NVMeoF hostname
                   type: string
+                secure:
+                  default: false
+                  description: Use a secure channel
+                  type: boolean
                 traddr:
                   description: NVMeoF transport address
                   type: string
@@ -10037,6 +10041,11 @@ paths:
                   default: 4420
                   description: NVMeoF transport service port
                   type: integer
+                verify_host_name:
+                  default: false
+                  description: Fail if the host name doesn't match the gateway's host
+                    name
+                  type: boolean
               required:
               - host_name
               - traddr


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75499

---

backport of https://github.com/ceph/ceph/pull/67760
parent tracker: https://tracker.ceph.com/issues/75447

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh