### PR TITLE
tentacle: qa/tasks/mgr: test_module_selftest set influx hostname to avoid warnings

### DIFF
--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -201,6 +201,10 @@ class TestModuleSelftest(MgrTestCase):
         Use the selftest module to exercise inter-module communication
         """
         self._load_module("selftest")
+        #before we are enabling influx, set config options to avoid errors
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            "config", "set", "mgr", "mgr/influx/hostname", "testhost")
+
         # The "self-test remote" operation just happens to call into
         # influx.
         self._load_module("influx")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74946

---

backport of https://github.com/ceph/ceph/pull/66376
parent tracker: https://tracker.ceph.com/issues/72747

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh