### PR TITLE
qa/tasks: add mgr_thrash task

### DIFF
--- a/qa/suites/rados/mgr/thrasher/aggressive.yaml
+++ b/qa/suites/rados/mgr/thrasher/aggressive.yaml
@@ -1,0 +1,5 @@
+tasks:
+- mgr_thrash:
+    thrash_delay: 2
+    duration: 300
+    timeout: 120

--- a/qa/suites/rados/mgr/thrasher/default.yaml
+++ b/qa/suites/rados/mgr/thrasher/default.yaml
@@ -1,0 +1,4 @@
+tasks:
+- mgr_thrash:
+    thrash_delay: 5
+    duration: 300

--- a/qa/suites/rados/mgr/thrasher/none.yaml
+++ b/qa/suites/rados/mgr/thrasher/none.yaml
@@ -1,0 +1,1 @@
+# mgr_thrash disable

--- a/qa/suites/rados/mgr/thrasher/slow.yaml
+++ b/qa/suites/rados/mgr/thrasher/slow.yaml
@@ -1,0 +1,5 @@
+tasks:
+- mgr_thrash:
+    thrash_delay: 30
+    duration: 600
+    timeout: 720

--- a/qa/suites/rados/thrash/thrashers/default.yaml
+++ b/qa/suites/rados/thrash/thrashers/default.yaml
@@ -27,3 +27,6 @@ tasks:
     chance_pgpnum_fix: 1
     chance_bluestore_reshard: 1
     bluestore_new_sharding: random
+- mgr_thrash:
+    thrash_delay: 10
+    duration: 0

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -2681,6 +2681,10 @@ class CephManager:
         out = self.raw_cluster_cmd('mgr', 'dump', '--format=json')
         return json.loads(out)
 
+    def get_mgr_stat(self):
+        out = self.raw_cluster_cmd('mgr', 'stat', '--format=json')
+        return json.loads(out)
+
     def get_stuck_pgs(self, type_, threshold):
         """
         :returns: stuck pg information from the cluster

--- a/qa/tasks/mgr_thrash.py
+++ b/qa/tasks/mgr_thrash.py
@@ -1,0 +1,132 @@
+"""
+CEPH-MGR Thrash -- Simulate MGR fails and switching between Standby and Active mgrs.
+"""
+import contextlib
+import logging
+import time
+
+import gevent
+import gevent.event
+
+from tasks import ceph_manager
+from teuthology import misc as teuthology
+from tasks.thrasher import Thrasher
+
+log = logging.getLogger(__name__)
+
+
+class ThrashMGRs(Thrasher):
+    """
+    Thrash the MGRs by randomly failing them (and then restarting them) until the
+    task is ended. This loops, and every thrash_delay seconds it randomly
+    chooses to fail or restart a MGR it will always keep at least one MGR active.
+
+    The config is optional, and is a dict containing some or all of:
+
+    cluster: (default 'ceph') the name of the cluster to thrash
+
+    thrash_delay: (5) the length of time to sleep between changing a
+       MGR's status
+
+    duration: (0) the length of time to run the task before stopping. If 0,
+       runs until __exit__ is called.
+
+    timeout: (duration + 60) the length of time to wait for the task to stop
+       before giving up and raising an exception. This should be longer than
+       duration to allow for the task to stop after the duration has elapsed.
+
+    for example, to thrash the MGRs for 10 minutes with a 30 second delay between operations:
+    tasks:
+    - mgr_thrash:
+        thrash_delay: 30
+        duration: 600
+    """
+    def __init__(self, ctx, manager, config, name, logger):
+        super(ThrashMGRs, self).__init__()
+
+        self.ceph_manager = manager
+        self.logger = logger
+        self.config = config or {}
+        self.name = name
+        self.stopping = gevent.event.Event()
+
+        self.cluster = self.config.get('cluster', 'ceph')
+        self.thrash_delay = self.config.get('thrash_delay', 5)
+        self.duration = self.config.get('duration', 0)
+        self.timeout = self.config.get('timeout', self.duration + 60)
+
+        self.thread = gevent.spawn(self.do_thrash)
+
+    def log(self, message):
+        self.logger.info(f'{self.name}: {message}')
+
+    def stop(self):
+        self.stopping.set()
+
+    def join(self):
+        self.thread.get()
+
+    def stop_and_join(self):
+        self.stop()
+        self.join()
+
+    def do_thrash(self):
+        try:
+            self._do_thrash()
+        except Exception as e:
+            self.set_thrasher_exception(e)
+            self.logger.exception("Exception in MGR thrash:")
+
+    def _do_thrash(self):
+        self.log('Starting MGR thrash')
+        self.ceph_manager.wait_for_mgr_available(self.timeout)
+        start_time = time.time()
+
+        while not self.stopping.is_set():
+            if self.duration and (time.time() - start_time) > self.duration:
+                self.log('Duration exceeded, stopping MGR thrash')
+                break
+
+            mgr_stats = self.ceph_manager.get_mgr_stat()
+            if not mgr_stats.get('active_name'):
+                self.log('No active MGR found, waiting for an active MGR before thrashing')
+                self.ceph_manager.wait_for_mgr_available(self.timeout)
+                continue
+
+            active = mgr_stats.get('active_name', '')
+            self.log('Failing active MGR: {active}'.format(active=active))
+
+            self.ceph_manager.raw_cluster_cmd('mgr', 'fail')
+            self.ceph_manager.wait_for_mgr_available(self.timeout)
+            gevent.sleep(self.thrash_delay)
+
+
+@contextlib.contextmanager
+def task(ctx, config):
+    if config is None:
+        config = {}
+
+    if config.get('cluster') is None:
+        config['cluster'] = 'ceph'
+
+    logger = config.get('logger', 'mgr_thrasher')
+
+    log.info('Starting MGR thrash task with config: {config}'.format(config=str(config)))
+    first_mon = teuthology.get_first_mon(ctx, config)
+    (mon,) = ctx.cluster.only(first_mon).remotes.keys()
+
+    manager = ceph_manager.CephManager(
+        mon,
+        ctx=ctx,
+        logger=log.getChild('ceph_manager'),
+        )
+
+    thrash_proc = ThrashMGRs(ctx, manager, config, "MGRThrasher", log.getChild(logger))
+    ctx.ceph[config['cluster']].thrashers.append(thrash_proc)
+    try:
+        log.debug('Yielding from MGR thrash task')
+        yield
+    finally:
+        log.info('Joining MGR thrash task')
+        thrash_proc.stop_and_join()
+        manager.wait_for_mgr_available(config.get('timeout', 60))


### PR DESCRIPTION
Add a new teuthology task that thrashes ceph-mgr daemons by repeatedly
failing the active MGR and waiting for a standby to take over. Supports
configurable thrash_delay, duration, and timeout.

Also add get_mgr_stat() to CephManager wrapping 'ceph mgr stat' as a
lightweight alternative to get_mgr_dump(), whose output is too verbose
for repeated polling during thrashing.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
