### PR TITLE
tentacle: mds: scrub pins more inodes than the mds_cache_memory_limit

### DIFF
--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -307,16 +307,16 @@ void ScrubStack::kick_off_scrubs()
 	}
       }
     } else if (CDir *dir = dynamic_cast<CDir*>(*it)) {
-      auto next = it;
-      ++next;
+      ++it;
+      bool added_children = false;
       bool done = false; // it's done, so pop it off the stack
-      scrub_dirfrag(dir, &done);
+      scrub_dirfrag(dir, &added_children, &done);
       if (done) {
-	dout(20) << __func__ << " dirfrag, done" << dendl;
-	++it; // child inodes were queued at bottom of stack
-	dequeue(dir);
-      } else {
-	it = next;
+        dout(20) << __func__ << " dirfrag, done" << dendl;
+        dequeue(dir);
+      }
+      if (added_children) {
+        it = scrub_stack.begin();
       }
     } else {
       ceph_assert(0 == "dentry in scrub stack");
@@ -487,7 +487,7 @@ void ScrubStack::scrub_dir_inode_final(CInode *in)
   return;
 }
 
-void ScrubStack::scrub_dirfrag(CDir *dir, bool *done)
+void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
 {
   ceph_assert(dir != NULL);
 
@@ -528,7 +528,8 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *done)
 	continue;
       }
       if (dnl->is_primary()) {
-	_enqueue(dnl->get_inode(), header, false);
+  *added_children = true;
+	_enqueue(dnl->get_inode(), header, true);
       } else if (dnl->is_remote()) {
 	// TODO: check remote linkage
       }

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -235,9 +235,10 @@ private:
    * scrub of the dirfrag.
    *
    * @param dir The dirfrag to scrub (must be auth)
+   * @param added_children set to true if we pushed some of our children
    * @param done set to true if we started to do final scrub
    */
-  void scrub_dirfrag(CDir *dir, bool *done);
+  void scrub_dirfrag(CDir *dir, bool *added_children, bool *done);
   /**
    * Scrub a directory-representing dentry.
    *


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75398

--------
backport of #65858
parent tracker: https://tracker.ceph.com/issues/71167
