### PR TITLE
rgw/dedup: Prevent dedup between 2 separate placements

### DIFF
--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -462,10 +462,41 @@ namespace rgw::dedup {
       return ret;
     }
     ldpp_dout(dpp, 20) << __func__ << "::" << p_bucket->get_name() << "/"
-                       << obj_name << " was written to block_idx="
-                       << rec_info.block_id << " rec_id=" << (int)rec_info.rec_id
-                       << dendl;
+                       << obj_name << " was written to block_idx=" << rec_info.block_id
+                       << " rec_id=" << (int)rec_info.rec_id << dendl;
     return 0;
+  }
+
+  //---------------------------------------------------------------------------
+  static void report_failed_add_entry(const DoutPrefixProvider* const dpp,
+                                      const std::string &obj_name,
+                                      md5_stats_t *p_stats)
+  {
+    // We allocate memory for the dedup on startup based on the existing obj count
+    // If the system grew significantly since that point we won't be able to
+    // accommodate all the objects in the hash-table.
+    // Please keep in mind that it is very unlikely since duplicates objects will
+    // consume a single entry and since we skip small objects so in reality
+    // I expect the allocation to be more than sufficient.
+    //
+    // However, if we filled up the system there is still value is continuing
+    // with this process since we might find duplicates to existing object (which
+    // don't take extra space)
+
+    int level = 15;
+    if (p_stats->failed_table_load % 0x10000 == 0) {
+      level = 5;
+    }
+    else if (p_stats->failed_table_load % 0x100 == 0) {
+      level = 10;
+    }
+    ldpp_dout(dpp, level) << __func__ << "::Failed p_table->add_entry(" << obj_name
+                          << ") with an overflow"
+                          << "::loaded_objects=" << p_stats->loaded_objects
+                          << "::failed_table_load=" << p_stats->failed_table_load
+                          << dendl;
+
+    p_stats->failed_table_load++;
   }
 
   //---------------------------------------------------------------------------
@@ -487,7 +518,7 @@ namespace rgw::dedup {
     bool has_shared_manifest = p_rec->s.flags.has_shared_manifest();
     ldpp_dout(dpp, 20) << __func__ << "::bucket=" << p_rec->bucket_name
                        << ", obj=" << p_rec->obj_name << ", block_id="
-                       << (uint32_t)block_id << ", rec_id=" << (uint32_t)rec_id
+                       << block_id << ", rec_id=" << (int)rec_id
                        << ", shared_manifest=" << has_shared_manifest
                        << "::num_parts=" << p_rec->s.num_parts
                        << "::size_4k_units=" << key.size_4k_units
@@ -495,8 +526,7 @@ namespace rgw::dedup {
                        << p_rec->s.md5_low << std::dec << dendl;
 
     int ret = p_table->add_entry(&key, block_id, rec_id, has_shared_manifest,
-                                 &p_stats->small_objs_stat, &p_stats->big_objs_stat,
-                                 &p_stats->dup_head_bytes_estimate);
+                                 &p_stats->big_objs_stat, &p_stats->dup_head_bytes_estimate);
     if (ret == 0) {
       p_stats->loaded_objects ++;
       ldpp_dout(dpp, 20) << __func__ << "::" << p_rec->bucket_name << "/"
@@ -504,30 +534,7 @@ namespace rgw::dedup {
                          << "::loaded_objects=" << p_stats->loaded_objects << dendl;
     }
     else {
-      // We allocate memory for the dedup on startup based on the existing obj count
-      // If the system grew significantly since that point we won't be able to
-      // accommodate all the objects in the hash-table.
-      // Please keep in mind that it is very unlikely since duplicates objects will
-      // consume a single entry and since we skip small objects so in reality
-      // I expect the allocation to be more than sufficient.
-      //
-      // However, if we filled up the system there is still value is continuing
-      // with this process since we might find duplicates to existing object (which
-      // don't take extra space)
-
-      int level = 15;
-      if (p_stats->failed_table_load % 0x10000 == 0) {
-        level = 5;
-      }
-      else if (p_stats->failed_table_load % 0x100 == 0) {
-        level = 10;
-      }
-      ldpp_dout(dpp, level) << __func__ << "::Failed p_table->add_entry (overflow)"
-                            << "::loaded_objects=" << p_stats->loaded_objects
-                            << "::failed_table_load=" << p_stats->failed_table_load
-                            << dendl;
-
-      p_stats->failed_table_load++;
+      report_failed_add_entry(dpp, p_rec->obj_name, p_stats);
     }
     return ret;
   }
@@ -1152,20 +1159,22 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   [[maybe_unused]]static void __attribute__ ((noinline))
   print_record(const DoutPrefixProvider* dpp,
-               const disk_record_t *p_tgt_rec,
+               const char          *caller,
+               const disk_record_t *p_rec,
                disk_block_id_t      block_id,
                record_id_t          rec_id,
                md5_shard_t          md5_shard)
   {
-    ldpp_dout(dpp, 20) << __func__ << "::bucket=" << p_tgt_rec->bucket_name
-                       << ", obj=" << p_tgt_rec->obj_name
-                       << ", bytes_size=" << p_tgt_rec->s.obj_bytes_size
+    ldpp_dout(dpp, 20) << caller << "::bucket=" << p_rec->bucket_name
+                       << ", obj=" << p_rec->obj_name
+                       << ", stor_class=" << p_rec->stor_class
+                       << ", bytes_size=" << p_rec->s.obj_bytes_size
                        << ", block_id=" << block_id
-                       << ", rec_id=" << (int)rec_id << "\n"
+                       << ", rec_id=" << (int)rec_id
                        << ", md5_shard=" << (int)md5_shard
-                       << "::num_parts=" << p_tgt_rec->s.num_parts
-                       << "::ETAG=" << std::hex << p_tgt_rec->s.md5_high
-                       << p_tgt_rec->s.md5_low << std::dec << dendl;
+                       << "::num_parts=" << p_rec->s.num_parts
+                       << "::ETAG=" << std::hex << p_rec->s.md5_high
+                       << p_rec->s.md5_low << std::dec << dendl;
   }
 
   //---------------------------------------------------------------------------
@@ -1199,6 +1208,7 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   int Background::add_obj_attrs_to_record(disk_record_t         *p_rec,
                                           const rgw::sal::Attrs &attrs,
+                                          const RGWObjManifest  &manifest,
                                           md5_stats_t           *p_stats) /*IN-OUT*/
   {
     // if TAIL_TAG exists -> use it as ref-tag, eitherwise take ID_TAG
@@ -1218,73 +1228,8 @@ namespace rgw::dedup {
       }
     }
     p_rec->s.ref_tag_len = p_rec->ref_tag.length();
-
-    // clear bufferlist first
-    p_rec->manifest_bl.clear();
-
-    bool need_to_split_head = false;
-    RGWObjManifest manifest;
-    itr = attrs.find(RGW_ATTR_MANIFEST);
-    if (itr != attrs.end()) {
-      const bufferlist &bl = itr->second;
-      try {
-        auto bl_iter = bl.cbegin();
-        decode(manifest, bl_iter);
-      } catch (buffer::error& err) {
-        ldpp_dout(dpp, 1)  << __func__
-                           << "::ERROR: unable to decode manifest" << dendl;
-        return -EINVAL;
-      }
-      need_to_split_head = should_split_head(manifest.get_head_size(),
-                                             p_rec->s.obj_bytes_size);
-
-      // force explicit tail_placement as the dedup could be on another bucket
-      const rgw_bucket_placement& tail_placement = manifest.get_tail_placement();
-      if (unlikely(invalid_tail_placement(tail_placement))) {
-        set_explicit_tail_placement(dpp, &manifest, p_stats);
-        encode(manifest, p_rec->manifest_bl);
-      }
-      else {
-        p_rec->manifest_bl = bl;
-      }
-      p_rec->s.manifest_len = p_rec->manifest_bl.length();
-    }
-    else {
-      ldpp_dout(dpp, 5)  << __func__ << "::ERROR: no manifest" << dendl;
-      return -EINVAL;
-    }
-    const auto &head_placement_rule = manifest.get_head_placement_rule();
-    const std::string& storage_class =
-      rgw_placement_rule::get_canonical_storage_class(head_placement_rule.storage_class);
-
-    // p_rec holds an the storage_class value taken from the bucket-index/obj-attr
-    if (unlikely(storage_class != p_rec->stor_class)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERROR::manifest storage_class="
-                        << storage_class << " != " << "::bucket-index storage_class="
-                        << p_rec->stor_class << dendl;
-      p_stats->different_storage_class++;
-      return -EINVAL;
-    }
-
-    itr = attrs.find(RGW_ATTR_SHARE_MANIFEST);
-    if (itr != attrs.end()) {
-      uint64_t hash = 0;
-      try {
-        auto bl_iter = itr->second.cbegin();
-        ceph::decode(hash, bl_iter);
-        p_rec->s.shared_manifest = hash;
-      } catch (buffer::error& err) {
-        ldpp_dout(dpp, 1) << __func__ << "::ERROR: bad shared_manifest" << dendl;
-        return -EINVAL;
-      }
-      ldpp_dout(dpp, 20) << __func__ << "::Set Shared_Manifest::OBJ_NAME="
-                         << p_rec->obj_name << "::shared_manifest=0x" << std::hex
-                         << p_rec->s.shared_manifest << std::dec << dendl;
-      p_rec->s.flags.set_shared_manifest();
-    }
-    else {
-      memset(&p_rec->s.shared_manifest, 0, sizeof(p_rec->s.shared_manifest));
-    }
+    bool need_to_split_head = should_split_head(manifest.get_head_size(),
+                                                p_rec->s.obj_bytes_size);
 
     itr = attrs.find(RGW_ATTR_BLAKE3);
     if (itr != attrs.end()) {
@@ -1324,8 +1269,8 @@ namespace rgw::dedup {
   // Need to read attributes from the Head-Object and output them to a new SLAB
   int Background::read_object_attribute(dedup_table_t    *p_table,
                                         disk_record_t    *p_rec,
-                                        disk_block_id_t   old_block_id,
-                                        record_id_t       old_rec_id,
+                                        disk_block_id_t   block_id,
+                                        record_id_t       rec_id,
                                         md5_shard_t       md5_shard,
                                         md5_stats_t      *p_stats /* IN-OUT */,
                                         disk_block_seq_t *p_disk,
@@ -1333,9 +1278,12 @@ namespace rgw::dedup {
   {
     bool should_print_debug = cct->_conf->subsys.should_gather<ceph_subsys_rgw_dedup, 20>();
     if (unlikely(should_print_debug)) {
-      print_record(dpp, p_rec, old_block_id, old_rec_id, md5_shard);
+      print_record(dpp, __func__, p_rec, block_id, rec_id, md5_shard);
     }
     p_stats->processed_objects ++;
+
+    // reset flags
+    p_rec->s.flags.clear();
 
     uint32_t size_4k_units = byte_size_to_disk_blocks(p_rec->s.obj_bytes_size);
     uint64_t ondisk_byte_size = disk_blocks_to_byte_size(size_4k_units);
@@ -1344,46 +1292,19 @@ namespace rgw::dedup {
     if (unlikely(sc_idx == remapper_t::NULL_IDX)) {
       return -EOVERFLOW;
     }
-    key_t key_from_bucket_index(p_rec->s.md5_high, p_rec->s.md5_low, size_4k_units,
-                                p_rec->s.num_parts, sc_idx);
-    dedup_table_t::value_t src_val;
-    int ret = p_table->get_val(&key_from_bucket_index, &src_val);
-    if (ret != 0) {
-      if (!dedupable_object(p_rec->multipart_object(), d_min_obj_size_for_dedup, ondisk_byte_size)) {
-        // record has no valid entry in table because it is a too small
-        // It was loaded to table for calculation and then purged
-        p_stats->skipped_purged_small++;
-        ldpp_dout(dpp, 20) << __func__ << "::skipped purged small obj::"
-                           << p_rec->obj_name << "::" << ondisk_byte_size << dendl;
-        // help small object tests pass - avoid complication differentiating between
-        // small objects ( < 64KB,  >= 64KB <= 4MB, > 4MB
-        p_stats->processed_objects--;
-      }
-      else {
-        // record has no valid entry in table because it is a singleton
-        p_stats->skipped_singleton++;
-        p_stats->skipped_singleton_bytes += ondisk_byte_size;
-        ldpp_dout(dpp, 20) << __func__ << "::skipped singleton::"
-                           << p_rec->obj_name << std::dec << dendl;
-      }
-      return 0;
-    }
 
-    // limit the number of ref_count in the SRC-OBJ to MAX_COPIES_PER_OBJ
-    // check <= because we also count the SRC-OBJ
-    if (src_val.get_count() <= MAX_COPIES_PER_OBJ) {
-      disk_block_id_t src_block_id = src_val.get_src_block_id();
-      record_id_t     src_rec_id   = src_val.get_src_rec_id();
-      // update the number of identical copies we got
-      ldpp_dout(dpp, 20) << __func__ << "::Obj " << p_rec->obj_name
-                         << " has " << src_val.get_count() << " copies" << dendl;
-      p_table->inc_count(&key_from_bucket_index, src_block_id, src_rec_id);
-    }
-    else {
-      // We don't want more than @MAX_COPIES_PER_OBJ to prevent OMAP overload
-      p_stats->skipped_too_many_copies++;
-      ldpp_dout(dpp, 10) << __func__ << "::Obj " << p_rec->obj_name
-                         << " has too many copies already" << dendl;
+    // get key using storage-class from BI without placement_rule
+    key_t key(p_rec->s.md5_high, p_rec->s.md5_low, size_4k_units,
+              p_rec->s.num_parts, sc_idx);
+    key_t *p_key = &key;
+    dedup_table_t::value_t src_val;
+    int ret = p_table->get_val(p_key, &src_val);
+    if (ret != 0) {
+      // record has no valid entry in table because it is a singleton
+      p_stats->skipped_singleton++;
+      p_stats->skipped_singleton_bytes += ondisk_byte_size;
+      ldpp_dout(dpp, 20) << __func__ << "::skipped singleton::"
+                         << p_rec->obj_name << std::dec << dendl;
       return 0;
     }
 
@@ -1399,6 +1320,7 @@ namespace rgw::dedup {
                          << cpp_strerror(-ret) << dendl;
       return 0;
     }
+
     const rgw_obj_index_key roi_key(p_rec->obj_name, p_rec->instance);
     unique_ptr<rgw::sal::Object> p_obj = bucket->get_object(roi_key);
     if (unlikely(!p_obj)) {
@@ -1419,19 +1341,6 @@ namespace rgw::dedup {
     }
 
     const rgw::sal::Attrs& attrs = p_obj->get_attrs();
-    if (src_val.has_shared_manifest() && (attrs.find(RGW_ATTR_SHARE_MANIFEST) != attrs.end())) {
-      // A shared_manifest object can't be a dedup target
-      // We only need to keep a single shared_manifest object
-      // to be used as a dedup-source (which we already got)
-      p_stats->skipped_shared_manifest++;
-      uint64_t dedupable_objects_bytes = __calc_deduped_bytes(p_rec->s.num_parts,
-                                                              ondisk_byte_size);
-      p_stats->shared_manifest_dedup_bytes += dedupable_objects_bytes;
-      ldpp_dout(dpp, 20) << __func__ << "::(1)skipped shared_manifest, SRC::block_id="
-                         << src_val.get_src_block_id()
-                         << "::rec_id=" << (int)src_val.get_src_rec_id() << dendl;
-      return 0;
-    }
 
     if (attrs.find(RGW_ATTR_CRYPT_MODE) != attrs.end()) {
       p_stats->ingress_skip_encrypted++;
@@ -1454,7 +1363,18 @@ namespace rgw::dedup {
     parsed_etag_t parsed_etag;
     auto itr = attrs.find(RGW_ATTR_ETAG);
     if (itr != attrs.end()) {
-      if (unlikely(!parse_etag_string(itr->second.to_str(), &parsed_etag))) {
+      if (parse_etag_string(itr->second.to_str(), &parsed_etag)) {
+        // compare ETAG attribute to the Bucket-Index ETAG
+        if (unlikely(parsed_etag.md5_high  != p_rec->s.md5_high ||
+                     parsed_etag.md5_low   != p_rec->s.md5_low  ||
+                     parsed_etag.num_parts != p_rec->s.num_parts)) {
+          ldpp_dout(dpp, 15) <<__func__ << "::object changed ETAG -> skip "
+                             << p_rec->obj_name << dendl;
+          p_stats->ingress_skip_changed_objs++;
+          return 0;
+        }
+      }
+      else {
         p_stats->ingress_corrupted_etag++;
         ldpp_dout(dpp, 10) << __func__ << "::ERROR: corrupted etag::" << p_rec->obj_name << dendl;
         return -EINVAL;
@@ -1466,40 +1386,133 @@ namespace rgw::dedup {
       return -EINVAL;
     }
 
-    std::string storage_class;
-    itr = attrs.find(RGW_ATTR_STORAGE_CLASS);
+    //===========================================================================
+    // Placement_Rule is not reported in bucket-index, only now we can add it
+    RGWObjManifest manifest;
+    itr = attrs.find(RGW_ATTR_MANIFEST);
     if (itr != attrs.end()) {
-      storage_class = itr->second.to_str();
+      const bufferlist &bl = itr->second;
+      try {
+        auto bl_iter = bl.cbegin();
+        decode(manifest, bl_iter);
+        if (unlikely(manifest.get_obj_size() != p_rec->s.obj_bytes_size)) {
+          ldpp_dout(dpp, 15) <<__func__ << "::object changed size from "
+                             << p_rec->s.obj_bytes_size << "::to"
+                             << manifest.get_obj_size() << dendl;
+          p_stats->ingress_skip_changed_objs++;
+          return 0;
+        }
+        // force explicit tail_placement as the dedup could be on another bucket
+        const rgw_bucket_placement& tail_placement = manifest.get_tail_placement();
+        if (unlikely(invalid_tail_placement(tail_placement))) {
+          set_explicit_tail_placement(dpp, &manifest, p_stats);
+          p_rec->manifest_bl.clear();
+          encode(manifest, p_rec->manifest_bl);
+        }
+        else {
+          p_rec->manifest_bl = bl;
+        }
+        p_rec->s.manifest_len = p_rec->manifest_bl.length();
+      } catch (buffer::error& err) {
+        ldpp_dout(dpp, 1)  << __func__
+                           << "::ERROR: unable to decode manifest" << dendl;
+        return -EINVAL;
+      }
     }
     else {
-      storage_class = RGW_STORAGE_CLASS_STANDARD;
-    }
-
-    // p_rec holds an the storage_class value taken from the bucket-index
-    if (unlikely(storage_class != p_rec->stor_class)) {
-      ldpp_dout(dpp, 5) << __func__ << "::ERROR::ATTR storage_class="
-                        << storage_class << " != " << "::bucket-index storage_class="
-                        << p_rec->stor_class << dendl;
-      p_stats->different_storage_class++;
+      ldpp_dout(dpp, 5)  << __func__ << "::ERROR: no manifest" << dendl;
       return -EINVAL;
     }
 
-    // no need to check for remap success as we compare keys bellow
-    sc_idx = remapper->remap(storage_class, dpp, &p_stats->failed_map_overflow);
-    key_t key_from_obj(parsed_etag.md5_high, parsed_etag.md5_low,
-                       byte_size_to_disk_blocks(p_obj->get_size()),
-                       parsed_etag.num_parts, sc_idx);
-    if (unlikely(key_from_obj != key_from_bucket_index ||
-                 p_rec->s.obj_bytes_size != p_obj->get_size())) {
-      ldpp_dout(dpp, 15) <<__func__ << "::Skipping changed object "
-                         << p_rec->obj_name << dendl;
-      p_stats->ingress_skip_changed_objs++;
+    bool placement_rule_load = false;
+    const rgw_bucket_placement& bucket_placement = manifest.get_tail_placement();
+    const rgw_placement_rule& tail_placement = bucket_placement.placement_rule;
+    const std::string storage_class_with_placement = tail_placement.to_str();
+    if (unlikely(storage_class_with_placement != p_rec->stor_class)) {
+      p_stats->non_default_placement ++;
+      ldpp_dout(dpp, 20) << __func__ << "::storage_class changed from: "
+                         << p_rec->stor_class << " to "
+                         << storage_class_with_placement << dendl;
+      p_rec->stor_class = storage_class_with_placement;
+      auto new_sc_idx = remapper->remap(storage_class_with_placement, dpp,
+                                        &p_stats->failed_map_overflow);
+      if (unlikely(new_sc_idx == remapper_t::NULL_IDX)) {
+        return -EOVERFLOW;
+      }
+
+      ldpp_dout(dpp, 20) << __func__ << "::stor_class_idx changed from: "
+                         << (int) p_key->stor_class_idx << " to "
+                         << (int) new_sc_idx << dendl;
+
+      // update the key with placement_rule
+      p_key->stor_class_idx = new_sc_idx;
+
+      // now get the correct value with Placement_Rule set in key
+      ret = p_table->get_val(p_key, &src_val);
+      if (ret != 0) {
+        ldpp_dout(dpp, 20) << __func__ << "::set new entry: " << p_rec->obj_name
+                           << "::block_id=" << block_id << dendl;
+        ret = p_table->add_entry(p_key, block_id, rec_id,
+                                 p_rec->s.flags.has_shared_manifest(),
+                                 nullptr, nullptr); // no need to update stats!
+        if (ret == 0) {
+          placement_rule_load = true;
+          ret = p_table->get_val(p_key, &src_val);
+          ceph_assert(ret == 0);
+        }
+        else {
+          report_failed_add_entry(dpp, p_rec->obj_name, p_stats);
+          return ret;
+        }
+      }
+    } // change to storage_class
+    //===========================================================================
+
+    itr = attrs.find(RGW_ATTR_SHARE_MANIFEST);
+    if (itr != attrs.end()) {
+      uint64_t hash = 0;
+      try {
+        auto bl_iter = itr->second.cbegin();
+        ceph::decode(hash, bl_iter);
+        p_rec->s.shared_manifest = hash;
+        p_rec->s.flags.set_shared_manifest();
+      } catch (buffer::error& err) {
+        ldpp_dout(dpp, 1) << __func__ << "::ERROR: bad shared_manifest" << dendl;
+        return -EINVAL;
+      }
+      ldpp_dout(dpp, 20) << __func__ << "::Set Shared_Manifest::OBJ_NAME="
+                         << p_rec->obj_name << "::shared_manifest=0x" << std::hex
+                         << p_rec->s.shared_manifest << std::dec << dendl;
+    }
+    else {
+      memset(&p_rec->s.shared_manifest, 0, sizeof(p_rec->s.shared_manifest));
+    }
+
+    if (src_val.has_shared_manifest() && p_rec->s.flags.has_shared_manifest()) {
+      // A shared_manifest object can't be a dedup target
+      // We only need to keep a single shared_manifest object
+      // to be used as a dedup-source (which we already got)
+      p_stats->skipped_shared_manifest++;
+      uint64_t dedupable_objects_bytes = __calc_deduped_bytes(p_rec->s.num_parts,
+                                                              ondisk_byte_size);
+      p_stats->shared_manifest_dedup_bytes += dedupable_objects_bytes;
+      ldpp_dout(dpp, 20) << __func__ << "::(1)skipped shared_manifest, SRC::block_id="
+                         << src_val.get_src_block_id()
+                         << "::rec_id=" << (int)src_val.get_src_rec_id() << dendl;
       return 0;
     }
 
-    // reset flags
-    p_rec->s.flags.clear();
-    ret = add_obj_attrs_to_record(p_rec, attrs, p_stats);
+    // limit the number of ref_count in the SRC-OBJ to MAX_COPIES_PER_OBJ
+    // check <= because we also count the SRC-OBJ
+    if (src_val.get_count() > MAX_COPIES_PER_OBJ) {
+      // We don't want more than @MAX_COPIES_PER_OBJ to prevent OMAP overload
+      p_stats->skipped_too_many_copies++;
+      ldpp_dout(dpp, 10) << __func__ << "::Obj " << p_rec->obj_name
+                         << " has too many copies already" << dendl;
+      return 0;
+    }
+
+    ret = add_obj_attrs_to_record(p_rec, attrs, manifest, p_stats);
     if (unlikely(ret != 0)) {
       ldpp_dout(dpp, 5) << __func__ << "::ERR: failed add_obj_attrs_to_record() ret="
                         << ret << "::" << cpp_strerror(-ret) << dendl;
@@ -1518,8 +1531,16 @@ namespace rgw::dedup {
                           << rec_info.block_id << "::rec_id=" << (int)rec_info.rec_id
                           << "::shared_manifest="
                           << p_rec->s.flags.has_shared_manifest() << dendl;
-      p_table->update_entry(&key_from_bucket_index, rec_info.block_id,
-                            rec_info.rec_id, p_rec->s.flags.has_shared_manifest());
+
+      // placement_rule reload already inc the counter, don't do it twice
+      bool inc_counters = !placement_rule_load;
+      uint32_t count = p_table->update_entry(p_key, rec_info.block_id,
+                                             rec_info.rec_id,
+                                             p_rec->s.flags.has_shared_manifest(),
+                                             inc_counters);
+      if (count > 1) {
+        p_stats->big_objs_stat.duplicate_count ++;
+      }
     }
     else {
       ldpp_dout(dpp, 5) << __func__ << "::ERR: Failed p_disk->add_record()"<< dendl;
@@ -1765,9 +1786,9 @@ namespace rgw::dedup {
     const rgw_bucket *p_bucket = &(src_manifest.get_tail_placement().bucket);
     build_and_set_explicit_manifest(dpp, p_bucket, *p_tail_name, &src_manifest);
 
-    bufferlist manifest_bl;
-    encode(src_manifest, manifest_bl);
-    p_src_rec->manifest_bl = manifest_bl;
+    p_src_rec->manifest_bl.clear();
+    encode(src_manifest, p_src_rec->manifest_bl);
+
     p_src_rec->s.manifest_len = p_src_rec->manifest_bl.length();
     p_src_rec->s.flags.set_split_head();
     return ret;
@@ -1957,7 +1978,7 @@ namespace rgw::dedup {
   {
     bool should_print_debug = cct->_conf->subsys.should_gather<ceph_subsys_rgw_dedup, 20>();
     if (unlikely(should_print_debug)) {
-      print_record(dpp, p_tgt_rec, block_id, rec_id, md5_shard);
+      print_record(dpp, __func__, p_tgt_rec, block_id, rec_id, md5_shard);
     }
     uint32_t size_4k_units = byte_size_to_disk_blocks(p_tgt_rec->s.obj_bytes_size);
     storage_class_idx_t sc_idx = remapper->remap(p_tgt_rec->stor_class, dpp,
@@ -1974,11 +1995,11 @@ namespace rgw::dedup {
     int ret = p_table->get_val(&key, &src_val);
     if (unlikely(ret != 0)) {
       // record has no valid entry in table because it is a singleton
-      // should never happened since we purged all singletons before
-      ldpp_dout(dpp, 5) << __func__ << "::skipped singleton::" << p_tgt_rec->bucket_name
-                        << "/" << p_tgt_rec->obj_name << "::num_parts=" << p_tgt_rec->s.num_parts
-                        << "::ETAG=" << std::hex << p_tgt_rec->s.md5_high
-                        << p_tgt_rec->s.md5_low << std::dec << dendl;
+      // This could legally happen after storage-class change
+      ldpp_dout(dpp, 20) << __func__ << "::skipped singleton::" << p_tgt_rec->bucket_name
+                         << "/" << p_tgt_rec->obj_name << "::num_parts=" << p_tgt_rec->s.num_parts
+                         << "::ETAG=" << std::hex << p_tgt_rec->s.md5_high
+                         << p_tgt_rec->s.md5_low << std::dec << dendl;
       p_stats->singleton_after_purge++;
       return 0;
     }
@@ -2267,7 +2288,33 @@ namespace rgw::dedup {
                        << parsed_etag.md5_low << std::dec << dendl;
   }
 
-  //---------------------------------------------------------------------------
+  //------------------------------------------------------------------------------
+  static std::string get_sc_with_default_placement(const DoutPrefixProvider *const dpp,
+                                                   rgw::sal::Driver *driver,
+                                                   worker_stats_t *p_worker_stats,
+                                                   uint64_t ondisk_byte_size,
+                                                   const rgw_bucket_dir_entry &entry)
+  {
+    const std::string& canonical_storage_class =
+      rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
+
+    if (canonical_storage_class == RGW_STORAGE_CLASS_STANDARD) {
+      p_worker_stats->default_storage_class_objs++;
+      p_worker_stats->default_storage_class_objs_bytes += ondisk_byte_size;
+    }
+    else {
+      p_worker_stats->non_default_storage_class_objs++;
+      p_worker_stats->non_default_storage_class_objs_bytes += ondisk_byte_size;
+    }
+
+    const rgw::sal::ZoneGroup& zonegroup = driver->get_zone()->get_zonegroup();
+    const std::string& default_placement = zonegroup.get_default_placement_name();
+    const rgw_placement_rule rp_rule(default_placement, canonical_storage_class);
+
+    return rp_rule.to_str();
+  }
+
+  //-------------------------------------------------------------------------------
   int Background::ingress_bucket_idx_single_object(disk_block_array_t         &disk_arr,
                                                    const rgw::sal::Bucket     *p_bucket,
                                                    const rgw_bucket_dir_entry &entry,
@@ -2287,39 +2334,17 @@ namespace rgw::dedup {
 
     // ceph store full blocks so need to round up and multiply by block_size
     uint64_t ondisk_byte_size = calc_on_disk_byte_size(entry.meta.size);
+
     // count all objects including too small and non default storage_class objs
     p_worker_stats->ingress_obj++;
     p_worker_stats->ingress_obj_bytes += ondisk_byte_size;
-
-    // We limit dedup to objects from the same storage_class
-    // TBD-Future:
-    // Should we use a skip-list of storage_classes we should skip (like glacier) ?
-    const std::string& storage_class =
-      rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
-    if (storage_class == RGW_STORAGE_CLASS_STANDARD) {
-      p_worker_stats->default_storage_class_objs++;
-      p_worker_stats->default_storage_class_objs_bytes += ondisk_byte_size;
-    }
-    else {
-      ldpp_dout(dpp, 20) << __func__ << "::" << entry.key.name
-                         << "::storage_class:" << entry.meta.storage_class << dendl;
-      p_worker_stats->non_default_storage_class_objs++;
-      p_worker_stats->non_default_storage_class_objs_bytes += ondisk_byte_size;
-    }
 
     if (ondisk_byte_size < d_min_obj_size_for_dedup) {
       if (parsed_etag.num_parts == 0) {
         // dedup only useful for objects bigger than 4MB
         p_worker_stats->ingress_skip_too_small++;
         p_worker_stats->ingress_skip_too_small_bytes += ondisk_byte_size;
-
-        if (ondisk_byte_size >= 64*1024) {
-          p_worker_stats->ingress_skip_too_small_64KB++;
-          p_worker_stats->ingress_skip_too_small_64KB_bytes += ondisk_byte_size;
-        }
-        else {
-          return 0;
-        }
+        return 0;
       }
       else {
         // multipart objects are always good candidates for dedup
@@ -2327,6 +2352,7 @@ namespace rgw::dedup {
         p_worker_stats->small_multipart_obj++;
       }
     }
+
     // multipart/single_part counters are for objects being fully processed
     if (parsed_etag.num_parts > 0) {
       p_worker_stats->multipart_objs++;
@@ -2334,6 +2360,17 @@ namespace rgw::dedup {
     else {
       p_worker_stats->single_part_objs++;
     }
+
+    // We limit dedup to objects from the same storage_class
+    // TBD-Future:
+    // Should we use a skip-list of storage_classes we should skip (like glacier) ?
+
+    // assume default_placement (will fix it later if non default)
+    // This will prevent extra work on most configurations
+    const std::string storage_class =
+      get_sc_with_default_placement(dpp, driver, p_worker_stats, ondisk_byte_size, entry);
+    ldpp_dout(dpp, 20) << __func__ << "::" << entry.key.name
+                       << "::storage_class_with_placement=" << storage_class << dendl;
 
     return add_disk_rec_from_bucket_idx(disk_arr, p_bucket, &parsed_etag,
                                         entry.key.name, entry.key.instance,
@@ -2531,8 +2568,6 @@ namespace rgw::dedup {
                        << "::total_count="      << obj_count_in_shard
                        << "::loaded_objects="   << p_stats->loaded_objects
                        << p_stats->big_objs_stat << dendl;
-    ldpp_dout(dpp, 10) << __func__ << "::small objs::"
-                       << p_stats->small_objs_stat << dendl;
   }
 
   //---------------------------------------------------------------------------
@@ -2557,9 +2592,9 @@ namespace rgw::dedup {
         return -ECANCELED;
       }
     }
-    p_table->count_duplicates(&p_stats->small_objs_stat, &p_stats->big_objs_stat);
-    display_table_stat_counters(dpp, p_stats);
 
+    p_table->count_duplicates(&p_stats->big_objs_stat);
+    display_table_stat_counters(dpp, p_stats);
     ldpp_dout(dpp, 10) << __func__ << "::MD5 Loop::" << d_ctl.dedup_type << dendl;
     if (d_ctl.dedup_type != dedup_req_type_t::DEDUP_TYPE_EXEC) {
       for (work_shard_t worker_id = 0; worker_id < num_work_shards; worker_id++) {
@@ -2573,7 +2608,16 @@ namespace rgw::dedup {
     return 0;
 #endif
 
-    p_table->remove_singletons_and_redistribute_keys();
+    p_table->remove_singletons_and_redistribute_keys("STEP_BUILD_TABLE", true);
+    // Reset the counters that will be recalculated during STEP_READ_ATTRIBUTES step.
+    // Note that dedup_bytes_estimate should not be reset, as it remains unmodified
+    //      during that step.
+    uint64_t singleton_count = p_stats->big_objs_stat.singleton_count;
+    uint64_t unique_count    = p_stats->big_objs_stat.unique_count;
+    uint64_t duplicate_count = p_stats->big_objs_stat.duplicate_count;
+    p_stats->big_objs_stat.unique_count = 0;
+    p_stats->big_objs_stat.duplicate_count = 0;
+
     // The SLABs holds minimal data set brought from the bucket-index
     // Objects participating in DEDUP need to read attributes from the Head-Object
     // TBD  - find a better name than num_work_shards for the combined output
@@ -2593,6 +2637,21 @@ namespace rgw::dedup {
       }
       disk_block_seq.flush_disk_records(d_dedup_cluster_ioctx);
     }
+    if (!p_stats->non_default_placement) {
+      // skip this step when no storage_class update !!
+      ldpp_dout(dpp, 10) << __func__ <<"::no storage_class update, skip second call"
+                         << " to p_table->count_duplicates()"<< dendl;
+      p_stats->big_objs_stat.singleton_count = singleton_count;
+      p_stats->big_objs_stat.unique_count    = unique_count;
+      p_stats->big_objs_stat.duplicate_count = duplicate_count;
+    }
+    else {
+      p_table->count_duplicates(&p_stats->big_objs_stat);
+      display_table_stat_counters(dpp, p_stats);
+    }
+
+    // There might be singleton after storage_class update
+    p_table->remove_singletons_and_redistribute_keys("STEP_READ_ATTRIBUTES", false);
 
     ldpp_dout(dpp, 10) << __func__ << "::STEP_REMOVE_DUPLICATES::started..." << dendl;
     uint32_t slab_count = 0;
@@ -2602,6 +2661,7 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 5) << __func__ << "::STEP_REMOVE_DUPLICATES::STOPPED\n" << dendl;
       return -ECANCELED;
     }
+
     ldpp_dout(dpp, 10) << __func__ << "::STEP_REMOVE_DUPLICATES::finished..." << dendl;
     // remove the special SLAB holding aggragted data
     remove_slabs(num_work_shards, md5_shard, slab_count);

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -2612,7 +2612,8 @@ namespace rgw::dedup {
     // Reset the counters that will be recalculated during STEP_READ_ATTRIBUTES step.
     // Note that dedup_bytes_estimate should not be reset, as it remains unmodified
     //      during that step.
-    uint64_t singleton_count = p_stats->big_objs_stat.singleton_count;
+    // Objects with singleton_count are cleared from the table after each step.
+    //      Keep the existing count and add to it new singleton (if created)
     uint64_t unique_count    = p_stats->big_objs_stat.unique_count;
     uint64_t duplicate_count = p_stats->big_objs_stat.duplicate_count;
     p_stats->big_objs_stat.unique_count = 0;
@@ -2641,7 +2642,6 @@ namespace rgw::dedup {
       // skip this step when no storage_class update !!
       ldpp_dout(dpp, 10) << __func__ <<"::no storage_class update, skip second call"
                          << " to p_table->count_duplicates()"<< dendl;
-      p_stats->big_objs_stat.singleton_count = singleton_count;
       p_stats->big_objs_stat.unique_count    = unique_count;
       p_stats->big_objs_stat.duplicate_count = duplicate_count;
     }

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -206,6 +206,7 @@ namespace rgw::dedup {
 
     int add_obj_attrs_to_record(disk_record_t         *p_rec,
                                 const rgw::sal::Attrs &attrs,
+                                const RGWObjManifest  &manifest,
                                 md5_stats_t           *p_stats); /* IN-OUT */
 
     int read_object_attribute(dedup_table_t    *p_table,

--- a/src/rgw/driver/rados/rgw_dedup_table.cc
+++ b/src/rgw/driver/rados/rgw_dedup_table.cc
@@ -316,12 +316,13 @@ namespace rgw::dedup {
         continue;
       }
 
-      if (hash_tab[tab_idx].val.not_enough_copies()) {
+      if (hash_tab[tab_idx].val.is_singleton()) {
         p_objs_stats->singleton_count++;
       }
-      else {
+      else if (hash_tab[tab_idx].val.get_count() > 1) {
         p_objs_stats->unique_count ++;
       }
+      // else -> this entry was removed after a change in placement
     }
   }
 

--- a/src/rgw/driver/rados/rgw_dedup_table.cc
+++ b/src/rgw/driver/rados/rgw_dedup_table.cc
@@ -16,6 +16,7 @@
 #include "include/ceph_assert.h"
 #include <cstring>
 #include <iostream>
+#include <algorithm>
 
 namespace rgw::dedup {
 
@@ -38,68 +39,108 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  void dedup_table_t::remove_singletons_and_redistribute_keys()
+  void dedup_table_t::reset_counters()
   {
     for (uint32_t tab_idx = 0; tab_idx < entries_count; tab_idx++) {
-      if (!hash_tab[tab_idx].val.is_occupied()) {
+      auto &val = hash_tab[tab_idx].val;
+      if (val.is_occupied()) {
+        // we no longer need the counter, reuse it to count actual dedup
+        val.reset_count();
+      }
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  void dedup_table_t::remove_singletons_and_redistribute_keys(const char* step,
+                                                              bool reset_count)
+  {
+    // stat counters
+    uint64_t redistributed_search_total = 0;
+    uint64_t redistributed_search_max = 0;
+    uint64_t redistributed_loopback = 0;
+    uint64_t redistributed_perfect = 0;
+    uint64_t redistributed_clear = 0, clear = 0;
+    uint64_t redistributed_not_needed = 0;
+
+    auto remove_entry = [this](uint32_t tab_idx) {
+      hash_tab[tab_idx].val.clear_flags();
+      occupied_count--;
+    };
+
+    for (uint32_t tab_idx = 0; tab_idx < entries_count; tab_idx++) {
+      auto &val = hash_tab[tab_idx].val;
+      if (!val.is_occupied()) {
         continue;
       }
 
-      if (hash_tab[tab_idx].val.is_singleton()) {
-        hash_tab[tab_idx].val.clear_flags();
-        redistributed_clear++;
+      if (val.not_enough_copies()) {
+        remove_entry(tab_idx);
+        clear++;
         continue;
       }
 
       const key_t &key = hash_tab[tab_idx].key;
-      // This is an approximation only since size is stored in 4KB resolution
-      uint64_t byte_size_approx = disk_blocks_to_byte_size(key.size_4k_units);
-      if (!dedupable_object(key.multipart_object(), min_obj_size_for_dedup, byte_size_approx)) {
-        hash_tab[tab_idx].val.clear_flags();
-        redistributed_clear++;
-        continue;
-      }
-
       uint32_t key_idx = key.hash() % entries_count;
+      // redistribute if key is not in direct hashing location
       if (key_idx != tab_idx) {
         uint64_t count = 1;
-        redistributed_count++;
         uint32_t idx = key_idx;
-        while (hash_tab[idx].val.is_occupied()   &&
-               !hash_tab[idx].val.is_singleton() &&
+        while (hash_tab[idx].val.is_occupied()        &&
+               !hash_tab[idx].val.not_enough_copies() &&
                (hash_tab[idx].key != key)) {
           count++;
           idx = (idx + 1) % entries_count;
         }
 
         if (idx != tab_idx) {
-          if (hash_tab[idx].val.is_occupied() && hash_tab[idx].val.is_singleton() ) {
-            redistributed_clear++;
-          }
           if (idx == key_idx) {
             redistributed_perfect++;
           }
+
+          if (hash_tab[idx].val.is_occupied()) {
+            ceph_assert(hash_tab[idx].key != key);
+            ceph_assert(hash_tab[idx].val.not_enough_copies());
+            remove_entry(idx);
+            redistributed_clear++;
+          }
+
           hash_tab[idx] = hash_tab[tab_idx];
+          // mark the old location as free
           hash_tab[tab_idx].val.clear_flags();
         }
         else {
+          // we are back where we started, there is no free entry between the
+          // perfect hashing and the allocated entry
           redistributed_loopback++;
         }
 
-        // we no longer need the counter, reuse it to count actual dedup
-        hash_tab[idx].val.reset_count();
         redistributed_search_max = std::max(redistributed_search_max, count);
         redistributed_search_total += count;
       }
       else {
-        // we no longer need the counter, reuse it to count actual dedup
-        hash_tab[tab_idx].val.reset_count();
         redistributed_not_needed++;
       }
     }
+
+    if (reset_count) {
+      reset_counters();
+    }
+    ldpp_dout(dpp, 10) << __func__ << "::" << step
+                       << "::redistributed_search_max=" << redistributed_search_max
+                       << "::redistributed_search_total=" << redistributed_search_total
+                       << (clear ? "::clear=" : "::") << clear
+                       << (redistributed_clear ? "::redistributed_clear=" : "::") << redistributed_clear
+                       << (redistributed_perfect ? "::redistributed_perfect=" : "::") << redistributed_perfect
+                       << (redistributed_not_needed ? "::redistributed_not_needed=" : "::") << redistributed_not_needed
+                       << (redistributed_loopback ? "::redistributed_loopback=" : "::") << redistributed_loopback
+                       << dendl;
   }
 
   //---------------------------------------------------------------------------
+  // find_entry() assumes that entries are not removed during operation
+  // remove_entry() is only called from remove_singletons_and_redistribute_keys()
+  //       doing a linear pass over the array.
+
   uint32_t dedup_table_t::find_entry(const key_t *p_key) const
   {
     uint32_t idx = p_key->hash() % entries_count;
@@ -113,34 +154,27 @@ namespace rgw::dedup {
 
   //---------------------------------------------------------------------------
   void dedup_table_t::inc_counters(const key_t *p_key,
-                                   dedup_stats_t *p_small_objs,
-                                   dedup_stats_t *p_big_objs,
+                                   dedup_stats_t *p_objs_stats,
                                    uint64_t *p_duplicate_head_bytes)
   {
     // This is an approximation only since size is stored in 4KB resolution
     uint64_t byte_size_approx = disk_blocks_to_byte_size(p_key->size_4k_units);
 
-    // skip small single part objects which we can't dedup
-    if (!dedupable_object(p_key->multipart_object(), min_obj_size_for_dedup, byte_size_approx)) {
-      p_small_objs->duplicate_count ++;
-      p_small_objs->dedup_bytes_estimate += byte_size_approx;
-      return;
-    }
-    else {
-      uint64_t dup_bytes_approx = calc_deduped_bytes(head_object_size,
-                                                     min_obj_size_for_dedup,
-                                                     max_obj_size_for_split,
-                                                     p_key->num_parts,
-                                                     byte_size_approx);
-      p_big_objs->duplicate_count ++;
-      p_big_objs->dedup_bytes_estimate += dup_bytes_approx;
+    uint64_t dup_bytes_approx = calc_deduped_bytes(head_object_size,
+                                                   min_obj_size_for_dedup,
+                                                   max_obj_size_for_split,
+                                                   p_key->num_parts,
+                                                   byte_size_approx);
+    p_objs_stats->duplicate_count ++;
+    p_objs_stats->dedup_bytes_estimate += dup_bytes_approx;
 
-      // object smaller than max_obj_size_for_split will split their head
-      // and won't dup it
-      if (!p_key->multipart_object() && byte_size_approx > max_obj_size_for_split) {
-        // single part objects duplicate the head object when dedup is used
-        *p_duplicate_head_bytes += head_object_size;
-      }
+    // object smaller than max_obj_size_for_split will split their head
+    // and won't dup it
+    if (!p_key->multipart_object() &&
+        (byte_size_approx > max_obj_size_for_split) &&
+        p_duplicate_head_bytes ) {
+      // single part objects duplicate the head object when dedup is used
+      *p_duplicate_head_bytes += head_object_size;
     }
   }
 
@@ -149,53 +183,61 @@ namespace rgw::dedup {
                                disk_block_id_t block_id,
                                record_id_t rec_id,
                                bool shared_manifest,
-                               dedup_stats_t *p_small_objs,
-                               dedup_stats_t *p_big_objs,
+                               dedup_stats_t *p_objs_stats,
                                uint64_t *p_duplicate_head_bytes)
   {
+    // When the table is full, we will need to perform a full table search to find
+    // an empty spot.
+    // To address this, we have allocated enough headroom by designing the system
+    // to be 10% larger than required.
+    if (occupied_count >= entries_count) {
+      return -EOVERFLOW;
+    }
+
     value_t new_val(block_id, rec_id, shared_manifest);
     uint32_t idx = find_entry(p_key);
     value_t &val = hash_tab[idx].val;
     if (!val.is_occupied()) {
-      if (occupied_count < entries_count) {
-        occupied_count++;
-      }
-      else {
-        return -EOVERFLOW;
-      }
+      occupied_count++;
+      ceph_assert(occupied_count <= entries_count);
 
       hash_tab[idx].key = *p_key;
       hash_tab[idx].val = new_val;
-      ldpp_dout(dpp, 20) << __func__ << "::add new entry" << dendl;
+      ldpp_dout(dpp, 20) << __func__ << "::new entry, idx=" << idx << dendl;
       ceph_assert(val.count == 1);
     }
     else {
       ceph_assert(hash_tab[idx].key == *p_key);
+
       if (val.count <= MAX_COPIES_PER_OBJ) {
-        inc_counters(p_key, p_small_objs, p_big_objs, p_duplicate_head_bytes);
-      }
-      if (val.count < std::numeric_limits<std::uint16_t>::max()) {
         val.count ++;
+        if(p_objs_stats) {
+          ldpp_dout(dpp, 20) << __func__ << "::entry exists, idx=" << idx
+                             << "::count=" << val.count << dendl;
+          inc_counters(p_key, p_objs_stats, p_duplicate_head_bytes);
+        }
       }
+
       if (!val.has_shared_manifest() && shared_manifest) {
         // replace value!
         ldpp_dout(dpp, 20) << __func__ << "::Replace with shared_manifest::["
                            << val.block_idx << "/" << (int)val.rec_id << "] -> ["
                            << block_id << "/" << (int)rec_id << "]" << dendl;
         new_val.count = val.count;
-        hash_tab[idx].val = new_val;
+        val = new_val;
       }
       ceph_assert(val.count > 1);
     }
-    ldpp_dout(dpp, 20) << __func__ << "::COUNT="<< val.count << dendl;
+    ldpp_dout(dpp, 20) << __func__ << "::IDX=" << idx << "::COUNT="<< val.count << dendl;
     return 0;
   }
 
   //---------------------------------------------------------------------------
-  void dedup_table_t::update_entry(key_t *p_key,
-                                   disk_block_id_t block_id,
-                                   record_id_t rec_id,
-                                   bool shared_manifest)
+  uint32_t dedup_table_t::update_entry(key_t *p_key,
+                                       disk_block_id_t block_id,
+                                       record_id_t rec_id,
+                                       bool shared_manifest,
+                                       bool inc_counters)
   {
     uint32_t idx = find_entry(p_key);
     ceph_assert(hash_tab[idx].key == *p_key);
@@ -216,6 +258,15 @@ namespace rgw::dedup {
 
       val = new_val;
     }
+    // caller already checks for MAX_COPIES_PER_OBJ, but better safe...
+    if (inc_counters && (val.count <= MAX_COPIES_PER_OBJ)) {
+      val.count ++;
+    }
+    ldpp_dout(dpp, 20) << __func__ << "::count=" << val.get_count()
+                       << "::shared_manifest=" << val.has_shared_manifest()
+                       << "::block_id=" << val.get_src_block_id() << dendl;
+
+    return val.count;
   }
 
   //---------------------------------------------------------------------------
@@ -243,34 +294,12 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  int dedup_table_t::inc_count(const key_t *p_key,
-                               disk_block_id_t block_id,
-                               record_id_t rec_id)
-  {
-    uint32_t idx = find_entry(p_key);
-    value_t &val = hash_tab[idx].val;
-    if (val.is_occupied()) {
-      if (val.block_idx == block_id && val.rec_id == rec_id) {
-        val.inc_count();
-        return 0;
-      }
-      else {
-        ldpp_dout(dpp, 5) << __func__ << "::ERR Failed Ncopies bloc/rec" << dendl;
-      }
-    }
-    else {
-      ldpp_dout(dpp, 5) << __func__ << "::ERR Failed Ncopies key" << dendl;
-    }
-
-    return -ENOENT;
-  }
-
-  //---------------------------------------------------------------------------
   int dedup_table_t::get_val(const key_t *p_key, struct value_t *p_val /*OUT*/)
   {
     uint32_t idx = find_entry(p_key);
     const value_t &val = hash_tab[idx].val;
     if (val.is_occupied()) {
+      ldpp_dout(dpp, 20) << __func__ << "::count=" << val.get_count() << dendl;
       *p_val = val;
       return 0;
     }
@@ -280,35 +309,18 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  void dedup_table_t::count_duplicates(dedup_stats_t *p_small_objs,
-                                       dedup_stats_t *p_big_objs)
+  void dedup_table_t::count_duplicates(dedup_stats_t *p_objs_stats)
   {
     for (uint32_t tab_idx = 0; tab_idx < entries_count; tab_idx++) {
       if (!hash_tab[tab_idx].val.is_occupied()) {
         continue;
       }
 
-      const key_t &key = hash_tab[tab_idx].key;
-      // This is an approximation only since size is stored in 4KB resolution
-      uint64_t byte_size_approx = disk_blocks_to_byte_size(key.size_4k_units);
-
-      // skip small single part objects which we can't dedup
-      if (!dedupable_object(key.multipart_object(), min_obj_size_for_dedup, byte_size_approx)) {
-        if (hash_tab[tab_idx].val.is_singleton()) {
-          p_small_objs->singleton_count++;
-        }
-        else {
-          p_small_objs->unique_count ++;
-        }
+      if (hash_tab[tab_idx].val.not_enough_copies()) {
+        p_objs_stats->singleton_count++;
       }
       else {
-        if (hash_tab[tab_idx].val.is_singleton()) {
-          p_big_objs->singleton_count++;
-        }
-        else {
-          ceph_assert(hash_tab[tab_idx].val.count > 1);
-          p_big_objs->unique_count ++;
-        }
+        p_objs_stats->unique_count ++;
       }
     }
   }

--- a/src/rgw/driver/rados/rgw_dedup_table.h
+++ b/src/rgw/driver/rados/rgw_dedup_table.h
@@ -105,9 +105,9 @@ namespace rgw::dedup {
         }
       }
       inline bool has_shared_manifest() const {return flags.has_shared_manifest(); }
-      inline uint16_t        get_count() { return this->count; }
-      inline disk_block_id_t get_src_block_id() { return this->block_idx; }
-      inline record_id_t     get_src_rec_id() { return this->rec_id; }
+      inline uint16_t        get_count() const { return this->count; }
+      inline disk_block_id_t get_src_block_id() const { return this->block_idx; }
+      inline record_id_t     get_src_rec_id() const { return this->rec_id; }
       inline bool has_valid_hash() const {return flags.has_valid_hash(); }
     private:
       inline void set_shared_manifest_src() { this->flags.set_shared_manifest(); }
@@ -116,6 +116,7 @@ namespace rgw::dedup {
       inline void clear_flags() { flags.clear(); }
       inline void set_has_valid_hash_src() { this->flags.set_has_valid_hash(); }
       inline bool is_singleton() const { return (count == 1); }
+      inline bool not_enough_copies() const { return (count <= 1); }
       inline bool is_occupied() const { return flags.is_occupied(); }
       inline void set_occupied() { this->flags.set_occupied();  }
       inline void clear_occupied() { this->flags.clear_occupied(); }
@@ -138,16 +139,16 @@ namespace rgw::dedup {
                   disk_block_id_t block_id,
                   record_id_t rec_id,
                   bool shared_manifest,
-                  dedup_stats_t *p_small_objs_stat,
-                  dedup_stats_t *p_big_objs_stat,
+                  dedup_stats_t *p_objs_stat,
                   uint64_t *p_duplicate_head_bytes);
 
-    void update_entry(key_t *p_key, disk_block_id_t block_id, record_id_t rec_id,
-                      bool shared_manifest);
+    uint32_t update_entry(key_t *p_key,
+                          disk_block_id_t block_id,
+                          record_id_t rec_id,
+                          bool shared_manifest,
+                          bool inc_counters);
 
     int  get_val(const key_t *p_key, struct value_t *p_val /*OUT*/);
-
-    int inc_count(const key_t *p_key, disk_block_id_t block_id, record_id_t rec_id);
 
     int set_shared_manifest_src_mode(const key_t *p_key,
                                      disk_block_id_t block_id,
@@ -159,10 +160,8 @@ namespace rgw::dedup {
                      bool set_shared_manifest_src,
                      bool set_has_valid_hash_src);
 
-    void count_duplicates(dedup_stats_t *p_small_objs_stat,
-                          dedup_stats_t *p_big_objs_stat);
-
-    void remove_singletons_and_redistribute_keys();
+    void count_duplicates(dedup_stats_t *p_objs_stat);
+    void remove_singletons_and_redistribute_keys(const char* step, bool reset_count);
   private:
     // 32 Bytes unified entries
     struct table_entry_t {
@@ -172,9 +171,9 @@ namespace rgw::dedup {
     static_assert(sizeof(table_entry_t) == 32);
 
     uint32_t find_entry(const key_t *p_key) const;
+    void     reset_counters();
     void     inc_counters(const key_t *p_key,
-                          dedup_stats_t *p_small_objs,
-                          dedup_stats_t *p_big_objs,
+                          dedup_stats_t *p_objs_stat,
                           uint64_t *p_duplicate_head_bytes);
 
     uint32_t       entries_count = 0;
@@ -184,14 +183,6 @@ namespace rgw::dedup {
     uint32_t       max_obj_size_for_split;
     table_entry_t *hash_tab = nullptr;
 
-    // stat counters
-    uint64_t redistributed_count = 0;
-    uint64_t redistributed_search_total = 0;
-    uint64_t redistributed_search_max = 0;
-    uint64_t redistributed_loopback = 0;
-    uint64_t redistributed_perfect = 0;
-    uint64_t redistributed_clear = 0;
-    uint64_t redistributed_not_needed = 0;
     const DoutPrefixProvider* dpp;
   };
 

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -382,8 +382,6 @@ namespace rgw::dedup {
     this->ingress_corrupted_etag += other.ingress_corrupted_etag;
     this->ingress_skip_too_small_bytes += other.ingress_skip_too_small_bytes;
     this->ingress_skip_too_small += other.ingress_skip_too_small;
-    this->ingress_skip_too_small_64KB_bytes += other.ingress_skip_too_small_64KB_bytes;
-    this->ingress_skip_too_small_64KB += other.ingress_skip_too_small_64KB;
 
     return *this;
   }
@@ -440,13 +438,6 @@ namespace rgw::dedup {
                          this->ingress_skip_too_small);
         f->dump_unsigned("Ingress skip: too small bytes",
                          this->ingress_skip_too_small_bytes);
-
-        if(this->ingress_skip_too_small_64KB) {
-          f->dump_unsigned("Ingress skip: 64KB<=size<=4MB Obj",
-                           this->ingress_skip_too_small_64KB);
-          f->dump_unsigned("Ingress skip: 64KB<=size<=4MB Bytes",
-                           this->ingress_skip_too_small_64KB_bytes);
-        }
       }
     }
 
@@ -499,9 +490,6 @@ namespace rgw::dedup {
     encode(w.ingress_skip_too_small_bytes, bl);
     encode(w.ingress_skip_too_small, bl);
 
-    encode(w.ingress_skip_too_small_64KB_bytes, bl);
-    encode(w.ingress_skip_too_small_64KB, bl);
-
     encode(w.duration, bl);
     ENCODE_FINISH(bl);
   }
@@ -528,8 +516,6 @@ namespace rgw::dedup {
     decode(w.ingress_corrupted_etag, bl);
     decode(w.ingress_skip_too_small_bytes, bl);
     decode(w.ingress_skip_too_small, bl);
-    decode(w.ingress_skip_too_small_64KB_bytes, bl);
-    decode(w.ingress_skip_too_small_64KB, bl);
 
     decode(w.duration, bl);
     DECODE_FINISH(bl);
@@ -538,7 +524,6 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   md5_stats_t& md5_stats_t::operator+=(const md5_stats_t& other)
   {
-    this->small_objs_stat               += other.small_objs_stat;
     this->big_objs_stat                 += other.big_objs_stat;
     this->ingress_slabs                 += other.ingress_slabs;
     this->ingress_failed_load_bucket    += other.ingress_failed_load_bucket;
@@ -566,7 +551,7 @@ namespace rgw::dedup {
     this->failed_rec_load         += other.failed_rec_load;
     this->failed_block_load       += other.failed_block_load;
 
-    this->different_storage_class       += other.different_storage_class;
+    this->non_default_placement         += other.non_default_placement;
     this->invalid_hash_no_split_head    += other.invalid_hash_no_split_head;
     this->invalid_storage_class_mapping += other.invalid_storage_class_mapping;
     this->singleton_after_purge         += other.singleton_after_purge;
@@ -640,15 +625,9 @@ namespace rgw::dedup {
     }
 
     // Potential Dedup Section:
-    // What could be gained by allowing dedup for smaller objects (64KB-4MB)
     // Space wasted because of duplicated head-object (4MB)
     {
       Formatter::ObjectSection potential(*f, "Potential Dedup");
-      const dedup_stats_t &ds = this->small_objs_stat;
-      f->dump_unsigned("Singleton Obj (64KB-4MB)", ds.singleton_count);
-      f->dump_unsigned("Unique Obj (64KB-4MB)", ds.unique_count);
-      f->dump_unsigned("Duplicate Obj (64KB-4MB)", ds.duplicate_count);
-      f->dump_unsigned("Dedup Bytes Estimate (64KB-4MB)", ds.dedup_bytes_estimate);
       f->dump_unsigned("Duplicated Head Bytes Estimate",
                        this->dup_head_bytes_estimate);
       f->dump_unsigned("Duplicated Head Bytes", this->dup_head_bytes);
@@ -667,6 +646,11 @@ namespace rgw::dedup {
       }
       if (this->failed_map_overflow) {
         f->dump_unsigned("Failed Remap Overflow", this->failed_map_overflow);
+      }
+
+      if (this->non_default_placement) {
+        f->dump_unsigned("non_default_placement",
+                         this->non_default_placement);
       }
 
       f->dump_unsigned("Valid HASH attrs", this->valid_hash_attrs);
@@ -782,10 +766,6 @@ namespace rgw::dedup {
       if (this->size_mismatch) {
         f->dump_unsigned("Size mismatch SRC/TGT", this->size_mismatch);
       }
-      if (this->different_storage_class) {
-        f->dump_unsigned("different_storage_class",
-                         this->different_storage_class);
-      }
       if (this->invalid_hash_no_split_head) {
         f->dump_unsigned("Failed rec has invalid hash w/o split-head ",
                          this->invalid_hash_no_split_head);
@@ -814,7 +794,6 @@ namespace rgw::dedup {
   {
     ENCODE_START(1, 1, bl);
 
-    encode(m.small_objs_stat, bl);
     encode(m.big_objs_stat, bl);
     encode(m.ingress_slabs, bl);
     encode(m.ingress_failed_load_bucket, bl);
@@ -842,7 +821,7 @@ namespace rgw::dedup {
     encode(m.failed_rec_load, bl);
     encode(m.failed_block_load, bl);
 
-    encode(m.different_storage_class, bl);
+    encode(m.non_default_placement, bl);
     encode(m.invalid_hash_no_split_head, bl);
     encode(m.invalid_storage_class_mapping, bl);
     encode(m.singleton_after_purge, bl);
@@ -885,7 +864,6 @@ namespace rgw::dedup {
   void decode(md5_stats_t& m, ceph::bufferlist::const_iterator& bl)
   {
     DECODE_START(1, bl);
-    decode(m.small_objs_stat, bl);
     decode(m.big_objs_stat, bl);
     decode(m.ingress_slabs, bl);
     decode(m.ingress_failed_load_bucket, bl);
@@ -913,7 +891,7 @@ namespace rgw::dedup {
     decode(m.failed_rec_load, bl);
     decode(m.failed_block_load, bl);
 
-    decode(m.different_storage_class, bl);
+    decode(m.non_default_placement, bl);
     decode(m.invalid_hash_no_split_head, bl);
     decode(m.invalid_storage_class_mapping, bl);
     decode(m.singleton_after_purge, bl);

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -159,6 +159,12 @@ namespace rgw::dedup {
 
   struct dedup_stats_t {
     dedup_stats_t& operator+=(const dedup_stats_t& other);
+    void clear() {
+      singleton_count = 0;
+      unique_count = 0;
+      duplicate_count = 0;
+      dedup_bytes_estimate = 0;
+    }
 
     uint64_t singleton_count = 0;
     uint64_t unique_count = 0;
@@ -198,9 +204,6 @@ namespace rgw::dedup {
     uint64_t ingress_skip_too_small_bytes = 0;
     uint64_t ingress_skip_too_small = 0;
 
-    uint64_t ingress_skip_too_small_64KB_bytes = 0;
-    uint64_t ingress_skip_too_small_64KB = 0;
-
     utime_t  duration = {0, 0};
   };
   std::ostream& operator<<(std::ostream &out, const worker_stats_t &s);
@@ -212,7 +215,6 @@ namespace rgw::dedup {
     md5_stats_t& operator +=(const md5_stats_t& other);
     void dump(Formatter *f) const;
 
-    dedup_stats_t small_objs_stat;
     dedup_stats_t big_objs_stat;
     uint64_t ingress_slabs = 0;
     uint64_t ingress_failed_load_bucket = 0;
@@ -240,7 +242,7 @@ namespace rgw::dedup {
     uint64_t failed_rec_load = 0;
     uint64_t failed_block_load = 0;
 
-    uint64_t different_storage_class = 0;
+    uint64_t non_default_placement = 0;
     uint64_t invalid_hash_no_split_head = 0;
     uint64_t invalid_storage_class_mapping = 0;
     uint64_t singleton_after_purge = 0;

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -9,6 +9,8 @@ import hashlib
 from multiprocessing import Process
 import filecmp
 import os
+import shlex
+import signal
 import string
 import shutil
 import pytest
@@ -16,6 +18,7 @@ import json
 from collections import namedtuple
 import boto3
 from boto3.s3.transfer import TransferConfig
+from typing import List, Tuple
 from dataclasses import dataclass
 
 from . import(
@@ -51,10 +54,6 @@ class Dedup_Stats:
     duplicate_obj : int = 0
     deduped_obj_bytes : int = 0
     non_default_storage_class_objs_bytes : int = 0
-    potential_singleton_obj : int = 0
-    potential_unique_obj : int = 0
-    potential_duplicate_obj : int = 0
-    potential_dedup_space : int = 0
 
 @dataclass
 class Dedup_Ratio:
@@ -92,6 +91,12 @@ def admin(args, **kwargs):
 def rados(args, **kwargs):
     """ rados command """
     cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_rados', 'noname'] + args
+    return bash(cmd, **kwargs)
+
+#-----------------------------------------------
+def ceph(args, **kwargs):
+    """ ceph command """
+    cmd = [test_path + 'test-rgw-call.sh', 'call_ceph', 'noname'] + args
     return bash(cmd, **kwargs)
 
 #-----------------------------------------------
@@ -280,7 +285,6 @@ def create_buckets(conn, max_copies_count):
 OUT_DIR="/tmp/dedup/"
 KB=(1024)
 MB=(1024*KB)
-POTENTIAL_OBJ_SIZE=(64*KB)
 DEDUP_MIN_OBJ_SIZE=(64*KB)
 SPLIT_HEAD_SIZE=(4*MB)
 RADOS_OBJ_SIZE=(4*MB)
@@ -317,7 +321,7 @@ def write_random(files, size, min_copies_count=1, max_copies_count=4):
     copies_count=random.randint(min_copies_count, max_copies_count)
     files.append((filename, size, copies_count))
     write_file(filename, size)
-
+    return copies_count
 
 #-------------------------------------------------------------------------------
 def gen_files_fixed_copies(files, count, size, copies_count):
@@ -354,6 +358,7 @@ def gen_files_in_range(files, count, min_size, max_size, alignment=RADOS_OBJ_SIZ
 
     size_range = max_size - min_size
     size=0
+    num_files_with_dups=0
     for i in range(0, count):
         size = min_size + random.randint(1, size_range-1)
         if size == 0:
@@ -370,8 +375,12 @@ def gen_files_in_range(files, count, min_size, max_size, alignment=RADOS_OBJ_SIZ
         assert(size_aligned)
         # force dedup by setting min_copies_count to 2
         write_random(files, size_aligned, 2, 3)
-        write_random(files, size, 1, 3)
+        num_files_with_dups += 1
+        copies_count=write_random(files, size, 1, 3)
+        if copies_count > 1:
+            num_files_with_dups += 1
 
+    return num_files_with_dups
 
 #-------------------------------------------------------------------------------
 def gen_files(files, start_size, factor, max_copies_count=4):
@@ -680,15 +689,6 @@ def calc_expected_stats(dedup_stats, obj_size, num_copies, config):
     if on_disk_byte_size < DEDUP_MIN_OBJ_SIZE and threshold > DEDUP_MIN_OBJ_SIZE:
         dedup_stats.skip_too_small += num_copies
         dedup_stats.skip_too_small_bytes += (on_disk_byte_size * num_copies)
-
-        if on_disk_byte_size >= POTENTIAL_OBJ_SIZE:
-            if num_copies == 1:
-                dedup_stats.potential_singleton_obj += 1
-            else:
-                dedup_stats.potential_unique_obj += 1
-                dedup_stats.potential_duplicate_obj += dups_count
-                dedup_stats.potential_dedup_space += (on_disk_byte_size * dups_count)
-
         return
 
     dedup_stats.total_processed_objects += num_copies
@@ -1399,12 +1399,6 @@ def read_dedup_stats(dry_run):
         dedup_stats.duplicate_obj = main['Duplicate Obj']
         dedup_stats.dedup_bytes_estimate = main['Dedup Bytes Estimate']
 
-        potential = md5_stats['Potential Dedup']
-        dedup_stats.potential_singleton_obj = potential['Singleton Obj (64KB-4MB)']
-        dedup_stats.potential_unique_obj = potential['Unique Obj (64KB-4MB)']
-        dedup_stats.potential_duplicate_obj = potential['Duplicate Obj (64KB-4MB)']
-        dedup_stats.potential_dedup_space = potential['Dedup Bytes Estimate (64KB-4MB)']
-
     dedup_work_was_completed=jstats['completed']
     if dedup_work_was_completed:
         dedup_ratio_estimate=read_dedup_ratio(jstats, 'dedup_ratio_estimate')
@@ -1420,7 +1414,6 @@ def set_bucket_index_throttling(limit):
     cmd = ['dedup', 'throttle', '--max-bucket-index-ops', str(limit)]
     result = admin(cmd)
     assert result[1] == 0
-    log.debug(result[0])
 
 #-------------------------------------------------------------------------------
 def exec_dedup_internal(expected_dedup_stats, dry_run, max_dedup_time):
@@ -1486,11 +1479,6 @@ def exec_dedup(expected_dedup_stats, dry_run, verify_stats=True, post_dedup_size
     if verify_stats == False:
         return ret
 
-    if dedup_stats.potential_unique_obj or expected_dedup_stats.potential_unique_obj:
-        log.debug("potential_unique_obj= %d / %d ", dedup_stats.potential_unique_obj,
-                  expected_dedup_stats.potential_unique_obj)
-
-
     #dedup_stats.set_hash = dedup_stats.invalid_hash
     if dedup_stats != expected_dedup_stats:
         log.debug("==================================================")
@@ -1512,14 +1500,6 @@ def prepare_test():
         assert(0)
 
     os.mkdir(OUT_DIR)
-
-#-------------------------------------------------------------------------------
-def copy_potential_stats(new_dedup_stats, dedup_stats):
-    new_dedup_stats.potential_singleton_obj = dedup_stats.potential_singleton_obj
-    new_dedup_stats.potential_unique_obj    = dedup_stats.potential_unique_obj
-    new_dedup_stats.potential_duplicate_obj = dedup_stats.potential_duplicate_obj
-    new_dedup_stats.potential_dedup_space   = dedup_stats.potential_dedup_space
-
 
 #-------------------------------------------------------------------------------
 def small_single_part_objs_dedup(conn, bucket_name, dry_run):
@@ -1548,7 +1528,7 @@ def small_single_part_objs_dedup(conn, bucket_name, dry_run):
         # expected stats for small objects - all zeros except for skip_too_small
         small_objs_dedup_stats = Dedup_Stats()
         #small_objs_dedup_stats.loaded_objects=dedup_stats.loaded_objects
-        copy_potential_stats(small_objs_dedup_stats, dedup_stats)
+
         small_objs_dedup_stats.size_before_dedup = dedup_stats.size_before_dedup
         small_objs_dedup_stats.skip_too_small_bytes=dedup_stats.size_before_dedup
         small_objs_dedup_stats.skip_too_small = s3_objects_total
@@ -2047,12 +2027,14 @@ def test_dedup_etag_corruption():
         key=gen_object_name(filename, 0)
 
         for corruption in CORRUPTIONS:
+            log.debug("corruption=%s", corruption)
             if corruption != "no corruption":
                 corrupted=corrupt_etag(key, corruption, expected_dedup_stats)
                 # no dedup will happen because of the inserted corruption
                 expected_dedup_stats.deduped_obj=0
                 expected_dedup_stats.deduped_obj_bytes=0
                 expected_dedup_stats.set_shared_manifest_src=0
+                expected_dedup_stats.skip_src_record=0
 
             dry_run=False
             ret=exec_dedup(expected_dedup_stats, dry_run)
@@ -2416,7 +2398,7 @@ def test_dedup_small_with_tenants():
         # expected stats for small objects - all zeros except for skip_too_small
         small_objs_dedup_stats = Dedup_Stats()
         #small_objs_dedup_stats.loaded_objects=dedup_stats.loaded_objects
-        copy_potential_stats(small_objs_dedup_stats, dedup_stats)
+
         small_objs_dedup_stats.size_before_dedup=dedup_stats.size_before_dedup
         small_objs_dedup_stats.skip_too_small_bytes=dedup_stats.size_before_dedup
         small_objs_dedup_stats.skip_too_small=s3_objects_total
@@ -2463,7 +2445,8 @@ def test_dedup_inc_0_with_tenants():
 
         dedup_stats2 = dedup_stats
         dedup_stats2.skip_shared_manifest=dedup_stats.deduped_obj
-        dedup_stats2.skip_src_record=dedup_stats.set_shared_manifest_src
+        #dedup_stats2.skip_src_record=dedup_stats.set_shared_manifest_src
+        dedup_stats2.skip_src_record=0
         dedup_stats2.set_shared_manifest_src=0
         dedup_stats2.deduped_obj=0
         dedup_stats2.deduped_obj_bytes=0
@@ -2489,7 +2472,7 @@ def test_dedup_inc_0_with_tenants():
 # 3) The stats-counters should show the same dedup ratio, but no change
 #    should be made to the system
 @pytest.mark.basic_test
-def test_dedup_inc_0():
+def test_dedup_inc_0_no_tenants():
     if full_dedup_is_disabled():
         return
 
@@ -2512,7 +2495,7 @@ def test_dedup_inc_0():
 
         dedup_stats2 = dedup_stats
         dedup_stats2.skip_shared_manifest=dedup_stats.deduped_obj
-        dedup_stats2.skip_src_record=dedup_stats.set_shared_manifest_src
+        dedup_stats2.skip_src_record=0
         dedup_stats2.set_shared_manifest_src=0
         dedup_stats2.deduped_obj=0
         dedup_stats2.deduped_obj_bytes=0
@@ -2561,6 +2544,7 @@ def test_dedup_inc_1_with_tenants():
         # upload more copies of the same objects
         indices=[]
         files_combined=[]
+        num_obj_with_new_dups=0
         for f in files:
             filename=f[0]
             obj_size=f[1]
@@ -2568,6 +2552,9 @@ def test_dedup_inc_1_with_tenants():
             # indices holds the start index of the new copies
             indices.append(num_copies_base)
             num_copies_to_add=random.randint(0, 2)
+            if num_copies_to_add:
+                num_obj_with_new_dups += 1
+
             num_copies_combined=num_copies_to_add+num_copies_base
             files_combined.append((filename, obj_size, num_copies_combined))
 
@@ -2576,8 +2563,7 @@ def test_dedup_inc_1_with_tenants():
         stats_combined=ret[1]
 
         stats_combined.skip_shared_manifest = stats_base.deduped_obj
-        stats_combined.skip_src_record     -= stats_base.skip_src_record
-        stats_combined.skip_src_record     += stats_base.set_shared_manifest_src
+        stats_combined.skip_src_record     = num_obj_with_new_dups
 
         stats_combined.set_shared_manifest_src -= stats_base.set_shared_manifest_src
         stats_combined.deduped_obj         -= stats_base.deduped_obj
@@ -2625,6 +2611,7 @@ def test_dedup_inc_1():
         # upload more copies of the same objects
         indices=[]
         files_combined=[]
+        num_obj_with_new_dups=0
         for f in files:
             filename=f[0]
             obj_size=f[1]
@@ -2632,6 +2619,9 @@ def test_dedup_inc_1():
             # indices holds the start index of the new copies
             indices.append(num_copies_base)
             num_copies_to_add=random.randint(0, 2)
+            if num_copies_to_add:
+                num_obj_with_new_dups += 1
+
             num_copies_combined=num_copies_to_add+num_copies_base
             files_combined.append((filename, obj_size, num_copies_combined))
 
@@ -2640,8 +2630,7 @@ def test_dedup_inc_1():
         expected_results = ret[0]
         stats_combined = ret[1]
         stats_combined.skip_shared_manifest = stats_base.deduped_obj
-        stats_combined.skip_src_record     -= stats_base.skip_src_record
-        stats_combined.skip_src_record     += stats_base.set_shared_manifest_src
+        stats_combined.skip_src_record     = num_obj_with_new_dups
 
         stats_combined.set_shared_manifest_src -= stats_base.set_shared_manifest_src
         stats_combined.deduped_obj         -= stats_base.deduped_obj
@@ -2693,6 +2682,7 @@ def test_dedup_inc_2_with_tenants():
         # upload more copies of the same files
         indices=[]
         files_combined=[]
+        num_obj_with_new_dups=0
         for f in files:
             filename=f[0]
             obj_size=f[1]
@@ -2700,12 +2690,16 @@ def test_dedup_inc_2_with_tenants():
             # indices holds the start index of the new copies
             indices.append(num_copies_base)
             num_copies_inc=random.randint(0, 2)
+            if num_copies_inc:
+                num_obj_with_new_dups += 1
+
             num_copies_combined=num_copies_inc+num_copies_base
             files_combined.append((filename, obj_size, num_copies_combined))
 
         # add new files
         num_files_new = 13
-        gen_files_in_range(files_combined, num_files_new, 2*MB, 32*MB)
+        num_files_with_dups = gen_files_in_range(files_combined, num_files_new, 2*MB, 32*MB)
+        num_obj_with_new_dups += num_files_with_dups
         pad_count = len(files_combined) - len(files)
         for i in range(0, pad_count):
             indices.append(0)
@@ -2715,8 +2709,7 @@ def test_dedup_inc_2_with_tenants():
         expected_results = ret[0]
         stats_combined = ret[1]
         stats_combined.skip_shared_manifest = stats_base.deduped_obj
-        stats_combined.skip_src_record     -= stats_base.skip_src_record
-        stats_combined.skip_src_record     += stats_base.set_shared_manifest_src
+        stats_combined.skip_src_record      = num_obj_with_new_dups
 
         stats_combined.set_shared_manifest_src -= stats_base.set_shared_manifest_src
         stats_combined.deduped_obj         -= stats_base.deduped_obj
@@ -2765,18 +2758,23 @@ def test_dedup_inc_2():
         # upload more copies of the same files
         indices=[]
         files_combined=[]
+        num_obj_with_new_dups=0
         for f in files:
             filename=f[0]
             obj_size=f[1]
             num_copies_base=f[2]
             indices.append(num_copies_base)
             num_copies_inc=random.randint(0, 2)
+            if num_copies_inc:
+                num_obj_with_new_dups += 1
+
             num_copies_combined=num_copies_inc+num_copies_base
             files_combined.append((filename, obj_size, num_copies_combined))
 
         # add new files
         num_files_new = 13
-        gen_files_in_range(files_combined, num_files_new, 2*MB, 32*MB)
+        num_files_with_dups = gen_files_in_range(files_combined, num_files_new, 2*MB, 32*MB)
+        num_obj_with_new_dups += num_files_with_dups
         pad_count = len(files_combined) - len(files)
         for i in range(0, pad_count):
             indices.append(0)
@@ -2787,8 +2785,7 @@ def test_dedup_inc_2():
         expected_results = ret[0]
         stats_combined = ret[1]
         stats_combined.skip_shared_manifest = stats_base.deduped_obj
-        stats_combined.skip_src_record     -= stats_base.skip_src_record
-        stats_combined.skip_src_record     += stats_base.set_shared_manifest_src
+        stats_combined.skip_src_record      = num_obj_with_new_dups
 
         stats_combined.set_shared_manifest_src -= stats_base.set_shared_manifest_src
         stats_combined.deduped_obj         -= stats_base.deduped_obj
@@ -2892,7 +2889,7 @@ def test_dedup_inc_with_remove_multi_tenants():
         dedup_stats.deduped_obj=0
         dedup_stats.deduped_obj_bytes=0
 
-        dedup_stats.skip_src_record=src_record
+        dedup_stats.skip_src_record=0
         dedup_stats.skip_shared_manifest=shared_manifest
         dedup_stats.valid_hash=valid_hash
         dedup_stats.invalid_hash=0
@@ -2993,7 +2990,7 @@ def test_dedup_inc_with_remove():
         dedup_stats.set_shared_manifest_src=0
         dedup_stats.deduped_obj=0
         dedup_stats.deduped_obj_bytes=0
-        dedup_stats.skip_src_record=src_record
+        dedup_stats.skip_src_record=0
         dedup_stats.skip_shared_manifest=shared_manifest
         dedup_stats.valid_hash=valid_hash
         dedup_stats.invalid_hash=0
@@ -3149,29 +3146,11 @@ def test_dedup_large_scale_with_tenants():
     prepare_test()
     max_copies_count=3
     num_threads=16
-    num_files=8*1024
+    num_files=10*1024
     size=1*KB
     files=[]
     config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
     log.debug("test_dedup_large_scale_with_tenants: connect to AWS ...")
-    gen_files_fixed_size(files, num_files, size, max_copies_count)
-    threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
-
-
-#-------------------------------------------------------------------------------
-@pytest.mark.basic_test
-def test_dedup_large_scale():
-    if full_dedup_is_disabled():
-        return
-
-    prepare_test()
-    max_copies_count=3
-    num_threads=16
-    num_files=8*1024
-    size=1*KB
-    files=[]
-    config=TransferConfig(multipart_threshold=size, multipart_chunksize=1*MB)
-    log.debug("test_dedup_dry_large_scale_with_tenants: connect to AWS ...")
     gen_files_fixed_size(files, num_files, size, max_copies_count)
     threads_dedup_basic_with_tenants_common(files, num_threads, config, False)
 
@@ -3205,6 +3184,7 @@ def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
     # upload more copies of the same files
     indices=[]
     files_combined=[]
+    num_obj_with_new_dups=0
     for f in files:
         filename=f[0]
         obj_size=f[1]
@@ -3212,12 +3192,16 @@ def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
         # indices holds the start index of the new copies
         indices.append(num_copies_base)
         num_copies_inc=random.randint(0, 2)
+        if num_copies_inc:
+            num_obj_with_new_dups += 1
+
         num_copies_combined=num_copies_inc+num_copies_base
         files_combined.append((filename, obj_size, num_copies_combined))
 
     # add new files
     num_files_new = 11
-    gen_files_in_range(files_combined, num_files_new, 1*MB, 32*MB)
+    num_files_with_dups = gen_files_in_range(files_combined, num_files_new, 1*MB, 32*MB)
+    num_obj_with_new_dups += num_files_with_dups
     pad_count = len(files_combined) - len(files)
     for i in range(0, pad_count):
         indices.append(0)
@@ -3236,7 +3220,7 @@ def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
             src_record += 1
 
     stats_combined.skip_shared_manifest = stats_base.deduped_obj
-    stats_combined.skip_src_record      = src_record
+    stats_combined.skip_src_record      = num_obj_with_new_dups
     stats_combined.set_shared_manifest_src -= stats_base.set_shared_manifest_src
     stats_combined.deduped_obj         -= stats_base.deduped_obj
     stats_combined.deduped_obj_bytes   -= stats_base.deduped_obj_bytes
@@ -3320,7 +3304,7 @@ def test_dedup_dry_small_with_tenants():
 
         # expected stats for small objects - all zeros except for skip_too_small
         small_objs_dedup_stats = Dedup_Stats()
-        copy_potential_stats(small_objs_dedup_stats, dedup_stats)
+
         small_objs_dedup_stats.size_before_dedup=dedup_stats.size_before_dedup
         small_objs_dedup_stats.skip_too_small_bytes=dedup_stats.size_before_dedup
         small_objs_dedup_stats.skip_too_small=s3_objects_total
@@ -3693,3 +3677,4 @@ def test_dedup_identical_copies_multipart_small():
     force_clean=True
     log.info("test_dedup_identical_copies_multipart:full test")
     __test_dedup_identical_copies(files, config, dry_run, verify, force_clean)
+

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -9,8 +9,6 @@ import hashlib
 from multiprocessing import Process
 import filecmp
 import os
-import shlex
-import signal
 import string
 import shutil
 import pytest
@@ -18,7 +16,6 @@ import json
 from collections import namedtuple
 import boto3
 from boto3.s3.transfer import TransferConfig
-from typing import List, Tuple
 from dataclasses import dataclass
 
 from . import(


### PR DESCRIPTION
rgw/dedup: Prevent deduplication between 2 different placements on the same storage class.

1. Rework RGW dedup ingestion/attribute-read flow to incorporate placement rule into storage class keys and adjust table bookkeeping.
2. Simplifies/removes “potential dedup” statistics since split-head added support for small objects dedup
3. Update rgw dedup tests/expectations and remove “potential dedup” stats




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
