### PR TITLE
rgw_file: always assign string_view of current common_prefix

### DIFF
--- a/qa/workunits/rgw/test_librgw_file.sh
+++ b/qa/workunits/rgw/test_librgw_file.sh
@@ -40,6 +40,11 @@ ceph_test_librgw_file_nfsns ${K} --dirs1 --verbose
 echo "phase 1.3"
 ceph_test_librgw_file_nfsns ${K} --hier1 --dirs1 --delete --verbose
 
+# common-prefix anti-regression test
+echo "phase 1.4"
+ceph_test_librgw_file_cpref ${K} --create
+ceph_test_librgw_file_cpref ${K} # crashed w/unfixed cp_ref assignment
+
 # bulk create/delete buckets
 echo "phase 2.1"
 ceph_test_librgw_file_cd ${K} --create --multi --verbose

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -1617,7 +1617,8 @@ public:
       void parse_cp() {
 	if (is_cp()) {
 	  /* leading-/ skip case */
-	  if (cp_iter->first == "/") {
+          if (cp_iter->first == "/") {
+	    cp_sref = std::string_view{cp_iter->first};
 	    _skip_cp = true;
 	    return;
 	  } else

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -322,6 +322,7 @@ install(TARGETS ceph_test_librgw_file DESTINATION ${CMAKE_INSTALL_BINDIR})
 add_dependencies(ceph_test_librgw_file
   ceph_test_librgw_file_cd
   ceph_test_librgw_file_gp
+  ceph_test_librgw_file_cpref
   ceph_test_librgw_file_rename
   ceph_test_librgw_file_nfsns
   ceph_test_librgw_file_aw
@@ -354,6 +355,20 @@ target_link_libraries(ceph_test_librgw_file_gp
   ${ALLOC_LIBS}
   )
 install(TARGETS ceph_test_librgw_file_gp DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# ceph_test_librgw_file_cpref (a special case common-prefix enumeration test)
+add_executable(ceph_test_librgw_file_cpref
+  librgw_file_cpref.cc
+  )
+target_link_libraries(ceph_test_librgw_file_cpref
+  rgw
+  librados
+  ceph-common
+  ${UNITTEST_LIBS}
+  ${EXTRALIBS}
+  ${ALLOC_LIBS}
+  )
+install(TARGETS ceph_test_librgw_file_cpref DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_nfsns (nfs namespace tests)
 add_executable(ceph_test_librgw_file_nfsns

--- a/src/test/librgw_file_cpref.cc
+++ b/src/test/librgw_file_cpref.cc
@@ -1,0 +1,256 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <stdint.h>
+#include <tuple>
+#include <iostream>
+#include <vector>
+#include <map>
+#include <random>
+#include "xxhash.h"
+
+#include "include/rados/librgw.h"
+#include "include/rados/rgw_file.h"
+
+#include "gtest/gtest.h"
+#include "common/ceph_argparse.h"
+#include "common/debug.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rgw
+
+using namespace std;
+
+namespace {
+  librgw_t rgw = nullptr;
+  string uid("testuser");
+  string access_key("");
+  string secret_key("");
+  struct rgw_fs *fs = nullptr;
+
+  bool do_create = false;
+
+  uint32_t owner_uid = 867;
+  uint32_t owner_gid = 5309;
+  uint32_t create_mask = RGW_SETATTR_UID | RGW_SETATTR_GID | RGW_SETATTR_MODE;
+
+  string bucket_name = "sdlc-test";
+
+  struct rgw_file_handle *bucket_fh = nullptr;
+  struct rgw_file_handle *object_fh = nullptr;
+
+  std::vector<std::string> obj_names = {
+      ".teste-c134272.txt.20260113110131.c134272",
+      "/catalog/sitip.tiptb001_emitente.ddl.json",
+      "/catalog/sitip.tiptb002_documento.ddl.json",
+      "/catalog/sitip.tiptb004_ocorrencia_documento.ddl.json",
+      "/catalog/sitip.tiptb005_evento.ddl.json",
+      "/catalog/sitip.tiptb006_situacao_evento.ddl.json",
+      "/catalog/sitip.tiptb007_ocorrencia_evento.ddl.json",
+      "/catalog/sitip.tiptb008_lote_evento.ddl.json",
+      "/catalog/sitip.tiptb009_processamento_lote.ddl.json",
+      "/catalog/sitip.tiptb010_tipo_evento.ddl.json",
+      "/catalog/sitip.tiptb011_periodo_movimento.ddl.json",
+      "/catalog/sitip.tiptb013_ocorrencia_lote.ddl.json",
+      "/catalog/sitip.tiptb014_acao_periodo_movto.ddl.json",
+      "file",
+      "my_schema_20260127/",
+      "my_schema_20260127/test_table/data/"
+      "35e9dbf6-10f2-44bf-9034-9c68aaedb54f.parquet",
+      "my_schema_20260127/test_table/metadata/"
+      "00000-6cb10a86-6b9e-446f-a662-38f403961f5d.metadata.json",
+      "my_schema_20260127/test_table/metadata/"
+      "00001-7d0c79e7-990a-4ed5-9650-e6c55d610e36.metadata.json",
+      "my_schema_20260127/test_table/metadata/"
+      "14521311-8384-4bac-acc8-44c653699c43-m0.avro",
+      "my_schema_20260127/test_table/metadata/"
+      "snap-7089720011427558043-1-14521311-8384-4bac-acc8-44c653699c43.avro",
+      "my_schema_3/",
+      "my_schema_3/test_table/data/"
+      "f14e4a46-8d04-4d34-bbb9-298de3bbde7f.parquet",
+      "my_schema_3/test_table/metadata/"
+      "00000-c6fae701-5b4f-4b7c-911e-c7710614bbd1.metadata.json",
+      "my_schema_3/test_table/metadata/"
+      "00001-f8d6e35e-f2a8-42f5-9466-654b3405e8b6.metadata.json",
+      "my_schema_3/test_table/metadata/"
+      "213de0bb-5d74-4d21-98f2-c55ec15e89d8-m0.avro",
+      "my_schema_3/test_table/metadata/"
+      "snap-4490949654564070735-1-213de0bb-5d74-4d21-98f2-c55ec15e89d8.avro",
+      "teste-c134272.txt"
+      };
+
+  typedef std::tuple<string,uint64_t, struct rgw_file_handle*> fid_type;
+  std::vector<fid_type> fids;
+
+  std::uniform_int_distribution<uint8_t> uint_dist;
+  std::mt19937 rng;
+
+  struct {
+    int argc;
+    char **argv;
+  } saved_args;
+}
+
+TEST(LibRGW, INIT1) {
+  int ret = librgw_create(&rgw, saved_args.argc, saved_args.argv);
+  ASSERT_EQ(ret, 0);
+  ASSERT_NE(rgw, nullptr);
+}
+
+TEST(LibRGW, MOUNT1) {
+  int ret = rgw_mount2(rgw, uid.c_str(), access_key.c_str(), secret_key.c_str(),
+                       "/", &fs, RGW_MOUNT_FLAG_NONE);
+  ASSERT_EQ(ret, 0);
+  ASSERT_NE(fs, nullptr);
+}
+
+TEST(LibRGW, CREATE_BUCKET) {
+  if (do_create) {
+    struct stat st;
+    struct rgw_file_handle *fh;
+
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
+    int ret = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), &st, create_mask,
+			&fh, RGW_MKDIR_FLAG_NONE);
+    ASSERT_EQ(ret, 0);
+  }
+}
+
+TEST(LibRGW, LOOKUP_BUCKET) {
+  int ret = rgw_lookup(fs, fs->root_fh, bucket_name.c_str(), &bucket_fh,
+		       nullptr, 0, RGW_LOOKUP_FLAG_NONE);
+  ASSERT_EQ(ret, 0);
+}
+
+TEST(LibRGW, CREATE_OBJECTS) {
+  if (do_create) {
+
+    size_t nbytes;
+    string data = "great justice";
+
+    for (auto& obj_name : obj_names) {
+      int ret = rgw_lookup(fs, bucket_fh, obj_name.c_str(), &object_fh,
+                           nullptr, 0, RGW_LOOKUP_FLAG_CREATE);
+      ASSERT_EQ(ret, 0);
+
+      ret = rgw_open(fs, object_fh, 0 /* posix flags */, 0 /* flags */);
+      ASSERT_EQ(ret, 0);
+
+      ret = rgw_write(fs, object_fh, 0, data.length(), &nbytes,
+                      (void*) data.c_str(), RGW_WRITE_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+      ASSERT_EQ(nbytes, data.length());
+      /* commit write transaction */
+      ret = rgw_close(fs, object_fh, 0 /* flags */);
+      ASSERT_EQ(ret, 0);
+    }
+  } /* create */
+}
+
+extern "C" {
+  static int r2_cb(const char* name, void *arg, uint64_t offset,
+		    struct stat *st, uint32_t st_mask,
+		    uint32_t flags) {
+    // don't need arg--it would point to fids
+    fids.push_back(fid_type(name, offset, nullptr));
+    return true; /* XXX ? */
+  }
+}
+
+TEST(LibRGW, LIST_OBJECTS) {
+
+  if (! do_create) {
+    /* list objects via readdir, bucketwise */
+    using std::get;
+
+    ldout(g_ceph_context, 0)
+        << __func__ << " readdir on bucket " << bucket_name << dendl;
+    bool eof = false;
+    uint64_t offset = 0;
+    int ret = rgw_readdir(
+        fs, bucket_fh, &offset, r2_cb, &fids, &eof, RGW_READDIR_FLAG_NONE);
+    for (auto& fid : fids) {
+      std::cout << "fname: " << get<0>(fid) << " fid: " << get<1>(fid)
+                << std::endl;
+    }
+    ASSERT_EQ(ret, 0);
+  } /* !create  */
+}
+
+TEST(LibRGW, UMOUNT) {
+  if (! fs)
+    return;
+
+  int ret = rgw_umount(fs, RGW_UMOUNT_FLAG_NONE);
+  ASSERT_EQ(ret, 0);
+}
+
+TEST(LibRGW, SHUTDOWN) {
+  librgw_shutdown(rgw);
+}
+
+int main(int argc, char *argv[])
+{
+  auto args = argv_to_vec(argc, argv);
+  env_to_vec(args);
+
+  char* v = getenv("AWS_ACCESS_KEY_ID");
+  if (v) {
+    access_key = v;
+  }
+
+  v = getenv("AWS_SECRET_ACCESS_KEY");
+  if (v) {
+    secret_key = v;
+  }
+
+  string val;
+  for (auto arg_iter = args.begin(); arg_iter != args.end();) {
+    if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
+			      (char*) nullptr)) {
+      access_key = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--secret",
+				     (char*) nullptr)) {
+      secret_key = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+				     (char*) nullptr)) {
+      uid = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--bn",
+				     (char*) nullptr)) {
+      bucket_name = val;
+    } else if (ceph_argparse_flag(args, arg_iter, "--create",
+					    (char*) nullptr)) {
+      do_create = true;
+    } else {
+      ++arg_iter;
+    }
+  }
+
+  /* don't accidentally run as anonymous */
+  if ((access_key == "") ||
+      (secret_key == "")) {
+    std::cout << argv[0] << " no AWS credentials, exiting" << std::endl;
+    return EPERM;
+  }
+
+  saved_args.argc = argc;
+  saved_args.argv = argv;
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75540





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
