### PR TITLE
os/bluestore: BlueFS SpillOver Cleaner

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4373,6 +4373,31 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: bluefs_spillover_cleaner
+  type: bool
+  level: advanced
+  desc: Enable Background BlueFS Spillover cleaner thread
+  long_desc: Enables a background cleaner thread in BlueFS that periodically scans files
+    that spilled over to the slow device and attempts to migrate them back to the
+    BlueFS DB device
+  default: false
+  see_also:
+  - bluefs_spillover_clean_interval
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluefs_spillover_clean_interval
+  type: uint
+  level: advanced
+  desc: Interval in seconds between BlueFS spillover cleaner scans.
+  long_desc: Controls how often the BlueFS spillover cleaner thread wakes up to scan
+    for files that have spilled over to the slow device
+  default: 1200
+  see_also:
+  - bluefs_spillover_cleaner
+  flags:
+  - runtime
+  with_legacy: true
 - name: bluestore_bluefs
   type: bool
   level: dev

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -115,6 +115,9 @@ public:
 					   "Injects 8K zeros into next BlueFS read. Debug only.");
 	ceph_assert(r == 0);
       }
+      r = admin_socket->register_command("bluefs spillover cleaner stats", hook,
+              "Show spillover cleaner thread stats");
+      ceph_assert(r == 0);
     }
     return hook;
   }
@@ -205,6 +208,24 @@ private:
       f->flush(out);
     } else if (command == "bluefs debug_inject_read_zeros") {
       bluefs->inject_read_zeros++;
+    } else if (command == "bluefs spillover cleaner stats") {
+      std::lock_guard l(bluefs->spillover_cleaner_lock);
+      auto& stats = bluefs->spillover_cleaner_thread.migration_stats;
+      f->open_array_section("spillover_migration_stats");
+      for (auto& s : stats) {
+        f->open_object_section("file");
+        f->dump_int("ino", s.first);
+        std::stringstream ss;
+        ss << "0x" << std::hex << s.second.migrated_bytes << std::dec
+          << " (" << s.second.migrated_bytes << " bytes)";
+        f->dump_string("migrated_bytes", ss.str());
+        ss.str("");
+        ss.clear();
+        ss << s.second.last_migration_time;
+        f->dump_string("last_migration_time", ss.str());
+        f->close_section();
+      }
+      f->close_section();
     } else {
       errss << "Invalid command" << std::endl;
       return -ENOSYS;
@@ -219,7 +240,8 @@ BlueFS::BlueFS(CephContext* cct)
     ioc(MAX_BDEV),
     alloc(MAX_BDEV),
     alloc_size(MAX_BDEV, 0),
-    locked_alloc(MAX_BDEV)
+    locked_alloc(MAX_BDEV),
+    spillover_cleaner_thread(this)
 {
   dirty.pending_release.resize(MAX_BDEV);
   discard_cb[BDEV_WAL] = wal_discard_cb;
@@ -2128,6 +2150,100 @@ int BlueFS::device_migrate_to_existing(
     new_log_dev_next,
     flags,
     layout);
+  return 0;
+}
+
+int BlueFS::migrate_file(
+  CephContext* cct,
+  FileRef file_ref,
+  int from_bdev,
+  int to_bdev,
+  std::function<void(uint64_t)> bt)
+{
+  vector<byte> buf;
+  bool buffered = cct->_conf->bluefs_buffered_io;
+  bufferlist bl;
+  mempool::bluefs::vector<bluefs_extent_t> old_fnode_extents;
+  bluefs_fnode_t new_fnode;
+
+  std::unique_lock l(file_ref->lock);
+
+  if (file_ref->deleted)
+    return 0;
+
+  bool rewrite = std::any_of(
+    file_ref->fnode.extents.begin(),
+    file_ref->fnode.extents.end(),
+    [=](auto& ext) {
+      return ext.bdev != to_bdev;
+    });
+
+  if (!rewrite)
+    return 0;
+
+  old_fnode_extents = file_ref->fnode.extents;
+
+  for (const auto &old_ext : old_fnode_extents) {
+    buf.resize(old_ext.length);
+    int r = _bdev_read_random(old_ext.bdev,
+      old_ext.offset,
+      old_ext.length,
+      (char*)&buf.at(0),
+      buffered);
+    if (r != 0) {
+      derr << __func__ << " failed to read 0x" << std::hex
+           << old_ext.offset << "~" << old_ext.length << std::dec
+           << " from " << (int)old_ext.bdev << dendl;
+      return -EIO;
+    }
+    bl.append((char*)&buf[0], old_ext.length);
+  }
+
+  auto r = _allocate(to_bdev, bl.length(), 0,
+    &new_fnode, nullptr, 0, false);
+  if (r < 0) {
+    dout(10) << __func__ << " unable to allocate len 0x" << std::hex
+        << bl.length() << std::dec << " from " << (int)to_bdev
+        << ": " << cpp_strerror(r) << dendl;
+    return -ENOSPC;
+  }
+
+  uint64_t off = 0;
+  for (auto& i : new_fnode.extents) {
+    bufferlist cur;
+    uint64_t cur_len = std::min<uint64_t>(i.length, bl.length() - off);
+    ceph_assert(cur_len > 0);
+    cur.substr_of(bl, off, cur_len);
+    int w = bdev[to_bdev]->write(i.offset, cur, buffered);
+    ceph_assert(w == 0);
+    off += cur_len;
+    vselector->add_usage(file_ref->vselector_hint, i);
+  }
+
+  if (bt) {
+    bt(off);
+  }
+
+  file_ref->fnode.swap_extents(new_fnode);
+  l.unlock();
+
+  {
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update(file_ref->fnode);
+  }
+
+  sync_metadata(false);
+
+  for (const auto &old_ext : old_fnode_extents) {
+    vselector->sub_usage(file_ref->vselector_hint, old_ext);
+    PExtentVector to_release;
+    to_release.emplace_back(old_ext.offset, old_ext.length);
+    alloc[old_ext.bdev]->release(to_release);
+    if (is_shared_alloc(old_ext.bdev)) {
+      shared_alloc->bluefs_used -= old_ext.length;
+    }
+  }
+
   return 0;
 }
 
@@ -4783,6 +4899,128 @@ void BlueFS::close_writer(FileWriter *h)
     _drain_writer(h);
   }
   delete h;
+}
+
+void BlueFS::spillover_cleaner_start()
+{
+  dout(10) << __func__ << dendl;
+  std::lock_guard l(spillover_cleaner_lock);
+  if (splclr_thread_created) {
+    dout(10) << __func__ << " already started" << dendl;
+    return;
+  }
+  spillover_cleaner_thread.create("bluefs_splclr");
+  splclr_thread_created = true;
+}
+
+void BlueFS::spillover_cleaner_stop()
+{
+  dout(10) << __func__ << dendl;
+  {
+    std::unique_lock l(spillover_cleaner_lock);
+    if (!splclr_thread_created) {
+      dout(10) << __func__ << " Spillover thread not started" << dendl;
+      return;
+    }
+    while(!splclr_thread_start) {
+      spillover_cleaner_cond.wait(l);
+    }
+    splclr_thread_stop = true;
+    spillover_cleaner_cond.notify_all();
+  }
+  spillover_cleaner_thread.join();
+  {
+    std::lock_guard l(spillover_cleaner_lock);
+    splclr_thread_stop = false;
+  }
+  dout(10) << __func__ << " stopped" << dendl;
+}
+
+void BlueFS::update_spillover_cleaner_from_config()
+{
+  if(cct->_conf->bluefs_spillover_cleaner) {
+    spillover_cleaner_start();
+  } else {
+    spillover_cleaner_stop();
+  }
+}
+
+void BlueFS::_spillover_cleaner_thread()
+{
+  dout(10) << __func__ << " started" << dendl;
+
+  {
+    std::lock_guard l(spillover_cleaner_lock);
+    splclr_thread_start = true;
+    spillover_cleaner_cond.notify_all();
+  }
+
+  while (true) {
+    {
+      std::lock_guard l(spillover_cleaner_lock);
+      if (splclr_thread_stop)
+        break;
+    }
+
+    std::vector<FileRef> to_move;
+    std::unique_lock nl(nodes.lock);
+    for (auto& [ino, file_ref] : nodes.file_map) {
+      if (ino == 1)
+        continue;
+
+      bool has_slow = std::any_of(
+        file_ref->fnode.extents.begin(),
+        file_ref->fnode.extents.end(),
+        [](const auto& e) {
+          return e.bdev != BDEV_DB;
+        });
+      if (!has_slow)
+        continue;
+
+      to_move.push_back(file_ref);
+    }
+    nl.unlock();
+
+    for (auto& file_ref : to_move) {
+      int r = migrate_file(cct,
+                file_ref,
+                BDEV_SLOW,
+                BDEV_DB,
+                [&](uint64_t b) {
+                  std::lock_guard l(spillover_cleaner_lock);
+                  auto& s = spillover_cleaner_thread.migration_stats[file_ref->fnode.ino];
+                  s.migrated_bytes = b;
+                  s.last_migration_time = ceph_clock_now();
+                });
+      if (r < 0) {
+        derr << __func__ << " failed to migrate file ino " << file_ref->fnode.ino
+            << " from bdev " << BDEV_SLOW
+            << " to bdev " << BDEV_DB
+            << ": " << cpp_strerror(r) << dendl;
+      }
+      std::lock_guard l(spillover_cleaner_lock);
+      if (splclr_thread_stop)
+        goto exit;
+    }
+
+    {
+      std::unique_lock l(spillover_cleaner_lock);
+      spillover_cleaner_cond.wait_for(
+        l,
+        std::chrono::seconds(cct->_conf->bluefs_spillover_clean_interval),
+        [this] { return splclr_thread_stop; }
+      );
+    }
+  }
+
+exit:
+  {
+    std::lock_guard l(spillover_cleaner_lock);
+    splclr_thread_start = false;
+    splclr_thread_created = false;
+  }
+
+  dout(10) << __func__ << " stopped" << dendl;
 }
 
 uint64_t BlueFS::debug_get_dirty_seq(FileWriter *h)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -115,6 +115,11 @@ public:
 					   "Injects 8K zeros into next BlueFS read. Debug only.");
 	ceph_assert(r == 0);
       }
+      r = admin_socket->register_command("bluefs volume_selector set "
+              "name=mode,type=CephChoices,strings=slow|db|normal,req=true"
+              , hook,
+              "Set volume selector mode");
+      ceph_assert(r == 0);
       r = admin_socket->register_command("bluefs spillover cleaner stats", hook,
               "Show spillover cleaner thread stats");
       ceph_assert(r == 0);
@@ -208,6 +213,11 @@ private:
       f->flush(out);
     } else if (command == "bluefs debug_inject_read_zeros") {
       bluefs->inject_read_zeros++;
+    } else if (command == "bluefs volume_selector set") {
+      std::string mode;
+      cmd_getval(cmdmap, "mode", mode);
+      auto sel = bluefs->vselector.get();
+      sel->set_mode(mode);
     } else if (command == "bluefs spillover cleaner stats") {
       std::lock_guard l(bluefs->spillover_cleaner_lock);
       auto& stats = bluefs->spillover_cleaner_thread.migration_stats;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -555,6 +555,25 @@ public:
     FileRef file;
     explicit FileLock(FileRef f) : file(std::move(f)) {}
   };
+
+  struct SpilloverCleanerThread : public Thread {
+    BlueFS* bluefs;
+    struct MigrationStats {
+      uint64_t migrated_bytes = 0;
+      utime_t last_migration_time;
+    };
+    std::unordered_map<uint64_t, MigrationStats> migration_stats;
+    explicit SpilloverCleanerThread(BlueFS* f) : bluefs(f) {}
+    void* entry() override {
+      bluefs->_spillover_cleaner_thread();
+      return nullptr;
+    }
+  };
+
+  void spillover_cleaner_start();
+  void spillover_cleaner_stop();
+  void update_spillover_cleaner_from_config();
+
 private:
   PerfCounters *logger = nullptr;
 
@@ -633,6 +652,13 @@ private:
     return id == shared_alloc_id;
   }
   std::atomic<int64_t> cooldown_deadline = 0;
+
+  SpilloverCleanerThread spillover_cleaner_thread;
+  ceph::mutex spillover_cleaner_lock = ceph::make_mutex("BlueFS::spillover_cleaner_lock");
+  ceph::condition_variable spillover_cleaner_cond;
+  bool splclr_thread_created = false;
+  bool splclr_thread_stop = false;
+  bool splclr_thread_start = false;
 
   class SocketHook;
   SocketHook* asok_hook = nullptr;
@@ -789,6 +815,8 @@ private:
     }
   }
 
+  void _spillover_cleaner_thread();
+
 public:
   BlueFS(CephContext* cct);
   ~BlueFS();
@@ -820,6 +848,13 @@ public:
     const std::set<int>& devs_source,
     int dev_target,
     const bluefs_layout_t& layout);
+  int migrate_file(
+    CephContext *cct,
+    FileRef file_ref,
+    int from_bdev,
+    int to_bdev,
+    std::function<void(uint64_t)> bt = nullptr
+  );
   int revert_wal_to_plain();
 
   uint64_t get_used();

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -211,6 +211,7 @@ public:
   /* used for sanity checking of vselector */
   virtual BlueFSVolumeSelector* clone_empty() const { return nullptr; }
   virtual bool compare(BlueFSVolumeSelector* other) { return true; };
+  virtual void set_mode(const std::string& mode) {};
 };
 
 struct bluefs_shared_alloc_context_t {
@@ -1277,6 +1278,100 @@ public:
   void dump(std::ostream& sout) override;
   BlueFSVolumeSelector* clone_empty() const override;
   bool compare(BlueFSVolumeSelector* other) override;
+};
+
+class TestBedBlueFSVolumeSelector : public RocksDBBlueFSVolumeSelector
+{
+public:
+  enum class Mode {
+    NORMAL = 0,
+    FORCE_SLOW,
+    FORCE_DB
+  };
+
+  enum {
+    TB_LEVEL_LOG = 1,
+    TB_LEVEL_WAL = 2,
+    TB_LEVEL_DB = 3,
+    TB_LEVEL_SLOW = 4
+  };
+
+  using RocksDBBlueFSVolumeSelector::add_usage;
+  using RocksDBBlueFSVolumeSelector::sub_usage;
+
+private:
+  std::atomic<Mode> mode;
+
+public:
+  TestBedBlueFSVolumeSelector(
+    uint64_t wal_total_,
+    uint64_t db_total_,
+    uint64_t slow_total_,
+    uint64_t level0_size_,
+    uint64_t level_base_,
+    uint64_t level_multiplier_,
+    bool new_pol_)
+  : RocksDBBlueFSVolumeSelector(
+        wal_total_,
+        db_total_,
+        slow_total_,
+        level0_size_,
+        level_base_,
+        level_multiplier_,
+        new_pol_),
+    mode(Mode::NORMAL)
+  {}
+
+  TestBedBlueFSVolumeSelector()
+  : RocksDBBlueFSVolumeSelector(
+        0, 0, 0, 0, 0, 0, false),
+    mode(Mode::NORMAL)
+  {}
+
+  void set_mode(const std::string& md) override {
+    if (md == "slow") {
+      this->mode.store(Mode::FORCE_SLOW, std::memory_order_relaxed);
+    } else if (md == "db") {
+      this->mode.store(Mode::FORCE_DB, std::memory_order_relaxed);
+    } else {
+      this->mode.store(Mode::NORMAL, std::memory_order_relaxed);
+    }
+  }
+
+  uint8_t select_prefer_bdev(void* h) override
+  {
+    Mode m = mode.load(std::memory_order_relaxed);
+    uint64_t hint = reinterpret_cast<uint64_t>(h);
+
+    if (hint == TB_LEVEL_WAL || hint == TB_LEVEL_LOG) {
+      return RocksDBBlueFSVolumeSelector::select_prefer_bdev(h);
+    }
+
+    if (m == Mode::FORCE_SLOW) {
+      return BlueFS::BDEV_SLOW;
+    }
+
+    if (m == Mode::FORCE_DB) {
+      return BlueFS::BDEV_DB;
+    }
+
+    // NORMAL mode → defer to RocksDB policy
+    return RocksDBBlueFSVolumeSelector::select_prefer_bdev(h);
+  }
+
+  BlueFSVolumeSelector* clone_empty() const override
+  {
+    auto* sel = new TestBedBlueFSVolumeSelector();
+    Mode m = mode.load(std::memory_order_relaxed);
+    if (m == Mode::FORCE_SLOW) {
+      sel->set_mode("slow");
+    } else if (m == Mode::FORCE_DB) {
+      sel->set_mode("db");
+    } else {
+      sel->set_mode("normal");
+    }
+    return sel;
+  }
 };
 
 /**

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5836,7 +5836,8 @@ std::vector<std::string> BlueStore::get_tracked_keys() const noexcept
     "bluestore_onode_segment_size"s,
     "bluestore_allocator_lookup_policy"s,
     "bluestore_volume_selection_reserved_factor"s,
-    "bluestore_volume_selection_reserved"s
+    "bluestore_volume_selection_reserved"s,
+    "bluefs_spillover_cleaner"s,
   };
 }
 
@@ -5919,6 +5920,11 @@ void BlueStore::handle_conf_change(const ConfigProxy& conf,
     changed.count("bluestore_volume_selection_reserved")) {
     if (bluefs)
       bluefs->update_volume_selector_from_config();
+  }
+  if (changed.count("bluefs_spillover_cleaner")) {
+    if (bluefs) {
+      bluefs->update_spillover_cleaner_from_config();
+    }
   }
 }
 
@@ -9570,6 +9576,10 @@ int BlueStore::_mount()
     }
   }
 
+  if (bluefs && cct->_conf.get_val<bool>("bluefs_spillover_cleaner")) {
+    bluefs->spillover_cleaner_start();
+  }
+
   mounted = true;
   return 0;
 }
@@ -9579,6 +9589,10 @@ int BlueStore::umount()
   dout(5) << __func__ << dendl;
   ceph_assert(_kv_only || mounted);
   _osr_drain_all();
+
+  if (bluefs) {
+    bluefs->spillover_cleaner_stop();
+  }
 
   mounted = false;
 


### PR DESCRIPTION
This PR introduces a background spillover cleaner thread in BlueFS that periodically scans files that have spilled over to the slow device and attempts to migrate them back to the DB device.

Two new runtime configuration options are added:

- `bluefs_spillover_cleaner` – enables/disables the background cleaner thread.

- `bluefs_spillover_clean_interval` – controls the interval (in seconds) between cleaner scans.

Enable the background spillover cleaner thread:

```
./bin/ceph config set osd bluefs_spillover_cleaner true
```
Disable the cleaner thread:
```
./bin/ceph config set osd bluefs_spillover_cleaner false
```

Set the interval (in seconds) between spillover cleaner scans:
```
./bin/ceph config set osd bluefs_spillover_clean_interval <t>
```

To observe spillover behavior easily, a `TestBedBlueFSVolumeSelector` was added that allows forcing BlueFS allocations to the slow device.
Force BlueFS to Allocate on Slow Device
```
./bin/ceph tell osd.0 bluefs volume_selector set slow
```
Force BlueFS to Allocate on DB Device
```
./bin/ceph tell osd.0 bluefs volume_selector set db
```
Fallback to default
```
./bin/ceph tell osd.0 bluefs volume_selector set default
```

Fixes: https://tracker.ceph.com/issues/74319

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
