### PR TITLE
tentacle: mgr/dashboard: fix add host API path for namespace mapping in NVMe/TCP

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -178,5 +178,17 @@ describe('NvmeofService', () => {
       );
       expect(req.request.method).toBe('DELETE');
     });
+
+    it('should call addNamespaceInitiators with UI namespace host endpoint', () => {
+      const request = {
+        subsystem_nqn: mockNQN,
+        host_nqn: 'nqn.2014-08.org.nvmexpress:uuid:11111111-1111-1111-1111-111111111111',
+        gw_group: mockGroupName
+      };
+      service.addNamespaceInitiators(mockNsid, request).subscribe();
+      const req = httpTesting.expectOne(`${UI_API_PATH}/namespace/${mockNsid}/host`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(request);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -2,9 +2,15 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import _ from 'lodash';
-import { Observable, of as observableOf } from 'rxjs';
-import { catchError, mapTo } from 'rxjs/operators';
+import { Observable, forkJoin, of as observableOf } from 'rxjs';
+import { catchError, map, mapTo, mergeMap } from 'rxjs/operators';
 import { CephServiceSpec } from '../models/service.interface';
+import { ListenerItem } from '../models/nvmeof';
+import { HostService } from './host.service';
+import { OrchestratorService } from './orchestrator.service';
+import { HostStatus } from '../enum/host-status.enum';
+import { Host } from '../models/host.interface';
+import { OrchestratorStatus } from '../models/orchestrator.interface';
 
 export const DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM = 512;
 
@@ -27,9 +33,11 @@ export type ListenerRequest = NvmeofRequest & {
 };
 
 export type NamespaceCreateRequest = NvmeofRequest & {
-  rbd_image_name: string;
+  rbd_image_name?: string;
   rbd_pool: string;
   rbd_image_size?: number;
+  no_auto_visible?: boolean;
+  block_size?: number;
   create_image: boolean;
 };
 
@@ -39,6 +47,16 @@ export type NamespaceUpdateRequest = NvmeofRequest & {
 
 export type InitiatorRequest = NvmeofRequest & {
   host_nqn: string;
+  dhchap_key?: string;
+};
+
+export type SubsystemInitiatorRequest = NvmeofRequest & {
+  hosts: Array<{ dhchap_key: string; host_nqn: string }>;
+  allow_all: boolean;
+};
+
+export type NamespaceInitiatorRequest = InitiatorRequest & {
+  subsystem_nqn: string;
 };
 
 const API_PATH = 'api/nvmeof';
@@ -48,7 +66,84 @@ const UI_API_PATH = 'ui-api/nvmeof';
   providedIn: 'root'
 })
 export class NvmeofService {
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private hostService: HostService,
+    private orchService: OrchestratorService
+  ) {}
+
+  getAvailableHosts(params: any = {}): Observable<Host[]> {
+    return forkJoin({
+      groups: this.listGatewayGroups(),
+      hosts: this.orchService.status().pipe(
+        mergeMap((orchStatus: OrchestratorStatus) => {
+          const factsAvailable = this.hostService.checkHostsFactsAvailable(orchStatus);
+          return this.hostService.list(params, factsAvailable.toString()) as Observable<Host[]>;
+        }),
+        map((hosts: Host[]) => {
+          return (hosts || []).map((host: Host) => ({
+            ...host,
+            status: host.status || HostStatus.AVAILABLE
+          }));
+        })
+      )
+    }).pipe(
+      map(({ groups, hosts }) => {
+        const usedHosts = new Set<string>();
+        (groups?.[0] ?? []).forEach((group: CephServiceSpec) => {
+          group.placement?.hosts?.forEach((hostname: string) => usedHosts.add(hostname));
+        });
+        return (hosts || []).filter((host: Host) => {
+          const isAvailable =
+            host.status === HostStatus.AVAILABLE || host.status === HostStatus.RUNNING;
+          return !usedHosts.has(host.hostname) && isAvailable;
+        });
+      })
+    );
+  }
+
+  fetchHostsAndGroups(): Observable<{ groups: CephServiceSpec[][]; hosts: Host[] }> {
+    return forkJoin({
+      groups: this.listGatewayGroups(),
+      hosts: this.hostService.getAllHosts().pipe(
+        map((hosts: Host[]) => {
+          return (hosts || []).map((host: Host) => ({
+            ...host,
+            status: host.status || HostStatus.AVAILABLE
+          }));
+        })
+      )
+    });
+  }
+
+  getHostsForGroup(groupName: string): Observable<Host[]> {
+    return forkJoin({
+      gwGroups: this.listGatewayGroups(),
+      allHosts: this.hostService.getAllHosts()
+    }).pipe(
+      map(({ gwGroups, allHosts }) => {
+        const group = gwGroups?.[0]?.find(
+          (gwGroup: CephServiceSpec) => gwGroup?.spec?.group === groupName
+        );
+        const placement = group?.placement || { hosts: [], label: [] };
+        const { hosts, label } = placement;
+
+        if (hosts?.length) {
+          return allHosts.filter((host: Host) => hosts.includes(host.hostname));
+        } else if (label?.length) {
+          if (typeof label === 'string') {
+            return allHosts.filter((host: Host) => host?.labels?.includes(label));
+          }
+          return allHosts.filter(
+            (host: Host) =>
+              host?.labels?.length === label?.length &&
+              _.isEqual([...host.labels].sort(), [...label].sort())
+          );
+        }
+        return [];
+      })
+    );
+  }
 
   // formats the gateway groups to be consumed for combobox item
   formatGwGroupsList(
@@ -74,7 +169,7 @@ export class NvmeofService {
 
   // Gateway groups
   listGatewayGroups() {
-    return this.http.get<GatewayGroup[][]>(`${API_PATH}/gateway/group`);
+    return this.http.get<CephServiceSpec[][]>(`${API_PATH}/gateway/group`);
   }
 
   // Gateways
@@ -95,7 +190,7 @@ export class NvmeofService {
     nqn: string;
     enable_ha: boolean;
     gw_group: string;
-    max_namespaces?: number;
+    dhchap_key: string;
   }) {
     return this.http.post(`${API_PATH}/subsystem`, request, { observe: 'response' });
   }
@@ -121,10 +216,26 @@ export class NvmeofService {
     return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}/host?gw_group=${group}`);
   }
 
-  addInitiators(subsystemNQN: string, request: InitiatorRequest) {
+  addSubsystemInitiators(subsystemNQN: string, request: SubsystemInitiatorRequest) {
     return this.http.post(`${UI_API_PATH}/subsystem/${subsystemNQN}/host`, request, {
       observe: 'response'
     });
+  }
+
+  addNamespaceInitiators(nsid: number | string, request: NamespaceInitiatorRequest) {
+    return this.http.post(`${UI_API_PATH}/namespace/${nsid}/host`, request, {
+      observe: 'response'
+    });
+  }
+
+  updateHostKey(subsystemNQN: string, request: InitiatorRequest) {
+    return this.http.put(
+      `${API_PATH}/subsystem/${subsystemNQN}/host/${request.host_nqn}/change_key`,
+      request,
+      {
+        observe: 'response'
+      }
+    );
   }
 
   removeInitiators(subsystemNQN: string, request: InitiatorRequest) {
@@ -145,6 +256,18 @@ export class NvmeofService {
     return this.http.post(`${API_PATH}/subsystem/${subsystemNQN}/listener`, request, {
       observe: 'response'
     });
+  }
+
+  createListeners(subsystemNQN: string, gwGroup: string, listeners: ListenerItem[]) {
+    const listenerCalls = listeners.map((listener: ListenerItem) =>
+      this.createListener(subsystemNQN, {
+        gw_group: gwGroup,
+        host_name: listener.content,
+        traddr: listener.addr,
+        trsvcid: 4420
+      })
+    );
+    return forkJoin(listenerCalls);
   }
 
   deleteListener(
@@ -168,8 +291,8 @@ export class NvmeofService {
   }
 
   // Namespaces
-  listNamespaces(group: string) {
-    return this.http.get(`${API_PATH}/gateway_group/${group}/namespace`);
+  listNamespaces(group: string, subsystemNQN: string = '*') {
+    return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}/namespace?gw_group=${group}`);
   }
 
   getNamespace(subsystemNQN: string, nsid: string, group: string) {
@@ -196,6 +319,22 @@ export class NvmeofService {
       {
         observe: 'response'
       }
+    );
+  }
+
+  // Check if gateway group exists
+  exists(groupName: string): Observable<boolean> {
+    return this.listGatewayGroups().pipe(
+      map((groups: CephServiceSpec[][]) => {
+        const groupsList = groups?.[0] ?? [];
+        return groupsList.some((group: CephServiceSpec) => group?.spec?.group === groupName);
+      }),
+      catchError((error: any) => {
+        if (_.isFunction(error?.preventDefault)) {
+          error.preventDefault();
+        }
+        return observableOf(false);
+      })
     );
   }
 }


### PR DESCRIPTION
fixes: https://tracker.ceph.com/issues/75407

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>
(cherry picked from commit 7c1f623c43936bbf5f2e8f77d59c3dc60d2bab5b)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
