### PR TITLE
tentacle: qa: Leak_StillReachable RocksDB error_handler

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -932,4 +932,15 @@
    fun:*ProtocolV2*
    ...
 }
+{
+   rocky10 still reachable rocksdb leak
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znam
+   fun:UnknownInlinedFun
+   fun:_GLOBAL__sub_I_error_handler.cc.lto_priv.0
+   fun:_sub_I_65535_0.0
+   fun:__libc_start_main@@GLIBC_2.34
+   fun:(below main)
+}
 


### PR DESCRIPTION
Leak stillreachable on RocksDB on Rocky10

Fixes: https://tracker.ceph.com/issues/75430
Signed-off-by: Nitzan Mordechai <nmordec@ibm.com>
(cherry picked from commit f77b160ed0b7fc9187824c9d3af60fbdd7296e8c)
