### PR TITLE
tentacle: erasure-code: Enable isa for ppc64le target.

### DIFF
--- a/src/erasure-code/CMakeLists.txt
+++ b/src/erasure-code/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(lrc)
 add_subdirectory(shec)
 add_subdirectory(clay)
 
-if(HAVE_NASM_X64_AVX2 OR HAVE_ARMV8_SIMD)
+if(HAVE_NASM_X64_AVX2 OR HAVE_ARMV8_SIMD OR HAS_ALTIVEC)
   set(WITH_EC_ISA_PLUGIN TRUE CACHE BOOL "")
 endif()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75562

---

backport of https://github.com/ceph/ceph/pull/66602
parent tracker: https://tracker.ceph.com/issues/74183

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh