### PR TITLE
tentacle: mgr: ensure that all modules have started before advertising active mgr

### DIFF
--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -31,6 +31,52 @@ which should now include a mgr status line::
 
     mgr active: $name
 
+Interpreting Ceph-Mgr Statuses
+==============================
+
+A cluster's health status will show each ``ceph-mgr`` daemon in one of three states:
+
+1. **active**
+
+   This mgr daemon has been fully initialized, which means it is ready to receive
+   and execute commands. Only one mgr will be in this state at a time.
+
+2. **active (starting)**
+
+   This mgr daemon has been chosen to be ``active``, but it is not done initializing.
+   Although it is not yet ready to execute commands, an operator may still issue commands,
+   which will be held and executed once the manager becomes ``active``. Only one mgr will
+   be in this state at a time.
+
+3. **standby**
+
+   This mgr daemon is not currently receiving or executing commands, but it is there to
+   take over if the current active mgr becomes unavailable. An operator may also manually
+   promote standby manager to active via ``ceph mgr fail`` if desired. All other mgr daemons
+   which are not ``active`` or ``active (starting)`` will be in this state.
+
+Each of these states are visible in the output of the ``ceph -s``. For example:
+
+.. code-block:: console
+
+   $ ceph -s
+     cluster:
+       id:     b150f540-745a-460c-a566-376b28b95ac3
+       health: HEALTH_OK
+
+     services:
+       mon: 3 daemons, quorum a,b,c (age 47m) [leader: a]
+       mgr: x(active, starting, since 3s)
+       mds: 1/1 daemons up, 2 standby
+       osd: 4 osds: 4 up (since 47m), 4 in (since 47m)
+
+     data:
+       volumes: 1/1 healthy
+       pools:   4 pools, 177 pgs
+       objects: 24 objects, 451 KiB
+       usage:   4.0 GiB used, 400 GiB / 404 GiB avail
+       pgs:     177 active+clean
+
 Client authentication
 ---------------------
 

--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -31,35 +31,35 @@ which should now include a mgr status line::
 
     mgr active: $name
 
-Interpreting Ceph-Mgr Statuses
-==============================
+Interpreting Manager Daemon Status
+==================================
 
 A cluster's health status will show each ``ceph-mgr`` daemon in one of three states:
 
 1. **active**
 
-   This mgr daemon has been fully initialized, which means it is ready to receive
-   and execute commands. Only one mgr will be in this state at a time.
+   This Manager daemon has been fully initialized, which means it is ready to receive
+   and execute commands. Only one Manager will be in this state at a time.
 
 2. **active (starting)**
 
-   This mgr daemon has been chosen to be ``active``, but it is not done initializing.
+   This Manager daemon has been chosen to be ``active``, but it is not done initializing.
    Although it is not yet ready to execute commands, an operator may still issue commands,
-   which will be held and executed once the manager becomes ``active``. Only one mgr will
-   be in this state at a time.
+   which will be held and executed once the Manager becomes ``active``. Only one Manager
+   will be in this state at a time.
 
 3. **standby**
 
-   This mgr daemon is not currently receiving or executing commands, but it is there to
-   take over if the current active mgr becomes unavailable. An operator may also manually
-   promote standby manager to active via ``ceph mgr fail`` if desired. All other mgr daemons
-   which are not ``active`` or ``active (starting)`` will be in this state.
+   This Manager daemon is not currently receiving or executing commands, but it is ready to
+   take over if the current active Manager becomes unavailable. An administrator may
+   manually promote a standby to become active via ``ceph mgr fail`` if desired. All other
+   Manager daemons which are not ``active`` or ``active (starting)`` will be in this state.
 
-Each of these states are visible in the output of the ``ceph -s``. For example:
+Each of these states are visible in the output of the ``ceph status`` command. For example:
 
 .. code-block:: console
 
-   $ ceph -s
+   $ ceph status
      cluster:
        id:     b150f540-745a-460c-a566-376b28b95ac3
        health: HEALTH_OK

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -314,6 +314,39 @@ However, if you believe the error is transient, you may restart your manager
 daemon(s) or use ``ceph mgr fail`` on the active daemon in order to force
 failover to another daemon.
 
+**Module failed to initialize**
+
+If the ``ceph health detail`` looks something like this, it means that some
+modules took too long to initialize after a Manager failover, and are unable to process
+commands:
+
+.. code-block:: console
+
+   HEALTH_ERR 4 mgr modules have failed
+   [ERR] MGR_MODULE_ERROR: 14 mgr modules have failed
+       Module 'rbd_support' has failed: Module failed to initialize.
+       Module 'status' has failed: Module failed to initialize.
+       Module 'telemetry' has failed: Module failed to initialize.
+       Module 'volumes' has failed: Module failed to initialize.
+
+
+You can also see these modules listed under ``pending_modules``
+in the output of the following command:
+
+.. prompt:: bash $
+
+   ceph tell mgr mgr_status
+
+To troubleshoot, you may run ``ceph mgr fail`` to reboot
+module initialization.
+
+Note that the health error may clear on its own since modules
+will continue to initialize in the background.
+
+If the modules are still failing to initialize, please file a bug
+report under the `"mgr" project <https://tracker.ceph.com/projects/mgr>`_
+for further assistance.
+
 OSDs
 ----
 

--- a/qa/suites/rados/mgr/tasks/4-units/mgr_module_loading_time.yaml
+++ b/qa/suites/rados/mgr/tasks/4-units/mgr_module_loading_time.yaml
@@ -1,0 +1,13 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(CEPHADM_STRAY_DAEMON\)
+      - \(CEPHADM_STRAY_HOST\)
+      - \(MGR_DOWN\)
+      - evicting unresponsive client
+
+tasks:
+  - workunit:
+      clients:
+        client.0:
+          - mgr/test_mgr_module_loading_time.sh

--- a/qa/suites/rados/mgr/tasks/4-units/mgr_module_loading_time.yaml
+++ b/qa/suites/rados/mgr/tasks/4-units/mgr_module_loading_time.yaml
@@ -1,11 +1,11 @@
 overrides:
   ceph:
     log-ignorelist:
-      - \(CEPHADM_STRAY_DAEMON\)
-      - \(CEPHADM_STRAY_HOST\)
-      - \(MGR_DOWN\)
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_STRAY_HOST
+      - MGR_DOWN
       - evicting unresponsive client
-
+      - MGR_MODULE_ERROR
 tasks:
   - workunit:
       clients:

--- a/qa/workunits/mgr/test_mgr_module_loading_time.sh
+++ b/qa/workunits/mgr/test_mgr_module_loading_time.sh
@@ -136,7 +136,7 @@ echo "Test 3: Inject large delay (10000000000 ms) that exceeds max loading expir
 orch_status_output=$("$ceph" orch status 2>&1)
 
 echo "$orch_status_output"
-if [[ "$orch_status_output" == *"Error ENOTSUP: Module 'orchestrator' is not enabled/loaded"* ]]; then
+if [[ "$orch_status_output" == *"Error ETIMEDOUT: Module 'orchestrator' did not initialize in time"* ]]; then
     echo "PASS: orch command failed during large delay as expected."
 else
     echo "FAIL: Unexpected error in orch command during large delay."

--- a/qa/workunits/mgr/test_mgr_module_loading_time.sh
+++ b/qa/workunits/mgr/test_mgr_module_loading_time.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+setup_cephadm() {
+    # This will create CEPHADM_STRAY_HOST warnings, but we just want to be able to run an orch command.
+    echo "Enabling cephadm module..."
+    ceph mgr module enable cephadm
+    ceph orch set backend cephadm
+}
+
+check_cluster_status() {
+    echo "Checking cluster status..."
+    ceph -s
+}
+
+set_balancer_delay() {
+    echo "Setting balancer module load delay..."
+    ceph config set mgr mgr_module_load_delay_name balancer
+    ceph config set mgr mgr_module_load_delay 10000
+}
+
+test_loading_time() {
+    echo "Testing with module load delay of 10000 ms..."
+    ceph mgr fail
+
+    local orch_status_output
+    if ! orch_status_output=$(ceph orch status 2>&1); then
+        echo "FAIL: 'ceph orch status' failed to run:"
+        echo "$orch_status_output"
+        exit 1
+    fi
+
+    echo "$orch_status_output"
+
+    if [[ "$orch_status_output" == *"Backend: cephadm"* ]]; then
+        echo "PASS: Excess loading time was properly supported."
+    elif [[ "$orch_status_output" == *"Error ENOTSUP: Warning: due to ceph-mgr restart, some PG states may not be up to date"* ]]; then
+        echo "FAIL: Excess loading time was not properly supported."
+        exit 1
+    else
+        echo "FAIL: Unexpected error in 'ceph orch status':"
+        echo "$orch_status_output"
+        exit 1
+    fi
+}
+
+main() {
+    setup_cephadm || return 1
+    check_cluster_status || return 1
+    set_balancer_delay || return 1
+    test_loading_time || return 1
+}
+
+main "$@"

--- a/qa/workunits/mgr/test_mgr_module_loading_time.sh
+++ b/qa/workunits/mgr/test_mgr_module_loading_time.sh
@@ -1,53 +1,167 @@
 #!/bin/bash
 
-setup_cephadm() {
-    # This will create CEPHADM_STRAY_HOST warnings, but we just want to be able to run an orch command.
-    echo "Enabling cephadm module..."
-    ceph mgr module enable cephadm
-    ceph orch set backend cephadm
-}
+# This script tests how the mgr handles different module loading times post failover.
+# The motivation is this tracker ticket: https://tracker.ceph.com/issues/71631
 
-check_cluster_status() {
-    echo "Checking cluster status..."
-    ceph -s
-}
+# To run this script on a vstart cluter, use the following command:
+#   cd ceph/build
+#   ../qa/workunits/mgr/test_mgr_module_loading_time.sh --vstart
 
-set_balancer_delay() {
-    echo "Setting balancer module load delay..."
-    ceph config set mgr mgr_module_load_delay_name balancer
-    ceph config set mgr mgr_module_load_delay 10000
-}
+vstart=0
+if [ "$1" = "--vstart" ]; then
+    vstart=1
+fi
 
-test_loading_time() {
-    echo "Testing with module load delay of 10000 ms..."
-    ceph mgr fail
+ceph="ceph"
+if [ $vstart -eq 1 ]; then
+    ceph="./bin/ceph"
+fi
 
-    local orch_status_output
-    if ! orch_status_output=$(ceph orch status 2>&1); then
-        echo "FAIL: 'ceph orch status' failed to run:"
-        echo "$orch_status_output"
-        exit 1
-    fi
 
+# This will create CEPHADM_STRAY_HOST warnings, but we just want to be able to run an orch command.
+echo "Enabling cephadm module..."
+"$ceph" mgr module enable cephadm
+"$ceph" orch set backend cephadm
+
+echo "Checking cluster status..."
+"$ceph" -s
+
+# ------ Test 1 ------
+echo "Test 1: Test normal module loading behavior without any injected delays"
+
+echo "Ensure that no module is set for a load delay..."
+"$ceph" config set mgr mgr_module_load_delay_name ""
+
+echo "Test 1: Ensure that there is no injected load delay..."
+"$ceph" config set mgr mgr_module_load_delay 0
+
+"$ceph" mgr fail
+orch_status_output=$("$ceph" orch status 2>&1)
+
+echo "$orch_status_output"
+if [[ "$orch_status_output" == *"Backend: cephadm"* ]]; then
+    echo "PASS: orch command succeeded during normal behavior."
+elif [[ "$orch_status_output" == *"Error ENOTSUP: Module 'orchestrator' is not enabled/loaded"* ]]; then
+    echo "FAIL: orch command failed during normal behavior."
+    exit 1
+else
+    echo "FAIL: Unexpected error in orch command during normal behavior."
     echo "$orch_status_output"
+    exit 1
+fi
 
-    if [[ "$orch_status_output" == *"Backend: cephadm"* ]]; then
-        echo "PASS: Excess loading time was properly supported."
-    elif [[ "$orch_status_output" == *"Error ENOTSUP: Warning: due to ceph-mgr restart, some PG states may not be up to date"* ]]; then
-        echo "FAIL: Excess loading time was not properly supported."
-        exit 1
-    else
-        echo "FAIL: Unexpected error in 'ceph orch status':"
-        echo "$orch_status_output"
-        exit 1
-    fi
-}
+echo "Ensure health detail DOES NOT warn about any modules that failed initialization..."
+health=$("$ceph" health detail 2>&1)
+if [[ "$health" == *"Module failed to initialize"* ]]; then
+    echo "FAIL: One or more modules failed to initialize during small delay."
+    echo "$health"
+    exit 1
+fi
 
-main() {
-    setup_cephadm || return 1
-    check_cluster_status || return 1
-    set_balancer_delay || return 1
-    test_loading_time || return 1
-}
+echo "Verify that mgr is active..."
+stat=$("$ceph" -s 2>&1)
+if [[ "$stat" != *"active, since"* ]]; then
+    echo "FAIL: Mgr should be in 'active' state."
+    echo "$stat"
+    exit 1
+fi
 
-main "$@"
+# ------ Test 2 ------
+echo "Select balancer module to receive loading delays..."
+"$ceph" config set mgr mgr_module_load_delay_name balancer
+
+echo "Test 2: Inject small delay (10000 ms) that should not exceed max loading retries"
+"$ceph" config set mgr mgr_module_load_delay 10000
+
+"$ceph" mgr fail
+orch_status_output=$("$ceph" orch status 2>&1)
+
+echo "$orch_status_output"
+if [[ "$orch_status_output" == *"Backend: cephadm"* ]]; then
+    echo "PASS: orch command succeeded during small delay."
+elif [[ "$orch_status_output" == *"Error ENOTSUP: Module 'orchestrator' is not enabled/loaded"* ]]; then
+    echo "FAIL: orch command failed during small delay."
+    exit 1
+else
+    echo "FAIL: Unexpected error in orch command during small delay."
+    echo "$orch_status_output"
+    exit 1
+fi
+
+echo "Ensure health detail DOES NOT warn about any modules that failed initialization..."
+health=$("$ceph" health detail 2>&1)
+if [[ "$health" == *"Module failed to initialize"* ]]; then
+    echo "FAIL: One or more modules failed to initialize during small delay."
+    echo "$health"
+    exit 1
+fi
+
+echo "Verify that mgr is active..."
+stat=$("$ceph" -s 2>&1)
+if [[ "$stat" != *"active, since"* ]]; then
+    echo "FAIL: Mgr should be in 'active' state."
+    echo "$stat"
+    exit 1
+fi
+
+# ------ Test 3 ------
+echo "Test 3: Inject large delay (10000000000 ms) that exceeds max loading retries and emits cluster error"
+"$ceph" config set mgr mgr_module_load_delay 10000000000
+
+"$ceph" mgr fail
+orch_status_output=$("$ceph" orch status 2>&1)
+
+echo "$orch_status_output"
+if [[ "$orch_status_output" == *"Error ENOTSUP: Module 'orchestrator' is not enabled/loaded"* ]]; then
+    echo "PASS: orch command failed during large delay as expected."
+else
+    echo "FAIL: Unexpected error in orch command during large delay."
+    echo "$orch_status_output"
+    exit 1
+fi
+
+echo "Ensure health detail DOES warn about any modules that failed initialization..."
+health=$("$ceph" health detail 2>&1)
+if [[ "$health" == *"Module failed to initialize"* ]]; then
+    echo "PASS: Cluster properly issued error about modules that failed to initialize."
+    echo "$health"
+else
+    echo "FAIL: Cluster did not properly issue error about modules that failed to initialize."
+    echo "$health"
+    exit 1
+fi
+
+echo "Verify that mgr is active..."
+stat=$("$ceph" -s 2>&1)
+if [[ "$stat" != *"active, since"* ]]; then
+    echo "FAIL: Mgr should be in 'active' state."
+    echo "$stat"
+    exit 1
+fi
+
+# ----- Test 4 -----
+echo "Test 4: Disable the problematic module and confirm that the health error goes away"
+
+echo "Disabling the balancer module..."
+"$ceph" mgr module force disable balancer --yes-i-really-mean-it
+
+echo "Sleeping for 10 seconds to allow the health error to clear up..."
+sleep 10
+
+echo "Ensure health detail no longer warns about any modules that failed initialization..."
+health=$("$ceph" health detail 2>&1)
+if [[ "$health" == *"Module failed to initialize"* ]]; then
+    echo "FAIL: One or more modules failed to initialize despite problem module being disabled."
+    echo "$health"
+    exit 1
+fi
+
+echo "Verify that mgr is active..."
+stat=$("$ceph" -s 2>&1)
+if [[ "$stat" != *"active, since"* ]]; then
+    echo "FAIL: Mgr should be in 'active' state."
+    echo "$stat"
+    exit 1
+fi
+
+echo "All tests passed."

--- a/qa/workunits/mgr/test_mgr_module_loading_time.sh
+++ b/qa/workunits/mgr/test_mgr_module_loading_time.sh
@@ -66,11 +66,23 @@ if [[ "$stat" != *"active, since"* ]]; then
     exit 1
 fi
 
+echo "Check mgr_status to ensure 'pending_modules' is empty..."
+expected='[]'
+mgr_status=$("$ceph" tell mgr mgr_status | jq -c '.pending_modules')
+if [[ "$mgr_status" == "$expected" ]]; then
+    echo "PASS: No modules are pending."
+else
+    echo "FAIL: Some modules are pending when they shouldn't be."
+    echo "Expected: $expected"
+    echo "Actual:   $mgr_status"
+    exit 1
+fi
+
 # ------ Test 2 ------
 echo "Select balancer module to receive loading delays..."
 "$ceph" config set mgr mgr_module_load_delay_name balancer
 
-echo "Test 2: Inject small delay (10000 ms) that should not exceed max loading retries"
+echo "Test 2: Inject small delay (10000 ms) that should not exceed max loading expiration"
 "$ceph" config set mgr mgr_module_load_delay 10000
 
 "$ceph" mgr fail
@@ -104,8 +116,20 @@ if [[ "$stat" != *"active, since"* ]]; then
     exit 1
 fi
 
+echo "Check mgr_status to ensure 'pending_modules' is empty..."
+expected='[]'
+mgr_status=$("$ceph" tell mgr mgr_status | jq -c '.pending_modules')
+if [[ "$mgr_status" == "$expected" ]]; then
+    echo "PASS: No modules are pending."
+else
+    echo "FAIL: Some modules are pending when there shouldn't be."
+    echo "Expected: $expected"
+    echo "Actual:   $mgr_status"
+    exit 1
+fi
+
 # ------ Test 3 ------
-echo "Test 3: Inject large delay (10000000000 ms) that exceeds max loading retries and emits cluster error"
+echo "Test 3: Inject large delay (10000000000 ms) that exceeds max loading expiration and emits cluster error"
 "$ceph" config set mgr mgr_module_load_delay 10000000000
 
 "$ceph" mgr fail
@@ -139,6 +163,18 @@ if [[ "$stat" != *"active, since"* ]]; then
     exit 1
 fi
 
+echo "Check mgr_status to ensure 'pending_modules' is populated with modules we expect..."
+expected='["balancer","cephadm","crash","devicehealth","iostat","nfs","orchestrator","pg_autoscaler","progress","rbd_support","status","telemetry","volumes"]'
+mgr_status=$("$ceph" tell mgr mgr_status | jq -c '.pending_modules')
+if [[ "$mgr_status" == "$expected" ]]; then
+    echo "PASS: Expected modules are pending."
+else
+    echo "FAIL: Expected output does not match actual."
+    echo "Expected: $expected"
+    echo "Actual:   $mgr_status"
+    exit 1
+fi
+
 # ----- Test 4 -----
 echo "Test 4: Disable the problematic module and confirm that the health error goes away"
 
@@ -163,5 +199,23 @@ if [[ "$stat" != *"active, since"* ]]; then
     echo "$stat"
     exit 1
 fi
+
+echo "Check mgr_status to ensure 'pending_modules' is empty..."
+expected='[]'
+mgr_status=$("$ceph" tell mgr mgr_status | jq -c '.pending_modules')
+if [[ "$mgr_status" == "$expected" ]]; then
+    echo "PASS: No modules are pending."
+else
+    echo "FAIL: Some modules are pending when there shouldn't be."
+    echo "Expected: $expected"
+    echo "Actual:   $mgr_status"
+    exit 1
+fi
+
+echo "Re-enabling the balancer module..."
+"$ceph" mgr module enable balancer
+
+# Give the health error a bit of time to clear
+sleep 10
 
 echo "All tests passed."

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -160,6 +160,29 @@ options:
   flags:
   - no_mon_update
   - cluster_create
+- name: mgr_module_load_delay
+  type: millisecs
+  level: dev
+  default: 0
+  desc: Number of milliseconds for Manager modules to delay loading. For testing purposes only.
+  long_desc: Number of milliseconds for Manager modules to delay loading. For testing purposes only.
+  see_also:
+  - mgr_module_load_delay_name
+  flags:
+  - runtime
+  services:
+  - mgr
+- name: mgr_module_load_delay_name
+  type: str
+  level: dev
+  desc: Specify which Manager module is to delay loading by mgr_module_load_delay milliseconds. For testing purposes only.
+  long_desc: Specify which Manager module is to delay loading by mgr_module_load_delay milliseconds. For testing purposes only.
+  see_also:
+  - mgr_module_load_delay
+  flags:
+  - runtime
+  services:
+  - mgr
 - name: cephadm_path
   type: str
   level: advanced

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -183,6 +183,18 @@ options:
   - runtime
   services:
   - mgr
+- name: mgr_module_load_expiration
+  type: millisecs
+  level: dev
+  default: 20000
+  desc: Maximum number of milliseconds the active mgr is allowed to load the mgr modules before declaring availability.
+  long_desc: Maximum number of milliseconds the active mgr is allowed to load the mgr modules. If any modules are still
+    uninitialized after the expiration is exceeded, the mgr proceeds to declare availability, but a health error will be
+    issued indicating which modules didn't load in time.
+  flags:
+  - runtime
+  services:
+  - mgr
 - name: cephadm_path
   type: str
   level: advanced

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -537,6 +537,14 @@ void ActivePyModules::start_one(PyModuleRef py_module)
   // Send all python calls down a Finisher to avoid blocking
   // C++ code, and avoid any potential lock cycles.
   finisher.queue(new LambdaContext([this, active_module, name](int) {
+    // Delay loading in testing scenarios
+    auto delay = g_conf().get_val<std::chrono::milliseconds>("mgr_module_load_delay");
+    std::string delayed_module = g_conf().get_val<std::string>("mgr_module_load_delay_name");
+    if ((name == delayed_module) && (delay > std::chrono::milliseconds{0})) {
+      dout(4) << "Delaying load time for module '" << name
+              << "' by " << delay << "..." << dendl;
+      std::this_thread::sleep_for(delay);
+    }
     int r = active_module->load(this);
     std::lock_guard l(lock);
     pending_modules.erase(name);
@@ -552,6 +560,12 @@ void ActivePyModules::start_one(PyModuleRef py_module)
       dout(4) << "Starting active module " << name <<" finisher thread "
         << active_module->get_fin_thread_name() << dendl;
       active_module->finisher.start();
+    }
+
+    // Signal when we're finally done starting up modules
+    if (pending_modules.empty() && recheck_modules_start) {
+      finisher.queue(recheck_modules_start);
+      recheck_modules_start = nullptr;
     }
   }));
 }
@@ -1757,4 +1771,14 @@ PyObject* ActivePyModules::get_daemon_health_metrics()
       }
       return f.get();
   });
+}
+
+void ActivePyModules::check_all_modules_started(Context *modules_start_complete) {
+  std::lock_guard l(lock);
+  if (pending_modules.empty()) {
+    // Modules are already done starting, signal completion right away
+    finisher.queue(modules_start_complete);
+  } else {
+    recheck_modules_start = modules_start_complete; // signal that we need to check again later
+  }
 }

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -223,6 +223,11 @@ public:
   bool is_pending(std::string_view name) const {
     return pending_modules.count(name) > 0;
   }
+
+  // Return set of active modules where class instances are not yet created
+  const std::set<std::string, std::less<>>& get_pending_modules() const {
+    return pending_modules;
+  }
   bool module_exists(const std::string &name) const
   {
     return modules.count(name) > 0;

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -46,6 +46,11 @@ class ActivePyModules
 {
   // module class instances not yet created
   std::set<std::string, std::less<>> pending_modules;
+  // This context is set during mgr initialization when
+  // modules need more time to finish starting up.
+  // See ActivePyModules::check_all_modules_started() and
+  // ActivePyModules::start_one().
+  Context *recheck_modules_start = nullptr;
   // module class instances already created
   std::map<std::string, std::shared_ptr<ActivePyModule>> modules;
   PyModuleConfig &module_config;
@@ -251,5 +256,11 @@ public:
 
   bool inject_python_on() const;
   void update_cache_metrics();
+  // Sends the "active" beacon right away if all mgr modules
+  // have finished startup. If some modules are still pending
+  // startup, the "active" beacon is scheduled to send later
+  // only after all modules are ready.
+  // See "PyModuleRegistry::check_all_modules_started()".
+  void check_all_modules_started(Context *modules_start_complete);
 };
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -3047,14 +3047,27 @@ bool DaemonServer::_handle_command(
     return true;
   }
 
+  // Validate that the module is enabled
+  auto& py_handler_name = py_command.module_name;
+  PyModuleRef module = py_modules.get_module(py_handler_name);
+  ceph_assert(module);
+  if (!module->is_enabled()) {
+    ss << "Module '" << py_handler_name << "' is not enabled (required by "
+          "command '" << prefix << "'): use `ceph mgr module enable "
+          << py_handler_name << "` to enable it";
+    dout(4) << ss.str() << dendl;
+    cmdctx->reply(-EOPNOTSUPP, ss);
+    return true;
+  }
+
   // Validate that the module is active
   auto& mod_name = py_command.module_name;
   if (!py_modules.is_module_active(mod_name)) {
-    ss << "Module '" << mod_name << "' is not enabled/loaded (required by "
-          "command '" << prefix << "'): use `ceph mgr module enable "
-          << mod_name << "` to enable it";
+    ss << "Module '" << mod_name << "' did not initialize in time (required by "
+          "command '" << prefix << "'): see https://docs.ceph.com/en/latest/rados/operations/health-checks/#mgr-module-error "
+	  "for troubleshooting tips.";
     dout(4) << ss.str() << dendl;
-    cmdctx->reply(-EOPNOTSUPP, ss);
+    cmdctx->reply(-ETIMEDOUT, ss);
     return true;
   }
 
@@ -3063,24 +3076,11 @@ bool DaemonServer::_handle_command(
   dout(10) << "passing through command '" << prefix << "' size " << cmdctx->cmdmap.size() << dendl;
   Finisher& mod_finisher = py_modules.get_active_module_finisher(mod_name);
 
-  mod_finisher.queue(new LambdaContext([this, cmdctx, session, py_command, prefix, op]
+  mod_finisher.queue(new LambdaContext([this, cmdctx, session, py_command, prefix, op, py_handler_name, module]
                                        (int r_) mutable {
     std::stringstream ss;
 
     dout(10) << "dispatching command '" << prefix << "' size " << cmdctx->cmdmap.size() << dendl;
-
-    // Validate that the module is enabled
-    auto& py_handler_name = py_command.module_name;
-    PyModuleRef module = py_modules.get_module(py_handler_name);
-    ceph_assert(module);
-    if (!module->is_enabled()) {
-      ss << "Module '" << py_handler_name << "' is not enabled (required by "
-            "command '" << prefix << "'): use `ceph mgr module enable "
-            << py_handler_name << "` to enable it";
-      dout(4) << ss.str() << dendl;
-      cmdctx->reply(-EOPNOTSUPP, ss);
-      return;
-    }
 
     // Hack: allow the self-test method to run on unhealthy modules.
     // Fix this in future by creating a special path for self test rather

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -828,12 +828,19 @@ int Mgr::call(
   try {
     if (admin_command == "mgr_status") {
       f->open_object_section("mgr_status");
-      cluster_state.with_mgrmap(
-	[f](const MgrMap& mm) {
-	  f->dump_unsigned("mgrmap_epoch", mm.get_epoch());
-	});
-      f->dump_bool("initialized", initialized);
+      {
+	cluster_state.with_mgrmap(
+	    [f](const MgrMap& mm) {
+	    f->dump_unsigned("mgrmap_epoch", mm.get_epoch());
+	    });
+        f->dump_bool("initialized", initialized);
+	f->open_array_section("pending_modules");
+        for (auto& mod : py_module_registry->get_pending_modules()) {
+          f->dump_string("module", mod);
+        }
+        f->close_section();
       f->close_section();
+      }
       return 0;
     } else {
       return -ENOSYS;

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -171,7 +171,15 @@ void Mgr::background_init(Context *completion)
 
   finisher.queue(new LambdaContext([this, completion](int r){
     init();
-    completion->complete(0);
+    py_module_registry->check_all_modules_started(
+	new LambdaContext([this, completion](int){
+	  {
+	    std::lock_guard l(lock);
+	    initializing = false;
+	    initialized = true;
+	  }
+	completion->complete(0);
+      }));
   }));
 }
 
@@ -389,8 +397,6 @@ void Mgr::init()
 #endif
 
   dout(4) << "Complete." << dendl;
-  initializing = false;
-  initialized = true;
 }
 
 void Mgr::load_all_metadata()

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -68,7 +68,8 @@ Mgr::Mgr(MonClient *monc_, const MgrMap& mgrmap,
   clog(clog_),
   audit_clog(audit_clog_),
   initialized(false),
-  initializing(false)
+  initializing(false),
+  initialization_start_time(ceph::coarse_mono_clock::zero())
 {
   cluster_state.set_objecter(objecter);
 }
@@ -166,6 +167,7 @@ void Mgr::background_init(Context *completion)
   ceph_assert(!initializing);
   ceph_assert(!initialized);
   initializing = true;
+  initialization_start_time = ceph::coarse_mono_clock::now();
 
   finisher.start();
 
@@ -760,6 +762,32 @@ bool Mgr::got_mgr_map(const MgrMap& m)
   server.got_mgr_map();
 
   return false;
+}
+
+bool Mgr::exceeded_initialization_expiration()
+{
+  // initialization_start_time=0 when initialization hasn't started yet,
+  // so know we can't have exceeded the time expiration.
+  if (ceph::coarse_mono_clock::is_zero(initialization_start_time)) {
+    return false;
+  }
+
+  // Save the amount of time elapsed
+  auto time_elapsed = ceph::coarse_mono_clock::now() - initialization_start_time;
+  dout(20) << "time elapsed since mgr initialization: " << time_elapsed << dendl;
+
+  // Reset start time if the expiration time has been exceeded.
+  // Signal initialization=true so the mgr forcibly sends an "active" beacon
+  auto expiration = g_conf().get_val<std::chrono::milliseconds>("mgr_module_load_expiration");
+  bool exceeded_expiration = time_elapsed > expiration;
+  if (exceeded_expiration) {
+    std::lock_guard l(lock);
+    initialization_start_time = ceph::coarse_mono_clock::zero();
+    initializing = false;
+    initialized = true;
+  }
+
+  return exceeded_expiration;
 }
 
 void Mgr::handle_mgr_digest(ref_t<MMgrDigest> m)

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -66,6 +66,7 @@ protected:
 
   bool initialized;
   bool initializing;
+  ceph::coarse_mono_time initialization_start_time;
 
 public:
   Mgr(MonClient *monc_, const MgrMap& mgrmap,
@@ -75,6 +76,7 @@ public:
   ~Mgr();
 
   bool is_initialized() const {return initialized;}
+  bool exceeded_initialization_expiration();
   entity_addrvec_t get_server_addrs() const {
     return server.get_myaddrs();
   }

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -277,8 +277,23 @@ void MgrStandby::send_beacon()
   }
 
   // Whether I think I am available (request MgrMonitor to set me
-  // as available in the map)
-  bool available = active_mgr != nullptr && active_mgr->is_initialized();
+  // as available in the map).
+  //
+  // The active mgr is marked available if:
+  // 1. The mon has chosen a standby to be active
+  // 2. The chosen active mgr has all of its modules initialized
+  //
+  // In extreme cases, if modules take very long to initialize (a buffer of extra time
+  // is allowed; see "mgr_module_load_expiration"), we will proceed to mark the chosen
+  // active mgr "available" to unblock other mgr functionality such as reporting PG
+  // availability. If this happens, a health error will be issued indicating which
+  // mgr modules got stuck initializing (See src/mgr/PyModuleRegistry.cc). This unblocks
+  // the rest of the mgr's functionality while making it clear that some modules
+  // are unusuable.
+  bool available = false;
+  if (active_mgr != nullptr) {
+    available = active_mgr->is_initialized() || active_mgr->exceeded_initialization_expiration();
+  }
 
   auto addrs = available ? active_mgr->get_server_addrs() : entity_addrvec_t();
   dout(10) << "sending beacon as gid " << monc.get_global_id() << dendl;

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -507,3 +507,7 @@ void PyModuleRegistry::handle_config_notify()
     active_modules->config_notify();
   }
 }
+
+void PyModuleRegistry::check_all_modules_started(Context *modules_start_complete) {
+  active_modules->check_all_modules_started(modules_start_complete);
+}

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -428,6 +428,8 @@ void PyModuleRegistry::get_health_checks(health_check_map_t *checks)
         //   checks (to avoid outputting two health messages about a
         //   module that said can_run=false but we tried running it anyway)
         failed_modules[module->get_name()] = module->get_error_string();
+      } else if ((active_modules->is_pending(module->get_name()))) {
+        failed_modules[module->get_name()] = "Module failed to initialize.";
       }
     }
 

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -245,5 +245,11 @@ public:
   // See "Mgr::background_init()".
   void check_all_modules_started(Context *modules_start_complete);
 
+  // Return set of active modules where class instances are not yet created.
+  // Protected by const; we only want to view the contents- not modify anything.
+  const std::set<std::string, std::less<>>& get_pending_modules() const {
+    return active_modules->get_pending_modules();
+  }
+
   // <<< (end of ActivePyModules cheeky call-throughs)
 };

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -238,5 +238,12 @@ public:
     return active_modules->get_module_finisher(name);
   }
 
+  // Sends the "active" beacon right away if all mgr modules
+  // have finished startup. If some modules are still pending
+  // startup, the "active" beacon is scheduled to send later
+  // after all modules are ready.
+  // See "Mgr::background_init()".
+  void check_all_modules_started(Context *modules_start_complete);
+
   // <<< (end of ActivePyModules cheeky call-throughs)
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75564

Note: 740de93366430e509a52ee31d1c54fe954b41991 to be included in a followup PR after https://github.com/ceph/ceph/pull/67641 merges.

---

backport of https://github.com/ceph/ceph/pull/63859
parent tracker: https://tracker.ceph.com/issues/71631

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh