### PR TITLE
librbd/mirror: separate image reference removal from group and defer image cleanup

### DIFF
--- a/src/librbd/mirror/GroupEnableRequest.cc
+++ b/src/librbd/mirror/GroupEnableRequest.cc
@@ -235,7 +235,7 @@ void GroupEnableRequest<I>::create_primary_group_snapshot() {
     lderr(m_cct) << "failed to retrieve min OSD release: " << cpp_strerror(r)
                  << dendl;
     m_ret_val = r;
-    close_images();
+    disable_mirror_group();
     return;
   }
 
@@ -272,7 +272,7 @@ void GroupEnableRequest<I>::handle_create_primary_group_snapshot(int r) {
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    close_images();
+    disable_mirror_group();
     return;
   }
 
@@ -325,7 +325,7 @@ void GroupEnableRequest<I>::handle_create_primary_image_snapshots(int r) {
       m_group_snap.snaps[i].snap_id = m_snap_ids[i];
     }
 
-    remove_primary_group_snapshot();
+    disable_mirror_group();
     return;
   }
 
@@ -364,7 +364,7 @@ void GroupEnableRequest<I>::handle_update_primary_group_snapshot(int r) {
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    remove_primary_group_snapshot();
+    disable_mirror_group();
     return;
   }
 

--- a/src/librbd/mirror/GroupPromoteRequest.cc
+++ b/src/librbd/mirror/GroupPromoteRequest.cc
@@ -611,48 +611,56 @@ void GroupPromoteRequest<I>::fix_group_membership(
     return;
   }
 
-  auto ctx = create_context_callback<
-      GroupPromoteRequest<I>,
-      &GroupPromoteRequest<I>::handle_fix_group_membership>(this);
+  remove_images_from_group();
+}
 
-  auto gather = new C_Gather(m_cct, ctx);
-  // remove images and disable mirroring
+template <typename I>
+void GroupPromoteRequest<I>::remove_images_from_group() {
+  ldout(m_cct, 10) << dendl;
+
+  auto gather = new C_Gather(m_cct,
+    create_context_callback<GroupPromoteRequest<I>,
+      &GroupPromoteRequest<I>::handle_remove_images_from_group>(this));
+
   for (auto& spec : m_to_remove) {
-    auto it = std::find_if(m_image_ctxs.begin(), m_image_ctxs.end(),
-      [&](auto* ictx) {
-        return spec.image_id == ictx->id &&
-               spec.pool_id == ictx->md_ctx.get_id();
-      });
+    librados::ObjectWriteOperation op;
+    cls_client::group_image_remove(&op, {spec.image_id, spec.pool_id});
 
-    if (it == m_image_ctxs.end()) {
-      continue;
-    }
-
-    auto* ictx = *it;
     Context* subctx = gather->new_sub();
-    auto req = mirror::GroupRemoveImageRequest<I>::create(
-        ictx, m_group_id, m_group_ioctx, subctx);
-    req->send();
+    auto comp = create_rados_callback(subctx);
+
+    int r = m_group_ioctx.aio_operate(util::group_header_name(m_group_id),
+                                      comp, &op);
+    ceph_assert(r == 0);
+
+    comp->release();
   }
 
   gather->activate();
 }
 
 template <typename I>
-void GroupPromoteRequest<I>::handle_fix_group_membership(int r) {
+void GroupPromoteRequest<I>::handle_remove_images_from_group(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed to remove images from group: "
+                 << cpp_strerror(r) << dendl;
+
     m_ret_val = r;
     release_exclusive_locks();
     return;
   }
 
-  // Safe erase of removed images
+  // make a copy and erase removed images
+  m_image_ctxs_old_membership = m_image_ctxs;
   for (auto& spec : m_to_remove) {
     auto it = std::find_if(
         m_image_ctxs.begin(), m_image_ctxs.end(),
-        [&](I* ictx) { return ictx->id == spec.image_id; });
+        [&](I* ictx) {
+          return ictx->id == spec.image_id &&
+                 ictx->md_ctx.get_id() == spec.pool_id;
+        });
 
     if (it != m_image_ctxs.end()) {
       m_image_ctxs.erase(it);
@@ -943,17 +951,66 @@ void GroupPromoteRequest<I>::handle_group_unlink_peer(int r) {
   if (r < 0) {
     lderr(m_cct) << "failed to unlink mirror group snapshot: "
                  << cpp_strerror(r) << dendl;
-  }
-
-  if (r == 0 && !m_to_remove.empty()) {
-    // At this point, any non-primary and incomplete primary group snapshots
-    // should already have been pruned. We can now safely remove the images
-    // that are no longer members of the group.
-    remove_non_member_images();
+    release_exclusive_locks();
     return;
   }
 
-  release_exclusive_locks();
+  disable_removed_images();
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::disable_removed_images() {
+  if (m_to_remove.empty()) {
+    release_exclusive_locks();
+    return;
+  }
+
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<GroupPromoteRequest<I>,
+    &GroupPromoteRequest<I>::handle_disable_removed_images>(this);
+
+  auto gather = new C_Gather(m_cct, ctx);
+  for (auto& spec : m_to_remove) {
+    auto it = std::find_if(m_image_ctxs_old_membership.begin(),
+      m_image_ctxs_old_membership.end(),
+      [&](auto* ictx) {
+        return spec.image_id == ictx->id &&
+               spec.pool_id == ictx->md_ctx.get_id();
+      });
+
+    if (it == m_image_ctxs_old_membership.end()) {
+      lderr(m_cct) << "missing ictx for image_id="
+                   << spec.image_id << " pool_id="
+                   << spec.pool_id << dendl;
+      continue;
+    }
+
+    auto* ictx = *it;
+    Context* subctx = gather->new_sub();
+    auto req = mirror::GroupRemoveImageRequest<I>::create(
+      ictx, m_group_id, m_group_ioctx, subctx);
+    req->send();
+  }
+
+  gather->activate();
+}
+
+template <typename I>
+void GroupPromoteRequest<I>::handle_disable_removed_images(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to disable removed images: "
+                 << cpp_strerror(r) << dendl;
+    release_exclusive_locks();
+    return;
+  }
+
+  // At this point, any non-primary and incomplete primary group snapshots
+  // should already have been pruned. We can now safely remove the images
+  // that are no longer members of the group.
+  remove_non_member_images();
 }
 
 template <typename I>
@@ -979,9 +1036,16 @@ void GroupPromoteRequest<I>::remove_non_member_images() {
   // promotion.
   for (const auto& image : m_images) {
     if (image.state == cls::rbd::GROUP_IMAGE_LINK_STATE_INCOMPLETE) {
-      ldout(m_cct, 10) << "removing incomplete image: "
+      ldout(m_cct, 10) << "removing image with incomplete group link state: "
                        << image.spec.image_id << dendl;
-      m_to_remove.push_back(image.spec);
+      auto exists = std::any_of(m_to_remove.begin(), m_to_remove.end(),
+        [&](const cls::rbd::GroupImageSpec& s) {
+          return s.image_id == image.spec.image_id &&
+          s.pool_id == image.spec.pool_id;
+        });
+      if (!exists) {
+        m_to_remove.push_back(image.spec);
+      }
     }
   }
 

--- a/src/librbd/mirror/GroupPromoteRequest.cc
+++ b/src/librbd/mirror/GroupPromoteRequest.cc
@@ -30,12 +30,6 @@
 namespace librbd {
 namespace mirror {
 
-namespace {
-
-const uint32_t MAX_RETURN = 1024;
-
-} // anonymous namespace
-
 using util::create_context_callback;
 using util::create_rados_callback;
 
@@ -533,58 +527,48 @@ void GroupPromoteRequest<I>::handle_acquire_exclusive_locks(int r) {
   if (!m_need_rollback) {
     ldout(m_cct, 10) << "no rollback required" << dendl;
     create_primary_group_snapshot();
-  } else {
-    // current membership
-    std::vector<cls::rbd::GroupImageSpec> current_membership;
-    for (const auto& image : m_images) {
-      current_membership.push_back(image.spec);
-    }
-
-    // rollback membership
-    auto* rollback_snap = &m_rollback_group_snap;
-    std::vector<cls::rbd::GroupImageSpec> rollback_membership;
-    for (auto& it : rollback_snap->snaps) {
-      rollback_membership.emplace_back(it.image_id, it.pool);
-    }
-
-    if (rollback_membership != current_membership) {
-      ldout(m_cct, 10) << "rollback group snapshot membership with snap id: "
-                       << rollback_snap->id
-                       << ", does not match current group membership"
-                       << dendl;
-      fix_group_membership(current_membership, rollback_membership);
-      return;
-    }
-    rollback();
+    return;
   }
-}
 
-template <typename I>
-void GroupPromoteRequest<I>::fix_group_membership(
-    std::vector<cls::rbd::GroupImageSpec>& current_membership,
-    std::vector<cls::rbd::GroupImageSpec>& rollback_membership) {
-  ldout(m_cct, 10) << dendl;
+  // current membership
+  std::vector<cls::rbd::GroupImageSpec> current_membership;
+  for (const auto& image : m_images) {
+    current_membership.push_back(image.spec);
+  }
 
-  m_to_add.clear();
-  m_to_remove.clear();
+  // rollback membership
+  auto* rollback_snap = &m_rollback_group_snap;
+  std::vector<cls::rbd::GroupImageSpec> rollback_membership;
+  for (auto& it : rollback_snap->snaps) {
+    rollback_membership.emplace_back(it.image_id, it.pool);
+  }
+
+  if (rollback_membership == current_membership) {
+    rollback();
+    return;
+  }
+
+  ldout(m_cct, 10) << "rollback group snapshot membership with snap id: "
+                   << rollback_snap->id
+                   << ", does not match current group membership"
+                   << dendl;
 
   std::set<std::pair<std::string, int64_t>> current_set;
   std::set<std::pair<std::string, int64_t>> rollback_set;
-
   for (auto& img : current_membership) {
     current_set.insert({img.image_id, img.pool_id});
   }
-
   for (auto& img : rollback_membership) {
     rollback_set.insert({img.image_id, img.pool_id});
   }
 
+  m_to_add.clear();
+  m_to_remove.clear();
   for (auto& img : rollback_membership) {
     if (!current_set.count({img.image_id, img.pool_id})) {
       m_to_add.push_back(img);
     }
   }
-
   for (auto& img : current_membership) {
     if (!rollback_set.count({img.image_id, img.pool_id})) {
       m_to_remove.push_back(img);
@@ -594,7 +578,6 @@ void GroupPromoteRequest<I>::fix_group_membership(
   ldout(m_cct, 10) << "fixing group membership, "
                    << "to_add=" << m_to_add.size()
                    << ", to_remove=" << m_to_remove.size() << dendl;
-
   if (!m_to_add.empty()) {
     lderr(m_cct) << "rollback requires adding images to group, but dynamic "
                  << "group removal is not supported today" << dendl;
@@ -602,8 +585,7 @@ void GroupPromoteRequest<I>::fix_group_membership(
     release_exclusive_locks();
     return;
   }
-
-  if (!m_to_remove.empty() && m_to_remove.size() > 1) {
+  if (m_to_remove.size() > 1) {
     lderr(m_cct) << "rollback requires more than one image to be removed from "
                  << "the group, this is not supported today" << dendl;
     m_ret_val = -EINVAL;
@@ -667,54 +649,22 @@ void GroupPromoteRequest<I>::handle_remove_images_from_group(int r) {
     }
   }
 
-  m_images.clear();
-  list_group_images();
-}
+  // Remove from m_images
+  for (auto& spec : m_to_remove) {
+    auto it = std::remove_if(
+        m_images.begin(), m_images.end(),
+        [&](const cls::rbd::GroupImageStatus& image) {
+          return image.spec.image_id == spec.image_id &&
+                 image.spec.pool_id == spec.pool_id;
+        });
 
-template <typename I>
-void GroupPromoteRequest<I>::list_group_images() {
-  ldout(m_cct, 10) << dendl;
-
-  librados::ObjectReadOperation op;
-  cls_client::group_image_list_start(&op, m_start_after, MAX_RETURN);
-
-  auto comp = create_rados_callback<
-    GroupPromoteRequest<I>,
-    &GroupPromoteRequest<I>::handle_list_group_images>(this);
-
-  m_out_bl.clear();
-  int r = m_group_ioctx.aio_operate(
-    librbd::util::group_header_name(m_group_id), comp, &op, &m_out_bl);
-  ceph_assert(r == 0);
-  comp->release();
-}
-
-template <typename I>
-void GroupPromoteRequest<I>::handle_list_group_images(int r) {
-  ldout(m_cct, 10) << "r=" << r << dendl;
-
-  std::vector<cls::rbd::GroupImageStatus> images;
-  if (r == 0) {
-    auto iter = m_out_bl.cbegin();
-    r = cls_client::group_image_list_finish(&iter, &images);
+    if (it != m_images.end()) {
+      m_images.erase(it, m_images.end());
+    }
   }
 
-  if (r < 0) {
-    lderr(m_cct) << "group_id=" << m_group_id
-                 << " error listing images in group: "
-                 << cpp_strerror(r) << dendl;
-    m_ret_val = r;
-    release_exclusive_locks();
-    return;
-  }
-
-  auto image_count = images.size();
-  m_images.insert(m_images.end(), images.begin(), images.end());
-  if (image_count == MAX_RETURN) {
-    m_start_after = images.rbegin()->spec;
-    list_group_images();
-    return;
- }
+  ldout(m_cct, 10) << "updated membership: "
+                   << "remaining images=" << m_images.size() << dendl;
 
   rollback();
 }

--- a/src/librbd/mirror/GroupPromoteRequest.h
+++ b/src/librbd/mirror/GroupPromoteRequest.h
@@ -83,13 +83,7 @@ private:
    * ACQUIRE_EXCLUSIVE_LOCKS ---------------------------|
    *    |                                               |
    *    v  (skip if not needed)                         |
-   * FIX_GROUP_MEMBERSHIP                               |
-   *    |                                               |
-   *    v  (skip if not needed)                         |
    * REMOVE_IMAGES_FROM_GROUP                           |
-   *    |                                               |
-   *    v  (skip if not needed)                         |
-   * LIST_GROUP_IMAGES                                  |
    *    |                                               |
    *    v                                               |
    * ROLLBACK                                           |
@@ -197,15 +191,8 @@ private:
   void acquire_exclusive_locks();
   void handle_acquire_exclusive_locks(int r);
 
-  void fix_group_membership(
-      std::vector<cls::rbd::GroupImageSpec>& current_membership,
-      std::vector<cls::rbd::GroupImageSpec>& rollback_membership);
-
   void remove_images_from_group();
   void handle_remove_images_from_group(int r);
-
-  void list_group_images();
-  void handle_list_group_images(int r);
 
   void rollback();
   void handle_rollback(int r);

--- a/src/librbd/mirror/GroupPromoteRequest.h
+++ b/src/librbd/mirror/GroupPromoteRequest.h
@@ -86,6 +86,9 @@ private:
    * FIX_GROUP_MEMBERSHIP                               |
    *    |                                               |
    *    v  (skip if not needed)                         |
+   * REMOVE_IMAGES_FROM_GROUP                           |
+   *    |                                               |
+   *    v  (skip if not needed)                         |
    * LIST_GROUP_IMAGES                                  |
    *    |                                               |
    *    v                                               |
@@ -105,6 +108,9 @@ private:
    *    |                                                |        |
    *    v                                                v        |
    * GROUP_UNLINK_PEER               ENABLE_NON_PRIMARY_FEATURES  |
+   *    |                                                |        |
+   *    v  (skip if not required)                        |        |
+   * DISABLE_REMOVED_IMAGES                              |        |
    *    |                                                |        |
    *    v  (skip if not required)                        |        |
    * REMOVE_NON_MEMBER_IMAGES                            |        |
@@ -137,6 +143,7 @@ private:
   std::set<std::string> m_mirror_peer_uuids;
   std::vector<cls::rbd::GroupImageStatus> m_images;
   std::vector<ImageCtxT *> m_image_ctxs;
+  std::vector<ImageCtxT *> m_image_ctxs_old_membership;
   std::vector<librados::IoCtx> m_remove_ioctxs;
   ceph::bufferlist m_out_bl;
   cls::rbd::GroupImageSpec m_start_after;
@@ -193,7 +200,9 @@ private:
   void fix_group_membership(
       std::vector<cls::rbd::GroupImageSpec>& current_membership,
       std::vector<cls::rbd::GroupImageSpec>& rollback_membership);
-  void handle_fix_group_membership(int r);
+
+  void remove_images_from_group();
+  void handle_remove_images_from_group(int r);
 
   void list_group_images();
   void handle_list_group_images(int r);
@@ -215,6 +224,9 @@ private:
 
   void group_unlink_peer();
   void handle_group_unlink_peer(int r);
+
+  void disable_removed_images();
+  void handle_disable_removed_images(int r);
 
   void remove_non_member_images();
   void handle_remove_non_member_images(int r);

--- a/src/librbd/mirror/GroupRemoveImageRequest.cc
+++ b/src/librbd/mirror/GroupRemoveImageRequest.cc
@@ -172,38 +172,6 @@ void GroupRemoveImageRequest<I>::handle_remove_group_ref_from_image(int r) {
     return;
   }
 
-  remove_image_from_group();
-}
-
-template <typename I>
-void GroupRemoveImageRequest<I>::remove_image_from_group() {
-  ldout(m_cct, 10) << dendl;
-
-  librados::ObjectWriteOperation op;
-  cls_client::group_image_remove(
-      &op, {m_image_ctx->id, m_image_ctx->md_ctx.get_id()});
-
-  auto comp = create_rados_callback<GroupRemoveImageRequest<I>,
-    &GroupRemoveImageRequest<I>::handle_remove_image_from_group>(this);
-
-  int r = m_group_io_ctx.aio_operate(
-      util::group_header_name(m_group_id), comp, &op);
-  ceph_assert(r == 0);
-
-  comp->release();
-}
-
-template <typename I>
-void GroupRemoveImageRequest<I>::handle_remove_image_from_group(int r) {
-  ldout(m_cct, 10) << "r=" << r << dendl;
-
-  if (r < 0 && r != -ENOENT) {
-    lderr(m_cct) << "failed to remove group image entry: "
-                 << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
   remove_global_mirror_image_entry();
 }
 

--- a/src/librbd/mirror/GroupRemoveImageRequest.h
+++ b/src/librbd/mirror/GroupRemoveImageRequest.h
@@ -55,9 +55,6 @@ private:
  *  REMOVE_GROUP_REF_FROM_IMAGE
  *      |
  *      v
- *  REMOVE_IMAGE_FROM_GROUP
- *      |
- *      v
  *  REMOVE_GLOBAL_MIRROR_IMAGE_ENTRY
  *      |
  *      v
@@ -92,9 +89,6 @@ private:
 
   void remove_group_ref_from_image();
   void handle_remove_group_ref_from_image(int r);
-
-  void remove_image_from_group();
-  void handle_remove_image_from_group(int r);
 
   void remove_global_mirror_image_entry();
   void handle_remove_global_mirror_image_entry(int r);


### PR DESCRIPTION
As part of group membership fixup, update only the group metadata by
removing image references from the group object.

defer image cleanup until after unlinking incomplete primary group snapshot,
ensuring image-level state is handled in a safe and consistent context.

This change decouples group metadata updates from image cleanup logic.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
