### PR TITLE
qa:  Add opt-in min_size protection to OSD thrasher

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -337,14 +337,79 @@ class OSDThrasher(Thrasher):
                 stdout=StringIO(),
                 stderr=StringIO())
 
-    def kill_osd(self, osd=None, mark_down=False, mark_out=False):
+    def _get_safe_to_kill_osds(self):
         """
-        :param osd: Osd to be killed.
-        :mark_down: Mark down if true.
-        :mark_out: Mark out if true.
+        Return list of OSDs that can be killed without violating any PG's min_size.
+        This provides soft protection against systematic min_size violations while
+        still allowing testing of edge cases.
+        """
+        safe_osds = set(self.live_osds)
+        
+        try:
+            pgs = self.ceph_manager.get_pg_stats()
+            if not pgs:
+                self.log('No PG stats available, allowing all live OSDs')
+                return list(safe_osds)
+            
+            pools_info = {}
+            for pg in pgs:
+                pool_id = int(pg['pgid'].split('.')[0])
+                
+                # Cache pool info to avoid repeated lookups
+                if pool_id not in pools_info:
+                    try:
+                        pool_info = self.ceph_manager.get_pool_dump(pool_id)
+                        min_size = pool_info.get('min_size')
+                        size = pool_info.get('size')
+                        if min_size is None or size is None:
+                            raise Exception(f'Pool {pool_id} missing required min_size or size in pool info')
+                        pools_info[pool_id] = {
+                            'min_size': min_size,
+                            'size': size
+                        }
+                    except Exception as e:
+                        self.log(f'Failed to get pool {pool_id} info: {e}')
+                        continue
+                
+                acting = pg.get('acting', [])
+                min_size = pools_info[pool_id]['min_size']
+                
+                # If this PG is at or below min_size, don't kill any of its OSDs
+                if len(acting) <= min_size:
+                    for osd in acting:
+                        if osd in safe_osds:
+                            safe_osds.discard(osd)
+                            self.log(f'OSD {osd} cannot be killed: PG {pg["pgid"]} '
+                                   f'has acting set {acting} at/below min_size {min_size}')
+        
+        except Exception as e:
+            self.log(f'Exception while checking safe OSDs: {e}')
+            # On error, return all live OSDs (fail-safe to allow thrashing)
+            return list(self.live_osds)
+        
+        return list(safe_osds)
+
+    def kill_osd(self, osd=None, mark_down=False, mark_out=False, respect_min_size=False):
+        """
+        :param osd: osd to be killed.
+        :param mark_down: Mark down if true.
+        :param mark_out: Mark out if true.
+        :param respect_min_size: If true, try to avoid violating PG min_size.
         """
         if osd is None:
-            osd = random.choice(self.live_osds)
+            if respect_min_size:
+                # Try to pick an OSD that won't violate min_size
+                safe_osds = self._get_safe_to_kill_osds()
+                if safe_osds:
+                    osd = random.choice(safe_osds)
+                    self.log(f'Selected OSD {osd} from {len(safe_osds)} safe candidates')
+                else:
+                    # No safe OSDs
+                    self.log('No safe OSDs available and random check failed, '
+                               'skipping kill to protect min_size')
+                    return
+            else:
+                osd = random.choice(self.live_osds)
         self.log("Killing osd %s, live_osds are %s" % (str(osd),
                                                        str(self.live_osds)))
         self.live_osds.remove(osd)


### PR DESCRIPTION
**Problem:**
    
The OSD thrasher randomly kills OSDs without checking if it would
violate any PG's min_size. This leads to data loss scenarios
where multiple OSDs in the same acting set are killed in quick succession,
leaving PGs with fewer replicas than min_size and resulting in unfound
objects that cannot be recovered.
    
**Solution:**
    Add opt-in protection to kill_osd() that checks PG states before selecting
    an OSD to kill:
    
    1. New _get_safe_to_kill_osds() method identifies OSDs whose death would
       not violate any PG's min_size by checking acting sets against pool
       min_size values.
    
    2. Modified kill_osd() to accept respect_min_size parameter (default False):
    
    3. Updated test_pool_min_size() to explicitly set respect_min_size=False
       since that test intentionally violates min_size.
    
    This provides protection against systematic min_size violations while
    
Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
