### PR TITLE
rgw: add bucket check orphan command to find/fix orphaned list entries

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -59,6 +59,13 @@
   both --marker and --object-version options together (e.g., ``--marker=obj1 --object-version=abc123``).
   This enables proper pagination through versioned bucket listings without duplicates or
   infinite loops. For non-versioned buckets, use only --marker as before (backward compatible).
+* RGW: A new ``radosgw-admin bucket check orphan`` command identifies orphaned list
+  entries in versioned buckets: plain (listing) entries that have no corresponding
+  instance entry. Such entries appear in bucket listings but cannot be read, and can
+  cause lifecycle processing to fail with ENOENT. With the ``--fix`` flag, only orphaned
+  delete markers are removed; entries that still reference object data are reported and
+  skipped to avoid orphaning RADOS data. This is the inverse of ``bucket check unlinked``,
+  which finds instance entries that are missing their list entry.
 * RGW: OpenSSL engine support is deprecated in favor of provider support.
   - Removed the `openssl_engine_opts` configuration option. OpenSSL engine configuration in string format is no longer supported.
   - Added the `openssl_conf` configuration option for loading specified providers as default providers.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -104,6 +104,13 @@
   individual bucket without suspending its owner. S3 requests against a suspended
   bucket fail with ``403 BucketSuspended``. The ``suspended`` field is now included
   in ``radosgw-admin bucket stats`` output.
+* RGW: A new ``radosgw-admin bucket check orphan`` command identifies orphaned list
+  entries in versioned buckets: plain (listing) entries that have no corresponding
+  instance entry. Such entries appear in bucket listings but cannot be read, and can
+  cause lifecycle processing to fail with ENOENT. With the ``--fix`` flag, only orphaned
+  delete markers are removed; entries that still reference object data are reported and
+  skipped to avoid orphaning RADOS data. This is the inverse of ``bucket check unlinked``,
+  which finds instance entries that are missing their list entry.
 * RGW: OpenSSL engine support is deprecated in favor of provider support.
   - Removed the `openssl_engine_opts` configuration option. OpenSSL engine configuration in string format is no longer supported.
   - Added the `openssl_conf` configuration option for loading specified providers as default providers.

--- a/qa/workunits/rgw/common.py
+++ b/qa/workunits/rgw/common.py
@@ -7,6 +7,8 @@ import boto3
 import botocore.exceptions
 import random
 import json
+import os
+import tempfile
 from time import sleep
 
 log.basicConfig(format = '%(message)s', level=log.DEBUG)
@@ -101,3 +103,102 @@ def create_unlinked_objects(conn, bucket, key_list):
         exec_cmd('ceph config rm client rgw_debug_inject_olh_cancel_modification_err')
     return object_versions
 
+
+def get_bucket_index_info(bucket_name):
+    """Get the bucket index pool, bucket ID, and number of shards."""
+    out = exec_cmd(f'radosgw-admin bucket stats --bucket {bucket_name}')
+    stats = json.loads(out)
+    bucket_id = stats['id']
+    num_shards = stats.get('num_shards', 1)
+    index_pool = 'default.rgw.buckets.index'
+    return index_pool, bucket_id, num_shards
+
+
+def create_orphaned_list_entries(conn, bucket, key_list):
+    """
+    Creates orphaned list entries for each key in key_list.
+    An orphaned list entry is a plain (list) entry WITHOUT a corresponding
+    instance entry. This simulates the corruption scenario where LC fails
+    with ENOENT because bi_get_instance() cannot find the instance entry.
+
+    Steps:
+    1. Create a normal object (creates list + instance + olh entries)
+    2. Delete the object via S3 (creates delete marker)
+    3. Use rados to surgically remove the instance and olh entries directly
+
+    Returns list of (key, version_id) tuples representing orphaned entries.
+    """
+    orphaned_entries = []
+    index_pool, bucket_id, num_shards = get_bucket_index_info(bucket.name)
+
+    for key in key_list:
+        # Create object and then delete to create a delete marker
+        bucket.put_object(Key=key, Body=b"orphan_test_data")
+        bucket.Object(key).delete()
+
+        # Get the bi list to find the delete marker's instance entry
+        out = exec_cmd(f'radosgw-admin bi list --bucket {bucket.name} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+
+        # Find ALL instance entries for this key
+        # We need to remove all of them to create orphaned list entry
+        FLAG_DELETE_MARKER = 0x4
+        all_instances = []
+        delete_marker_instance = None
+        for entry in entries:
+            if entry['type'] == 'instance':
+                ent = entry['entry']
+                instance_id = ent['instance']
+                all_instances.append(instance_id)
+                flags = ent.get('flags', 0)
+                if (flags & FLAG_DELETE_MARKER) != 0:
+                    delete_marker_instance = instance_id
+                    log.debug(f'Found delete marker: {ent["name"]}:{instance_id} flags={flags}')
+
+        if not delete_marker_instance:
+            log.error(f'Could not identify delete marker instance for key={key}, skipping')
+            continue
+
+        orphaned_entries.append((key, delete_marker_instance))
+
+        # Now, we need to remove these instance entries and the OLH entry
+        # to create an orphaned list entry state
+        olh_key_bytes = b'\x801001_' + key.encode()
+
+        # Try all shards; object could be in any shard
+        for shard_num in range(num_shards):
+            shard_oid = f'.dir.{bucket_id}.{shard_num}'
+
+            # Remove ALL instance entries for this key
+            for instance_id in all_instances:
+                instance_key_bytes = b'\x801000_' + key.encode() + b'\x00i' + instance_id.encode()
+                with tempfile.NamedTemporaryFile(delete=False) as f:
+                    f.write(instance_key_bytes)
+                    instance_key_file = f.name
+                try:
+                    exec_cmd(f"rados -p {index_pool} rmomapkey {shard_oid} --omap-key-file {instance_key_file}",
+                             check_retcode=False)
+                finally:
+                    os.unlink(instance_key_file)
+
+            # Remove OLH entry
+            with tempfile.NamedTemporaryFile(delete=False) as f:
+                f.write(olh_key_bytes)
+                olh_key_file = f.name
+            try:
+                exec_cmd(f"rados -p {index_pool} rmomapkey {shard_oid} --omap-key-file {olh_key_file}",
+                         check_retcode=False)
+            finally:
+                os.unlink(olh_key_file)
+
+    # Verify orphaned state - should only have plain entries now
+    for key, instance in orphaned_entries:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {bucket.name} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        if 'instance' in entry_types or 'olh' in entry_types:
+            log.error(f'Key {key} still has instance/olh entries after removal attempt')
+        else:
+            log.info(f'Successfully created orphaned list entry for {key}:{instance}')
+
+    return orphaned_entries

--- a/qa/workunits/rgw/common.py
+++ b/qa/workunits/rgw/common.py
@@ -202,3 +202,81 @@ def create_orphaned_list_entries(conn, bucket, key_list):
             log.info(f'Successfully created orphaned list entry for {key}:{instance}')
 
     return orphaned_entries
+
+
+def create_orphaned_data_list_entries(conn, bucket, key_list):
+    """
+    Creates orphaned list entries that still reference object DATA (exists=true).
+
+    This is the data-carrying counterpart of create_orphaned_list_entries (which
+    orphans delete markers, exists=false). Here we leave a live (non-deleted)
+    versioned object's plain (list) entry behind after removing its instance and
+    OLH entries. Because these orphans still point at RADOS data, 'bucket check
+    orphan --fix' must SKIP them rather than remove them, to avoid orphaning that
+    data. Used to exercise the data-loss safeguard.
+
+    Returns list of (key, version_id) tuples representing orphaned data entries.
+    """
+    orphaned_entries = []
+    index_pool, bucket_id, num_shards = get_bucket_index_info(bucket.name)
+
+    for key in key_list:
+        # Create a live versioned object; do NOT delete, so the current version
+        # is a data object (exists=true) rather than a delete marker.
+        bucket.put_object(Key=key, Body=b"orphan_data")
+
+        # Find all instance entries for this key, and the data version's instance
+        out = exec_cmd(f'radosgw-admin bi list --bucket {bucket.name} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        all_instances = []
+        data_instance = None
+        for entry in entries:
+            if entry['type'] == 'instance':
+                ent = entry['entry']
+                instance_id = ent['instance']
+                all_instances.append(instance_id)
+                if ent.get('exists', False):
+                    data_instance = instance_id
+
+        if not data_instance:
+            log.error(f'Could not identify data instance for key={key}, skipping')
+            continue
+
+        orphaned_entries.append((key, data_instance))
+
+        # Remove instance and OLH entries, leaving only the plain (list) entry
+        olh_key_bytes = b'\x801001_' + key.encode()
+        for shard_num in range(num_shards):
+            shard_oid = f'.dir.{bucket_id}.{shard_num}'
+
+            for instance_id in all_instances:
+                instance_key_bytes = b'\x801000_' + key.encode() + b'\x00i' + instance_id.encode()
+                with tempfile.NamedTemporaryFile(delete=False) as f:
+                    f.write(instance_key_bytes)
+                    instance_key_file = f.name
+                try:
+                    exec_cmd(f"rados -p {index_pool} rmomapkey {shard_oid} --omap-key-file {instance_key_file}",
+                             check_retcode=False)
+                finally:
+                    os.unlink(instance_key_file)
+
+            with tempfile.NamedTemporaryFile(delete=False) as f:
+                f.write(olh_key_bytes)
+                olh_key_file = f.name
+            try:
+                exec_cmd(f"rados -p {index_pool} rmomapkey {shard_oid} --omap-key-file {olh_key_file}",
+                         check_retcode=False)
+            finally:
+                os.unlink(olh_key_file)
+
+    # Verify orphaned state - should only have plain entries now
+    for key, instance in orphaned_entries:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {bucket.name} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        if 'instance' in entry_types or 'olh' in entry_types:
+            log.error(f'Key {key} still has instance/olh entries after removal attempt')
+        else:
+            log.info(f'Successfully created orphaned data list entry for {key}:{instance}')
+
+    return orphaned_entries

--- a/qa/workunits/rgw/test_rgw_bucket_check.py
+++ b/qa/workunits/rgw/test_rgw_bucket_check.py
@@ -3,7 +3,7 @@
 import logging as log
 import json
 import botocore
-from common import exec_cmd, create_user, boto_connect, put_objects, create_unlinked_objects
+from common import exec_cmd, create_user, boto_connect, put_objects, create_unlinked_objects, create_orphaned_list_entries
 from botocore.config import Config
 
 """
@@ -197,6 +197,120 @@ def test_stats_with_unlinked(connection, bucket):
     assert json_out['usage']['rgw.main']['size_kb_utilized'] == 0
 
 
+def test_orphaned_list_entries(connection, bucket):
+    """
+    Test orphaned list entries (list entry WITHOUT instance entry).
+
+    This is the OPPOSITE of "unlinked" entries:
+    - Unlinked: instance entry exists, but list entry is missing
+    - Orphaned: list entry exists, but instance entry is missing
+
+    Bug scenario: LC fails with ENOENT when trying to delete a delete marker
+    that has a list entry but is missing its corresponding instance entry.
+
+    This test:
+    1. Creates orphaned list entries (simulating the corruption)
+    2. Verifies existing bucket check commands do NOT fix the issue
+    """
+    log.debug('TEST SUITE: Orphaned List Entries (list entry WITHOUT instance entry)')
+
+    # Clean up any existing objects first
+    bucket.object_versions.all().delete()
+
+    # Ensure versioning is enabled
+    connection.BucketVersioning(BUCKET_NAME).enable()
+
+    orphaned_keys = ['orphan1', 'orphan2']
+
+    # =========================================================================
+    # STEP 1: Create orphaned list entries
+    # =========================================================================
+    log.debug('TEST: orphaned list entries can be created\n')
+    orphaned_objs = create_orphaned_list_entries(connection, bucket, orphaned_keys)
+    assert len(orphaned_objs) == len(orphaned_keys), \
+        f'Expected {len(orphaned_keys)} orphaned entries, got {len(orphaned_objs)}'
+    log.info(f'Successfully created {len(orphaned_objs)} orphaned list entries')
+
+    # =========================================================================
+    # STEP 2: Verify the orphaned state
+    # =========================================================================
+    log.debug('TEST: orphaned list entries appear in bucket listing\n')
+    listed_versions = list(bucket.object_versions.all())
+    listed_keys = set(ov.key for ov in listed_versions)
+    for key in orphaned_keys:
+        assert key in listed_keys, f'orphaned key {key} should appear in bucket listing'
+    log.info(f'Orphaned keys visible in listing: {orphaned_keys}')
+
+    log.debug('TEST: bi list shows only PLAIN entry for orphaned objects\n')
+    for key, instance in orphaned_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        assert 'plain' in entry_types, f'orphaned entry {key} should have plain entry'
+        assert 'instance' not in entry_types, f'orphaned entry {key} should NOT have instance entry'
+        assert 'olh' not in entry_types, f'orphaned entry {key} should NOT have olh entry'
+        log.info(f'  {key}: entry types = {entry_types} (expected: only plain)')
+
+    # =========================================================================
+    # STEP 3: Verify existing bucket check commands do NOT fix the issue
+    # =========================================================================
+    log.debug('Verifying existing bucket check commands do NOT fix orphaned entries')
+
+    log.debug('TEST: bucket check --fix does not fix orphaned list entries\n')
+    exec_cmd(f'radosgw-admin bucket check --fix --bucket {BUCKET_NAME}')
+    # Verify orphaned entries still exist
+    for key, instance in orphaned_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        assert 'plain' in entry_types, f'orphaned entry {key} should still have plain entry after bucket check --fix'
+        assert 'instance' not in entry_types, f'orphaned entry {key} should still be missing instance entry'
+    log.info('  bucket check --fix: Did NOT fix orphaned entries (as expected)')
+
+    log.debug('TEST: bucket check --check-objects does not fix orphaned list entries\n')
+    out, ret = exec_cmd(f'radosgw-admin bucket check --check-objects --fix --bucket {BUCKET_NAME}', check_retcode=False)
+    # Verify orphaned entries still exist
+    for key, instance in orphaned_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        assert 'plain' in entry_types, f'orphaned entry {key} should still have plain entry after bucket check --check-objects'
+    log.info('  bucket check --check-objects --fix: Did NOT fix orphaned entries (as expected)')
+
+    log.debug('TEST: bucket check unlinked does not find orphaned list entries\n')
+    out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --min-age-hours 0 --dump-keys')
+    json_out = json.loads(out)
+    assert len(json_out) == 0, \
+        'bucket check unlinked should not find orphaned list entries (it finds the OPPOSITE problem)'
+    log.info('  bucket check unlinked: Found 0 entries (expected - it finds opposite problem)')
+
+    log.debug('TEST: bucket check unlinked --fix does not fix orphaned list entries\n')
+    out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --fix --min-age-hours 0 --dump-keys')
+    json_out = json.loads(out)
+    # Verify orphaned entries still exist
+    for key, instance in orphaned_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        assert 'plain' in entry_types, f'orphaned entry {key} should still exist after bucket check unlinked --fix'
+    log.info('  bucket check unlinked --fix: Did NOT fix orphaned entries (as expected)')
+
+    log.debug('TEST: bucket check olh does not find orphaned list entries\n')
+    out = exec_cmd(f'radosgw-admin bucket check olh --bucket {BUCKET_NAME} --dump-keys')
+    json_out = json.loads(out)
+    log.info(f'  bucket check olh: Found {len(json_out)} entries')
+
+    log.debug('TEST: bucket check olh --fix does not fix orphaned list entries\n')
+    out = exec_cmd(f'radosgw-admin bucket check olh --bucket {BUCKET_NAME} --fix --dump-keys')
+    # Verify orphaned entries still exist
+    for key, instance in orphaned_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        assert 'plain' in entry_types, f'orphaned entry {key} should still exist after bucket check olh --fix'
+    log.info('  bucket check olh --fix: Did NOT fix orphaned entries (as expected)')
+
+
 def main():
     """
     Execute bucket check command tests.
@@ -232,6 +346,9 @@ def main():
     test_null_versions_preserved(connection, bucket, null_version_keys, null_version_objs)
 
     test_stats_with_unlinked(connection, bucket)
+
+    # Test orphaned list entries (the opposite of unlinked entries)
+    test_orphaned_list_entries(connection, bucket)
 
     # Final cleanup - use bucket rm to force-delete even corrupted entries
     log.debug("Deleting bucket {}".format(BUCKET_NAME))

--- a/qa/workunits/rgw/test_rgw_bucket_check.py
+++ b/qa/workunits/rgw/test_rgw_bucket_check.py
@@ -23,6 +23,20 @@ ACCESS_KEY = 'OJODXSLNX4LUNHQG99PA'
 SECRET_KEY = '3l6ffld34qaymfomuh832j94738aie2x4p2o8h6n'
 BUCKET_NAME = 'check-bucket'
 
+def verify_orphaned_entries_exist(orphaned_objs, context_msg):
+    """
+    Verify that orphaned list entries still exist in the bucket index.
+    Used to confirm that various bucket check commands do NOT fix orphaned entries.
+    """
+    for key, instance in orphaned_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        assert 'plain' in entry_types, \
+            f'orphaned entry {key} should still have plain entry {context_msg}'
+        assert 'instance' not in entry_types, \
+            f'orphaned entry {key} should still be missing instance entry {context_msg}'
+
 
 def test_bucket_check_stats(connection, bucket):
     """Test that bucket check --fix correctly recalculates bucket stats."""
@@ -258,23 +272,12 @@ def test_orphaned_list_entries(connection, bucket):
 
     log.debug('TEST: bucket check --fix does not fix orphaned list entries\n')
     exec_cmd(f'radosgw-admin bucket check --fix --bucket {BUCKET_NAME}')
-    # Verify orphaned entries still exist
-    for key, instance in orphaned_objs:
-        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
-        entries = json.loads(out.replace(b'\x80', b'0x80'))
-        entry_types = [e['type'] for e in entries]
-        assert 'plain' in entry_types, f'orphaned entry {key} should still have plain entry after bucket check --fix'
-        assert 'instance' not in entry_types, f'orphaned entry {key} should still be missing instance entry'
+    verify_orphaned_entries_exist(orphaned_objs, "after bucket check --fix")
     log.info('  bucket check --fix: Did NOT fix orphaned entries (as expected)')
 
     log.debug('TEST: bucket check --check-objects does not fix orphaned list entries\n')
     out, ret = exec_cmd(f'radosgw-admin bucket check --check-objects --fix --bucket {BUCKET_NAME}', check_retcode=False)
-    # Verify orphaned entries still exist
-    for key, instance in orphaned_objs:
-        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
-        entries = json.loads(out.replace(b'\x80', b'0x80'))
-        entry_types = [e['type'] for e in entries]
-        assert 'plain' in entry_types, f'orphaned entry {key} should still have plain entry after bucket check --check-objects'
+    verify_orphaned_entries_exist(orphaned_objs, "after bucket check --check-objects --fix")
     log.info('  bucket check --check-objects --fix: Did NOT fix orphaned entries (as expected)')
 
     log.debug('TEST: bucket check unlinked does not find orphaned list entries\n')
@@ -285,14 +288,8 @@ def test_orphaned_list_entries(connection, bucket):
     log.info('  bucket check unlinked: Found 0 entries (expected - it finds opposite problem)')
 
     log.debug('TEST: bucket check unlinked --fix does not fix orphaned list entries\n')
-    out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --fix --min-age-hours 0 --dump-keys')
-    json_out = json.loads(out)
-    # Verify orphaned entries still exist
-    for key, instance in orphaned_objs:
-        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
-        entries = json.loads(out.replace(b'\x80', b'0x80'))
-        entry_types = [e['type'] for e in entries]
-        assert 'plain' in entry_types, f'orphaned entry {key} should still exist after bucket check unlinked --fix'
+    exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --fix --min-age-hours 0 --dump-keys')
+    verify_orphaned_entries_exist(orphaned_objs, "after bucket check unlinked --fix")
     log.info('  bucket check unlinked --fix: Did NOT fix orphaned entries (as expected)')
 
     log.debug('TEST: bucket check olh does not find orphaned list entries\n')
@@ -301,13 +298,8 @@ def test_orphaned_list_entries(connection, bucket):
     log.info(f'  bucket check olh: Found {len(json_out)} entries')
 
     log.debug('TEST: bucket check olh --fix does not fix orphaned list entries\n')
-    out = exec_cmd(f'radosgw-admin bucket check olh --bucket {BUCKET_NAME} --fix --dump-keys')
-    # Verify orphaned entries still exist
-    for key, instance in orphaned_objs:
-        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
-        entries = json.loads(out.replace(b'\x80', b'0x80'))
-        entry_types = [e['type'] for e in entries]
-        assert 'plain' in entry_types, f'orphaned entry {key} should still exist after bucket check olh --fix'
+    exec_cmd(f'radosgw-admin bucket check olh --bucket {BUCKET_NAME} --fix --dump-keys')
+    verify_orphaned_entries_exist(orphaned_objs, "after bucket check olh --fix")
     log.info('  bucket check olh --fix: Did NOT fix orphaned entries (as expected)')
 
 

--- a/qa/workunits/rgw/test_rgw_bucket_check.py
+++ b/qa/workunits/rgw/test_rgw_bucket_check.py
@@ -225,6 +225,9 @@ def test_orphaned_list_entries(connection, bucket):
     This test:
     1. Creates orphaned list entries (simulating the corruption)
     2. Verifies existing bucket check commands do NOT fix the issue
+    3. Then, verifies that the new bucket check orphan command finds and
+       fixes the orphaned delete marker entries, while skipping data objects
+       to avoid orphaning RADOS data.
     """
     log.debug('TEST SUITE: Orphaned List Entries (list entry WITHOUT instance entry)')
 
@@ -301,6 +304,59 @@ def test_orphaned_list_entries(connection, bucket):
     exec_cmd(f'radosgw-admin bucket check olh --bucket {BUCKET_NAME} --fix --dump-keys')
     verify_orphaned_entries_exist(orphaned_objs, "after bucket check olh --fix")
     log.info('  bucket check olh --fix: Did NOT fix orphaned entries (as expected)')
+
+    # =========================================================================
+    # STEP 4: Test bucket check orphan command
+    # =========================================================================
+    log.debug('TEST: bucket check orphan finds orphaned list entries\n')
+    out = exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --dump-keys')
+    json_out = json.loads(out)
+    # bucket check orphan reports delete markers (delete_marker=true) and skipped
+    # data objects (action=skipped). Only delete markers are fixed.
+    delete_markers = [e for e in json_out if e.get('delete_marker', False) and e.get('action') != 'skipped']
+    skipped_data_objs = [e for e in json_out if e.get('action') == 'skipped']
+    log.info(f'  bucket check orphan: Found {len(delete_markers)} delete markers, {len(skipped_data_objs)} skipped data objects')
+
+    assert len(delete_markers) == len(orphaned_keys), \
+        f'bucket check orphan should find {len(orphaned_keys)} delete marker orphans, found {len(delete_markers)}'
+
+    # Verify delete markers match our orphaned objects
+    found_keys = set((e['name'], e['instance']) for e in delete_markers)
+    for key, instance in orphaned_objs:
+        assert (key, instance) in found_keys, f'orphaned entry {key}:{instance} not found by bucket check orphan'
+
+    log.debug('TEST: bucket check orphan --fix removes orphaned delete markers\n')
+    out = exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --fix --dump-keys')
+    json_out = json.loads(out)
+    fixed_delete_markers = [e for e in json_out if e.get('delete_marker', False) and e.get('action') != 'skipped']
+    assert len(fixed_delete_markers) == len(orphaned_keys), \
+        f'bucket check orphan --fix should report {len(orphaned_keys)} fixed delete markers, reported {len(fixed_delete_markers)}'
+    log.info(f'  bucket check orphan --fix: Removed {len(fixed_delete_markers)} orphaned delete markers')
+
+    # Verify orphaned delete marker entries are removed after fix.
+    # Data objects (exists=true) are intentionally skipped to avoid orphaning RADOS data.
+    # OLH markers (flags=8, empty instance) may also remain.
+    log.debug('TEST: orphaned delete marker entries are removed after fix\n')
+    for key, instance in orphaned_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        # Filter to delete marker entries (exists=false, non-empty instance)
+        delete_marker_entries = [e for e in entries
+                                 if e.get('entry', {}).get('instance', '')
+                                 and not e.get('entry', {}).get('exists', True)]
+        assert len(delete_marker_entries) == 0, \
+            f'orphaned delete marker {key}:{instance} should be removed after bucket check orphan --fix'
+    log.info('  Verified: All orphaned delete marker entries removed')
+
+    # Verify bucket check orphan only finds skipped data objects (no delete markers)
+    log.debug('TEST: bucket check orphan finds no delete marker orphans after fix\n')
+    out = exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --dump-keys')
+    json_out = json.loads(out)
+    delete_markers_remaining = [e for e in json_out if e.get('delete_marker', False) and e.get('action') != 'skipped']
+    assert len(delete_markers_remaining) == 0, \
+        f'bucket check orphan should find 0 delete marker orphans after fix, found {len(delete_markers_remaining)}'
+    skipped_entries = [e for e in json_out if e.get('action') == 'skipped']
+    log.info(f'  bucket check orphan: Found 0 delete markers, {len(skipped_entries)} skipped data objects (expected)')
 
 
 def main():

--- a/qa/workunits/rgw/test_rgw_bucket_check.py
+++ b/qa/workunits/rgw/test_rgw_bucket_check.py
@@ -23,27 +23,10 @@ ACCESS_KEY = 'OJODXSLNX4LUNHQG99PA'
 SECRET_KEY = '3l6ffld34qaymfomuh832j94738aie2x4p2o8h6n'
 BUCKET_NAME = 'check-bucket'
 
-def main():
-    """
-    execute bucket check commands
-    """
-    create_user(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY)
 
-    connection = boto_connect(ACCESS_KEY, SECRET_KEY, Config(retries = {
-        'total_max_attempts': 1,
-    }))
-
-    # pre-test cleanup
-    try:
-        bucket = connection.Bucket(BUCKET_NAME)
-        bucket.objects.all().delete()
-        bucket.object_versions.all().delete()
-        bucket.delete()
-    except botocore.exceptions.ClientError as e:
-        if not e.response['Error']['Code'] == 'NoSuchBucket':
-            raise
-
-    bucket = connection.create_bucket(Bucket=BUCKET_NAME)
+def test_bucket_check_stats(connection, bucket):
+    """Test that bucket check --fix correctly recalculates bucket stats."""
+    log.debug('TEST: recalculated bucket check stats are correct\n')
 
     null_version_keys = ['a', 'z']
     null_version_objs = put_objects(bucket, null_version_keys)
@@ -51,17 +34,23 @@ def main():
     connection.BucketVersioning(BUCKET_NAME).enable()
 
     ok_keys = ['a', 'b', 'c', 'd']
-    unlinked_keys = ['c', 'd', 'e', 'f']
     ok_objs = put_objects(bucket, ok_keys)
-    
+
     # TESTCASE 'recalculated bucket check stats are correct'
-    log.debug('TEST: recalculated bucket check stats are correct\n')
     exec_cmd(f'radosgw-admin bucket check --fix --bucket {BUCKET_NAME}')
     out = exec_cmd(f'radosgw-admin bucket stats --bucket {BUCKET_NAME}')
     json_out = json.loads(out)
     log.debug(json_out['usage'])
     assert json_out['usage']['rgw.main']['num_objects'] == 6
-    
+
+    return null_version_keys, null_version_objs, ok_keys, ok_objs
+
+
+def test_bucket_check_unlinked(connection, bucket, ok_keys, ok_objs, null_version_keys, null_version_objs):
+    """Test bucket check unlinked - finds instance entries without list entries."""
+
+    unlinked_keys = ['c', 'd', 'e', 'f']
+
     # TESTCASE 'bucket check unlinked does not report normal entries'
     log.debug('TEST: bucket check unlinked does not report normal entries\n')
     out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --min-age-hours 0 --dump-keys')
@@ -116,7 +105,13 @@ def main():
     out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --min-age-hours 0 --dump-keys')
     json_out = json.loads(out)
     assert len(json_out) == 0
-    
+
+    return unlinked_keys, unlinked_objs
+
+
+def test_bucket_check_olh(connection, bucket, ok_keys, ok_objs, unlinked_keys):
+    """Test bucket check olh - finds leftover OLH entries."""
+
     # for this set of keys we can produce leftover OLH object/entries by
     # deleting the normal object instance since we should already have a leftover
     # pending xattr on the OLH object due to the errors associated with the 
@@ -155,6 +150,10 @@ def main():
     json_out = json.loads(out)
     assert len(json_out) == 0
 
+
+def test_null_versions_preserved(connection, bucket, null_version_keys, null_version_objs):
+    """Test that bucket check fixes do not affect null version objects."""
+
     # TESTCASE 'bucket check fixes do not affect null version objects'
     log.debug('TEST: verify that bucket check fixes do not affect null version objects\n')
     for o in null_version_objs:
@@ -164,12 +163,23 @@ def main():
     for key in null_version_keys:
         assert (key, 'null') in all_versions
 
+
+def test_stats_with_unlinked(connection, bucket):
+    """Test bucket check stats are correct in the presence of unlinked entries."""
+
+    null_version_keys = ['a', 'z']
+    ok_keys = ['a', 'b', 'c', 'd']
+    unlinked_keys = ['c', 'd', 'e', 'f']
+
     # TESTCASE 'bucket check stats are correct in the presence of unlinked entries'
     log.debug('TEST: bucket check stats are correct in the presence of unlinked entries\n')
     bucket.object_versions.all().delete()
-    null_version_objs = put_objects(bucket, null_version_keys)
-    ok_objs = put_objects(bucket, ok_keys)
-    unlinked_objs = create_unlinked_objects(connection, bucket, unlinked_keys)
+    put_objects(bucket, null_version_keys)
+
+    connection.BucketVersioning(BUCKET_NAME).enable()
+
+    put_objects(bucket, ok_keys)
+    create_unlinked_objects(connection, bucket, unlinked_keys)
     exec_cmd(f'radosgw-admin bucket check --fix --bucket {BUCKET_NAME}')
     out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --fix --min-age-hours 0 --rgw-olh-pending-timeout-sec 0 --dump-keys')
     json_out = json.loads(out)
@@ -186,10 +196,47 @@ def main():
     assert json_out['usage']['rgw.main']['size_kb_actual'] == 0
     assert json_out['usage']['rgw.main']['size_kb_utilized'] == 0
 
-    # Clean up
+
+def main():
+    """
+    Execute bucket check command tests.
+    """
+    create_user(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY)
+
+    connection = boto_connect(ACCESS_KEY, SECRET_KEY, Config(retries = {
+        'total_max_attempts': 1,
+    }))
+
+    # pre-test cleanup
+    try:
+        bucket = connection.Bucket(BUCKET_NAME)
+        bucket.objects.all().delete()
+        bucket.object_versions.all().delete()
+        bucket.delete()
+    except botocore.exceptions.ClientError as e:
+        if not e.response['Error']['Code'] == 'NoSuchBucket':
+            raise
+
+    bucket = connection.create_bucket(Bucket=BUCKET_NAME)
+
+    #
+    # Run test suites
+    #
+    null_version_keys, null_version_objs, ok_keys, ok_objs = test_bucket_check_stats(connection, bucket)
+
+    unlinked_keys, unlinked_objs = test_bucket_check_unlinked(
+        connection, bucket, ok_keys, ok_objs, null_version_keys, null_version_objs)
+
+    test_bucket_check_olh(connection, bucket, ok_keys, ok_objs, unlinked_keys)
+
+    test_null_versions_preserved(connection, bucket, null_version_keys, null_version_objs)
+
+    test_stats_with_unlinked(connection, bucket)
+
+    # Final cleanup - use bucket rm to force-delete even corrupted entries
     log.debug("Deleting bucket {}".format(BUCKET_NAME))
-    bucket.object_versions.all().delete()
-    bucket.delete()
+    exec_cmd(f'radosgw-admin bucket rm --bucket {BUCKET_NAME} --purge-objects --yes-i-really-mean-it', check_retcode=False)
+
 
 main()
 log.info("Completed bucket check tests")

--- a/qa/workunits/rgw/test_rgw_bucket_check.py
+++ b/qa/workunits/rgw/test_rgw_bucket_check.py
@@ -3,7 +3,7 @@
 import logging as log
 import json
 import botocore
-from common import exec_cmd, create_user, boto_connect, put_objects, create_unlinked_objects, create_orphaned_list_entries
+from common import exec_cmd, create_user, boto_connect, put_objects, create_unlinked_objects, create_orphaned_list_entries, create_orphaned_data_list_entries
 from botocore.config import Config
 
 """
@@ -237,10 +237,63 @@ def test_orphaned_list_entries(connection, bucket):
     # Ensure versioning is enabled
     connection.BucketVersioning(BUCKET_NAME).enable()
 
+    # =========================================================================
+    # STEP 1: Verify normal objects are not affected by bucket check orphan
+    # =========================================================================
+    # Create a "sane" versioned object: upload twice, then delete.
+    # This creates a non-current data version + current delete marker.
+    # bucket check orphan should NOT report or touch these normal entries.
+    log.debug('TEST: bucket check orphan does not report normal versioned objects\n')
+    sane_key = 'sane-object'
+    # Upload twice to create non-current version
+    bucket.put_object(Key=sane_key, Body=b'version1')
+    bucket.put_object(Key=sane_key, Body=b'version2')
+    # Delete to create current delete marker
+    bucket.Object(sane_key).delete()
+
+    # Verify the object has proper index entries (plain + instance for each version)
+    out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {sane_key}')
+    sane_entries = json.loads(out.replace(b'\x80', b'0x80'))
+    sane_entry_types = [e['type'] for e in sane_entries]
+    assert 'plain' in sane_entry_types, 'sane object should have plain entries'
+    assert 'instance' in sane_entry_types, 'sane object should have instance entries'
+    log.info(f'  Created sane object {sane_key} with entry types: {sane_entry_types}')
+
+    # bucket check orphan should not report this sane object
+    out = exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --dump-keys')
+    json_out = json.loads(out)
+    sane_in_output = [e for e in json_out if e.get('name') == sane_key]
+    assert len(sane_in_output) == 0, \
+        f'bucket check orphan should not report sane object {sane_key}, but found: {sane_in_output}'
+    log.info('  bucket check orphan: Did not report sane object (as expected)')
+
+    # bucket check orphan --fix should not touch sane object
+    log.debug('TEST: bucket check orphan --fix does not touch normal versioned objects\n')
+    out = exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --fix --dump-keys')
+    json_out = json.loads(out)
+    sane_in_output = [e for e in json_out if e.get('name') == sane_key]
+    assert len(sane_in_output) == 0, \
+        f'bucket check orphan --fix should not report sane object {sane_key}, but found: {sane_in_output}'
+
+    # Verify index entries are still intact after --fix
+    out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {sane_key}')
+    sane_entries_after = json.loads(out.replace(b'\x80', b'0x80'))
+    assert len(sane_entries_after) == len(sane_entries), \
+        f'sane object index entries changed after --fix: before={len(sane_entries)}, after={len(sane_entries_after)}'
+    log.info('  bucket check orphan --fix: Did not touch sane object (as expected)')
+
+    # Clean up sane object
+    for e in sane_entries:
+        if e['type'] == 'plain':
+            continue  # Will be cleaned up with instance
+        instance = e.get('entry', {}).get('instance', '')
+        if instance:
+            connection.ObjectVersion(bucket.name, sane_key, instance).delete()
+
     orphaned_keys = ['orphan1', 'orphan2']
 
     # =========================================================================
-    # STEP 1: Create orphaned list entries
+    # STEP 2: Create orphaned list entries
     # =========================================================================
     log.debug('TEST: orphaned list entries can be created\n')
     orphaned_objs = create_orphaned_list_entries(connection, bucket, orphaned_keys)
@@ -249,7 +302,7 @@ def test_orphaned_list_entries(connection, bucket):
     log.info(f'Successfully created {len(orphaned_objs)} orphaned list entries')
 
     # =========================================================================
-    # STEP 2: Verify the orphaned state
+    # STEP 3: Verify the orphaned state
     # =========================================================================
     log.debug('TEST: orphaned list entries appear in bucket listing\n')
     listed_versions = list(bucket.object_versions.all())
@@ -269,7 +322,7 @@ def test_orphaned_list_entries(connection, bucket):
         log.info(f'  {key}: entry types = {entry_types} (expected: only plain)')
 
     # =========================================================================
-    # STEP 3: Verify existing bucket check commands do NOT fix the issue
+    # STEP 4: Verify existing bucket check commands do NOT fix the issue
     # =========================================================================
     log.debug('Verifying existing bucket check commands do NOT fix orphaned entries')
 
@@ -306,7 +359,7 @@ def test_orphaned_list_entries(connection, bucket):
     log.info('  bucket check olh --fix: Did NOT fix orphaned entries (as expected)')
 
     # =========================================================================
-    # STEP 4: Test bucket check orphan command
+    # STEP 5: Test bucket check orphan command with orphaned entries
     # =========================================================================
     log.debug('TEST: bucket check orphan finds orphaned list entries\n')
     out = exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --dump-keys')
@@ -357,6 +410,40 @@ def test_orphaned_list_entries(connection, bucket):
         f'bucket check orphan should find 0 delete marker orphans after fix, found {len(delete_markers_remaining)}'
     skipped_entries = [e for e in json_out if e.get('action') == 'skipped']
     log.info(f'  bucket check orphan: Found 0 delete markers, {len(skipped_entries)} skipped data objects (expected)')
+
+    # =========================================================================
+    # STEP 6: Verify orphaned DATA objects (exists=true) are skipped, never removed
+    # =========================================================================
+    # An orphaned list entry that still references object data must be reported
+    # but SKIPPED by --fix; removing it would orphan the underlying RADOS data.
+    # This exercises the data-loss safeguard (the exists=true branch).
+    log.debug('TEST: bucket check orphan skips orphaned data objects\n')
+    data_keys = ['orphan-data1', 'orphan-data2']
+    data_objs = create_orphaned_data_list_entries(connection, bucket, data_keys)
+    assert len(data_objs) == len(data_keys), \
+        f'Expected {len(data_keys)} orphaned data entries, got {len(data_objs)}'
+
+    # Without --fix: data orphans are reported as skipped, not as delete markers
+    out = exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --dump-keys')
+    json_out = json.loads(out)
+    skipped = [e for e in json_out if e.get('action') == 'skipped']
+    skipped_keys = set(e['name'] for e in skipped)
+    for key in data_keys:
+        assert key in skipped_keys, f'data orphan {key} should be reported as skipped'
+    assert all(not e.get('delete_marker') for e in skipped), \
+        'skipped data objects must not be reported as delete markers'
+    log.info(f'  bucket check orphan: Reported {len(skipped)} skipped data objects (as expected)')
+
+    # With --fix: data orphans are still skipped and their plain entries preserved
+    log.debug('TEST: bucket check orphan --fix does not remove orphaned data objects\n')
+    exec_cmd(f'radosgw-admin bucket check orphan --bucket {BUCKET_NAME} --fix --dump-keys')
+    for key, instance in data_objs:
+        out = exec_cmd(f'radosgw-admin bi list --bucket {BUCKET_NAME} --object {key}')
+        entries = json.loads(out.replace(b'\x80', b'0x80'))
+        entry_types = [e['type'] for e in entries]
+        assert 'plain' in entry_types, \
+            f'data orphan {key} plain entry should be preserved after --fix (skipping avoids orphaning RADOS data)'
+    log.info('  bucket check orphan --fix: Did NOT remove orphaned data objects (as expected)')
 
 
 def main():

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -944,6 +944,126 @@ static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
 }
 
 /**
+ * Check for orphaned list entries in a bucket shard - list entries that
+ * don't have a corresponding instance entry. This can happen due to
+ * incomplete cleanup or data corruption. These orphaned entries cause
+ * lifecycle operations to fail with ENOENT when they try to access the
+ * instance data. If op_state.fix_index is true, we remove the orphaned
+ * plain entry from the bucket index.
+ */
+static int check_index_orphan(rgw::sal::RadosStore* const rados_store,
+                              rgw::sal::Bucket* const bucket,
+                              const DoutPrefixProvider *dpp,
+                              RGWBucketAdminOpState& op_state,
+                              RGWFormatterFlusher& flusher,
+                              const int shard,
+                              uint64_t* const count_out,
+                              optional_yield y)
+{
+  const std::string empty_delim;
+  cls_rgw_obj_key marker;
+  rgw_cls_list_ret result;
+
+  RGWRados* store = rados_store->getRados();
+  RGWRados::BucketShard bs(store);
+
+  int ret = bs.init(dpp, bucket->get_info(), bucket->get_info().layout.current_index, shard, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, -1) << "ERROR bs.init(bucket=" << bucket << "): " << cpp_strerror(-ret) << dendl;
+    return ret;
+  }
+
+  *count_out = 0;
+  do {
+    librados::ObjectReadOperation op;
+    cls_rgw_bucket_list_op(op, marker, "", empty_delim, listing_max_entries,
+                           true /* list_versions */, &result);
+    bufferlist ibl;
+    ret = bs.bucket_obj.operate(dpp, std::move(op), &ibl, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, -1) << "ERROR cls_rgw_bucket_list_op(): " << cpp_strerror(-ret) << dendl;
+      return ret;
+    }
+
+    for (auto const& entry : result.dir.m) {
+      const rgw_bucket_dir_entry& dir_entry = entry.second;
+      marker = dir_entry.key;
+
+      // Skip entries without instance (non-versioned objects)
+      if (dir_entry.key.instance.empty()) {
+        continue;
+      }
+
+      // Check if the instance entry exists
+      rgw_obj obj(bucket->get_key(), dir_entry.key);
+      rgw_bucket_dir_entry instance_entry;
+      ret = store->bi_get_instance(dpp, bucket->get_info(), obj, &instance_entry, y);
+      if (ret == 0) {
+        // Instance entry exists, not an orphan
+        continue;
+      }
+      if (ret != -ENOENT) {
+        ldpp_dout(dpp, -1) << "ERROR bi_get_instance(key='" << dir_entry.key << "'): "
+                          << cpp_strerror(-ret) << dendl;
+        continue;
+      }
+
+      // Instance entry doesn't exist - this is an orphan
+      // Only process delete markers (exists=false) to avoid data loss.
+      // Data-carrying objects (exists=true) would leave RADOS data orphaned.
+      if (dir_entry.exists) {
+        ldpp_dout(dpp, 0) << "WARNING: skipping orphaned data object '" << dir_entry.key
+                         << "' (exists=true). Removing would orphan RADOS data." << dendl;
+        // Report skipped data objects in JSON output
+        if (op_state.dump_keys) {
+          Formatter* const formatter = flusher.get_formatter();
+          formatter->open_object_section("object_instance");
+          formatter->dump_string("name", dir_entry.key.name);
+          formatter->dump_string("instance", dir_entry.key.instance);
+          formatter->dump_bool("delete_marker", false);
+          formatter->dump_string("action", "skipped");
+          formatter->dump_string("reason", "data object - removing would orphan RADOS data");
+          formatter->close_section();
+          if (formatter->get_len() > FORMATTER_LEN_FLUSH_THRESHOLD) {
+            flusher.flush();
+          }
+        }
+        continue;
+      }
+
+      if (op_state.will_fix_index()) {
+        // Remove the plain entry directly from omap
+        std::set<std::string> keys_to_remove;
+        keys_to_remove.insert(entry.first);
+        librados::ObjectWriteOperation wop;
+        wop.omap_rm_keys(keys_to_remove);
+        ret = bs.bucket_obj.operate(dpp, std::move(wop), y);
+        if (ret < 0) {
+          ldpp_dout(dpp, -1) << "ERROR removing orphan plain entry for key='" << dir_entry.key
+                            << "': " << cpp_strerror(-ret) << dendl;
+          continue;
+        }
+      }
+      if (op_state.dump_keys) {
+        Formatter* const formatter = flusher.get_formatter();
+        formatter->open_object_section("object_instance");
+        formatter->dump_string("name", dir_entry.key.name);
+        formatter->dump_string("instance", dir_entry.key.instance);
+        formatter->dump_bool("delete_marker", dir_entry.is_delete_marker());
+        formatter->dump_string("action", op_state.will_fix_index() ? "removed" : "would be removed with fix option");
+        formatter->close_section();
+        if (formatter->get_len() > FORMATTER_LEN_FLUSH_THRESHOLD) {
+          flusher.flush();
+        }
+      }
+      *count_out += 1;
+    }
+  } while (result.is_truncated);
+  flusher.flush();
+  return 0;
+}
+
+/**
  * Spawns separate coroutines to check each bucket shard for unlinked
  * instance entries (and remove them if op_state.fix_index is true).
  */
@@ -988,6 +1108,81 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
         if (!op_state.hide_progress) {
           ldpp_dout(dpp, 1) << "NOTICE: finished shard " << shard << " (" << shard_count <<
             " entries " << verb << ")" << dendl;
+        }
+      }
+    }, [] (std::exception_ptr eptr) {
+      if (eptr) std::rethrow_exception(eptr);
+    });
+  }
+  try {
+    context.run();
+  } catch (const std::system_error& e) {
+    return -e.code().value();
+  }
+
+  if (!op_state.hide_progress) {
+    ldpp_dout(dpp, 1) << "NOTICE: finished all shards (" << count_out <<
+      " entries " << verb << ")" << dendl;
+  }
+  if (op_state.dump_keys) {
+    formatter->close_section();
+    flusher.flush();
+  }
+  return 0;
+}
+
+/**
+ * Spawns separate coroutines to check each bucket shard for orphaned
+ * list entries (and remove them if op_state.fix_index is true).
+ */
+int RGWBucket::check_index_orphan(rgw::sal::RadosStore* const rados_store,
+                                  const DoutPrefixProvider *dpp,
+                                  RGWBucketAdminOpState& op_state,
+                                  RGWFormatterFlusher& flusher)
+{
+  const RGWBucketInfo& bucket_info = get_bucket_info();
+  if ((bucket_info.versioning_status() & BUCKET_VERSIONED) == 0) {
+    ldpp_dout(dpp, 0) << "WARNING: this command is only applicable to versioned buckets" << dendl;
+    if (op_state.dump_keys) {
+      // emit an empty JSON array so --dump-keys output is always valid JSON
+      Formatter* formatter = flusher.get_formatter();
+      formatter->open_array_section("");
+      formatter->close_section();
+      flusher.flush();
+    }
+    return 0;
+  }
+
+  Formatter* formatter = flusher.get_formatter();
+  if (op_state.dump_keys) {
+    formatter->open_array_section("");
+  }
+
+  const int max_shards = rgw::num_shards(bucket_info.layout.current_index);
+  std::string verb = op_state.will_fix_index() ? "removed" : "found";
+  uint64_t count_out = 0;
+
+  int max_aio = std::max(1, op_state.get_max_aio());
+  int next_shard = 0;
+  boost::asio::io_context context;
+  for (int i=0; i<max_aio; i++) {
+    boost::asio::spawn(context, [&](boost::asio::yield_context yield) {
+      while (true) {
+        int shard = next_shard;
+        next_shard += 1;
+        if (shard >= max_shards) {
+          return;
+        }
+        uint64_t shard_count = 0;
+        int r = ::check_index_orphan(rados_store, &*bucket, dpp, op_state, flusher, shard, &shard_count, yield);
+        if (r < 0) {
+          ldpp_dout(dpp, -1) << "ERROR: error processing shard " << shard <<
+            " check_index_orphan(): " << r << dendl;
+        }
+        count_out += shard_count;
+        if (!op_state.hide_progress) {
+          ldpp_dout(dpp, 1) << "NOTICE: finished shard " << shard << " (" << shard_count <<
+                " entries " << verb << ")" << dendl;
         }
       }
     }, [] (std::exception_ptr eptr) {
@@ -1402,6 +1597,27 @@ int RGWBucketAdminOp::check_index_unlinked(rgw::sal::RadosStore* store,
   ret = bucket.check_index_unlinked(store, dpp, op_state, flusher);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "check_index_unlinked(): " << ret << dendl;
+    return ret;
+  }
+  flusher.flush();
+  return 0;
+}
+
+int RGWBucketAdminOp::check_index_orphan(rgw::sal::RadosStore* store,
+                                         RGWBucketAdminOpState& op_state,
+                                         RGWFormatterFlusher& flusher,
+                                         const DoutPrefixProvider *dpp)
+{
+  flusher.start(0);
+  RGWBucket bucket;
+  int ret = bucket.init(store, op_state, null_yield, dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, -1) << "bucket.init(): " << ret << dendl;
+    return ret;
+  }
+  ret = bucket.check_index_orphan(store, dpp, op_state, flusher);
+  if (ret < 0) {
+    ldpp_dout(dpp, -1) << "check_index_orphan(): " << ret << dendl;
     return ret;
   }
   flusher.flush();

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -984,6 +984,126 @@ static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
 }
 
 /**
+ * Check for orphaned list entries in a bucket shard - list entries that
+ * don't have a corresponding instance entry. This can happen due to
+ * incomplete cleanup or data corruption. These orphaned entries cause
+ * lifecycle operations to fail with ENOENT when they try to access the
+ * instance data. If op_state.fix_index is true, we remove the orphaned
+ * plain entry from the bucket index.
+ */
+static int check_index_orphan(rgw::sal::RadosStore* const rados_store,
+                              rgw::sal::Bucket* const bucket,
+                              const DoutPrefixProvider *dpp,
+                              RGWBucketAdminOpState& op_state,
+                              RGWFormatterFlusher& flusher,
+                              const int shard,
+                              uint64_t* const count_out,
+                              optional_yield y)
+{
+  const std::string empty_delim;
+  cls_rgw_obj_key marker;
+  rgw_cls_list_ret result;
+
+  RGWRados* store = rados_store->getRados();
+  RGWRados::BucketShard bs(store);
+
+  int ret = bs.init(dpp, bucket->get_info(), bucket->get_info().layout.current_index, shard, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, -1) << "ERROR bs.init(bucket=" << bucket << "): " << cpp_strerror(-ret) << dendl;
+    return ret;
+  }
+
+  *count_out = 0;
+  do {
+    librados::ObjectReadOperation op;
+    cls_rgw_bucket_list_op(op, marker, "", empty_delim, listing_max_entries,
+                           true /* list_versions */, &result);
+    bufferlist ibl;
+    ret = bs.bucket_obj.operate(dpp, std::move(op), &ibl, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, -1) << "ERROR cls_rgw_bucket_list_op(): " << cpp_strerror(-ret) << dendl;
+      return ret;
+    }
+
+    for (auto const& entry : result.dir.m) {
+      const rgw_bucket_dir_entry& dir_entry = entry.second;
+      marker = dir_entry.key;
+
+      // Skip entries without instance (non-versioned objects)
+      if (dir_entry.key.instance.empty()) {
+        continue;
+      }
+
+      // Check if the instance entry exists
+      rgw_obj obj(bucket->get_key(), dir_entry.key);
+      rgw_bucket_dir_entry instance_entry;
+      ret = store->bi_get_instance(dpp, bucket->get_info(), obj, &instance_entry, y);
+      if (ret == 0) {
+        // Instance entry exists, not an orphan
+        continue;
+      }
+      if (ret != -ENOENT) {
+        ldpp_dout(dpp, -1) << "ERROR bi_get_instance(key='" << dir_entry.key << "'): "
+                          << cpp_strerror(-ret) << dendl;
+        continue;
+      }
+
+      // Instance entry doesn't exist - this is an orphan
+      // Only process delete markers (exists=false) to avoid data loss.
+      // Data-carrying objects (exists=true) would leave RADOS data orphaned.
+      if (dir_entry.exists) {
+        ldpp_dout(dpp, 0) << "WARNING: skipping orphaned data object '" << dir_entry.key
+                         << "' (exists=true). Removing would orphan RADOS data." << dendl;
+        // Report skipped data objects in JSON output
+        if (op_state.dump_keys) {
+          Formatter* const formatter = flusher.get_formatter();
+          formatter->open_object_section("object_instance");
+          formatter->dump_string("name", dir_entry.key.name);
+          formatter->dump_string("instance", dir_entry.key.instance);
+          formatter->dump_bool("delete_marker", false);
+          formatter->dump_string("action", "skipped");
+          formatter->dump_string("reason", "data object - removing would orphan RADOS data");
+          formatter->close_section();
+          if (formatter->get_len() > FORMATTER_LEN_FLUSH_THRESHOLD) {
+            flusher.flush();
+          }
+        }
+        continue;
+      }
+
+      if (op_state.will_fix_index()) {
+        // Remove the plain entry directly from omap
+        std::set<std::string> keys_to_remove;
+        keys_to_remove.insert(entry.first);
+        librados::ObjectWriteOperation wop;
+        wop.omap_rm_keys(keys_to_remove);
+        ret = bs.bucket_obj.operate(dpp, std::move(wop), y);
+        if (ret < 0) {
+          ldpp_dout(dpp, -1) << "ERROR removing orphan plain entry for key='" << dir_entry.key
+                            << "': " << cpp_strerror(-ret) << dendl;
+          continue;
+        }
+      }
+      if (op_state.dump_keys) {
+        Formatter* const formatter = flusher.get_formatter();
+        formatter->open_object_section("object_instance");
+        formatter->dump_string("name", dir_entry.key.name);
+        formatter->dump_string("instance", dir_entry.key.instance);
+        formatter->dump_bool("delete_marker", dir_entry.is_delete_marker());
+        formatter->dump_string("action", op_state.will_fix_index() ? "removed" : "would be removed with fix option");
+        formatter->close_section();
+        if (formatter->get_len() > FORMATTER_LEN_FLUSH_THRESHOLD) {
+          flusher.flush();
+        }
+      }
+      *count_out += 1;
+    }
+  } while (result.is_truncated);
+  flusher.flush();
+  return 0;
+}
+
+/**
  * Spawns separate coroutines to check each bucket shard for unlinked
  * instance entries (and remove them if op_state.fix_index is true).
  */
@@ -1028,6 +1148,81 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
         if (!op_state.hide_progress) {
           ldpp_dout(dpp, 1) << "NOTICE: finished shard " << shard << " (" << shard_count <<
             " entries " << verb << ")" << dendl;
+        }
+      }
+    }, [] (std::exception_ptr eptr) {
+      if (eptr) std::rethrow_exception(eptr);
+    });
+  }
+  try {
+    context.run();
+  } catch (const std::system_error& e) {
+    return -e.code().value();
+  }
+
+  if (!op_state.hide_progress) {
+    ldpp_dout(dpp, 1) << "NOTICE: finished all shards (" << count_out <<
+      " entries " << verb << ")" << dendl;
+  }
+  if (op_state.dump_keys) {
+    formatter->close_section();
+    flusher.flush();
+  }
+  return 0;
+}
+
+/**
+ * Spawns separate coroutines to check each bucket shard for orphaned
+ * list entries (and remove them if op_state.fix_index is true).
+ */
+int RGWBucket::check_index_orphan(rgw::sal::RadosStore* const rados_store,
+                                  const DoutPrefixProvider *dpp,
+                                  RGWBucketAdminOpState& op_state,
+                                  RGWFormatterFlusher& flusher)
+{
+  const RGWBucketInfo& bucket_info = get_bucket_info();
+  if ((bucket_info.versioning_status() & BUCKET_VERSIONED) == 0) {
+    ldpp_dout(dpp, 0) << "WARNING: this command is only applicable to versioned buckets" << dendl;
+    if (op_state.dump_keys) {
+      // emit an empty JSON array so --dump-keys output is always valid JSON
+      Formatter* formatter = flusher.get_formatter();
+      formatter->open_array_section("");
+      formatter->close_section();
+      flusher.flush();
+    }
+    return 0;
+  }
+
+  Formatter* formatter = flusher.get_formatter();
+  if (op_state.dump_keys) {
+    formatter->open_array_section("");
+  }
+
+  const int max_shards = rgw::num_shards(bucket_info.layout.current_index);
+  std::string verb = op_state.will_fix_index() ? "removed" : "found";
+  uint64_t count_out = 0;
+
+  int max_aio = std::max(1, op_state.get_max_aio());
+  int next_shard = 0;
+  boost::asio::io_context context;
+  for (int i=0; i<max_aio; i++) {
+    boost::asio::spawn(context, [&](boost::asio::yield_context yield) {
+      while (true) {
+        int shard = next_shard;
+        next_shard += 1;
+        if (shard >= max_shards) {
+          return;
+        }
+        uint64_t shard_count = 0;
+        int r = ::check_index_orphan(rados_store, &*bucket, dpp, op_state, flusher, shard, &shard_count, yield);
+        if (r < 0) {
+          ldpp_dout(dpp, -1) << "ERROR: error processing shard " << shard <<
+            " check_index_orphan(): " << r << dendl;
+        }
+        count_out += shard_count;
+        if (!op_state.hide_progress) {
+          ldpp_dout(dpp, 1) << "NOTICE: finished shard " << shard << " (" << shard_count <<
+                " entries " << verb << ")" << dendl;
         }
       }
     }, [] (std::exception_ptr eptr) {
@@ -1442,6 +1637,27 @@ int RGWBucketAdminOp::check_index_unlinked(rgw::sal::RadosStore* store,
   ret = bucket.check_index_unlinked(store, dpp, op_state, flusher);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "check_index_unlinked(): " << ret << dendl;
+    return ret;
+  }
+  flusher.flush();
+  return 0;
+}
+
+int RGWBucketAdminOp::check_index_orphan(rgw::sal::RadosStore* store,
+                                         RGWBucketAdminOpState& op_state,
+                                         RGWFormatterFlusher& flusher,
+                                         const DoutPrefixProvider *dpp)
+{
+  flusher.start(0);
+  RGWBucket bucket;
+  int ret = bucket.init(store, op_state, null_yield, dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, -1) << "bucket.init(): " << ret << dendl;
+    return ret;
+  }
+  ret = bucket.check_index_orphan(store, dpp, op_state, flusher);
+  if (ret < 0) {
+    ldpp_dout(dpp, -1) << "check_index_orphan(): " << ret << dendl;
     return ret;
   }
   flusher.flush();

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -357,6 +357,8 @@ public:
                       RGWFormatterFlusher& flusher);
   int check_index_unlinked(rgw::sal::RadosStore* rados_store, const DoutPrefixProvider *dpp, RGWBucketAdminOpState& op_state,
                            RGWFormatterFlusher& flusher);
+  int check_index_orphan(rgw::sal::RadosStore* rados_store, const DoutPrefixProvider *dpp, RGWBucketAdminOpState& op_state,
+                         RGWFormatterFlusher& flusher);
 
   int check_index(const DoutPrefixProvider *dpp, optional_yield y,
           RGWBucketAdminOpState& op_state,
@@ -397,6 +399,8 @@ public:
                              RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
   static int check_index_unlinked(rgw::sal::RadosStore* driver, RGWBucketAdminOpState& op_state,
                                   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
+  static int check_index_orphan(rgw::sal::RadosStore* driver, RGWBucketAdminOpState& op_state,
+                                RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
 
   static int remove_bucket(rgw::sal::Driver* driver, const rgw::SiteConfig& site, RGWBucketAdminOpState& op_state, optional_yield y,
 			   const DoutPrefixProvider *dpp, bool bypass_gc = false, bool keep_index_consistent = true, bool forwarded_request = false);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -192,6 +192,7 @@ void usage()
   cout << "  bucket check                     check bucket index by verifying size and object count stats\n";
   cout << "  bucket check olh                 check for olh index entries and objects that are pending removal\n";
   cout << "  bucket check unlinked            check for object versions that are not visible in a bucket listing \n";
+  cout << "  bucket check orphan              check for list entries without corresponding instance entries\n";
   cout << "  bucket chown                     link bucket to specified user and update its object ACLs\n";
   cout << "  bucket reshard                   reshard bucket\n";
   cout << "  bucket set-min-shards            set the minimum number of shards that dynamic resharding will consider for a bucket\n";
@@ -750,6 +751,7 @@ enum class OPT {
   BUCKET_CHECK,
   BUCKET_CHECK_OLH,
   BUCKET_CHECK_UNLINKED,
+  BUCKET_CHECK_ORPHAN,
   BUCKET_SYNC_CHECKPOINT,
   BUCKET_SYNC_INFO,
   BUCKET_SYNC_STATUS,
@@ -1036,6 +1038,7 @@ static SimpleCmd::Commands all_cmds = {
   { "bucket check", OPT::BUCKET_CHECK },
   { "bucket check olh", OPT::BUCKET_CHECK_OLH },
   { "bucket check unlinked", OPT::BUCKET_CHECK_UNLINKED },
+  { "bucket check orphan", OPT::BUCKET_CHECK_ORPHAN },
   { "bucket sync checkpoint", OPT::BUCKET_SYNC_CHECKPOINT },
   { "bucket sync info", OPT::BUCKET_SYNC_INFO },
   { "bucket sync status", OPT::BUCKET_SYNC_STATUS },
@@ -9568,6 +9571,15 @@ next:
       return 0;
     }
     RGWBucketAdminOp::check_index_unlinked(store, bucket_op, stream_flusher, dpp());
+  }
+
+  if (opt_cmd == OPT::BUCKET_CHECK_ORPHAN) {
+    rgw::sal::RadosStore* store = dynamic_cast<rgw::sal::RadosStore*>(driver);
+    if (!store) {
+      cerr << "WARNING: this command is only relevant when the cluster has a RADOS backing store." << std::endl;
+      return 0;
+    }
+    RGWBucketAdminOp::check_index_orphan(store, bucket_op, stream_flusher, dpp());
   }
 #endif
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -199,6 +199,7 @@ void usage()
   cout << "  bucket check                     check bucket index by verifying size and object count stats\n";
   cout << "  bucket check olh                 check for olh index entries and objects that are pending removal\n";
   cout << "  bucket check unlinked            check for object versions that are not visible in a bucket listing \n";
+  cout << "  bucket check orphan              check for list entries without corresponding instance entries\n";
   cout << "  bucket chown                     link bucket to specified user and update its object ACLs\n";
   cout << "  bucket reshard                   reshard bucket\n";
   cout << "  bucket set-min-shards            set the minimum number of shards that dynamic resharding will consider for a bucket\n";
@@ -768,6 +769,7 @@ enum class OPT {
   BUCKET_CHECK,
   BUCKET_CHECK_OLH,
   BUCKET_CHECK_UNLINKED,
+  BUCKET_CHECK_ORPHAN,
   BUCKET_SYNC_CHECKPOINT,
   BUCKET_SYNC_INFO,
   BUCKET_SYNC_STATUS,
@@ -1061,6 +1063,7 @@ static SimpleCmd::Commands all_cmds = {
   { "bucket check", OPT::BUCKET_CHECK },
   { "bucket check olh", OPT::BUCKET_CHECK_OLH },
   { "bucket check unlinked", OPT::BUCKET_CHECK_UNLINKED },
+  { "bucket check orphan", OPT::BUCKET_CHECK_ORPHAN },
   { "bucket sync checkpoint", OPT::BUCKET_SYNC_CHECKPOINT },
   { "bucket sync info", OPT::BUCKET_SYNC_INFO },
   { "bucket sync status", OPT::BUCKET_SYNC_STATUS },
@@ -9847,6 +9850,15 @@ next:
       return 0;
     }
     RGWBucketAdminOp::check_index_unlinked(store, bucket_op, stream_flusher, dpp());
+  }
+
+  if (opt_cmd == OPT::BUCKET_CHECK_ORPHAN) {
+    rgw::sal::RadosStore* store = dynamic_cast<rgw::sal::RadosStore*>(driver);
+    if (!store) {
+      cerr << "WARNING: this command is only relevant when the cluster has a RADOS backing store." << std::endl;
+      return 0;
+    }
+    RGWBucketAdminOp::check_index_orphan(store, bucket_op, stream_flusher, dpp());
   }
 #endif
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -43,6 +43,7 @@
     bucket check                     check bucket index by verifying size and object count stats
     bucket check olh                 check for olh index entries and objects that are pending removal
     bucket check unlinked            check for object versions that are not visible in a bucket listing 
+    bucket check orphan              check for list entries without corresponding instance entries
     bucket chown                     link bucket to specified user and update its object ACLs
     bucket reshard                   reshard bucket
     bucket set-min-shards            set the minimum number of shards that dynamic resharding will consider for a bucket

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -45,6 +45,7 @@
     bucket check                     check bucket index by verifying size and object count stats
     bucket check olh                 check for olh index entries and objects that are pending removal
     bucket check unlinked            check for object versions that are not visible in a bucket listing 
+    bucket check orphan              check for list entries without corresponding instance entries
     bucket chown                     link bucket to specified user and update its object ACLs
     bucket reshard                   reshard bucket
     bucket set-min-shards            set the minimum number of shards that dynamic resharding will consider for a bucket


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75571

Note: marked "No doc update is appropriate" since - other than high level man page for bucket check - I don't see any further doc for the sub-commands like olh, unlinked.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [X] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
