### PR TITLE
Crimson: Implement seastar based QoS 

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -36,6 +36,84 @@ options:
   flags:
   - startup
 
+- name: crimson_enable_scheduling_groups
+  type: bool
+  level: advanced
+  default: false
+  desc: Enable Seastar scheduling groups for crimson OSD
+
+- name: crimson_sg_client_shares
+  type: float
+  level: advanced
+  default: 1000
+  desc: Seastar scheduling group shares for client I/O
+
+- name: crimson_sg_peering_shares
+  type: float
+  level: advanced
+  default: 300
+  desc: Seastar scheduling group shares for peering
+
+- name: crimson_sg_urgent_recovery_shares
+  type: float
+  level: advanced
+  default: 200
+  desc: Seastar scheduling group shares for urgent recovery
+
+- name: crimson_sg_recovery_shares
+  type: float
+  level: advanced
+  default: 100
+  desc: Seastar scheduling group shares for background recovery
+
+- name: crimson_sg_scrub_shares
+  type: float
+  level: advanced
+  default: 50
+  desc: Seastar scheduling group shares for scrub
+
+- name: crimson_sg_background_shares
+  type: float
+  level: advanced
+  default: 50
+  desc: Seastar scheduling group shares for background tasks
+
+- name: crimson_sg_client_bandwidth
+  type: uint
+  level: advanced
+  default: 0
+  desc: IO bandwidth limit bytes/sec for client scheduling group
+
+- name: crimson_sg_peering_bandwidth
+  type: uint
+  level: advanced
+  default: 0
+  desc: IO bandwidth limit bytes/sec for peering scheduling group
+
+- name: crimson_sg_urgent_recovery_bandwidth
+  type: uint
+  level: advanced
+  default: 0
+  desc: IO bandwidth limit bytes/sec for urgent recovery scheduling group
+
+- name: crimson_sg_recovery_bandwidth
+  type: uint
+  level: advanced
+  default: 0
+  desc: IO bandwidth limit bytes/sec for recovery scheduling group
+
+- name: crimson_sg_scrub_bandwidth
+  type: uint
+  level: advanced
+  default: 0
+  desc: IO bandwidth limit bytes/sec for scrub scheduling group
+
+- name: crimson_sg_background_bandwidth
+  type: uint
+  level: advanced
+  default: 0
+  desc: IO bandwidth limit bytes/sec for background scheduling group
+
 # Reactor options:
 
 - name: crimson_reactor_backend

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -28,6 +28,14 @@ options:
   min: 0
   max: 32
 
+- name: crimson_io_properties_file
+  type: str
+  level: advanced
+  desc: Path to Seastar IO properties YAML file used to override
+        auto detected disk performance characteristics.
+  flags:
+  - startup
+
 # Reactor options:
 
 - name: crimson_reactor_backend

--- a/src/crimson/osd/main_config_bootstrap_helpers.cc
+++ b/src/crimson/osd/main_config_bootstrap_helpers.cc
@@ -96,7 +96,8 @@ const std::vector<SeastarOption> seastar_options = {
   {"--io-latency-goal-ms", "crimson_reactor_io_latency_goal_ms", Option::TYPE_FLOAT},
   {"--idle-poll-time-us", "crimson_reactor_idle_poll_time_us", Option::TYPE_UINT},
   {"--poll-mode", "crimson_poll_mode", Option::TYPE_BOOL},
-  {"--reactor-backend", "crimson_reactor_backend", Option::TYPE_STR}
+  {"--reactor-backend", "crimson_reactor_backend", Option::TYPE_STR},
+  {"--io-properties-file", "crimson_io_properties_file", Option::TYPE_STR}
 };
 
 std::optional<std::string> get_option_value(const SeastarOption& option) {

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -468,7 +468,7 @@ seastar::future<> OSD::start()
     ).then([this] {
       return osd_singleton_state.start_single(
         whoami, std::ref(*cluster_msgr), std::ref(*public_msgr),
-        std::ref(*monc), std::ref(*mgrc));
+        std::ref(*monc), std::ref(*mgrc), std::ref(shard_services));
     }).then([this] {
       return osd_states.start();
     }).then([this, store_shard_nums] {
@@ -483,6 +483,32 @@ seastar::future<> OSD::start()
         osd_singleton_state.local().recoverystate_perf,
         std::ref(store),
         std::ref(osd_states));
+    });
+  }).then([this] {
+    auto shares = [](const char* opt) {
+      return static_cast<float> (local_conf().get_val<double>(opt));
+    };
+    return seastar::when_all_succeed(
+      seastar::create_scheduling_group("client", shares("crimson_sg_client_shares")),
+      seastar::create_scheduling_group("peering", shares("crimson_sg_peering_shares")),
+      seastar::create_scheduling_group("ug_recovery", shares("crimson_sg_urgent_recovery_shares")),
+      seastar::create_scheduling_group("recovery", shares("crimson_sg_recovery_shares")),
+      seastar::create_scheduling_group("scrub", shares("crimson_sg_scrub_shares")),
+      seastar::create_scheduling_group("background", shares("crimson_sg_background_shares"))
+    ).then_unpack([this](auto client, auto peering, auto ug_recovery, auto recovery,
+		         auto scrub, auto background) {
+       const bool enabled = local_conf().get_val<bool>
+         ("crimson_enable_scheduling_groups");
+       return shard_services.invoke_on_all(
+         [=](ShardServices &ss) {
+           ss.sg_client = client;
+	   ss.sg_peering = peering;
+	   ss.sg_urgent_recovery = ug_recovery;
+	   ss.sg_recovery = recovery;
+	   ss.sg_scrub = scrub;
+	   ss.sg_background = background;
+	   ss.scheduling_groups_enabled = enabled;
+       });
     });
   }).then([this, FNAME] {
     heartbeat.reset(new Heartbeat{

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -71,19 +71,26 @@ seastar::future<> BackgroundRecoveryT<T>::start()
 
   LOG_PREFIX(BackgroundRecoveryT<T>::start);
   DEBUGDPPI("{}: start", *pg, *this);
+  auto sg = (scheduler_class == SchedulerClass::immediate)
+    ? pg->get_shard_services().get_sg_urgent_recovery()
+    : pg->get_shard_services().get_sg_recovery();
+
   auto maybe_delay = seastar::now();
   if (delay) {
     maybe_delay = seastar::sleep(
       std::chrono::milliseconds(std::lround(delay * 1000)));
   }
-  return maybe_delay.then([ref, this] {
-    return seastar::repeat([ref, this] {
-      return interruptor::with_interruption([this] {
-       return do_recovery();
-      }, [](std::exception_ptr) {
-       return seastar::make_ready_future<seastar::stop_iteration>(seastar::stop_iteration::yes);
-      }, pg, epoch_started);
-    });
+  return maybe_delay.then([ref, this, sg] {
+    return pg->get_shard_services().with_sg(sg,
+      [ref, this]() mutable -> seastar::future<> {
+        return seastar::repeat([ref, this] {
+          return interruptor::with_interruption([this] {
+            return do_recovery();
+          }, [](std::exception_ptr) {
+            return seastar::make_ready_future<seastar::stop_iteration>(seastar::stop_iteration::yes);
+          }, pg, epoch_started);
+        });
+      });
   });
 }
 

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -233,6 +233,9 @@ seastar::future<> ClientRequest::with_pg_process(
   ceph_assert_always(shard_services);
   LOG_PREFIX(ClientRequest::with_pg_process);
 
+  return shard_services->with_sg(
+	 shard_services->get_sg_client(),
+	 [this, FNAME, pgref=std::move(pgref)]() mutable {
   epoch_t same_interval_since = pgref->get_interval_start_epoch();
   DEBUGDPP("{}: same_interval_since: {}", *pgref, *this, same_interval_since);
   const auto this_instance_id = instance_id++;
@@ -258,6 +261,7 @@ seastar::future<> ClientRequest::with_pg_process(
 	DEBUGDPP("{}.{}: exit", *pgref, *this, this_instance_id);
 	return ihref.handle.complete(
 	).finally([instance_handle=std::move(instance_handle)] {});
+    });
     });
 }
 

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -121,6 +121,9 @@ seastar::future<> InternalClientRequest::start()
   LOG_PREFIX(InternalClientRequest::start);
   DEBUGI("{}: in repeat", *this);
 
+  return pg->get_shard_services().with_sg(
+    pg->get_shard_services().get_sg_client(),
+    [this]() mutable {
   return interruptor::with_interruption([this]() mutable {
     return with_interruption();
   }, [](std::exception_ptr eptr) {
@@ -133,6 +136,7 @@ seastar::future<> InternalClientRequest::start()
   }).finally([this] {
     logger().debug("{}: exit", *this);
     return handle.complete();
+  });
   });
 }
 

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -68,7 +68,9 @@ seastar::future<> LogMissingRequest::with_pg(
 {
   LOG_PREFIX(LogMissingRequest::with_pg);
   DEBUGI("{}: LogMissingRequest::with_pg", *this);
-
+  return shard_services.with_sg(
+    shard_services.get_sg_client(),
+    [this, pg=std::move(pg)]() mutable -> seastar::future<> {
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
     LOG_PREFIX(LogMissingRequest::with_pg);
@@ -93,6 +95,7 @@ seastar::future<> LogMissingRequest::with_pg(
     logger().debug("{}: exit", *this);
     handle.exit();
   });
+    });
 }
 
 }

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -65,6 +65,9 @@ template <class T>
 seastar::future<> PeeringEvent<T>::with_pg(
   ShardServices &shard_services, Ref<PG> pg)
 {
+  return shard_services.with_sg(
+    shard_services.get_sg_peering(),
+    [this, &shard_services, pg=std::move(pg)]() mutable -> seastar::future<> {
   using interruptor = typename T::interruptor;
   LOG_PREFIX(PeeringEvent<T>::with_pg);
   if (!pg) {
@@ -116,6 +119,7 @@ seastar::future<> PeeringEvent<T>::with_pg(
     logger().debug("{}: exit", *this);
     that()->get_handle().exit();
   });
+    });
 }
 
 template <class T>

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -67,6 +67,9 @@ seastar::future<> PGAdvanceMap::start()
 
   DEBUG("{}: start", *this);
 
+  return pg->get_shard_services().with_sg(
+    pg->get_shard_services().get_sg_peering(),
+    [this, FNAME]() mutable -> seastar::future<> {
   IRef ref = this;
   return enter_stage<>(
     peering_pp(*pg).process
@@ -119,6 +122,7 @@ seastar::future<> PGAdvanceMap::start()
     DEBUG("{}: exit", *this);
     handle.exit();
   });
+ });
 }
 
 seastar::future<> PGAdvanceMap::check_for_splits(

--- a/src/crimson/osd/osd_operations/pgpct_request.cc
+++ b/src/crimson/osd/osd_operations/pgpct_request.cc
@@ -78,6 +78,9 @@ seastar::future<> PGPCTRequest::with_pg(
   LOG_PREFIX(PGPCTRequest::with_pg);
   DEBUGDPP("{}", *pgref, *this);
 
+  return shard_services.with_sg(
+    shard_services.get_sg_client(),
+    [FNAME, this, pgref=std::move(pgref)]() mutable -> seastar::future<> {
   PG &pg = *pgref;
   IRef ref = this;
   return interruptor::with_interruption([this, &pg] {
@@ -90,6 +93,7 @@ seastar::future<> PGPCTRequest::with_pg(
       return handle.complete(
       ).then([ref=std::move(ref), pgref=std::move(pgref)] {});
     });
+  });
 }
 
 }

--- a/src/crimson/osd/osd_operations/recovery_subrequest.cc
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.cc
@@ -31,6 +31,9 @@ seastar::future<> RecoverySubRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pgref)
 {
   track_event<StartEvent>();
+  return shard_services.with_sg(
+    shard_services.get_sg_recovery(),
+    [this, pgref=std::move(pgref)]() mutable -> seastar::future<> {
   IRef opref = this;
   return interruptor::with_interruption([this, pgref] {
     LOG_PREFIX(RecoverySubRequest::with_pg);
@@ -49,6 +52,7 @@ seastar::future<> RecoverySubRequest::with_pg(
     track_event<CompletionEvent>();
     handle.exit();
   });
+    });
 }
 
 ConnectionPipeline &RecoverySubRequest::get_connection_pipeline()

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -103,6 +103,9 @@ seastar::future<> RepRequest::with_pg(
 {
   LOG_PREFIX(RepRequest::with_pg);
   DEBUGI("{}", *this);
+  return shard_services.with_sg(
+    shard_services.get_sg_client(),
+    [this, pg=std::move(pg)]() mutable -> seastar::future<> {
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
     return with_pg_interruptible(pg);
@@ -113,6 +116,7 @@ seastar::future<> RepRequest::with_pg(
     logger().debug("{}: exit", *this);
     return handle.complete(
     ).finally([ref=std::move(ref), pg=std::move(pg)] {});
+  });
   });
 }
 

--- a/src/crimson/osd/osd_operations/scrub_events.cc
+++ b/src/crimson/osd/osd_operations/scrub_events.cc
@@ -38,6 +38,9 @@ seastar::future<> RemoteScrubEventBaseT<T>::with_pg(
   ShardServices &shard_services, Ref<PG> pg)
 {
   LOG_PREFIX(RemoteEventBaseT::with_pg);
+   return shard_services.with_sg(
+    shard_services.get_sg_scrub(),
+    [FNAME, this, pg=std::move(pg)]() mutable -> seastar::future<> {
   return interruptor::with_interruption([FNAME, this, pg] {
     DEBUGDPP("{} pg present", *pg, *that());
     return this->template enter_stage<interruptor>(
@@ -58,6 +61,7 @@ seastar::future<> RemoteScrubEventBaseT<T>::with_pg(
   }, [FNAME, pg, this](std::exception_ptr ep) {
     DEBUGDPP("{} interrupted with {}", *pg, *that(), ep);
   }, pg, epoch);
+ });
 }
 
 ScrubRequested::ifut<> ScrubRequested::handle_event(PG &pg)
@@ -83,6 +87,8 @@ typename ScrubAsyncOpT<T>::template ifut<> ScrubAsyncOpT<T>::start()
 {
   LOG_PREFIX(ScrubAsyncOpT::start);
   DEBUGDPP("{} starting", *pg, *this);
+  // TODO run under sg_scrub will not work because it accepts
+  // seastar::future returning callables but here it returns ifut
   return run(*pg);
 }
 

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -69,6 +69,10 @@ SnapTrimEvent::start()
 
   /* TODO: add a way to expose progress via the optracker without misusing
    * pipeline stages. https://tracker.ceph.com/issues/66473 */
+
+  /* TODO: run this under sg_background but plain with_sg accepts
+   * seastar::future-returning callables and the body below returns
+   * an errorated interruptible future */
   ShardServices &shard_services = pg->get_shard_services();
   {
     co_await pg->background_process_lock.lock_with_op(*this);

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -134,7 +134,8 @@ OSDSingletonState::OSDSingletonState(
   crimson::net::Messenger &cluster_msgr,
   crimson::net::Messenger &public_msgr,
   crimson::mon::Client &monc,
-  crimson::mgr::Client &mgrc)
+  crimson::mgr::Client &mgrc,
+  seastar::sharded<ShardServices> &sharded_ss)
   : whoami(whoami),
     cluster_msgr(cluster_msgr),
     public_msgr(public_msgr),
@@ -153,7 +154,8 @@ OSDSingletonState::OSDSingletonState(
     snap_reserver(
       &cct,
       &finisher,
-      crimson::common::local_conf()->osd_max_trimming_pgs)
+      crimson::common::local_conf()->osd_max_trimming_pgs),
+    sharded_ss(sharded_ss)
 {
   crimson::common::local_conf().add_observer(this);
   osdmaps[0] = boost::make_local_shared<OSDMap>();
@@ -337,7 +339,20 @@ std::vector<std::string> OSDSingletonState::get_tracked_keys() const noexcept
   return {
     "osd_max_backfills"s,
     "osd_min_recovery_priority"s,
-    "osd_max_trimming_pgs"s
+    "osd_max_trimming_pgs"s,
+    "crimson_sg_client_shares"s,
+    "crimson_sg_peering_shares"s,
+    "crimson_sg_urgent_recovery_shares"s,
+    "crimson_sg_recovery_shares"s,
+    "crimson_sg_scrub_shares"s,
+    "crimson_sg_background_shares"s,
+    "crimson_enable_scheduling_groups"s,
+    "crimson_sg_client_bandwidth"s,
+    "crimson_sg_peering_bandwidth"s,
+    "crimson_sg_urgent_recovery_bandwidth"s,
+    "crimson_sg_recovery_bandwidth"s,
+    "crimson_sg_scrub_bandwidth"s,
+    "crimson_sg_background_bandwidth"s
   };
 }
 
@@ -345,6 +360,7 @@ void OSDSingletonState::handle_conf_change(
   const ConfigProxy& conf,
   const std::set <std::string> &changed)
 {
+  LOG_PREFIX(OSDSingletonState::handle_conf_change);
   if (changed.count("osd_max_backfills")) {
     local_reserver.set_max(conf->osd_max_backfills);
     remote_reserver.set_max(conf->osd_max_backfills);
@@ -355,6 +371,37 @@ void OSDSingletonState::handle_conf_change(
   }
   if (changed.count("osd_max_trimming_pgs")) {
     snap_reserver.set_max(conf->osd_max_trimming_pgs);
+  }
+
+  if (changed.count("crimson_enable_scheduling_groups")) {
+    bool enabled = conf.get_val<bool>("crimson_enable_scheduling_groups");
+    INFO("handle_conf_change: change crimson_enable_scheduling_groups {}", enabled);
+    std::ignore = sharded_ss.invoke_on_all([enabled](ShardServices &ss) {
+      ss.scheduling_groups_enabled = enabled;
+    });
+  }
+
+  auto &ss = sharded_ss.local();
+  for (const auto &[key, sg_member] : ShardServices::sg_share_keys) {
+    if (changed.count(key.data())) {
+       auto new_shares = static_cast<float>(conf.get_val<double>(key));
+       INFO("handle_conf_change: updating {} to {}", std::string(key), new_shares);
+       std::ignore = sharded_ss.invoke_on_all([sg_member, new_shares] (auto& ss) mutable {
+         (ss.*sg_member).set_shares(new_shares);
+       });
+    }
+  }
+
+  for (const auto &[key, sg_member] : ShardServices::sg_bandwidth_keys) {
+    if (changed.count(key.data())) {
+      auto bandwidth = conf.get_val<uint64_t>(key);
+      INFO("handle_conf_change: updating {} to {} bytes/sec",
+           std::string(key), bandwidth);
+      std::ignore = (ss.*sg_member).update_io_bandwidth(bandwidth)
+        .handle_exception([key, FNAME](std::exception_ptr ep) {
+         ERROR("failed to update bandwidth for {}: {}", key, ep);
+      });
+    }
   }
 }
 

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -244,14 +244,6 @@ class OSDSingletonState : public md_config_obs_t {
   using local_cached_map_t = OSDMapService::local_cached_map_t;
   using read_errorator = crimson::os::FuturizedStore::Shard::read_errorator;
 
-public:
-  OSDSingletonState(
-    int whoami,
-    crimson::net::Messenger &cluster_msgr,
-    crimson::net::Messenger &public_msgr,
-    crimson::mon::Client &monc,
-    crimson::mgr::Client &mgrc);
-
 private:
   const int whoami;
 
@@ -371,6 +363,16 @@ private:
   seastar::future<> store_maps(ceph::os::Transaction& t,
                                epoch_t start, Ref<MOSDMap> m);
   void trim_maps(ceph::os::Transaction& t, OSDSuperblock& superblock);
+
+public:
+  OSDSingletonState(
+    int whoami,
+    crimson::net::Messenger &cluster_msgr,
+    crimson::net::Messenger &public_msgr,
+    crimson::mon::Client &monc,
+    crimson::mgr::Client &mgrc,
+    seastar::sharded<ShardServices> &sharded_ss);
+  seastar::sharded<ShardServices> &sharded_ss;
 };
 
 /**
@@ -434,6 +436,62 @@ public:
 	    });
 	});
     }, std::move(orderer));
+  }
+
+  bool scheduling_groups_enabled = false;
+  seastar::scheduling_group sg_client;
+  seastar::scheduling_group sg_peering;
+  seastar::scheduling_group sg_urgent_recovery;
+  seastar::scheduling_group sg_recovery;
+  seastar::scheduling_group sg_scrub;
+  seastar::scheduling_group sg_background;
+
+  static constexpr std::pair<std::string_view, seastar::scheduling_group ShardServices::*>
+  sg_share_keys[] = {
+    {"crimson_sg_client_shares",           &ShardServices::sg_client},
+    {"crimson_sg_peering_shares",          &ShardServices::sg_peering},
+    {"crimson_sg_urgent_recovery_shares",  &ShardServices::sg_urgent_recovery},
+    {"crimson_sg_recovery_shares",         &ShardServices::sg_recovery},
+    {"crimson_sg_scrub_shares",            &ShardServices::sg_scrub},
+    {"crimson_sg_background_shares",       &ShardServices::sg_background},
+  };
+
+  static constexpr std::pair<std::string_view, seastar::scheduling_group ShardServices::*>
+  sg_bandwidth_keys[] = {
+    {"crimson_sg_client_bandwidth",           &ShardServices::sg_client},
+    {"crimson_sg_peering_bandwidths",         &ShardServices::sg_peering},
+    {"crimson_sg_urgent_recovery_bandwidth",  &ShardServices::sg_urgent_recovery},
+    {"crimson_sg_recovery_bandwidth",         &ShardServices::sg_recovery},
+    {"crimson_sg_scrub_bandwidth",            &ShardServices::sg_scrub},
+    {"crimson_sg_background_bandwidth",       &ShardServices::sg_background},
+  };
+
+  seastar::scheduling_group get_sg_client() {
+    return sg_client;
+  }
+  seastar::scheduling_group get_sg_peering() {
+    return sg_peering;
+  }
+  seastar::scheduling_group get_sg_urgent_recovery() {
+    return sg_urgent_recovery;
+  }
+  seastar::scheduling_group get_sg_recovery() {
+    return sg_recovery;
+  }
+  seastar::scheduling_group get_sg_scrub() {
+    return sg_scrub;
+  }
+  seastar::scheduling_group get_sg_background() {
+    return sg_background;
+  }
+
+  template <typename Func>
+  auto with_sg(seastar::scheduling_group sg, Func &&func) {
+    if (scheduling_groups_enabled) {
+      return seastar::with_scheduling_group(sg, std::forward<Func>(func));
+    } else {
+      return func();
+    }
   }
 
 private:

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -281,7 +281,8 @@ options:
 	--osds-per-host: populate crush_location as each host holds the specified number of osds if set
 	--require-osd-and-client-version: if supplied, do set-require-min-compat-client and require-osd-release to specified value
 	--use-crush-tunables: if supplied, set tunables to specified value
-	--reactor-backend: configre seastar reactor backend options like io_uring or linux-aio
+       --reactor-backend: configre seastar reactor backend options like io_uring or linux-aio
+       --io-properties-file: Provide a path to seastar io properties YAML file
 \n
 EOF
 
@@ -619,6 +620,10 @@ case $1 in
         ;;
     --reactor-backend)
         crimson_reactor_backend=$2
+        shift
+        ;;
+    --io-properties-file)
+        crimson_io_properties_file=$2
         shift
         ;;
     --crimson-alien-num-threads)
@@ -1264,6 +1269,10 @@ start_osd() {
         if [ -n "$crimson_reactor_backend" ]; then
             echo "$CEPH_BIN/ceph -c $conf_fn config set osd.$osd crimson_reactor_backend $crimson_reactor_backend"
             $CEPH_BIN/ceph -c $conf_fn config set osd.$osd crimson_reactor_backend $crimson_reactor_backend
+        fi
+	if [ -n "$crimson_io_properties_file" ]; then
+            echo "$CEPH_BIN/ceph -c $conf_fn config set osd.$osd crimson_io_properties_file $crimson_io_properties_file"
+            $CEPH_BIN/ceph -c $conf_fn config set osd.$osd crimson_io_properties_file $crimson_io_properties_file
         fi
     fi
 	if [ "$new" -eq 1 -o $inc_osd_num -gt 0 ]; then


### PR DESCRIPTION
Crimson: introduce scheduling-group based QoS with io-properties support

Introduce scheduling-group based QoS framework for Crimson OSD,
including configuration, initialization, and execution path integration.

- Add io-properties-file support in Seastore
- Introduce QoS-related configuration options
- Create scheduling groups during OSD startup with dynamic reconfiguration
- Integrate scheduling groups into OSD operation execution via with_sg

Fixes: https://tracker.ceph.com/issues/75190

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
