### PR TITLE
mgr/dashboard: decouple overview storage from PromQL

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -221,6 +221,26 @@ class PrometheusRESTController(RESTController):
 @APIRouter('/prometheus', Scope.PROMETHEUS)
 @APIDoc("Prometheus Management API", "Prometheus")
 class Prometheus(PrometheusRESTController):
+    AVG_CONSUMPTION_QUERY = 'sum(rate(ceph_osd_stat_bytes_used[7d])) * 86400'
+    TIME_UNTIL_FULL_QUERY = \
+        '(sum(ceph_osd_stat_bytes)) / (sum(rate(ceph_osd_stat_bytes_used[7d])) * 86400)'
+    TOTAL_RAW_USED_QUERY = 'sum(ceph_osd_stat_bytes_used)'
+    RAW_USED_BY_STORAGE_TYPE_QUERY = \
+        'sum by (application) (ceph_pool_bytes_used * on(pool_id) ' \
+        'group_left(instance, name, application) ' \
+        'ceph_pool_metadata{application=~"(.*Block.*)|(.*Filesystem.*)|(.*Object.*)|(..*)"})'
+    FULL_NEARFULL_QUERY = '{__name__=~"ceph_osd_full_ratio|ceph_osd_nearfull_ratio"}'
+
+    def _run_prometheus_query(self, query, query_path='/query', **params):
+        params['query'] = query
+        return self.prometheus_proxy('GET', query_path, params)
+
+    @staticmethod
+    def _first_prometheus_value(result):
+        if result and 'value' in result[0] and len(result[0]['value']) > 1:
+            return result[0]['value'][1]
+        return None
+
     def list(self, cluster_filter=False, **params):
         if cluster_filter:
             try:
@@ -265,6 +285,47 @@ class Prometheus(PrometheusRESTController):
     def get_prometeus_query_data(self, **params):
         params['query'] = params.pop('params')
         return self.prometheus_proxy('GET', '/query', params)
+
+    @RESTController.Collection(method='GET', path='/overview/storage')
+    def get_overview_storage(self):
+        average_consumption = self._run_prometheus_query(self.AVG_CONSUMPTION_QUERY)
+        time_until_full = self._run_prometheus_query(self.TIME_UNTIL_FULL_QUERY)
+        breakdown = self._run_prometheus_query(self.RAW_USED_BY_STORAGE_TYPE_QUERY)
+        thresholds = self._run_prometheus_query(self.FULL_NEARFULL_QUERY)
+
+        return {
+            'average_consumption_per_day': self._first_prometheus_value(average_consumption),
+            'time_until_full_days': self._first_prometheus_value(time_until_full),
+            'breakdown': [
+                {
+                    'application': item.get('metric', {}).get('application'),
+                    'value': item.get('value', [None, None])[1]
+                } for item in breakdown
+            ],
+            'osd_full_ratio': next(
+                (
+                    item.get('value', [None, None])[1] for item in thresholds
+                    if item.get('metric', {}).get('__name__') == 'ceph_osd_full_ratio'
+                ),
+                None
+            ),
+            'osd_nearfull_ratio': next(
+                (
+                    item.get('value', [None, None])[1] for item in thresholds
+                    if item.get('metric', {}).get('__name__') == 'ceph_osd_nearfull_ratio'
+                ),
+                None
+            )
+        }
+
+    @RESTController.Collection(method='GET', path='/overview/storage/trend')
+    def get_overview_storage_trend(self, start, end, step):
+        result = self._run_prometheus_query(self.TOTAL_RAW_USED_QUERY,
+                                            query_path='/query_range',
+                                            start=start, end=end, step=step)
+        return {
+            'total_raw_used': result[0].get('values', []) if result else []
+        }
 
 
 @APIRouter('/prometheus/notifications', Scope.PROMETHEUS)

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/storage-overview.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/storage-overview.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { configureTestBed } from '~/testing/unit-test-helper';
@@ -7,6 +7,7 @@ import { OverviewStorageService } from './storage-overview.service';
 
 describe('OverviewStorageService', () => {
   let service: OverviewStorageService;
+  let httpMock: HttpTestingController;
 
   configureTestBed({
     imports: [HttpClientTestingModule]
@@ -15,9 +16,11 @@ describe('OverviewStorageService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(OverviewStorageService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
+    httpMock.verify();
     jest.clearAllMocks();
   });
 
@@ -26,214 +29,139 @@ describe('OverviewStorageService', () => {
   });
 
   describe('getTrendData', () => {
-    it('should call getRangeQueriesData with correct params', () => {
-      const promSpy = jest.spyOn(service['prom'], 'getRangeQueriesData').mockReturnValue({} as any);
+    it('should request semantic storage trend data and normalize NaN values', (done) => {
+      service.getTrendData(1000, 2000, 60).subscribe((result) => {
+        expect(result).toEqual({
+          TOTAL_RAW_USED: [
+            [1, '10'],
+            [2, '0']
+          ]
+        });
+        done();
+      });
 
-      service.getTrendData(1000, 2000, 60);
-
-      expect(promSpy).toHaveBeenCalledWith(
-        { start: 1000, end: 2000, step: 60 },
-        { TOTAL_RAW_USED: 'sum(ceph_osd_stat_bytes_used)' },
-        true
+      const req = httpMock.expectOne(
+        'api/prometheus/overview/storage/trend?start=1000&end=2000&step=60'
       );
+      expect(req.request.method).toBe('GET');
+      req.flush({ total_raw_used: [[1, '10'], [2, 'NaN']] });
     });
   });
 
   describe('getAverageConsumption', () => {
     it('should format bytes per day correctly', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '1073741824'] }] }) as any);
       jest.spyOn(service['formatter'], 'formatToBinary').mockReturnValue(['1.0', 'GiB'] as any);
 
       service.getAverageConsumption().subscribe((result) => {
         expect(result).toBe('1.0 GiB/day');
         done();
       });
+
+      httpMock
+        .expectOne('api/prometheus/overview/storage')
+        .flush({ average_consumption_per_day: '1073741824' });
     });
 
     it('should return 0 formatted when no result', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [] }) as any);
       jest.spyOn(service['formatter'], 'formatToBinary').mockReturnValue(['0', 'B'] as any);
 
       service.getAverageConsumption().subscribe((result) => {
         expect(result).toBe('0 B/day');
         done();
       });
-    });
 
-    it('should handle null response gracefully', (done) => {
-      jest.spyOn(service['prom'], 'getPrometheusQueryData').mockReturnValue(of(null) as any);
-      jest.spyOn(service['formatter'], 'formatToBinary').mockReturnValue(['0', 'B'] as any);
-
-      service.getAverageConsumption().subscribe((result) => {
-        expect(result).toBe('0 B/day');
-        done();
-      });
+      httpMock.expectOne('api/prometheus/overview/storage').flush({});
     });
   });
 
   describe('getTimeUntilFull', () => {
-    it('should return N/A when days is Infinity', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [] }) as any);
-
+    const expectValue = (days: string | null, expected: string, done: DoneFn) => {
       service.getTimeUntilFull().subscribe((result) => {
-        expect(result).toBe('N/A');
+        expect(result).toBe(expected);
         done();
       });
+
+      httpMock.expectOne('api/prometheus/overview/storage').flush({ time_until_full_days: days });
+    };
+
+    it('should return N/A when days is Infinity', (done) => {
+      expectValue(null, 'N/A', done);
     });
 
     it('should return hours when days < 1', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '0.5'] }] }) as any);
-
-      service.getTimeUntilFull().subscribe((result) => {
-        expect(result).toBe('12.0 hours');
-        done();
-      });
+      expectValue('0.5', '12.0 hours', done);
     });
 
     it('should return days when 1 <= days < 30', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '15'] }] }) as any);
-
-      service.getTimeUntilFull().subscribe((result) => {
-        expect(result).toBe('15.0 days');
-        done();
-      });
+      expectValue('15', '15.0 days', done);
     });
 
     it('should return months when days >= 30 and < 365', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '60'] }] }) as any);
-
-      service.getTimeUntilFull().subscribe((result) => {
-        expect(result).toBe('2.0 months');
-        done();
-      });
+      expectValue('60', '2.0 months', done);
     });
 
     it('should return years when days >= 365', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '730'] }] }) as any);
-
-      service.getTimeUntilFull().subscribe((result) => {
-        expect(result).toBe('2.0 years');
-        done();
-      });
+      expectValue('730', '2.0 years', done);
     });
 
     it('should return N/A when days <= 0', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '-5'] }] }) as any);
-
-      service.getTimeUntilFull().subscribe((result) => {
-        expect(result).toBe('N/A');
-        done();
-      });
+      expectValue('-5', 'N/A', done);
     });
   });
 
   describe('getTopPools', () => {
     it('should map pool results with name', (done) => {
-      jest.spyOn(service['prom'], 'getPrometheusQueryData').mockReturnValue(
-        of({
-          result: [{ metric: { name: 'mypool' }, value: [null, '0.5'] }]
-        }) as any
-      );
-
       service.getTopPools('some_query').subscribe((result) => {
         expect(result).toEqual([{ group: 'mypool', value: 50 }]);
         done();
       });
+
+      const req = httpMock.expectOne(
+        (request) =>
+          request.url === 'api/prometheus/prometheus_query_data' &&
+          request.params.get('params') === 'some_query'
+      );
+      req.flush({
+        result: [{ metric: { name: 'mypool' }, value: [null, '0.5'] }]
+      });
     });
 
     it('should fallback to pool label when name is absent', (done) => {
-      jest.spyOn(service['prom'], 'getPrometheusQueryData').mockReturnValue(
-        of({
-          result: [{ metric: { pool: 'fallback_pool' }, value: [null, '0.25'] }]
-        }) as any
-      );
-
       service.getTopPools('some_query').subscribe((result) => {
         expect(result).toEqual([{ group: 'fallback_pool', value: 25 }]);
         done();
       });
-    });
 
-    it('should use unknown when no name or pool label', (done) => {
-      jest.spyOn(service['prom'], 'getPrometheusQueryData').mockReturnValue(
-        of({
-          result: [{ metric: {}, value: [null, '0.1'] }]
-        }) as any
-      );
-
-      service.getTopPools('some_query').subscribe((result) => {
-        expect(result).toEqual([{ group: 'unknown', value: 10 }]);
-        done();
-      });
-    });
-
-    it('should return empty array when result is empty', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [] }) as any);
-
-      service.getTopPools('some_query').subscribe((result) => {
-        expect(result).toEqual([]);
-        done();
-      });
+      httpMock
+        .expectOne('api/prometheus/prometheus_query_data?params=some_query')
+        .flush({ result: [{ metric: { pool: 'fallback_pool' }, value: [null, '0.25'] }] });
     });
   });
 
   describe('getCount', () => {
     it('should return numeric count from query result', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '42'] }] }) as any);
-
       service.getCount('some_query').subscribe((result) => {
         expect(result).toBe(42);
         done();
       });
+
+      httpMock
+        .expectOne('api/prometheus/prometheus_query_data?params=some_query')
+        .flush({ result: [{ value: [null, '42'] }] });
     });
 
-    it('should return 0 when result is empty', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [] }) as any);
-
+    it('should return 0 when response is empty', (done) => {
       service.getCount('some_query').subscribe((result) => {
         expect(result).toBe(0);
         done();
       });
-    });
 
-    it('should return 0 when response is null', (done) => {
-      jest.spyOn(service['prom'], 'getPrometheusQueryData').mockReturnValue(of(null) as any);
-
-      service.getCount('some_query').subscribe((result) => {
-        expect(result).toBe(0);
-        done();
-      });
+      httpMock.expectOne('api/prometheus/prometheus_query_data?params=some_query').flush({});
     });
   });
 
   describe('getObjectCounts', () => {
     it('should return bucket and pool counts', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '3'] }] }) as any);
-
       const mockRgwService = {
         getTotalBucketsAndUsersLength: () => of({ buckets_count: 10 })
       };
@@ -242,35 +170,43 @@ describe('OverviewStorageService', () => {
         expect(result).toEqual({ buckets: 10, pools: 3 });
         done();
       });
+
+      httpMock
+        .expectOne(
+          (request) =>
+            request.url === 'api/prometheus/prometheus_query_data' &&
+            request.params.get('params') === 'count(ceph_pool_metadata{application="Object"})'
+        )
+        .flush({ result: [{ value: [null, '3'] }] });
     });
+  });
 
-    it('should default buckets to 0 when buckets_count is missing', (done) => {
-      jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({ result: [{ value: [null, '2'] }] }) as any);
-
-      const mockRgwService = {
-        getTotalBucketsAndUsersLength: () => of({})
-      };
-
-      service.getObjectCounts(mockRgwService).subscribe((result) => {
-        expect(result).toEqual({ buckets: 0, pools: 2 });
+  describe('getRawCapacityThresholds', () => {
+    it('should parse ratios from storage insights', (done) => {
+      service.getRawCapacityThresholds().subscribe((result) => {
+        expect(result).toEqual({
+          osdFullRatio: 0.95,
+          osdNearfullRatio: 0.85
+        });
         done();
+      });
+
+      httpMock.expectOne('api/prometheus/overview/storage').flush({
+        osd_full_ratio: '0.95',
+        osd_nearfull_ratio: '0.85'
       });
     });
   });
 
   describe('getStorageBreakdown', () => {
-    it('should call getPrometheusQueryData with storage breakdown query', () => {
-      const promSpy = jest
-        .spyOn(service['prom'], 'getPrometheusQueryData')
-        .mockReturnValue(of({}) as any);
+    it('should return semantic breakdown data', (done) => {
+      service.getStorageBreakdown().subscribe((result) => {
+        expect(result).toEqual([{ application: 'Block', value: '123' }]);
+        done();
+      });
 
-      service.getStorageBreakdown().subscribe();
-
-      expect(promSpy).toHaveBeenCalledWith({
-        params:
-          'sum by (application) (ceph_pool_bytes_used * on(pool_id) group_left(instance, name, application) ceph_pool_metadata{application=~"(.*Block.*)|(.*Filesystem.*)|(.*Object.*)|(..*)"})'
+      httpMock.expectOne('api/prometheus/overview/storage').flush({
+        breakdown: [{ application: 'Block', value: '123' }]
       });
     });
   });
@@ -306,13 +242,11 @@ describe('OverviewStorageService', () => {
         .mockImplementation((value: number) => Number(value));
 
       const result = service.mapStorageChartData(
-        {
-          result: [
-            { metric: { application: 'Block' }, value: [0, '100'] },
-            { metric: { application: 'Filesystem' }, value: [0, '200'] },
-            { metric: { application: 'Object' }, value: [0, '300'] }
-          ]
-        } as any,
+        [
+          { application: 'Block', value: '100' },
+          { application: 'Filesystem', value: '200' },
+          { application: 'Object', value: '300' }
+        ],
         'B',
         600
       );
@@ -325,17 +259,13 @@ describe('OverviewStorageService', () => {
     });
 
     it('should add System metadata for unassigned bytes', () => {
-      jest
-        .spyOn(service, 'convertBytesToUnit')
-        .mockImplementation((value: string | number) => Number(value));
+      jest.spyOn(service, 'convertBytesToUnit').mockImplementation((value: number) => Number(value));
 
       const result = service.mapStorageChartData(
-        {
-          result: [
-            { metric: { application: 'Block' }, value: [0, '100'] },
-            { metric: { application: 'Filesystem' }, value: [0, '200'] }
-          ]
-        } as any,
+        [
+          { application: 'Block', value: '100' },
+          { application: 'Filesystem', value: '200' }
+        ],
         'B',
         500
       );
@@ -345,62 +275,6 @@ describe('OverviewStorageService', () => {
         { group: 'File system', value: 200 },
         { group: 'System metadata', value: 200 }
       ]);
-    });
-
-    it('should treat unknown application bytes as system metadata', () => {
-      jest
-        .spyOn(service, 'convertBytesToUnit')
-        .mockImplementation((value: string | number) => Number(value));
-
-      const result = service.mapStorageChartData(
-        {
-          result: [
-            { metric: { application: 'Unknown' }, value: [0, '50'] },
-            { metric: { application: 'Block' }, value: [0, '100'] }
-          ]
-        } as any,
-        'B',
-        150
-      );
-
-      expect(result).toEqual([
-        { group: 'Block', value: 100 },
-        { group: 'System metadata', value: 50 }
-      ]);
-    });
-
-    it('should return empty array when unit is missing', () => {
-      const result = service.mapStorageChartData({ result: [] } as any, '', 100);
-      expect(result).toEqual([]);
-    });
-
-    it('should return empty array when data is null', () => {
-      const result = service.mapStorageChartData(null as any, 'B', 100);
-      expect(result).toEqual([]);
-    });
-
-    it('should return empty array when totalUsedBytes is null', () => {
-      const result = service.mapStorageChartData({ result: [] } as any, 'B', null as any);
-      expect(result).toEqual([]);
-    });
-
-    it('should filter out zero-value converted entries', () => {
-      jest
-        .spyOn(service, 'convertBytesToUnit')
-        .mockImplementation((value: string | number) => Number(value));
-      const result = service.mapStorageChartData(
-        {
-          result: [
-            { metric: { application: 'mgr' }, value: [0, '50'] },
-            { metric: { application: 'Object' }, value: [0, '0'] },
-            { metric: { application: 'Block' }, value: [0, '0'] }
-          ]
-        } as any,
-        'B',
-        50
-      );
-
-      expect(result).toEqual([{ group: 'System metadata', value: 50 }]);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/storage-overview.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/storage-overview.service.ts
@@ -1,13 +1,8 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import {
-  PrometheusService,
-  PromethuesGaugeMetricResult,
-  PromqlGuageMetric
-} from '~/app/shared/api/prometheus.service';
 import { FormatterService } from '~/app/shared/services/formatter.service';
 import { map } from 'rxjs/operators';
 import { forkJoin, Observable } from 'rxjs';
-import { CapacityCardQueries } from '../enum/dashboard-promqls.enum';
 import { BreakdownChartData, CapacityThreshold } from '../models/overview';
 
 const StorageType = {
@@ -17,38 +12,50 @@ const StorageType = {
   SYSTEM_METADATA: $localize`System metadata`
 } as const;
 
+type StorageBreakdownMetric = {
+  application: string;
+  value: string;
+};
+
+type OverviewStorageInsights = {
+  average_consumption_per_day: string | null;
+  time_until_full_days: string | null;
+  breakdown: StorageBreakdownMetric[];
+  osd_full_ratio: string | null;
+  osd_nearfull_ratio: string | null;
+};
+
 @Injectable({ providedIn: 'root' })
 export class OverviewStorageService {
-  private readonly prom = inject(PrometheusService);
+  private readonly http = inject(HttpClient);
   private readonly formatter = inject(FormatterService);
-  private readonly AVG_CONSUMPTION_QUERY = 'sum(rate(ceph_osd_stat_bytes_used[7d])) * 86400';
-  private readonly TIME_UNTIL_FULL_QUERY = `(sum(ceph_osd_stat_bytes)) / (sum(rate(ceph_osd_stat_bytes_used[7d])) * 86400)`;
-  private readonly TOTAL_RAW_USED_QUERY = 'sum(ceph_osd_stat_bytes_used)';
-  private readonly OBJECT_POOLS_COUNT_QUERY = 'count(ceph_pool_metadata{application="Object"})';
-  private readonly RAW_USED_BY_STORAGE_TYPE_QUERY =
-    'sum by (application) (ceph_pool_bytes_used * on(pool_id) group_left(instance, name, application) ceph_pool_metadata{application=~"(.*Block.*)|(.*Filesystem.*)|(.*Object.*)|(..*)"})';
-  private readonly FULL_NEARFULL_QUERY = `{__name__=~"${CapacityCardQueries.OSD_FULL}|${CapacityCardQueries.OSD_NEARFULL}"}`;
+  private readonly baseUrl = 'api/prometheus/overview/storage';
+  private readonly objectPoolsCountUrl = 'api/prometheus/prometheus_query_data';
+  private readonly objectPoolsCountQuery = 'count(ceph_pool_metadata{application="Object"})';
 
   getTrendData(start: number, end: number, stepSec: number) {
-    const range = {
-      start,
-      end,
-      step: stepSec
-    };
-
-    return this.prom.getRangeQueriesData(
-      range,
-      {
-        TOTAL_RAW_USED: this.TOTAL_RAW_USED_QUERY
-      },
-      true
-    );
+    return this.http
+      .get<{ total_raw_used: [number, string][] }>(`${this.baseUrl}/trend`, {
+        params: {
+          start,
+          end,
+          step: stepSec
+        }
+      })
+      .pipe(
+        map((result) => ({
+          TOTAL_RAW_USED: (result?.total_raw_used ?? []).map((value) => [
+            value[0],
+            isNaN(parseFloat(value[1])) ? '0' : value[1]
+          ]) as [number, string][]
+        }))
+      );
   }
 
   getAverageConsumption(): Observable<string> {
-    return this.prom.getPrometheusQueryData({ params: this.AVG_CONSUMPTION_QUERY }).pipe(
+    return this.getStorageInsights().pipe(
       map((res) => {
-        const v = Number(res?.result?.[0]?.value?.[1] ?? 0);
+        const v = Number(res?.average_consumption_per_day ?? 0);
         const [val, unit] = this.formatter.formatToBinary(v, true);
         return `${val} ${unit}/day`;
       })
@@ -56,9 +63,9 @@ export class OverviewStorageService {
   }
 
   getTimeUntilFull(): Observable<string> {
-    return this.prom.getPrometheusQueryData({ params: this.TIME_UNTIL_FULL_QUERY }).pipe(
+    return this.getStorageInsights().pipe(
       map((res) => {
-        const days = Number(res?.result?.[0]?.value?.[1] ?? Infinity);
+        const days = Number(res?.time_until_full_days ?? Infinity);
         if (!isFinite(days) || days <= 0) return 'N/A';
 
         if (days < 1) return `${(days * 24).toFixed(1)} hours`;
@@ -70,26 +77,33 @@ export class OverviewStorageService {
   }
 
   getTopPools(query: string): Observable<{ group: string; value: number }[]> {
-    return this.prom.getPrometheusQueryData({ params: query }).pipe(
-      map((data: PromqlGuageMetric) => {
-        return (data?.result ?? []).map((r) => ({
-          group: r.metric?.name || r.metric?.pool || 'unknown',
-          value: Number(r.value?.[1]) * 100
-        }));
-      })
-    );
+    return this.http
+      .get<{ result: Array<{ metric?: Record<string, string>; value?: [number, string] }> }>(
+        this.objectPoolsCountUrl,
+        { params: { params: query } }
+      )
+      .pipe(
+        map((data) => {
+          return (data?.result ?? []).map((r) => ({
+            group: r.metric?.name || r.metric?.pool || 'unknown',
+            value: Number(r.value?.[1]) * 100
+          }));
+        })
+      );
   }
 
   getCount(query: string): Observable<number> {
-    return this.prom
-      .getPrometheusQueryData({ params: query })
+    return this.http
+      .get<{ result: Array<{ value?: [number, string] }> }>(this.objectPoolsCountUrl, {
+        params: { params: query }
+      })
       .pipe(map((res: any) => Number(res?.result?.[0]?.value?.[1]) || 0));
   }
 
   getObjectCounts(rgwBucketService: any) {
     return forkJoin({
       buckets: rgwBucketService.getTotalBucketsAndUsersLength(),
-      pools: this.getCount(this.OBJECT_POOLS_COUNT_QUERY)
+      pools: this.getCount(this.objectPoolsCountQuery)
     }).pipe(
       map(({ buckets, pools }: { buckets: { buckets_count: number }; pools: number }) => ({
         buckets: buckets?.buckets_count ?? 0,
@@ -102,26 +116,18 @@ export class OverviewStorageService {
     osdFullRatio: number | null;
     osdNearfullRatio: number | null;
   }> {
-    return this.prom.getGaugeQueryData(this.FULL_NEARFULL_QUERY).pipe(
-      map((data: PromqlGuageMetric) => {
-        const result = data?.result ?? [];
-
-        const osdFull = result.find((r) => r.metric?.__name__ === CapacityCardQueries.OSD_FULL)
-          ?.value?.[1];
-        const osdNearfull = result.find(
-          (r) => r.metric?.__name__ === CapacityCardQueries.OSD_NEARFULL
-        )?.value?.[1];
-
+    return this.getStorageInsights().pipe(
+      map((data) => {
         return {
-          osdFullRatio: this.prom.formatGuageMetric(osdFull),
-          osdNearfullRatio: this.prom.formatGuageMetric(osdNearfull)
+          osdFullRatio: this.formatGaugeMetric(data?.osd_full_ratio),
+          osdNearfullRatio: this.formatGaugeMetric(data?.osd_nearfull_ratio)
         };
       })
     );
   }
 
-  getStorageBreakdown(): Observable<PromqlGuageMetric> {
-    return this.prom.getPrometheusQueryData({ params: this.RAW_USED_BY_STORAGE_TYPE_QUERY });
+  getStorageBreakdown(): Observable<StorageBreakdownMetric[]> {
+    return this.getStorageInsights().pipe(map((data) => data?.breakdown ?? []));
   }
 
   getThresholdStatus(total, used, nearfull, full): CapacityThreshold {
@@ -157,7 +163,7 @@ export class OverviewStorageService {
   }
 
   mapStorageChartData(
-    data: PromqlGuageMetric,
+    data: StorageBreakdownMetric[],
     unit: string,
     totalUsedBytes: number
   ): BreakdownChartData[] {
@@ -165,12 +171,11 @@ export class OverviewStorageService {
 
     let assignedBytes = 0;
 
-    const result: PromethuesGaugeMetricResult[] = data.result ?? [];
-    const chartData = result.reduce<BreakdownChartData[]>((acc, r) => {
-      const rawBytes = Number(r?.value?.[1] ?? 0);
+    const chartData = data.reduce<BreakdownChartData[]>((acc, r) => {
+      const rawBytes = Number(r?.value ?? 0);
       if (!rawBytes) return acc;
 
-      const group = this.normalizeGroup(r?.metric?.application);
+      const group = this.normalizeGroup(r?.application);
       const value = this.convertBytesToUnit(rawBytes, unit);
 
       if (this.isAStorage(group) && value > 0) {
@@ -191,5 +196,14 @@ export class OverviewStorageService {
     }
 
     return chartData;
+  }
+
+  private getStorageInsights(): Observable<OverviewStorageInsights> {
+    return this.http.get<OverviewStorageInsights>(this.baseUrl);
+  }
+
+  private formatGaugeMetric(data: string | null): number | null {
+    const value = parseFloat(data ?? '');
+    return isFinite(value) ? value : null;
   }
 }

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -108,6 +108,42 @@ class PrometheusControllerTest(ControllerTestCase):
                                             json=None, params={}, verify=True, cert=None, auth=None)
 
     @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
+    def test_get_overview_storage(self):
+        with patch.object(Prometheus, 'prometheus_proxy') as mock_proxy:
+            mock_proxy.side_effect = [
+                [{'value': [0, '1073741824']}],
+                [{'value': [0, '30']}],
+                [{'metric': {'application': 'Block'}, 'value': [0, '123']}],
+                [
+                    {'metric': {'__name__': 'ceph_osd_full_ratio'}, 'value': [0, '0.95']},
+                    {'metric': {'__name__': 'ceph_osd_nearfull_ratio'}, 'value': [0, '0.85']}
+                ]
+            ]
+
+            self._get('/api/prometheus/overview/storage')
+
+            self.assertStatus(200)
+            self.assertJsonBody({
+                'average_consumption_per_day': '1073741824',
+                'time_until_full_days': '30',
+                'breakdown': [{'application': 'Block', 'value': '123'}],
+                'osd_full_ratio': '0.95',
+                'osd_nearfull_ratio': '0.85'
+            })
+
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
+    def test_get_overview_storage_trend(self):
+        with patch.object(Prometheus, 'prometheus_proxy') as mock_proxy:
+            mock_proxy.return_value = [{'values': [[1, '10'], [2, '20']]}]
+
+            self._get('/api/prometheus/overview/storage/trend?start=1&end=2&step=3')
+
+            self.assertStatus(200)
+            self.assertJsonBody({
+                'total_raw_used': [[1, '10'], [2, '20']]
+            })
+
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_add_silence(self):
         with patch('requests.request') as mock_request:
             self._post('/api/prometheus/silence', {'id': 'new-silence'})


### PR DESCRIPTION


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
  - [ ] Updates relevant documentation
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

## Summary
This change reduces tight coupling between the Dashboard overview storage card and raw PromQL queries.

The overview storage logic no longer keeps PromQL expressions in the Angular service for average consumption, time-until-full, storage breakdown, capacity thresholds, and trend data. Instead, the Dashboard backend now exposes semantic storage-focused endpoints and the frontend consumes that higher-level API.

## What Changed
- Added backend overview storage endpoints in the Prometheus controller
- Moved overview storage query ownership from frontend code to backend code
- Updated the frontend storage overview service to consume semantic Dashboard endpoints
- Kept the existing overview card behavior and formatting intact
- Added unit coverage for the new backend/frontend contract

## Testing
- `npx jest --runInBand src/pybind/mgr/dashboard/frontend/src/app/shared/api/storage-overview.service.spec.ts`

## Tracker
Fixes: https://tracker.ceph.com/issues/74957
