### PR TITLE
mds: fix data race on subvolume_metrics_map in MetricsHandler

### DIFF
--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -382,24 +382,23 @@ void MetricsHandler::handle_payload(Session* session,  const SubvolumeMetricsPay
   std::vector<std::string> resolved_paths;
   resolved_paths.reserve(payload.subvolume_metrics.size());
 
-  // RAII guard: unlock on construction, re-lock on destruction (even on exceptions)
-  UnlockGuard unlock_guard{lk};
-
-  // unlocked: resolve paths, no contention with mds lock
-  for (const auto& metric : payload.subvolume_metrics) {
-    std::string path = mds->get_path(metric.subvolume_id);
-    if (path.empty()) {
-      dout(10) << " path not found for " << metric.subvolume_id << dendl;
+  {
+    // Scoped unlock: resolve paths without holding the metrics lock
+    // to avoid contention with mds_lock inside get_path().
+    UnlockGuard unlock_guard{lk};
+    for (const auto& metric : payload.subvolume_metrics) {
+      std::string path = mds->get_path(metric.subvolume_id);
+      if (path.empty()) {
+        dout(10) << " path not found for " << metric.subvolume_id << dendl;
+      }
+      resolved_paths.emplace_back(std::move(path));
     }
-    resolved_paths.emplace_back(std::move(path));
-  }
+  } // lock re-acquired here
 
-  // locked again (via UnlockGuard dtor): update metrics map
   const auto now_ms = static_cast<int64_t>(
-  std::chrono::duration_cast<std::chrono::milliseconds>(
-std::chrono::steady_clock::now().time_since_epoch()).count());
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now().time_since_epoch()).count());
 
-  // Keep index pairing but avoid double map lookup
   for (size_t i = 0; i < resolved_paths.size(); ++i) {
     const auto& path = resolved_paths[i];
     if (path.empty()) continue;
@@ -407,8 +406,6 @@ std::chrono::steady_clock::now().time_since_epoch()).count());
     auto& vec = subvolume_metrics_map[path];
 
     dout(20) << " accumulating subv_metric " << payload.subvolume_metrics[i] << dendl;
-    // std::move of the const expression of the trivially-copyable type 'const value_type'
-    // (aka 'const AggregatedIOMetrics') has no effect; remove std::move()
     vec.emplace_back(payload.subvolume_metrics[i]);
     vec.back().time_stamp = now_ms;
   }
@@ -524,28 +521,26 @@ void MetricsHandler::update_rank0(std::unique_lock<ceph::mutex>& locker) {
     }
   }
 
-  // Step 2 (unlocked): fetch rbytes under mds_lock via helper, release metric log
-  // it allows to proceed another update in metrics handler
-  UnlockGuard unlock_guard{locker};
-
-  // here the metrics handler lock witll be retaken via the UnlockGuard dtor
+  // Step 2 (unlocked): fetch rbytes under mds_lock via helper
   std::unordered_map<inodeno_t, uint64_t> subvol_used_bytes;
-  for (inodeno_t subvol_id : subvol_ids) {
-    if (subvol_used_bytes.count(subvol_id) == 0) {
-      uint64_t rbytes = mds->get_inode_rbytes(subvol_id);
-      subvol_used_bytes[subvol_id] = rbytes;
-      dout(20) << "resolved used_bytes for subvol " << subvol_id << " = " << rbytes << dendl;
+  {
+    UnlockGuard unlock_guard{locker};
+    for (inodeno_t subvol_id : subvol_ids) {
+      if (subvol_used_bytes.count(subvol_id) == 0) {
+        uint64_t rbytes = mds->get_inode_rbytes(subvol_id);
+        subvol_used_bytes[subvol_id] = rbytes;
+        dout(20) << "resolved used_bytes for subvol " << subvol_id << " = " << rbytes << dendl;
+      }
     }
-  }
+  } // lock re-acquired here
 
-  // subvolume metrics, reserve 100 entries per subvolume ? good enough?
-  metrics_message.subvolume_metrics.reserve(subvolume_metrics_map.size()* 100);
+  // Step 3 (locked): aggregate and clear subvolume metrics
+  metrics_message.subvolume_metrics.reserve(subvolume_metrics_map.size() * 100);
   for (auto &[path, aggregated_metrics] : subvolume_metrics_map) {
     metrics_message.subvolume_metrics.emplace_back();
     aggregate_subvolume_metrics(path, aggregated_metrics, subvol_used_bytes,
                                 metrics_message.subvolume_metrics.back());
   }
-  // if we need to show local MDS metrics, we need to save a last copy...
   subvolume_metrics_map.clear();
 
   // Evict stale subvolume quota entries
@@ -572,7 +567,12 @@ void MetricsHandler::update_rank0(std::unique_lock<ceph::mutex>& locker) {
   dout(20) << ": sending " << metrics_message.subvolume_metrics.size() << " subv_metrics to aggregator"
 	   << dendl;
 
-  mds->send_message_mds(make_message<MMDSMetrics>(std::move(metrics_message)), *addr_rank0);
+  // Step 4 (unlocked): send message without holding the metrics lock
+  // to avoid deadlock with mds_lock (see comment on lock member)
+  {
+    UnlockGuard unlock_guard{locker};
+    mds->send_message_mds(make_message<MMDSMetrics>(std::move(metrics_message)), *addr_rank0);
+  } // lock re-acquired here
 }
 
 void MetricsHandler::aggregate_subvolume_metrics(const std::string& subvolume_path,


### PR DESCRIPTION
The UnlockGuard in handle_payload() and update_rank0() had function-wide scope, causing subvolume_metrics_map to be read and written without the metrics lock held. This race between the ms_dispatch thread (handle_payload) and the mds-metrics thread (update_rank0) led to heap corruption under concurrent client subvolume I/O.

Narrow the UnlockGuard scope to only the sections that need the lock dropped (path resolution and rbytes fetch), ensuring subvolume_metrics_map is always accessed under lock.

Confirmed with TSAN: 8 data races before fix, 0 after.

Fixes: https://tracker.ceph.com/issues/75343





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
