### PR TITLE
tentacle: Revive nvme module

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2004,6 +2004,7 @@ fi
 %{_datadir}/ceph/mgr/telemetry
 %{_datadir}/ceph/mgr/test_orchestrator
 %{_datadir}/ceph/mgr/volumes
+%{_datadir}/ceph/mgr/nvmeof
 
 %files mgr-rook
 %{_datadir}/ceph/mgr/rook

--- a/debian/ceph-mgr-modules-core.install
+++ b/debian/ceph-mgr-modules-core.install
@@ -24,3 +24,4 @@ usr/share/ceph/mgr/telegraf
 usr/share/ceph/mgr/telemetry
 usr/share/ceph/mgr/test_orchestrator
 usr/share/ceph/mgr/volumes
+usr/share/ceph/mgr/nvmeof

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -153,7 +153,7 @@ options:
     first started after installation, to populate the list of enabled manager modules.  Subsequent
     updates are done using the 'mgr module [enable|disable]' commands.  List may be
     comma or space separated.
-  default: iostat nfs
+  default: iostat nfs nvmeof
   services:
   - mon
   - common

--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -27,6 +27,7 @@ set(mgr_modules
   devicehealth
   diskprediction_local
   # hello is an example for developers, not for user
+  nvmeof
   influx
   insights
   iostat

--- a/src/pybind/mgr/nvmeof/__init__.py
+++ b/src/pybind/mgr/nvmeof/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .module import NVMeoF

--- a/src/pybind/mgr/nvmeof/module.py
+++ b/src/pybind/mgr/nvmeof/module.py
@@ -1,0 +1,57 @@
+import logging
+from typing import Any
+
+from mgr_module import MgrModule
+import rbd
+
+logger = logging.getLogger(__name__)
+
+POOL_NAME = ".nvmeof"
+
+
+class NVMeoF(MgrModule):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(NVMeoF, self).__init__(*args, **kwargs)
+
+    def _pool_exists(self, pool_name: str) -> bool:
+        logger.info(f"checking if pool {pool_name} exists")
+        pool_exists = self.pool_exists(pool_name)
+        if pool_exists:
+            logger.info(f"pool {pool_name} already exists")
+        else:
+            logger.info(f"pool {pool_name} doesn't exist")
+        return pool_exists
+
+    def _create_pool(self, pool_name: str) -> None:
+        try:
+            self.create_pool(pool_name)
+            logger.info(f"Pool '{pool_name}' created.")
+        except Exception:
+            logger.error(f"Error creating pool '{pool_name}", exc_info=True)
+            raise
+
+    def _enable_rbd_application(self, pool_name: str) -> None:
+        try:
+            self.appify_pool(pool_name, 'rbd')
+            logger.info(f"'rbd' application enabled on pool '{pool_name}'.")
+        except Exception:
+            logger.error(
+                f"Failed to enable 'rbd' application on '{pool_name}'",
+                exc_info=True
+            )
+            raise
+
+    def _rbd_pool_init(self, pool_name: str) -> None:
+        try:
+            with self.rados.open_ioctx(pool_name) as ioctx:
+                rbd.RBD().pool_init(ioctx, False)
+            logger.info(f"RBD pool_init completed on '{pool_name}'.")
+        except Exception:
+            logger.error(f"Failed to initialize RBD pool '{pool_name}'", exc_info=True)
+            raise
+
+    def create_pool_if_not_exists(self) -> None:
+        if not self._pool_exists(POOL_NAME):
+            self._create_pool(POOL_NAME)
+        self._enable_rbd_application(POOL_NAME)
+        self._rbd_pool_init(POOL_NAME)

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -93,6 +93,7 @@ commands =
            -m devicehealth \
            -m diskprediction_local \
            -m hello \
+           -m nvmeof \
            -m influx \
            -m iostat \
            -m localpool \
@@ -146,6 +147,7 @@ modules =
     devicehealth \
     diskprediction_local \
     hello \
+    nvmeof \
     iostat \
     localpool \
     mgr_module.py \


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75220

---

backport of https://github.com/ceph/ceph/pull/67641
parent tracker: https://tracker.ceph.com/issues/74702

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh