### PR TITLE
tentacle: qa/standalone: fix/improve bluefs tests

### DIFF
--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -30,7 +30,7 @@ function TEST_bluestore() {
     CEPH_ARGS+="--bluestore_block_size=2147483648 "
     CEPH_ARGS+="--bluestore_block_db_create=true "
     CEPH_ARGS+="--bluestore_block_db_size=1073741824 "
-    CEPH_ARGS+="--bluestore_block_wal_size=536870912 "
+    CEPH_ARGS+="--bluestore_block_wal_size=1073741824 "
     CEPH_ARGS+="--bluestore_block_wal_create=true "
     CEPH_ARGS+="--bluestore_fsck_on_mount=true "
     #choosing randomly allocation from file
@@ -167,7 +167,7 @@ function TEST_bluestore() {
     # slow, DB -> slow, DB, WAL
     ceph-bluestore-tool --path $dir/0 fsck || return 1
 
-    dd if=/dev/zero  of=$dir/0/wal count=512 bs=1M
+    dd if=/dev/zero  of=$dir/0/wal count=1024 bs=1M
     ceph-bluestore-tool --path $dir/0 \
       --dev-target $dir/0/wal \
       --command bluefs-bdev-new-wal || return 1
@@ -253,7 +253,7 @@ function TEST_bluestore() {
 
     # slow, DB, WAL1 -> slow, DB, WAL2
 
-    dd if=/dev/zero  of=$dir/0/wal2 count=512 bs=1M
+    dd if=/dev/zero  of=$dir/0/wal2 count=1024 bs=1M
     ceph-bluestore-tool --path $dir/0 \
       --devs-source $dir/0/block.wal \
       --dev-target $dir/0/wal2 \

--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -52,7 +52,7 @@ function TEST_bluestore() {
     create_pool foo 16
 
     # write some objects
-    timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
+    timeout 60 rados bench -p foo 15 write -b 4096 --no-cleanup #|| return 1
 
     echo "after bench"
 
@@ -152,7 +152,7 @@ function TEST_bluestore() {
     wait_for_clean || return 1
 
     # write some objects
-    timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
+    timeout 60 rados bench -p foo 15 write -b 4096 --no-cleanup #|| return 1
 
     # kill
     while kill $osd_pid0; do sleep 1 ; done
@@ -180,7 +180,8 @@ function TEST_bluestore() {
     dd if=/dev/zero  of=$dir/1/db count=1024 bs=1M
     ceph-bluestore-tool --path $dir/1 \
       --dev-target $dir/1/db \
-      --command bluefs-bdev-new-db || return 1
+      --command bluefs-bdev-new-db \
+      --log-file $dir/bluestore_tool.log || return 1
 
     ceph-bluestore-tool --path $dir/1 \
       --devs-source $dir/1/block \
@@ -228,7 +229,7 @@ function TEST_bluestore() {
     osd_pid3=$(cat $dir/osd.3.pid)
 
     # write some objects
-    timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
+    timeout 60 rados bench -p foo 15 write -b 4096 --no-cleanup #|| return 1
 
     # kill
     while kill $osd_pid0; do sleep 1 ; done
@@ -334,7 +335,7 @@ function TEST_bluestore() {
     osd_pid3=$(cat $dir/osd.3.pid)
 
     # write some objects
-    timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
+    timeout 60 rados bench -p foo 15 write -b 4096 --no-cleanup #|| return 1
 
     wait_for_clean || return 1
 }
@@ -431,7 +432,7 @@ function TEST_bluestore_expand() {
     create_pool foo 16
 
     # write some objects
-    timeout 60 rados bench -p foo 30 write -b 4096 --no-cleanup #|| return 1
+    timeout 60 rados bench -p foo 10 write -b 4096 --no-cleanup #|| return 1
     sleep 5
     
     total_space_before=$( ceph tell osd.0 perf dump bluefs | jq ".bluefs.slow_total_bytes" )

--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -447,7 +447,7 @@ function TEST_bluestore_expand() {
     # expand slow devices
     ceph-bluestore-tool --log-file $dir/bluestore_tool.log --path $dir/0 fsck || return 1
 
-    requested_space=4294967296 # 4GB
+    requested_space=5368709120 # 5GB
     truncate $dir/0/block -s $requested_space
     ceph-bluestore-tool --log-file $dir/bluestore_tool.log --path $dir/0 bluefs-bdev-expand || return 1
 
@@ -467,22 +467,16 @@ function TEST_bluestore_expand() {
     total_space_after=$( ceph tell osd.0 perf dump bluefs | jq ".bluefs.slow_total_bytes" )
     free_space_after=`ceph tell osd.0 bluestore bluefs device info | grep "BDEV_SLOW" -A 2 | grep free | cut -d':' -f 2 | cut -d"," -f 1 | cut -d' ' -f 2`
 
-    if [ $total_space_after != $requested_space ]; then
-	echo "total_space_after = $total_space_after"
-	echo "requested_space   = $requested_space"
-	return 1;
+    if [ $total_space_after -ne $requested_space ]; then
+        echo "total_space_after = $total_space_after"
+        echo "requested_space   = $requested_space"
+        return 1;
     fi
 
-    total_space_added=$((total_space_after - total_space_before))
-    free_space_added=$((free_space_after - free_space_before))
-
-    let new_used_space=($total_space_added - $free_space_added)
-    echo $new_used_space
-    # allow upto 128KB to be consumed
-    if [ $new_used_space -gt 131072 ]; then
-	echo "total_space_added = $total_space_added"
-	echo "free_space_added  = $free_space_added"
-	return 1;
+    if [ $free_space_after -le $free_space_before ]; then
+       echo "total_space_after = $total_space_after"
+       echo "requested_space   = $requested_space"
+       return 1;
     fi
     
     # kill


### PR DESCRIPTION
Backports: https://github.com/ceph/ceph/pull/67275
Parent tracker: https://tracker.ceph.com/issues/74525
Fixes: https://tracker.ceph.com/issues/75491

Contribution Guidelines


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
