### PR TITLE
mgr/dashboard: remove text-right wrapper from auth form buttons

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.html
@@ -84,6 +84,6 @@
                           [form]="userForm"
                           [disabled]="userForm.invalid"
                           [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                          wrappingClass="text-right"></cd-form-button-panel>
+                          wrappingClass="form-button"></cd-form-button-panel>
   </form>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
@@ -65,8 +65,7 @@
       <div class="form-item">
         <cd-form-button-panel (submitActionEvent)="submit()"
                               [form]="roleForm"
-                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                              wrappingClass="text-right">
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)">
         </cd-form-button-panel>
       </div>
     </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -196,7 +196,7 @@
       <cd-form-button-panel (submitActionEvent)="submit()"
                             [form]="userForm"
                             [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                            wrappingClass="text-right">
+                            wrappingClass="form-button">
       </cd-form-button-panel>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
@@ -62,7 +62,7 @@
         <cd-form-button-panel (submitActionEvent)="onSubmit()"
                               [form]="userForm"
                               [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                              wrappingClass="text-right form-button"></cd-form-button-panel>
+                              wrappingClass="form-button"></cd-form-button-panel>
       </div>
     </div>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.html
@@ -17,8 +17,7 @@
         <cd-form-button-panel (submitActionEvent)="submit(model, formUISchema.taskInfo)"
                               [form]="formDir"
                               [submitText]="formUISchema.title"
-                              [disabled]="!form.valid"
-                              wrappingClass="text-right"></cd-form-button-panel>
+                              [disabled]="!form.valid"></cd-form-button-panel>
       </div>
     </form>
   </div>


### PR DESCRIPTION
This PR removes the old `text-right` wrapper from a small set of auth/shared
forms in the dashboard. The tracker issue is broader, so I kept this PR scoped to one reviewable slice
instead of changing every remaining place at once.

## What changed

I updated these templates:

- `login-password-form.component.html`
- `user-password-form.component.html`
- `role-form.component.html`
- `user-form.component.html`
- `shared/forms/crud-form.component.html`

Changes made:

- replaced `wrappingClass="text-right"` with `wrappingClass="form-button"`
  where button spacing was still needed
- removed `wrappingClass="text-right"` completely where the extra wrapper class
  was not needed

## Why

These forms were still using the old Bootstrap-style `text-right` class on
`cd-form-button-panel`.

This cleanup removes that legacy alignment class from this auth/shared slice
and keeps the button panel styling closer to the current Carbon-based form
pattern.

## Validation

Ran and passed:

- relevant template lint checks
- `login-password-form.component.spec.ts`
- `user-password-form.component.spec.ts`
- `role-form.component.spec.ts`
- `user-form.component.spec.ts`
- `crud-form.component.spec.ts`

Local result:

- 5 test suites passed
- 30 tests passed

Manual UI check:

- `#/user-profile/edit`
- `#/user-management/users/create`
- `#/user-management/users/edit/admin`
- `#/user-management/roles/create`

## Screenshots

### Before

#### User Profile / Change Password
<img width="2878" height="1529" alt="CHANGE PASSWORD" src="https://github.com/user-attachments/assets/7516e793-1ceb-4778-936b-bcc0d7fff2eb" />


#### User Management / Create User
<img width="2878" height="1529" alt="CREATE USER" src="https://github.com/user-attachments/assets/6c6deec3-4241-494a-85be-2b954e9adf52" />


#### User Management / Edit User
<img width="2878" height="1529" alt="EDIT USER" src="https://github.com/user-attachments/assets/6441a885-d609-4a67-bd03-770e1f180b81" />


#### Role Management / Create Role
<img width="2878" height="1529" alt="ROLE" src="https://github.com/user-attachments/assets/255a889e-bde5-4b81-9ee1-d45bf68f9285" />


### After

#### User Profile / Change Password
<img width="2878" height="1529" alt="CHANGE PASSWORD" src="https://github.com/user-attachments/assets/e02116ba-de22-472f-a6f0-0bde586963aa" />


#### User Management / Create User
<img width="2878" height="1529" alt="CREATE USER" src="https://github.com/user-attachments/assets/425f4b10-811a-4e2d-8e8b-7757722b8350" />


#### User Management / Edit User
<img width="2878" height="1529" alt="EDIT USER" src="https://github.com/user-attachments/assets/0abc75ae-f851-401b-a928-d85ad522fe94" />


#### Role Management / Create Role
<img width="2878" height="1529" alt="CREATE ROLE" src="https://github.com/user-attachments/assets/edc62338-31b3-4064-8e41-b545e73e41ea" />

```
