### PR TITLE
rgw: hide sensitive Swift headers

### DIFF
--- a/qa/workunits/rgw/test_swift_sensitive_headers.py
+++ b/qa/workunits/rgw/test_swift_sensitive_headers.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import logging as log
+import os
+import requests
+from common import exec_cmd
+
+"""
+Tests filtering of sensitive Swift headers for non-owners.
+"""
+
+OWNER_UID = "swift-owner"
+OWNER_SUBUSER = "swift-owner:swift"
+OWNER_SECRET = "ownersecret"
+
+NON_OWNER_UID = "swift-nonowner"
+NON_OWNER_SUBUSER = "swift-nonowner:swift"
+NON_OWNER_SECRET = "nonownersecret"
+
+CONTAINER_NAME = "test-sensitive-headers-container"
+
+
+def setup_swift_user(uid, subuser, secret):
+    exec_cmd(f'radosgw-admin user create --uid={uid} --display-name="Test {uid}"')
+    exec_cmd(f"radosgw-admin subuser create --uid={uid} --subuser={subuser} --access=full")
+    exec_cmd(f"radosgw-admin key create --subuser={subuser} --key-type=swift --secret={secret}")
+
+
+def teardown_user(uid):
+    exec_cmd(f"radosgw-admin user rm --uid={uid} --purge-data")
+
+
+def get_swift_auth(endpoint, subuser, secret):
+    headers = {"X-Auth-User": subuser, "X-Auth-Key": secret}
+    resp = requests.get(f"{endpoint}/auth/1.0", headers=headers)
+    resp.raise_for_status()
+    return resp.headers["X-Storage-Url"], resp.headers["X-Auth-Token"]
+
+
+def main():
+    log.basicConfig(level=log.DEBUG)
+    endpoint = os.environ.get("RGW_URL", "http://localhost:8000")
+
+    setup_swift_user(OWNER_UID, OWNER_SUBUSER, OWNER_SECRET)
+    setup_swift_user(NON_OWNER_UID, NON_OWNER_SUBUSER, NON_OWNER_SECRET)
+
+    owner_url = None
+    owner_token = None
+    try:
+        owner_url, owner_token = get_swift_auth(endpoint, OWNER_SUBUSER, OWNER_SECRET)
+        non_owner_url, non_owner_token = get_swift_auth(endpoint, NON_OWNER_SUBUSER, NON_OWNER_SECRET)
+
+        sensitive_headers = {
+            "X-Auth-Token": owner_token,
+            "X-Container-Read": ".r:*",
+            "X-Container-Meta-Temp-Url-Key": "supersecretkey",
+        }
+        resp = requests.put(f"{owner_url}/{CONTAINER_NAME}", headers=sensitive_headers)
+        resp.raise_for_status()
+
+        log.debug("TEST: owner can see sensitive swift headers\n")
+        owner_resp = requests.head(f"{owner_url}/{CONTAINER_NAME}", headers={"X-Auth-Token": owner_token})
+        owner_resp.raise_for_status()
+
+        headers_lower = {k.lower(): v for k, v in owner_resp.headers.items()}
+        assert ("x-container-read" in headers_lower), "FAIL: Owner is missing X-Container-Read"
+        assert ("x-container-meta-temp-url-key" in headers_lower), "FAIL: Owner is missing Temp-Url-Key"
+
+        non_owner_resp = requests.head(f"{owner_url}/{CONTAINER_NAME}", headers={"X-Auth-Token": non_owner_token})
+        non_owner_resp.raise_for_status()
+
+        no_headers_lower = {k.lower(): v for k, v in non_owner_resp.headers.items()}
+        assert ("x-container-read" not in no_headers_lower), "FAIL: Non-owner has access to X-Container-Read"
+        assert ("x-container-meta-temp-url-key" not in no_headers_lower), "FAIL: Non-owner has access to Temp-Url-Key"
+        assert ("x-account-meta-temp-url-key" not in no_headers_lower), "FAIL: Non-owner has access to Account Temp-Url-Key"
+
+    finally:
+        log.debug(f"Deleting container {CONTAINER_NAME}")
+        if owner_url and owner_token:
+            requests.delete(f"{owner_url}/{CONTAINER_NAME}", headers={"X-Auth-Token": owner_token})
+        teardown_user(OWNER_UID)
+        teardown_user(NON_OWNER_UID)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -261,6 +261,11 @@ static void dump_account_metadata(req_state * const s,
     if (geniter != rgw_to_http_attrs.end()) {
       dump_header(s, geniter->second, iter->second);
     } else if (strncmp(name, RGW_ATTR_META_PREFIX, PREFIX_LEN) == 0) {
+      if (s->perm_mask != RGW_PERM_FULL_CONTROL && 
+         (boost::algorithm::iequals(name + PREFIX_LEN, "temp-url-key") || 
+          boost::algorithm::iequals(name + PREFIX_LEN, "temp-url-key-2"))) {
+        continue;
+      }
       dump_header_prefixed(s, "X-Account-Meta-",
                            camelcase_dash_http_attr(name + PREFIX_LEN, false),
                            iter->second);
@@ -269,7 +274,7 @@ static void dump_account_metadata(req_state * const s,
 
   /* Dump account ACLs, if any */
   auto account_acls = rgw::swift::format_account_acl(policy);
-  if (account_acls) {
+  if (account_acls && s->perm_mask == RGW_PERM_FULL_CONTROL) {
     dump_header(s, "X-Account-Access-Control", std::move(*account_acls));
   }
 }
@@ -571,14 +576,15 @@ static void dump_container_metadata(req_state *s,
     dump_header(s, "X-Container-Bytes-Used-Actual", stats->size_rounded);
   }
 
+  const bool is_owner = s->system_request || (s->auth.identity->is_owner_of(s->bucket->get_info().owner));
   if (rgw::sal::Object::empty(s->object.get())) {
     std::string read_acl, write_acl;
     rgw::swift::format_container_acls(s->bucket_acl, read_acl, write_acl);
 
-    if (read_acl.size()) {
+    if (read_acl.size() && is_owner) {
       dump_header(s, "X-Container-Read", read_acl);
     }
-    if (write_acl.size()) {
+    if (write_acl.size() && is_owner) {
       dump_header(s, "X-Container-Write", write_acl);
     }
     if (!s->bucket->get_placement_rule().name.empty()) {
@@ -598,6 +604,10 @@ static void dump_container_metadata(req_state *s,
       if (geniter != rgw_to_http_attrs.end()) {
         dump_header(s, geniter->second, iter->second);
       } else if (strncmp(name, RGW_ATTR_META_PREFIX, PREFIX_LEN) == 0) {
+        if (!is_owner && (boost::algorithm::iequals(name + PREFIX_LEN, "temp-url-key") || 
+                          boost::algorithm::iequals(name + PREFIX_LEN, "temp-url-key-2"))) {
+          continue; 
+        }
         dump_header_prefixed(s, "X-Container-Meta-",
                              camelcase_dash_http_attr(name + PREFIX_LEN, false),
                              iter->second);


### PR DESCRIPTION
Fixes an issue where sensitive Swift ACL headers (X-Container-Read and X-Container-Write) were exposed to non-owners.

Fixes: https://tracker.ceph.com/issues/68477


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
