### PR TITLE
tentacle: mgr/dashboard: Add restore events in notification screen

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.html
@@ -14,6 +14,7 @@
             columnMode="flex"
             selectionType="single"
             identifier="Id"
+            [autoReload]="true"
             (updateSelection)="updateSelection($event)"
             (fetchData)="fetchData()">
   <cd-table-actions class="table-actions"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.ts
@@ -74,7 +74,7 @@ export class RgwBucketNotificationListComponent extends ListWithDetails implemen
       },
       {
         name: $localize`Destination`,
-        prop: 'Destination',
+        prop: 'Topic',
         flexGrow: 1,
         cellTransformation: CellTemplate.copy
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.html
@@ -1,8 +1,13 @@
   <ng-container>
+  <legend>
+  <cd-help-text i18n>
+   A topic specifies where and how event notifications from a bucket are delivered, including the target system (e.g., Kafka or HTTP) and its configuration.
+  </cd-help-text>
+  </legend>
   <cd-table #table
             headerTitle="Notification destination"
             headerDescription="Delivers bucket and object change notifications to external services like Kafka or AMQP."
-            [autoReload]="false"
+            [autoReload]="true"
             [data]="topics$ | async"
             [columns]="columns"
             columnMode="flex"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+
 import { RgwTopicListComponent } from './rgw-topic-list.component';
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed, PermissionHelper } from '~/testing/unit-test-helper';
@@ -48,7 +49,7 @@ describe('RgwTopicListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-    expect(rgwTopicServiceListSpy).toHaveBeenCalledTimes(2);
+    expect(rgwTopicServiceListSpy.calls.count()).toBe(1);
   });
 
   it('should test all TableActions combinations', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/notification-configuration.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/notification-configuration.model.ts
@@ -44,6 +44,10 @@ export const events: ComboBoxItem[] = [
     name: 's3:ObjectCreated:CompleteMultipartUpload'
   },
   { content: 's3:ObjectRemoved:*', name: 's3:ObjectRemoved:*' },
+  { content: 's3:ObjectRestore:*', name: 's3:ObjectRestore:*' },
+  { content: 's3:ObjectRestore:Post', name: 's3:ObjectRestore:Post' },
+  { content: 's3:ObjectRestore:Completed', name: 's3:ObjectRestore:Completed' },
+  { content: 's3:ObjectRestore:Delete', name: 's3:ObjectRestore:Delete' },
   { content: 's3:ObjectRemoved:Delete', name: 's3:ObjectRemoved:Delete' },
   { content: 's3:ObjectRemoved:DeleteMarkerCreated', name: 's3:ObjectRemoved:DeleteMarkerCreated' }
 ];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75487

---

backport of https://github.com/ceph/ceph/pull/65405
parent tracker: https://tracker.ceph.com/issues/72887

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh