### PR TITLE
mon/PGMap: sort 'osd df' and 'osd perf' outputs by OSD ID

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2100,27 +2100,28 @@ int PGMap::dump_stuck_pg_stats(
   return 0;
 }
 
+std::vector<std::pair<int32_t, const osd_stat_t*>> get_sorted_osd_stats() const
+{
+  std::vector<std::pair<int32_t, osd_stat_t>> sorted_stats(osd_stat.begin(), osd_stat.end());
+  std::sort(sorted_stats.begin(), sorted_stats.end(), [](const auto& a, const auto& b) {
+    return a.first < b.first;
+  });
+  return sorted_stats;
+}
+
 void PGMap::dump_osd_perf_stats(ceph::Formatter *f) const
 {
   f->open_array_section("osd_perf_infos");
-  std::vector<int> sorted_osds;
-  for (auto i = osd_stat.begin(); i != osd_stat.end(); ++i) {
-    sorted_osds.push_back(i->first);
-  }
-  std::sort(sorted_osds.begin(), sorted_osds.end());
 
-  for (int osd_id : sorted_osds) {
-    auto i = osd_stat.find(osd_id);
-    if (i != osd_stat.end()) {
-      f->open_object_section("osd");
-      f->dump_int("id", i->first);
-      {
-        f->open_object_section("perf_stats");
-        i->second.os_perf_stat.dump(f);
-        f->close_section();
-      }
+  for (const auto& [osd_id, stat] : get_sorted_osd_stats()) {
+    f->open_object_section("osd");
+    f->dump_int("id", osd_id);
+    {
+      f->open_object_section("perf_stats");
+      stat.os_perf_stat.dump(f);
       f->close_section();
     }
+    f->close_section();
   }
   f->close_section();
 }
@@ -2131,20 +2132,11 @@ void PGMap::print_osd_perf_stats(std::ostream *ss) const
   tab.define_column("commit_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("apply_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
 
-  std::vector<int32_t> sorted_osds;
-  for (auto i = osd_stat.begin(); i != osd_stat.end(); ++i) {
-    sorted_osds.push_back(i->first);
-  }
-  std::sort(sorted_osds.begin(), sorted_osds.end());
-
-  for (int osd_id : sorted_osds) {
-    auto i = osd_stat.find(osd_id);
-    if (i != osd_stat.end()) {
-      tab << i->first;
-      tab << i->second.os_perf_stat.os_commit_latency_ns / 1000000ull;
-      tab << i->second.os_perf_stat.os_apply_latency_ns / 1000000ull;
-      tab << TextTable::endrow;
-    }
+  for (const auto& [osd_id, stat] : get_sorted_osd_stats()) {
+    tab << osd_id;
+    tab << stat.os_perf_stat.os_commit_latency_ns / 1000000ull;
+    tab << stat.os_perf_stat.os_apply_latency_ns / 1000000ull;
+    tab << TextTable::endrow;
   }
   (*ss) << tab;
 }

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2100,12 +2100,14 @@ int PGMap::dump_stuck_pg_stats(
   return 0;
 }
 
-std::vector<std::pair<int32_t, const osd_stat_t*>> get_sorted_osd_stats() const
+std::vector<std::pair<int32_t, osd_stat_t>> PGMap::get_sorted_osd_stats() const
 {
   std::vector<std::pair<int32_t, osd_stat_t>> sorted_stats(osd_stat.begin(), osd_stat.end());
+
   std::sort(sorted_stats.begin(), sorted_stats.end(), [](const auto& a, const auto& b) {
     return a.first < b.first;
   });
+
   return sorted_stats;
 }
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -25,6 +25,8 @@
 
 #include <iomanip> // for std::setw()
 #include <sstream>
+#include <algorithm>
+#include <vector>
 
 #define dout_context g_ceph_context
 
@@ -2101,17 +2103,24 @@ int PGMap::dump_stuck_pg_stats(
 void PGMap::dump_osd_perf_stats(ceph::Formatter *f) const
 {
   f->open_array_section("osd_perf_infos");
-  for (auto i = osd_stat.begin();
-       i != osd_stat.end();
-       ++i) {
-    f->open_object_section("osd");
-    f->dump_int("id", i->first);
-    {
-      f->open_object_section("perf_stats");
-      i->second.os_perf_stat.dump(f);
+  std::vector<int> sorted_osds;
+  for (auto i = osd_stat.begin(); i != osd_stat.end(); ++i) {
+    sorted_osds.push_back(i->first);
+  }
+  std::sort(sorted_osds.begin(), sorted_osds.end());
+
+  for (int osd_id : sorted_osds) {
+    auto i = osd_stat.find(osd_id);
+    if (i != osd_stat.end()) {
+      f->open_object_section("osd");
+      f->dump_int("id", i->first);
+      {
+        f->open_object_section("perf_stats");
+        i->second.os_perf_stat.dump(f);
+        f->close_section();
+      }
       f->close_section();
     }
-    f->close_section();
   }
   f->close_section();
 }
@@ -2121,13 +2130,21 @@ void PGMap::print_osd_perf_stats(std::ostream *ss) const
   tab.define_column("osd", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("commit_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("apply_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
-  for (auto i = osd_stat.begin();
-       i != osd_stat.end();
-       ++i) {
-    tab << i->first;
-    tab << i->second.os_perf_stat.os_commit_latency_ns / 1000000ull;
-    tab << i->second.os_perf_stat.os_apply_latency_ns / 1000000ull;
-    tab << TextTable::endrow;
+
+  std::vector<int32_t> sorted_osds;
+  for (auto i = osd_stat.begin(); i != osd_stat.end(); ++i) {
+    sorted_osds.push_back(i->first);
+  }
+  std::sort(sorted_osds.begin(), sorted_osds.end());
+
+  for (int osd_id : sorted_osds) {
+    auto i = osd_stat.find(osd_id);
+    if (i != osd_stat.end()) {
+      tab << i->first;
+      tab << i->second.os_perf_stat.os_commit_latency_ns / 1000000ull;
+      tab << i->second.os_perf_stat.os_apply_latency_ns / 1000000ull;
+      tab << TextTable::endrow;
+    }
   }
   (*ss) << tab;
 }

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -376,7 +376,7 @@ public:
                              const utime_t ts,
                              const int64_t pool,
                              const pool_stat_t& old_pool_sum);
-  std::vector<std::pair<int32_t, const osd_stat_t*>> get_sorted_osd_stats() const;
+  std::vector<std::pair<int32_t, osd_stat_t>> get_sorted_osd_stats() const;
 
  public:
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -376,6 +376,7 @@ public:
                              const utime_t ts,
                              const int64_t pool,
                              const pool_stat_t& old_pool_sum);
+  std::vector<std::pair<int32_t, const osd_stat_t*>> get_sorted_osd_stats() const;
 
  public:
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -7030,7 +7030,7 @@ public:
     average_util = average_utilization();
   }
 
-  void dump(F *f){
+  void dump(F *f) {
     if (tree) {
       CrushTreeDumper::Dumper<F>::dump(f);
     } else {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -7030,6 +7030,29 @@ public:
     average_util = average_utilization();
   }
 
+  void dump(F *f){
+    if (tree) {
+      CrushTreeDumper::Dumper<F>::dump(f);
+    } else {
+      this->reset();
+      CrushTreeDumper::Item qi;
+      std::vector<CrushTreeDumper::Item> flat_items;
+
+      while (this->next(qi)) {
+        if (!qi.is_bucket()) {
+          flat_items.push_back(qi);
+        }
+      }
+
+      std::sort(flat_items.begin(), flat_items.end(),
+                [](const auto& a, const auto& b) { return a.id < b.id; });
+
+      for (const auto& item : flat_items) {
+        this->dump_item(item, f);
+      }
+    }
+  }
+
 protected:
 
   bool should_dump(int id) const {


### PR DESCRIPTION
Currently, the outputs of `ceph osd df` (in plain mode) and `ceph osd perf`
display OSDs in an unordered manner, as they iterate directly over hash maps.
This makes it difficult for administrators to quickly scan and compare
metrics across specific OSDs during critical cluster operations.

This PR introduces OSD ID ascending sorting to both commands:
- For `osd perf`: Collected OSD IDs from `osd_stat` into a vector and
  applied `std::sort` before formatting text and JSON outputs.
- For `osd df`: Overrode the `dump()` method in `OSDUtilizationDumper`
  to branch based on the `tree` mode. In plain mode (!tree), it leverages
  `next()` to traverse the CRUSH map (maintaining the `touched` set for
  proper stray OSD handling), collects non-bucket items, and sorts them by
  OSD ID before calling `dump_item()`. Tree mode output remains unaffected.


Fixes: https://tracker.ceph.com/issues/75429
Signed-off-by: Sangyun Lee <falconlee236@gmail.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
