### PR TITLE
tentacle: src/ceph-volume: fast device unavailable as error

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -438,8 +438,8 @@ class Batch(object):
                                                  num_osds,
                                                  fast_type)
         if fast_devices and not fast_allocations:
-            mlogger.info('{} fast devices were passed, but none are available'.format(len(fast_devices)))
-            return []
+            mlogger.error('{} fast devices were passed, but none are available'.format(len(fast_devices)))
+            exit(1)
         if fast_devices and not len(fast_allocations) == num_osds:
             mlogger.error('{} fast allocations != {} num_osds'.format(
                 len(fast_allocations), num_osds))
@@ -450,8 +450,8 @@ class Batch(object):
                                                       num_osds,
                                                       'block_wal')
         if very_fast_devices and not very_fast_allocations:
-            mlogger.info('{} very fast devices were passed, but none are available'.format(len(very_fast_devices)))
-            return []
+            mlogger.error('{} very fast devices were passed, but none are available'.format(len(very_fast_devices)))
+            exit(1)
         if very_fast_devices and not len(very_fast_allocations) == num_osds:
             mlogger.error('{} very fast allocations != {} num_osds'.format(
                 len(very_fast_allocations), num_osds))

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -43,6 +43,57 @@ class TestBatch(object):
         with pytest.raises(ArgumentError):
             arg_validators.ValidBatchDevice()('foo')
 
+    def test_exit_on_unavailable_fast_allocation(self, factory, conf_ceph_stub, mock_device_generator):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        devs = [mock_device_generator() for _ in range(5)]
+        fast_devs = [mock_device_generator()]
+        fast_devs[0].available_lvm = False
+        args = factory(data_slots=1,
+                       osds_per_device=1,
+                       osd_ids=[],
+                       devices=devs,
+                       db_devices=fast_devs,
+                       wal_devices=[],
+                       objectstore='bluestore',
+                       block_db_size="1G",
+                       block_db_slots=1.0,
+                       dmcrypt=True,
+                       data_allocate_fraction=1.0,
+                       has_block_db_size_without_db_devices=None
+                      )
+        b = batch.Batch([])
+        b.args = args
+        with pytest.raises(SystemExit) as err:
+            b.get_deployment_layout()
+        assert err.value.code == 1
+
+    def test_exit_on_unavailable_very_fast_allocation(self, factory, conf_ceph_stub, mock_device_generator):
+        # ensure json reports are valid when empty
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        devs = [mock_device_generator() for _ in range(5)]
+        fast_devs = [mock_device_generator()]
+        fast_devs[0].available_lvm = False
+        very_fast_devs = [mock_device_generator()]
+        very_fast_devs[0].available_lvm = False
+        args = factory(data_slots=1,
+                       osds_per_device=1,
+                       osd_ids=[],
+                       devices=devs,
+                       db_devices=fast_devs,
+                       wal_devices=very_fast_devs,
+                       objectstore='bluestore',
+                       block_db_size="1G",
+                       block_db_slots=5,
+                       dmcrypt=True,
+                       data_allocate_fraction=1.0,
+                       has_block_db_size_without_db_devices=None
+                      )
+        b = batch.Batch([])
+        b.args = args
+        with pytest.raises(SystemExit) as err:
+            b.get_deployment_layout()
+        assert err.value.code == 1
+
     @pytest.mark.parametrize('format_', ['pretty', 'json', 'json-pretty'])
     def test_report(self, format_, factory, conf_ceph_stub, mock_device_generator):
         # just ensure reporting works
@@ -85,65 +136,6 @@ class TestBatch(object):
                        block_db_size="1G",
                        dmcrypt=True,
                        data_allocate_fraction=1.0,
-                      )
-        b = batch.Batch([])
-        b.args = args
-        plan = b.get_deployment_layout()
-        report = b._create_report(plan)
-        json.loads(report)
-
-    @pytest.mark.parametrize('format_', ['json', 'json-pretty'])
-    def test_json_report_valid_empty_unavailable_fast(self, format_, factory, conf_ceph_stub, mock_device_generator):
-        # ensure json reports are valid when empty
-        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
-        devs = [mock_device_generator() for _ in range(5)]
-        fast_devs = [mock_device_generator()]
-        fast_devs[0].available_lvm = False
-        args = factory(data_slots=1,
-                       osds_per_device=1,
-                       osd_ids=[],
-                       report=True,
-                       format=format_,
-                       devices=devs,
-                       db_devices=fast_devs,
-                       wal_devices=[],
-                       objectstore='bluestore',
-                       block_db_size="1G",
-                       block_db_slots=1.0,
-                       dmcrypt=True,
-                       data_allocate_fraction=1.0,
-                       has_block_db_size_without_db_devices=None
-                      )
-        b = batch.Batch([])
-        b.args = args
-        plan = b.get_deployment_layout()
-        report = b._create_report(plan)
-        json.loads(report)
-
-
-    @pytest.mark.parametrize('format_', ['json', 'json-pretty'])
-    def test_json_report_valid_empty_unavailable_very_fast(self, format_, factory, conf_ceph_stub, mock_device_generator):
-        # ensure json reports are valid when empty
-        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
-        devs = [mock_device_generator() for _ in range(5)]
-        fast_devs = [mock_device_generator()]
-        fast_devs[0].available_lvm = False
-        very_fast_devs = [mock_device_generator()]
-        very_fast_devs[0].available_lvm = False
-        args = factory(data_slots=1,
-                       osds_per_device=1,
-                       osd_ids=[],
-                       report=True,
-                       format=format_,
-                       devices=devs,
-                       db_devices=fast_devs,
-                       wal_devices=very_fast_devs,
-                       objectstore='bluestore',
-                       block_db_size="1G",
-                       block_db_slots=5,
-                       dmcrypt=True,
-                       data_allocate_fraction=1.0,
-                       has_block_db_size_without_db_devices=None
                       )
         b = batch.Batch([])
         b.args = args

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -72,14 +72,18 @@ class OSDService(CephService):
             self.mgr.cache.save_host(host)
             return ret_msg
 
-        async def all_hosts() -> List[Optional[str]]:
+        async def all_hosts() -> List[str]:
             futures = [create_from_spec_one(h, ds)
                        for h, ds in self.prepare_drivegroup(drive_group)]
-            return await gather(*futures)
+            results = await gather(*futures, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    self.mgr.log.error(f'Failed to create OSD: {result}')
+            return [result for result in results if isinstance(result, str)]
 
         with self.mgr.async_timeout_handler('cephadm deploy (osd daemon)'):
             ret = self.mgr.wait_async(all_hosts())
-        return ", ".join(filter(None, ret))
+        return ", ".join(ret)
 
     async def create_single_host(self,
                                  drive_group: DriveGroupSpec,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75634

---

backport of https://github.com/ceph/ceph/pull/67745
parent tracker: https://tracker.ceph.com/issues/75462

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh