### PR TITLE
rgw: support prefix in s3 list buckets

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -311,7 +311,7 @@ static int cls_user_list_buckets(cls_method_context_t hctx, bufferlist *in, buff
   if (max_entries > MAX_ENTRIES)
     max_entries = MAX_ENTRIES;
 
-  string match_prefix;
+  const string& match_prefix = op.prefix;
   cls_user_list_buckets_ret ret;
 
   int rc = cls_cxx_map_get_vals(hctx, from_index, match_prefix, max_entries, &keys, &ret.truncated);

--- a/src/cls/user/cls_user_client.cc
+++ b/src/cls/user/cls_user_client.cc
@@ -78,6 +78,7 @@ public:
 void cls_user_bucket_list(librados::ObjectReadOperation& op,
                           const string& in_marker,
                           const string& end_marker,
+                          const string& prefix,
                           int max_entries,
                           list<cls_user_bucket_entry>& entries,
                           string *out_marker,
@@ -88,6 +89,7 @@ void cls_user_bucket_list(librados::ObjectReadOperation& op,
   cls_user_list_buckets_op call;
   call.marker = in_marker;
   call.end_marker = end_marker;
+  call.prefix = prefix;
   call.max_entries = max_entries;
 
   encode(call, inbl);

--- a/src/cls/user/cls_user_client.h
+++ b/src/cls/user/cls_user_client.h
@@ -24,6 +24,7 @@ void cls_user_remove_bucket(librados::ObjectWriteOperation& op,  const cls_user_
 void cls_user_bucket_list(librados::ObjectReadOperation& op,
 			  const std::string& in_marker,
 			  const std::string& end_marker,
+			  const std::string& prefix,
 			  int max_entries,
 			  std::list<cls_user_bucket_entry>& entries,
 			  std::string *out_marker,

--- a/src/cls/user/cls_user_ops.cc
+++ b/src/cls/user/cls_user_ops.cc
@@ -50,6 +50,8 @@ list<cls_user_remove_bucket_op> cls_user_remove_bucket_op::generate_test_instanc
 void cls_user_list_buckets_op::dump(Formatter *f) const
 {
   encode_json("marker", marker, f);
+  encode_json("end_marker", end_marker, f);
+  encode_json("prefix", prefix, f);
   encode_json("max_entries", max_entries, f);
 }
 
@@ -59,6 +61,8 @@ list<cls_user_list_buckets_op> cls_user_list_buckets_op::generate_test_instances
   ls.emplace_back();
   cls_user_list_buckets_op op;;
   op.marker = "marker";
+  op.end_marker = "end";
+  op.prefix = "prefix";
   op.max_entries = 1000;
   ls.push_back(std::move(op));
   return ls;

--- a/src/cls/user/cls_user_ops.h
+++ b/src/cls/user/cls_user_ops.h
@@ -59,6 +59,7 @@ WRITE_CLASS_ENCODER(cls_user_remove_bucket_op)
 struct cls_user_list_buckets_op {
   std::string marker;
   std::string end_marker;
+  std::string prefix;
   int max_entries; /* upperbound to returned num of entries
                       might return less than that and still be truncated */
 
@@ -66,19 +67,23 @@ struct cls_user_list_buckets_op {
     : max_entries(0) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(marker, bl);
     encode(max_entries, bl);
     encode(end_marker, bl);
+    encode(prefix, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(marker, bl);
     decode(max_entries, bl);
     if (struct_v >= 2) {
       decode(end_marker, bl);
+    }
+    if (struct_v >= 3) {
+      decode(prefix, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -48,8 +48,9 @@ using ::ceph::encode;
 int DaosStore::list_buckets(const DoutPrefixProvider* dpp,
                             const rgw_owner& owner, const std::string& tenant,
                             const string& marker, const string& end_marker,
-                            uint64_t max, bool need_stats, BucketList& buckets,
-                            optional_yield y) {
+                            const string& prefix, uint64_t max, bool need_stats,
+                            BucketList& buckets, optional_yield y) {
+  (void)prefix;
   ldpp_dout(dpp, 20) << "DEBUG: list_user_buckets: marker=" << marker
                      << " end_marker=" << end_marker << " max=" << max << dendl;
   int ret = 0;

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -930,7 +930,7 @@ class DaosStore : public StoreDriver {
   int list_buckets(const DoutPrefixProvider* dpp,
                    const rgw_owner& owner, const std::string& tenant,
                    const std::string& marker, const std::string& end_marker,
-                   uint64_t max, bool need_stats,
+                   const std::string& prefix, uint64_t max, bool need_stats,
                    BucketList& buckets, optional_yield y) override;
   virtual bool is_meta_master() override;
   virtual Zone* get_zone() { return &zone; }

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -159,9 +159,10 @@ void MotrMetaCache::set_enabled(bool status)
 // with starting key `marker`.
 int MotrStore::list_buckets(const DoutPrefixProvider *dpp,
     const rgw_owner& owner, const std::string& tenant,
-    const string& marker, const string& end_marker, uint64_t max,
-    bool need_stats, BucketList &buckets, optional_yield y)
+    const string& marker, const string& end_marker, const string& prefix,
+    uint64_t max, bool need_stats, BucketList &buckets, optional_yield y)
 {
+  (void)prefix;
   int rc;
   vector<string> keys(max);
   vector<bufferlist> vals(max);

--- a/src/rgw/driver/motr/rgw_sal_motr.h
+++ b/src/rgw/driver/motr/rgw_sal_motr.h
@@ -1003,7 +1003,8 @@ class MotrStore : public StoreDriver {
     int list_buckets(const DoutPrefixProvider *dpp,
         const rgw_owner& owner, const std::string& tenant,
         const std::string& marker, const std::string& end_marker,
-        uint64_t max, bool need_stats, BucketList& buckets, optional_yield y) override;
+        const std::string& prefix, uint64_t max, bool need_stats,
+        BucketList& buckets, optional_yield y) override;
     virtual bool is_meta_master() override;
     virtual Zone* get_zone() { return &zone; }
     virtual std::string zone_unique_id(uint64_t unique_num) override;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2180,9 +2180,10 @@ std::unique_ptr<Notification> POSIXDriver::get_notification(
 // TODO: marker and other params
 int POSIXDriver::list_buckets(const DoutPrefixProvider* dpp, const rgw_owner& owner,
 			     const std::string& tenant, const std::string& marker,
-			     const std::string& end_marker, uint64_t max,
-			     bool need_stats, BucketList &result, optional_yield y)
+			     const std::string& end_marker, const std::string& prefix, uint64_t max,
+		     bool need_stats, BucketList &result, optional_yield y)
 {
+  (void)prefix;
   DIR* dir;
   struct dirent* entry;
   int dfd;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -638,8 +638,8 @@ public:
   virtual int list_buckets(const DoutPrefixProvider* dpp,
 			   const rgw_owner& owner, const std::string& tenant,
 			   const std::string& marker, const std::string& end_marker,
-			   uint64_t max, bool need_stats, BucketList& buckets,
-			   optional_yield y) override;
+			   const std::string& prefix, uint64_t max, bool need_stats,
+		   BucketList& buckets, optional_yield y) override;
   virtual bool is_meta_master() override { return true; }
   virtual Zone* get_zone() override { return &zone; }
   virtual std::string zone_unique_id(uint64_t unique_num) override { return ""; }

--- a/src/rgw/driver/rados/buckets.cc
+++ b/src/rgw/driver/rados/buckets.cc
@@ -80,7 +80,7 @@ int remove(const DoutPrefixProvider* dpp, optional_yield y,
 int list(const DoutPrefixProvider* dpp, optional_yield y,
          librados::Rados& rados, const rgw_raw_obj& obj,
          const std::string& tenant, const std::string& start_marker,
-         const std::string& end_marker, uint64_t max,
+         const std::string& end_marker, const std::string& prefix, uint64_t max,
          rgw::sal::BucketList& listing)
 {
   listing.buckets.clear();
@@ -100,7 +100,7 @@ int list(const DoutPrefixProvider* dpp, optional_yield y,
 
     librados::ObjectReadOperation op;
     int rc = 0;
-    ::cls_user_bucket_list(op, marker, end_marker, count,
+    ::cls_user_bucket_list(op, marker, end_marker, prefix, count,
                            entries, &marker, &truncated, &rc);
 
     bufferlist bl;

--- a/src/rgw/driver/rados/buckets.h
+++ b/src/rgw/driver/rados/buckets.h
@@ -56,6 +56,7 @@ int list(const DoutPrefixProvider* dpp,
          const std::string& tenant,
          const std::string& marker,
          const std::string& end_marker,
+         const std::string& prefix,
          uint64_t max,
          rgw::sal::BucketList& buckets);
 

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -143,14 +143,15 @@ static rgw_raw_obj get_owner_buckets_obj(RGWSI_User* svc_user,
 int RadosStore::list_buckets(const DoutPrefixProvider* dpp,
                              const rgw_owner& owner, const std::string& tenant,
                              const std::string& marker, const std::string& end_marker,
-                             uint64_t max, bool need_stats,
-                             BucketList& listing, optional_yield y)
+                             const std::string& prefix, uint64_t max,
+                             bool need_stats, BucketList& listing,
+                             optional_yield y)
 {
   librados::Rados& rados = *getRados()->get_rados_handle();
   const rgw_raw_obj& obj = get_owner_buckets_obj(svc()->user, svc()->zone, owner);
 
   int ret = rgwrados::buckets::list(dpp, y, rados, obj, tenant,
-                                    marker, end_marker, max, listing);
+                                    marker, end_marker, prefix, max, listing);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -271,7 +271,8 @@ class RadosStore : public StoreDriver {
     int list_buckets(const DoutPrefixProvider* dpp,
 		     const rgw_owner& owner, const std::string& tenant,
 		     const std::string& marker, const std::string& end_marker,
-		     uint64_t max, bool need_stats, BucketList& buckets,
+		     const std::string& prefix, uint64_t max,
+		     bool need_stats, BucketList& buckets,
 		     optional_yield y) override;
     virtual bool is_meta_master() override;
     virtual Zone* get_zone() { return zone.get(); }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2943,7 +2943,8 @@ void RGWListBuckets::execute(optional_yield y)
     }
 
     op_ret = driver->list_buckets(this, s->owner.id, s->auth.identity->get_tenant(),
-                                  marker, end_marker, read_count, should_get_stats(), listing, y);
+                                  marker, end_marker, prefix, read_count,
+                                  should_get_stats(), listing, y);
 
     if (op_ret < 0) {
       /* hmm.. something wrong here.. the user was authenticated, so it
@@ -2951,6 +2952,12 @@ void RGWListBuckets::execute(optional_yield y)
       ldpp_dout(this, 10) << "WARNING: failed on list_buckets owner="
 			<< s->owner.id << dendl;
       break;
+    }
+
+    if (!prefix.empty()) {
+      std::erase_if(listing.buckets, [this](const auto& ent) {
+        return !boost::algorithm::starts_with(ent.bucket.name, prefix);
+      });
     }
 
     marker = listing.next_marker;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -916,6 +916,7 @@ protected:
   int64_t limit;
   uint64_t limit_max;
   bool is_truncated;
+  std::string prefix;
 
   RGWUsageStats global_stats;
   std::map<std::string, RGWUsageStats> policies_stats;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1624,6 +1624,8 @@ void RGWDeleteBucketReplication_ObjStore_S3::send_response()
 
 int RGWListBuckets_ObjStore_S3::get_params(optional_yield y)
 {
+  prefix = s->info.args.get("prefix");
+
   auto continuation_token = s->info.args.get_optional("continuation-token");
   if (continuation_token) {
     marker = *continuation_token;
@@ -1642,7 +1644,7 @@ int RGWListBuckets_ObjStore_S3::get_params(optional_yield y)
     }
     limit = *value;
   }
-  // TODO: support "prefix" and "bucket-region" params?
+  // TODO: support "bucket-region" params?
 
   // a request is only considered to be "paginated" if it specifies
   // either "max-buckets" or "continuation-token"
@@ -1652,6 +1654,7 @@ int RGWListBuckets_ObjStore_S3::get_params(optional_yield y)
 
   return 0;
 }
+
 
 void RGWListBuckets_ObjStore_S3::send_response_begin(bool has_buckets)
 {

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -485,7 +485,8 @@ class Driver {
     virtual int list_buckets(const DoutPrefixProvider* dpp,
 			     const rgw_owner& owner, const std::string& tenant,
 			     const std::string& marker, const std::string& end_marker,
-			     uint64_t max, bool need_stats, BucketList& buckets,
+			     const std::string& prefix, uint64_t max,
+			     bool need_stats, BucketList& buckets,
 			     optional_yield y) = 0;
     /** For multisite, this driver is the zone's master */
     virtual bool is_meta_master() = 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -36,9 +36,10 @@ namespace rgw::sal {
 
   int DBStore::list_buckets(const DoutPrefixProvider *dpp,
       const rgw_owner& owner, const std::string& tenant,
-      const string& marker, const string& end_marker, uint64_t max,
-      bool need_stats, BucketList &result, optional_yield y)
+      const string& marker, const string& end_marker, const string& prefix,
+      uint64_t max, bool need_stats, BucketList &result, optional_yield y)
   {
+    (void)prefix;
     RGWUserBuckets ulist;
     bool is_truncated = false;
 

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -894,7 +894,8 @@ public:
       int list_buckets(const DoutPrefixProvider *dpp,
           const rgw_owner& owner, const std::string& tenant,
           const std::string& marker, const std::string& end_marker,
-          uint64_t max, bool need_stats, BucketList& buckets, optional_yield y) override;
+          const std::string& prefix, uint64_t max, bool need_stats,
+          BucketList& buckets, optional_yield y) override;
       virtual bool is_meta_master() override;
       virtual Zone* get_zone() { return &zone; }
       virtual std::string zone_unique_id(uint64_t unique_num) override;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -388,10 +388,11 @@ int FilterDriver::load_bucket(const DoutPrefixProvider* dpp, const rgw_bucket& b
 int FilterDriver::list_buckets(const DoutPrefixProvider* dpp,
                                const rgw_owner& owner, const std::string& tenant,
                                const std::string& marker, const std::string& end_marker,
-                               uint64_t max, bool need_stats, BucketList &buckets, optional_yield y)
+                               const std::string& prefix, uint64_t max,
+                               bool need_stats, BucketList& buckets, optional_yield y)
 {
   return next->list_buckets(dpp, owner, tenant, marker, end_marker,
-                            max, need_stats, buckets, y);
+                            prefix, max, need_stats, buckets, y);
 }
 
 bool FilterDriver::is_meta_master()

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -279,7 +279,8 @@ public:
   int list_buckets(const DoutPrefixProvider* dpp,
                    const rgw_owner& owner, const std::string& tenant,
                    const std::string& marker, const std::string& end_marker,
-                   uint64_t max, bool need_stats, BucketList& buckets,
+                   const std::string& prefix, uint64_t max,
+                   bool need_stats, BucketList& buckets,
                    optional_yield y) override;
 
   virtual bool is_meta_master() override;


### PR DESCRIPTION
## Title

rgw: support prefix in s3 list buckets

## Summary

This fixes tracker #75463 by adding support for the `prefix` query parameter in the S3 `ListBuckets` API.

Before this change, RGW parsed pagination parameters for `ListBuckets` but ignored `prefix`, so clients such as boto3 received all buckets instead of only buckets whose names matched the requested prefix.

This change:
- parses the S3 `prefix` request argument
- filters listed buckets before they are counted and returned
- preserves pagination behavior based on the filtered result set
- adds an rgw integration test covering matching and non-matching bucket names

Fixes: https://tracker.ceph.com/issues/75463

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [x] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests
