### PR TITLE
squid: RGW/multisite: fix bucket-full-sync infinite loop caused by stale bucket_list_result reuse

### DIFF
--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -200,6 +200,11 @@ class Cluster(multisite.Cluster):
             assert r == 0
         return s, r
 
+    def ceph_admin(self, args=None, **kwargs):
+        """ ceph command """
+        cluster_manager = self.ctx.managers[self.name]
+        return cluster_manager.raw_cluster_cmd(*args, **kwargs)
+
 class Gateway(multisite.Gateway):
     """ Controls a radosgw instance using its daemon """
     def __init__(self, role, remote, daemon, *args, **kwargs):

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2570,6 +2570,36 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_inject_delay_sec
+  type: float
+  level: dev
+  desc: delay duration in seconds for test injection points
+  long_desc: Intended for integration and stress testing. When set to a positive
+    value, this option introduces an artificial delay at specific code paths to
+    help deterministically reproduce timing-sensitive scenarios. It is used in
+    conjunction with `rgw_inject_delay_pattern` to control which delay points
+    are activated.
+  default: 0
+  services:
+  - rgw
+  see_also:
+  - rgw_inject_delay_pattern
+  with_legacy: true
+- name: rgw_inject_delay_pattern
+  type: str
+  level: dev
+  desc: select which delay injection points are activated
+  long_desc: Used together with `rgw_inject_delay_sec` to target specific delay
+    injection points within the RGW code. The pattern should match a string
+    associated with one or more delay locations (e.g., "delay_bucket_full_sync_loop")
+    to activate them during testing.
+  services:
+  - rgw
+  flags:
+  - runtime
+  see_also:
+  - rgw_inject_delay_sec
+  with_legacy: true
 - name: rgw_sync_trace_history_size
   type: size
   level: advanced

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4549,12 +4549,14 @@ public:
         yield call(sync_env->error_logger->log_error_cr(dpp, sc->conn->get_remote_id(), "data", error_ss.str(), -retcode, string("failed to sync object") + cpp_strerror(-sync_status)));
       }
 done:
+      tn->log(20, SSTR("before marker tracker finish sync_status=" << sync_status << " retcode=" << retcode));
       if (sync_status == 0) {
         /* update marker */
         set_status() << "calling marker_tracker->finish(" << entry_marker << ")";
         yield call(marker_tracker->finish(entry_marker));
         sync_status = retcode;
       }
+      tn->log(20, SSTR("sync_status=" << sync_status << " retcode=" << retcode));
       if (sync_status < 0) {
         return set_cr_error(sync_status);
       }
@@ -4683,14 +4685,20 @@ int RGWBucketFullSyncCR::operate(const DoutPrefixProvider *dpp)
 
       yield call(new RGWListRemoteBucketCR(sc, bs, list_marker, &list_result));
       if (retcode < 0 && retcode != -ENOENT) {
+        tn->log(5, SSTR("failed bucket listing retcode=" << retcode));
         set_status("failed bucket listing, going down");
         drain_all();
         yield spawn(marker_tracker.flush(), true);
         return set_cr_error(retcode);
       }
+
+      tn->log(20, SSTR("listed bucket for full sync list_result.entries.size=" <<
+        list_result.entries.size() << " is_truncated=" << list_result.is_truncated)
+      );
       if (list_result.entries.size() > 0) {
         tn->set_flag(RGW_SNS_FLAG_ACTIVE); /* actually have entries to sync */
       }
+
       entries_iter = list_result.entries.begin();
       for (; entries_iter != list_result.entries.end(); ++entries_iter) {
         if (lease_cr && !lease_cr->is_locked()) {
@@ -4736,6 +4744,8 @@ int RGWBucketFullSyncCR::operate(const DoutPrefixProvider *dpp)
       }
     } while (list_result.is_truncated && sync_result == 0);
     set_status("done iterating over all objects");
+    tn->log(20, SSTR("done iterating over all objects sync_result=" << sync_result <<
+      " list_result.is_truncated=" << list_result.is_truncated));
 
     /* wait for all operations to complete */
     drain_all_cb([&](uint64_t stack_id, int ret) {

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4718,6 +4718,18 @@ int RGWBucketFullSyncCR::operate(const DoutPrefixProvider *dpp)
           }
           return set_cr_error(-ECANCELED);
         }
+        // for testing purpose to slow down the execution pace of the this loop
+        if (cct->_conf->rgw_inject_delay_sec > 0) {
+          if (std::string_view(cct->_conf->rgw_inject_delay_pattern) ==
+              "delay_bucket_full_sync_loop") {
+            yield {
+              utime_t dur;
+              dur.set_from_double(cct->_conf->rgw_inject_delay_sec);
+              tn->log(0, SSTR("injecting a delay of " << dur << "s"));
+              wait(dur);
+            }
+          }
+        }
         tn->log(20, SSTR("[full sync] syncing object: "
             << bucket_shard_str{bs} << "/" << entries_iter->key));
         entry = &(*entries_iter);

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4111,7 +4111,9 @@ public:
   RGWListRemoteBucketCR(RGWDataSyncCtx *_sc, const rgw_bucket_shard& bs,
                         rgw_obj_key& _marker_position, bucket_list_result *_result)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env), bs(bs),
-      marker_position(_marker_position), result(_result) {}
+      marker_position(_marker_position), result(_result) {
+        result->reset_entries();
+      }
 
   int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4083,6 +4083,11 @@ struct bucket_list_result {
 
   bucket_list_result() : max_keys(0), is_truncated(false) {}
 
+  void reset_entries() {
+    entries.clear();
+    is_truncated = false;
+  }
+
   void decode_json(JSONObj *obj) {
     JSONDecoder::decode_json("Name", name, obj);
     JSONDecoder::decode_json("Prefix", prefix, obj);

--- a/src/rgw/driver/rados/rgw_sync_trace.h
+++ b/src/rgw/driver/rados/rgw_sync_trace.h
@@ -15,11 +15,7 @@
 #include <shared_mutex>
 #include <boost/circular_buffer.hpp>
 
-#define SSTR(o) ({      \
-  std::stringstream ss; \
-  ss << o;              \
-  ss.str();             \
-})
+#define SSTR(o) ((std::ostringstream{} << o).str())
 
 #define RGW_SNS_FLAG_ACTIVE   1
 #define RGW_SNS_FLAG_ERROR    2

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -264,6 +264,13 @@ target_include_directories(unittest_rgw_url
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_url ${rgw_libs})
 
+# unittest_rgw_sync_trace
+add_executable(unittest_rgw_sync_trace test_rgw_sync_trace.cc)
+add_ceph_unittest(unittest_rgw_sync_trace)
+target_include_directories(unittest_rgw_sync_trace
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_sync_trace)
+
 add_executable(ceph_test_rgw_gc_log test_rgw_gc_log.cc $<TARGET_OBJECTS:unit-main>)
 target_include_directories(ceph_test_rgw_gc_log
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")

--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -14,6 +14,10 @@ class Cluster:
         """ execute a radosgw-admin command """
         pass
 
+    def ceph_admin(self, args = None, **kwargs):
+        """ execute a ceph command """
+        pass
+
 class Gateway:
     """ interface to control a single radosgw instance """
     __metaclass__ = ABCMeta

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1,7 +1,6 @@
 import json
 import random
 import string
-import sys
 import time
 import logging
 import errno

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -5,6 +5,8 @@ import time
 import logging
 import errno
 import dateutil.parser
+import re
+import datetime
 
 from itertools import combinations
 from itertools import zip_longest
@@ -389,6 +391,48 @@ def zonegroup_bucket_checkpoint(zonegroup_conns, bucket_name):
     for source_conn, target_conn in combinations(zonegroup_conns.zones, 2):
         if target_conn.zone.has_buckets():
             target_conn.check_bucket_eq(source_conn, bucket_name)
+
+def get_oldest_incremental_change_not_applied_epoch(zone):
+    cmd = ['sync', 'status']
+    sync_status_output, retcode = zone.cluster.admin(cmd, check_retcode=False, read_only=True)
+    assert(retcode == 0)
+
+    # extract the "data sync source:" section from the output
+    data_sync_match = re.search(r"data sync source:.*", sync_status_output, re.DOTALL)
+    if not data_sync_match:
+        # no data sync section found; return epoch 0 to signal no progress
+        return 0.0
+
+    data_sync_section = data_sync_match.group(0)
+
+    # 1) look for "oldest incremental change not applied" in the data sync section
+    match = re.search(r"oldest incremental change not applied:\s*([0-9T:\.\+\-Z]+)", data_sync_section)
+    if match:
+        return datetime.datetime.strptime(match.group(1), "%Y-%m-%dT%H:%M:%S.%f%z").timestamp()
+
+    # 2) if data is caught up with source, return None (no work pending)
+    if "data is caught up with source" in data_sync_section:
+        return None
+
+    # 3) data sync section exists but neither marker found; return epoch 0
+    #    so the caller knows data sync is not making progress
+    return 0.0
+
+def data_sync_making_progress(zone, time_window_sec=180, check_interval_sec=30):
+    deadline = time.time() + time_window_sec
+    oldest_inc_change = None
+    result = False
+    while time.time() < deadline:
+        new_reading = get_oldest_incremental_change_not_applied_epoch(zone)
+        if new_reading is not None:
+            if oldest_inc_change is None:
+                oldest_inc_change = new_reading
+            elif oldest_inc_change != new_reading:
+                result = True
+                oldest_inc_change = new_reading
+                break
+        time.sleep(check_interval_sec)
+    return result or oldest_inc_change is None
 
 def set_master_zone(zone):
     zone.modify(zone.cluster, ['--master'])
@@ -3761,3 +3805,146 @@ def test_bucket_create_location_constraint():
                     assert False, "expected 400 error"
                 except ClientError as e:
                     assert e.response['ResponseMetadata']['HTTPStatusCode'] == 400
+
+def test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime():
+    num_objects_to_upload = (
+        3000  # must be more than 1000 to have pagination at full sync
+    )
+    bucket_full_sync_listing_inject_delay_sec = 100
+    bucket_full_sync_listing_inject_delay_pattern = "delay_bucket_full_sync_loop"
+
+    # get client connection
+    master_zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(master_zonegroup)
+    primary_zone_client_conn = zonegroup_conns.master_zone
+
+    # get cluster connections
+    primary_zone_cluster_conn = master_zonegroup.master_zone
+    secondary_zone_cluster_conn = None
+    for zg in realm.current_period.zonegroups:
+        for zone in zg.zones:
+            if zone.cluster != primary_zone_cluster_conn.cluster and zone != zg.master_zone:
+                secondary_zone_cluster_conn = zone
+                break
+        if secondary_zone_cluster_conn is not None:
+            break
+    else:
+        raise SkipTest("test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime is skipped. "
+                       "Requires a secondary zone in a different cluster.")
+
+    bucket = primary_zone_client_conn.create_bucket(gen_bucket_name())
+    log.info(f"created bucket={bucket.name}")
+
+    log.info(f"disable sync for bucket={bucket.name}")
+    disable_bucket_sync(realm.meta_master_zone(), bucket.name)
+
+    try:
+        log.info(f"upload {num_objects_to_upload} objects to bucket={bucket.name}")
+        num_objects_to_uploaded = 0
+        for i in range(num_objects_to_upload):
+            if i % 100 == 0:
+                log.debug(f"uploaded {i} objects to bucket={bucket.name}...")
+            try:
+                primary_zone_client_conn.s3_client.put_object(
+                    Bucket=bucket.name, Key=f"obj-{i:04d}", Body="..."
+                )
+                num_objects_to_uploaded += 1
+            except Exception as e:
+                log.debug(f"failed to upload object to bucket={bucket.name}: {e}")
+        log.info(
+            f"successfully uploaded {num_objects_to_uploaded} objects to bucket={bucket.name}"
+        )
+
+        log.info("trim bucket bilog to avoid any incremental sync happening")
+        primary_zone_cluster_conn.cluster.admin(["bilog", "trim", "--bucket", bucket.name])
+        log.info("set rgw_inject_delay_sec and rgw_inject_delay_pattern to slow down bucket full sync")
+        secondary_zone_cluster_conn.cluster.ceph_admin(
+            ["config", "set", "client.rgw", "rgw_inject_delay_sec", str(bucket_full_sync_listing_inject_delay_sec)]
+        )
+        secondary_zone_cluster_conn.cluster.ceph_admin(
+            ["config", "set", "client.rgw", "rgw_inject_delay_pattern", bucket_full_sync_listing_inject_delay_pattern]
+        )
+        log.info("enable bucket sync to initiate full sync")
+        enable_bucket_sync(realm.meta_master_zone(), bucket.name)
+
+        # Since incremenetal sync is not possible and full sync is stalled,
+        # we should see that the bucket's sync is stalled.
+        log.info("verify that bucket sync is stalled")
+        deadline = time.time() + bucket_full_sync_listing_inject_delay_sec
+        oldest_inc_change = None
+        while True:
+            if time.time() > deadline:
+                raise Exception("failed to verify the stall of bucket sync")
+            new_reading = get_oldest_incremental_change_not_applied_epoch(
+                secondary_zone_cluster_conn
+            )
+            if new_reading is not None:
+                if oldest_inc_change is None or oldest_inc_change != new_reading:
+                    oldest_inc_change = new_reading
+                elif (
+                    oldest_inc_change == new_reading
+                ):  # 2 back-to-back readings are the same
+                    break
+            time.sleep(10)
+        log.info(
+            f"verified that bucket sync is stalled, oldest incremental change not applied epoch: {oldest_inc_change}"
+        )
+
+        # while bucket sync is stalled, delete all objects and the bucket.
+        log.info(f"delete {num_objects_to_upload} objects from bucket={bucket.name}")
+        for i in range(num_objects_to_upload):
+            primary_zone_client_conn.s3_client.delete_object(
+                Bucket=bucket.name,
+                Key=f"obj-{i:04d}",
+            )
+        log.info(f"delete bucket={bucket.name}")
+        primary_zone_client_conn.s3_client.delete_bucket(Bucket=bucket.name)
+
+        log.info(f"verify that bucket={bucket.name} is deleted on secondary zone")
+        for zg in realm.current_period.zonegroups:
+            zonegroup_meta_checkpoint(zg)
+
+        log.info(
+            "removing rgw_inject_delay_sec and rgw_inject_delay_pattern to allow bucket full sync to run normally to the completion"
+        )
+        secondary_zone_cluster_conn.cluster.ceph_admin(
+            ["config", "rm", "client.rgw", "rgw_inject_delay_sec"]
+        )
+        secondary_zone_cluster_conn.cluster.ceph_admin(
+            ["config", "rm", "client.rgw", "rgw_inject_delay_pattern"]
+        )
+        time.sleep(
+            bucket_full_sync_listing_inject_delay_sec
+        )  # wait to make sure bucket sync loop resumes to normal pace
+
+        log.info("wait for data sync to complete")
+        zonegroup_data_checkpoint(zonegroup_conns)
+    except Exception as e:
+        log.error(f"test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime failed: {e}")
+        log.info(f"delete {num_objects_to_upload} objects from bucket={bucket.name}")
+        for i in range(num_objects_to_upload):
+            try:
+                primary_zone_client_conn.s3_client.delete_object(
+                    Bucket=bucket.name,
+                    Key=f"obj-{i:04d}",
+                )
+            except:
+                pass
+        log.info(f"delete bucket={bucket.name}")
+        try:
+            primary_zone_client_conn.s3_client.delete_bucket(Bucket=bucket.name)
+        except:
+            pass
+        log.info(
+            "reset rgw_inject_delay settings"
+        )
+        try:
+            secondary_zone_cluster_conn.cluster.ceph_admin(
+                ["config", "rm", "client.rgw", "rgw_inject_delay_sec"]
+            )
+            secondary_zone_cluster_conn.cluster.ceph_admin(
+                ["config", "rm", "client.rgw", "rgw_inject_delay_pattern"]
+            )
+        except:
+            pass
+        raise

--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -86,6 +86,11 @@ function rgw {
   echo "$mrgw $name $port $ssl_port $rgw_flags $@"
 }
 
+function ceph {
+  [ $# -lt 1 ] && echo "ceph() needs atleast 1 param" && exit 1
+  echo "$mrun $1 ceph"
+}
+
 function init_first_zone {
   [ $# -ne 7 ] && echo "init_first_zone() needs 7 params" && exit 1
 
@@ -159,6 +164,13 @@ function call_rgw_admin {
   cid=$1
   shift 1
   x $(rgw_admin $cid) "$@"
+}
+
+function call_ceph {
+  cid=$1
+  shift 1
+  echo $@
+  x $(ceph $cid) "$@"
 }
 
 function get_mstart_parameters {

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -64,6 +64,13 @@ class Cluster(multisite.Cluster):
             cmd += ['--rgw-cache-enabled=false']
         return bash(cmd, **kwargs)
 
+    def ceph_admin(self, args = None, **kwargs):
+        """ ceph command """
+        cmd = [test_path + 'test-rgw-call.sh', 'call_ceph', self.cluster_id]
+        if args:
+            cmd += args
+        return bash(cmd, **kwargs)
+
     def start(self):
         cmd = [mstart_path + 'mstart.sh', self.cluster_id]
         env = None

--- a/src/test/rgw/test_rgw_sync_trace.cc
+++ b/src/test/rgw/test_rgw_sync_trace.cc
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include <gtest/gtest.h>
+#include "rgw/driver/rados/rgw_sync_trace.h"
+
+TEST(TestSSTR, using_a_var_named_ss)
+{
+  std::stringstream ss;
+
+  ss << "aaa";
+  auto result = SSTR("this is ss=" << ss.str());
+  ASSERT_EQ(result, "this is ss=aaa");
+}
+
+TEST(TestSSTR, using_a_var_named_other_than_ss)
+{
+  std::stringstream ss2;
+
+  ss2 << "aaa";
+  auto result = SSTR("this is ss2=" << ss2.str());
+  ASSERT_EQ(result, "this is ss2=aaa");
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75438

---

backport of https://github.com/ceph/ceph/pull/66203
parent tracker: https://tracker.ceph.com/issues/73799

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

---

Adding /config check ok comment as the config items introduced are for development/testing purposes and not client-facing.