### PR TITLE
dashboard: replace Bootstrap btn classes with Carbon cdsButton in error component

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package-lock.json
+++ b/src/pybind/mgr/dashboard/frontend/package-lock.json
@@ -5512,7 +5512,7 @@
     },
     "node_modules/@ibm/plex": {
       "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex/-/plex-6.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@ibm/plex/-/plex-6.4.0.tgz",
       "integrity": "sha512-P70hmNoSJhpV6fGG4++JEivoccUVuvkyZoXprsDmPTtv3s6QvL+Q8bK3HFSGmK/VgyLMDptoKPV7b/h/1xaWAw==",
       "license": "OFL-1.1"
     },

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/error/error.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/error/error.component.html
@@ -18,15 +18,14 @@
           </h4>
         </div>
       </div>
-
       <div class="mt-4">
         <div class="text-center"
              *ngIf="(buttonName && buttonRoute) || uiConfig; else dashboardButton">
-          <button class="btn btn-primary ms-1"
+          <button cdsButton="primary"
                   [routerLink]="buttonRoute"
                   *ngIf="!uiConfig; else configureButtonTpl"
                   i18n>{{ buttonName }}</button>
-          <button class="btn btn-light ms-1"
+          <button cdsButton="secondary"
                   [routerLink]="secondaryButtonRoute"
                   *ngIf="secondaryButtonName && secondaryButtonRoute"
                   i18n>{{ secondaryButtonName }}</button>
@@ -35,41 +34,34 @@
     </div>
   </div>
 </div>
-
 <ng-template #configureButtonTpl>
-  <button class="btn btn-primary"
+  <button cdsButton="primary"
           (click)="doConfigure()"
           [attr.title]="buttonTitle"
           *ngIf="uiConfig"
           i18n>{{ buttonName }}</button>
 </ng-template>
-
-
 <ng-template #elseBlock>
-  <i class="fa fa-exclamation-triangle mx-auto d-block text-danger"></i>
-
+  <svg cdsIcon="warning" class="cds-danger-color cds-icon--size-10"></svg>
   <div class="mt-4 text-center">
     <h3 i18n><b>Page not Found</b></h3>
-
     <h4 class="mt-4"
-        i18n>Sorry, we couldn’t find what you were looking for.
+        i18n>Sorry, we couldn't find what you were looking for.
              The page you requested may have been changed or moved.</h4>
   </div>
 </ng-template>
-
 <ng-template #dashboardButton>
   <div class="mt-4 text-center"
        *ngIf="!module_name; else enableButton">
-    <button class="btn btn-primary"
+    <button cdsButton="primary"
             [routerLink]="'/overview'"
             i18n>Go To Overview</button>
   </div>
 </ng-template>
-
 <ng-template #enableButton>
   <div class="mt-4 text-center"
        *ngIf="module_name && !(buttonName && buttonRoute)">
-    <button class="btn btn-primary"
+    <button cdsButton="primary"
             (click)="enableModule()"
             i18n>Enable {{ module_name | upperFirst }} module</button>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/config' with (
-  $font-path: '~@ibm/plex',
+  $font-path: '/Users/apple/ceph/ceph/src/pybind/mgr/dashboard/frontend/node_modules/@ibm/plex',
   $flex-grid-columns: 16,
   $use-flexbox-grid: true,
 );


### PR DESCRIPTION
dashboard: replace Bootstrap btn classes with Carbon cdsButton in error component

Replaces deprecated Bootstrap button classes with Carbon Design System 
cdsButton directive in the error component.

Changes:
- Replace `class="btn btn-primary"` with `cdsButton="primary"`
- Replace Font Awesome warning icon with Carbon svg cdsIcon

This is part of the Carbonization effort to standardize the Ceph Dashboard 
UI by migrating from Bootstrap to IBM Carbon Design System.

Signed-off-by: Srikar <srikarpolimera2005@gmail.com>