### PR TITLE
Issue 75611 iscsi service unable to contact the local api endpoint

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1051,6 +1051,9 @@ def deploy_daemon_units(
             _osd_unit_poststop_commands(ctx, ident, osd_fsid)
         )
     if ident.daemon_type == CephIscsi.daemon_type:
+        # Load target_core_user so rbd-target-api can contact the API (required on
+        # some distros e.g. Fedora 43 where it is in kernel-modules-extra).
+        pre_start_commands.append(CephIscsi.shell_load_target_core_user())
         pre_start_commands.append(
             CephIscsi.configfs_mount_umount(data_dir, mount=True)
         )

--- a/src/cephadm/cephadmlib/container_types.py
+++ b/src/cephadm/cephadmlib/container_types.py
@@ -499,6 +499,10 @@ class InitContainer(BasicContainer):
 
 
 class SidecarContainer(BasicContainer):
+    """Sidecar systemd script may inject optional host shell before container run."""
+
+    pre_start_shell: str = ''
+
     @classmethod
     def from_primary_and_values(
         cls,
@@ -510,6 +514,7 @@ class SidecarContainer(BasicContainer):
         entrypoint: str = '',
         args: Optional[List[str]] = None,
         init: Optional[bool] = None,
+        pre_start_shell: str = '',
     ) -> 'SidecarContainer':
         assert primary.identity
         identity = DaemonSubIdentity.from_parent(
@@ -527,6 +532,7 @@ class SidecarContainer(BasicContainer):
             ctr.args = args
         if init is not None:
             ctr.init = init
+        ctr.pre_start_shell = pre_start_shell
         return ctr
 
     def build_engine_run_args(self) -> List[str]:

--- a/src/cephadm/cephadmlib/daemons/iscsi.py
+++ b/src/cephadm/cephadmlib/daemons/iscsi.py
@@ -173,6 +173,29 @@ class CephIscsi(ContainerDaemonForm):
             cname = '%s-%s' % (cname, desc)
         return cname
 
+    @staticmethod
+    def shell_load_target_core_user() -> str:
+        """Host shell: ensure target_core_user is loaded if missing."""
+        return (
+            'if ! [ -e /sys/module/target_core_user ]; then '
+            'modinfo target_core_user && modprobe target_core_user; fi'
+        )
+
+    @staticmethod
+    def configfs_mount_umount(data_dir: str, mount: bool = True) -> str:
+        mount_path = os.path.join(data_dir, 'configfs')
+        if mount:
+            cmd = (
+                'if ! grep -qs {0} /proc/mounts; then '
+                'mount -t configfs none {0}; fi'.format(mount_path)
+            )
+        else:
+            cmd = (
+                'if grep -qs {0} /proc/mounts; then '
+                'umount {0}; fi'.format(mount_path)
+            )
+        return cmd
+
     def create_daemon_dirs(self, data_dir, uid, gid):
         # type: (str, int, int) -> None
         """Create files under the container data dir"""
@@ -197,21 +220,6 @@ class CephIscsi(ContainerDaemonForm):
         # we want the tcmu runner entrypoint script to be executable
         # populate_files will give it 0o600 by default
         os.chmod(os.path.join(data_dir, 'tcmu-runner-entrypoint.sh'), 0o700)
-
-    @staticmethod
-    def configfs_mount_umount(data_dir: str, mount: bool = True) -> str:
-        mount_path = os.path.join(data_dir, 'configfs')
-        if mount:
-            cmd = (
-                'if ! grep -qs {0} /proc/mounts; then '
-                'mount -t configfs none {0}; fi'.format(mount_path)
-            )
-        else:
-            cmd = (
-                'if grep -qs {0} /proc/mounts; then '
-                'umount {0}; fi'.format(mount_path)
-            )
-        return cmd
 
     @staticmethod
     def tcmu_runner_entrypoint_script() -> str:
@@ -275,6 +283,7 @@ done
     def sidecar_containers(
         self, ctx: CephadmContext
     ) -> List[SidecarContainer]:
+        data_dir = self.identity.data_dir(ctx.data_dir)
         tcmu_sidecar = SidecarContainer.from_primary_and_values(
             ctx,
             self.container(ctx),
@@ -284,5 +293,10 @@ done
             # releases and should eventually be removed in at least squid
             # onward
             entrypoint='/usr/local/scripts/tcmu-runner-entrypoint.sh',
+            pre_start_shell=(
+                CephIscsi.shell_load_target_core_user()
+                + '\n'
+                + CephIscsi.configfs_mount_umount(data_dir, mount=True)
+            ),
         )
         return [tcmu_sidecar]

--- a/src/cephadm/cephadmlib/templates/sidecar.run.j2
+++ b/src/cephadm/cephadmlib/templates/sidecar.run.j2
@@ -7,6 +7,9 @@ if [ "$1" = stop ] || [ "$1" = poststop ]; then
     ! {{ ctx.container_engine.path }} inspect {{ sidecar.cname | shellquote }} &>/dev/null
     exit $?
 fi
+{% if sidecar.pre_start_shell -%}
+{{ sidecar.pre_start_shell }}
+{% endif %}
 
 ! {{ sidecar.rm_cmd() | map('shellquote') | join(' ') }} 2> /dev/null
 {%- if has_podman_engine %}

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -2211,9 +2211,14 @@ class TestCephVolume(object):
 
 class TestIscsi:
     def test_unit_run(self, cephadm_fs, funkypatch):
+        # Same uid/gid as cephadm_fs fixture's cephadm.extract_uid_gid so
+        # 0o700 daemon dirs remain writable under pyfakefs.
         funkypatch.patch(
             'cephadmlib.daemons.iscsi.extract_uid_gid'
-        ).return_value = (123, 123)
+        ).return_value = (os.getuid(), os.getgid())
+        funkypatch.patch(
+            'cephadmlib.exe_utils.find_program'
+        ).return_value = '/usr/bin/python3'
 
         fsid = '9b9d7609-f4d5-4aba-94c8-effa764d96c9'
         config_json = {
@@ -2235,6 +2240,7 @@ class TestIscsi:
             with open('/var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/unit.run') as f:
                 contents = f.read()
                 assert contents == """set -e
+if ! [ -e /sys/module/target_core_user ]; then modinfo target_core_user && modprobe target_core_user; fi
 if ! grep -qs /var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/configfs /proc/mounts; then mount -t configfs none /var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/configfs; fi
 # iscsi.daemon_id
 ! /usr/bin/docker rm -f ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9-iscsi.daemon_id 2> /dev/null
@@ -2252,6 +2258,9 @@ if [ "$1" = stop ] || [ "$1" = poststop ]; then
     ! /usr/bin/docker inspect ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9-iscsi-daemon_id-tcmu &>/dev/null
     exit $?
 fi
+if ! [ -e /sys/module/target_core_user ]; then modinfo target_core_user && modprobe target_core_user; fi
+if ! grep -qs /var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/configfs /proc/mounts; then mount -t configfs none /var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/configfs; fi
+
 
 ! /usr/bin/docker rm -f ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9-iscsi-daemon_id-tcmu 2> /dev/null
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
