### PR TITLE
test/rgw: link test_build_librgw with ALLOC_LIBS

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -130,7 +130,12 @@ target_link_libraries(test_build_libcommon ceph-common pthread ${CRYPTO_LIBS} ${
 
 if(WITH_RADOSGW)
   add_executable(test_build_librgw buildtest_skeleton.cc)
-  target_link_libraries(test_build_librgw rgw_a pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+  target_link_libraries(test_build_librgw
+    rgw_a
+    pthread
+    ${CRYPTO_LIBS}
+    ${EXTRALIBS}
+    ${ALLOC_LIBS})
 endif(WITH_RADOSGW)
 
 if(WITH_LIBCEPHFS)


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests

## Summary

This fixes an RGW allocator-linking gap related to tracker #75613.

Ceph already carries upstream fixes to avoid allocator mismatches by linking
`${ALLOC_LIBS}` only where appropriate in RGW-related targets. One remaining
target, `test_build_librgw`, still linked `rgw_a` without `${ALLOC_LIBS}`.
This patch aligns that target with the existing allocator-linking fixes used by
other librgw-related test targets.

## Details

The change updates `src/test/CMakeLists.txt` so `test_build_librgw` links:
- `rgw_a`
- `pthread`
- `${CRYPTO_LIBS}`
- `${EXTRALIBS}`
- `${ALLOC_LIBS}`

This is intended to prevent allocator mismatch problems that can surface as
crashes in `libtcmalloc.so`.

Fixes: https://tracker.ceph.com/issues/75613
