### PR TITLE
tentacle: mgr/dashboard: Breadcrumb should allow going back to subsystem tab

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -40,7 +40,6 @@ import { RbdTrashRestoreModalComponent } from './rbd-trash-restore-modal/rbd-tra
 import { NvmeofGatewayComponent } from './nvmeof-gateway/nvmeof-gateway.component';
 import { NvmeofSubsystemsComponent } from './nvmeof-subsystems/nvmeof-subsystems.component';
 import { NvmeofSubsystemsDetailsComponent } from './nvmeof-subsystems-details/nvmeof-subsystems-details.component';
-import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
 import { NvmeofSubsystemsFormComponent } from './nvmeof-subsystems-form/nvmeof-subsystems-form.component';
 import { NvmeofListenersFormComponent } from './nvmeof-listeners-form/nvmeof-listeners-form.component';
 import { NvmeofListenersListComponent } from './nvmeof-listeners-list/nvmeof-listeners-list.component';
@@ -48,6 +47,14 @@ import { NvmeofNamespacesListComponent } from './nvmeof-namespaces-list/nvmeof-n
 import { NvmeofNamespacesFormComponent } from './nvmeof-namespaces-form/nvmeof-namespaces-form.component';
 import { NvmeofInitiatorsListComponent } from './nvmeof-initiators-list/nvmeof-initiators-list.component';
 import { NvmeofInitiatorsFormComponent } from './nvmeof-initiators-form/nvmeof-initiators-form.component';
+import { NvmeofGatewayGroupComponent } from './nvmeof-gateway-group/nvmeof-gateway-group.component';
+import { NvmeofSubsystemsStepOneComponent } from './nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component';
+import { NvmeofSubsystemsStepThreeComponent } from './nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component';
+import { NvmeofSubsystemsStepTwoComponent } from './nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component';
+import { NvmeofGatewayNodeComponent } from './nvmeof-gateway-node/nvmeof-gateway-node.component';
+import { NvmeofGroupFormComponent } from './nvmeof-group-form/nvmeof-group-form.component';
+import { NvmeofEditHostKeyModalComponent } from './nvmeof-edit-host-key-modal/nvmeof-edit-host-key-modal.component';
+import { NvmeofSubsystemsStepFourComponent } from './nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component';
 
 import {
   ButtonModule,
@@ -64,16 +71,37 @@ import {
   SelectModule,
   UIShellModule,
   TreeviewModule,
+  SideNavModule,
   TabsModule,
-  TagModule
+  TagModule,
+  LayoutModule,
+  ContainedListModule,
+  LayerModule,
+  ThemeModule
 } from 'carbon-components-angular';
 
 // Icons
 import ChevronDown from '@carbon/icons/es/chevron--down/16';
 import Close from '@carbon/icons/es/close/32';
-import AddFilled from '@carbon/icons/es/add--filled/32';
+import AddFilled from '@carbon/icons/es/add--filled/20';
 import SubtractFilled from '@carbon/icons/es/subtract--filled/32';
 import Reset from '@carbon/icons/es/reset/32';
+import SubtractAlt from '@carbon/icons/es/subtract--alt/20';
+import ProgressBarRound from '@carbon/icons/es/progress-bar--round/32';
+import Search from '@carbon/icons/es/search/32';
+import Datastore from '@carbon/icons/es/datastore/16';
+import { NvmeofGatewaySubsystemComponent } from './nvmeof-gateway-subsystem/nvmeof-gateway-subsystem.component';
+import { NvmeofNamespaceExpandModalComponent } from './nvmeof-namespace-expand-modal/nvmeof-namespace-expand-modal.component';
+import { NvmeGatewayViewComponent } from './nvme-gateway-view/nvme-gateway-view.component';
+import { NvmeGatewayViewBreadcrumbResolver } from './nvme-gateway-view/nvme-gateway-view-breadcrumb.resolver';
+import { NvmeofGatewayNodeMode } from '~/app/shared/enum/nvmeof.enum';
+import { NvmeofGatewayNodeAddModalComponent } from './nvmeof-gateway-node/nvmeof-gateway-node-add-modal/nvmeof-gateway-node-add-modal.component';
+import { NvmeofSubsystemNamespacesListComponent } from './nvmeof-subsystem-namespaces-list/nvmeof-subsystem-namespaces-list.component';
+import { NvmeofSubsystemOverviewComponent } from './nvmeof-subsystem-overview/nvmeof-subsystem-overview.component';
+import { NvmeSubsystemViewBreadcrumbResolver } from './nvme-subsystem-view/nvme-subsystem-view-breadcrumb.resolver';
+import { NvmeSubsystemViewComponent } from './nvme-subsystem-view/nvme-subsystem-view.component';
+import { NvmeofSubsystemPerformanceComponent } from './nvmeof-subsystem-performance/nvmeof-subsystem-performance.component';
+import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
 
 @NgModule({
   imports: [
@@ -90,8 +118,8 @@ import Reset from '@carbon/icons/es/reset/32';
     TreeviewModule,
     UIShellModule,
     InputModule,
-    GridModule,
     ButtonModule,
+    GridModule,
     IconModule,
     CheckboxModule,
     RadioModule,
@@ -101,7 +129,13 @@ import Reset from '@carbon/icons/es/reset/32';
     DatePickerModule,
     ComboBoxModule,
     TabsModule,
-    TagModule
+    TagModule,
+    GridModule,
+    LayerModule,
+    ContainedListModule,
+    SideNavModule,
+    LayoutModule,
+    ThemeModule
   ],
   declarations: [
     RbdListComponent,
@@ -131,20 +165,47 @@ import Reset from '@carbon/icons/es/reset/32';
     NvmeofGatewayComponent,
     NvmeofSubsystemsComponent,
     NvmeofSubsystemsDetailsComponent,
-    NvmeofTabsComponent,
+    NvmeofGatewayGroupComponent,
     NvmeofSubsystemsFormComponent,
     NvmeofListenersFormComponent,
     NvmeofListenersListComponent,
     NvmeofNamespacesListComponent,
+    NvmeofSubsystemNamespacesListComponent,
     NvmeofNamespacesFormComponent,
     NvmeofInitiatorsListComponent,
-    NvmeofInitiatorsFormComponent
+    NvmeofInitiatorsFormComponent,
+    NvmeofGatewayNodeComponent,
+    NvmeofGroupFormComponent,
+    NvmeofSubsystemsStepOneComponent,
+    NvmeofSubsystemsStepTwoComponent,
+    NvmeofSubsystemsStepThreeComponent,
+    NvmeGatewayViewComponent,
+    NvmeofGatewaySubsystemComponent,
+    NvmeofGatewayNodeAddModalComponent,
+    NvmeofNamespaceExpandModalComponent,
+    NvmeSubsystemViewComponent,
+    NvmeofEditHostKeyModalComponent,
+    NvmeofSubsystemsStepFourComponent,
+    NvmeofSubsystemOverviewComponent,
+    NvmeofSubsystemPerformanceComponent,
+    NvmeofTabsComponent
   ],
+
   exports: [RbdConfigurationListComponent, RbdConfigurationFormComponent]
 })
 export class BlockModule {
   constructor(private iconService: IconService) {
-    this.iconService.registerAll([ChevronDown, Close, AddFilled, SubtractFilled, Reset]);
+    this.iconService.registerAll([
+      ChevronDown,
+      Close,
+      AddFilled,
+      SubtractFilled,
+      Reset,
+      ProgressBarRound,
+      SubtractAlt,
+      Search,
+      Datastore
+    ]);
   }
 }
 
@@ -283,45 +344,143 @@ const routes: Routes = [
       }
     },
     children: [
-      { path: '', redirectTo: 'subsystems', pathMatch: 'full' },
+      { path: '', redirectTo: 'gateways', pathMatch: 'full' },
       {
-        path: 'subsystems',
-        component: NvmeofSubsystemsComponent,
-        data: { breadcrumbs: 'Subsystems' },
+        path: 'gateways',
+        data: { breadcrumbs: 'Gateways' },
         children: [
-          // subsystems
-          { path: '', component: NvmeofSubsystemsComponent },
+          {
+            path: '',
+            component: NvmeofGatewayGroupComponent
+          },
           {
             path: URLVerbs.CREATE,
-            component: NvmeofSubsystemsFormComponent,
-            outlet: 'modal'
-          },
-          // listeners
-          {
-            path: `${URLVerbs.CREATE}/:subsystem_nqn/listener`,
-            component: NvmeofListenersFormComponent,
-            outlet: 'modal'
-          },
-          // namespaces
-          {
-            path: `${URLVerbs.CREATE}/:subsystem_nqn/namespace`,
-            component: NvmeofNamespacesFormComponent,
-            outlet: 'modal'
+            component: NvmeofGroupFormComponent,
+            data: {
+              breadcrumbs: ActionLabels.CREATE,
+              pageHeader: {
+                title: $localize`Create Gateway Group`,
+                description: $localize`A logical group of gateways that hosts will connect to.`
+              }
+            }
           },
           {
-            path: `${URLVerbs.EDIT}/:subsystem_nqn/namespace/:nsid`,
-            component: NvmeofNamespacesFormComponent,
-            outlet: 'modal'
-          },
-          // initiators
-          {
-            path: `${URLVerbs.ADD}/:subsystem_nqn/initiator`,
-            component: NvmeofInitiatorsFormComponent,
-            outlet: 'modal'
+            path: `${URLVerbs.VIEW}/:group`,
+            component: NvmeGatewayViewComponent,
+            data: { breadcrumbs: NvmeGatewayViewBreadcrumbResolver },
+            children: [
+              { path: '', redirectTo: 'nodes', pathMatch: 'full' },
+              {
+                path: 'nodes',
+                component: NvmeofGatewayNodeComponent,
+                data: { breadcrumbs: $localize`Gateway nodes`, mode: NvmeofGatewayNodeMode.DETAILS }
+              },
+              {
+                path: 'subsystems',
+                component: NvmeofGatewaySubsystemComponent,
+                data: { breadcrumbs: $localize`Subsystems` }
+              }
+            ]
           }
         ]
       },
-      { path: 'gateways', component: NvmeofGatewayComponent, data: { breadcrumbs: 'Gateways' } }
+      {
+        path: 'subsystems',
+        data: { breadcrumbs: 'Subsystems' },
+        children: [
+          {
+            path: '',
+            component: NvmeofSubsystemsComponent,
+            children: [
+              {
+                path: URLVerbs.CREATE,
+                component: NvmeofSubsystemsFormComponent,
+                outlet: 'modal'
+              },
+              {
+                path: `${URLVerbs.CREATE}/:subsystem_nqn/listener`,
+                component: NvmeofListenersFormComponent,
+                outlet: 'modal'
+              },
+              {
+                path: `${URLVerbs.EDIT}/:subsystem_nqn/namespace/:nsid`,
+                component: NvmeofNamespaceExpandModalComponent,
+                outlet: 'modal'
+              },
+              {
+                path: `${URLVerbs.ADD}/:subsystem_nqn/initiator`,
+                component: NvmeofInitiatorsFormComponent,
+                outlet: 'modal'
+              }
+            ]
+          },
+          {
+            path: ':subsystem_nqn',
+            component: NvmeSubsystemViewComponent,
+            data: { breadcrumbs: NvmeSubsystemViewBreadcrumbResolver },
+            children: [
+              { path: '', redirectTo: 'overview', pathMatch: 'full' },
+              {
+                path: 'overview',
+                component: NvmeofSubsystemOverviewComponent
+              },
+              {
+                path: 'hosts',
+                component: NvmeofInitiatorsListComponent
+              },
+              {
+                path: 'namespaces',
+                component: NvmeofSubsystemNamespacesListComponent
+              },
+              {
+                path: 'listeners',
+                component: NvmeofListenersListComponent
+              },
+              {
+                path: 'performance',
+                component: NvmeofSubsystemPerformanceComponent
+              },
+              {
+                path: `${URLVerbs.ADD}/initiator`,
+                component: NvmeofInitiatorsFormComponent,
+                outlet: 'modal'
+              },
+              {
+                path: `${URLVerbs.ADD}/listener`,
+                component: NvmeofListenersFormComponent,
+                outlet: 'modal'
+              },
+              {
+                path: `${URLVerbs.EDIT}/:subsystem_nqn/namespace/:nsid`,
+                component: NvmeofNamespaceExpandModalComponent,
+                outlet: 'modal'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        path: 'namespaces',
+        data: { breadcrumbs: 'Namespaces' },
+        children: [
+          {
+            path: '',
+            component: NvmeofNamespacesListComponent,
+            children: [
+              {
+                path: `${URLVerbs.EDIT}/:subsystem_nqn/namespace/:nsid`,
+                component: NvmeofNamespaceExpandModalComponent,
+                outlet: 'modal'
+              }
+            ]
+          },
+          {
+            path: URLVerbs.CREATE,
+            component: NvmeofNamespacesFormComponent,
+            data: { breadcrumbs: ActionLabels.CREATE }
+          }
+        ]
+      }
     ]
   }
 ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
@@ -1,3 +1,5 @@
+<cd-nvmeof-tabs></cd-nvmeof-tabs>
+
 <ng-container *ngIf="gatewayGroup$ | async as gateways">
   <cd-table
     #table

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
@@ -1,138 +1,73 @@
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import _ from 'lodash';
 
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
-
-import { GroupsComboboxItem, NvmeofService } from '../../../shared/api/nvmeof.service';
-import { CephServiceSpec } from '~/app/shared/models/service.interface';
-import { CephServiceService } from '~/app/shared/api/ceph-service.service';
-import { Daemon } from '~/app/shared/models/daemon.interface';
-
-type Gateway = {
-  id: string;
-  hostname: string;
-  status: number;
-  status_desc: string;
-};
+import { BreadcrumbService } from '~/app/shared/services/breadcrumb.service';
 
 enum TABS {
-  'gateways',
-  'overview'
+  gateways = 'gateways',
+  subsystem = 'subsystem',
+  namespace = 'namespace'
 }
 
-const DEFAULT_PLACEHOLDER = $localize`Enter group name`;
+const TAB_LABELS: Record<TABS, string> = {
+  [TABS.gateways]: $localize`Gateways`,
+  [TABS.subsystem]: $localize`Subsystem`,
+  [TABS.namespace]: $localize`Namespace`
+};
 
 @Component({
   selector: 'cd-nvmeof-gateway',
   templateUrl: './nvmeof-gateway.component.html',
-  styleUrls: ['./nvmeof-gateway.component.scss']
+  styleUrls: ['./nvmeof-gateway.component.scss'],
+  standalone: false
 })
-export class NvmeofGatewayComponent implements OnInit {
+export class NvmeofGatewayComponent implements OnInit, OnDestroy {
   selectedTab: TABS;
+  activeTab: TABS = TABS.gateways;
+
+  @ViewChild('statusTpl', { static: true })
+  statusTpl: TemplateRef<any>;
+  selection = new CdTableSelection();
+
+  constructor(
+    public actionLabels: ActionLabelsI18n,
+    private route: ActivatedRoute,
+    private router: Router,
+    private breadcrumbService: BreadcrumbService
+  ) {}
+
+  ngOnInit() {
+    this.route.queryParams.subscribe((params) => {
+      if (params['tab'] && Object.values(TABS).includes(params['tab'])) {
+        this.activeTab = params['tab'] as TABS;
+      } else {
+        this.activeTab = TABS.gateways;
+      }
+      this.breadcrumbService.setTabCrumb(TAB_LABELS[this.activeTab]);
+    });
+  }
+
+  ngOnDestroy() {
+    this.breadcrumbService.clearTabCrumb();
+  }
 
   onSelected(tab: TABS) {
     this.selectedTab = tab;
+    this.activeTab = tab;
+    this.breadcrumbService.setTabCrumb(TAB_LABELS[tab]);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab },
+      queryParamsHandling: 'merge',
+      replaceUrl: true
+    });
   }
 
   public get Tabs(): typeof TABS {
     return TABS;
-  }
-
-  @ViewChild('statusTpl', { static: true })
-  statusTpl: TemplateRef<any>;
-
-  gateways: Gateway[] = [];
-  gatewayColumns: any;
-  selection = new CdTableSelection();
-  gwGroups: GroupsComboboxItem[] = [];
-  groupService: string = null;
-  selectedGatewayGroup: string = null;
-  gwGroupsEmpty: boolean = false;
-  gwGroupPlaceholder: string = DEFAULT_PLACEHOLDER;
-
-  constructor(
-    private nvmeofService: NvmeofService,
-    private cephServiceService: CephServiceService,
-    public actionLabels: ActionLabelsI18n
-  ) {}
-
-  ngOnInit() {
-    this.setGatewayGroups();
-    this.gatewayColumns = [
-      {
-        name: $localize`Gateway ID`,
-        prop: 'id'
-      },
-      {
-        name: $localize`Hostname`,
-        prop: 'hostname'
-      },
-      {
-        name: $localize`Status`,
-        prop: 'status_desc',
-        cellTemplate: this.statusTpl
-      }
-    ];
-  }
-
-  // for Status column
-  getStatusClass(row: Gateway): string {
-    return _.get(
-      {
-        '-1': 'tag-danger',
-        '0': 'tag-warning',
-        '1': 'tag-success'
-      },
-      row.status,
-      'tag-dark'
-    );
-  }
-
-  // Gateways
-  getGateways() {
-    this.cephServiceService.getDaemons(this.groupService).subscribe((daemons: Daemon[]) => {
-      this.gateways = daemons.length
-        ? daemons.map((daemon: Daemon) => {
-            return {
-              id: `client.${daemon.daemon_name}`,
-              hostname: daemon.hostname,
-              status_desc: daemon.status_desc,
-              status: daemon.status
-            };
-          })
-        : [];
-    });
-  }
-
-  // Gateway groups
-  onGroupSelection(selected: GroupsComboboxItem) {
-    selected.selected = true;
-    this.groupService = selected.serviceName;
-    this.selectedGatewayGroup = selected.content;
-    this.getGateways();
-  }
-
-  onGroupClear() {
-    this.groupService = null;
-    this.getGateways();
-  }
-
-  setGatewayGroups() {
-    this.nvmeofService.listGatewayGroups().subscribe((response: CephServiceSpec[][]) => {
-      if (response?.[0]?.length) {
-        this.gwGroups = this.nvmeofService.formatGwGroupsList(response, true);
-      } else this.gwGroups = [];
-      // Select first group if no group is selected
-      if (!this.groupService && this.gwGroups.length) {
-        this.onGroupSelection(this.gwGroups[0]);
-        this.gwGroupsEmpty = false;
-        this.gwGroupPlaceholder = DEFAULT_PLACEHOLDER;
-      } else {
-        this.gwGroupsEmpty = true;
-        this.gwGroupPlaceholder = $localize`No groups available`;
-      }
-    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
@@ -1,0 +1,155 @@
+<form
+  #formDir="ngForm"
+  [formGroup]="groupForm"
+  novalidate
+>
+  <div cdsGrid
+       [useCssGrid]="true"
+       [narrow]="true"
+       [fullWidth]="true">
+    <div cdsCol
+         [columnNumbers]="{sm: 4, md: 8}">
+      <div cdsRow
+           class="form-heading form-item">
+      <cd-help-text [formAllFieldsRequired]="true"></cd-help-text>
+      </div>
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-text-label
+            labelInputID="name"
+            i18n
+            i18n-helperText
+            helperText="A unique name to identify this gateway group."
+            cdRequiredField="Gateway group name"
+            [invalid]="groupName.isInvalid">
+            Gateway group name
+            <input
+              cdsText
+              cdValidate
+              type="text"
+              id="groupName"
+              #groupName="cdValidate"
+              autofocus
+              formControlName="groupName"
+              [invalid]="groupName.isInvalid"
+            />
+          </cds-text-label>
+          <span
+            class="invalid-feedback"
+            *ngIf="groupForm.showError('groupName', formDir, 'required')"
+            i18n>This field is required.</span>
+          <span
+            class="invalid-feedback"
+            *ngIf="groupForm.get('groupName')?.hasError('notUnique') && (groupForm.get('groupName')?.dirty || groupForm.get('groupName')?.touched)"
+            i18n>Group name must be unique.</span>
+          <span
+            class="invalid-feedback"
+            *ngIf="groupForm.get('groupName')?.hasError('invalidChars') && (groupForm.get('groupName')?.dirty || groupForm.get('groupName')?.touched)"
+            i18n>Special characters are not allowed.</span>
+
+        </div>
+      </div>
+      <!-- Pool -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-select
+            label="Block pool"
+            helperText="An RBD application-enabled pool in which the gateway configuration can be managed."
+            labelInputID="pool"
+            id="pool"
+            formControlName="pool"
+            cdRequiredField="Block pool"
+            [invalid]="groupForm.controls.pool.invalid && groupForm.controls.pool.dirty"
+            [invalidText]="poolError"
+            i18n-label
+            i18n-helperText
+          >
+            <option *ngIf="poolsLoading"
+                    [ngValue]="null"
+                    i18n>Loading...</option>
+            <option *ngIf="!poolsLoading && pools.length === 0"
+                    [ngValue]="null"
+                    i18n>-- No block pools available --</option>
+            <option *ngFor="let pool of pools"
+                    [value]="pool.pool_name">{{ pool.pool_name }}</option>
+          </cds-select>
+          <ng-template #poolError>
+            <span class="invalid-feedback"
+                  *ngIf="groupForm.showError('pool', formDir, 'required')"
+                  i18n>This field is required.</span>
+          </ng-template>
+        </div>
+      </div>
+
+      <!-- CDS Checkbox -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-checkbox id="enableCds"
+                        formControlName="enableEncryption"
+                        i18n>Enable encryption
+          </cds-checkbox>
+        </div>
+      </div>
+
+      <!-- CDS Input (shown when checkbox is checked) -->
+      @if (groupForm.controls.enableEncryption.value) {
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-textarea-label
+            labelInputID="cdsInput"
+            helperText="Provide the encryption configuration details."
+            i18n
+            i18n-helperText>Encryption configuration
+            <textarea cdsTextArea
+                      id="cdsInput"
+                      formControlName="encryptionConfig"
+                      cols="100"
+                      rows="4">
+            </textarea>
+          </cds-textarea-label>
+        </div>
+      </div>
+      }
+
+      <!-- Target Nodes Selection -->
+      <div
+        cdsRow
+        class="form-item"
+      >
+      <div cdsCol>
+        <h1 class="cds--type-heading-02">Select target nodes</h1>
+      <cd-help-text>
+        <span i18n>
+          Gateway nodes to run NVMe-oF target pods/services
+        </span>
+      </cd-help-text>
+      </div>
+      <div
+        cdsCol
+        class="cds-pt-3 cds-pb-3"
+      >
+        <cd-nvmeof-gateway-node
+          (hostsLoaded)="onHostsLoaded($event)"
+        ></cd-nvmeof-gateway-node>
+      </div>
+      </div>
+
+      <div cdsRow>
+        <cd-form-button-panel
+          (submitActionEvent)="onSubmit()"
+          [form]="groupForm"
+          [submitText]="(action | titlecase) + ' ' + (resource)"
+          [disabled]="isCreateDisabled"
+          wrappingClass="text-right form-button"
+        >
+        </cd-form-button-panel>
+      </div>
+    </div>
+  </div>
+</form>
+
+

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
@@ -1,16 +1,19 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import {
   NamespaceCreateRequest,
-  NamespaceUpdateRequest,
+  NamespaceInitiatorRequest,
   NvmeofService
 } from '~/app/shared/api/nvmeof.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
-import { NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
+import {
+  NvmeofSubsystem,
+  NvmeofSubsystemInitiator,
+  NvmeofSubsystemNamespace
+} from '~/app/shared/models/nvmeof';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -18,7 +21,8 @@ import { Pool } from '../../pool/pool';
 import { PoolService } from '~/app/shared/api/pool.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { HttpResponse } from '@angular/common/http';
@@ -26,7 +30,8 @@ import { HttpResponse } from '@angular/common/http';
 @Component({
   selector: 'cd-nvmeof-namespaces-form',
   templateUrl: './nvmeof-namespaces-form.component.html',
-  styleUrls: ['./nvmeof-namespaces-form.component.scss']
+  styleUrls: ['./nvmeof-namespaces-form.component.scss'],
+  standalone: false
 })
 export class NvmeofNamespacesFormComponent implements OnInit {
   action: string;
@@ -34,14 +39,19 @@ export class NvmeofNamespacesFormComponent implements OnInit {
   poolPermission: Permission;
   resource: string;
   pageURL: string;
-  edit: boolean = false;
+
+  title: string = '';
+  description: string = '';
+
   nsForm: CdFormGroup;
   subsystemNQN: string;
+  subsystems: NvmeofSubsystem[] = [];
   rbdPools: Array<Pool> = null;
-  units: Array<string> = ['MiB', 'GiB', 'TiB'];
+  rbdImages: any[] = [];
+  initiatorCandidates: { content: string; selected: boolean }[] = [];
+
   nsid: string;
-  currentBytes: number;
-  invalidSizeError: boolean;
+
   group: string;
   MAX_NAMESPACE_CREATE: number = 5;
   MIN_NAMESPACE_CREATE: number = 1;
@@ -57,167 +67,385 @@ export class NvmeofNamespacesFormComponent implements OnInit {
     private rbdService: RbdService,
     private router: Router,
     private route: ActivatedRoute,
-    public activeModal: NgbActiveModal,
+    private cdr: ChangeDetectorRef,
     public formatterService: FormatterService,
     public dimlessBinaryPipe: DimlessBinaryPipe
   ) {
     this.permission = this.authStorageService.getPermissions().nvmeof;
     this.poolPermission = this.authStorageService.getPermissions().pool;
     this.resource = $localize`Namespace`;
-    this.pageURL = 'block/nvmeof/subsystems';
+    this.pageURL = 'block/nvmeof/namespaces';
   }
 
   init() {
-    this.route.queryParams.subscribe((params) => {
-      this.group = params?.['group'];
-    });
     this.createForm();
     this.action = this.actionLabels.CREATE;
-    this.route.params.subscribe((params: { subsystem_nqn: string; nsid: string }) => {
-      this.subsystemNQN = params.subsystem_nqn;
-      this.nsid = params?.nsid;
-    });
-  }
+    this.title = this.action + ' ' + this.resource;
+    this.description = $localize`Namespaces define the storage volumes that subsystems present to hosts.`;
 
-  initForEdit() {
-    this.edit = true;
-    this.action = this.actionLabels.EDIT;
-    this.nvmeofService
-      .getNamespace(this.subsystemNQN, this.nsid, this.group)
-      .subscribe((res: NvmeofSubsystemNamespace) => {
-        const convertedSize = this.dimlessBinaryPipe.transform(res.rbd_image_size).split(' ');
-        this.currentBytes = res.rbd_image_size;
-        this.nsForm.get('pool').setValue(res.rbd_pool_name);
-        this.nsForm.get('unit').setValue(convertedSize[1]);
-        this.nsForm.get('image_size').setValue(convertedSize[0]);
-        this.nsForm.get('image_size').addValidators(Validators.required);
-        this.nsForm.get('pool').disable();
-      });
+    this.route.params.subscribe((params: Params) => {
+      if (params['subsystem_nqn']) {
+        this.subsystemNQN = params['subsystem_nqn'];
+      }
+      this.nsid = params['nsid'];
+      if (params['group']) {
+        this.group = params['group'];
+      }
+      if (this.subsystemNQN && this.group) {
+        this.pageURL = `block/nvmeof/subsystems/${this.subsystemNQN}/namespaces`;
+        this.action = this.actionLabels.ADD;
+        this.title = this.action + ' ' + this.resource;
+        this.description = $localize`Create a new namespace associated with this subsystem.`;
+      }
+    });
+    this.route.queryParams.subscribe((params: Params) => {
+      if (params['group']) {
+        this.group = params['group'];
+      }
+      if (params['subsystem_nqn']) {
+        this.subsystemNQN = params['subsystem_nqn'];
+      }
+      if (this.subsystemNQN && this.group) {
+        this.pageURL = `block/nvmeof/subsystems/${this.subsystemNQN}/namespaces`;
+        this.action = this.actionLabels.ADD;
+        this.title = this.action + ' ' + this.resource;
+        this.description = $localize`Create a new namespace associated with this subsystem.`;
+      }
+    });
   }
 
   initForCreate() {
     this.poolService.getList().subscribe((resp: Pool[]) => {
       this.rbdPools = resp.filter(this.rbdService.isRBDPool);
-      if (this.rbdPools?.length) {
-        this.nsForm.get('pool').setValue(this.rbdPools[0].pool_name);
-      }
     });
+    if (this.group) {
+      this.fetchUsedImages();
+      this.nvmeofService
+        .listSubsystems(this.group)
+        .subscribe((res: NvmeofSubsystem[] | NvmeofSubsystem) => {
+          this.subsystems = Array.isArray(res) ? res : [res];
+          this.cdr.detectChanges();
+          if (this.subsystemNQN) {
+            const selectedSubsystem = this.subsystems.find((s) => s.nqn === this.subsystemNQN);
+            if (selectedSubsystem) {
+              this.nsForm.get('subsystem').setValue(selectedSubsystem.nqn);
+            }
+          }
+        });
+    }
   }
 
   ngOnInit() {
     this.init();
-    if (this.router.url.includes('subsystems/(modal:edit')) {
-      this.initForEdit();
-    } else {
-      this.initForCreate();
+    this.initForCreate();
+    const subsystemControl = this.nsForm.get('subsystem');
+    if (subsystemControl) {
+      subsystemControl.valueChanges.subscribe((nqn: string) => {
+        this.onSubsystemChange(nqn);
+      });
     }
+  }
+
+  // Stores all RBD images fetched for the selected pool
+  private allRbdImages: { name: string; size: number }[] = [];
+  // Maps pool name to a Set of used image names for O(1) lookup
+  private usedRbdImages: Map<string, Set<string>> = new Map();
+
+  onPoolChange(): void {
+    const pool = this.nsForm.getValue('pool');
+    if (!pool) return;
+
+    this.rbdService
+      .list({ pool_name: pool, offset: '0', limit: '-1' })
+      .subscribe((pools: { pool_name: string; value: { name: string; size: number }[] }[]) => {
+        const selectedPool = pools.find((p) => p.pool_name === pool);
+        this.allRbdImages = selectedPool?.value ?? [];
+        this.filterImages();
+
+        const imageControl = this.nsForm.get('rbd_image_name');
+        const currentImage = this.nsForm.getValue('rbd_image_name');
+        if (currentImage && !this.rbdImages.some((img) => img.name === currentImage)) {
+          imageControl.setValue(null);
+        }
+        imageControl.markAsUntouched();
+        imageControl.markAsPristine();
+      });
+  }
+
+  fetchUsedImages(): void {
+    if (!this.group) return;
+
+    this.nvmeofService.listNamespaces(this.group).subscribe((response: any) => {
+      const namespaces: NvmeofSubsystemNamespace[] = Array.isArray(response)
+        ? response
+        : response?.namespaces ?? [];
+      this.usedRbdImages = namespaces.reduce((map, ns) => {
+        if (!map.has(ns.rbd_pool_name)) {
+          map.set(ns.rbd_pool_name, new Set<string>());
+        }
+        map.get(ns.rbd_pool_name)!.add(ns.rbd_image_name);
+        return map;
+      }, new Map<string, Set<string>>());
+      this.filterImages();
+    });
+  }
+
+  onSubsystemChange(nqn: string): void {
+    if (!nqn) return;
+    this.nvmeofService
+      .getInitiators(nqn, this.group)
+      .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
+        const initiators = Array.isArray(response) ? response : response?.hosts || [];
+        this.initiatorCandidates = initiators.map((initiator) => ({
+          content: initiator.nqn,
+          selected: false
+        }));
+      });
+  }
+
+  onInitiatorSelection(event: any) {
+    // Carbon ComboBox (selected) emits the full array of selected items
+    const selectedInitiators = Array.isArray(event) ? event.map((e: any) => e.content) : [];
+    this.nsForm
+      .get('initiators')
+      .setValue(selectedInitiators.length > 0 ? selectedInitiators : null);
+    this.nsForm.get('initiators').markAsDirty();
+    this.nsForm.get('initiators').markAsTouched();
+  }
+
+  private filterImages(): void {
+    const pool = this.nsForm.getValue('pool');
+    if (!pool) {
+      this.rbdImages = [];
+      return;
+    }
+    const usedInPool = this.usedRbdImages.get(pool);
+    this.rbdImages = usedInPool
+      ? this.allRbdImages.filter((img) => !usedInPool.has(img.name))
+      : [...this.allRbdImages];
   }
 
   createForm() {
     this.nsForm = new CdFormGroup({
-      pool: new UntypedFormControl(null, {
+      pool: new UntypedFormControl('', {
         validators: [Validators.required]
       }),
-      image_size: new UntypedFormControl(1, [CdValidators.number(false), Validators.min(1)]),
-      unit: new UntypedFormControl(this.units[1]),
+      subsystem: new UntypedFormControl('', {
+        validators: [Validators.required]
+      }),
+      image_size: new UntypedFormControl(null, {
+        validators: [Validators.required]
+      }),
       nsCount: new UntypedFormControl(this.MAX_NAMESPACE_CREATE, [
         Validators.required,
         Validators.max(this.MAX_NAMESPACE_CREATE),
         Validators.min(this.MIN_NAMESPACE_CREATE)
-      ])
-    });
-  }
+      ]),
+      rbd_image_creation: new UntypedFormControl('gateway_provisioned'),
 
-  buildUpdateRequest(rbdImageSize: number): Observable<HttpResponse<Object>> {
-    const request: NamespaceUpdateRequest = {
-      gw_group: this.group,
-      rbd_image_size: rbdImageSize
-    };
-    return this.nvmeofService.updateNamespace(
-      this.subsystemNQN,
-      this.nsid,
-      request as NamespaceUpdateRequest
-    );
+      rbd_image_name: new UntypedFormControl(null, [
+        CdValidators.custom('rbdImageName', (value: any) => {
+          if (!value) return null;
+          return /^[^@/]+$/.test(value) ? null : { rbdImageName: true };
+        })
+      ]),
+      namespace_size: new UntypedFormControl(null, {
+        validators: [CdValidators.blockSizeMultiple()]
+      }), // UI only - not sent to backend
+      host_access: new UntypedFormControl('all'), // UI only - determines visibility
+      initiators: new UntypedFormControl([]) // UI only - selected hosts
+    });
+
+    this.nsForm.get('pool').valueChanges.subscribe(() => {
+      this.onPoolChange();
+    });
+
+    this.nsForm.get('nsCount').valueChanges.subscribe((count: number) => {
+      if (count > 1) {
+        const creationControl = this.nsForm.get('rbd_image_creation');
+        if (creationControl.value === 'externally_managed') {
+          creationControl.setValue('gateway_provisioned');
+        }
+      }
+    });
+
+    this.nsForm.get('rbd_image_creation').valueChanges.subscribe((mode: string) => {
+      const nameControl = this.nsForm.get('rbd_image_name');
+      const sizeControl = this.nsForm.get('image_size');
+      const countControl = this.nsForm.get('nsCount');
+
+      if (mode === 'externally_managed') {
+        countControl.setValue(1);
+        countControl.disable();
+        this.onPoolChange();
+        nameControl.addValidators(Validators.required);
+        sizeControl.removeValidators(Validators.required);
+        sizeControl.disable();
+      } else {
+        sizeControl.enable();
+        countControl.enable();
+        nameControl.removeValidators(Validators.required);
+        sizeControl.addValidators(Validators.required);
+      }
+      nameControl.updateValueAndValidity();
+      sizeControl.updateValueAndValidity();
+    });
+
+    this.nsForm.get('host_access').valueChanges.subscribe((mode: string) => {
+      const initiatorsControl = this.nsForm.get('initiators');
+      if (mode === 'specific') {
+        initiatorsControl.addValidators(Validators.required);
+      } else {
+        initiatorsControl.removeValidators(Validators.required);
+        initiatorsControl.setValue([]);
+        this.initiatorCandidates.forEach((i) => (i.selected = false));
+      }
+      initiatorsControl.updateValueAndValidity();
+    });
   }
 
   randomString() {
     return Math.random().toString(36).substring(2);
   }
 
-  buildCreateRequest(rbdImageSize: number, nsCount: number): Observable<HttpResponse<Object>>[] {
+  private normalizeImageSizeInput(value: string | number): string {
+    const input = String(value ?? '').trim();
+    if (!input) {
+      return input;
+    }
+    if (typeof value === 'number') {
+      return input;
+    }
+    // Accept plain numeric values as GiB (e.g. "45" => "45GiB").
+    return /^\d+(\.\d+)?$/.test(input) ? `${input}GiB` : input;
+  }
+
+  buildCreateRequest(
+    rbdImageSize: number,
+    nsCount: number,
+    noAutoVisible: boolean
+  ): Observable<HttpResponse<Object>>[] {
     const pool = this.nsForm.getValue('pool');
     const requests: Observable<HttpResponse<Object>>[] = [];
+    const creationMode = this.nsForm.getValue('rbd_image_creation');
+    const isGatewayProvisioned = creationMode === 'gateway_provisioned';
 
-    for (let i = 1; i <= nsCount; i++) {
+    const loopCount = isGatewayProvisioned ? nsCount : 1;
+
+    for (let i = 1; i <= loopCount; i++) {
       const request: NamespaceCreateRequest = {
         gw_group: this.group,
-        rbd_image_name: `nvme_${pool}_${this.group}_${this.randomString()}`,
         rbd_pool: pool,
-        create_image: true
+        create_image: isGatewayProvisioned,
+        no_auto_visible: noAutoVisible
       };
-      if (rbdImageSize) {
-        request['rbd_image_size'] = rbdImageSize;
+
+      const blockSize = this.nsForm.getValue('namespace_size');
+      if (blockSize) {
+        request.block_size = blockSize;
       }
-      requests.push(this.nvmeofService.createNamespace(this.subsystemNQN, request));
+
+      if (isGatewayProvisioned) {
+        const rbdImageName = this.nsForm.getValue('rbd_image_name');
+        if (rbdImageName) {
+          request.rbd_image_name = loopCount > 1 ? `${rbdImageName}-${i}` : rbdImageName;
+        } else {
+          request.rbd_image_name = `nvme_${pool}_${this.group}_${this.randomString()}`;
+        }
+        if (rbdImageSize) {
+          request['rbd_image_size'] = rbdImageSize;
+        }
+      } else {
+        const rbdImageName = this.nsForm.getValue('rbd_image_name');
+        if (rbdImageName) {
+          request['rbd_image_name'] = rbdImageName;
+        }
+      }
+
+      const subsystemNQN = this.nsForm.getValue('subsystem') || this.subsystemNQN;
+      requests.push(this.nvmeofService.createNamespace(subsystemNQN, request));
     }
 
     return requests;
   }
 
-  validateSize() {
-    const unit = this.nsForm.getValue('unit');
-    const image_size = this.nsForm.getValue('image_size');
-    if (image_size && unit) {
-      const bytes = this.formatterService.toBytes(image_size + unit);
-      return bytes <= this.currentBytes;
-    }
-    return null;
-  }
-
   onSubmit() {
-    if (this.validateSize()) {
-      this.invalidSizeError = true;
+    if (this.nsForm.invalid) {
       this.nsForm.setErrors({ cdSubmitButton: true });
-    } else {
-      this.invalidSizeError = false;
-      const component = this;
-      const taskUrl: string = `nvmeof/namespace/${this.edit ? URLVerbs.EDIT : URLVerbs.CREATE}`;
-      const image_size = this.nsForm.getValue('image_size');
-      const nsCount = this.nsForm.getValue('nsCount');
-      let action: Observable<HttpResponse<Object>>;
-      let rbdImageSize: number = null;
-
-      if (image_size) {
-        const image_size_unit = this.nsForm.getValue('unit');
-        const value: number = this.formatterService.toBytes(image_size + image_size_unit);
-        rbdImageSize = value;
-      }
-      if (this.edit) {
-        action = this.taskWrapperService.wrapTaskAroundCall({
-          task: new FinishedTask(taskUrl, {
-            nqn: this.subsystemNQN,
-            nsid: this.nsid
-          }),
-          call: this.buildUpdateRequest(rbdImageSize)
-        });
-      } else {
-        action = this.taskWrapperService.wrapTaskAroundCall({
-          task: new FinishedTask(taskUrl, {
-            nqn: this.subsystemNQN,
-            nsCount
-          }),
-          call: forkJoin(this.buildCreateRequest(rbdImageSize, nsCount))
-        });
-      }
-
-      action.subscribe({
-        error() {
-          component.nsForm.setErrors({ cdSubmitButton: true });
-        },
-        complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
-        }
-      });
+      this.nsForm.markAllAsTouched();
+      return;
     }
+
+    const component = this;
+    const taskUrl: string = `nvmeof/namespace/${URLVerbs.CREATE}`;
+    const image_size = this.nsForm.getValue('image_size');
+    const nsCount = this.nsForm.getValue('nsCount');
+    const hostAccess = this.nsForm.getValue('host_access');
+    const selectedHosts: string[] = this.nsForm.getValue('initiators') || [];
+    const noAutoVisible = hostAccess === 'specific';
+    let action: Observable<any>;
+    let rbdImageSize: number = null;
+
+    if (image_size) {
+      const normalizedSize = this.normalizeImageSizeInput(image_size);
+      rbdImageSize = this.formatterService.toBytes(normalizedSize);
+      if (rbdImageSize === null) {
+        this.nsForm.get('image_size').setErrors({ invalid: true });
+        this.nsForm.setErrors({ cdSubmitButton: true });
+        return;
+      }
+    }
+
+    const subsystemNQN = this.nsForm.getValue('subsystem');
+
+    // Step 1: Create namespaces
+    // Step 2: If specific hosts selected, chain addNamespaceInitiators calls
+    const createObs = forkJoin(this.buildCreateRequest(rbdImageSize, nsCount, noAutoVisible));
+
+    const combinedObs = createObs.pipe(
+      switchMap((responses: HttpResponse<Object>[]) => {
+        if (noAutoVisible && selectedHosts.length > 0) {
+          const initiatorObs: Observable<any>[] = [];
+
+          responses.forEach((res) => {
+            const body: any = res.body;
+            if (body && body.nsid) {
+              selectedHosts.forEach((host: string) => {
+                const req: NamespaceInitiatorRequest = {
+                  gw_group: this.group,
+                  subsystem_nqn: subsystemNQN || this.subsystemNQN,
+                  host_nqn: host
+                };
+                initiatorObs.push(this.nvmeofService.addNamespaceInitiators(body.nsid, req));
+              });
+            }
+          });
+
+          if (initiatorObs.length > 0) {
+            return forkJoin(initiatorObs);
+          }
+        }
+        return of(responses);
+      })
+    );
+
+    action = this.taskWrapperService.wrapTaskAroundCall({
+      task: new FinishedTask(taskUrl, {
+        nqn: subsystemNQN,
+        nsCount
+      }),
+      call: combinedObs
+    });
+
+    action.subscribe({
+      error: () => {
+        component.nsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.router.navigate([this.pageURL], {
+          queryParams: { group: this.group }
+        });
+      }
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
@@ -1,18 +1,41 @@
-<legend>
-  <cd-help-text>
-    An NVMe namespace is a quantity of non-volatile storage that can be formatted into logical blocks and presented to a host as a standard block device.
-  </cd-help-text>
-</legend>
-<cd-table [data]="namespaces"
-          columnMode="flex"
-          (fetchData)="listNamespaces()"
-          [columns]="namespacesColumns"
-          selectionType="single"
-          (updateSelection)="updateSelection($event)"
-          emptyStateTitle="No namespaces created."
-          i18n-emptyStateTitle
-          emptyStateMessage="Namespaces are storage volumes mapped to subsystems for host access. Create a namespace to start provisioning storage within a subsystem."
-          i18n-emptyStateMessage>
+<cd-nvmeof-tabs></cd-nvmeof-tabs>
+
+<div cdsGrid
+     [useCssGrid]="true"
+     [narrow]="true"
+     [fullWidth]="true">
+<div cdsCol
+     [columnNumbers]="{sm: 4, md: 8}">
+  <div class="pb-3 form-item"
+       cdsRow>
+    <cds-combo-box
+        type="single"
+        label="Selected Gateway Group"
+        i18n-label
+        [placeholder]="gwGroupPlaceholder"
+        [items]="gwGroups"
+        (selected)="onGroupSelection($event)"
+        (clear)="onGroupClear()"
+        [disabled]="gwGroupsEmpty">
+      <cds-dropdown-list></cds-dropdown-list>
+    </cds-combo-box>
+  </div>
+</div>
+</div>
+
+<ng-container *ngIf="namespaces$ | async as namespaces">
+  <cd-table [data]="namespaces"
+            columnMode="flex"
+            (fetchData)="fetchData()"
+            [columns]="namespacesColumns"
+            identifier="unique_id"
+            [forceIdentifier]="true"
+            selectionType="single"
+            (updateSelection)="updateSelection($event)"
+            emptyStateTitle="No namespaces created."
+            i18n-emptyStateTitle
+            emptyStateMessage="Namespaces are storage volumes mapped to subsystems for host access. Create a namespace to start provisioning storage within a subsystem."
+            i18n-emptyStateMessage>
 
   <div class="table-actions">
     <cd-table-actions [permission]="permission"
@@ -22,3 +45,6 @@
     </cd-table-actions>
   </div>
 </cd-table>
+</ng-container>
+
+<router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
@@ -1,160 +1,261 @@
-import { Component, DestroyRef, OnInit } from '@angular/core';
-import { FormControlStatus, UntypedFormControl, Validators } from '@angular/forms';
+import { Component, DestroyRef, OnInit, SecurityContext, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
-import { CdValidators } from '~/app/shared/forms/cd-validators';
-import { Permission } from '~/app/shared/models/permissions';
-import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
-import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
-import { FinishedTask } from '~/app/shared/models/finished-task';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { ActivatedRoute, Router } from '@angular/router';
-import {
-  DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM,
-  NvmeofService
-} from '~/app/shared/api/nvmeof.service';
 import { Step } from 'carbon-components-angular';
-import { startWith } from 'rxjs/operators';
+import { NvmeofService, SubsystemInitiatorRequest } from '~/app/shared/api/nvmeof.service';
+import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
+import {
+  AUTHENTICATION,
+  HOST_TYPE,
+  HostStepType,
+  ListenerItem,
+  AuthStepType,
+  DetailsStepType
+} from '~/app/shared/models/nvmeof';
+import { from, Observable, of } from 'rxjs';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { catchError, concatMap, map, tap } from 'rxjs/operators';
+import { DomSanitizer } from '@angular/platform-browser';
+
+export type SubsystemPayload = {
+  nqn: string;
+  gw_group: string;
+  subsystemDchapKey: string;
+  addedHosts: string[];
+  hostType: string;
+  listeners: ListenerItem[];
+  authType: AUTHENTICATION.Bidirectional | AUTHENTICATION.Unidirectional;
+  hostDchapKeyList: Array<{ dhchap_key: string; host_nqn: string }>;
+};
+
+type StepResult = { step: string; success: boolean; error?: string };
+
+const STEP_LABELS = {
+  DETAILS: 'Subsystem details',
+  HOSTS: 'Host access control',
+  AUTH: 'Authentication',
+  REVIEW: 'Review'
+} as const;
 
 @Component({
   selector: 'cd-nvmeof-subsystems-form',
   templateUrl: './nvmeof-subsystems-form.component.html',
-  styleUrls: ['./nvmeof-subsystems-form.component.scss']
+  styleUrls: ['./nvmeof-subsystems-form.component.scss'],
+  standalone: false
 })
 export class NvmeofSubsystemsFormComponent implements OnInit {
-  permission: Permission;
-  subsystemForm: CdFormGroup;
   action: string;
-  resource: string;
-  pageURL: string;
-  defaultMaxNamespace: number = DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM;
   group: string;
-  steps: Step[] = [
-    {
-      label: $localize`Subsystem Details`,
-      complete: false,
-      invalid: false
-    },
-    {
-      label: $localize`Host access control`,
-      complete: false
-    },
-    {
-      label: $localize`Authentication`,
-      complete: false
-    },
-    {
-      label: $localize`Advanced Options`,
-      complete: false,
-      secondaryLabel: $localize`Advanced`
-    }
-  ];
+  steps: Step[] = [];
   title: string = $localize`Create Subsystem`;
   description: string = $localize`Subsytems define how hosts connect to NVMe namespaces and ensure secure access to storage.`;
+  isSubmitLoading: boolean = false;
+  private lastCreatedNqn: string;
+  stepTwoValue: HostStepType = null;
+  showAuthStep = true;
+
+  @ViewChild(TearsheetComponent) tearsheet!: TearsheetComponent;
+
+  // Review step data
+  reviewNqn: string = '';
+  reviewListeners: any[] = [];
+  reviewHostType: string = HOST_TYPE.SPECIFIC;
+  reviewAddedHosts: string[] = [];
+  reviewAuthType: string = AUTHENTICATION.Unidirectional;
+  reviewSubsystemDchapKey: string = '';
+  reviewHostDchapKeyCount: number = 0;
 
   constructor(
-    private authStorageService: AuthStorageService,
     public actionLabels: ActionLabelsI18n,
     public activeModal: NgbActiveModal,
-    private nvmeofService: NvmeofService,
-    private taskWrapperService: TaskWrapperService,
-    private router: Router,
     private route: ActivatedRoute,
-    private destroyRef: DestroyRef
-  ) {
-    this.permission = this.authStorageService.getPermissions().nvmeof;
-    this.resource = $localize`Subsystem`;
-    this.pageURL = 'block/nvmeof/subsystems';
-  }
-
-  DEFAULT_NQN = 'nqn.2001-07.com.ceph:' + Date.now();
-  NQN_REGEX = /^nqn\.(19|20)\d\d-(0[1-9]|1[0-2])\.\D{2,3}(\.[A-Za-z0-9-]+)+(:[A-Za-z0-9-\.]+(:[A-Za-z0-9-\.]+)*)$/;
-  NQN_REGEX_UUID = /^nqn\.2014-08\.org\.nvmexpress:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
-  customNQNValidator = CdValidators.custom(
-    'pattern',
-    (nqnInput: string) =>
-      !!nqnInput && !(this.NQN_REGEX.test(nqnInput) || this.NQN_REGEX_UUID.test(nqnInput))
-  );
+    private destroyRef: DestroyRef,
+    private nvmeofService: NvmeofService,
+    private notificationService: NotificationService,
+    private router: Router,
+    private sanitizer: DomSanitizer
+  ) {}
 
   ngOnInit() {
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.group = params?.['group'];
     });
-
-    this.createForm();
-    this.action = this.actionLabels.CREATE;
-
-    this.subsystemForm.statusChanges
-      .pipe(startWith(this.subsystemForm.status), takeUntilDestroyed(this.destroyRef))
-      .subscribe((status: FormControlStatus) => {
-        const step = this.steps[0];
-        step.invalid = status === 'INVALID';
-      });
+    this.rebuildSteps();
   }
 
-  createForm() {
-    this.subsystemForm = new CdFormGroup({
-      nqn: new UntypedFormControl(this.DEFAULT_NQN, {
-        validators: [
-          this.customNQNValidator,
-          Validators.required,
-          this.customNQNValidator,
-          CdValidators.custom(
-            'maxLength',
-            (nqnInput: string) => new TextEncoder().encode(nqnInput).length > 223
-          )
-        ],
-        asyncValidators: [
-          CdValidators.unique(
-            this.nvmeofService.isSubsystemPresent,
-            this.nvmeofService,
-            null,
-            null,
-            this.group
-          )
-        ]
-      }),
-      max_namespaces: new UntypedFormControl(this.defaultMaxNamespace, {
-        validators: [CdValidators.number(false), Validators.min(1)]
-      })
-    });
+  private setAuthStepVisibility(nextShowAuth: boolean) {
+    if (this.showAuthStep === nextShowAuth) return;
+    this.showAuthStep = nextShowAuth;
+    this.rebuildSteps();
   }
 
-  onSubmit() {
-    const component = this;
-    const nqn: string = this.subsystemForm.getValue('nqn');
-    const max_namespaces: number = Number(this.subsystemForm.getValue('max_namespaces'));
-    let taskUrl = `nvmeof/subsystem/${URLVerbs.CREATE}`;
+  populateReviewData() {
+    if (!this.tearsheet) return;
 
-    const request = {
-      nqn,
-      enable_ha: true,
-      gw_group: this.group,
-      max_namespaces
-    };
+    const step1 = this.tearsheet.getStepValueByLabel<DetailsStepType>(STEP_LABELS.DETAILS);
+    const step2 = this.tearsheet.getStepValueByLabel<HostStepType>(STEP_LABELS.HOSTS);
 
-    if (!max_namespaces) {
-      delete request.max_namespaces;
+    if (step1) {
+      this.reviewNqn = step1.nqn ?? '';
+      this.reviewListeners = step1.listeners ?? [];
     }
-    this.taskWrapperService
-      .wrapTaskAroundCall({
-        task: new FinishedTask(taskUrl, {
-          nqn: nqn
-        }),
-        call: this.nvmeofService.createSubsystem(request)
+
+    if (step2) {
+      this.reviewHostType = step2.hostType ?? HOST_TYPE.SPECIFIC;
+      this.reviewAddedHosts = step2.addedHosts ?? [];
+      this.stepTwoValue = step2;
+    }
+
+    const nextShowAuth = (step2?.hostType ?? HOST_TYPE.SPECIFIC) === HOST_TYPE.SPECIFIC;
+
+    if (nextShowAuth !== this.showAuthStep) {
+      this.setAuthStepVisibility(nextShowAuth);
+      return;
+    }
+
+    const authStep = this.tearsheet.getStepValueByLabel<AuthStepType>(STEP_LABELS.AUTH);
+
+    if (this.showAuthStep && authStep) {
+      this.reviewAuthType = authStep.authType ?? AUTHENTICATION.Unidirectional;
+      this.reviewSubsystemDchapKey = authStep.subsystemDchapKey ?? '';
+      const hostKeyList = authStep.hostDchapKeyList ?? [];
+      this.reviewHostDchapKeyCount = hostKeyList.filter((item) => !!item?.dhchap_key)?.length;
+    } else {
+      this.reviewAuthType = null;
+      this.reviewSubsystemDchapKey = '';
+      this.reviewHostDchapKeyCount = 0;
+    }
+  }
+
+  rebuildSteps() {
+    const steps: Step[] = [
+      { label: STEP_LABELS.DETAILS, invalid: false },
+      { label: STEP_LABELS.HOSTS, invalid: false }
+    ];
+
+    if (this.showAuthStep) {
+      steps.push({ label: STEP_LABELS.AUTH, invalid: false });
+    }
+
+    steps.push({ label: STEP_LABELS.REVIEW, invalid: false });
+
+    this.steps = steps;
+
+    if (this.tearsheet?.currentStep >= steps.length) {
+      this.tearsheet.currentStep = steps.length - 1;
+    }
+  }
+
+  onSubmit(payload: SubsystemPayload) {
+    this.isSubmitLoading = true;
+    this.lastCreatedNqn = payload.nqn;
+    const stepResults: StepResult[] = [];
+    const initiatorRequest: SubsystemInitiatorRequest = {
+      allow_all: payload.hostType === HOST_TYPE.ALL,
+      hosts: payload.hostType === HOST_TYPE.SPECIFIC ? payload.hostDchapKeyList : [],
+      gw_group: this.group
+    };
+    this.nvmeofService
+      .createSubsystem({
+        nqn: payload.nqn,
+        gw_group: this.group,
+        enable_ha: true,
+        dhchap_key: payload.subsystemDchapKey
       })
       .subscribe({
-        error() {
-          // instead have error message set, not setting form status INVALID
-          // which will show input as false
-          component.subsystemForm.setErrors({ cdSubmitButton: true });
+        next: () => {
+          stepResults.push({ step: this.steps[0].label, success: true });
+          const sequentialSteps: { step: string; call: () => Observable<any> }[] = [];
+
+          if (payload.listeners && payload.listeners.length > 0) {
+            sequentialSteps.push({
+              step: $localize`Listeners`,
+              call: () =>
+                this.nvmeofService.createListeners(
+                  `${payload.nqn}.${this.group}`,
+                  this.group,
+                  payload.listeners
+                )
+            });
+          }
+
+          sequentialSteps.push({
+            step: this.steps[1].label,
+            call: () =>
+              this.nvmeofService.addSubsystemInitiators(
+                `${payload.nqn}.${this.group}`,
+                initiatorRequest
+              )
+          });
+
+          this.runSequentialSteps(sequentialSteps, stepResults).subscribe({
+            complete: () => this.showFinalNotification(stepResults)
+          });
         },
-        complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
+        error: (err) => {
+          err.preventDefault();
+          const errorMsg = err?.error?.detail || $localize`Subsystem creation failed`;
+          this.notificationService.show(
+            NotificationType.error,
+            $localize`Subsystem creation failed`,
+            errorMsg
+          );
+          this.isSubmitLoading = false;
+          this.router.navigate(['block/nvmeof/subsystems'], {
+            queryParams: { group: this.group }
+          });
         }
       });
+  }
+
+  private runSequentialSteps(
+    steps: { step: string; call: () => Observable<any> }[],
+    stepResults: StepResult[]
+  ): Observable<void> {
+    return from(steps).pipe(
+      concatMap((step) =>
+        step.call().pipe(
+          tap(() => stepResults.push({ step: step.step, success: true })),
+          catchError((err) => {
+            err.preventDefault();
+            const errorMsg = err?.error?.detail || '';
+            stepResults.push({ step: step.step, success: false, error: errorMsg });
+            return of(null);
+          })
+        )
+      ),
+      map(() => void 0)
+    );
+  }
+
+  private showFinalNotification(stepResults: StepResult[]) {
+    this.isSubmitLoading = false;
+
+    const messageLines = stepResults.map((stepResult) =>
+      stepResult.success
+        ? $localize`<div>${stepResult.step} step created successfully</div><br/>`
+        : $localize`<div>${stepResult.step} step failed: <code>${stepResult.error}</code></div><br/>`
+    );
+
+    const rawHtml = messageLines.join('<br/>');
+    const sanitizedHtml = this.sanitizer.sanitize(SecurityContext.HTML, rawHtml) ?? '';
+
+    const hasFailure = stepResults.some((r) => !r.success);
+    const type = hasFailure ? NotificationType.error : NotificationType.success;
+    const title = hasFailure
+      ? $localize`Subsystem created (with errors)`
+      : $localize`Subsystem created`;
+
+    this.notificationService.show(type, title, sanitizedHtml);
+    this.router.navigate(['block/nvmeof/subsystems'], {
+      queryParams: {
+        group: this.group,
+        nqn: stepResults[0]?.success ? this.lastCreatedNqn : null
+      }
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
@@ -1,53 +1,94 @@
 <cd-nvmeof-tabs></cd-nvmeof-tabs>
 
-<div class="pb-3"
-     cdsCol
-     [columnNumbers]="{md: 4}">
-  <cds-combo-box
-      type="single"
-      label="Selected Gateway Group"
-      i18n-label
-      [placeholder]="gwGroupPlaceholder"
-      [items]="gwGroups"
-      (selected)="onGroupSelection($event)"
-      (clear)="onGroupClear()"
-      [disabled]="gwGroupsEmpty">
-    <cds-dropdown-list></cds-dropdown-list>
-  </cds-combo-box>
-</div>
-
-<legend i18n>
-  Subsystems
-  <cd-help-text>
-    A subsystem provides access control to which hosts can access the namespaces within the subsystem.
-  </cd-help-text>
-</legend>
-<cd-table [data]="subsystems"
-          columnMode="flex"
-          (fetchData)="getSubsystems()"
-          [columns]="subsystemsColumns"
-          selectionType="single"
-          [hasDetails]="true"
-          (setExpandedRow)="setExpandedRow($event)"
-          (updateSelection)="updateSelection($event)"
-          emptyStateTitle="No subsystems created"
-          i18n-emptyStateTitle
-          emptyStateMessage="Subsystems group NVMe namespaces and manage host access. Create a subsystem to start mapping NVMe volumes to hosts."
-          i18n-emptyStateMessage>
-
-  <div class="table-actions">
-    <cd-table-actions [permission]="permissions.nvmeof"
-                      [selection]="selection"
-                      class="btn-group"
-                      [tableActions]="tableActions">
-    </cd-table-actions>
+<div cdsGrid
+     [useCssGrid]="true"
+     [narrow]="true"
+     [fullWidth]="true">
+<div cdsCol
+     [columnNumbers]="{sm: 4, md: 8}">
+  <div class="pb-3 form-item"
+       cdsRow>
+    <cds-combo-box
+        type="single"
+        label="Selected Gateway Group"
+        i18n-label
+        [placeholder]="gwGroupPlaceholder"
+        [items]="gwGroups"
+        (selected)="onGroupSelection($event)"
+        (clear)="onGroupClear()"
+        [disabled]="gwGroupsEmpty">
+      <cds-dropdown-list></cds-dropdown-list>
+    </cds-combo-box>
   </div>
+</div>
+</div>
+<ng-container *ngIf="subsystems$ | async as subsystems">
+  <cd-table #table
+            [data]="subsystems"
+            [columns]="subsystemsColumns"
+            columnMode="flex"
+            selectionType="single"
+            (updateSelection)="updateSelection($event)"
+            (fetchData)="fetchData()"
+            emptyStateTitle="No subsystems created"
+            i18n-emptyStateTitle
+            emptyStateMessage="Subsystems group NVMe namespaces and manage host access. Create a subsystem to start mapping NVMe volumes to hosts."
+            i18n-emptyStateMessage>
 
-  <cd-nvmeof-subsystems-details *cdTableDetail
-                                [selection]="expandedRow"
-                                [permissions]="permissions"
-                                [group]="group">
-  </cd-nvmeof-subsystems-details>
-</cd-table>
+    <div class="table-actions">
+      <cd-table-actions [permission]="permissions.nvmeof"
+                        [selection]="selection"
+                        class="btn-group"
+                        [tableActions]="tableActions">
+      </cd-table-actions>
+    </div>
+
+    <cd-nvmeof-subsystems-details *cdTableDetail
+                                  [selection]="expandedRow"
+                                  [permissions]="permissions"
+                                  [group]="expandedRow?.gw_group">
+    </cd-nvmeof-subsystems-details>
+  </cd-table>
+</ng-container>
+
+<ng-template #customTableItemTemplate
+             let-value="data.value"
+             let-row="data.row">
+  <a cdsLink
+     [routerLink]="['/block/nvmeof/subsystems', value]"
+     [queryParams]="{ group: row.gw_group }"
+     (click)="$event.stopPropagation()">
+    {{ value }}
+  </a>
+</ng-template>
+
+<ng-template #authenticationTpl
+             let-row="data.row">
+  <div [cdsStack]="'horizontal'"
+       gap="4">
+  @if (row.auth === authType.NO_AUTH) {
+    <cd-icon type="warning"></cd-icon>
+  } @else {
+    <cd-icon type="success"></cd-icon>
+  }
+  <span class="cds-ml-3">{{ row.auth }}</span>
+  </div>
+</ng-template>
+
+<ng-template #encryptionTpl
+             let-row="data.row">
+  <div [cdsStack]="'horizontal'"
+       gap="4">
+  @if (row.enable_ha) {
+    <cd-icon type="success"></cd-icon>
+    <span class="cds-ml-3"
+          i18n>Enabled</span>
+  } @else {
+    <cd-icon type="error"></cd-icon>
+    <span class="cds-ml-3"
+          i18n>Disabled</span>
+  }
+  </div>
+</ng-template>
 
 <router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
@@ -1,16 +1,31 @@
-<ul class="nav nav-tabs">
-  <li class="nav-item">
-    <a class="nav-link"
-       routerLink="/block/nvmeof/subsystems"
-       routerLinkActive="active"
-       ariaCurrentWhenActive="page"
-       i18n>Subsystems</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link"
-       routerLink="/block/nvmeof/gateways"
-       routerLinkActive="active"
-       ariaCurrentWhenActive="page"
-       i18n>Gateways</a>
-  </li>
-</ul>
+<fieldset>
+  <legend>
+    <h1 class="cds--type-heading-03">NVMe over Fabrics (TCP)</h1>
+  <cd-help-text>Monitor and manage NVMe-over-TCP resources for high-performance block storage.</cd-help-text>
+  </legend>
+</fieldset>
+<section>
+  <cds-tabs type="contained"
+            followFocus="true"
+            isNavigation="true"
+            [cacheActive]="false">
+  <cds-tab
+    heading="Gateways"
+    i18n-heading
+    [active]="activeTab === Tabs.gateways"
+    (selected)="onSelected(Tabs.gateways)">
+  </cds-tab>
+  <cds-tab
+    heading="Subsystems"
+    i18n-heading
+    [active]="activeTab === Tabs.subsystems"
+    (selected)="onSelected(Tabs.subsystems)">
+  </cds-tab>
+  <cds-tab
+    heading="Namespaces"
+    i18n-heading
+    [active]="activeTab === Tabs.namespaces"
+    (selected)="onSelected(Tabs.namespaces)">
+  </cds-tab>
+</cds-tabs>
+</section>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
@@ -1,22 +1,81 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { TabsModule } from 'carbon-components-angular';
 
 import { NvmeofTabsComponent } from './nvmeof-tabs.component';
+import { SharedModule } from '~/app/shared/shared.module';
 
 describe('NvmeofTabsComponent', () => {
   let component: NvmeofTabsComponent;
   let fixture: ComponentFixture<NvmeofTabsComponent>;
+  let router: Router;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [NvmeofTabsComponent]
+      declarations: [NvmeofTabsComponent],
+      imports: [RouterTestingModule, SharedModule, TabsModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofTabsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    router = TestBed.inject(Router);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should default activeTab to gateways', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/gateways');
+    component.ngOnInit();
+    expect(component.activeTab).toBe(component.Tabs.gateways);
+  });
+
+  it('should set activeTab to subsystems when URL contains subsystems', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/subsystems');
+    component.ngOnInit();
+    expect(component.activeTab).toBe(component.Tabs.subsystems);
+  });
+
+  it('should set activeTab to namespaces when URL contains namespaces', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/namespaces');
+    component.ngOnInit();
+    expect(component.activeTab).toBe(component.Tabs.namespaces);
+  });
+
+  it('should fallback to gateways when URL does not match any tab', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/unknown');
+    component.ngOnInit();
+    expect(component.activeTab).toBe(component.Tabs.gateways);
+  });
+
+  it('should navigate to correct path on tab selection', () => {
+    spyOn(router, 'navigate');
+    component.onSelected(component.Tabs.subsystems);
+    expect(component.selectedTab).toBe(component.Tabs.subsystems);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/subsystems']);
+  });
+
+  it('should navigate to gateways on selecting gateways tab', () => {
+    spyOn(router, 'navigate');
+    component.onSelected(component.Tabs.gateways);
+    expect(component.selectedTab).toBe(component.Tabs.gateways);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/gateways']);
+  });
+
+  it('should navigate to namespaces on selecting namespaces tab', () => {
+    spyOn(router, 'navigate');
+    component.onSelected(component.Tabs.namespaces);
+    expect(component.selectedTab).toBe(component.Tabs.namespaces);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/namespaces']);
+  });
+
+  it('should expose TABS enum via Tabs getter', () => {
+    const tabs = component.Tabs;
+    expect(tabs.gateways).toBe('gateways');
+    expect(tabs.subsystems).toBe('subsystems');
+    expect(tabs.namespaces).toBe('namespaces');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
@@ -1,8 +1,37 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+
+const NVMEOF_PATH = 'block/nvmeof';
+
+enum TABS {
+  gateways = 'gateways',
+  subsystems = 'subsystems',
+  namespaces = 'namespaces'
+}
 
 @Component({
   selector: 'cd-nvmeof-tabs',
   templateUrl: './nvmeof-tabs.component.html',
-  styleUrls: ['./nvmeof-tabs.component.scss']
+  styleUrls: ['./nvmeof-tabs.component.scss'],
+  standalone: false
 })
-export class NvmeofTabsComponent {}
+export class NvmeofTabsComponent implements OnInit {
+  selectedTab: TABS;
+  activeTab: TABS = TABS.gateways;
+
+  constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    const currentPath = this.router.url;
+    this.activeTab = Object.values(TABS).find((tab) => currentPath.includes(tab)) || TABS.gateways;
+  }
+
+  onSelected(tab: TABS) {
+    this.selectedTab = tab;
+    this.router.navigate([`${NVMEOF_PATH}/${tab}`]);
+  }
+
+  public get Tabs(): typeof TABS {
+    return TABS;
+  }
+}


### PR DESCRIPTION
Fixes:  https://tracker.ceph.com/issues/75288

Signed-off-by: pujaoshahu <pshahu@redhat.com>
(cherry picked from commit 69a7c6bf151a1e1d256b15c4dd1e5c590145005e)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
