### PR TITLE
squid: doc/monitoring: Remove section that does not apply to Squid in index.rst

### DIFF
--- a/doc/monitoring/index.rst
+++ b/doc/monitoring/index.rst
@@ -70,35 +70,6 @@ most important cluster and service metrics.  Many of the examples in this docume
 are taken from Dashboard graphics or extrapolated from metrics exposed by the
 Ceph Dashboard.
 
-Ceph daemon health metrics
-==========================
-
-The ``ceph_exporter`` provides a metric named ``ceph_daemon_socket_up`` that
-indicates the health status of a Ceph daemon based on its ability to respond
-via the admin socket, where a value of ``1`` means healthy, and ``0`` means
-unhealthy. Although a Ceph daemon might still be "alive" when it
-reports ``ceph_daemon_socket_up=0``, this status indicates a significant issue
-in its functionality. As such, this metric serves as an excellent means of
-detecting problems in any of the main Ceph daemons.
-
-The ``ceph_daemon_socket_up`` Prometheus metrics also have labels as described below:
-* ``ceph_daemon``: Identifier of the Ceph daemon exposing an admin socket on the host.
-* ``hostname``: Name of the host where the Ceph daemon is running.
-
-Example:
-
-.. code-block:: bash
-
-   ceph_daemon_socket_up{ceph_daemon="mds.a",hostname="testhost"} 1
-   ceph_daemon_socket_up{ceph_daemon="osd.1",hostname="testhost"} 0
-
-To identify any Ceph daemons that were not responsive at any point in the last
-12 hours, you can use the following PromQL expression:
-
-.. code-block:: bash
-
-   ceph_daemon_socket_up == 0 or min_over_time(ceph_daemon_socket_up[12h]) == 0
-
 Performance metrics
 ===================
 


### PR DESCRIPTION
This PR reverts a documentation change in Squid for code that has not been backported to Squid.  
The change being reverted was introduced to Squid in a larger rewrite of the `doc/monitoring/index.rst` file in 5f57b8eb30d1051d49a55510fcd7dc7f39af863e .

The section being removed was introduced to main in 3c9b07eb87e67027e9988c1587c07e27ed168657 which added also the code in file `src/exporter/DaemonMetricCollector.cc`. A backport for this change has not been completed (but the issue for backport *does* exist) as per [Tracker](https://tracker.ceph.com/issues/71333) and nothing relevant could be found in GH.

Additionally, inspecting `DaemonMetricCollector.cc` as of current `squid` branch [does not show](https://github.com/ceph/ceph/blob/squid/src/exporter/DaemonMetricCollector.cc#L222) the code that `main` [has](https://github.com/ceph/ceph/blob/main/src/exporter/DaemonMetricCollector.cc#L263) `add_metric(..., "ceph_daemon_socket_up", ...)` which this section documents.

So, remove this section.

Preparation for backporting later changes for this file.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
