### PR TITLE
mgr/dashboard : add stretch cluster validation for pools form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -15,6 +15,11 @@
         class="form-header"
       >
         {{ action | titlecase }} {{ resource | upperFirst }}
+      @if (isStretchMode) {
+      <cd-help-text>
+        Stretch cluster is enabled. Only replicated pool type is supported in Stretch mode.
+      </cd-help-text>
+      }
       </div>
       <!-- Name -->
       <div
@@ -93,6 +98,32 @@
           >
             Pool type
           </legend>
+          @if (isStretchMode) {
+          <cds-tooltip
+            description="In stretch mode, only replicated pool type is supported."
+            placement="right"
+            [highContrast]="true"
+            [caret]="true"
+          >
+            <cds-radio-group
+              formControlName="poolType"
+              cdRequiredField="Pool type"
+              data-testid="pool-type-select"
+            >
+              @for (poolType of data.poolTypes; track poolType) {
+              <cds-radio
+                [value]="poolType"
+                [id]="poolType"
+                [disabled]="isStretchMode && !editing && poolType === 'erasure'"
+                (change)="data.erasureInfo = false; data.crushInfo = false;"
+                i18n
+              >
+                {{ poolType | upperFirst }}
+              </cds-radio>
+              }
+            </cds-radio-group>
+          </cds-tooltip>
+          } @else {
           <cds-radio-group
             formControlName="poolType"
             cdRequiredField="Pool type"
@@ -102,6 +133,7 @@
             <cds-radio
               [value]="poolType"
               [id]="poolType"
+              [disabled]="isStretchMode && !editing && poolType === 'erasure'"
               (change)="data.erasureInfo = false; data.crushInfo = false;"
               i18n
             >
@@ -109,6 +141,7 @@
             </cds-radio>
             }
           </cds-radio-group>
+          }
           @if (form.showError('poolType', formDir, 'required')) {
           <span
             class="cds--form-requirement invalid-feedback"
@@ -262,6 +295,11 @@
               }
             </ng-template>
             <ng-template #sizeWarning>
+              @if (isStretchMode) {
+              <span i18n>
+                The replicated size value is predefined for stretch cluster
+              </span>
+              }
               @if (form.getValue('size') === 1) {
               <span
                 class="text-warning-dark"
@@ -621,10 +659,14 @@
             [columnNumbers]="{ lg: 13 }"
           >
             <cds-select
+              cdValidate
+              #crushRuleRef="cdValidate"
               formControlName="crushRule"
               label="Crush ruleset"
               i18n-label
               id="crushRule"
+              [invalid]="crushRuleRef.isInvalid"
+              [invalidText]="crushRuleError"
             >
               <option [value]="null"
                       i18n>-- Select a crush rule --
@@ -635,6 +677,16 @@
               </option>
               }
             </cds-select>
+            <ng-template #crushRuleError>
+              @if (form.showError('crushRule', formDir, 'required')) {
+              <span
+                class="invalid-feedback"
+                i18n
+              >
+                This field is required!
+              </span>
+              }
+            </ng-template>
           </div>
           } @else {
           <div cdsCol>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -38,6 +38,7 @@ import { Pool } from '../pool';
 import { PoolFormData } from './pool-form-data';
 import { PoolEditModeResponseModel } from '../../block/mirroring/pool-edit-mode-modal/pool-edit-mode-response.model';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { MonitorService } from '~/app/shared/api/monitor.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 
 interface FormFieldDescription {
@@ -47,6 +48,12 @@ interface FormFieldDescription {
   replaceFn?: Function;
   editable?: boolean;
   resetValue?: any;
+}
+
+interface MonitorResponse {
+  mon_status?: {
+    stretch_mode?: boolean;
+  };
 }
 
 @Component({
@@ -95,6 +102,12 @@ export class PoolFormComponent extends CdForm implements OnInit {
   DEFAULT_RATIO = 0.875;
   isApplicationsSelected = true;
   msrCrush: boolean = false;
+  isStretchMode: boolean = false;
+
+  readonly DEFAULT_REPLICATED_MIN_SIZE = 1;
+  readonly DEFAULT_REPLICATED_MAX_SIZE = 3;
+  readonly STRETCH_REPLICATED_MIN_SIZE = 2;
+  readonly STRETCH_REPLICATED_MAX_SIZE = 4;
 
   private modalSubscription: Subscription;
 
@@ -111,6 +124,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
     private crushRuleService: CrushRuleService,
     public actionLabels: ActionLabelsI18n,
     private rbdMirroringService: RbdMirroringService,
+    private monitorService: MonitorService,
     private cdr: ChangeDetectorRef
   ) {
     super();
@@ -205,6 +219,13 @@ export class PoolFormComponent extends CdForm implements OnInit {
   }
 
   ngOnInit() {
+    this.monitorService.getMonitor().subscribe((data: MonitorResponse) => {
+      this.isStretchMode = data?.mon_status?.stretch_mode || false;
+      if (this.isStretchMode) {
+        this.applyStretchModeRestrictions();
+      }
+      this.replicatedRuleChange();
+    });
     this.poolService.getInfo().subscribe((info: PoolFormInfo) => {
       this.initInfo(info);
       if (this.editing) {
@@ -459,7 +480,29 @@ export class PoolFormComponent extends CdForm implements OnInit {
       this.setListControlStatus('crushRule', rules);
     }
     this.replicatedRuleChange();
+    if (this.isStretchMode) {
+      this.applyStretchModeRestrictions();
+    }
     this.pgCalc();
+  }
+
+  private applyStretchModeRestrictions() {
+    if (!this.editing && this.form.getValue('poolType') === 'erasure') {
+      this.form.silentSet('poolType', 'replicated');
+      this.poolTypeChange('replicated');
+      return;
+    }
+    if (this.editing) {
+      return;
+    }
+    const sizeControl = this.form.get('size');
+    if (this.isStretchMode) {
+      if (sizeControl.enabled) {
+        sizeControl.disable({ emitEvent: false });
+      }
+    } else if (sizeControl.disabled) {
+      sizeControl.enable({ emitEvent: false });
+    }
   }
 
   private setTypeBooleans(replicated: boolean, erasure: boolean) {
@@ -472,7 +515,9 @@ export class PoolFormComponent extends CdForm implements OnInit {
       return;
     }
     const control = this.form.get('size');
-    let size = this.form.getValue('size') || 3;
+    let size =
+      this.form.getValue('size') ||
+      (this.isStretchMode ? this.STRETCH_REPLICATED_MAX_SIZE : this.DEFAULT_REPLICATED_MAX_SIZE);
     const min = this.getMinSize();
     const max = this.getMaxSize();
     if (size < min) {
@@ -489,7 +534,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
     if (!this.info || this.info.osd_count < 1) {
       return 0;
     }
-    return 1;
+    return this.isStretchMode ? this.STRETCH_REPLICATED_MIN_SIZE : this.DEFAULT_REPLICATED_MIN_SIZE;
   }
 
   getMaxSize(): number {
@@ -497,10 +542,9 @@ export class PoolFormComponent extends CdForm implements OnInit {
     if (!this.info) {
       return 0;
     }
+    if (this.isStretchMode) return this.STRETCH_REPLICATED_MAX_SIZE;
     if (!rule) {
-      const osds = this.info.osd_count;
-      const defaultSize = 3;
-      return Math.min(osds, defaultSize);
+      return Math.min(this.info.osd_count, this.DEFAULT_REPLICATED_MAX_SIZE);
     }
     return rule.usable_size;
   }


### PR DESCRIPTION
fixes : https://tracker.ceph.com/issues/75667
Signed-off-by: Abhishek Desai <abhishek.desai1@ibm.com>




normal cluster : 

min : 1
max: 3 



<img width="1794" height="344" alt="image" src="https://github.com/user-attachments/assets/78d880c7-bb4d-42aa-9ed5-2837d355103c" />



Streched cluster : 

min : 2 
max: 4 
<img width="1794" height="344" alt="image" src="https://github.com/user-attachments/assets/55237e8b-0677-4098-aff9-7804c681cfc0" />


<img width="3338" height="1308" alt="image" src="https://github.com/user-attachments/assets/b2a8d449-cee7-41e2-adba-2ce98d2ca769" />

<img width="2050" height="2006" alt="image" src="https://github.com/user-attachments/assets/bb264958-98ea-4f01-a1e8-aa3159d52cf1" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
