### PR TITLE
mgr/dashboard: remove notification area css

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
@@ -1,6 +1,4 @@
-<div
-  [ngClass]="{'empty-body': todayNotifications.length === 0 && previousNotifications.length === 0}"
-  class="notification-area">
+<div [ngClass]="{'empty-body': todayNotifications.length === 0 && previousNotifications.length === 0}">
 @if (executingTasks.length > 0) {
 <div
   class="notification-section-heading"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
@@ -1,4 +1,3 @@
-@use './src/styles/defaults' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/type';
@@ -120,11 +119,6 @@
   border-bottom: 1px solid $border-subtle-01;
 }
 
-.notification-area {
-  display: block;
-  height: 100%;
-  background-color: $layer-01;
-}
 
 .empty-body {
   max-block-size: var(--panel-height);


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

## Summary

Removes obsolete notification area CSS left behind in the dashboard frontend.

This drops the unused `notification-area` wrapper class from the template and removes the matching dead SCSS rule and unused import from the notification area stylesheet. The functional behavior of the notification panel is unchanged.

Fixes: https://tracker.ceph.com/issues/74256
