### PR TITLE
mds: Fix deadlock in file_blockdiff

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14692,7 +14692,11 @@ void MDCache::file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, ui
   }
 
   C_ListSnapsAggregator *on_finish = new C_ListSnapsAggregator(mds, in1, in2, block_diff, ctx);
-  MDSGatherBuilder gather_ctx(g_ceph_context, on_finish);
+  // Defer the MDSIOContext finisher to mds->finisher so gather activate() does
+  // not call MDSIOContext::complete() inline while mds_lock is held.
+  // See https://tracker.ceph.com/issues/75676
+  C_GatherBuilder gather_ctx(g_ceph_context,
+			     new C_OnFinisher(on_finish, mds->finisher));
 
   while (scans > 0) {
     ObjectOperation op;


### PR DESCRIPTION
The MDCache::file_blockdiff can deadlock
itself with the mds_lock.

The MDSDaemon::ms_dispatch2 takes the mds_lock
and MDCache::file_blockdiff tries to acquire
same lock while finishing it's context synchronously
at gather_ctx.activate()

The fix is to call finish() directly in synchronous case and
use a noop gather finisher only to tear down the gather.

Following is the traceback

```
-----------------------------
(gdb) bt
0  0x0000ffff7da4656c in __futex_abstimed_wait_cancelable64 () from /lib64/libc.so.6 
1  0x0000ffff7da48ff0 [PAC] in pthread_cond_wait@@GLIBC_2.17 () from /lib64/libc.so.6 
2  0x0000ffff7efe0380 [PAC] in ceph::condition_variable_debug::wait (this=this@entry=0xaaaace348018, lock=...) at /lsandbox/upstream/ceph/src/common/mutex_debug.h:153 
3  0x0000aaaaaf698b70 in ceph::condition_variable_debug::wait<ceph::fair_mutex::lock()::{lambda()#1}>(std::unique_lock<ceph::mutex_debug_detail::mutex_debug_impl<false> >&, ceph::fair_mutex::lock()::{lambda()#1}) (
   this=0xaaaace348018, lock=..., pred=...) at /lsandbox/upstream/ceph/src/common/condition_variable_debug.h:34
4  ceph::fair_mutex::lock (this=this@entry=0xaaaace348010) at /lsandbox/upstream/ceph/src/common/fair_mutex.h:28 5  0x0000aaaaaf9d71a0 in std::lock_guard<ceph::fair_mutex>::lock_guard (this=0xffff786cb760, __m=...) at /usr/include/c++/14/bits/std_mutex.h:250
 6  MDSIOContextBase::complete (this=0xaaaadd1f3800, r=0) at /lsandbox/upstream/ceph/src/mds/MDSContext.cc:102 
7  0x0000aaaaaf6f00a0 in C_GatherBase<MDSContext, C_MDSInternalNoop>::delete_me (this=this@entry=0xaaaadd167450) at /lsandbox/upstream/ceph/src/include/Context.h:351 
8  0x0000aaaaaf6f0114 in C_GatherBase<MDSContext, C_MDSInternalNoop>::activate (this=0xaaaadd167450) at /lsandbox/upstream/ceph/src/include/Context.h:401 
9  0x0000aaaaaf6f016c in C_GatherBuilderBase<MDSContext, C_GatherBase<MDSContext, C_MDSInternalNoop> >::activate (this=this@entry=0xffff786cb898) at /lsandbox/upstream/ceph/src/include/Context.h:490 
10 0x0000aaaaaf83ac5c in MDCache::file_blockdiff (this=0xaaaace3f4000, in1=in1@entry=0xaaaadcc12680, in2=in2@entry=0xaaaad386cc00, block_diff=block_diff@entry=0xaaaadf0b0a30, max_objects=<optimized out>,
   max_objects@entry=16, ctx=ctx@entry=0xaaaadf0b0a10) at /lsandbox/upstream/ceph/src/mds/MDCache.cc:14933
11 0x0000aaaaaf78afa0 in Server::handle_client_file_blockdiff (this=this@entry=0xaaaad30f9d40, mdr=...) at /lsandbox/upstream/ceph/src/mds/Server.cc:12619 
12 0x0000aaaaaf79ed08 in Server::dispatch_client_request (this=this@entry=0xaaaad30f9d40, mdr=...) at /lsandbox/upstream/ceph/src/mds/Server.cc:2942 
13 0x0000aaaaaf79fbc4 in Server::handle_client_request (this=this@entry=0xaaaad30f9d40, req=...) at /lsandbox/upstream/ceph/src/mds/Server.cc:2713
 14 0x0000aaaaaf7a2d60 in Server::dispatch (this=0xaaaad30f9d40, m=...) at /lsandbox/upstream/ceph/src/mds/Server.cc:403 
15 0x0000aaaaaf6b4674 in MDSRank::handle_message (this=this@entry=0xaaaace374008, m=...) at /lsandbox/upstream/ceph/src/mds/MDSRank.cc:1252
 16 0x0000aaaaaf6b6548 in MDSRank::_dispatch (this=this@entry=0xaaaace374008, m=..., new_msg=new_msg@entry=true) at /lsandbox/upstream/ceph/src/mds/MDSRank.cc:1075 
17 0x0000aaaaaf6b6e6c in MDSRankDispatcher::ms_dispatch (this=this@entry=0xaaaace374000, m=...) at /lsandbox/upstream/ceph/src/mds/MDSRank.cc:1049 
18 0x0000aaaaaf6a44f4 in MDSDaemon::ms_dispatch2 (this=0xaaaace348000, m=...) at /lsandbox/upstream/ceph/src/common/RefCountedObj.h:57 
19 0x0000ffff7f089a88 in Messenger::ms_deliver_dispatch (this=0xaaaad30b8000, m=...) at /lsandbox/upstream/ceph/src/msg/Messenger.h:748 
20 0x0000ffff7f0860b8 in DispatchQueue::entry (this=0xaaaad30b83d8) at /lsandbox/upstream/ceph/src/msg/DispatchQueue.cc:203 
21 0x0000ffff7f1411c0 in DispatchQueue::DispatchThread::entry (this=<optimized out>) at /lsandbox/upstream/ceph/src/msg/DispatchQueue.h:102
 22 0x0000ffff7ef211b8 in Thread::entry_wrapper (this=0xaaaad30b8540) at /lsandbox/upstream/ceph/src/common/Thread.cc:88
 23 0x0000ffff7ef211d8 in Thread::_entry_func (arg=<optimized out>) at /lsandbox/upstream/ceph/src/common/Thread.cc:75 
24 0x0000ffff7da49b68 in start_thread () from /lib64/libc.so.6 25 0x0000ffff7dab350c [PAC] in thread_start () from /lib64/libc.so.6 ---------------
```

Check the tracker for more details

Fixes: https://tracker.ceph.com/issues/75676





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
