### PR TITLE
rados: deprecate ceph osd pool set threshold

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -290,6 +290,9 @@
   to upgrade all OSDs in the cluster. For more details see tracker:
   https://tracker.ceph.com/issues/73031.
 
+* RADOS: The `ceph osd pool set threshold` command is deprecated in favor of the
+  `ceph config set mgr mgr/pg_autoscaler/threshold` command.
+
 >=19.2.1
 
 * CephFS: The `fs subvolume create` command now allows tagging subvolumes through option

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -165,6 +165,12 @@ The output will resemble the following::
 
      ceph osd pool set threshold 2.0
 
+  .. note::
+
+     The ``ceph osd pool set threshold <val>`` command is deprecated and will be removed in a future release.
+     Use ``ceph config set mgr mgr/pg_autoscaler/threshold <val>`` instead.
+
+
   To get the current ``threshold`` value, run the following command:
 
   .. prompt:: bash #

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -249,7 +249,14 @@ class PgAutoscaler(MgrModule):
         if num < 1.0:
             return 22, "", "threshold cannot be set less than 1.0"
         self.set_module_option("threshold", num)
-        return 0, "threshold updated", ""
+
+        self.log.warning(f"'ceph osd pool set threshold {num}' is deprecated, "
+                         f"use 'ceph config set mgr mgr/pg_autoscaler/threshold {num}' instead")
+        return 0, "threshold updated", (
+                  f"Deprecation warning: 'ceph osd pool set threshold {num}' is deprecated "
+                  "and will be removed in a future release. "
+                  f"Use 'ceph config set mgr mgr/pg_autoscaler/threshold {num}' instead."
+        ) 
 
     @PGAutoscalerCLICommand.Read("osd pool get threshold")
     def get_scaling_threshold(self) -> Tuple[int, str, str]:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75631

```console
# ./bin/ceph -c ./ceph.conf -k ./keyring config get mgr mgr/pg_autoscaler/threshold
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
3.000000


# ./bin/ceph -c ./ceph.conf -k ./keyring osd pool set threshold 2.0
Warning: 'ceph osd pool set threshold 2.0' is deprecated and will be removed in a future release. .
Please use 'ceph config set mgr mgr/pg_autoscaler/threshold 2.0' instead.
threshold updated.


# ./bin/ceph -c ./ceph.conf -k ./keyring config get mgr mgr/pg_autoscaler/threshold
2.000000
```