### PR TITLE
Mon: Prevent pool creation if it will exceed mon_max_pg_per_osd

### DIFF
--- a/qa/suites/rados/singleton/all/pg-autoscaler-exceed-mon-max-pg-create.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler-exceed-mon-max-pg-create.yaml
@@ -1,0 +1,41 @@
+roles:
+- - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - osd.4
+  - osd.5
+  - client.0
+openstack:
+  - volumes: # attached to each instance
+      count: 4
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    create_rbd_pool: false
+    conf:
+      global:
+        mon_max_pg_per_osd: 75
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - \(TOO_MANY_PGS\) 
+      - slow request
+      - \(POOL_APP_NOT_ENABLED\)
+- workunit:
+    clients:
+      all:
+        - mon/pg_autoscaler_exceed_mon_max_pg_create.sh

--- a/qa/suites/rados/singleton/all/pg-autoscaler-exceed-mon-max-pg-size.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler-exceed-mon-max-pg-size.yaml
@@ -1,0 +1,40 @@
+roles:
+- - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - osd.4
+  - osd.5
+  - client.0
+openstack:
+  - volumes: # attached to each instance
+      count: 4
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    create_rbd_pool: false
+    conf:
+      global:
+        mon_max_pg_per_osd: 85
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - slow request
+      - \(POOL_APP_NOT_ENABLED\)
+- workunit:
+    clients:
+      all:
+        - mon/pg_autoscaler_exceed_mon_max_pg_size.sh

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 NUM_OSDS=$(ceph osd ls | wc -l)
-if [ $NUM_OSDS -lt 6 ]; then
+if [ $NUM_OSDS -lt ]; then
     echo "test requires at least 6 OSDs"
     exit 1
 fi
@@ -341,8 +341,11 @@ EOF
     # -6  pg_target = 100
     # -7: pg_target = 100
 
-    TARGET_PG_1=$(power2_floor $MON_TARGET_PG_PER_OSD)
-    TARGET_PG_2=$(power2_floor $(( ($NUM_OSDS - 3) * $MON_TARGET_PG_PER_OSD )))
+    POOL_SIZE_1=$(ceph osd pool get data0 size| grep -Eo '[0-9]{1,4}')
+    POOL_SIZE_2=$(ceph osd pool get data3 size| grep -Eo '[0-9]{1,4}')
+
+    TARGET_PG_1=$(power2_floor $(( $MON_TARGET_PG_PER_OSD / $POOL_SIZE_1 )))
+    TARGET_PG_2=$(power2_floor $(( ($NUM_OSDS - 3) * $MON_TARGET_PG_PER_OSD / $POOL_SIZE_2 )))
 
 
     wait_for 300 "ceph osd pool get data0 pg_num | grep $TARGET_PG_1"
@@ -365,7 +368,7 @@ ceph osd pool set threshold 1.0
 test_autoscaler_basic || return 1
 test_pool_starvation || return 1
 test_exact_budget || return 1
-test_overlapping_roots || exit 1
+test_overlapping_roots || return 1
 
 echo OK
 

--- a/qa/workunits/mon/pg_autoscaler_exceed_mon_max_pg_create.sh
+++ b/qa/workunits/mon/pg_autoscaler_exceed_mon_max_pg_create.sh
@@ -1,0 +1,75 @@
+#!/bin/bash -ex
+
+NUM_OSDS=$(ceph osd ls | wc -l)
+if [ $NUM_OSDS -ne 6 ]; then
+    echo "test requires 6 OSDs"
+    exit 1
+fi
+
+NUM_POOLS=$(ceph osd pool ls | wc -l)
+if [ $NUM_POOLS -gt 0 ]; then
+    echo "test requires no preexisting pools"
+    exit 1
+fi
+
+function wait_for() {
+    local sec=$1
+    local cmd=$2
+
+    while true ; do
+        if bash -c "$cmd" ; then
+            break
+        fi
+        sec=$(( $sec - 1 ))
+        if [ $sec -eq 0 ]; then
+            echo failed
+            return 1
+        fi
+        sleep 1
+    done
+    return 0
+}
+
+function power2_floor() { echo "x=l($1)/l(2); scale=0; 2^(x/1)" | bc -l;}
+
+function power2_ceil() { echo "x=l($1)/l(2); scale=0; 2^((x+0.999)/1)" | bc -l; }
+
+function eval_actual_expected_val() {
+    local actual_value=$1
+    local expected_value=$2
+    if [[ $actual_value = $expected_value ]]
+    then
+     echo "Success: " $actual_value "=" $expected_value
+    else
+      echo "Error: " $actual_value "!=" $expected_value
+      exit 1
+    fi
+}
+
+# enable
+ceph config set mgr mgr/pg_autoscaler/sleep_interval 60
+ceph mgr module enable pg_autoscaler
+ceph osd pool set threshold 1.0
+
+# Don't create pool if exceeding mon_max_pg_per_osd ceiling
+MON_TARGET_PG_PER_OSD=70
+ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+ceph osd pool create bulk0 --bulk --size=3 --autoscale_mode=on
+ceph osd pool create bulk1 --bulk --size=3 --autoscale_mode=on
+
+sleep 60
+
+if ! ceph osd pool create data1 --size=3 --autoscale_mode=on 2>&1 | grep -q "Error ERANGE"; then
+    echo "failed"
+    exit 1
+fi
+
+if ceph osd pool create data1 --size=3 --autoscale_mode=on --force-pg-limit 2>&1 | grep -q "Error ERANGE"; then
+    echo "failed"
+    exit 1
+fi
+
+ceph osd pool rm bulk0 bulk0 --yes-i-really-really-mean-it
+ceph osd pool rm bulk1 bulk1 --yes-i-really-really-mean-it
+
+echo OK

--- a/qa/workunits/mon/pg_autoscaler_exceed_mon_max_pg_size.sh
+++ b/qa/workunits/mon/pg_autoscaler_exceed_mon_max_pg_size.sh
@@ -1,0 +1,74 @@
+#!/bin/bash -ex
+
+NUM_OSDS=$(ceph osd ls | wc -l)
+if [ $NUM_OSDS -ne 6 ]; then
+    echo "test requires 6 OSDs"
+    exit 1
+fi
+
+NUM_POOLS=$(ceph osd pool ls | wc -l)
+if [ $NUM_POOLS -gt 0 ]; then
+    echo "test requires no preexisting pools"
+    exit 1
+fi
+
+function wait_for() {
+    local sec=$1
+    local cmd=$2
+
+    while true ; do
+        if bash -c "$cmd" ; then
+            break
+        fi
+        sec=$(( $sec - 1 ))
+        if [ $sec -eq 0 ]; then
+            echo failed
+            return 1
+        fi
+        sleep 1
+    done
+    return 0
+}
+
+function power2_floor() { echo "x=l($1)/l(2); scale=0; 2^(x/1)" | bc -l;}
+
+function power2_ceil() { echo "x=l($1)/l(2); scale=0; 2^((x+0.999)/1)" | bc -l; }
+
+function eval_actual_expected_val() {
+    local actual_value=$1
+    local expected_value=$2
+    if [[ $actual_value = $expected_value ]]
+    then
+     echo "Success: " $actual_value "=" $expected_value
+    else
+      echo "Error: " $actual_value "!=" $expected_value
+      exit 1
+    fi
+}
+
+# enable
+ceph config set mgr mgr/pg_autoscaler/sleep_interval 60
+ceph mgr module enable pg_autoscaler
+ceph osd pool set threshold 1.0
+
+# Don't increase pool size if exceeding mon_max_pg_per_osd ceiling
+MON_TARGET_PG_PER_OSD=80
+ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+ceph osd pool create bulk0 --bulk --size=3 --autoscale_mode=on
+ceph osd pool create bulk1 --bulk --size=3 --autoscale_mode=on
+ceph osd pool set threshold 1.0
+
+sleep 60
+ceph osd pool create data1 --size=3 --autoscale_mode=on
+if ! ceph osd pool set data1 size 4 2>&1 | grep -q "Error ERANGE"; then
+    echo "failed"
+    exit 1
+fi
+
+ceph osd pool rm bulk0 bulk0 --yes-i-really-really-mean-it
+ceph osd pool rm bulk1 bulk1 --yes-i-really-really-mean-it
+ceph osd pool rm data1 data1 --yes-i-really-really-mean-it
+
+
+echo OK
+

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1145,6 +1145,7 @@ COMMAND("osd pool create "
 	"name=bulk,type=CephBool,req=false "
 	"name=target_size_bytes,type=CephInt,range=0,req=false "
 	"name=target_size_ratio,type=CephFloat,range=0.0,req=false "\
+	"name=force_pg_limit,type=CephBool,req=false"
 	"name=yes_i_really_mean_it,type=CephBool,req=false"
 	"name=crimson,type=CephBool,req=false",
 	"create pool", "osd", "rw")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7625,12 +7625,14 @@ int OSDMonitor::prepare_new_pool(MonOpRequestRef op)
   stringstream ss;
   string rule_name;
   bool bulk = false;
+  bool force_create = false;
   int ret = 0;
   ret = prepare_new_pool(m->name, m->crush_rule, rule_name,
 			 0, 0, 0, 0, 0, 0, 0.0,
 			 erasure_code_profile,
 			 pg_pool_t::TYPE_REPLICATED, 0, FAST_READ_OFF, {}, bulk,
 			 cct->_conf.get_val<bool>("osd_pool_default_crimson"),
+       force_create,
 			 &ss);
 
   if (ret < 0) {
@@ -8230,7 +8232,16 @@ int OSDMonitor::check_pg_num(int64_t pool,
   // assume min cluster size 3
   osd_num_by_crush = std::max(osd_num_by_crush, 3u);
   auto projected_pgs_per_osd = projected / osd_num_by_crush;
-
+  uint64_t pg_limit = max_pgs_per_osd * osd_num_by_crush;
+  if (projected > pg_limit) {
+      *ss << " pg_num " << pg_num
+      << " size " << size
+      << " for this pool would result in "
+      << projected
+      << " cumulative PGs which exceeds the limit of "
+      << "value of " << max_pgs_per_osd;
+    return -ERANGE;
+  }
   if (projected_pgs_per_osd > max_pgs_per_osd) {
     if (pool >= 0) {
       *ss << "pool id " << pool;
@@ -8285,6 +8296,7 @@ int OSDMonitor::prepare_new_pool(string& name,
 				 string pg_autoscale_mode,
 				 bool bulk,
 				 bool crimson,
+         bool force_create,
 				 ostream *ss)
 {
   if (crimson && pg_autoscale_mode.empty()) {
@@ -8298,15 +8310,7 @@ int OSDMonitor::prepare_new_pool(string& name,
     return -EINVAL;
 
   if (pg_num == 0) {
-    auto pg_num_from_mode =
-      [pg_num=g_conf().get_val<uint64_t>("osd_pool_default_pg_num")]
-      (const string& mode) {
-      return mode == "on" ? 1 : pg_num;
-    };
-    pg_num = pg_num_from_mode(
-      pg_autoscale_mode.empty() ?
-      g_conf().get_val<string>("osd_pool_default_pg_autoscale_mode") :
-      pg_autoscale_mode);
+    pg_num = g_conf().get_val<uint64_t>("osd_pool_default_pg_num");
   }
   if (pgp_num == 0)
     pgp_num = g_conf().get_val<uint64_t>("osd_pool_default_pgp_num");
@@ -8379,7 +8383,7 @@ int OSDMonitor::prepare_new_pool(string& name,
              << duration << dendl;
   }
   r = check_pg_num(-1, pg_num, size, crush_rule, ss);
-  if (r) {
+  if (r && !force_create) {
     dout(10) << "check_pg_num returns " << r << dendl;
     return r;
   }
@@ -8395,7 +8399,6 @@ int OSDMonitor::prepare_new_pool(string& name,
     dout(10) << "prepare_pool_stripe_width returns " << r << dendl;
     return r;
   }
-  
   bool fread = false;
   if (pool_type == pg_pool_t::TYPE_ERASURE) {
     switch (fast_read) {
@@ -14130,7 +14133,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     bool crimson = cmd_getval_or<bool>(cmdmap, "crimson", false) ||
       cct->_conf.get_val<bool>("osd_pool_default_crimson");
-
+    bool force_create = false;
+    cmd_getval(cmdmap, "force_pg_limit", force_create);
     err = prepare_new_pool(poolstr,
 			   -1, // default crush rule
 			   rule_name,
@@ -14142,6 +14146,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 			   pg_autoscale_mode,
 			   bulk,
 			   crimson,
+         force_create,
 			   &ss);
     if (err < 0) {
       switch(err) {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -549,6 +549,7 @@ private:
 		       std::string pg_autoscale_mode,
 		       bool bulk,
 		       bool crimson,
+           bool force_create,
 		       std::ostream *ss);
   int prepare_new_pool(MonOpRequestRef op);
 

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -23,8 +23,6 @@ Some terminology is made up for the purposes of this module:
 
 INTERVAL = 5
 
-PG_NUM_MIN = 32  # unless specified on a per-pool basis
-
 if TYPE_CHECKING:
     import sys
     if sys.version_info >= (3, 8):
@@ -191,6 +189,7 @@ class PgAutoscaler(MgrModule):
     NATIVE_OPTIONS = [
         'mon_target_pg_per_osd',
         'mon_max_pg_per_osd',
+        'osd_pool_default_pg_num'
     ]
 
     MODULE_OPTIONS = [
@@ -221,6 +220,7 @@ class PgAutoscaler(MgrModule):
             self.sleep_interval = 60
             self.mon_target_pg_per_osd = 0
             self.threshold = 3.0
+            self.osd_pool_default_pg_num = 32
 
     def config_notify(self) -> None:
         for opt in self.NATIVE_OPTIONS:
@@ -523,7 +523,7 @@ class PgAutoscaler(MgrModule):
         """
         for i, group in enumerate(pool_groups):
             for pool_name, p in group.pools.items():
-                min_pg = p.get('options', {}).get('pg_num_min', PG_NUM_MIN)
+                min_pg = p.get('options', {}).get('pg_num_min', self.osd_pool_default_pg_num)
                 max_pg = p.get('options', {}).get('pg_num_max')
                 pool_pg_target = int(group.pg_target_total / group.size())
                 final_pool_pg_target_total = backtrack[i].current_pg_sum - backtrack[i].prev_pg_sum + group.rd_down_total

--- a/src/pybind/mgr/pg_autoscaler/tests/test_calculate_final_pool_pg_target.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_calculate_final_pool_pg_target.py
@@ -23,7 +23,7 @@ class TestPgAutoscaler(object):
     def setup_method(self):
         # a bunch of attributes for testing.
         self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
-
+        self.autoscaler.osd_pool_default_pg_num = 32
     def create_group(self,
         pools: Dict[str, Any],
         root_map: Dict[int, RootMapItem],


### PR DESCRIPTION
Problem:

- If pools are already close to mon_max_pg_per_osd, creating a new pool with min_pg_num = 32 may push the total PG count over mon_max_pg_per_osd, resulting in HEALTH_WARN: too many PGs per OSD. Same issue occurs if we increase a pool's replication size.

Solution:
- Add checks for if the total PG count after creating a new pool or increasing replication size would cause the maximum number of PGs to be exceeded. Stop the operation if so. Change newly created pool pg_num to always be osd_pool_default_pg_num instead of 1 when autoscale mode is on.

Fixes: https://tracker.ceph.com/issues/75423

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
