### PR TITLE
doc: document Ceph Release Manager role

### DIFF
--- a/doc/dev/crm.rst
+++ b/doc/dev/crm.rst
@@ -1,0 +1,161 @@
+=============================
+Ceph Release Manager
+=============================
+
+Purpose
+=======
+The Ceph Release Manager (CRM) coordinates the release lifecycle to ensure the
+predictability, stability, and quality of Ceph releases. The role serves as a
+centralized point of contact for release engineering, maintaining the
+consistency of stable branches, and overseeing the execution of quality
+assurance gates.
+
+Function
+========
+The core function of the CRM is to guide releases from the stabilization phase
+through to general availability. This involves:
+
+* **Release Gatekeeping:** Determining the readiness of release candidates based
+  on test results, upgrade coverage, and community feedback.
+* **Branch Management:** Enforcing strict merge discipline on stable branches to
+  prioritize release stability.
+* **Dependency Coordination:** Overseeing changes to build dependencies,
+  compiler features, and build tools on stable branches to prevent disruption
+  during stabilization periods.
+
+Responsibilities
+================
+
+Schedule and Cadence
+--------------------
+* Maintain and communicate a consistent release cadence for Major (X.2.z) and
+  Minor (x.2.Z) releases.
+* Define and manage merge windows to ensure code has adequate stabilization
+  time.
+
+Branch Discipline and Gatekeeping
+---------------------------------
+* **Main Branch Autonomy:** The CRM does not actively police or gate merges
+  into the ``main`` development branch.
+* **Single Release Branch Policy:** Maintain a single ``$release`` branch for
+  each stable version. Alternate branches will be made as necessary to issue
+  hotfixes and release candidates. The legacy staging branch
+  ``$release-release`` is no longer used to keep the release branch open for
+  merges. This is to enforce release discipline, maintain a stable release
+  branch, allow for regular upgrade testing from the release branch, and avoid
+  confusing the provenance of backports caused by cherry-picking to the release
+  staging branch.
+* **GitHub Branch Protections:** The CRM manages branch protection rules to
+  safeguard stability. End of Life (EOL) branches are marked read-only.
+  Living release branches utilize protection rules mirroring the ``main``
+  development branch. Furthermore, a specific "Release Branch Protection"
+  GitHub ruleset restricts direct modifications and merge privileges
+  exclusively to the Ceph Release Manager team. This prevents accidental
+  or unauthorized merges by component leads without CRM approval.
+* **Upstream-First Policy:** Enforce that bug fixes must be merged into the
+  ``main`` branch before being backported to a ``$release`` branch, barring
+  exceptional release-specific build or integration issues.
+
+Quality Assurance and Automation
+--------------------------------
+* **Upgrade Testing:** Ensure comprehensive upgrade test coverage exists and is
+  successfully executed to validate safe upgrade paths for end-users. Another
+  reason to freeze the branch is to have upgrade tests (for other branches)
+  QA'ing the actual code being planned to ship, not acting as a testing ground.
+* **Backport Automation:** Ensure that functional and reliable automations exist
+  for backporting changes to stable release branches.
+* **Release Tooling:** Maintain and improve the CI/CD automation related to the
+  release pipeline to reduce manual toil.
+
+Artifact Generation and Signing
+-------------------------------
+* **Build Pipeline:** The CRM initiates the generation of release artifacts
+  via the `ceph-release-pipeline
+  <https://jenkins.ceph.com/view/all/job/ceph-release-pipeline/build>`_
+  Jenkins job.
+* **Cryptographic Signing:** The CRM is responsible for establishing and
+  maintaining the process for the cryptographic signing of releases, whether
+  utilizing historical Ceph GPG keys or implementing modern signing methods.
+
+Security and Lifecycle Management
+---------------------------------
+* **CVE Coordination:** Act as the central coordinator for embargoed security
+  releases, ensuring that CVE patches are cleanly backported, tested, and
+  staged for coordinated public disclosure.
+* **End of Life (EOL) Management:** Manage the lifecycle of stable branches.
+  Ceph officially supports the two most recent major releases (N-2). Shortly
+  after a new major release is published, the CRM transitions the N-3 release
+  to EOL status by closing all open backport PRs, closing associated backport
+  tracker tickets, and freezing the branch.
+
+Communication and Visibility
+----------------------------
+* **Release Engineering Meeting:** Host an at-least weekly "Ceph Release
+  Engineering" call to facilitate upstream and community discussion regarding
+  upcoming releases and the release process.
+* **Release Notes:** Ensure effective, accurate, and comprehensive documentation
+  for releases, including modernized release notes and public mailing list
+  announcements.
+* **Tracker Management:** Maintain the issue tracker to clearly surface release
+  status and highlight "Blocker" issues.
+* **Blocker Definition:** A "Blocker" is strictly defined as a bug resulting
+  in data loss, data corruption, or an issue of similarly critical severity
+  that prevents safe deployment.
+
+Major Release Process
+=====================
+While minor releases follow a strict cadence, major releases follow a distinct,
+annual lifecycle. The ``main`` branch accumulates changes throughout the year,
+with a general target of a Spring release. 
+
+* **Distribution Matrix:** A critical gatekeeping duty of the CRM for major
+  releases is establishing and maintaining the matrix of supported
+  distributions (e.g., supported OS versions and architectures) for the
+  lifespan of that release.
+* **Release Kickoff:** Shortly after a major release is branched off of
+  ``main``, the CRM or a designated deputy executes the official release
+  kickoff process. See the `Major Release Kickoff Checklist
+  <http://LINK_TO_KICKOFF_DOC>`_ for detailed steps.
+* **Release Candidates:** The formalization of Release Candidates (RCs) for
+  major releases is currently deferred pending an upcoming overhaul of the
+  Ceph versioning schema.
+
+Minor Release Blueprint
+=======================
+The CRM orchestrates minor releases using a structured 8-week cycle. To ensure
+predictable delivery, the two actively supported ("live") releases are scheduled
+with non-overlapping merge windows. These merge windows may be offset or shifted
+as necessary in the event of minor release delays to maintain the staggered
+cadence.
+
+Release Tracker
+--------------
+The release cycle is initiated by creating an authoritative tracker ticket in the
+`Stable Releases tracker <https://tracker.ceph.com/projects/ceph-releases>`_
+to manage and document the work of the release.
+
+Phase 1: Merge Window (4 Weeks)
+-------------------------------
+* **Tagging:** Component leads or the CRM label open backport Pull Requests
+  (PRs) with the ``needs-qa`` label.
+* **Aggregation & QA:** The CRM (or a designated deputy) aggregates the tagged
+  PRs into testing suites for Quality Assurance execution.
+* **Review & Gatekeeping:** The CRM coordinates the review of QA results to
+  determine suitability for merging. The CRM actively gates PRs during this
+  phase to ensure branch stability is maintained before code is merged.
+
+Phase 2: QA and Stabilization (4 Weeks)
+---------------------------------------
+* **Validation:** Dedicated time allocated for extensive QA testing, regression
+  checks, and the validation required to push out the minor release.
+* **Silent Period:** Any unused time remaining in this 4-week allocation acts
+  as a "silent" stabilization period before the release is officially cut and
+  published.
+
+Out-of-Band (Hotfix) Releases
+=============================
+Critical vulnerabilities (e.g., zero-day CVEs) or severe regressions (e.g.,
+data loss bugs) may necessitate an out-of-band "hotfix" release. These
+releases bypass the standard 8-week minor release blueprint and are managed
+on an expedited timeline. All out-of-band releases must be strictly
+coordinated with the CRM.

--- a/doc/dev/development-workflow.rst
+++ b/doc/dev/development-workflow.rst
@@ -64,7 +64,7 @@ Stable (LTS) <../../releases>`_.  See `Understanding the release cycle
 Merging bug fixes or features
 =============================
 
-The development branch is ``master`` and the workflow followed by all
+The development branch is ``main`` and the workflow followed by all
 developers can be summarized as follows:
 
 * The developer prepares a series of commits
@@ -110,7 +110,7 @@ status of an open issue can be:
 
 For each ``Pending Backport`` issue, there exists at least one issue in the
 ``Backport`` tracker to record the work done to cherry pick the necessary
-commits from the master branch to the target stable branch. See `the backporter
+commits from the ``main`` branch to the target stable branch. See `the backporter
 manual
 <https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst>`_ for
 more information.
@@ -134,15 +134,15 @@ results are posted on `pulpito <http://pulpito.ceph.com/>`_ and the
 The ``quality engineer`` is either a developer or a member of the QE
 team. There is at least one integration test suite per project:
 
-* `rgw <https://github.com/ceph/ceph/tree/master/qa/suites/rgw>`_ suite
-* `CephFS <https://github.com/ceph/ceph/tree/master/qa/suites/fs>`_ suite
-* `rados <https://github.com/ceph/ceph/tree/master/qa/suites/rados>`_ suite
-* `rbd <https://github.com/ceph/ceph/tree/master/qa/suites/rbd>`_ suite
+* `rgw <https://github.com/ceph/ceph/tree/main/qa/suites/rgw>`_ suite
+* `CephFS <https://github.com/ceph/ceph/tree/main/qa/suites/fs>`_ suite
+* `rados <https://github.com/ceph/ceph/tree/main/qa/suites/rados>`_ suite
+* `rbd <https://github.com/ceph/ceph/tree/main/qa/suites/rbd>`_ suite
 
 and many others such as
 
-* `upgrade <https://github.com/ceph/ceph/tree/master/qa/suites/upgrade>`_ suites
-* `power-cyle <https://github.com/ceph/ceph/tree/master/qa/suites/powercycle>`_ suite
+* `upgrade <https://github.com/ceph/ceph/tree/main/qa/suites/upgrade>`_ suites
+* `power-cyle <https://github.com/ceph/ceph/tree/main/qa/suites/powercycle>`_ suite
 * ...
 
 Preparing a new release

--- a/doc/dev/development-workflow.rst
+++ b/doc/dev/development-workflow.rst
@@ -20,11 +20,11 @@ interference. In practice it is not necessary for Ceph because:
   to merge anything that may cause issues
 
 This ad-hoc approach implies the workflows are changed on a regular
-basis to adapt. For instance, ``quality engineers`` were not involved
+basis to adapt. For instance, **quality engineers** were not involved
 in the workflow to publish ``dumpling`` point releases. The number of
 commits being backported to ``firefly`` made it impractical for developers
 tasked to write code or fix bugs to also run and verify the full suite
-of integration tests. Inserting ``quality engineers`` makes it
+of integration tests. Inserting **quality engineers** makes it
 possible for someone to participate in the workflow by analyzing test
 results.
 
@@ -33,33 +33,6 @@ not make sense. For instance, if the release notes for a point release
 were not written prior to checking all integration tests, they can be
 committed to the stable branch and the result sent for publication
 without going through another run of integration tests.
-
-Release Cycle
-=============
-
-::
-
-    Ceph              hammer                             infernalis
-    Developer          CDS                                  CDS 
-    Summit              |                                    |
-                        |                                    |
-    development         |                                    |
-    release             |  v0.88  v0.89  v0.90   ...         |  v9.0.0
-                   --v--^----^--v---^------^--v-     ---v----^----^---  2015       
-                     |          |             |         |
-    stable         giant        |             |      hammer
-    release        v0.87        |             |      v0.94
-                                |             |          
-    point                    firefly       dumpling
-    release                  v0.80.8       v0.67.12
-
-
-Four times a year, the development roadmap is discussed online during
-the `Ceph Developer Summit <http://tracker.ceph.com/projects/ceph/wiki/Planning#Ceph-Developer-Summit>`_. A
-new stable release (hammer, infernalis, jewel ...) is published at the same
-frequency.  Every other release (firefly, hammer, jewel...) is a `Long Term
-Stable (LTS) <../../releases>`_.  See `Understanding the release cycle
-<../../releases#understanding-the-release-cycle>`_ for more information.
 
 Merging bug fixes or features
 =============================
@@ -131,7 +104,7 @@ results are posted on `pulpito <http://pulpito.ceph.com/>`_ and the
 * If the bug is known, a pulpito URL to the failed job is added to the issue
 * If the bug is new, an issue is created
 
-The ``quality engineer`` is either a developer or a member of the QE
+The **quality engineer** is either a developer or a member of the QE
 team. There is at least one integration test suite per project:
 
 * `rgw <https://github.com/ceph/ceph/tree/main/qa/suites/rgw>`_ suite
@@ -142,99 +115,31 @@ team. There is at least one integration test suite per project:
 and many others such as
 
 * `upgrade <https://github.com/ceph/ceph/tree/main/qa/suites/upgrade>`_ suites
-* `power-cyle <https://github.com/ceph/ceph/tree/main/qa/suites/powercycle>`_ suite
+* `powercycle <https://github.com/ceph/ceph/tree/main/qa/suites/powercycle>`_ suite
 * ...
 
-Preparing a new release
-=======================
+Preparing and Cutting a New Release
+===================================
 
-A release is prepared in a dedicated branch, different from the
-``master`` branch.
+The process for preparing and cutting new Ceph releases is orchestrated by the
+Ceph Release Manager (CRM). For a detailed breakdown of the release lifecycle,
+merge windows, and branch discipline, please see the `Ceph Release Manager
+(CRM) <../crm>`_ documentation.
 
-* For a stable releases it is the branch matching the release code
-  name (dumpling, firefly, etc.)
-* For a development release it is the ``next`` branch
+To see the exact steps taken to publish a release, including building, signing,
+and artifact generation, refer to the `Ceph Release Process
+<release-process>`_ and the `Release Checklists <release-checklists>`_.
 
-The workflow expected of all developers to stabilize the release
-candidate is the same as the normal development workflow with the
-following differences:
+The person responsible for the release process is:
 
-* The pull requests must target the stable branch or next instead of
-  master
-* The reviewer rejects pull requests that are not bug fixes
-* The ``Backport`` issues matching a teuthology test failure and set
-  with priority ``Urgent`` must be fixed before the release
-
-Cutting a new stable release
-============================
-
-A new stable release can be cut when:
-
-* all ``Backport`` issues with priority ``Urgent`` are fixed
-* integration and upgrade tests run successfully
-
-Publishing a new stable release implies a risk of regression or
-discovering new bugs during the upgrade, no matter how carefully it is
-tested. The decision to cut a release must take this into account: it
-may not be wise to publish a stable release that only fixes a few
-minor bugs. For instance if only one commit has been backported to a
-stable release that is not a LTS, it is better to wait until there are
-more.
-
-When a stable release is to be retired, it may be safer to
-recommend an upgrade to the next LTS release instead of
-proposing a new point release to fix a problem. For instance, the
-``dumpling`` v0.67.11 release has bugs related to backfilling which have
-been fixed in ``firefly`` v0.80.x. A backport fixing these backfilling
-bugs has been tested in the draft point release ``dumpling`` v0.67.12 but
-they are large enough to introduce a risk of regression. As ``dumpling``
-is to be retired, users suffering from this bug can
-upgrade to ``firefly`` to fix it. Unless users manifest themselves and ask
-for ``dumpling`` v0.67.12, this draft release may never be published.
-
-* The ``Ceph lead`` decides a new stable release must be published
-* The ``release master`` gets approval from all leads
-* The ``release master`` writes and commits the release notes
-* The ``release master`` informs the ``quality engineer`` that the
-  branch is ready for testing
-* The ``quality engineer`` runs additional integration tests
-* If the ``quality engineer`` discovers new bugs that require an
-  ``Urgent Backport``, the release goes back to being prepared, it
-  was not ready after all
-* The ``quality engineer`` informs the ``publisher`` that the branch
-  is ready for release
-* The ``publisher`` `creates the packages and sets the release tag
-  <../release-process>`_
-
-The person responsible for each role is:
-
-* Sage Weil is the ``Ceph lead``
-* Sage Weil is the ``release master`` for major stable releases
-  (``firefly`` 0.80, ``hammer`` 0.94 etc.)
-* Loic Dachary is the ``release master`` for stable point releases
-  (``firefly`` 0.80.10, ``hammer`` 0.94.1 etc.)
-* Yuri Weinstein is the ``quality engineer``
-* Alfredo Deza is the ``publisher``
-
-Cutting a new development release
-=================================
-
-The publication workflow of a development release is the same as
-preparing a new release and cutting it, with the following
-differences:
-
-* The ``next`` branch is reset to the tip of ``master`` after
-  publication
-* The ``quality engineer`` is not required to run additional tests,
-  the ``release master`` directly informs the ``publisher`` that the
-  release is ready to be published.
-
+* Patrick Donnelly is the `Ceph Release Manager (CRM) <../crm>`_
+ 
 Publishing point releases and backporting
 =========================================
 
-The publication workflow of the point releases is the same as
-preparing a new release and cutting it, with the following
-differences:
+The publication workflow of point releases follows the standard release
+preparation and cutting process, with the following additions for
+backporting:
 
 * The ``backport`` field of each issue contains the code name of the
   stable release

--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -7,7 +7,7 @@ Dev Kickoff
 
 These steps should be taken when starting a new major release, just after
 the previous release has been tagged (vX.2.0) and that tag has been merged
-back into master.
+back into ``main``.
 
 X is the release we are just starting development on.  X-1 is the one
 that was just released (X-1).2.0.

--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -27,9 +27,9 @@ For each new major (alphabetical) release, you must create one ``ceph-release`` 
 Summarized build process
 ========================
 
-1. QE finishes testing and finds a stopping point.  That commit is pushed to the ``$release-release`` branch in ceph.git (e.g., ``squid-release``).  This allows work to continue in the working ``$release`` branch without having to freeze it during the release process.
-2. The Ceph Council approves and notifies the "Build Lead".
-3. The "Build Lead" starts the `Jenkins multijob <https://jenkins.ceph.com/view/all/job/ceph>`_, which triggers all builds.
+1. QE finishes testing and finds a stopping point. The working ``$release`` branch (e.g., ``squid``) is then frozen to ensure that upgrade tests are QA'ing the actual code planned to ship.
+2. The Ceph Release Manager (CRM) approves the release.
+3. The CRM or deputy starts the `Jenkins multijob <https://jenkins.ceph.com/view/all/job/ceph>`_, which triggers all builds.
 4. Packages are pushed to chacra.ceph.com.
 5. Packages are pulled from chacra.ceph.com to the Signer VM.
 6. Packages are signed.
@@ -47,12 +47,12 @@ A hotfix release has a couple differences.
 1. Check out the most recent tag. For example, if we're releasing a hotfix on top of 19.2.1, ``git checkout -f -B squid-release tags/v19.2.1``.
 2. ``git cherry-pick -x`` the necessary hotfix commits (Note: only "cherry-pick" must be used).
 3. ``git push -f origin squid-release``.
-4. Verify the commits in the ``$release-release`` branch:
+4. Verify the commits in the hotfix branch:
 
    1. To check against the previous point release (if we are making 19.2.2, this would be 19.2.1), run ``git log --pretty=oneline --no-merges tags/v19.2.1..origin/squid-release``. Verify that the commits produced are exactly what we want in the next point release.
-   2. To check against the RC in the "ceph-ci" repo (``ceph-ci`` in this example), run ``git log --pretty=oneline --no-merges origin/squid-release...ceph-ci/squid-release``. There should be no output produced if the ``$release-release`` branch in the ceph repo is identical to the RC in ``ceph-ci``. Note the use of git `triple dot notation <https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection>`_, which shows any commit discrepencies between both references.
-5. Notify the "Build Lead" to start the build.
-6. The "Build Lead" should set ``RELEASE_TYPE=HOTFIX`` instead of ``STABLE``.
+   2. To check against the RC in the "ceph-ci" repo (``ceph-ci`` in this example), run ``git log --pretty=oneline --no-merges origin/squid-release...ceph-ci/squid-release``. There should be no output produced if the hotfix branch in the ceph repo is identical to the RC in ``ceph-ci``. Note the use of git `triple dot notation <https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection>`_, which shows any commit discrepencies between both references.
+5. Notify the CRM to start the build.
+6. The CRM should set ``RELEASE_TYPE=HOTFIX`` instead of ``STABLE``.
 
 Security Release Process Deviation
 ----------------------------------
@@ -60,15 +60,15 @@ Security Release Process Deviation
 A security/CVE release is similar to a hotfix release with two differences:
 
     1. The fix should be pushed to the `ceph-private <https://github.com/ceph/ceph-private>`_ repo instead of ceph.git (requires GitHub Admin Role).
-    2. The tags (e.g., v19.2.3) must be manually pushed to ceph.git by the "Build Lead."
+    2. The tags (e.g., v19.2.3) must be manually pushed to ceph.git by the CRM.
 
 1. Check out the most recent tag. For example, if we're releasing a security fix on top of 19.2.2, ``git checkout -f -B squid-release origin/v19.2.2``
 2. ``git cherry-pick -x`` the necessary security fix commits
 3. ``git remote add security git@github.com:ceph/ceph-private.git``
 4. ``git push -f security squid-release``
-5. Notify the "Build Lead" to start the build.
-6. The "Build Lead" should set ``RELEASE_TYPE=SECURITY`` instead of ``STABLE``.
-7. Finally, the `ceph-tag <https://github.com/ceph/ceph-build/blob/main/ansible/roles/ceph-release/tasks/push.yml>`_ steps need to be manually run by the "Build Lead" as close to the Announcement time as possible::
+5. Notify the CRM to start the build.
+6. The CRM should set ``RELEASE_TYPE=SECURITY`` instead of ``STABLE``.
+7. Finally, the `ceph-tag <https://github.com/ceph/ceph-build/blob/main/ansible/roles/ceph-release/tasks/push.yml>`_ steps need to be manually run by the CRM as close to the Announcement time as possible::
 
     # Example using squid pretending 19.2.3 is the security release version
     # Add the ceph-releases repo (also requires GitHub Admin Role). The `ceph-setup <https://jenkins.ceph.com/job/ceph-setup>`_ job will have already created and pushed the tag to ceph-releases.git.
@@ -83,9 +83,11 @@ A security/CVE release is similar to a hotfix release with two differences:
 1. Preparing the release branch
 ===============================
 
-Once QE has determined a stopping point in the working (e.g., ``squid``) branch, that commit should be pushed to the corresponding ``squid-release`` branch.
+Once QE has determined a stopping point in the working (e.g., ``squid``)
+branch, the branch is frozen and the **Ceph Release Manager** is notified that
+the release branch is ready.
 
-Notify the "Build Lead" that the release branch is ready.
+Notify the CRM that the release branch is ready.
 
 2. Starting the build
 =====================


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
