### PR TITLE
squid: ceph-volume: include LVM mapper devices in get_devices()

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -413,6 +413,28 @@ class TestGetDevices(object):
             result = disk.get_devices()
         assert result[sda_path]['actuators'] == fake_actuator_nb
 
+    def test_lvm_device_is_included(self, patched_get_block_devs_sysfs, fake_filesystem):
+        lv_path = '/dev/vg_test/lv1'
+        dm_path = '/dev/dm-0'
+        mapper_path = '/dev/mapper/vg_test-lv1'
+        patched_get_block_devs_sysfs.return_value = [
+            [dm_path, mapper_path, 'lvm', dm_path]
+        ]
+        fake_filesystem.create_dir('/sys/block/dm-0/slaves')
+        fake_filesystem.create_dir('/sys/block/dm-0/queue')
+        fake_filesystem.create_file('/sys/block/dm-0/size', contents='204800')
+        fake_filesystem.create_file('/sys/block/dm-0/queue/rotational', contents='1')
+        fake_filesystem.create_file('/sys/block/dm-0/queue/hw_sector_size', contents='512')
+        with patch("ceph_volume.util.disk.UdevData") as MockUdevData:
+            mock_instance = MagicMock()
+            mock_instance.slashed_path = lv_path
+            mock_instance.environment = {}
+            MockUdevData.return_value = mock_instance
+            result = disk.get_devices()
+        assert lv_path in result
+        assert result[lv_path]['type'] == 'lvm'
+        assert result[lv_path]['human_readable_size'] == '100.00 MB'
+
 
 class TestGetBlockDevsSysfs(object):
     def test_optical_device_is_skipped(self, fake_filesystem):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -800,14 +800,6 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         if is_ceph_rbd(diskname):
             continue
 
-        # If the mapper device is a logical volume it gets excluded
-        try:
-            if UdevData(diskname).is_lvm:
-                continue
-        except RuntimeError:
-            logger.debug("get_devices(): device {} couldn't be found.".format(diskname))
-            continue
-
         # all facts that have no defaults
         # (<name>, <path relative to _sys_block_path>)
         facts = [('removable', 'removable'),

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -914,14 +914,6 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         if is_ceph_rbd(diskname):
             continue
 
-        # If the mapper device is a logical volume it gets excluded
-        try:
-            if UdevData(diskname).is_lvm:
-                continue
-        except RuntimeError:
-            logger.debug("get_devices(): device {} couldn't be found.".format(diskname))
-            continue
-
         # all facts that have no defaults
         # (<name>, <path relative to _sys_block_path>)
         facts = [('removable', 'removable'),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74968

---

backport of https://github.com/ceph/ceph/pull/67231
parent tracker: https://tracker.ceph.com/issues/74775

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh