### PR TITLE
mgr/dashboard: Rename namespace block size field and reorder namespace form order

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
@@ -62,9 +62,9 @@
            class="form-item">
         <div cdsCol>
           <cds-number
-            formControlName="nsCount"
             cdValidate
             #nsCountRef="cdValidate"
+            formControlName="nsCount"
             label="Number of namespaces"
             helperText="No. of namespaces to generate. Value must be between 1 and 5."
             [min]="MIN_NAMESPACE_CREATE"
@@ -77,28 +77,35 @@
         </div>
       </div>
 
-      <!-- Namespace Size (UI only) -->
+      <!-- Image Size -->
       <div cdsRow
            class="form-item">
-        <div cdsCol>
-          <cds-number
-            formControlName="namespace_size"
-            cdValidate
-            #namespaceSizeRef="cdValidate"
-            label="Namespace size (GiB)"
-            helperText="Specify the size to expose to hosts. Leave blank for full device/file."
-            placeholder="e.g. 100"
-            [min]="0"
-            [invalid]="namespaceSizeRef.isInvalid"
-            [invalidText]="namespaceSizeError"
+        <div
+          cdsCol
+          [columnNumbers]="{md: 4}">
+          <cds-text-label
+            label="Image size (GiB)"
+            helperText="The size of the namespace image."
+            [invalid]="imageSize.isInvalid"
+            [invalidText]="sizeError"
+            cdRequiredField="Image Size"
             i18n-label
             i18n-helperText>
-          </cds-number>
-          <ng-template #namespaceSizeError>
-            @if (nsForm.controls['namespace_size'].hasError('blockSizeMultiple')) {
+            <input cdsText
+                   cdValidate
+                   #imageSize="cdValidate"
+                   type="text"
+                   placeholder="e.g. 100 GiB"
+                   id="image_size"
+                   formControlName="image_size"
+                   defaultUnit="GiB"
+                   [min]="0"
+                   [invalid]="imageSize.isInvalid"
+                   cdDimlessBinary>
+          </cds-text-label>
+          <ng-template #sizeError>
             <span
-              i18n>Size must be a multiple of the block size (typically 512 or 4096 bytes).</span>
-            }
+              i18n>Enter a valid size (e.g., 10GiB).</span>
           </ng-template>
         </div>
       </div>
@@ -245,15 +252,16 @@
               i18n>Image name (optional)</label>
             <cds-text-label
               helperText="Provide a name for the images. For bulk creation, this will be used as the base prefix with numeric suffixes (e.g., img-1, img-2). Leave blank to auto-generate."
-              [invalid]="rbdImageNameRef.isInvalid"
+              [invalid]="rbdImageName.isInvalid"
               [invalidText]="nsForm.getError('rbdImageName', 'rbd_image_name') ? 'Image name contains invalid characters' : ''"
               i18n-helperText
               i18n-invalidText>
               <input cdsText
                      cdValidate
-                     #rbdImageNameRef="cdValidate"
+                     #rbdImageName="cdValidate"
                      placeholder="Enter a name"
-                     formControlName="rbd_image_name" />
+                     formControlName="rbd_image_name"
+                     [invalid]="rbdImageName.isInvalid" />
             </cds-text-label>
           </div>
         </div>
@@ -289,36 +297,21 @@
       </div>
       }
 
-      <!-- Image Size -->
+      <!-- Namespace Block Size (bytes) -->
       <div cdsRow
            class="form-item">
-        <div
-          cdsCol
-          [columnNumbers]="{md: 4}">
-          <cds-text-label
-            label="Image size (GiB)"
-            helperText="The size of the namespace image."
-            [invalid]="imageSizeRef.isInvalid"
-            [invalidText]="sizeError"
-            cdRequiredField="Image Size"
+        <div cdsCol>
+          <cds-number
+            cdValidate
+            #namespaceSize="cdValidate"
+            formControlName="namespace_size"
+            label="Namespace block size (bytes)"
+            helperText="Specify the block size to expose to the hosts. Leave blank for the default block size of 512 bytes."
+            [min]="0"
+            [invalid]="namespaceSize.isInvalid"
             i18n-label
             i18n-helperText>
-            <input cdsText
-                   cdValidate
-                   #imageSizeRef="cdValidate"
-                   type="text"
-                   placeholder="e.g. 100 GiB"
-                   id="image_size"
-                   formControlName="image_size"
-                   defaultUnit="GiB"
-                   [min]="0"
-                   [invalid]="imageSizeRef.isInvalid"
-                   cdDimlessBinary>
-          </cds-text-label>
-          <ng-template #sizeError>
-            <span
-              i18n>Enter a valid size (e.g., 10GiB).</span>
-          </ng-template>
+          </cds-number>
         </div>
       </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
@@ -249,7 +249,7 @@ export class NvmeofNamespacesFormComponent implements OnInit {
           return /^[^@/]+$/.test(value) ? null : { rbdImageName: true };
         })
       ]),
-      namespace_size: new UntypedFormControl(null), // UI only - not sent to backend
+      namespace_size: new UntypedFormControl(512), // Block size in bytes; default 512
       host_access: new UntypedFormControl('all'), // UI only - determines visibility
       initiators: new UntypedFormControl([]) // UI only - selected hosts
     });


### PR DESCRIPTION
mgr/dashboard: Rename namespace block size field and reorder namespace form order

Fixes: https://tracker.ceph.com/issues/75707

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

Screencast : 

https://github.com/user-attachments/assets/971f8272-221f-4089-97bb-1419894da38d



PR Decription:

- Rename field label to: `Namespace block size (bytes)`
- Update helper text to clarify usage and default:
  - `Specify the block size to expose to the hosts. Leave blank for the default block size of 512 bytes.`
- Prepopulate default value as `512`
- Reorder form fields:
  - Move `Image size` higher in the form
  - Keep `Namespace block size` as the last field section before submit

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
