### PR TITLE
rgw/iam: User/Group/Role apis map ECANCELED to ERR_CONCURRENT_MODIFICATION

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -139,7 +139,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_NO_SUCH_PUBLIC_ACCESS_BLOCK_CONFIGURATION, {404, "NoSuchPublicAccessBlockConfiguration"}},
     { ERR_ACCOUNT_EXISTS, {409, "AccountAlreadyExists"}},
     { ERR_RESTORE_ALREADY_IN_PROGRESS, {409, "RestoreAlreadyInProgress"}},
-    { ECANCELED, {409, "ConcurrentModification"}},
+    { ERR_CONCURRENT_MODIFICATION, {409, "ConcurrentModification"}},
     { EDQUOT, {507, "InsufficientCapacity"}},
     { ENOSPC, {507, "InsufficientCapacity"}},
     { ERR_ACLS_NOT_SUPPORTED, {400, "AccessControlListNotSupported"}},

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -359,6 +359,7 @@ inline constexpr const char* RGW_REST_STS_XMLNS =
 #define ERR_BUSY_RESHARDING      2300 // also in cls_rgw_types.h, don't change!
 #define ERR_NO_SUCH_ENTITY       2301
 #define ERR_LIMIT_EXCEEDED       2302
+#define ERR_CONCURRENT_MODIFICATION 2303
 
 // STS Errors
 #define ERR_PACKED_POLICY_TOO_LARGE 2400

--- a/src/rgw/rgw_rest_iam.h
+++ b/src/rgw/rgw_rest_iam.h
@@ -50,6 +50,10 @@ int retry_raced_user_write(const DoutPrefixProvider* dpp, optional_yield y,
       r = f();
     }
   }
+  if (r == -ECANCELED) {
+    // map ECANCELED to 409 ConcurrentModification
+    return -ERR_CONCURRENT_MODIFICATION;
+  }
   return r;
 }
 
@@ -70,6 +74,10 @@ int retry_raced_group_write(const DoutPrefixProvider* dpp, optional_yield y,
       r = f();
     }
   }
+  if (r == -ECANCELED) {
+    // map ECANCELED to 409 ConcurrentModification
+    return -ERR_CONCURRENT_MODIFICATION;
+  }
   return r;
 }
 
@@ -87,6 +95,10 @@ int retry_raced_role_write(const DoutPrefixProvider* dpp, optional_yield y,
     if (r >= 0) {
       r = f();
     }
+  }
+  if (r == -ECANCELED) {
+    // map ECANCELED to 409 ConcurrentModification
+    return -ERR_CONCURRENT_MODIFICATION;
   }
   return r;
 }


### PR DESCRIPTION
avoid mapping generic ECANCELED errors to 409 by introducing a new ERR_CONCURRENT_MODIFICATION specifically for this mapping. other ECANCELED will default back to 500 UnknownError as they did prior to a9c49a5ce7a2eb74e50cde11f6a8aab32764aa89

for iam apis, retry helper functions retry_raced_user_write() etc. map the resulting ECANCELED errors to ERR_CONCURRENT_MODIFICATION after exhausting the retry counter

https://docs.aws.amazon.com/IAM/latest/APIReference/API_Operations.html isn't very consistent about which of its actions are allowed to return ConcurrentModification. rgw may return this for any metadata writes that are protected by cls_version but are not exclusive creates

Fixes: https://tracker.ceph.com/issues/75722

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
