### PR TITLE
smb: improve smb mgr module resource type error handling

### DIFF
--- a/src/pybind/mgr/smb/resourcelib.py
+++ b/src/pybind/mgr/smb/resourcelib.py
@@ -187,6 +187,31 @@ class MissingRequiredFieldError(KeyError, ResourceTypeError):
         return f'data object missing required field: {self.key}'
 
 
+class InvalidObjectTypeFieldError(ResourceTypeError):
+    """Exception raised when an object can not be converted from unstructured
+    data due to having an incorrect type in the unstructured data.
+    """
+
+    def __init__(self, key: str, expected: str = '', found: str = '') -> None:
+        self.key = key
+        self.expected = expected
+        self.found = found
+
+    def __str__(self) -> str:
+        msg = f'invalid type for field: {self.key}'
+        if self.expected:
+            msg += f': expected {self.expected}'
+        if self.found:
+            msg += f', found {self.found}'
+        return msg
+
+    @classmethod
+    def from_value(cls, key: str, value: Any, expected: str = '') -> Self:
+        tname = type(value).__name__
+        tname = 'string' if tname == 'str' else tname
+        return cls(key, expected=expected, found=tname)
+
+
 # ---- Internal Resource Types ----
 
 # Sentinel object for unset/missing value conditions.
@@ -390,24 +415,41 @@ class Resource:
             return _fs(value)
 
         if fld.takes(list):
-            if isinstance(value, str):
-                raise ResourceTypeError(
-                    f'{fld.name} expects a list not a string'
-                )
-            subtype = fld.list_element_type()
-            return [
-                self._object_sub_from_simplified(subtype, v) for v in value
-            ]
+            return self._extract_list_field(fld, value)
         if fld.takes(dict):
-            ktype, vtype = fld.dict_element_types()
-            # keys must be simple types right now so we just
-            # cast it directly
-            return {
-                ktype(k): self._object_sub_from_simplified(vtype, v)
-                for k, v in value.items()
-            }
+            return self._extract_dict_field(fld, value)
 
         return inner_type(value)
+
+    @_xt
+    def _extract_list_field(self, fld: Field, value: Any) -> Any:
+        # reject iterable but insufficiently list-like types
+        if isinstance(value, (str, bytes)):
+            raise InvalidObjectTypeFieldError(
+                fld.name, expected='list', found='string'
+            )
+        if isinstance(value, dict):
+            raise InvalidObjectTypeFieldError(
+                fld.name, expected='list', found='object/mapping'
+            )
+        subtype = fld.list_element_type()
+        return [self._object_sub_from_simplified(subtype, v) for v in value]
+
+    @_xt
+    def _extract_dict_field(self, fld: Field, value: Any) -> Any:
+        try:
+            _items = value.items()
+        except AttributeError:
+            raise InvalidObjectTypeFieldError.from_value(
+                fld.name, value, expected='object/mapping'
+            )
+        ktype, vtype = fld.dict_element_types()
+        # keys must be simple types right now so we just
+        # cast it directly
+        return {
+            ktype(k): self._object_sub_from_simplified(vtype, v)
+            for k, v in _items
+        }
 
     @_xt
     def _object_sub_from_simplified(

--- a/src/pybind/mgr/smb/tests/test_resourcelib.py
+++ b/src/pybind/mgr/smb/tests/test_resourcelib.py
@@ -271,6 +271,7 @@ class BigBiz:
     address: List[str]
     ceo: Worker
     units: Optional[List[Unit]] = None
+    departments: Optional[Dict[str, str]] = None
 
 
 @smb.resourcelib.resource('smallbiz')
@@ -449,6 +450,54 @@ def test_explicit_none_in_data():
         'address': ['1 MegaLo Drive', 'Mango', 'TX', '22020'],
         'ceo': {'name': 'D. B. Bawes', 'age': 61},
         'units': None,
+        'departments': {
+            'marketing': 'Tells stuff',
+            'sales': 'Sells stuff',
+        },
     }
     obj = BigBiz._resource_config.object_from_simplified(data)
     assert obj.units is None
+
+
+def test_invalid_str_in_list_field():
+    data = {
+        'resource_type': 'smallbiz',
+        'name': 'Le Shoppe',
+        'address': '12 Fashion Way, Urbia  WA  01209',
+        'people': [
+            {'name': 'Madelyn', 'age': 39},
+            {'age': 39},
+        ],
+    }
+    with pytest.raises(smb.resourcelib.InvalidObjectTypeFieldError):
+        smb.resourcelib.load(data)
+
+
+def test_invalid_dict_in_list_field():
+    data = {
+        'resource_type': 'smallbiz',
+        'name': 'Le Shoppe',
+        'address': {'nope': 'wrong'},
+        'people': [
+            {'name': 'Madelyn', 'age': 39},
+            {'age': 39},
+        ],
+    }
+    with pytest.raises(smb.resourcelib.InvalidObjectTypeFieldError):
+        smb.resourcelib.load(data)
+
+
+def test_invalid_list_in_dict_field():
+    data = {
+        'resource_type': 'bigbiz',
+        'name': 'MegaLoMart',
+        'address': ['1 MegaLo Drive', 'Mango', 'TX', '22020'],
+        'ceo': {'name': 'D. B. Bawes', 'age': 61},
+        'units': None,
+        'departments': [
+            {'marketing': 'Tells stuff'},
+            {'sales': 'Sells stuff'},
+        ],
+    }
+    with pytest.raises(smb.resourcelib.InvalidObjectTypeFieldError):
+        smb.resourcelib.load(data)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75723

Improve the kinds of error text returned by the smb mgr module when the user provides an incorrect type in a field expecting a list or dict type.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
