### PR TITLE
test/rgw: cover kafka verify-ssl connection reuse

### DIFF
--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -278,6 +278,14 @@ if(WITH_RADOSGW_AMQP_ENDPOINT)
   target_link_libraries(unittest_rgw_amqp ${rgw_libs})
 endif()
 
+if(WITH_RADOSGW_KAFKA_ENDPOINT)
+  add_executable(unittest_rgw_kafka test_rgw_kafka.cc)
+  add_ceph_unittest(unittest_rgw_kafka)
+  target_include_directories(unittest_rgw_kafka
+    SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+  target_link_libraries(unittest_rgw_kafka ${rgw_libs})
+endif()
+
 # unittest_rgw_xml
 add_executable(unittest_rgw_xml test_rgw_xml.cc)
 add_ceph_unittest(unittest_rgw_xml)

--- a/src/test/rgw/test_rgw_kafka.cc
+++ b/src/test/rgw/test_rgw_kafka.cc
@@ -1,0 +1,98 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "rgw_kafka.h"
+#include "common/ceph_context.h"
+#include <gtest/gtest.h>
+
+using namespace rgw;
+
+class CctCleaner {
+  CephContext* cct;
+public:
+  explicit CctCleaner(CephContext* _cct) : cct(_cct) {}
+  ~CctCleaner() {
+#ifdef WITH_CRIMSON
+    delete cct;
+#else
+    cct->put();
+#endif
+  }
+};
+
+auto cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
+
+CctCleaner cleaner(cct);
+
+class TestKafka : public ::testing::Test {
+protected:
+  void SetUp() override {
+    ASSERT_TRUE(kafka::init(cct));
+  }
+
+  void TearDown() override {
+    kafka::shutdown();
+  }
+};
+
+TEST_F(TestKafka, ConnectionReuseWithSameVerifySSL)
+{
+  const auto connection_number = kafka::get_connection_count();
+
+  kafka::connection_id_t conn_id1;
+  auto rc = kafka::connect(conn_id1,
+                           "kafka://localhost:9093",
+                           true,
+                           true,
+                           boost::none,
+                           boost::none,
+                           boost::none,
+                           boost::none,
+                           boost::none);
+  ASSERT_TRUE(rc);
+  EXPECT_EQ(kafka::get_connection_count(), connection_number + 1);
+
+  kafka::connection_id_t conn_id2;
+  rc = kafka::connect(conn_id2,
+                      "kafka://localhost:9093",
+                      true,
+                      true,
+                      boost::none,
+                      boost::none,
+                      boost::none,
+                      boost::none,
+                      boost::none);
+  ASSERT_TRUE(rc);
+  EXPECT_EQ(kafka::get_connection_count(), connection_number + 1);
+}
+
+TEST_F(TestKafka, ConnectionReuseDistinguishesVerifySSL)
+{
+  const auto connection_number = kafka::get_connection_count();
+
+  kafka::connection_id_t conn_id1;
+  auto rc = kafka::connect(conn_id1,
+                           "kafka://localhost:9093",
+                           true,
+                           true,
+                           boost::none,
+                           boost::none,
+                           boost::none,
+                           boost::none,
+                           boost::none);
+  ASSERT_TRUE(rc);
+  EXPECT_EQ(kafka::get_connection_count(), connection_number + 1);
+
+  kafka::connection_id_t conn_id2;
+  rc = kafka::connect(conn_id2,
+                      "kafka://localhost:9093",
+                      true,
+                      false,
+                      boost::none,
+                      boost::none,
+                      boost::none,
+                      boost::none,
+                      boost::none);
+  ASSERT_TRUE(rc);
+  EXPECT_EQ(kafka::get_connection_count(), connection_number + 2);
+}


### PR DESCRIPTION
## Checklist
  - Tracker (select at least one)
    - [x] Code cleanup (no ticket needed)
  - Component impact
    - [x] No impact that needs to be tracked
  - Documentation (select at least one)
    - [x] No doc update is appropriate
  - Tests (select at least one)
    - [x] Includes unit test(s)

  ## Summary

  This PR adds the C++ unit coverage for Kafka `verify-ssl` connection reuse behavior that was requested separately during review.

  It covers:
  - reusing the same cached connection when `verify_ssl` is unchanged
  - creating a distinct cached connection when `verify_ssl` differs

  ## Notes

  This PR is intentionally split from the feature fix per review feedback.

  Depends on #67978.