### PR TITLE
client,pybind: Adding fcopyfilex implementation

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -19140,6 +19140,74 @@ SubvolumeMetricTracker::aggregate(bool clean) {
 }
 // --- subvolume metrics tracking --- //
 
+int64_t Client::_copyfile(int source_fd, off_t src_offset, int dest_fd,
+                          off_t dest_offset, size_t size)
+{
+  Fh *src_fh = nullptr;
+  Fh *dest_fh = nullptr;
+  uint64_t max_read_size = INT_MAX;
+  {
+    std::scoped_lock lock(client_lock);
+    src_fh = get_filehandle(source_fd);
+    if (!src_fh)
+      return -EBADF;
+    dest_fh = get_filehandle(dest_fd);
+    if (!dest_fh)
+      return -EBADF;
+#if defined(__linux__) && defined(O_PATH)
+    if (src_fh->flags & O_PATH || dest_fh->flags & O_PATH)
+      return -EBADF;
+#endif
+#if defined(__linux__)
+    Inode *src_in = src_fh->inode.get();
+    if (src_in->is_fscrypt_enabled()) {
+      max_read_size = FSCRYPT_MAXIO_SIZE;
+    }
+#endif
+  }
+
+  size_t remaining = size;
+  const size_t chunk_size = 1048576; // 1MB chunks
+  int r = 0;
+  int w = 0;
+  while (remaining > 0) {
+    bufferlist bl;
+    size_t to_read = std::min(remaining, chunk_size);
+    uint64_t rd_size = std::min<uint64_t>(to_read, max_read_size);
+
+    {
+      std::scoped_lock lock(client_lock);
+      r = _read(src_fh, src_offset, rd_size, &bl);
+      if (r < 0) {
+        ldout(cct, 10) << __func__ << ": error reading at offset=" << src_offset
+                       << " size=" << to_read << " r=" << r << dendl;
+        return r;
+      }
+      if (r == 0) {
+        // EOF reached
+        break;
+      }
+      w = _write(dest_fh, dest_offset, r, std::move(bl));
+      if (w < 0) {
+        ldout(cct, 10) << __func__ << ": error writing at offset=" << dest_offset
+                       << " size=" << r << " w=" << w << dendl;
+        return w;
+      }
+      if (w != r) {
+        ldout(cct, 10) << __func__ << ": short write at offset=" << dest_offset
+                       << " r=" << r << " w=" << w << dendl;
+        return -EIO;
+      }
+    }
+
+    src_offset += r;
+    dest_offset += r;
+    remaining -= r;
+  }
+
+  return size - remaining;
+}
+
 int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mode_t mode) {
   ldout(cct, 10) << "fcopyfile spath=" << spath << " dpath=" << dpath << " mode=" << mode << dendl;
 
@@ -19175,9 +19243,8 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
       ldout(cct, 10) << "fcopyfile could not create dest dir=" << dpath << " r=" << r << dendl;
       return r;
     }
-  } else if(srcin->is_file()) {
-    int r = 0;
-    size_t size = srcin->size;
+  } else if (srcin->is_file()) {
+    const size_t size = srcin->size;
 
     int dest = do_openat(CEPHFS_AT_FDCWD, dpath, O_CREAT | O_TRUNC | O_WRONLY, perms, mode, 0,0,0, NULL, alt_name, foptions);
     if (dest < 0) {
@@ -19185,60 +19252,61 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
       return dest;
     }
 
-    bool need_read = true;
-    if (size == 0)
-      need_read = false;
-
-    int src;
-    if (need_read) {
-      src = open(spath, O_RDONLY, perms, mode);
-      if (src < 0) {
-        ldout(cct, 10) << "fcopyfile could not open source file=" << spath << " ret=" << src << dendl;
-        close(dest);
-        return src;
-      }
-
-      char in_buf[1048576];
-      size_t off = 0;
-      size_t len = sizeof(in_buf) / sizeof(in_buf[0]);
-
-      len = std::min(size, len);
-
-      while (true) {
-        // include fstat here to reverify size (statx)
-        r = read(src, in_buf, len, off);
-        if (r < 0) {
-          ldout(cct, 10) << "fcopyfile: error reading copy data, r=" << r << dendl;
-          goto out;
-        } else {
-	  len = r;
-	}
-
-        r = write(dest, in_buf, len, off);
-        if (r < 0) {
-          ldout(cct, 10) << "fcopyfile: error writing copy data, r=" << r << dendl;
-          goto out;
-        }
-        off = off + len;
-
-        if (off == size) {
-          break;
-	} else if (off > size) {
-	  ldout(cct, 0) << __FILE__ << ",  " << __func__ << "() at " << __LINE__
-		        << " internal error: \"off\" is greater than \"size\"; "
-			" off = " << off << " size = " << size << dendl;
-	  r = -1;
-	  goto out;
-	}
-      }
-    }
-    out:
+    if (size == 0) {
       close(dest);
-      if (need_read)
-        close(src);
-      return r;
+      return 0;
+    }
+
+    int src = open(spath, O_RDONLY, perms, mode);
+    if (src < 0) {
+      ldout(cct, 10) << "fcopyfile could not open source file=" << spath << " ret=" << src << dendl;
+      close(dest);
+      return src;
+    }
+
+    int64_t copied = _copyfile(src, 0, dest, 0, size);
+    close(dest);
+    close(src);
+
+    if (copied < 0) {
+      ldout(cct, 10) << "fcopyfile: _copyfile failed, r=" << copied << dendl;
+      return copied;
+    }
+    if (static_cast<size_t>(copied) != size) {
+      ldout(cct, 10) << "fcopyfile: short copy, copied=" << copied << " expected=" << size << dendl;
+      return -EIO;
+    }
   }
   return 0;
+}
+
+int Client::fcopyfilex(int source_fd, off_t src_offset, int dest_fd, off_t dest_offset, size_t size, unsigned flags)
+{
+  RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
+  if (!mref_reader.is_state_satisfied())
+    return -ENOTCONN;
+
+  ldout(cct, 10) << "fcopyfilex source_fd=" << source_fd << " src_offset=" << src_offset
+                 << " dest_fd=" << dest_fd << " dest_offset=" << dest_offset
+                 << " size=" << size << " flags=" << flags << dendl;
+
+  if (size == 0)
+    return 0;
+
+  // Following copy_file_range(2), flags is reserved for future extensions and
+  // must be 0 so that new copy behaviors can be added without an API change.
+  if (flags != 0)
+    return -EINVAL;
+
+  int64_t copied = _copyfile(source_fd, src_offset, dest_fd, dest_offset, size);
+  if (copied < 0) {
+    ldout(cct, 10) << "fcopyfilex: _copyfile failed, r=" << copied << dendl;
+    return copied;
+  }
+  if (static_cast<size_t>(copied) != size) {
+    ldout(cct, 10) << "fcopyfilex: short copy, copied=" << copied << " expected=" << size << dendl;
+  }
+  return copied;
 }
 
 StandaloneClient::StandaloneClient(Messenger *m, MonClient *mc,

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -19206,6 +19206,74 @@ SubvolumeMetricTracker::aggregate(bool clean) {
 }
 // --- subvolume metrics tracking --- //
 
+int64_t Client::_copyfile(int source_fd, off_t src_offset, int dest_fd,
+                          off_t dest_offset, size_t size)
+{
+  Fh *src_fh = nullptr;
+  Fh *dest_fh = nullptr;
+  uint64_t max_read_size = INT_MAX;
+  {
+    std::scoped_lock lock(client_lock);
+    src_fh = get_filehandle(source_fd);
+    if (!src_fh)
+      return -EBADF;
+    dest_fh = get_filehandle(dest_fd);
+    if (!dest_fh)
+      return -EBADF;
+#if defined(__linux__) && defined(O_PATH)
+    if (src_fh->flags & O_PATH || dest_fh->flags & O_PATH)
+      return -EBADF;
+#endif
+#if defined(__linux__)
+    Inode *src_in = src_fh->inode.get();
+    if (src_in->is_fscrypt_enabled()) {
+      max_read_size = FSCRYPT_MAXIO_SIZE;
+    }
+#endif
+  }
+
+  size_t remaining = size;
+  const size_t chunk_size = 1048576; // 1MB chunks
+  int r = 0;
+  int w = 0;
+  while (remaining > 0) {
+    bufferlist bl;
+    size_t to_read = std::min(remaining, chunk_size);
+    uint64_t rd_size = std::min<uint64_t>(to_read, max_read_size);
+
+    {
+      std::scoped_lock lock(client_lock);
+      r = _read(src_fh, src_offset, rd_size, &bl);
+      if (r < 0) {
+        ldout(cct, 10) << __func__ << ": error reading at offset=" << src_offset
+                       << " size=" << to_read << " r=" << r << dendl;
+        return r;
+      }
+      if (r == 0) {
+        // EOF reached
+        break;
+      }
+      w = _write(dest_fh, dest_offset, r, std::move(bl));
+      if (w < 0) {
+        ldout(cct, 10) << __func__ << ": error writing at offset=" << dest_offset
+                       << " size=" << r << " w=" << w << dendl;
+        return w;
+      }
+      if (w != r) {
+        ldout(cct, 10) << __func__ << ": short write at offset=" << dest_offset
+                       << " r=" << r << " w=" << w << dendl;
+        return -EIO;
+      }
+    }
+
+    src_offset += r;
+    dest_offset += r;
+    remaining -= r;
+  }
+
+  return size - remaining;
+}
+
 int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mode_t mode) {
   ldout(cct, 10) << "fcopyfile spath=" << spath << " dpath=" << dpath << " mode=" << mode << dendl;
 
@@ -19241,9 +19309,8 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
       ldout(cct, 10) << "fcopyfile could not create dest dir=" << dpath << " r=" << r << dendl;
       return r;
     }
-  } else if(srcin->is_file()) {
-    int r = 0;
-    size_t size = srcin->size;
+  } else if (srcin->is_file()) {
+    const size_t size = srcin->size;
 
     int dest = do_openat(CEPHFS_AT_FDCWD, dpath, O_CREAT | O_TRUNC | O_WRONLY, perms, mode, 0,0,0, NULL, alt_name, foptions);
     if (dest < 0) {
@@ -19251,60 +19318,61 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
       return dest;
     }
 
-    bool need_read = true;
-    if (size == 0)
-      need_read = false;
-
-    int src;
-    if (need_read) {
-      src = open(spath, O_RDONLY, perms, mode);
-      if (src < 0) {
-        ldout(cct, 10) << "fcopyfile could not open source file=" << spath << " ret=" << src << dendl;
-        close(dest);
-        return src;
-      }
-
-      char in_buf[1048576];
-      size_t off = 0;
-      size_t len = sizeof(in_buf) / sizeof(in_buf[0]);
-
-      len = std::min(size, len);
-
-      while (true) {
-        // include fstat here to reverify size (statx)
-        r = read(src, in_buf, len, off);
-        if (r < 0) {
-          ldout(cct, 10) << "fcopyfile: error reading copy data, r=" << r << dendl;
-          goto out;
-        } else {
-	  len = r;
-	}
-
-        r = write(dest, in_buf, len, off);
-        if (r < 0) {
-          ldout(cct, 10) << "fcopyfile: error writing copy data, r=" << r << dendl;
-          goto out;
-        }
-        off = off + len;
-
-        if (off == size) {
-          break;
-	} else if (off > size) {
-	  ldout(cct, 0) << __FILE__ << ",  " << __func__ << "() at " << __LINE__
-		        << " internal error: \"off\" is greater than \"size\"; "
-			" off = " << off << " size = " << size << dendl;
-	  r = -1;
-	  goto out;
-	}
-      }
-    }
-    out:
+    if (size == 0) {
       close(dest);
-      if (need_read)
-        close(src);
-      return r;
+      return 0;
+    }
+
+    int src = open(spath, O_RDONLY, perms, mode);
+    if (src < 0) {
+      ldout(cct, 10) << "fcopyfile could not open source file=" << spath << " ret=" << src << dendl;
+      close(dest);
+      return src;
+    }
+
+    int64_t copied = _copyfile(src, 0, dest, 0, size);
+    close(dest);
+    close(src);
+
+    if (copied < 0) {
+      ldout(cct, 10) << "fcopyfile: _copyfile failed, r=" << copied << dendl;
+      return copied;
+    }
+    if (static_cast<size_t>(copied) != size) {
+      ldout(cct, 10) << "fcopyfile: short copy, copied=" << copied << " expected=" << size << dendl;
+      return -EIO;
+    }
   }
   return 0;
+}
+
+int Client::fcopyfilex(int source_fd, off_t src_offset, int dest_fd, off_t dest_offset, size_t size, unsigned flags)
+{
+  RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
+  if (!mref_reader.is_state_satisfied())
+    return -ENOTCONN;
+
+  ldout(cct, 10) << "fcopyfilex source_fd=" << source_fd << " src_offset=" << src_offset
+                 << " dest_fd=" << dest_fd << " dest_offset=" << dest_offset
+                 << " size=" << size << " flags=" << flags << dendl;
+
+  if (size == 0)
+    return 0;
+
+  // Following copy_file_range(2), flags is reserved for future extensions and
+  // must be 0 so that new copy behaviors can be added without an API change.
+  if (flags != 0)
+    return -EINVAL;
+
+  int64_t copied = _copyfile(source_fd, src_offset, dest_fd, dest_offset, size);
+  if (copied < 0) {
+    ldout(cct, 10) << "fcopyfilex: _copyfile failed, r=" << copied << dendl;
+    return copied;
+  }
+  if (static_cast<size_t>(copied) != size) {
+    ldout(cct, 10) << "fcopyfilex: short copy, copied=" << copied << " expected=" << size << dendl;
+  }
+  return copied;
 }
 
 StandaloneClient::StandaloneClient(Messenger *m, MonClient *mc,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -395,6 +395,8 @@ public:
   int is_encrypted(int fd, UserPerm& perms, char* enctag);
 #endif
   int fcopyfile(const char *sname, const char *dname, UserPerm& perms, mode_t mode);
+  int fcopyfilex(int source_fd, off_t src_offset, int dest_fd, off_t dest_offset,
+                 size_t size, unsigned flags);
 
   int mds_command(
     const std::string &mds_spec,
@@ -2144,6 +2146,8 @@ private:
   loff_t _lseek(Fh *fh, loff_t offset, int whence);
   int64_t _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl,
   		Context *onfinish = nullptr, bool read_for_write = false);
+  int64_t _copyfile(int source_fd, off_t src_offset, int dest_fd,
+                    off_t dest_offset, size_t size);
   void do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len);
   int64_t _write_success(Fh *fh, utime_t start, uint64_t fpos,
                          int64_t request_offset, uint64_t request_size,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -396,6 +396,8 @@ public:
   int is_encrypted(int fd, UserPerm& perms, char* enctag);
 #endif
   int fcopyfile(const char *sname, const char *dname, UserPerm& perms, mode_t mode);
+  int fcopyfilex(int source_fd, off_t src_offset, int dest_fd, off_t dest_offset,
+                 size_t size, unsigned flags);
 
   int mds_command(
     const std::string &mds_spec,
@@ -2161,6 +2163,8 @@ private:
   loff_t _lseek(Fh *fh, loff_t offset, int whence);
   int64_t _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl,
   		Context *onfinish = nullptr, bool read_for_write = false);
+  int64_t _copyfile(int source_fd, off_t src_offset, int dest_fd,
+                    off_t dest_offset, size_t size);
   void do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len);
   int64_t _write_success(Fh *fh, utime_t start, uint64_t fpos,
                          int64_t request_offset, uint64_t request_size,

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -2433,6 +2433,24 @@ void ceph_free_snap_info_buffer(struct snap_info *snap_info);
 int ceph_get_perf_counters(struct ceph_mount_info *cmount, char **perf_dump);
 
 int ceph_fcopyfile(struct ceph_mount_info *cmount, const char *spath, const char *dpath, mode_t mode);
+
+/**
+ * Copy a range of bytes from one open file to another.
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param source_fd the file descriptor of the source file.
+ * @param src_offset the offset in the source file to copy from.
+ * @param dest_fd the file descriptor of the destination file.
+ * @param dest_offset the offset in the destination file to copy to.
+ * @param size the number of bytes to copy.
+ * @param flags reserved for future extensions; must be 0.  Following the
+ *              same convention as copy_file_range(2), this parameter is
+ *              present so that future copy behaviors can be added without
+ *              changing the function signature.  Non-zero values return -EINVAL.
+ * @returns the number of bytes copied on success, or a negative error code on failure.
+ */
+int ceph_fcopyfilex(struct ceph_mount_info *cmount, int source_fd, off_t src_offset,
+                    int dest_fd, off_t dest_offset, size_t size, unsigned flags);
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -2494,6 +2494,24 @@ int ceph_get_perf_counters(struct ceph_mount_info *cmount, char **perf_dump);
 
 int ceph_fcopyfile(struct ceph_mount_info *cmount, const char *spath, const char *dpath, mode_t mode);
 
+/**
+ * Copy a range of bytes from one open file to another.
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param source_fd the file descriptor of the source file.
+ * @param src_offset the offset in the source file to copy from.
+ * @param dest_fd the file descriptor of the destination file.
+ * @param dest_offset the offset in the destination file to copy to.
+ * @param size the number of bytes to copy.
+ * @param flags reserved for future extensions; must be 0.  Following the
+ *              same convention as copy_file_range(2), this parameter is
+ *              present so that future copy behaviors can be added without
+ *              changing the function signature.  Non-zero values return -EINVAL.
+ * @returns the number of bytes copied on success, or a negative error code on failure.
+ */
+int ceph_fcopyfilex(struct ceph_mount_info *cmount, int source_fd, off_t src_offset,
+                    int dest_fd, off_t dest_offset, size_t size, unsigned flags);
+
 #if __GNUC__ >= 4
   #pragma GCC diagnostic pop
 #endif

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2692,3 +2692,13 @@ extern "C" int ceph_fcopyfile(struct ceph_mount_info *cmount, const char *spath,
     return -ENOTCONN;
   return cmount->get_client()->fcopyfile(spath, dpath, cmount->default_perms, mode);
 }
+
+extern "C" int ceph_fcopyfilex(struct ceph_mount_info *cmount, int source_fd,
+                               off_t src_offset, int dest_fd, off_t dest_offset,
+                               size_t size, unsigned flags)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+  return cmount->get_client()->fcopyfilex(source_fd, src_offset, dest_fd,
+                                          dest_offset, size, flags);
+}

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2793,3 +2793,13 @@ extern "C" int ceph_fcopyfile(struct ceph_mount_info *cmount, const char *spath,
     return -ENOTCONN;
   return cmount->get_client()->fcopyfile(spath, dpath, cmount->default_perms, mode);
 }
+
+extern "C" int ceph_fcopyfilex(struct ceph_mount_info *cmount, int source_fd,
+                               off_t src_offset, int dest_fd, off_t dest_offset,
+                               size_t size, unsigned flags)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+  return cmount->get_client()->fcopyfilex(source_fd, src_offset, dest_fd,
+                                          dest_offset, size, flags);
+}

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -134,6 +134,8 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_flistxattr(ceph_mount_info *cmount, int fd, char *list, size_t size)
     int ceph_llistxattr(ceph_mount_info *cmount, const char *path, char *list, size_t size)
     int ceph_fcopyfile(ceph_mount_info *cmount, const char *spath, const char *dpath, mode_t mode)
+    int ceph_fcopyfilex(ceph_mount_info *cmount, int source_fd, int64_t src_offset,
+                        int dest_fd, int64_t dest_offset, size_t size, unsigned flags)
     int ceph_write(ceph_mount_info *cmount, int fd, const char *buf, int64_t size, int64_t offset)
     int ceph_pwritev(ceph_mount_info *cmount, int fd, iovec *iov, int iovcnt, int64_t offset)
     int ceph_read(ceph_mount_info *cmount, int fd, char *buf, int64_t size, int64_t offset)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -137,6 +137,8 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_flistxattr(ceph_mount_info *cmount, int fd, char *list, size_t size)
     int ceph_llistxattr(ceph_mount_info *cmount, const char *path, char *list, size_t size)
     int ceph_fcopyfile(ceph_mount_info *cmount, const char *spath, const char *dpath, mode_t mode)
+    int ceph_fcopyfilex(ceph_mount_info *cmount, int source_fd, int64_t src_offset,
+                        int dest_fd, int64_t dest_offset, size_t size, unsigned flags)
     int ceph_write(ceph_mount_info *cmount, int fd, const char *buf, int64_t size, int64_t offset)
     int ceph_pwritev(ceph_mount_info *cmount, int fd, iovec *iov, int iovcnt, int64_t offset)
     int ceph_read(ceph_mount_info *cmount, int fd, char *buf, int64_t size, int64_t offset)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2159,6 +2159,38 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "error in fcopyfile")
 
+    def fcopyfilex(self, source_fd, src_offset, dest_fd, dest_offset, size, flags=0):
+        """
+        Copy data from one file descriptor to another with offsets.
+
+        :param source_fd: the source file descriptor.
+        :param src_offset: the starting offset in the source file.
+        :param dest_fd: the destination file descriptor.
+        :param dest_offset: the starting offset in the destination file.
+        :param size: the number of bytes to copy.
+        :param flags: reserved for future extensions; must be 0.  Like
+            copy_file_range(2), this allows future copy behaviors without
+            changing the API.  Non-zero values return EINVAL.
+        :return: the number of bytes copied.
+        """
+        self.require_state("mounted")
+
+        cdef:
+            int _source_fd = source_fd
+            int64_t _src_offset = src_offset
+            int _dest_fd = dest_fd
+            int64_t _dest_offset = dest_offset
+            size_t _size = size
+            unsigned _flags = flags
+
+        with nogil:
+            ret = ceph_fcopyfilex(self.cluster, _source_fd, _src_offset, _dest_fd, _dest_offset, _size, _flags)
+
+        if ret < 0:
+            raise make_ex(ret, "error in fcopyfilex")
+
+        return ret
+
     def stat(self, path, follow_symlink=True):
         """
         Get a file's extended statistics and attributes.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2252,6 +2252,38 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "error in fcopyfile")
 
+    def fcopyfilex(self, source_fd, src_offset, dest_fd, dest_offset, size, flags=0):
+        """
+        Copy data from one file descriptor to another with offsets.
+
+        :param source_fd: the source file descriptor.
+        :param src_offset: the starting offset in the source file.
+        :param dest_fd: the destination file descriptor.
+        :param dest_offset: the starting offset in the destination file.
+        :param size: the number of bytes to copy.
+        :param flags: reserved for future extensions; must be 0.  Like
+            copy_file_range(2), this allows future copy behaviors without
+            changing the API.  Non-zero values return EINVAL.
+        :return: the number of bytes copied.
+        """
+        self.require_state("mounted")
+
+        cdef:
+            int _source_fd = source_fd
+            int64_t _src_offset = src_offset
+            int _dest_fd = dest_fd
+            int64_t _dest_offset = dest_offset
+            size_t _size = size
+            unsigned _flags = flags
+
+        with nogil:
+            ret = ceph_fcopyfilex(self.cluster, _source_fd, _src_offset, _dest_fd, _dest_offset, _size, _flags)
+
+        if ret < 0:
+            raise make_ex(ret, "error in fcopyfilex")
+
+        return ret
+
     def stat(self, path, follow_symlink=True):
         """
         Get a file's extended statistics and attributes.

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -183,6 +183,9 @@ cdef nogil:
         pass
     int ceph_fcopyfile(ceph_mount_info *cmount, const char *spath, const char *dpath, mode_t mode):
         pass
+    int ceph_fcopyfilex(ceph_mount_info *cmount, int source_fd, int64_t src_offset,
+                        int dest_fd, int64_t dest_offset, size_t size, unsigned flags):
+        pass
     int ceph_write(ceph_mount_info *cmount, int fd, const char *buf, int64_t size, int64_t offset):
         pass
     int ceph_pwritev(ceph_mount_info *cmount, int fd, iovec *iov, int iovcnt, int64_t offset):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -186,6 +186,9 @@ cdef nogil:
         pass
     int ceph_fcopyfile(ceph_mount_info *cmount, const char *spath, const char *dpath, mode_t mode):
         pass
+    int ceph_fcopyfilex(ceph_mount_info *cmount, int source_fd, int64_t src_offset,
+                        int dest_fd, int64_t dest_offset, size_t size, unsigned flags):
+        pass
     int ceph_write(ceph_mount_info *cmount, int fd, const char *buf, int64_t size, int64_t offset):
         pass
     int ceph_pwritev(ceph_mount_info *cmount, int fd, iovec *iov, int iovcnt, int64_t offset):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -3470,3 +3470,169 @@ class TestDoSnapMdOp:
 
         cephfs.rmsnap(dir_path, snap_name)
         cephfs.rmdir(dir_path)
+
+
+class TestFcopyfilex:
+    '''
+    Tests for fcopyfilex() method of CephFS Python bindings.
+    '''
+
+    PERMS = 0o755
+    FILE_SRC = b'file_src'
+    FILE_DST = b'file_dst'
+
+    def _create_test_files(self, data_size, dst_initial_size=0):
+        '''
+        Helper function to create source and destination test files.
+        Returns the pattern data array for verification.
+        '''
+        # Create pattern data: repeating sequence for easy verification
+        pattern = bytes(range(256))
+        data = (pattern * ((data_size // 256) + 1))[:data_size]
+
+        # Write source file
+        fd_src_write = cephfs.open(self.FILE_SRC, 'w', self.PERMS)
+        cephfs.write(fd_src_write, data, 0)
+        cephfs.close(fd_src_write)
+
+        # Create destination file with initial content
+        fd_dst = cephfs.open(self.FILE_DST, 'w+', self.PERMS)
+        cephfs.write(fd_dst, b'0' * dst_initial_size, 0)
+        cephfs.close(fd_dst)
+
+        return data
+
+    def _write_file_and_test_fcopyfilex(self, data_size, src_offset, dst_offset,
+                                        copy_length, expected_copied=None):
+        '''
+        Helper function to test fcopyfilex() with specified offsets.
+        Creates a source file with pattern data, opens it for reading,
+        creates a destination file, calls fcopyfilex() with the given parameters,
+        and verifies the data was copied correctly to the destination at the right offset.
+
+        Args:
+            expected_copied: Expected number of bytes actually copied (defaults to copy_length for full copies)
+        '''
+        if expected_copied is None:
+            expected_copied = copy_length
+
+        data = self._create_test_files(data_size, dst_offset + copy_length)
+
+        # Reopen source for reading
+        fd_src = cephfs.open(self.FILE_SRC, 'r', self.PERMS)
+
+        # Reopen destination for writing
+        fd_dst = cephfs.open(self.FILE_DST, 'w+', self.PERMS)
+
+        # Perform fcopyfilex
+        copied = cephfs.fcopyfilex(fd_src, src_offset, fd_dst, dst_offset, copy_length)
+        assert copied == expected_copied
+
+        # Close files
+        cephfs.close(fd_src)
+        cephfs.close(fd_dst)
+
+        # Verify the copied data
+        fd_verify = cephfs.open(self.FILE_DST, 'r', self.PERMS)
+        result_data = cephfs.read(fd_verify, dst_offset, expected_copied)
+        cephfs.close(fd_verify)
+
+        expected_data = data[src_offset:src_offset + expected_copied]
+        assert result_data == expected_data
+
+    def test_fcopyfilex_with_offset(self, testdir):
+        '''
+        Test that fcopyfilex() copies a byte range from one file descriptor to another.
+        '''
+        self._write_file_and_test_fcopyfilex(24, 5, 10, 10)
+
+    def test_with_regfile_of_size_0_5MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 0.5 MB file correctly.
+        '''
+        size = int(0.5 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_2MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 2 MB file correctly.
+        '''
+        size = int(2 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1 MB file correctly.
+        '''
+        size = int(1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_2MiB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 2 MiB file correctly.
+        '''
+        size = int(2 * 1024 * 1024)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1_15MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1.15 MB file correctly.
+        '''
+        size = int(1.15 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1_5MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1.5 MB file correctly.
+        '''
+        size = int(1.5 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1GB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1 GB file correctly.
+        '''
+        size = int(1 * 1000 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_fcopyfilex_source_offset_beyond_file(self, testdir):
+        '''
+        Test that fcopyfilex() copies 0 bytes when source offset is beyond file size.
+        '''
+        data_size = 100
+        src_offset = 150  # Beyond file size
+        dst_offset = 0
+        copy_length = 50
+
+        self._write_file_and_test_fcopyfilex(data_size, src_offset, dst_offset, copy_length, expected_copied=0)
+
+    def test_fcopyfilex_partial_copy_due_to_source_size(self, testdir):
+        '''
+        Test that fcopyfilex() handles partial copy when source offset + length exceeds file size.
+        '''
+        data_size = 50
+        src_offset = 20
+        dst_offset = 0
+        copy_length = 50  # This will exceed available data (50 - 20 = 30 bytes available)
+        expected_copied = 30  # Only 30 bytes available from offset 20
+
+        self._write_file_and_test_fcopyfilex(data_size, src_offset, dst_offset,
+                                             copy_length, expected_copied)
+
+    def test_fcopyfilex_destination_offset_beyond_size(self, testdir):
+        '''
+        Test that fcopyfilex() handles destination offset beyond current file size.
+        '''
+        data_size = 50
+        src_offset = 0
+        dst_offset = 100  # Beyond current destination file size
+        copy_length = 20
+
+        self._write_file_and_test_fcopyfilex(data_size, src_offset, dst_offset, copy_length)
+
+
+    def test_fcopyfilex_invalid_fd(self, testdir):
+        '''
+        Test that fcopyfilex() fails when file descriptors are invalid.
+        '''
+        assert_raises(libcephfs.Error, cephfs.fcopyfilex, 0xab01, 0, 0xab02, 0, 16, 0)

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -3508,3 +3508,169 @@ class TestDoSnapMdOp:
 
         cephfs.rmsnap(dir_path, snap_name)
         cephfs.rmdir(dir_path)
+
+
+class TestFcopyfilex:
+    '''
+    Tests for fcopyfilex() method of CephFS Python bindings.
+    '''
+
+    PERMS = 0o755
+    FILE_SRC = b'file_src'
+    FILE_DST = b'file_dst'
+
+    def _create_test_files(self, data_size, dst_initial_size=0):
+        '''
+        Helper function to create source and destination test files.
+        Returns the pattern data array for verification.
+        '''
+        # Create pattern data: repeating sequence for easy verification
+        pattern = bytes(range(256))
+        data = (pattern * ((data_size // 256) + 1))[:data_size]
+
+        # Write source file
+        fd_src_write = cephfs.open(self.FILE_SRC, 'w', self.PERMS)
+        cephfs.write(fd_src_write, data, 0)
+        cephfs.close(fd_src_write)
+
+        # Create destination file with initial content
+        fd_dst = cephfs.open(self.FILE_DST, 'w+', self.PERMS)
+        cephfs.write(fd_dst, b'0' * dst_initial_size, 0)
+        cephfs.close(fd_dst)
+
+        return data
+
+    def _write_file_and_test_fcopyfilex(self, data_size, src_offset, dst_offset,
+                                        copy_length, expected_copied=None):
+        '''
+        Helper function to test fcopyfilex() with specified offsets.
+        Creates a source file with pattern data, opens it for reading,
+        creates a destination file, calls fcopyfilex() with the given parameters,
+        and verifies the data was copied correctly to the destination at the right offset.
+
+        Args:
+            expected_copied: Expected number of bytes actually copied (defaults to copy_length for full copies)
+        '''
+        if expected_copied is None:
+            expected_copied = copy_length
+
+        data = self._create_test_files(data_size, dst_offset + copy_length)
+
+        # Reopen source for reading
+        fd_src = cephfs.open(self.FILE_SRC, 'r', self.PERMS)
+
+        # Reopen destination for writing
+        fd_dst = cephfs.open(self.FILE_DST, 'w+', self.PERMS)
+
+        # Perform fcopyfilex
+        copied = cephfs.fcopyfilex(fd_src, src_offset, fd_dst, dst_offset, copy_length)
+        assert copied == expected_copied
+
+        # Close files
+        cephfs.close(fd_src)
+        cephfs.close(fd_dst)
+
+        # Verify the copied data
+        fd_verify = cephfs.open(self.FILE_DST, 'r', self.PERMS)
+        result_data = cephfs.read(fd_verify, dst_offset, expected_copied)
+        cephfs.close(fd_verify)
+
+        expected_data = data[src_offset:src_offset + expected_copied]
+        assert result_data == expected_data
+
+    def test_fcopyfilex_with_offset(self, testdir):
+        '''
+        Test that fcopyfilex() copies a byte range from one file descriptor to another.
+        '''
+        self._write_file_and_test_fcopyfilex(24, 5, 10, 10)
+
+    def test_with_regfile_of_size_0_5MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 0.5 MB file correctly.
+        '''
+        size = int(0.5 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_2MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 2 MB file correctly.
+        '''
+        size = int(2 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1 MB file correctly.
+        '''
+        size = int(1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_2MiB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 2 MiB file correctly.
+        '''
+        size = int(2 * 1024 * 1024)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1_15MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1.15 MB file correctly.
+        '''
+        size = int(1.15 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1_5MB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1.5 MB file correctly.
+        '''
+        size = int(1.5 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_with_regfile_of_size_1GB(self, testdir):
+        '''
+        Test that fcopyfilex() copies a 1 GB file correctly.
+        '''
+        size = int(1 * 1000 * 1000 * 1000)
+        self._write_file_and_test_fcopyfilex(size, 0, 0, size)
+
+    def test_fcopyfilex_source_offset_beyond_file(self, testdir):
+        '''
+        Test that fcopyfilex() copies 0 bytes when source offset is beyond file size.
+        '''
+        data_size = 100
+        src_offset = 150  # Beyond file size
+        dst_offset = 0
+        copy_length = 50
+
+        self._write_file_and_test_fcopyfilex(data_size, src_offset, dst_offset, copy_length, expected_copied=0)
+
+    def test_fcopyfilex_partial_copy_due_to_source_size(self, testdir):
+        '''
+        Test that fcopyfilex() handles partial copy when source offset + length exceeds file size.
+        '''
+        data_size = 50
+        src_offset = 20
+        dst_offset = 0
+        copy_length = 50  # This will exceed available data (50 - 20 = 30 bytes available)
+        expected_copied = 30  # Only 30 bytes available from offset 20
+
+        self._write_file_and_test_fcopyfilex(data_size, src_offset, dst_offset,
+                                             copy_length, expected_copied)
+
+    def test_fcopyfilex_destination_offset_beyond_size(self, testdir):
+        '''
+        Test that fcopyfilex() handles destination offset beyond current file size.
+        '''
+        data_size = 50
+        src_offset = 0
+        dst_offset = 100  # Beyond current destination file size
+        copy_length = 20
+
+        self._write_file_and_test_fcopyfilex(data_size, src_offset, dst_offset, copy_length)
+
+
+    def test_fcopyfilex_invalid_fd(self, testdir):
+        '''
+        Test that fcopyfilex() fails when file descriptors are invalid.
+        '''
+        assert_raises(libcephfs.Error, cephfs.fcopyfilex, 0xab01, 0, 0xab02, 0, 16, 0)


### PR DESCRIPTION
Adding the fcopyfilex() implementation and the
required pybindings for it.

Fixes: https://tracker.ceph.com/issues/74401



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
