### PR TITLE
tools/cephfs_mirror: Add metrics

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -78,6 +78,11 @@
   ``ceph fs snapshot mirror daemon status`` now shows the remote cluster's
   monitor addresses and cluster ID for each configured peer, making it easier
   to verify peer connectivity and troubleshoot mirroring issues.
+* CephFS Mirroring: The ``fs mirror peer status`` admin socket command reports
+  additional per-directory sync metrics (sync mode, throughput, crawl and
+  data-sync queue timing, bytes/files progress, and ETA). Output is grouped
+  under ``metrics/<mirrored-dir-path>/peer/<peer-uuid>``. For more information,
+  see https://tracker.ceph.com/issues/73453
 * RBD: Mirror snapshot creation and trash purge schedules are now automatically
   staggered when no explicit "start-time" is specified. This reduces scheduling
   spikes and distributes work more evenly over time.

--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -356,20 +356,112 @@ command parameter is of format ``filesystem-name@filesystem-id peer-uuid``::
 
   $ ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror peer status cephfs@360 a2dc7784-e7a1-4723-b103-03ee8d8768f8
   {
-    "/d0": {
-        "state": "idle",
-        "last_synced_snap": {
-            "id": 120,
-            "name": "snap1",
-            "sync_duration": 3,
-            "sync_time_stamp": "274900.558797s",
-            "sync_bytes": 52428800
-        },
-        "snaps_synced": 2,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
+    "metrics": {
+        "/d0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "idle",
+                    "last_synced_snap": {
+                        "id": 120,
+                        "name": "snap1",
+                        "crawl_duration": "2s",
+                        "datasync_queue_wait_duration": "1s",
+                        "sync_duration": "33s",
+                        "sync_time_stamp": "274900.558797s",
+                        "sync_bytes": "149.94 MiB",
+                        "sync_files": 5000
+                    },
+                    "snaps_synced": 2,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
+        }
     }
   }
+
+The per-directory fields are nested under ``metrics/<mirrored-dir-path>/peer/<peer-uuid>`` so
+the same directory path can be reported for multiple peers without key collisions.
+
+.. _cephfs_mirror_peer_status_formatting:
+
+Value formatting
+----------------
+
+Several fields in the status output are formatted for readability rather than reported as raw
+numbers. The subsections below describe each format; field tables later in this section refer
+back to them.
+
+.. _cephfs_mirror_status_durations:
+
+Durations
+---------
+
+Fields: ``crawl_duration``, ``datasync_queue_wait_duration``, ``sync_duration``,
+``crawl.duration``, ``datasync_queue_wait.duration``, and ``eta``.
+
+Elapsed time is rounded to the nearest whole second and displayed as a combination of days,
+hours, minutes, and seconds. The format adapts to the magnitude:
+
+- ``<SS>s`` — seconds only, when less than one minute (for example, ``2s`` or ``33s``)
+- ``<M>m <SS>s`` — minutes and seconds, when less than one hour (for example, ``5m 12s``)
+- ``<H>h <MM>m <SS>s`` — hours, minutes, and seconds, when less than one day
+  (for example, ``1h 05m 30s``)
+- ``<D>d <HH>h <MM>m <SS>s`` — days, hours, minutes, and seconds, when one day or longer
+  (for example, ``1d 02h 30m 45s``)
+
+.. _cephfs_mirror_status_data_sizes:
+
+Data sizes
+----------
+
+Fields: ``sync_bytes``, ``bytes.sync_bytes``, ``bytes.total_bytes``, and the byte counts in
+``last_synced_snap``.
+
+Byte counts use binary (IEC) units with two decimal places. The unit is chosen automatically
+from ``B``, ``KiB``, ``MiB``, ``GiB``, ``TiB``, or ``PiB`` (powers of 1024). For example,
+``149.94 MiB``.
+
+.. _cephfs_mirror_status_throughput:
+
+Throughput
+----------
+
+Fields: ``avg_read_throughput_bytes`` and ``avg_write_throughput_bytes``.
+
+Average transfer rate in bytes per second, using the same binary units as :ref:`data sizes
+<cephfs_mirror_status_data_sizes>` with a ``/s`` suffix. For example, ``13.03 MiB/s`` means
+13.03 mebibytes per second.
+
+.. _cephfs_mirror_status_percentages:
+
+Percentages
+-----------
+
+Fields: ``bytes.sync_percent`` and ``files.sync_percent``.
+
+Percentage complete with two decimal places and a ``%`` suffix (for example, ``40.29%``).
+
+.. _cephfs_mirror_status_counts:
+
+Counts
+------
+
+Fields: ``sync_files``, ``total_files``, ``snaps_synced``, ``snaps_deleted``, ``snaps_renamed``,
+and snapshot ``id``.
+
+Plain unsigned integers with no unit suffix.
+
+.. _cephfs_mirror_status_timestamp:
+
+Timestamp
+---------
+
+Field: ``sync_time_stamp``.
+
+Monotonic clock time in seconds (since daemon startup) when the snapshot sync finished,
+printed with sub-second precision and an ``s`` suffix (for example, ``274900.558797s``). This
+is not a wall-clock or epoch timestamp.
 
 Synchronization stats including ``snaps_synced``, ``snaps_deleted`` and ``snaps_renamed`` are reset
 on daemon restart and/or when a directory is reassigned to another mirror daemon (when
@@ -386,26 +478,127 @@ When a directory is currently being synchronized, the mirror daemon marks it as 
 
   $ ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror peer status cephfs@360 a2dc7784-e7a1-4723-b103-03ee8d8768f8
   {
-    "/d0": {
-        "state": "syncing",
-        "current_syncing_snap": {
-            "id": 121,
-            "name": "snap2"
-        },
-        "last_synced_snap": {
-            "id": 120,
-            "name": "snap1",
-            "sync_duration": 3,
-            "sync_time_stamp": "274900.558797s",
-            "sync_bytes": 52428800
-        },
-        "snaps_synced": 2,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
+    "metrics": {
+        "/d0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "syncing",
+                    "current_syncing_snap": {
+                        "id": 121,
+                        "name": "snap2",
+                        "sync-mode": "full",
+                        "avg_read_throughput_bytes": "13.03 MiB/s",
+                        "avg_write_throughput_bytes": "24.24 MiB/s",
+                        "crawl": {
+                            "state": "completed",
+                            "duration": "2s"
+                        },
+                        "datasync_queue_wait": {
+                            "state": "complete",
+                            "duration": "1s"
+                        },
+                        "bytes": {
+                            "sync_bytes": "60.40 MiB",
+                            "total_bytes": "149.94 MiB",
+                            "sync_percent": "40.29%"
+                        },
+                        "files": {
+                            "sync_files": 2013,
+                            "total_files": 5000,
+                            "sync_percent": "40.26%"
+                        },
+                        "eta": "7s"
+                    },
+                    "snaps_synced": 2,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
+        }
     }
   }
 
 The mirror daemon marks it back to ``idle``, when the syncing completes.
+
+When ``state`` is ``syncing``, ``current_syncing_snap`` includes the following
+progress fields (see :ref:`cephfs_mirror_peer_status_formatting` for how values are
+displayed):
+
+.. list-table::
+   :widths: 35 65
+   :header-rows: 1
+
+   * - Field
+     - Description
+   * - ``sync-mode``
+     - Whether the snapshot is synchronized with a full tree copy (``full``) or incremental snapdiff/blockdiff (``delta``).
+   * - ``avg_read_throughput_bytes``
+     - Average read rate from the primary filesystem for this snapshot sync. See
+       :ref:`Throughput <cephfs_mirror_status_throughput>`.
+   * - ``avg_write_throughput_bytes``
+     - Average write rate to the remote peer for this snapshot sync. See
+       :ref:`Throughput <cephfs_mirror_status_throughput>`.
+   * - ``crawl.state``
+     - Whether the directory tree walk is ``in-progress`` or ``completed``. While
+       ``in-progress``, ``bytes.total_bytes`` and ``files.total_files`` reflect only what
+       has been discovered so far and may keep increasing; once ``completed``, those totals
+       are fully discovered for this snapshot sync.
+   * - ``crawl.duration``
+     - Elapsed crawl time so far, or total crawl time once ``crawl.state`` is ``completed``.
+       See :ref:`Durations <cephfs_mirror_status_durations>`.
+   * - ``datasync_queue_wait.state``
+     - Whether the snapshot is still ``waiting`` in the data-sync queue or has started transfer (``complete``).
+   * - ``datasync_queue_wait.duration``
+     - Elapsed queue wait time so far, or total queue wait time once transfer has started.
+       See :ref:`Durations <cephfs_mirror_status_durations>`.
+   * - ``bytes.sync_bytes``
+     - Amount of file data synchronized so far for this snapshot. See
+       :ref:`Data sizes <cephfs_mirror_status_data_sizes>`.
+   * - ``bytes.total_bytes``
+     - Total file data discovered for this snapshot sync. See
+       :ref:`Data sizes <cephfs_mirror_status_data_sizes>`. Increases during the crawl while
+       ``crawl.state`` is ``in-progress``; final once ``crawl.state`` is ``completed``.
+   * - ``bytes.sync_percent``
+     - Percentage of ``total_bytes`` synchronized so far. See
+       :ref:`Percentages <cephfs_mirror_status_percentages>`.
+   * - ``files.sync_files``
+     - Number of files synchronized so far for this snapshot. See
+       :ref:`Counts <cephfs_mirror_status_counts>`.
+   * - ``files.total_files``
+     - Total number of files discovered for this snapshot sync. See
+       :ref:`Counts <cephfs_mirror_status_counts>`. Increases during the crawl while
+       ``crawl.state`` is ``in-progress``; final once ``crawl.state`` is ``completed``.
+   * - ``files.sync_percent``
+     - Percentage of ``total_files`` synchronized so far. See
+       :ref:`Percentages <cephfs_mirror_status_percentages>`.
+   * - ``eta``
+     - Estimated time remaining to finish the snapshot sync, or ``calculating...`` until enough
+       samples are collected. See :ref:`Durations <cephfs_mirror_status_durations>`.
+
+``last_synced_snap`` includes these additional fields for the last completed snapshot sync
+(see :ref:`cephfs_mirror_peer_status_formatting` for how values are displayed):
+
+.. list-table::
+   :widths: 35 65
+   :header-rows: 1
+
+   * - Field
+     - Description
+   * - ``crawl_duration``
+     - Total time spent walking the directory tree for that snapshot sync. See
+       :ref:`Durations <cephfs_mirror_status_durations>`.
+   * - ``datasync_queue_wait_duration``
+     - Total time the snapshot waited in the data-sync queue before file transfer began. See
+       :ref:`Durations <cephfs_mirror_status_durations>`.
+   * - ``sync_duration``
+     - Total elapsed time for the snapshot sync. See :ref:`Durations <cephfs_mirror_status_durations>`.
+   * - ``sync_time_stamp``
+     - When the sync finished. See :ref:`Timestamp <cephfs_mirror_status_timestamp>`.
+   * - ``sync_bytes``
+     - Total file data synchronized for that snapshot. See
+       :ref:`Data sizes <cephfs_mirror_status_data_sizes>`.
+   * - ``sync_files``
+     - Number of files synchronized for that snapshot. See :ref:`Counts <cephfs_mirror_status_counts>`.
 
 When a directory experiences a configured number of consecutive synchronization failures, the
 mirror daemon marks it as ``failed``. Synchronization for these directories is retried.
@@ -419,24 +612,37 @@ E.g., adding a regular file for synchronization would result in failed status::
   $ ceph fs snapshot mirror add cephfs /f0
   $ ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror peer status cephfs@360 a2dc7784-e7a1-4723-b103-03ee8d8768f8
   {
-    "/d0": {
-        "state": "idle",
-        "last_synced_snap": {
-            "id": 121,
-            "name": "snap2",
-            "sync_duration": 5,
-            "sync_time_stamp": "500900.600797s",
-            "sync_bytes": 78643200
+    "metrics": {
+        "/d0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "idle",
+                    "last_synced_snap": {
+                        "id": 121,
+                        "name": "snap2",
+                        "crawl_duration": "2s",
+                        "datasync_queue_wait_duration": "1s",
+                        "sync_duration": "44s",
+                        "sync_time_stamp": "500900.600797s",
+                        "sync_bytes": "149.94 MiB",
+                        "sync_files": 5000
+                    },
+                    "snaps_synced": 3,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
         },
-        "snaps_synced": 3,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
-    },
-    "/f0": {
-        "state": "failed",
-        "snaps_synced": 0,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
+        "/f0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "failed",
+                    "snaps_synced": 0,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
+        }
     }
   }
 
@@ -454,24 +660,38 @@ In the remote filesystem::
 
   $ ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror peer status cephfs@360 a2dc7784-e7a1-4723-b103-03ee8d8768f8
   {
-    "/d0": {
-        "state": "failed",
-        "failure_reason": "snapshot 'snap2' has invalid metadata",
-        "last_synced_snap": {
-            "id": 120,
-            "name": "snap1",
-            "sync_duration": 3,
-            "sync_time_stamp": "274900.558797s"
+    "metrics": {
+        "/d0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "failed",
+                    "failure_reason": "snapshot 'snap2' has invalid metadata",
+                    "last_synced_snap": {
+                        "id": 120,
+                        "name": "snap1",
+                        "crawl_duration": "2s",
+                        "datasync_queue_wait_duration": "1s",
+                        "sync_duration": "33s",
+                        "sync_time_stamp": "274900.558797s",
+                        "sync_bytes": "149.94 MiB",
+                        "sync_files": 5000
+                    },
+                    "snaps_synced": 2,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
         },
-        "snaps_synced": 2,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
-    },
-    "/f0": {
-        "state": "failed",
-        "snaps_synced": 0,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
+        "/f0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "failed",
+                    "snaps_synced": 0,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
+        }
     }
   }
 

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -393,19 +393,34 @@ status. Commands of this kind take the form ``filesystem-name@filesystem-id peer
 ::
 
   {
-    "/d0": {
-        "state": "idle",
-        "last_synced_snap": {
-            "id": 120,
-            "name": "snap1",
-            "sync_duration": 0.079997898999999997,
-            "sync_time_stamp": "274900.558797s"
-        },
-        "snaps_synced": 2,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
+    "metrics": {
+        "/d0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "idle",
+                    "last_synced_snap": {
+                        "id": 120,
+                        "name": "snap1",
+                        "crawl_duration": "2s",
+                        "datasync_queue_wait_duration": "1s",
+                        "sync_duration": "33s",
+                        "sync_time_stamp": "274900.558797s",
+                        "sync_bytes": "149.94 MiB",
+                        "sync_files": 5000
+                    },
+                    "snaps_synced": 2,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
+        }
     }
   }
+
+Several fields in the status output are formatted for readability rather than reported as raw
+numbers. See :ref:`Value formatting <cephfs_mirror_peer_status_formatting>` in
+:doc:`/cephfs/cephfs-mirroring` for duration, data size, throughput, percentage, count, and
+timestamp formats.
 
 Synchronization stats such as ``snaps_synced``, ``snaps_deleted`` and
 ``snaps_renamed`` are reset when the daemon is restarted or (when multiple
@@ -418,6 +433,49 @@ A directory can be in one of the following states::
   - `idle`: The directory is currently not being synchronized
   - `syncing`: The directory is currently being synchronized
   - `failed`: The directory has hit upper limit of consecutive failures
+
+::
+
+  {
+    "metrics": {
+        "/d0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "syncing",
+                    "current_syncing_snap": {
+                        "id": 121,
+                        "name": "snap2",
+                        "sync-mode": "full",
+                        "avg_read_throughput_bytes": "13.03 MiB/s",
+                        "avg_write_throughput_bytes": "24.24 MiB/s",
+                        "crawl": {
+                            "state": "completed",
+                            "duration": "2s"
+                        },
+                        "datasync_queue_wait": {
+                            "state": "complete",
+                            "duration": "1s"
+                        },
+                        "bytes": {
+                            "sync_bytes": "60.40 MiB",
+                            "total_bytes": "149.94 MiB",
+                            "sync_percent": "40.29%"
+                        },
+                        "files": {
+                            "sync_files": 2013,
+                            "total_files": 5000,
+                            "sync_percent": "40.26%"
+                        },
+                        "eta": "7s"
+                    },
+                    "snaps_synced": 2,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
+        }
+    }
+  }
 
 When a directory hits a configured number of consecutive synchronization
 failures, the mirror daemon marks it as ``failed``. Synchronization for these
@@ -439,23 +497,37 @@ status:
 ::
 
   {
-    "/d0": {
-        "state": "idle",
-        "last_synced_snap": {
-            "id": 120,
-            "name": "snap1",
-            "sync_duration": 0.079997898999999997,
-            "sync_time_stamp": "274900.558797s"
+    "metrics": {
+        "/d0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "idle",
+                    "last_synced_snap": {
+                        "id": 120,
+                        "name": "snap1",
+                        "crawl_duration": "2s",
+                        "datasync_queue_wait_duration": "1s",
+                        "sync_duration": "33s",
+                        "sync_time_stamp": "274900.558797s",
+                        "sync_bytes": "149.94 MiB",
+                        "sync_files": 5000
+                    },
+                    "snaps_synced": 2,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
         },
-        "snaps_synced": 2,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
-    },
-    "/f0": {
-        "state": "failed",
-        "snaps_synced": 0,
-        "snaps_deleted": 0,
-        "snaps_renamed": 0
+        "/f0": {
+            "peer": {
+                "a2dc7784-e7a1-4723-b103-03ee8d8768f8": {
+                    "state": "failed",
+                    "snaps_synced": 0,
+                    "snaps_deleted": 0,
+                    "snaps_renamed": 0
+                }
+            }
+        }
     }
   }
 

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 import base64
 import errno
@@ -260,7 +261,61 @@ class TestMirroring(CephFSTestCase):
         self.assertEqual(peer['stats']['recovery_count'], 1)
 
     def peer_dir_status(self, res, dir_name, peer_uuid):
+        self.assertIn('metrics', res)
         return res['metrics'][dir_name]['peer'][peer_uuid]
+
+    def assert_last_synced_snap_metrics(self, last_synced_snap):
+        for key in ('crawl_duration', 'datasync_queue_wait_duration', 'sync_duration',
+                    'sync_time_stamp', 'sync_bytes', 'sync_files'):
+            self.assertIn(key, last_synced_snap, msg=f'missing last_synced_snap.{key}')
+        self.assertRegex(
+            last_synced_snap['sync_bytes'],
+            r'^\d+(\.\d+)?\s+(B|KiB|MiB|GiB|TiB|PiB)$')
+        self.assertIsInstance(last_synced_snap['sync_files'], int)
+        self.assertGreaterEqual(last_synced_snap['sync_files'], 0)
+
+    def assert_syncing_snap_metrics(self, snap, sync_mode=None):
+        for key in ('sync-mode', 'avg_read_throughput_bytes', 'avg_write_throughput_bytes',
+                    'crawl', 'bytes', 'files', 'eta'):
+            self.assertIn(key, snap, msg=f'missing current_syncing_snap.{key}')
+        if sync_mode is not None:
+            self.assertEqual(snap['sync-mode'], sync_mode)
+        self.assertTrue(snap['avg_read_throughput_bytes'].endswith('/s'))
+        self.assertTrue(snap['avg_write_throughput_bytes'].endswith('/s'))
+        self.assertIn(snap['crawl']['state'], ('in-progress', 'completed'))
+        self.assertTrue(snap['crawl']['duration'])
+        bytes_obj = snap['bytes']
+        self.assertIn('sync_bytes', bytes_obj)
+        self.assertIn('total_bytes', bytes_obj)
+        if bytes_obj.get('total_bytes') and bytes_obj['total_bytes'] != '0.00 B':
+            self.assertIn('sync_percent', bytes_obj)
+        files_obj = snap['files']
+        self.assertIn('sync_files', files_obj)
+        self.assertIn('total_files', files_obj)
+        if files_obj.get('total_files', 0) > 0:
+            self.assertIn('sync_percent', files_obj)
+        self.assertTrue(
+            snap['eta'] == 'calculating...' or bool(re.search(r'\d', snap['eta'])))
+
+    @retry_assert(timeout=120, interval=1)
+    def check_peer_syncing_progress_metrics(self, fs_name, fs_id, peer_spec, dir_name,
+                                            snap_name, sync_mode=None):
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
+                                         'fs', 'mirror', 'peer', 'status',
+                                         f'{fs_name}@{fs_id}', peer_uuid)
+        try:
+            dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+            self.assertEqual(dir_stat['state'], 'syncing')
+            snap = dir_stat['current_syncing_snap']
+            self.assertEqual(snap['name'], snap_name)
+            self.assert_syncing_snap_metrics(snap, sync_mode=sync_mode)
+            if 'datasync_queue_wait' in snap:
+                self.assertIn(snap['datasync_queue_wait']['state'],
+                              ('waiting', 'completed'))
+        except RETRY_EXCEPTIONS as e:
+            e.res = res
+            raise
 
     @retry_assert(timeout=60, interval=3)
     def check_peer_status_empty(self, fs_name, fs_id, peer_spec):
@@ -1595,6 +1650,7 @@ class TestMirroring(CephFSTestCase):
                    failure_reason == dir_stat.get('failure_reason', {}) and \
                    snap_name == dir_stat['last_synced_snap']['name'] and \
                    expected_snap_count == dir_stat['snaps_synced']):
+                    self.assert_last_synced_snap_metrics(dir_stat['last_synced_snap'])
                     break
         # remove the directory in the remote fs and check status restores to 'idle'
         self.mount_b.run_shell(['sudo', 'rmdir', remote_snap_path], omit_sudo=False)
@@ -1607,7 +1663,65 @@ class TestMirroring(CephFSTestCase):
                 if('idle' == dir_stat['state'] and 'failure_reason' not in dir_stat and \
                    snap_name == dir_stat['last_synced_snap']['name'] and \
                    expected_snap_count == dir_stat['snaps_synced']):
+                    self.assert_last_synced_snap_metrics(dir_stat['last_synced_snap'])
                     break
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_peer_status_last_synced_metrics(self):
+        """Peer status last_synced_snap reports new sync timing and size metrics."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+
+        dir_name = 'metrics_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.mount_a.create_n_files(f'{dir_name}/file', 50, sync=True)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap_name = 'snap0'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap_name, 1)
+
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        res = self.mirror_daemon_command(f'peer status for fs: {self.primary_fs_name}',
+                                         'fs', 'mirror', 'peer', 'status',
+                                         f'{self.primary_fs_name}@{self.primary_fs_id}',
+                                         peer_uuid)
+        self.assert_last_synced_snap_metrics(
+            self.peer_dir_status(res, f'/{dir_name}', peer_uuid)['last_synced_snap'])
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_peer_status_syncing_progress_metrics(self):
+        """Peer status current_syncing_snap reports sync progress metrics."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+
+        dir_name = 'd0'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.mount_a.create_n_files(f'{dir_name}/file', 3000, sync=True)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap0 = 'snap0'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap0}'])
+        self.check_peer_syncing_progress_metrics(
+            self.primary_fs_name, self.primary_fs_id, peer_spec, f'/{dir_name}',
+            snap0, sync_mode='full')
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', snap0, 1)
+
+        self.mount_a.write_n_mb(os.path.join(dir_name, 'file.0'), 1)
+        self.mount_a.create_n_files(f'{dir_name}/snapdiff_file', 3000, sync=True)
+        snap1 = 'snap1'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap1}'])
+        self.check_peer_syncing_progress_metrics(
+            self.primary_fs_name, self.primary_fs_id, peer_spec, f'/{dir_name}',
+            snap1, sync_mode='delta')
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', snap1, 2)
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
     def test_cephfs_mirror_sync_already_existing_snapshots(self):

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -259,6 +259,9 @@ class TestMirroring(CephFSTestCase):
         self.assertEqual(peer['stats']['failure_count'], 1)
         self.assertEqual(peer['stats']['recovery_count'], 1)
 
+    def peer_dir_status(self, res, dir_name, peer_uuid):
+        return res['metrics'][dir_name]['peer'][peer_uuid]
+
     @retry_assert(timeout=60, interval=3)
     def check_peer_status_empty(self, fs_name, fs_id, peer_spec):
         peer_uuid = self.get_peer_uuid(peer_spec)
@@ -266,7 +269,7 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
         try:
-            self.assertFalse(res)
+            self.assertFalse(res.get('metrics'))
         except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
@@ -279,9 +282,9 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
         try:
-            self.assertTrue(dir_name in res)
-            self.assertTrue(res[dir_name]['last_synced_snap']['name'] == expected_snap_name)
-            self.assertTrue(res[dir_name]['snaps_synced'] == expected_snap_count)
+            dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+            self.assertTrue(dir_stat['last_synced_snap']['name'] == expected_snap_name)
+            self.assertTrue(dir_stat['snaps_synced'] == expected_snap_count)
         except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
@@ -294,10 +297,10 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
         try:
-            self.assertTrue(dir_name in res)
-            self.assertTrue('idle' == res[dir_name]['state'])
-            self.assertTrue(expected_snap_name == res[dir_name]['last_synced_snap']['name'])
-            self.assertTrue(expected_snap_count == res[dir_name]['snaps_synced'])
+            dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+            self.assertTrue('idle' == dir_stat['state'])
+            self.assertTrue(expected_snap_name == dir_stat['last_synced_snap']['name'])
+            self.assertTrue(expected_snap_count == dir_stat['snaps_synced'])
         except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
@@ -310,8 +313,8 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
         try:
-            self.assertTrue(dir_name in res)
-            self.assertTrue(res[dir_name]['snaps_deleted'] == expected_delete_count)
+            dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+            self.assertTrue(dir_stat['snaps_deleted'] == expected_delete_count)
         except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
@@ -324,8 +327,8 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
         try:
-            self.assertTrue(dir_name in res)
-            self.assertTrue(res[dir_name]['snaps_renamed'] == expected_rename_count)
+            dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+            self.assertTrue(dir_stat['snaps_renamed'] == expected_rename_count)
         except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
@@ -339,8 +342,9 @@ class TestMirroring(CephFSTestCase):
                                              'fs', 'mirror', 'peer', 'status',
                                              f'{fs_name}@{fs_id}', peer_uuid)
 
-            self.assertTrue('syncing' == res[dir_name]['state'])
-            self.assertTrue(res[dir_name]['current_syncing_snap']['name'] == snap_name)
+            dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+            self.assertTrue('syncing' == dir_stat['state'])
+            self.assertTrue(dir_stat['current_syncing_snap']['name'] == snap_name)
         except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
@@ -364,7 +368,7 @@ class TestMirroring(CephFSTestCase):
         res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
-        self.assertTrue('failed' == res[dir_name]['state'])
+        self.assertTrue('failed' == self.peer_dir_status(res, dir_name, peer_uuid)['state'])
 
     def get_peer_uuid(self, peer_spec):
         status = self.fs.status()
@@ -1451,8 +1455,9 @@ class TestMirroring(CephFSTestCase):
                                                  'fs', 'mirror', 'peer', 'status',
                                                  f'{self.primary_fs_name}@{self.primary_fs_id}',
                                                  peer_uuid)
-                if ('syncing' == res["/d0"]['state'] and 'syncing' == res["/d1"]['state'] and \
-                    'syncing' == res["/d2"]['state']):
+                if ('syncing' == self.peer_dir_status(res, '/d0', peer_uuid)['state'] and
+                    'syncing' == self.peer_dir_status(res, '/d1', peer_uuid)['state'] and
+                    'syncing' == self.peer_dir_status(res, '/d2', peer_uuid)['state']):
                     break
 
         log.debug('removing directory 1')
@@ -1585,10 +1590,11 @@ class TestMirroring(CephFSTestCase):
                 res = self.mirror_daemon_command(f'peer status for fs: {self.primary_fs_name}',
                                                  'fs', 'mirror', 'peer', 'status',
                                                  f'{self.primary_fs_name}@{self.primary_fs_id}', peer_uuid)
-                if('failed' == res[dir_name]['state'] and \
-                   failure_reason == res.get(dir_name, {}).get('failure_reason', {}) and \
-                   snap_name == res[dir_name]['last_synced_snap']['name'] and \
-                   expected_snap_count == res[dir_name]['snaps_synced']):
+                dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+                if('failed' == dir_stat['state'] and \
+                   failure_reason == dir_stat.get('failure_reason', {}) and \
+                   snap_name == dir_stat['last_synced_snap']['name'] and \
+                   expected_snap_count == dir_stat['snaps_synced']):
                     break
         # remove the directory in the remote fs and check status restores to 'idle'
         self.mount_b.run_shell(['sudo', 'rmdir', remote_snap_path], omit_sudo=False)
@@ -1597,9 +1603,10 @@ class TestMirroring(CephFSTestCase):
                 res = self.mirror_daemon_command(f'peer status for fs: {self.primary_fs_name}',
                                                  'fs', 'mirror', 'peer', 'status',
                                                  f'{self.primary_fs_name}@{self.primary_fs_id}', peer_uuid)
-                if('idle' == res[dir_name]['state'] and 'failure_reason' not in res and \
-                   snap_name == res[dir_name]['last_synced_snap']['name'] and \
-                   expected_snap_count == res[dir_name]['snaps_synced']):
+                dir_stat = self.peer_dir_status(res, dir_name, peer_uuid)
+                if('idle' == dir_stat['state'] and 'failure_reason' not in dir_stat and \
+                   snap_name == dir_stat['last_synced_snap']['name'] and \
+                   expected_snap_count == dir_stat['snaps_synced']):
                     break
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
@@ -1700,9 +1707,12 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{self.primary_fs_name}@{self.primary_fs_id}',
                                          peer_uuid)
-        d0_sync_time_stamp = float(res["/d0"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
-        d1_sync_time_stamp = float(res["/d1"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
-        d2_sync_time_stamp = float(res["/d2"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+        d0_sync_time_stamp = float(self.peer_dir_status(res, '/d0', peer_uuid)
+                                  ['last_synced_snap']['sync_time_stamp'].rstrip('s'))
+        d1_sync_time_stamp = float(self.peer_dir_status(res, '/d1', peer_uuid)
+                                  ['last_synced_snap']['sync_time_stamp'].rstrip('s'))
+        d2_sync_time_stamp = float(self.peer_dir_status(res, '/d2', peer_uuid)
+                                  ['last_synced_snap']['sync_time_stamp'].rstrip('s'))
 
         self.assertGreaterEqual(d1_sync_time_stamp, d0_sync_time_stamp)
         self.assertGreaterEqual(d2_sync_time_stamp, d0_sync_time_stamp)
@@ -1769,9 +1779,12 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{self.primary_fs_name}@{self.primary_fs_id}',
                                          peer_uuid)
-        d0_sync_time_stamp = float(res["/d0"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
-        d1_sync_time_stamp = float(res["/d1"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
-        d2_sync_time_stamp = float(res["/d2"]["last_synced_snap"]["sync_time_stamp"].rstrip('s'))
+        d0_sync_time_stamp = float(self.peer_dir_status(res, '/d0', peer_uuid)
+                                  ['last_synced_snap']['sync_time_stamp'].rstrip('s'))
+        d1_sync_time_stamp = float(self.peer_dir_status(res, '/d1', peer_uuid)
+                                  ['last_synced_snap']['sync_time_stamp'].rstrip('s'))
+        d2_sync_time_stamp = float(self.peer_dir_status(res, '/d2', peer_uuid)
+                                  ['last_synced_snap']['sync_time_stamp'].rstrip('s'))
 
         self.assertLess(d1_sync_time_stamp, d0_sync_time_stamp)
         self.assertLess(d2_sync_time_stamp, d0_sync_time_stamp)

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2662,7 +2662,7 @@ std::string PeerReplayer::format_bytes(double bytes) {
   return out.str();
 };
 
-double PeerReplayer::compute_eta(PeerReplayer::SnapSyncStat& sync_stat) {
+double PeerReplayer::compute_eta(const PeerReplayer::SnapSyncStat& sync_stat) {
   // mlock is held by the caller
 
   static constexpr uint64_t MIN_FILES_SAMPLE = 25;
@@ -2720,119 +2720,129 @@ double PeerReplayer::compute_eta(PeerReplayer::SnapSyncStat& sync_stat) {
   }
 }
 
-void PeerReplayer::peer_status(Formatter *f) {
-  std::scoped_lock locker(m_lock);
-  f->open_object_section("stats");
-  for (auto &[dir_root, sync_stat] : m_snap_sync_stats) {
-    f->open_object_section(dir_root);
-    if (sync_stat.failed) {
-      f->dump_string("state", "failed");
-      if (sync_stat.last_failed_reason) {
-	f->dump_string("failure_reason", *sync_stat.last_failed_reason);
-      }
-    } else if (!sync_stat.current_syncing_snap) {
-      f->dump_string("state", "idle");
-    } else {
-      f->dump_string("state", "syncing");
-      f->open_object_section("current_syncing_snap");
-      f->dump_unsigned("id", (*sync_stat.current_syncing_snap).first);
-      f->dump_string("name", (*sync_stat.current_syncing_snap).second);
-      if (sync_stat.snapdiff)
-        f->dump_string("sync-mode", "delta");
-      else
-        f->dump_string("sync-mode", "full");
-
-      //avg read/write throughput
-      double read_bps = sync_stat.read_time_sec > 0 ?
-          sync_stat.bytes_read / sync_stat.read_time_sec : 0;
-      double write_bps = sync_stat.write_time_sec > 0 ?
-          sync_stat.bytes_written / sync_stat.write_time_sec : 0;
-      f->dump_string("avg_read_throughput_bytes", format_bytes(read_bps) + "/s");
-      f->dump_string("avg_write_throughput_bytes", format_bytes(write_bps) + "/s");
-
-      f->open_object_section("crawl");
-      if (sync_stat.crawl_finished) {
-        f->dump_string("state", "completed");
-        f->dump_string("duration", format_time(sync_stat.crawl_duration));
-      } else {
-        f->dump_string("state", "in-progress");
-        auto cur_time = clock::now();
-        sec_duration crawl_duration_till_now{0};
-        crawl_duration_till_now = sec_duration(cur_time - sync_stat.crawl_start_time);
-        f->dump_string("duration", format_time(crawl_duration_till_now.count()));
-      }
-      f->close_section(); //crawl
-      if (sync_stat.datasync_queue_wait_duration ||
-          sync_stat.datasync_queue_wait_start_time) {
-        f->open_object_section("datasync_queue_wait");
-        if (sync_stat.datasync_queue_wait_duration) {
-          f->dump_string("state", "completed");
-          f->dump_string("duration",
-                         format_time(*sync_stat.datasync_queue_wait_duration));
-        } else {
-          f->dump_string("state", "waiting");
-          auto cur_time = clock::now();
-          sec_duration dq_wait{0};
-          dq_wait = sec_duration(cur_time - *sync_stat.datasync_queue_wait_start_time);
-          f->dump_string("duration", format_time(dq_wait.count()));
-        }
-        f->close_section();
-      }
-      f->open_object_section("bytes");
-      f->dump_string("sync_bytes", format_bytes(sync_stat.sync_bytes));
-      f->dump_string("total_bytes", format_bytes(sync_stat.total_bytes));
-      if (sync_stat.total_bytes > 0) {
-        double sync_pct = (static_cast<double>(sync_stat.sync_bytes) * 100.0) / sync_stat.total_bytes;
-        std::ostringstream os;
-        os << std::fixed << std::setprecision(2) << sync_pct << "%";
-        f->dump_string("sync_percent", os.str());
-      }
-      f->close_section(); //bytes
-      f->open_object_section("files");
-      f->dump_unsigned("sync_files", sync_stat.sync_files);
-      f->dump_unsigned("total_files", sync_stat.total_files);
-      if (sync_stat.total_files > 0) {
-        double sync_file_pct = (static_cast<double>(sync_stat.sync_files) * 100.0) / sync_stat.total_files;
-        std::ostringstream os;
-        os << std::fixed << std::setprecision(2) << sync_file_pct << "%";
-        f->dump_string("sync_percent", os.str());
-      }
-      f->close_section(); //files
-      double eta = compute_eta(sync_stat);
-      if (eta == -1.0)
-        f->dump_string("eta", "calculating...");
-      else
-        f->dump_string("eta", format_time(compute_eta(sync_stat)));
-      f->close_section(); //current_syncing_snap
+void PeerReplayer::dump_sync_stat(Formatter *f, const SnapSyncStat &sync_stat) {
+  if (sync_stat.failed) {
+    f->dump_string("state", "failed");
+    if (sync_stat.last_failed_reason) {
+      f->dump_string("failure_reason", *sync_stat.last_failed_reason);
     }
-    if (sync_stat.last_synced_snap) {
-      f->open_object_section("last_synced_snap");
-      f->dump_unsigned("id", (*sync_stat.last_synced_snap).first);
-      f->dump_string("name", (*sync_stat.last_synced_snap).second);
-      if (sync_stat.last_sync_crawl_duration) {
-        f->dump_string("crawl_duration", format_time(*sync_stat.last_sync_crawl_duration));
-      }
-      if (sync_stat.last_sync_datasync_queue_wait_duration) {
-        f->dump_string("datasync_queue_wait_duration",
-                       format_time(*sync_stat.last_sync_datasync_queue_wait_duration));
-      }
-      if (sync_stat.last_sync_duration) {
-        f->dump_string("sync_duration", format_time(*sync_stat.last_sync_duration));
-        f->dump_stream("sync_time_stamp") << sync_stat.last_synced;
-      }
-      if (sync_stat.last_sync_bytes) {
-	    f->dump_string("sync_bytes", format_bytes(*sync_stat.last_sync_bytes));
-      }
-      if (sync_stat.last_sync_files) {
-	    f->dump_unsigned("sync_files", *sync_stat.last_sync_files);
+  } else if (!sync_stat.current_syncing_snap) {
+    f->dump_string("state", "idle");
+  } else {
+    f->dump_string("state", "syncing");
+    f->open_object_section("current_syncing_snap");
+    f->dump_unsigned("id", (*sync_stat.current_syncing_snap).first);
+    f->dump_string("name", (*sync_stat.current_syncing_snap).second);
+    if (sync_stat.snapdiff)
+      f->dump_string("sync-mode", "delta");
+    else
+      f->dump_string("sync-mode", "full");
+
+    //avg read/write throughput
+    double read_bps = sync_stat.read_time_sec > 0 ?
+        sync_stat.bytes_read / sync_stat.read_time_sec : 0;
+    double write_bps = sync_stat.write_time_sec > 0 ?
+        sync_stat.bytes_written / sync_stat.write_time_sec : 0;
+    f->dump_string("avg_read_throughput_bytes", format_bytes(read_bps) + "/s");
+    f->dump_string("avg_write_throughput_bytes", format_bytes(write_bps) + "/s");
+
+    f->open_object_section("crawl");
+    if (sync_stat.crawl_finished) {
+      f->dump_string("state", "completed");
+      f->dump_string("duration", format_time(sync_stat.crawl_duration));
+    } else {
+      f->dump_string("state", "in-progress");
+      auto cur_time = clock::now();
+      sec_duration crawl_duration_till_now{0};
+      crawl_duration_till_now = sec_duration(cur_time - sync_stat.crawl_start_time);
+      f->dump_string("duration", format_time(crawl_duration_till_now.count()));
+    }
+    f->close_section(); //crawl
+    if (sync_stat.datasync_queue_wait_duration ||
+        sync_stat.datasync_queue_wait_start_time) {
+      f->open_object_section("datasync_queue_wait");
+      if (sync_stat.datasync_queue_wait_duration) {
+        f->dump_string("state", "completed");
+        f->dump_string("duration",
+                       format_time(*sync_stat.datasync_queue_wait_duration));
+      } else {
+        f->dump_string("state", "waiting");
+        auto cur_time = clock::now();
+        sec_duration dq_wait{0};
+        dq_wait = sec_duration(cur_time - *sync_stat.datasync_queue_wait_start_time);
+        f->dump_string("duration", format_time(dq_wait.count()));
       }
       f->close_section();
     }
-    f->dump_unsigned("snaps_synced", sync_stat.synced_snap_count);
-    f->dump_unsigned("snaps_deleted", sync_stat.deleted_snap_count);
-    f->dump_unsigned("snaps_renamed", sync_stat.renamed_snap_count);
+    f->open_object_section("bytes");
+    f->dump_string("sync_bytes", format_bytes(sync_stat.sync_bytes));
+    f->dump_string("total_bytes", format_bytes(sync_stat.total_bytes));
+    if (sync_stat.total_bytes > 0) {
+      double sync_pct = (static_cast<double>(sync_stat.sync_bytes) * 100.0) / sync_stat.total_bytes;
+      std::ostringstream os;
+      os << std::fixed << std::setprecision(2) << sync_pct << "%";
+      f->dump_string("sync_percent", os.str());
+    }
+    f->close_section(); //bytes
+    f->open_object_section("files");
+    f->dump_unsigned("sync_files", sync_stat.sync_files);
+    f->dump_unsigned("total_files", sync_stat.total_files);
+    if (sync_stat.total_files > 0) {
+      double sync_file_pct = (static_cast<double>(sync_stat.sync_files) * 100.0) / sync_stat.total_files;
+      std::ostringstream os;
+      os << std::fixed << std::setprecision(2) << sync_file_pct << "%";
+      f->dump_string("sync_percent", os.str());
+    }
+    f->close_section(); //files
+    double eta = compute_eta(sync_stat);
+    if (eta == -1.0)
+      f->dump_string("eta", "calculating...");
+    else
+      f->dump_string("eta", format_time(compute_eta(sync_stat)));
+    f->close_section(); //current_syncing_snap
+  }
+  if (sync_stat.last_synced_snap) {
+    f->open_object_section("last_synced_snap");
+    f->dump_unsigned("id", (*sync_stat.last_synced_snap).first);
+    f->dump_string("name", (*sync_stat.last_synced_snap).second);
+    if (sync_stat.last_sync_crawl_duration) {
+      f->dump_string("crawl_duration", format_time(*sync_stat.last_sync_crawl_duration));
+    }
+    if (sync_stat.last_sync_datasync_queue_wait_duration) {
+      f->dump_string("datasync_queue_wait_duration",
+                     format_time(*sync_stat.last_sync_datasync_queue_wait_duration));
+    }
+    if (sync_stat.last_sync_duration) {
+      f->dump_string("sync_duration", format_time(*sync_stat.last_sync_duration));
+      f->dump_stream("sync_time_stamp") << sync_stat.last_synced;
+    }
+    if (sync_stat.last_sync_bytes) {
+      f->dump_string("sync_bytes", format_bytes(*sync_stat.last_sync_bytes));
+    }
+    if (sync_stat.last_sync_files) {
+      f->dump_unsigned("sync_files", *sync_stat.last_sync_files);
+    }
+    f->close_section();
+  }
+  f->dump_unsigned("snaps_synced", sync_stat.synced_snap_count);
+  f->dump_unsigned("snaps_deleted", sync_stat.deleted_snap_count);
+  f->dump_unsigned("snaps_renamed", sync_stat.renamed_snap_count);
+}
+
+void PeerReplayer::peer_status(Formatter *f) {
+  std::scoped_lock locker(m_lock);
+  f->open_object_section("stats");
+  f->open_object_section("metrics");
+  for (auto &[dir_root, sync_stat] : m_snap_sync_stats) {
+    f->open_object_section(dir_root);
+    f->open_object_section("peer");
+    f->open_object_section(m_peer.uuid);
+    dump_sync_stat(f, sync_stat);
+    f->close_section(); // peer uuid
+    f->close_section(); // peer
     f->close_section(); // dir_root
   }
+  f->close_section(); // metrics
   f->close_section(); // stats
 }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1353,10 +1353,17 @@ PeerReplayer::SyncMechanism::~SyncMechanism() {
 void PeerReplayer::SyncMechanism::push_dataq_entry(SyncEntry e) {
   dout(10) << ": snapshot data replayer dataq pushed" << " syncm=" << this
 	   << " epath=" << e.epath << dendl;
-  m_peer_replayer.inc_total_bytes_files(std::string(m_dir_root), e.stx.stx_size);
+  const uint64_t entry_bytes = e.stx.stx_size;
   std::unique_lock lock(sdq_lock);
+  if (!m_first_dataq_push_time) {
+    m_first_dataq_push_time = clock::now();
+    m_peer_replayer.set_datasync_queue_wait_start_time(std::string(m_dir_root),
+                                                       *m_first_dataq_push_time);
+  }
   m_sync_dataq.push(std::move(e));
   sdq_cv.notify_all();
+  lock.unlock();
+  m_peer_replayer.inc_total_bytes_files(std::string(m_dir_root), entry_bytes);
 }
 
 bool PeerReplayer::SyncMechanism::pop_dataq_entry(SyncEntry &out_entry) {
@@ -1402,6 +1409,12 @@ bool PeerReplayer::SyncMechanism::pop_dataq_entry(SyncEntry &out_entry) {
     return false; // no more work
   }
 
+  if (!m_datasync_queue_wait_reported && m_first_dataq_push_time) {
+    sec_duration dq_wait{0};
+    dq_wait = sec_duration(clock::now() - *m_first_dataq_push_time);
+    m_peer_replayer.set_datasync_queue_wait_duration(std::string(m_dir_root), dq_wait.count());
+    m_datasync_queue_wait_reported = true;
+  }
   out_entry = std::move(m_sync_dataq.front());
   m_sync_dataq.pop();
   dout(10) << ": snapshot data replayer dataq popped" << " syncm=" << this
@@ -2749,6 +2762,22 @@ void PeerReplayer::peer_status(Formatter *f) {
         f->dump_string("duration", format_time(crawl_duration_till_now.count()));
       }
       f->close_section(); //crawl
+      if (sync_stat.datasync_queue_wait_duration ||
+          sync_stat.datasync_queue_wait_start_time) {
+        f->open_object_section("datasync_queue_wait");
+        if (sync_stat.datasync_queue_wait_duration) {
+          f->dump_string("state", "completed");
+          f->dump_string("duration",
+                         format_time(*sync_stat.datasync_queue_wait_duration));
+        } else {
+          f->dump_string("state", "waiting");
+          auto cur_time = clock::now();
+          sec_duration dq_wait{0};
+          dq_wait = sec_duration(cur_time - *sync_stat.datasync_queue_wait_start_time);
+          f->dump_string("duration", format_time(dq_wait.count()));
+        }
+        f->close_section();
+      }
       f->open_object_section("bytes");
       f->dump_string("sync_bytes", format_bytes(sync_stat.sync_bytes));
       f->dump_string("total_bytes", format_bytes(sync_stat.total_bytes));
@@ -2782,6 +2811,10 @@ void PeerReplayer::peer_status(Formatter *f) {
       f->dump_string("name", (*sync_stat.last_synced_snap).second);
       if (sync_stat.last_sync_crawl_duration) {
         f->dump_string("crawl_duration", format_time(*sync_stat.last_sync_crawl_duration));
+      }
+      if (sync_stat.last_sync_datasync_queue_wait_duration) {
+        f->dump_string("datasync_queue_wait_duration",
+                       format_time(*sync_stat.last_sync_datasync_queue_wait_duration));
       }
       if (sync_stat.last_sync_duration) {
         f->dump_string("sync_duration", format_time(*sync_stat.last_sync_duration));

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -30,6 +30,7 @@
                            << m_peer.uuid << ") " << __func__
 
 using namespace std;
+using sec_duration = std::chrono::duration<double>;
 
 // Performance Counters
 enum {
@@ -1421,12 +1422,16 @@ bool PeerReplayer::SyncMechanism::has_pending_work() const {
   return true;
 }
 
-void PeerReplayer::SyncMechanism::mark_crawl_finished(int ret) {
-  std::unique_lock lock(sdq_lock);
-  m_crawl_finished = true;
-  if (ret < 0)
-    m_crawl_error = true;
-  sdq_cv.notify_all();
+void PeerReplayer::SyncMechanism::mark_crawl_finished(int ret, double crawl_duration_secs) {
+  {
+    std::unique_lock lock(sdq_lock);
+    m_crawl_finished = true;
+    if (ret < 0)
+      m_crawl_error = true;
+    sdq_cv.notify_all();
+  }
+  // for crawl-state metrics
+  m_peer_replayer.set_crawl_finished(m_dir_root, true, crawl_duration_secs);
 }
 
 // Returns false if there is any error during data sync
@@ -1752,7 +1757,7 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
   return r;
 }
 
-void PeerReplayer::SnapDiffSync::finish_crawl(int ret) {
+void PeerReplayer::SnapDiffSync::finish_crawl(int ret, double crawl_duration_secs) {
   dout(20) << dendl;
 
   while (!m_sync_stack.empty()) {
@@ -1768,7 +1773,7 @@ void PeerReplayer::SnapDiffSync::finish_crawl(int ret) {
   }
 
   // Crawl and entry operations are done syncing here. So mark crawl finished here
-  mark_crawl_finished(ret);
+  mark_crawl_finished(ret, crawl_duration_secs);
 }
 
 PeerReplayer::RemoteSync::RemoteSync(PeerReplayer& peer_replayer, std::string_view dir_root,
@@ -1905,7 +1910,7 @@ int PeerReplayer::RemoteSync::get_entry(std::string *epath, struct ceph_statx *s
   return 0;
 }
 
-void PeerReplayer::RemoteSync::finish_crawl(int ret) {
+void PeerReplayer::RemoteSync::finish_crawl(int ret, double crawl_duration_secs) {
   dout(20) << dendl;
 
   while (!m_sync_stack.empty()) {
@@ -1921,7 +1926,7 @@ void PeerReplayer::RemoteSync::finish_crawl(int ret) {
   }
 
   // Crawl and entry operations are done syncing here. So mark stack finished here
-  mark_crawl_finished(ret);
+  mark_crawl_finished(ret, crawl_duration_secs);
 }
 
 int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current,
@@ -1951,9 +1956,11 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   if (fh.p_mnt == m_local_mount) {
     syncm = std::make_shared<SnapDiffSync>(*this, dir_root, m_local_mount, m_remote_mount,
                                            &fh, m_peer, current, prev);
+    set_snapdiff(dir_root, true); //for stats
   } else {
     syncm = std::make_shared<RemoteSync>(*this, dir_root, m_local_mount, m_remote_mount,
                                          &fh, m_peer, current, boost::none);
+    set_snapdiff(dir_root, false); //for stats
   }
 
   r = syncm->init_sync();
@@ -1968,6 +1975,9 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
 
   // starting from this point we shouldn't care about manual closing of fh.c_fd,
   // it will be closed automatically when bound tdirp is closed.
+  sec_duration crawl_duration_time{0};
+  auto crawl_start_time = clock::now();
+  set_crawl_start_time(dir_root);
   while (true) {
     if (should_backoff(dir_root, &r)) {
       dout(0) << ": backing off r=" << r << dendl;
@@ -1996,7 +2006,9 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
     }
   }
 
-  syncm->finish_crawl(r);
+  auto crawl_end_time = clock::now();
+  crawl_duration_time = sec_duration(crawl_end_time - crawl_start_time);
+  syncm->finish_crawl(r, crawl_duration_time.count());
 
   dout(20) << " cur:" << fh.c_fd
            << " prev:" << fh.p_fd
@@ -2524,6 +2536,40 @@ void PeerReplayer::run_datasync(SnapshotDataSyncThread *data_replayer) {
   } // outer while
 }
 
+std::string PeerReplayer::format_time(double total_seconds_d) {
+    // Round to nearest second
+    uint64_t total_seconds = static_cast<uint64_t>(std::llround(total_seconds_d));
+
+    uint64_t days = total_seconds / 86400;
+    total_seconds %= 86400;
+
+    uint64_t hours = total_seconds / 3600;
+    total_seconds %= 3600;
+
+    uint64_t minutes = total_seconds / 60;
+    uint64_t seconds = total_seconds % 60;
+
+    std::ostringstream oss;
+
+    if (days > 0) {
+        oss << days << "d "
+            << std::setw(2) << std::setfill('0') << hours   << "h "
+            << std::setw(2) << std::setfill('0') << minutes << "m "
+            << std::setw(2) << std::setfill('0') << seconds << "s";
+    } else if (hours > 0) {
+        oss << hours << "h "
+            << std::setw(2) << std::setfill('0') << minutes << "m "
+            << std::setw(2) << std::setfill('0') << seconds << "s";
+    } else if (minutes > 0) {
+        oss << minutes << "m "
+            << std::setw(2) << std::setfill('0') << seconds << "s";
+    } else {
+        oss << seconds << "s";
+    }
+
+    return oss.str();
+}
+
 std::string PeerReplayer::format_bytes(double bytes) {
   static constexpr double KiB = 1024.0;
   static constexpr double MiB = KiB * 1024.0;
@@ -2567,6 +2613,22 @@ void PeerReplayer::peer_status(Formatter *f) {
       f->open_object_section("current_syncing_snap");
       f->dump_unsigned("id", (*sync_stat.current_syncing_snap).first);
       f->dump_string("name", (*sync_stat.current_syncing_snap).second);
+      if (sync_stat.snapdiff)
+        f->dump_string("sync-mode", "delta");
+      else
+        f->dump_string("sync-mode", "full");
+      f->open_object_section("crawl");
+      if (sync_stat.crawl_finished) {
+        f->dump_string("state", "completed");
+        f->dump_string("duration", format_time(sync_stat.crawl_duration));
+      } else {
+        f->dump_string("state", "in-progress");
+        auto cur_time = clock::now();
+        sec_duration crawl_duration_till_now{0};
+        crawl_duration_till_now = sec_duration(cur_time - sync_stat.crawl_start_time);
+        f->dump_string("duration", format_time(crawl_duration_till_now.count()));
+      }
+      f->close_section(); //crawl
       f->open_object_section("bytes");
       f->dump_string("sync_bytes", format_bytes(sync_stat.sync_bytes));
       f->dump_string("total_bytes", format_bytes(sync_stat.total_bytes));
@@ -2593,8 +2655,11 @@ void PeerReplayer::peer_status(Formatter *f) {
       f->open_object_section("last_synced_snap");
       f->dump_unsigned("id", (*sync_stat.last_synced_snap).first);
       f->dump_string("name", (*sync_stat.last_synced_snap).second);
+      if (sync_stat.last_sync_crawl_duration) {
+        f->dump_string("crawl_duration", format_time(*sync_stat.last_sync_crawl_duration));
+      }
       if (sync_stat.last_sync_duration) {
-        f->dump_float("sync_duration", *sync_stat.last_sync_duration);
+        f->dump_string("sync_duration", format_time(*sync_stat.last_sync_duration));
         f->dump_stream("sync_time_stamp") << sync_stat.last_synced;
       }
       if (sync_stat.last_sync_bytes) {

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -707,6 +707,9 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
   uint64_t bytes_written = 0;
   sec_duration read_time{0};
   sec_duration write_time{0};
+  uint64_t discovered_delta = 0;
+
+  inc_files_started(dir_root);
   int r = ceph_openat(m_local_mount, fh.c_fd, epath.c_str(), O_RDONLY | O_NOFOLLOW, 0);
   if (r < 0) {
     derr << ": failed to open local file path=" << epath << ": "
@@ -734,6 +737,8 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
   while (num_blocks > 0) {
     auto offset = b->offset;
     auto len = b->len;
+    discovered_delta += b->len;
+    inc_delta_bytes(dir_root, discovered_delta);
 
     dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << ", block: ["
              << offset << "~" << len << "]" << dendl;
@@ -802,6 +807,7 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
         break;
       }
       bytes_written += r;
+      inc_actual_sync_bytes(dir_root, r);
 
       offset += r;
     }
@@ -1726,8 +1732,20 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
   dout(20) << ": dir_root=" << m_dir_root << ", epath=" << epath
            << ", sync_check=" << sync_check << dendl;
 
+  using clock = std::chrono::steady_clock;
+  using seconds = std::chrono::duration<double>;
+  seconds blockdiff_time{0};
+  uint64_t bd_synced_bytes = 0;
+
   if (!sync_check || stx.stx_size <= m_peer_replayer.get_blockdiff_min_file_size()) {
-    return SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+    auto bd_s = clock::now();
+    int r = SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+    auto bd_e = clock::now();
+    blockdiff_time = seconds(bd_e - bd_s);
+    bd_synced_bytes = stx.stx_size;
+    if ( r == 0 )
+      m_peer_replayer.set_blockdiff_metrics(m_dir_root, bd_synced_bytes, blockdiff_time.count());
+    return r;
   }
 
   ceph_file_blockdiff_info info;
@@ -1740,10 +1758,18 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
 
   if (r < 0) {
     dout(20) << ": new file epath=" << epath << dendl;
-    return SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+    auto bd_s = clock::now();
+    int r = SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+    auto bd_e = clock::now();
+    blockdiff_time = seconds(bd_e - bd_s);
+    bd_synced_bytes = stx.stx_size;
+    if ( r == 0 )
+      m_peer_replayer.set_blockdiff_metrics(m_dir_root, bd_synced_bytes, blockdiff_time.count());
+    return r;
   }
 
   r = 1;
+  auto bd_s = clock::now();
   while (true) {
     ceph_file_blockdiff_changedblocks blocks;
     r = ceph_file_blockdiff(&info, &blocks);
@@ -1754,11 +1780,18 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
 
     int rr = r;
     if (blocks.num_blocks) {
+      auto bd_num_blocks = blocks.num_blocks;
+      auto bd_cblock = blocks.b;
       r = callback(blocks.num_blocks, blocks.b);
       ceph_free_file_blockdiff_buffer(&blocks);
       if (r < 0) {
         derr << ": blockdiff callback returned error: r=" << r << dendl;
         break;
+      }
+      while(bd_num_blocks > 0) {
+        bd_synced_bytes += bd_cblock->len;
+	    --bd_num_blocks;
+	    bd_cblock++;
       }
     }
 
@@ -1767,6 +1800,11 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
     }
     // else fetch next changed blocks
   }
+  // blockdiff throughput
+  auto bd_e = clock::now();
+  blockdiff_time = seconds(bd_e - bd_s);
+  if ( r == 0 )
+    m_peer_replayer.set_blockdiff_metrics(m_dir_root, bd_synced_bytes, blockdiff_time.count());
 
   ceph_file_blockdiff_finish(&info);
   return r;
@@ -2611,6 +2649,64 @@ std::string PeerReplayer::format_bytes(double bytes) {
   return out.str();
 };
 
+double PeerReplayer::compute_eta(PeerReplayer::SnapSyncStat& sync_stat) {
+  // mlock is held by the caller
+
+  static constexpr uint64_t MIN_FILES_SAMPLE = 25;
+  static constexpr uint64_t MIN_BYTES_SAMPLE = 1ULL * 16 * 1024 * 1024; // 16MiB
+
+  double read_time = sync_stat.read_time_sec;
+  double write_time = sync_stat.write_time_sec;
+  double bytes_read = sync_stat.bytes_read;
+  double bytes_written = sync_stat.bytes_written;
+  uint64_t files_started = sync_stat.files_started;
+  uint64_t files_synced = sync_stat.sync_files;
+  double read_bps = read_time > 0 ?  bytes_read / read_time : 0;
+  double write_bps = write_time > 0 ?  bytes_written / write_time : 0;
+  uint64_t discovered_delta_bytes = sync_stat.discovered_delta_bytes;
+  uint64_t synced_bytes = sync_stat.actual_sync_bytes;
+  uint64_t file_synced_bytes = sync_stat.sync_bytes;
+  uint64_t total_files = sync_stat.total_files;
+
+  if (read_time == 0 || write_time == 0)
+    return -1.0; //Calculating
+  if (files_synced < MIN_FILES_SAMPLE && file_synced_bytes < MIN_BYTES_SAMPLE)
+    return -1.0; //Calculating
+
+
+  if (sync_stat.snapdiff) {
+    /* blockdiff :
+     *   - total number of files with delta to be synced is known
+     *   - delta of each file is unknown, the avg delta per file is estimated
+     *   - effective bandwidth should accommodate blockdiff time
+     *   - effective bandwidth is based on cumulative synced bytes and time taken, so
+     *     it considers total average past performance and hence it is mostly pessimistic
+     */
+    double avg_delta_per_file = (double)discovered_delta_bytes / (double)files_started;
+    double estimated_total_delta = avg_delta_per_file * total_files;
+    double effective_bw = (double) sync_stat.blockdiff_sync_bytes / sync_stat.blockdiff_time_sec;
+
+    uint64_t remaining =
+        estimated_total_delta > synced_bytes
+        ? static_cast<uint64_t>(estimated_total_delta - synced_bytes)
+        : 0;
+
+    if (effective_bw <= 0)
+      return -1.0;
+    return remaining / effective_bw;
+  } else {
+    /* full sync :
+     *   -  effective bandwidth is mostly dependant on read and write, again
+     *      it's cumulative, so prediction is based on average past performace.
+     */
+    uint64_t remaining = sync_stat.total_bytes - synced_bytes;
+    double effective_bw = std::min(read_bps, write_bps);
+    if (effective_bw <= 0)
+      return -1.0; //Calculating
+    return remaining / effective_bw;
+  }
+}
+
 void PeerReplayer::peer_status(Formatter *f) {
   std::scoped_lock locker(m_lock);
   f->open_object_section("stats");
@@ -2673,6 +2769,11 @@ void PeerReplayer::peer_status(Formatter *f) {
         f->dump_string("sync_percent", os.str());
       }
       f->close_section(); //files
+      double eta = compute_eta(sync_stat);
+      if (eta == -1.0)
+        f->dump_string("eta", "calculating...");
+      else
+        f->dump_string("eta", format_time(compute_eta(sync_stat)));
       f->close_section(); //current_syncing_snap
     }
     if (sync_stat.last_synced_snap) {

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -910,6 +910,7 @@ int PeerReplayer::remote_file_op(std::shared_ptr<SyncMechanism>& syncm, const st
     }
   }
 
+  inc_sync_files(dir_root);
   return 0;
 }
 
@@ -1330,6 +1331,7 @@ PeerReplayer::SyncMechanism::~SyncMechanism() {
 void PeerReplayer::SyncMechanism::push_dataq_entry(SyncEntry e) {
   dout(10) << ": snapshot data replayer dataq pushed" << " syncm=" << this
 	   << " epath=" << e.epath << dendl;
+  m_peer_replayer.inc_total_bytes_files(std::string(m_dir_root), e.stx.stx_size);
   std::unique_lock lock(sdq_lock);
   m_sync_dataq.push(std::move(e));
   sdq_cv.notify_all();
@@ -2522,6 +2524,32 @@ void PeerReplayer::run_datasync(SnapshotDataSyncThread *data_replayer) {
   } // outer while
 }
 
+std::string PeerReplayer::format_bytes(double bytes) {
+  static constexpr double KiB = 1024.0;
+  static constexpr double MiB = KiB * 1024.0;
+  static constexpr double GiB = MiB * 1024.0;
+  static constexpr double TiB = GiB * 1024.0;
+  static constexpr double PiB = TiB * 1024.0;
+
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(2);
+
+  if (bytes >= PiB) {
+    out << (bytes / PiB) << " PiB";
+  } else if (bytes >= TiB) {
+    out << (bytes / TiB) << " TiB";
+  } else if (bytes >= GiB) {
+    out << (bytes / GiB) << " GiB";
+  } else if (bytes >= MiB) {
+    out << (bytes / MiB) << " MiB";
+  } else if (bytes >= KiB) {
+    out << (bytes / KiB) << " KiB";
+  } else {
+    out << bytes << " B";
+  }
+  return out.str();
+};
+
 void PeerReplayer::peer_status(Formatter *f) {
   std::scoped_lock locker(m_lock);
   f->open_object_section("stats");
@@ -2539,7 +2567,27 @@ void PeerReplayer::peer_status(Formatter *f) {
       f->open_object_section("current_syncing_snap");
       f->dump_unsigned("id", (*sync_stat.current_syncing_snap).first);
       f->dump_string("name", (*sync_stat.current_syncing_snap).second);
-      f->close_section();
+      f->open_object_section("bytes");
+      f->dump_string("sync_bytes", format_bytes(sync_stat.sync_bytes));
+      f->dump_string("total_bytes", format_bytes(sync_stat.total_bytes));
+      if (sync_stat.total_bytes > 0) {
+        double sync_pct = (static_cast<double>(sync_stat.sync_bytes) * 100.0) / sync_stat.total_bytes;
+        std::ostringstream os;
+        os << std::fixed << std::setprecision(2) << sync_pct << "%";
+        f->dump_string("sync_percent", os.str());
+      }
+      f->close_section(); //bytes
+      f->open_object_section("files");
+      f->dump_unsigned("sync_files", sync_stat.sync_files);
+      f->dump_unsigned("total_files", sync_stat.total_files);
+      if (sync_stat.total_files > 0) {
+        double sync_file_pct = (static_cast<double>(sync_stat.sync_files) * 100.0) / sync_stat.total_files;
+        std::ostringstream os;
+        os << std::fixed << std::setprecision(2) << sync_file_pct << "%";
+        f->dump_string("sync_percent", os.str());
+      }
+      f->close_section(); //files
+      f->close_section(); //current_syncing_snap
     }
     if (sync_stat.last_synced_snap) {
       f->open_object_section("last_synced_snap");
@@ -2550,7 +2598,10 @@ void PeerReplayer::peer_status(Formatter *f) {
         f->dump_stream("sync_time_stamp") << sync_stat.last_synced;
       }
       if (sync_stat.last_sync_bytes) {
-	f->dump_unsigned("sync_bytes", *sync_stat.last_sync_bytes);
+	    f->dump_string("sync_bytes", format_bytes(*sync_stat.last_sync_bytes));
+      }
+      if (sync_stat.last_sync_files) {
+	    f->dump_unsigned("sync_files", *sync_stat.last_sync_files);
       }
       f->close_section();
     }

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -703,6 +703,10 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
   void *ptr;
   struct iovec iov[NR_IOVECS];
 
+  uint64_t bytes_read = 0;
+  uint64_t bytes_written = 0;
+  sec_duration read_time{0};
+  sec_duration write_time{0};
   int r = ceph_openat(m_local_mount, fh.c_fd, epath.c_str(), O_RDONLY | O_NOFOLLOW, 0);
   if (r < 0) {
     derr << ": failed to open local file path=" << epath << ": "
@@ -765,12 +769,16 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
         }
       }
 
+      auto rs = clock::now();
       r = ceph_preadv(m_local_mount, l_fd, iov, num_buffers, offset);
+      auto re = clock::now();
+      read_time += sec_duration(re - rs);
       if (r < 0) {
         derr << ": failed to read local file path=" << epath << ": "
              << cpp_strerror(r) << dendl;
         break;
       }
+      bytes_read += r;
       dout(10) << ": read: " << r << " bytes" << dendl;
       if (r == 0) {
         break;
@@ -784,12 +792,16 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
       }
 
       dout(10) << ": writing to offset: " << offset << dendl;
+      auto ws = clock::now();
       r = ceph_pwritev(m_remote_mount, r_fd, iov, iovs, offset);
+      auto we = clock::now();
+      write_time += sec_duration(we - ws);
       if (r < 0) {
         derr << ": failed to write remote file path=" << epath << ": "
              << cpp_strerror(r) << dendl;
         break;
       }
+      bytes_written += r;
 
       offset += r;
     }
@@ -797,6 +809,9 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
     --num_blocks;
     ++b;
   }
+
+  //io accounting for metrics
+  add_io(dir_root, bytes_read, bytes_written, read_time.count(), write_time.count());
 
   if (num_blocks == 0 && r >= 0) { // handle blocklist case
     dout(20) << ": truncating epath=" << epath << " to " << stx.stx_size << " bytes"
@@ -2617,6 +2632,15 @@ void PeerReplayer::peer_status(Formatter *f) {
         f->dump_string("sync-mode", "delta");
       else
         f->dump_string("sync-mode", "full");
+
+      //avg read/write throughput
+      double read_bps = sync_stat.read_time_sec > 0 ?
+          sync_stat.bytes_read / sync_stat.read_time_sec : 0;
+      double write_bps = sync_stat.write_time_sec > 0 ?
+          sync_stat.bytes_written / sync_stat.write_time_sec : 0;
+      f->dump_string("avg_read_throughput_bytes", format_bytes(read_bps) + "/s");
+      f->dump_string("avg_write_throughput_bytes", format_bytes(write_bps) + "/s");
+
       f->open_object_section("crawl");
       if (sync_stat.crawl_finished) {
         f->dump_string("state", "completed");

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -735,9 +735,10 @@ private:
   }
 
   // format routines for peer_status
+  static void dump_sync_stat(Formatter *f, const SnapSyncStat &sync_stat);
   static std::string format_bytes(double bytes);
   static std::string format_time(double total_seconds);
-  static double compute_eta(SnapSyncStat& sync_stat);
+  static double compute_eta(const SnapSyncStat& sync_stat);
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -319,6 +319,8 @@ private:
     bool m_datasync_error = false;
     int m_datasync_errno = 0;
     bool m_backoff = false;
+    boost::optional<monotime> m_first_dataq_push_time;
+    bool m_datasync_queue_wait_reported = false;
   };
 
   class RemoteSync : public SyncMechanism {
@@ -385,6 +387,7 @@ private:
     monotime last_synced = clock::zero();
     boost::optional<double> last_sync_duration;
     boost::optional<double> last_sync_crawl_duration;
+    boost::optional<double> last_sync_datasync_queue_wait_duration;
     boost::optional<uint64_t> last_sync_bytes; //last sync bytes for display in status
     boost::optional<uint64_t> last_sync_files; //last num of sync files for display in status
     uint64_t sync_bytes = 0; //sync bytes counter, independently for each directory sync.
@@ -407,6 +410,8 @@ private:
     uint64_t discovered_delta_bytes = 0; //discovered delta bytes counter, independently for each directory sync.
     uint64_t blockdiff_sync_bytes = 0; //actual bytes synced using SnapDiff/blockdiff counter
     double blockdiff_time_sec = 0.0; //actual sync time using SnapDiff/blockdiff counter
+    boost::optional<double> datasync_queue_wait_duration; // first data_q push to first pop (final)
+    boost::optional<monotime> datasync_queue_wait_start_time; // until first pop; for in-progress display
   };
 
   void _inc_failed_count(const std::string &dir_root) {
@@ -455,6 +460,8 @@ private:
     sync_stat.discovered_delta_bytes = 0;
     sync_stat.blockdiff_sync_bytes = 0;
     sync_stat.blockdiff_time_sec = 0.0;
+    sync_stat.datasync_queue_wait_duration = boost::none;
+    sync_stat.datasync_queue_wait_start_time = boost::none;
   }
   void _set_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name) {
@@ -497,6 +504,9 @@ private:
     sync_stat.last_synced = clock::now();
     sync_stat.last_sync_duration = duration;
     sync_stat.last_sync_crawl_duration = sync_stat.crawl_duration;
+    //For empty snapshot sync, datasync_queue_wait_duration is 0
+    sync_stat.last_sync_datasync_queue_wait_duration =
+      sync_stat.datasync_queue_wait_duration.value_or(0.0);
     sync_stat.last_sync_bytes = sync_stat.sync_bytes;
     sync_stat.last_sync_files = sync_stat.sync_files;
     ++sync_stat.synced_snap_count;
@@ -512,6 +522,21 @@ private:
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.crawl_finished = state;
     sync_stat.crawl_duration = seconds;
+  }
+  void set_datasync_queue_wait_start_time(const std::string &dir_root, monotime t) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    if (!sync_stat.datasync_queue_wait_start_time && !sync_stat.datasync_queue_wait_duration) {
+      sync_stat.datasync_queue_wait_start_time = t;
+    }
+  }
+  void set_datasync_queue_wait_duration(const std::string &dir_root, double seconds) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    if (!sync_stat.datasync_queue_wait_duration) {
+      sync_stat.datasync_queue_wait_duration = seconds;
+      sync_stat.datasync_queue_wait_start_time = boost::none;
+    }
   }
   void set_blockdiff_metrics(const std::string &dir_root, const uint64_t bd_syncbytes, const double bd_time) {
     std::scoped_lock locker(m_lock);

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -400,6 +400,13 @@ private:
     uint64_t bytes_written = 0; //actual bytes written counter, independently for each directory sync.
     double read_time_sec = 0.0; //actual read time in seconds counter, independently for each directroy sync.
     double write_time_sec = 0.0; //actual write time in seconds counter, independently for each directroy sync.
+    // eta related
+    // files_started will be ahead of sync_files as it's incremented just after delta discovery
+    uint64_t files_started = 0; //files picked up for sync counter, independently for each directory sync.
+    uint64_t actual_sync_bytes = 0; //actual bytes synced using delta, counter, independently for each directory sync.
+    uint64_t discovered_delta_bytes = 0; //discovered delta bytes counter, independently for each directory sync.
+    uint64_t blockdiff_sync_bytes = 0; //actual bytes synced using SnapDiff/blockdiff counter
+    double blockdiff_time_sec = 0.0; //actual sync time using SnapDiff/blockdiff counter
   };
 
   void _inc_failed_count(const std::string &dir_root) {
@@ -443,6 +450,11 @@ private:
     sync_stat.bytes_written = 0;
     sync_stat.read_time_sec = 0.0;
     sync_stat.write_time_sec = 0.0;
+    sync_stat.files_started = 0;
+    sync_stat.actual_sync_bytes = 0;
+    sync_stat.discovered_delta_bytes = 0;
+    sync_stat.blockdiff_sync_bytes = 0;
+    sync_stat.blockdiff_time_sec = 0.0;
   }
   void _set_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name) {
@@ -501,6 +513,12 @@ private:
     sync_stat.crawl_finished = state;
     sync_stat.crawl_duration = seconds;
   }
+  void set_blockdiff_metrics(const std::string &dir_root, const uint64_t bd_syncbytes, const double bd_time) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.blockdiff_sync_bytes += bd_syncbytes;
+    sync_stat.blockdiff_time_sec += bd_time;
+  }
   void add_io(const std::string &dir_root, const uint64_t& br, const uint64_t bw,
               const double rt, const double wt) {
     std::scoped_lock locker(m_lock);
@@ -510,10 +528,25 @@ private:
     sync_stat.read_time_sec += rt;
     sync_stat.write_time_sec += wt;
   }
+  void inc_delta_bytes(const std::string &dir_root, const uint64_t& b) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.discovered_delta_bytes += b;
+  }
   void inc_sync_bytes(const std::string &dir_root, const uint64_t& b) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.sync_bytes += b;
+  }
+  void inc_actual_sync_bytes(const std::string &dir_root, const uint64_t& b) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.actual_sync_bytes += b;
+  }
+  void inc_files_started(const std::string &dir_root) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.files_started++;
   }
   void inc_sync_files(const std::string &dir_root) {
     std::scoped_lock locker(m_lock);
@@ -679,6 +712,7 @@ private:
   // format routines for peer_status
   static std::string format_bytes(double bytes);
   static std::string format_time(double total_seconds);
+  static double compute_eta(SnapSyncStat& sync_stat);
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -385,7 +385,11 @@ private:
     monotime last_synced = clock::zero();
     boost::optional<double> last_sync_duration;
     boost::optional<uint64_t> last_sync_bytes; //last sync bytes for display in status
+    boost::optional<uint64_t> last_sync_files; //last num of sync files for display in status
     uint64_t sync_bytes = 0; //sync bytes counter, independently for each directory sync.
+    uint64_t total_bytes = 0; //total bytes counter, independently for each directory sync.
+    uint64_t sync_files = 0; //sync files counter, independently for each directory sync.
+    uint64_t total_files = 0; //total files counter, independently for each directory sync.
   };
 
   void _inc_failed_count(const std::string &dir_root) {
@@ -415,6 +419,13 @@ private:
     sync_stat.last_failed_reason = boost::none;
   }
 
+  void _reset_sync_stat(const std::string &dir_root) {
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.sync_bytes = 0;
+    sync_stat.total_bytes = 0;
+    sync_stat.sync_files = 0;
+    sync_stat.total_files = 0;
+  }
   void _set_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name) {
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
@@ -425,14 +436,13 @@ private:
                             const std::string &snap_name) {
     std::scoped_lock locker(m_lock);
     _set_last_synced_snap(dir_root, snap_id, snap_name);
-    auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.sync_bytes = 0;
   }
   void set_current_syncing_snap(const std::string &dir_root, uint64_t snap_id,
                                 const std::string &snap_name) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.current_syncing_snap = std::make_pair(snap_id, snap_name);
+    _reset_sync_stat(dir_root); //reset counters at the start of every snap sync
   }
   void clear_current_syncing_snap(const std::string &dir_root) {
     std::scoped_lock locker(m_lock);
@@ -457,12 +467,25 @@ private:
     sync_stat.last_synced = clock::now();
     sync_stat.last_sync_duration = duration;
     sync_stat.last_sync_bytes = sync_stat.sync_bytes;
+    sync_stat.last_sync_files = sync_stat.sync_files;
     ++sync_stat.synced_snap_count;
+    _reset_sync_stat(dir_root);
   }
   void inc_sync_bytes(const std::string &dir_root, const uint64_t& b) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.sync_bytes += b;
+  }
+  void inc_sync_files(const std::string &dir_root) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.sync_files++;
+  }
+  void inc_total_bytes_files(const std::string &dir_root, const uint64_t& b) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.total_bytes += b;
+    sync_stat.total_files++;
   }
   bool should_backoff(const std::string &dir_root, int *retval) {
     if (m_fs_mirror->is_blocklisted()) {
@@ -608,6 +631,9 @@ private:
   uint64_t set_datasync_files_per_batch(uint64_t value) {
     return datasync_files_per_batch.exchange(value, std::memory_order_relaxed);
   }
+
+  // format routines for peer_status
+  static std::string format_bytes(double bytes);
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -395,6 +395,11 @@ private:
     bool crawl_finished = false; // crawl_state - in-progress/completed
     clock::time_point crawl_start_time; // to show current crawl duration if crawl is in progress
     double crawl_duration = 0.0; // time taken to complete the crawl, includes a few entry operation like mkdir as well
+    // actual io accounting
+    uint64_t bytes_read = 0; //actual bytes read counter, independently for each directory sync.
+    uint64_t bytes_written = 0; //actual bytes written counter, independently for each directory sync.
+    double read_time_sec = 0.0; //actual read time in seconds counter, independently for each directroy sync.
+    double write_time_sec = 0.0; //actual write time in seconds counter, independently for each directroy sync.
   };
 
   void _inc_failed_count(const std::string &dir_root) {
@@ -434,6 +439,10 @@ private:
     sync_stat.crawl_finished = false;
     sync_stat.crawl_start_time = clock::now();
     sync_stat.crawl_duration = 0.0;
+    sync_stat.bytes_read = 0;
+    sync_stat.bytes_written = 0;
+    sync_stat.read_time_sec = 0.0;
+    sync_stat.write_time_sec = 0.0;
   }
   void _set_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name) {
@@ -491,6 +500,15 @@ private:
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.crawl_finished = state;
     sync_stat.crawl_duration = seconds;
+  }
+  void add_io(const std::string &dir_root, const uint64_t& br, const uint64_t bw,
+              const double rt, const double wt) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.bytes_read += br;
+    sync_stat.bytes_written += bw;
+    sync_stat.read_time_sec += rt;
+    sync_stat.write_time_sec += wt;
   }
   void inc_sync_bytes(const std::string &dir_root, const uint64_t& b) {
     std::scoped_lock locker(m_lock);

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -221,12 +221,12 @@ private:
                                    const struct ceph_statx &stx, bool sync_check,
                                    const std::function<int (uint64_t, struct cblock *)> &callback);
 
-    virtual void finish_crawl(int ret) = 0;
+    virtual void finish_crawl(int ret, double crawl_duration_secs) = 0;
 
     void push_dataq_entry(PeerReplayer::SyncEntry e);
     bool pop_dataq_entry(PeerReplayer::SyncEntry &out);
     bool has_pending_work() const;
-    void mark_crawl_finished(int ret);
+    void mark_crawl_finished(int ret, double crawl_duration_secs);
     bool is_dataq_empty_unlocked() const {
       return m_sync_dataq.empty();
     }
@@ -335,7 +335,7 @@ private:
                   const std::function<int (const std::string&)> &dirsync_func,
                   const std::function<int (const std::string&)> &purge_func);
 
-    void finish_crawl(int ret);
+    void finish_crawl(int ret, double crawl_duration_secs);
   };
 
   class SnapDiffSync : public SyncMechanism {
@@ -355,7 +355,7 @@ private:
                            const struct ceph_statx &stx, bool sync_check,
                            const std::function<int (uint64_t, struct cblock *)> &callback);
 
-    void finish_crawl(int ret);
+    void finish_crawl(int ret, double crawl_duration_secs);
 
   private:
     int init_directory(const std::string &epath,
@@ -384,12 +384,17 @@ private:
     uint64_t renamed_snap_count = 0;
     monotime last_synced = clock::zero();
     boost::optional<double> last_sync_duration;
+    boost::optional<double> last_sync_crawl_duration;
     boost::optional<uint64_t> last_sync_bytes; //last sync bytes for display in status
     boost::optional<uint64_t> last_sync_files; //last num of sync files for display in status
     uint64_t sync_bytes = 0; //sync bytes counter, independently for each directory sync.
     uint64_t total_bytes = 0; //total bytes counter, independently for each directory sync.
     uint64_t sync_files = 0; //sync files counter, independently for each directory sync.
     uint64_t total_files = 0; //total files counter, independently for each directory sync.
+    bool snapdiff = false; // RemoteSync/Snapdiff aka full/delta
+    bool crawl_finished = false; // crawl_state - in-progress/completed
+    clock::time_point crawl_start_time; // to show current crawl duration if crawl is in progress
+    double crawl_duration = 0.0; // time taken to complete the crawl, includes a few entry operation like mkdir as well
   };
 
   void _inc_failed_count(const std::string &dir_root) {
@@ -425,6 +430,10 @@ private:
     sync_stat.total_bytes = 0;
     sync_stat.sync_files = 0;
     sync_stat.total_files = 0;
+    sync_stat.snapdiff = false;
+    sync_stat.crawl_finished = false;
+    sync_stat.crawl_start_time = clock::now();
+    sync_stat.crawl_duration = 0.0;
   }
   void _set_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name) {
@@ -466,10 +475,22 @@ private:
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.last_synced = clock::now();
     sync_stat.last_sync_duration = duration;
+    sync_stat.last_sync_crawl_duration = sync_stat.crawl_duration;
     sync_stat.last_sync_bytes = sync_stat.sync_bytes;
     sync_stat.last_sync_files = sync_stat.sync_files;
     ++sync_stat.synced_snap_count;
     _reset_sync_stat(dir_root);
+  }
+  void set_snapdiff(const std::string &dir_root, bool snapdiff) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.snapdiff = snapdiff;
+  }
+  void set_crawl_finished(const std::string &dir_root, bool state, double seconds) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.crawl_finished = state;
+    sync_stat.crawl_duration = seconds;
   }
   void inc_sync_bytes(const std::string &dir_root, const uint64_t& b) {
     std::scoped_lock locker(m_lock);
@@ -480,6 +501,11 @@ private:
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     sync_stat.sync_files++;
+  }
+  void set_crawl_start_time(const std::string &dir_root) {
+    std::scoped_lock locker(m_lock);
+    auto &sync_stat = m_snap_sync_stats.at(dir_root);
+    sync_stat.crawl_start_time = clock::now();
   }
   void inc_total_bytes_files(const std::string &dir_root, const uint64_t& b) {
     std::scoped_lock locker(m_lock);
@@ -634,6 +660,7 @@ private:
 
   // format routines for peer_status
   static std::string format_bytes(double bytes);
+  static std::string format_time(double total_seconds);
 };
 
 } // namespace mirror


### PR DESCRIPTION
Add following metrics which are accessed through asok interface.

1. bytes progress
2. files progress
3. "crawl": {
           "state": "completed",
           "duration": "37s"
       }
4. sync-mode - full/delta
5. read_bytes_per_sec
6. write_bytes_per_sec
7.   "datasync_queue_wait": {
                "state": "waiting",
                "duration": "12s"
            },
8. eta


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
