### PR TITLE
librbd/api/mirror: make group promote and demote crash-consistent

### DIFF
--- a/src/librbd/mirror/GroupPromoteRequest.cc
+++ b/src/librbd/mirror/GroupPromoteRequest.cc
@@ -129,6 +129,11 @@ void GroupPromoteRequest<I>::handle_check_group_primary_state(int r) {
       continue;
     }
 
+    if (ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY &&
+        !is_mirror_group_snapshot_complete(it->state, ns->complete)) {
+      continue;
+    }
+
     // XXXMG: check primary_mirror_uuid matches?
     group_snap_state = it->state;
     state = ns->state;

--- a/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
@@ -428,13 +428,6 @@ void GroupPrepareImagesRequest<I>::get_images_mirror_info() {
             new_sub_ctx->complete(-EINVAL);
             return;
           }
-        } else if (m_operation == OP_DEMOTE) {
-          if (m_images_promotion_states[i] != PROMOTION_STATE_PRIMARY) {
-            lderr(image_cct) << "image_id=" << m_images[i].spec.image_id
-                             << " image is not primary" << dendl;
-            new_sub_ctx->complete(-EINVAL);
-            return;
-          }
         } else if (m_operation == OP_PROMOTE) {
           if (m_images_promotion_states[i] == PROMOTION_STATE_NON_PRIMARY && !m_force) {
             lderr(image_cct) << "image_id=" << m_images[i].spec.image_id

--- a/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
@@ -436,12 +436,7 @@ void GroupPrepareImagesRequest<I>::get_images_mirror_info() {
             return;
           }
         } else if (m_operation == OP_PROMOTE) {
-          if (m_images_promotion_states[i] == PROMOTION_STATE_PRIMARY) {
-            lderr(image_cct) << "image_id=" << m_images[i].spec.image_id
-                             << " image is already primary" << dendl;
-            new_sub_ctx->complete(-EINVAL);
-            return;
-          } else if (m_images_promotion_states[i] == PROMOTION_STATE_NON_PRIMARY && !m_force) {
+          if (m_images_promotion_states[i] == PROMOTION_STATE_NON_PRIMARY && !m_force) {
             lderr(image_cct) << "image_id=" << m_images[i].spec.image_id
                              << " image is primary within a remote cluster or demotion is not propagated yet"
                              << dendl;

--- a/src/librbd/mirror/snapshot/Utils.cc
+++ b/src/librbd/mirror/snapshot/Utils.cc
@@ -81,6 +81,13 @@ bool can_create_primary_snapshot(I *image_ctx, bool demoted, bool force,
     }
     ldout(cct, 20) << "previous snapshot snap_id=" << it->first << " "
                    << *mirror_ns << dendl;
+    if (mirror_ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED &&
+        demoted) {
+      // allow creation of a primary demoted snapshot
+      // when previous snapshot is primary demoted
+      return true;
+    }
+
     if (mirror_ns->is_demoted() && !force) {
       lderr(cct) << "trying to create primary snapshot without force "
                  << "when previous primary snapshot is demoted"

--- a/src/test/librbd/mirror/snapshot/test_mock_Utils.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_Utils.cc
@@ -117,6 +117,11 @@ TEST_F(TestMockMirrorSnapshotUtils, CanCreatePrimarySnapshot) {
     cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED, {"uuid"}, "", CEPH_NOSNAP};
   snap_create(mock_image_ctx, pns, "PS1");
 
+  // previous primary snapshot is demoted, can create another primary demoted
+  // snapshot without force
+  ASSERT_TRUE(util::can_create_primary_snapshot(&mock_image_ctx, true, false,
+                                                nullptr, nullptr));
+
   // previous primary snapshot is demoted, no force
   ASSERT_FALSE(util::can_create_primary_snapshot(&mock_image_ctx, false, false,
                                                  nullptr, nullptr));


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
