### PR TITLE
mgr/dashboard: Enable gray 10 theme as per carbon standards

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
@@ -6,7 +6,7 @@
      [fullWidth]="true">
 <div cdsCol
      [columnNumbers]="{sm: 4, md: 8}">
-  <div class="pb-3 form-item"
+  <div class="cds-mt-3 form-item"
        cdsRow>
     <cds-combo-box
         type="single"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
@@ -6,7 +6,7 @@
      [fullWidth]="true">
 <div cdsCol
      [columnNumbers]="{sm: 4, md: 8}">
-  <div class="pb-3 form-item"
+  <div class="cds-mt-3 form-item"
        cdsRow>
     <cds-combo-box
         type="single"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/prometheus-tabs/prometheus-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/prometheus-tabs/prometheus-tabs.component.html
@@ -1,5 +1,8 @@
-<ul class="nav nav-tabs">
-  <li class="nav-item">
+<nav
+  class="nav nav-tabs"
+  ngbNav
+  #nav="ngbNav">
+  <ng-container ngbNavItem>
     <a class="nav-link"
        routerLink="/monitoring/active-alerts"
        routerLinkActive="active"
@@ -10,21 +13,21 @@
         class="tag-danger ms-1">{{ prometheusAlertService.activeCriticalAlerts }}</cds-tag>
     <cds-tag *ngIf="prometheusAlertService.activeWarningAlerts > 0"
         class="tag-warning ms-1">{{ prometheusAlertService.activeWarningAlerts }}</cds-tag></a>
-  </li>
-  <li class="nav-item">
+  </ng-container>
+  <ng-container ngbNavItem>
     <a class="nav-link"
        routerLink="/monitoring/silences"
        routerLinkActive="active"
        ariaCurrentWhenActive="page"
        [routerLinkActiveOptions]="{exact: true}"
        i18n>Silences</a>
-  </li>
-  <li class="nav-item">
+  </ng-container>
+  <ng-container ngbNavItem>
     <a class="nav-link"
        routerLink="/monitoring/alerts"
        routerLinkActive="active"
        ariaCurrentWhenActive="page"
        [routerLinkActiveOptions]="{exact: true}"
        i18n>Alert Rules</a>
-  </li>
-</ul>
+  </ng-container>
+</nav>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -6,7 +6,8 @@
         i18n>{{ action | titlecase }} {{ resource }}</h3>
     <cd-help-text></cd-help-text>
   </cds-modal-header>
-  <section cdsModalContent>
+  <section cdsModalContent
+           hasForm="true">
     <form #frm="ngForm"
           [formGroup]="serviceForm"
           novalidate>
@@ -186,8 +187,7 @@
               <input cdsText
                      type="text"
                      [value]="serviceForm.controls.service_type.value + '.'"
-                     [disabled]="editing"
-                     readonly="true">
+                     disabled="true">
             </cds-text-label>
           </div>
           <cds-text-label [invalid]="serviceForm.controls.service_id.invalid && serviceForm.controls.service_id.dirty"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
@@ -1,7 +1,6 @@
 @use './src/styles/vendor/variables' as vv;
 
 .overview {
-  background-color: var(--cds-background);
   margin: 0;
   padding: 0;
 }
@@ -10,6 +9,7 @@
   overflow: auto;
   padding-top: var(--cds-spacing-09);
   padding-bottom: var(--cds-spacing-09);
+  background-color: var(--cds-background);
 
   &:has(.tearsheet--full) {
     padding-left: 0;
@@ -29,10 +29,6 @@
       padding-left: var(--cds-spacing-07);
     }
   }
-}
-
-.rgw-dashboard {
-  background-color: var(--cds-background);
 }
 
 .cd-alert-container {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
@@ -1,7 +1,7 @@
 @use './src/styles/vendor/variables' as vv;
 
 .overview {
-  background-color: vv.$body-bg-alt;
+  background-color: var(--cds-background);
   margin: 0;
   padding: 0;
 }
@@ -32,7 +32,7 @@
 }
 
 .rgw-dashboard {
-  background-color: vv.$body-bg-alt;
+  background-color: var(--cds-background);
 }
 
 .cd-alert-container {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
@@ -1,5 +1,6 @@
 <div
   cdsGrid
+  [useCssGrid]="false"
   [fullWidth]="true"
   class="notifications-page__container">
   <!-- Left Panel - Notifications List -->

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -34,7 +34,6 @@ $grid-breakpoints: (
 @import './src/styles/ceph-custom/forms';
 @import './src/styles/ceph-custom/grid';
 @import './src/styles/ceph-custom/icons';
-@import './src/styles/ceph-custom/navs';
 @import './src/styles/ceph-custom/toast';
 @import './src/styles/ceph-custom/spacings';
 

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -182,15 +182,6 @@ Breadcrumbs
 }
 
 /******************************************
-Dashboard page
-******************************************/
-// keeping this on 12px for now until we have responsive design
-// based on carbon
-cd-dashboard {
-  font-size: 12px;
-}
-
-/******************************************
 Code snippet
 ******************************************/
 
@@ -235,10 +226,6 @@ Tabs
   height: layout.$spacing-10;
   margin: auto;
   width: layout.$spacing-10;
-}
-
-.cds-mb-4 {
-  margin-bottom: layout.$spacing-02;
 }
 
 .cds--text-truncate--end {

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -224,35 +224,6 @@ Code snippet
 }
 
 /******************************************
-Tooltip
-******************************************/
-.cds--tooltip-content {
-  background-color: theme.$layer-02;
-}
-
-/******************************************
-Carbon Popover
-******************************************/
-.cds--popover {
-  .cds--popover-caret {
-    background-color: theme.$background;
-  }
-}
-
-.cds--popover-content {
-  background-color: theme.$background;
-  padding: layout.$spacing-05;
-}
-
-// inner container class for overflow
-.cds--popover-scroll-container {
-  max-height: layout.$spacing-13;
-  overflow-y: auto;
-  margin-right: -1rem;
-  padding-right: 1rem;
-}
-
-/******************************************
 Tabs
 ******************************************/
 .cds--tab-content {

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -235,3 +235,20 @@ Tabs
 .cds--text-truncate--end {
   @include textTruncate.text-truncate-end;
 }
+
+/******************************************
+Modals
+******************************************/
+
+/* Temporary workaround for Carbon modal form field background bug.
+ https://github.com/carbon-design-system/carbon-components-angular/issues/3340
+ */
+.cds--modal {
+  .cds--select-input,
+  .cds--text-input,
+  .cds--list-box,
+  .cds--number input[type='number'],
+  .cds--text-area {
+    background-color: var(--cds-layer-02);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -193,7 +193,11 @@ Code snippet
 Tabs
 ******************************************/
 .cds--tab-content {
-  background: var(--cds-layer-01);
+  padding: 0;
+}
+
+.cds--data-table-container {
+  padding: 0;
 }
 
 .cds-success-color {

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -182,31 +182,6 @@ Breadcrumbs
 }
 
 /******************************************
-Modals
-******************************************/
-.cds--modal-container {
-  background-color: colors.$gray-10;
-
-  .cds--modal-close {
-    background-color: transparent;
-
-    &:hover {
-      background-color: colors.$gray-10-hover;
-    }
-
-    &:focus,
-    &:active {
-      background-color: transparent;
-    }
-  }
-
-  .cds--modal-scroll-content {
-    max-height: 70vh;
-    overflow-y: auto;
-  }
-}
-
-/******************************************
 Dashboard page
 ******************************************/
 // keeping this on 12px for now until we have responsive design

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_navs.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_navs.scss
@@ -1,5 +1,0 @@
-@use '../vendor/variables' as vv;
-
-.nav-tabs {
-  margin-bottom: vv.$nav-tabs-margin-bottom;
-}

--- a/src/pybind/mgr/dashboard/frontend/src/styles/themes/_content.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/themes/_content.scss
@@ -16,8 +16,6 @@ $content-theme: map-merge(
   compat.$g10,
   (
     background-brand: vv.$secondary,
-    background-inverse: vv.$light,
-    background-inverse-hover: vv.$gray-300,
     link-primary: vv.$primary,
     link-primary-hover: vv.$secondary,
     link-secondary: vv.$secondary,
@@ -26,14 +24,7 @@ $content-theme: map-merge(
     focus: vv.$primary,
     focus-inset: lighten(vv.$primary, 45%),
     focus-inverse: lighten(vv.$primary, 25%),
-    text-inverse: vv.$dark,
     support-info: vv.$info,
-    layer-01: vv.$light,
-    layer-hover-01: colors.$gray-20,
-    text-primary: vv.$dark,
-    text-disabled: vv.$gray-500,
-    icon-secondary: vv.$gray-800,
-    field-01: colors.$gray-10,
     interactive: vv.$primary,
     border-interactive: vv.$primary
   )


### PR DESCRIPTION
@ceph/dashboard PTAL at the components you all designed with this PR.

As per the gray10 theme, the base - gray and anything layered on top white.

See more [here](https://angular.carbondesignsystem.com/?path=/docs/components-theme--docs#with-layer)

<img width="1651" height="875" alt="image" src="https://github.com/user-attachments/assets/076e919c-752d-4c1c-9859-640a9aa95607" />
<img width="1663" height="848" alt="image" src="https://github.com/user-attachments/assets/f52b4ee5-9de8-4eb7-a68f-b92fac1c526d" />
<img width="456" height="135" alt="image" src="https://github.com/user-attachments/assets/614e1406-d19a-470f-923d-a555937d5d91" />
<img width="1387" height="781" alt="image" src="https://github.com/user-attachments/assets/6d557567-6299-4c77-ba63-b2789e674f46" />
<img width="1387" height="781" alt="image" src="https://github.com/user-attachments/assets/b28b8dd6-a1fc-4055-990a-f4626390b5e9" />
<img width="1655" height="834" alt="image" src="https://github.com/user-attachments/assets/d6089e6c-3bc2-4c71-bc41-6f2e22881f3f" />


I have checked forms, tooltips and modals, so far so good. Please let know if anything missing or not updated