### PR TITLE
tentacle: rgw: ListRoles returns "Access Denied" for a regular user with valid allow policy 

### DIFF
--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -514,6 +514,11 @@ int RGWListRoles::init_processing(optional_yield y)
   if (const auto* id = std::get_if<rgw_account_id>(&s->owner.id); id) {
     account_id = *id;
   }
+
+  const std::string resource_name = "";
+  const rgw::ARN arn{resource_name, "role", account_id, true};
+  resource = arn;
+
   return 0;
 }
 


### PR DESCRIPTION
This is a backport of the fix for RGW ListRoles permission issues.
The ListRoles method didn't initialise the arn resource, which caused an implicit deny for regular users even with a valid allow policy.

**Cherry-picked from commit:** 6594f6c6cc6

### Checklist
- Tracker
  - [x] References tracker ticket: https://tracker.ceph.com/issues/74399
- Component impact
  - [x] No impact that needs to be tracked (Backport of existing fix)
- Documentation
  - [x] No doc update is appropriate
- Tests
  - [x] No tests (Cherry-pick of a verified fix; original PR contained tests)