### PR TITLE
rgw/multisite: remove old zonegroup name on the remote zone after a rename

### DIFF
--- a/src/rgw/driver/rados/config/period.cc
+++ b/src/rgw/driver/rados/config/period.cc
@@ -148,8 +148,6 @@ int RadosConfigStore::create_period(const DoutPrefixProvider* dpp,
     return r;
   }
 
-  // non const RGWPeriod
-  (void) this->update_latest_epoch(dpp, y, info.get_id(), info.get_epoch());
   return 0;
 }
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2123,11 +2123,24 @@ static int commit_period(rgw::sal::ConfigStore* cfgstore,
         << cpp_strerror(ret) << std::endl;
     return ret;
   }
+
+  ret = cfgstore->update_latest_epoch(dpp(), null_yield, period.get_id(), period.get_epoch());
+  if (ret == -EEXIST) {
+    // already have this epoch (or a more recent one)
+    cerr << "already have epoch >= " << period.get_epoch()
+        << " for period " << period.get_id() << std::endl;
+  }
+  if (ret < 0) {
+    cerr << "Error updating latest epoch for period " << period.get_id() << ": " << cpp_strerror(ret) << std::endl;
+    return ret;
+  }
+
   ret = rgw::reflect_period(dpp(), null_yield, cfgstore, period);
   if (ret < 0) {
     cerr << "Error updating local objects: " << cpp_strerror(ret) << std::endl;
     return ret;
   }
+
   (void) cfgstore->realm_notify_new_period(dpp(), null_yield, period);
   return ret;
 }
@@ -2242,6 +2255,19 @@ static int do_period_pull(rgw::sal::ConfigStore* cfgstore,
   if (ret < 0) {
     cerr << "Error storing period " << period->get_id() << ": " << cpp_strerror(ret) << std::endl;
   }
+
+  ret = cfgstore->update_latest_epoch(dpp(), null_yield, period->get_id(), period->get_epoch());
+  if (ret == -EEXIST) {
+    // already have this epoch (or a more recent one)
+    cerr << "already have epoch >= " << period->get_epoch()
+        << " for period " << period->get_id() << std::endl;
+    return 0;
+  }
+  if (ret < 0) {
+    cerr << "Error updating latest epoch for period " << period->get_id() << ": " << cpp_strerror(ret) << std::endl;
+    return ret;
+  }
+
   return 0;
 }
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2129,6 +2129,7 @@ static int commit_period(rgw::sal::ConfigStore* cfgstore,
     // already have this epoch (or a more recent one)
     cerr << "already have epoch >= " << period.get_epoch()
         << " for period " << period.get_id() << std::endl;
+    return 0;
   }
   if (ret < 0) {
     cerr << "Error updating latest epoch for period " << period.get_id() << ": " << cpp_strerror(ret) << std::endl;

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1070,10 +1070,10 @@ int create_realm(const DoutPrefixProvider* dpp, optional_yield y,
 
     r = cfgstore->update_latest_epoch(dpp, y, period->id, period->epoch);
     if (r == -EEXIST) {
-    // already have this epoch (or a more recent one)
-    ldpp_dout(dpp, -1) << "already have epoch >= " << period->get_epoch()
-        << " for period " << period->get_id() << dendl;
-    return 0;
+      // already have this epoch (or a more recent one)
+      ldpp_dout(dpp, -1) << "already have epoch >= " << period->get_epoch()
+          << " for period " << period->get_id() << dendl;
+      return 0;
     }
     if (r < 0) {
       ldpp_dout(dpp, -1) << "Error updating latest epoch for period " << period->get_id() <<
@@ -1150,28 +1150,29 @@ int reflect_period(const DoutPrefixProvider* dpp, optional_yield y,
   }
 
   for (auto& [zonegroup_id, zonegroup] : info.period_map.zonegroups) {
-    // read the existing zonegroup
+    // read the existing zonegroup to detect renames
     RGWZoneGroup existing_zg;
     std::unique_ptr<sal::ZoneGroupWriter> writer;
     r = cfgstore->read_zonegroup_by_id(dpp, y, zonegroup_id, existing_zg, &writer);
-    if (r == 0) {
+    if (r == 0 && existing_zg.name != zonegroup.name) {
       // if the name changed, call rename() instead of create
-      if (existing_zg.name != zonegroup.name) {
-        RGWZoneGroup new_zg = zonegroup; // copy because zonegroup is const
-        std::string new_name = std::move(new_zg.name);
-        new_zg.name = std::move(existing_zg.name); // rename() expects old name
-        r = writer->rename(dpp, y, new_zg, new_name);
-        if (r < 0) {
-          ldpp_dout(dpp, -1) << __func__ << " failed to remove old zonegroup name "
-              << existing_zg.name << " with " << cpp_strerror(r) << dendl;
-        }
+      RGWZoneGroup new_zg = zonegroup; // copy because zonegroup is const
+      std::string new_name = std::move(new_zg.name);
+      new_zg.name = std::move(existing_zg.name); // rename() expects current name in info
+      r = writer->rename(dpp, y, new_zg, new_name);
+      if (r < 0) {
+        ldpp_dout(dpp, -1) << __func__ << " failed to rename zonegroup from "
+            << existing_zg.name << " to " << new_name
+            << ": " << cpp_strerror(r) << dendl;
+        return r;
       }
-    }
-    r = cfgstore->create_zonegroup(dpp, y, exclusive, zonegroup, nullptr);
-    if (r < 0) {
-      ldpp_dout(dpp, -1) << __func__ << " failed to store zonegroup id="
-          << zonegroup_id << " with " << cpp_strerror(r) << dendl;
-      return r;
+    } else {
+      r = cfgstore->create_zonegroup(dpp, y, exclusive, zonegroup, nullptr);
+      if (r < 0) {
+        ldpp_dout(dpp, -1) << __func__ << " failed to store zonegroup id="
+            << zonegroup_id << " with " << cpp_strerror(r) << dendl;
+        return r;
+      }
     }
     if (zonegroup.is_master) {
       // set master as default if no default exists
@@ -1326,10 +1327,10 @@ int commit_period(const DoutPrefixProvider* dpp, optional_yield y,
     }
     r = cfgstore->update_latest_epoch(dpp, y, info.id, info.epoch);
     if (r == -EEXIST) {
-    // already have this epoch (or a more recent one)
-    ldpp_dout(dpp, 0) << "already have epoch >= " << info.get_epoch()
-        << " for period " << info.get_id() << dendl;
-    return 0;
+      // already have this epoch (or a more recent one)
+      ldpp_dout(dpp, 0) << "already have epoch >= " << info.get_epoch()
+          << " for period " << info.get_id() << dendl;
+      return 0;
     }
     if (r < 0) {
       ldpp_dout(dpp, 0) << "Error updating latest epoch for period " << info.get_id() <<
@@ -1370,9 +1371,10 @@ int commit_period(const DoutPrefixProvider* dpp, optional_yield y,
   }
   r = cfgstore->update_latest_epoch(dpp, y, info.id, info.epoch);
   if (r == -EEXIST) {
-  // already have this epoch (or a more recent one)
-  ldpp_dout(dpp, 0) << "already have epoch >= " << info.get_epoch()
-      << " for period " << info.get_id() << dendl;
+    // already have this epoch (or a more recent one)
+    ldpp_dout(dpp, 0) << "already have epoch >= " << info.get_epoch()
+        << " for period " << info.get_id() << dendl;
+    return 0;
   }
   if (r < 0) {
     ldpp_dout(dpp, 0) << "Error updating latest epoch for period " << info.get_id() <<

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1137,6 +1137,23 @@ int reflect_period(const DoutPrefixProvider* dpp, optional_yield y,
   }
 
   for (auto& [zonegroup_id, zonegroup] : info.period_map.zonegroups) {
+    // read the existing zonegroup
+    RGWZoneGroup existing_zg;
+    std::unique_ptr<sal::ZoneGroupWriter> writer;
+    r = cfgstore->read_zonegroup_by_id(dpp, y, zonegroup_id, existing_zg, &writer);
+    if (r == 0) {
+      // if the name changed, call rename() instead of create
+      if (existing_zg.name != zonegroup.name) {
+        RGWZoneGroup new_zg = zonegroup; // copy because zonegroup is const
+        std::string new_name = std::move(new_zg.name);
+        new_zg.name = std::move(existing_zg.name); // rename() expects old name
+        r = writer->rename(dpp, y, new_zg, new_name);
+        if (r < 0) {
+          ldpp_dout(dpp, -1) << __func__ << " failed to remove old zonegroup name "
+              << existing_zg.name << " with " << cpp_strerror(r) << dendl;
+        }
+      }
+    }
     r = cfgstore->create_zonegroup(dpp, y, exclusive, zonegroup, nullptr);
     if (r < 0) {
       ldpp_dout(dpp, -1) << __func__ << " failed to store zonegroup id="
@@ -1294,6 +1311,7 @@ int commit_period(const DoutPrefixProvider* dpp, optional_yield y,
       ldpp_dout(dpp, 0) << "failed to create new period: " << cpp_strerror(-r) << dendl;
       return r;
     }
+
     // set as current period
     r = realm_set_current_period(dpp, y, cfgstore, realm_writer, realm, info);
     if (r < 0) {

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1067,6 +1067,19 @@ int create_realm(const DoutPrefixProvider* dpp, optional_yield y,
           << " with " << cpp_strerror(r) << dendl;
       return r;
     }
+
+    r = cfgstore->update_latest_epoch(dpp, y, period->id, period->epoch);
+    if (r == -EEXIST) {
+    // already have this epoch (or a more recent one)
+    ldpp_dout(dpp, -1) << "already have epoch >= " << period->get_epoch()
+        << " for period " << period->get_id() << dendl;
+    return 0;
+    }
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << "Error updating latest epoch for period " << period->get_id() <<
+      ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
   }
 
   // update the realm's current_period
@@ -1311,6 +1324,18 @@ int commit_period(const DoutPrefixProvider* dpp, optional_yield y,
       ldpp_dout(dpp, 0) << "failed to create new period: " << cpp_strerror(-r) << dendl;
       return r;
     }
+    r = cfgstore->update_latest_epoch(dpp, y, info.id, info.epoch);
+    if (r == -EEXIST) {
+    // already have this epoch (or a more recent one)
+    ldpp_dout(dpp, 0) << "already have epoch >= " << info.get_epoch()
+        << " for period " << info.get_id() << dendl;
+    return 0;
+    }
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "Error updating latest epoch for period " << info.get_id() <<
+      ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
 
     // set as current period
     r = realm_set_current_period(dpp, y, cfgstore, realm_writer, realm, info);
@@ -1343,6 +1368,18 @@ int commit_period(const DoutPrefixProvider* dpp, optional_yield y,
     ldpp_dout(dpp, 0) << "failed to store period: " << cpp_strerror(r) << dendl;
     return r;
   }
+  r = cfgstore->update_latest_epoch(dpp, y, info.id, info.epoch);
+  if (r == -EEXIST) {
+  // already have this epoch (or a more recent one)
+  ldpp_dout(dpp, 0) << "already have epoch >= " << info.get_epoch()
+      << " for period " << info.get_id() << dendl;
+  }
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "Error updating latest epoch for period " << info.get_id() <<
+    ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
   r = reflect_period(dpp, y, cfgstore, info);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "failed to update local objects: " << cpp_strerror(r) << dendl;

--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -290,6 +290,14 @@ class ZoneGroup(SystemObject, SystemObject.CreateDelete, SystemObject.GetSet, Sy
             self.zones.remove(zone)
         return data, r
 
+    def rename(self, cluster, new_name, args = None, **kwargs):
+        """ rename the zonegroup; 'rename' outputs no JSON so use command() """
+        args = ['--zonegroup-new-name', new_name] + (args or [])
+        _, r = self.command(cluster, 'rename', args, **kwargs)
+        if r == 0:
+            self.name = new_name
+        return r
+
     def realm(self):
         return self.period.realm if self.period else None
 

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1576,6 +1576,50 @@ def test_zg_master_zone_delete():
     rm_zg.delete(master_cluster)
     master_zg.period.update(master_zone, commit=True)
 
+def test_zonegroup_rename():
+    master_zg = realm.master_zonegroup()
+    master_zone = master_zg.master_zone
+    master_cluster = master_zone.cluster
+
+    old_name = 'rename_test_zg'
+    new_name = 'rename_test_zg_renamed'
+
+    # create a temporary zonegroup with a zone and commit the period
+    test_zg = ZoneGroup(old_name, master_zg.period)
+    test_zg.create(master_cluster)
+    test_zone = Zone('rename_test_zone', test_zg, master_cluster)
+    test_zone.create(master_cluster)
+    master_zg.period.update(master_zone, commit=True)
+
+    realm_meta_checkpoint(realm)
+
+    # rename the zonegroup on the master and commit the updated period
+    r = test_zg.rename(master_cluster, new_name)
+    assert r == 0, "zonegroup rename failed with %d" % r
+    master_zg.period.update(master_zone, commit=True)
+
+    realm_meta_checkpoint(realm)
+
+    time.sleep(config.reconfigure_delay)
+
+    # verify on each zone:
+    new_zg = ZoneGroup(new_name, master_zg.period)
+    old_zg = ZoneGroup(old_name, master_zg.period)
+    for zone in master_zg.zones:
+        _, r = new_zg.get(zone.cluster, check_retcode=False)
+        assert r == 0, \
+            "new zonegroup name '%s' not found on zone %s" % (new_name, zone.name)
+
+        _, r = old_zg.get(zone.cluster, check_retcode=False)
+        assert r == errno.ENOENT, \
+            "old zonegroup name '%s' still present on zone %s (r=%d)" % (old_name, zone.name, r)
+
+    # clean up
+    test_zone.delete(master_cluster)
+    test_zg.delete(master_cluster)
+    master_zg.period.update(master_zone, commit=True)
+    time.sleep(config.reconfigure_delay)
+
 def test_set_bucket_website():
     buckets, zone_bucket = create_bucket_per_zone_in_realm()
     for zone, bucket in zone_bucket:


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
