### PR TITLE
os/bluestore: print effective extra in 'bluefs stats' report

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -5425,6 +5425,27 @@ void FitToFastVolumeSelector::get_paths(const std::string& base, paths& res) con
   res.emplace_back(base, 1);  // size of the last db_path has no effect
 }
 
+uint64_t RocksDBBlueFSVolumeSelector::get_effective_extra() const {
+  // considering statically available db space vs.
+  // - observed maximums on DB dev for DB/WAL/UNSORTED data
+  // - observed maximum spillovers
+
+  // max db usage we potentially observed
+  uint64_t max_db_use = 0;
+  max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_DB, LEVEL_LOG - LEVEL_FIRST);
+  max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_DB, LEVEL_WAL - LEVEL_FIRST);
+  max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_DB, LEVEL_DB - LEVEL_FIRST);
+  // this could go to db hence using it in the estimation
+  max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_SLOW, LEVEL_DB - LEVEL_FIRST);
+
+  auto db_total = l_totals[LEVEL_DB - LEVEL_FIRST];
+  uint64_t avail = std::min(
+    db_avail4slow,
+    max_db_use < db_total ? db_total - max_db_use : 0);
+
+  return avail;
+}
+
 uint8_t RocksDBBlueFSVolumeSelector::select_prefer_bdev(void* h) {
   ceph_assert(h != nullptr);
   uint64_t hint = reinterpret_cast<uint64_t>(h);
@@ -5433,21 +5454,8 @@ uint8_t RocksDBBlueFSVolumeSelector::select_prefer_bdev(void* h) {
   case LEVEL_SLOW:
     res = BlueFS::BDEV_SLOW;
     if (db_avail4slow > 0) {
-      // considering statically available db space vs.
-      // - observed maximums on DB dev for DB/WAL/UNSORTED data
-      // - observed maximum spillovers
-      uint64_t max_db_use = 0; // max db usage we potentially observed
-      max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_DB, LEVEL_LOG - LEVEL_FIRST);
-      max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_DB, LEVEL_WAL - LEVEL_FIRST);
-      max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_DB, LEVEL_DB - LEVEL_FIRST);
-      // this could go to db hence using it in the estimation
-      max_db_use += per_level_per_dev_max.at(BlueFS::BDEV_SLOW, LEVEL_DB - LEVEL_FIRST);
 
-      auto db_total = l_totals[LEVEL_DB - LEVEL_FIRST];
-      uint64_t avail = std::min(
-	db_avail4slow,
-	max_db_use < db_total ? db_total - max_db_use : 0);
-
+      auto avail = get_effective_extra();
       // considering current DB dev usage for SLOW data
       if (avail > per_level_per_dev_usage.at(BlueFS::BDEV_DB, LEVEL_SLOW - LEVEL_FIRST)) {
 	res = BlueFS::BDEV_DB;
@@ -5504,8 +5512,9 @@ void RocksDBBlueFSVolumeSelector::dump(ostream& sout) {
   auto max_y = per_level_per_dev_usage.get_max_y();
 
   sout << "RocksDBBlueFSVolumeSelector " << std::endl;
-  sout << ">>Settings<<"
-    << " extra=" << byte_u_t(db_avail4slow)
+  sout << ">>Parameters<<"
+    << " effective extra=" << byte_u_t(get_effective_extra())
+    << " max extra=" << byte_u_t(db_avail4slow)
     << ", extra level=" << extra_level
     << ", l0_size=" << byte_u_t(level0_size)
     << ", l_base=" << byte_u_t(level_base)

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -1152,12 +1152,27 @@ public:
     }
   }
 
-  uint64_t get_available_extra() const {
-    return db_avail4slow;
-  }
+  // Returns a static value (based on disk layout and store's settings)
+  // of the first RocksDB level which doesn't fully fit into "fast" volume.
+  // So with the selector's help data belonging to this level could be 
+  // [partially] allocated at that volume if get_*_extra() methods below
+  // indicate non-zero values. 
   uint64_t get_extra_level() const {
     return extra_level;
   }
+  // Returns a static value (based on disk layout and store's settings)
+  // of the extra space at DB volume which
+  // this volume selector permits for using by data from "slow" levels.
+  // Takes both maximum historical observations and store's settings
+  // into account
+  uint64_t get_max_extra() const {
+    return db_avail4slow;
+  }
+  // Calculates the effective amount of extra space at "fast" volume which
+  // this volume selector permits for using by data from "slow" levels.
+  // Takes both the maximum historical observations and the value from 
+  // get_max_extra() into account to get the final result.
+  uint64_t get_effective_extra() const;
   void* get_hint_for_log() const override {
     return  reinterpret_cast<void*>(LEVEL_LOG);
   }

--- a/src/test/objectstore/test_bluestore_vselector.cc
+++ b/src/test/objectstore/test_bluestore_vselector.cc
@@ -34,7 +34,8 @@ TEST(rocksdb_bluefs_vselector, basic) {
   bluefs_extent_t e;
 
   ASSERT_EQ(4, selector.get_extra_level());
-  ASSERT_EQ(30ull << 30, selector.get_available_extra()); // 168GB - 1GB (L0) - 1GB (L1) - 8GB (L2) - 2*64GB (L3)
+  ASSERT_EQ(30ull << 30, selector.get_max_extra()); // 168GB - 1GB (L0) - 1GB (L1) - 8GB (L2) - 2*64GB (L3)
+  ASSERT_EQ(30ull << 30, selector.get_effective_extra()); // no history so we get max extra
 
   ASSERT_EQ(0, selector.select_prefer_bdev((void*)log_bdev));
   ASSERT_EQ(0, selector.select_prefer_bdev((void*)wal_bdev));
@@ -46,18 +47,34 @@ TEST(rocksdb_bluefs_vselector, basic) {
     e.length = 1ull * (1 << 30);
     selector.add_usage((void*)db_bdev, e);
   }
+
+  ASSERT_EQ(30ull << 30, selector.get_effective_extra()); // still 30GB is available
+
   ASSERT_EQ(0, selector.select_prefer_bdev((void*)log_bdev));
   ASSERT_EQ(0, selector.select_prefer_bdev((void*)wal_bdev));
   ASSERT_EQ(1, selector.select_prefer_bdev((void*)db_bdev));
   ASSERT_EQ(1, selector.select_prefer_bdev((void*)slow_bdev));
 
-  // 'Use' 30GB Slow level data at DB vol
-  for (size_t i = 0; i < 30; i++) {
+  // 'Use' 20GB Slow level data at DB vol
+  for (size_t i = 0; i < 20; i++) {
     e.bdev = 1; // DB dev
     e.length = 1ull * (1 << 30);
     ASSERT_EQ(1, selector.select_prefer_bdev((void*)slow_bdev));
     selector.add_usage((void*)slow_bdev, e);
   }
+  ASSERT_EQ(0, selector.select_prefer_bdev((void*)log_bdev));
+  ASSERT_EQ(0, selector.select_prefer_bdev((void*)wal_bdev));
+  ASSERT_EQ(1, selector.select_prefer_bdev((void*)db_bdev));
+  ASSERT_EQ(1, selector.select_prefer_bdev((void*)slow_bdev));
+
+  // 'Use' 10GB more Slow level data at DB vol
+  for (size_t i = 0; i < 10; i++) {
+    e.bdev = 1; // DB dev
+    e.length = 1ull * (1 << 30);
+    ASSERT_EQ(1, selector.select_prefer_bdev((void*)slow_bdev));
+    selector.add_usage((void*)slow_bdev, e);
+  }
+  // now slow data to be targeted to slow dev
   ASSERT_EQ(0, selector.select_prefer_bdev((void*)log_bdev));
   ASSERT_EQ(0, selector.select_prefer_bdev((void*)wal_bdev));
   ASSERT_EQ(1, selector.select_prefer_bdev((void*)db_bdev));
@@ -93,6 +110,9 @@ TEST(rocksdb_bluefs_vselector, basic) {
     ASSERT_EQ(1, selector.select_prefer_bdev((void*)slow_bdev));
     selector.add_usage((void*)db_bdev, e);
   }
+  ASSERT_EQ(10ull << 30, selector.get_effective_extra()); // reduced extra due to historic usage
+
+  // 'Use' 10GB more slw level data at DB vol
   for (size_t i = 0; i < 10; i++) {
     e.bdev = 1; // DB dev
     e.length = 1ull * (1 << 30);
@@ -100,6 +120,7 @@ TEST(rocksdb_bluefs_vselector, basic) {
     selector.add_usage((void*)slow_bdev, e);
   }
   ASSERT_EQ(2, selector.select_prefer_bdev((void*)slow_bdev));
+  ASSERT_EQ(10ull << 30, selector.get_effective_extra()); // reduced extra due to historic usage
 
   // 'Unuse' remaining 10GB Slow level data at DB vol
   for (size_t i = 0; i < 10; i++) {
@@ -115,6 +136,7 @@ TEST(rocksdb_bluefs_vselector, basic) {
     selector.add_usage((void*)db_bdev, e);
   }
   ASSERT_EQ(2, selector.select_prefer_bdev((void*)slow_bdev));
+  ASSERT_EQ(0, selector.get_effective_extra()); // historic usage results in no extra
 
   // 'Unuse' 50GB DB level data, thi s wouldn't let slow data use DB volume anyway
   // due to updated historic maximum
@@ -124,6 +146,7 @@ TEST(rocksdb_bluefs_vselector, basic) {
     selector.sub_usage((void*)db_bdev, e);
   }
   ASSERT_EQ(2, selector.select_prefer_bdev((void*)slow_bdev));
+  ASSERT_EQ(0, selector.get_effective_extra()); // historic usage results in no extra
 
   {
     std::stringstream ss;
@@ -137,7 +160,9 @@ TEST(rocksdb_bluefs_vselector, basic) {
     ASSERT_EQ(0, selector.get_max_db_total());
     selector.dump(ss);
     std::cout << ss.str() << std::endl;
+    ASSERT_EQ(30ull << 30, selector.get_effective_extra()); // no history any more
   }
+
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
I.e. the one which takes historic maximum into account.

Here is the new look, note 'effective extra vs. max extra' in Parameters section:
```
RocksDBBlueFSVolumeSelector
>>Parameters<< effective extra=0 B max extra=30 GiB, extra level=4, l0_size=1 GiB, l_base=1 GiB, l_multi=8 B
LEV/DEV     WAL         DB          SLOW        *           *           REAL        FILES
log         0 B         0 B         0 B         0 B         0 B         0 B         0
db.wal      0 B         0 B         0 B         0 B         0 B         0 B         0
db          0 B         118 GiB     0 B         0 B         0 B         0 B         0
db.slow     0 B         0 B         0 B         0 B         0 B         0 B         0
TOTAL       0 B         118 GiB     0 B         0 B         0 B         0 B         0
MAXIMUMS:
log         0 B         0 B         0 B         0 B         0 B         0 B
db.wal      0 B         0 B         0 B         0 B         0 B         0 B
db          0 B         168 GiB     0 B         0 B         0 B         0 B
db.slow     0 B         30 GiB      0 B         0 B         0 B         0 B
TOTAL       0 B         168 GiB     0 B         0 B         0 B         0 B
>> SIZE <<  10 GiB      168 GiB     1000 GiB

``` 




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
