### PR TITLE
tentacle: librbd: rbd_aio_write_with_crc32c 

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1280,9 +1280,11 @@ CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
 CEPH_RBD_API int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
                                 const char *buf, rbd_completion_t c,
                                 int op_flags);
-
 /*
- * @param precomputed_crc32c: CRC32C checksum that was precomputed (e.g., by SPDK NVMf)
+ * @param precomputed_crc32c: CRC32C checksum that was precomputed with -1
+ *        as the initial value (i.e. with the CRC "register" initialized to
+ *        0xFFFFFFFF)
+ * @param op_flags: see librados.h constants beginning with LIBRADOS_OP_FLAG
  */
 CEPH_RBD_API int rbd_aio_write_with_crc32c(rbd_image_t image, uint64_t off,
                                            size_t len, const char *buf,

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1280,6 +1280,14 @@ CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
 CEPH_RBD_API int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
                                 const char *buf, rbd_completion_t c,
                                 int op_flags);
+
+/*
+ * @param precomputed_crc32c: CRC32C checksum that was precomputed (e.g., by SPDK NVMf)
+ */
+CEPH_RBD_API int rbd_aio_write_with_crc32c(rbd_image_t image, uint64_t off,
+                                           size_t len, const char *buf,
+                                           uint32_t precomputed_crc32c,
+                                           rbd_completion_t c, int op_flags);
 CEPH_RBD_API int rbd_aio_writev(rbd_image_t image, const struct iovec *iov,
                                 int iovcnt, uint64_t off, rbd_completion_t c);
 CEPH_RBD_API int rbd_aio_read(rbd_image_t image, uint64_t off, size_t len,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -25,6 +25,7 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/TracepointProvider.h"
+#include "include/buffer_raw.h"
 #include "include/Context.h"
 
 #include "cls/rbd/cls_rbd_client.h"
@@ -6403,6 +6404,25 @@ extern "C" int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
   librbd::api::Io<>::aio_write(
     *ictx, aio_completion, off, len, std::move(bl), op_flags, true);
   tracepoint(librbd, aio_write_exit, 0);
+  return 0;
+}
+
+extern "C" int rbd_aio_write_with_crc32c(rbd_image_t image, uint64_t off,
+                                         size_t len, const char *buf,
+                                         uint32_t precomputed_crc32c,
+                                         rbd_completion_t c, int op_flags)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+
+  auto aio_completion = get_aio_completion(comp);
+  auto raw = create_write_raw(ictx, buf, len, aio_completion);
+  raw->set_crc(std::make_pair(0, len),
+               std::make_pair(0, precomputed_crc32c));
+  bufferlist bl;
+  bl.push_back(std::move(raw));
+  librbd::api::Io<>::aio_write(
+    *ictx, aio_completion, off, len, std::move(bl), op_flags, true);
   return 0;
 }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -6417,8 +6417,9 @@ extern "C" int rbd_aio_write_with_crc32c(rbd_image_t image, uint64_t off,
 
   auto aio_completion = get_aio_completion(comp);
   auto raw = create_write_raw(ictx, buf, len, aio_completion);
+  // store with initial value -1
   raw->set_crc(std::make_pair(0, len),
-               std::make_pair(0, precomputed_crc32c));
+               std::make_pair(-1, precomputed_crc32c));
   bufferlist bl;
   bl.push_back(std::move(raw));
   librbd::api::Io<>::aio_write(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75747

---

backport of 

 - https://github.com/ceph/ceph/pull/65901
 - https://github.com/ceph/ceph/pull/66377
                      
parent tracker: https://tracker.ceph.com/issues/75747

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh