### PR TITLE
tentacle: mgr/dashboard: fix subsystem creation issue

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
@@ -7,46 +8,81 @@ import { ToastrModule } from 'ngx-toastr';
 
 import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 
-import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { SharedModule } from '~/app/shared/shared.module';
-import { NvmeofSubsystemsFormComponent } from './nvmeof-subsystems-form.component';
-import { FormHelper } from '~/testing/unit-test-helper';
 import {
-  DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM,
-  NvmeofService
-} from '~/app/shared/api/nvmeof.service';
+  NvmeofSubsystemsFormComponent,
+  SubsystemPayload
+} from './nvmeof-subsystems-form.component';
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { NvmeofSubsystemsStepOneComponent } from './nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component';
+import {
+  ComboBoxModule,
+  GridModule,
+  InputModule,
+  RadioModule,
+  TagModule
+} from 'carbon-components-angular';
+import { NvmeofSubsystemsStepThreeComponent } from './nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component';
+import { AUTHENTICATION, HOST_TYPE } from '~/app/shared/models/nvmeof';
+import { NvmeofSubsystemsStepTwoComponent } from './nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component';
+import { NvmeofSubsystemsStepFourComponent } from './nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component';
+import { of } from 'rxjs';
 
 describe('NvmeofSubsystemsFormComponent', () => {
   let component: NvmeofSubsystemsFormComponent;
   let fixture: ComponentFixture<NvmeofSubsystemsFormComponent>;
   let nvmeofService: NvmeofService;
-  let form: CdFormGroup;
-  let formHelper: FormHelper;
   const mockTimestamp = 1720693470789;
   const mockGroupName = 'default';
+  const mockPayload: SubsystemPayload = {
+    nqn: '',
+    gw_group: mockGroupName,
+    subsystemDchapKey: 'Q2VwaE52bWVvRkNoYXBTeW50aGV0aWNLZXkxMjM0NTY=',
+    addedHosts: [],
+    hostType: HOST_TYPE.ALL,
+    listeners: [],
+    hostDchapKeyList: [],
+    authType: AUTHENTICATION.Bidirectional
+  };
 
   beforeEach(async () => {
     spyOn(Date, 'now').and.returnValue(mockTimestamp);
     await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemsFormComponent],
-      providers: [NgbActiveModal],
+      declarations: [
+        NvmeofSubsystemsFormComponent,
+        NvmeofSubsystemsStepOneComponent,
+        NvmeofSubsystemsStepThreeComponent,
+        NvmeofSubsystemsStepTwoComponent,
+        NvmeofSubsystemsStepFourComponent
+      ],
+      providers: [
+        NgbActiveModal,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({ group: mockGroupName })
+          }
+        }
+      ],
       imports: [
         HttpClientTestingModule,
         NgbTypeaheadModule,
         ReactiveFormsModule,
         RouterTestingModule,
         SharedModule,
-        ToastrModule.forRoot()
+        InputModule,
+        GridModule,
+        RadioModule,
+        TagModule,
+        ToastrModule.forRoot(),
+        ComboBoxModule
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofSubsystemsFormComponent);
     component = fixture.componentInstance;
     component.ngOnInit();
-    form = component.subsystemForm;
-    formHelper = new FormHelper(form);
     fixture.detectChanges();
-    component.group = mockGroupName;
   });
 
   it('should create', () => {
@@ -56,48 +92,41 @@ describe('NvmeofSubsystemsFormComponent', () => {
   describe('should test form', () => {
     beforeEach(() => {
       nvmeofService = TestBed.inject(NvmeofService);
-      spyOn(nvmeofService, 'createSubsystem').and.stub();
+      spyOn(nvmeofService, 'createSubsystem').and.returnValue(of({}));
+      spyOn(nvmeofService, 'addSubsystemInitiators').and.returnValue(of({}));
     });
 
     it('should be creating request correctly', () => {
       const expectedNqn = 'nqn.2001-07.com.ceph:' + mockTimestamp;
-      component.onSubmit();
+      mockPayload['nqn'] = expectedNqn;
+      component.onSubmit(mockPayload);
       expect(nvmeofService.createSubsystem).toHaveBeenCalledWith({
         nqn: expectedNqn,
-        max_namespaces: DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM,
-        enable_ha: true,
-        gw_group: mockGroupName
+        gw_group: mockGroupName,
+        dhchap_key: 'Q2VwaE52bWVvRkNoYXBTeW50aGV0aWNLZXkxMjM0NTY='
       });
     });
 
-    it('should give error on invalid nqn', () => {
-      formHelper.setValue('nqn', 'nqn:2001-07.com.ceph:');
-      component.onSubmit();
-      formHelper.expectError('nqn', 'pattern');
-    });
+    it('should add initiators with wildcard when hostType is ALL', () => {
+      const payload: SubsystemPayload = {
+        nqn: 'test-nqn',
+        gw_group: mockGroupName,
+        addedHosts: [],
+        hostType: HOST_TYPE.ALL,
+        subsystemDchapKey: 'Q2VwaE52bWVvRkNoYXBTeW50aGV0aWNLZXkxMjM0NTY=',
+        listeners: [],
+        authType: AUTHENTICATION.Bidirectional,
+        hostDchapKeyList: []
+      };
 
-    it('should give error on invalid max_namespaces', () => {
-      formHelper.setValue('max_namespaces', -56);
-      component.onSubmit();
-      formHelper.expectError('max_namespaces', 'pattern');
-    });
+      component.group = mockGroupName;
+      component.onSubmit(payload);
 
-    it(`should not give error on max_namespaces greater than ${DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM}`, () => {
-      const expectedNqn = 'nqn.2001-07.com.ceph:' + mockTimestamp;
-      formHelper.setValue('max_namespaces', 600);
-      component.onSubmit();
-      expect(nvmeofService.createSubsystem).toHaveBeenCalledWith({
-        nqn: expectedNqn,
-        max_namespaces: DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM,
-        enable_ha: true,
+      expect(nvmeofService.addSubsystemInitiators).toHaveBeenCalledWith('test-nqn.default', {
+        allow_all: true,
+        hosts: [],
         gw_group: mockGroupName
       });
-    });
-
-    it('should give error on max_namespaces lesser than 1', () => {
-      formHelper.setValue('max_namespaces', 0);
-      component.onSubmit();
-      formHelper.expectError('max_namespaces', 'min');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
@@ -1,22 +1,45 @@
-import { Component, DestroyRef, OnInit } from '@angular/core';
-import { FormControlStatus, UntypedFormControl, Validators } from '@angular/forms';
+import { Component, DestroyRef, OnInit, SecurityContext, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { from, Observable, of } from 'rxjs';
+import { catchError, concatMap, map, tap } from 'rxjs/operators';
+import { DomSanitizer } from '@angular/platform-browser';
 
-import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
-import { CdValidators } from '~/app/shared/forms/cd-validators';
-import { Permission } from '~/app/shared/models/permissions';
-import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
-import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
-import { FinishedTask } from '~/app/shared/models/finished-task';
-import { ActivatedRoute, Router } from '@angular/router';
-import {
-  DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM,
-  NvmeofService
-} from '~/app/shared/api/nvmeof.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { Step } from 'carbon-components-angular';
-import { startWith } from 'rxjs/operators';
+import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
+import {
+  AUTHENTICATION,
+  HOST_TYPE,
+  HostStepType,
+  ListenerItem,
+  AuthStepType,
+  DetailsStepType
+} from '~/app/shared/models/nvmeof';
+
+export type SubsystemPayload = {
+  nqn: string;
+  gw_group: string;
+  subsystemDchapKey: string;
+  addedHosts: string[];
+  hostType: string;
+  listeners: ListenerItem[];
+  authType: AUTHENTICATION.Bidirectional | AUTHENTICATION.Unidirectional;
+  hostDchapKeyList: Array<{ dhchap_key: string; host_nqn: string }>;
+};
+
+type StepResult = { step: string; success: boolean; error?: string };
+
+const STEP_LABELS = {
+  DETAILS: 'Subsystem details',
+  HOSTS: 'Host access control',
+  AUTH: 'Authentication',
+  REVIEW: 'Review'
+} as const;
 
 @Component({
   selector: 'cd-nvmeof-subsystems-form',
@@ -24,137 +47,213 @@ import { startWith } from 'rxjs/operators';
   styleUrls: ['./nvmeof-subsystems-form.component.scss']
 })
 export class NvmeofSubsystemsFormComponent implements OnInit {
-  permission: Permission;
-  subsystemForm: CdFormGroup;
   action: string;
-  resource: string;
-  pageURL: string;
-  defaultMaxNamespace: number = DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM;
   group: string;
-  steps: Step[] = [
-    {
-      label: $localize`Subsystem Details`,
-      complete: false,
-      invalid: false
-    },
-    {
-      label: $localize`Host access control`,
-      complete: false
-    },
-    {
-      label: $localize`Authentication`,
-      complete: false
-    },
-    {
-      label: $localize`Advanced Options`,
-      complete: false,
-      secondaryLabel: $localize`Advanced`
-    }
-  ];
+  steps: Step[] = [];
   title: string = $localize`Create Subsystem`;
   description: string = $localize`Subsytems define how hosts connect to NVMe namespaces and ensure secure access to storage.`;
+  isSubmitLoading: boolean = false;
+  private lastCreatedNqn: string;
+  stepTwoValue: HostStepType = null;
+  showAuthStep = true;
+
+  @ViewChild(TearsheetComponent) tearsheet!: TearsheetComponent;
+
+  // Review step data
+  reviewNqn: string = '';
+  reviewListeners: any[] = [];
+  reviewHostType: string = HOST_TYPE.SPECIFIC;
+  reviewAddedHosts: string[] = [];
+  reviewAuthType: string = AUTHENTICATION.Unidirectional;
+  reviewSubsystemDchapKey: string = '';
+  reviewHostDchapKeyCount: number = 0;
 
   constructor(
-    private authStorageService: AuthStorageService,
     public actionLabels: ActionLabelsI18n,
     public activeModal: NgbActiveModal,
-    private nvmeofService: NvmeofService,
-    private taskWrapperService: TaskWrapperService,
-    private router: Router,
     private route: ActivatedRoute,
-    private destroyRef: DestroyRef
-  ) {
-    this.permission = this.authStorageService.getPermissions().nvmeof;
-    this.resource = $localize`Subsystem`;
-    this.pageURL = 'block/nvmeof/subsystems';
-  }
-
-  DEFAULT_NQN = 'nqn.2001-07.com.ceph:' + Date.now();
-  NQN_REGEX = /^nqn\.(19|20)\d\d-(0[1-9]|1[0-2])\.\D{2,3}(\.[A-Za-z0-9-]+)+(:[A-Za-z0-9-\.]+(:[A-Za-z0-9-\.]+)*)$/;
-  NQN_REGEX_UUID = /^nqn\.2014-08\.org\.nvmexpress:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
-  customNQNValidator = CdValidators.custom(
-    'pattern',
-    (nqnInput: string) =>
-      !!nqnInput && !(this.NQN_REGEX.test(nqnInput) || this.NQN_REGEX_UUID.test(nqnInput))
-  );
+    private destroyRef: DestroyRef,
+    private nvmeofService: NvmeofService,
+    private notificationService: NotificationService,
+    private router: Router,
+    private sanitizer: DomSanitizer
+  ) {}
 
   ngOnInit() {
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.group = params?.['group'];
     });
-
-    this.createForm();
-    this.action = this.actionLabels.CREATE;
-
-    this.subsystemForm.statusChanges
-      .pipe(startWith(this.subsystemForm.status), takeUntilDestroyed(this.destroyRef))
-      .subscribe((status: FormControlStatus) => {
-        const step = this.steps[0];
-        step.invalid = status === 'INVALID';
-      });
+    this.rebuildSteps();
   }
 
-  createForm() {
-    this.subsystemForm = new CdFormGroup({
-      nqn: new UntypedFormControl(this.DEFAULT_NQN, {
-        validators: [
-          this.customNQNValidator,
-          Validators.required,
-          this.customNQNValidator,
-          CdValidators.custom(
-            'maxLength',
-            (nqnInput: string) => new TextEncoder().encode(nqnInput).length > 223
-          )
-        ],
-        asyncValidators: [
-          CdValidators.unique(
-            this.nvmeofService.isSubsystemPresent,
-            this.nvmeofService,
-            null,
-            null,
-            this.group
-          )
-        ]
-      }),
-      max_namespaces: new UntypedFormControl(this.defaultMaxNamespace, {
-        validators: [CdValidators.number(false), Validators.min(1)]
-      })
-    });
+  private setAuthStepVisibility(nextShowAuth: boolean) {
+    if (this.showAuthStep === nextShowAuth) return;
+    this.showAuthStep = nextShowAuth;
+    this.rebuildSteps();
   }
 
-  onSubmit() {
-    const component = this;
-    const nqn: string = this.subsystemForm.getValue('nqn');
-    const max_namespaces: number = Number(this.subsystemForm.getValue('max_namespaces'));
-    let taskUrl = `nvmeof/subsystem/${URLVerbs.CREATE}`;
+  populateReviewData() {
+    if (!this.tearsheet) return;
 
-    const request = {
-      nqn,
-      enable_ha: true,
-      gw_group: this.group,
-      max_namespaces
-    };
+    const step1 = this.tearsheet.getStepValueByLabel<DetailsStepType>(STEP_LABELS.DETAILS);
+    const step2 = this.tearsheet.getStepValueByLabel<HostStepType>(STEP_LABELS.HOSTS);
 
-    if (!max_namespaces) {
-      delete request.max_namespaces;
+    if (step1) {
+      this.reviewNqn = step1.nqn ?? '';
+      this.reviewListeners = step1.listeners ?? [];
     }
-    this.taskWrapperService
-      .wrapTaskAroundCall({
-        task: new FinishedTask(taskUrl, {
-          nqn: nqn
-        }),
-        call: this.nvmeofService.createSubsystem(request)
+
+    if (step2) {
+      this.reviewHostType = step2.hostType ?? HOST_TYPE.SPECIFIC;
+      this.reviewAddedHosts = step2.addedHosts ?? [];
+      this.stepTwoValue = step2;
+    }
+
+    const nextShowAuth = (step2?.hostType ?? HOST_TYPE.SPECIFIC) === HOST_TYPE.SPECIFIC;
+
+    if (nextShowAuth !== this.showAuthStep) {
+      this.setAuthStepVisibility(nextShowAuth);
+      return;
+    }
+
+    const authStep = this.tearsheet.getStepValueByLabel<AuthStepType>(STEP_LABELS.AUTH);
+
+    if (this.showAuthStep && authStep) {
+      this.reviewAuthType = authStep.authType ?? AUTHENTICATION.Unidirectional;
+      this.reviewSubsystemDchapKey = authStep.subsystemDchapKey ?? '';
+      const hostKeyList = authStep.hostDchapKeyList ?? [];
+      this.reviewHostDchapKeyCount = hostKeyList.filter((item) => !!item?.dhchap_key)?.length;
+    } else {
+      this.reviewAuthType = null;
+      this.reviewSubsystemDchapKey = '';
+      this.reviewHostDchapKeyCount = 0;
+    }
+  }
+
+  rebuildSteps() {
+    const steps: Step[] = [
+      { label: STEP_LABELS.DETAILS, invalid: false },
+      { label: STEP_LABELS.HOSTS, invalid: false }
+    ];
+
+    if (this.showAuthStep) {
+      steps.push({ label: STEP_LABELS.AUTH, invalid: false });
+    }
+
+    steps.push({ label: STEP_LABELS.REVIEW, invalid: false });
+
+    this.steps = steps;
+
+    if (this.tearsheet?.currentStep >= steps.length) {
+      this.tearsheet.currentStep = steps.length - 1;
+    }
+  }
+
+  onSubmit(payload: SubsystemPayload) {
+    this.isSubmitLoading = true;
+    this.lastCreatedNqn = payload.nqn;
+    const stepResults: StepResult[] = [];
+    const initiatorRequest: any = {
+      allow_all: payload.hostType === HOST_TYPE.ALL,
+      hosts: payload.hostType === HOST_TYPE.SPECIFIC ? payload.hostDchapKeyList : [],
+      gw_group: this.group
+    };
+    this.nvmeofService
+      .createSubsystem({
+        nqn: payload.nqn,
+        gw_group: this.group,
+        dhchap_key: payload.subsystemDchapKey
       })
       .subscribe({
-        error() {
-          // instead have error message set, not setting form status INVALID
-          // which will show input as false
-          component.subsystemForm.setErrors({ cdSubmitButton: true });
+        next: () => {
+          stepResults.push({ step: this.steps[0].label, success: true });
+          const sequentialSteps: { step: string; call: () => Observable<any> }[] = [];
+
+          if (payload.listeners && payload.listeners.length > 0) {
+            sequentialSteps.push({
+              step: $localize`Listeners`,
+              call: () =>
+                this.nvmeofService.createListeners(
+                  `${payload.nqn}.${this.group}`,
+                  this.group,
+                  payload.listeners
+                )
+            });
+          }
+
+          sequentialSteps.push({
+            step: this.steps[1].label,
+            call: () =>
+              this.nvmeofService.addSubsystemInitiators(
+                `${payload.nqn}.${this.group}`,
+                initiatorRequest
+              )
+          });
+
+          this.runSequentialSteps(sequentialSteps, stepResults).subscribe({
+            complete: () => this.showFinalNotification(stepResults)
+          });
         },
-        complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
+        error: (err) => {
+          err.preventDefault();
+          const errorMsg = err?.error?.detail || $localize`Subsystem creation failed`;
+          this.notificationService.show(
+            NotificationType.error,
+            $localize`Subsystem creation failed`,
+            errorMsg
+          );
+          this.isSubmitLoading = false;
+          this.router.navigate(['block/nvmeof/subsystems'], {
+            queryParams: { group: this.group }
+          });
         }
       });
+  }
+
+  private runSequentialSteps(
+    steps: { step: string; call: () => Observable<any> }[],
+    stepResults: StepResult[]
+  ): Observable<void> {
+    return from(steps).pipe(
+      concatMap((step) =>
+        step.call().pipe(
+          tap(() => stepResults.push({ step: step.step, success: true })),
+          catchError((err) => {
+            err.preventDefault();
+            const errorMsg = err?.error?.detail || '';
+            stepResults.push({ step: step.step, success: false, error: errorMsg });
+            return of(null);
+          })
+        )
+      ),
+      map(() => void 0)
+    );
+  }
+
+  private showFinalNotification(stepResults: StepResult[]) {
+    this.isSubmitLoading = false;
+
+    const messageLines = stepResults.map((stepResult) =>
+      stepResult.success
+        ? `<div>${stepResult.step} step created successfully</div><br/>`
+        : `<div>${stepResult.step} step failed: <code>${stepResult.error}</code></div><br/>`
+    );
+
+    const rawHtml = messageLines.join('<br/>');
+    const sanitizedHtml = this.sanitizer.sanitize(SecurityContext.HTML, rawHtml) ?? '';
+
+    const hasFailure = stepResults.some((r) => !r.success);
+    const type = hasFailure ? NotificationType.error : NotificationType.success;
+    const title = hasFailure
+      ? $localize`Subsystem created (with errors)`
+      : $localize`Subsystem created`;
+
+    this.notificationService.show(type, title, sanitizedHtml);
+    this.router.navigate(['block/nvmeof/subsystems'], {
+      queryParams: {
+        group: this.group,
+        nqn: stepResults[0]?.success ? this.lastCreatedNqn : null
+      }
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -61,9 +61,8 @@ describe('NvmeofService', () => {
     it('should call createSubsystem', () => {
       const request = {
         nqn: mockNQN,
-        enable_ha: true,
-        initiators: '*',
-        gw_group: mockGroupName
+        gw_group: mockGroupName,
+        dhchap_key: ''
       };
       service.createSubsystem(request).subscribe();
       const req = httpTesting.expectOne(`${API_PATH}/subsystem`);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -91,12 +91,7 @@ export class NvmeofService {
     return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}?gw_group=${group}`);
   }
 
-  createSubsystem(request: {
-    nqn: string;
-    enable_ha: boolean;
-    gw_group: string;
-    max_namespaces?: number;
-  }) {
+  createSubsystem(request: { nqn: string; gw_group: string; dhchap_key: string }) {
     return this.http.post(`${API_PATH}/subsystem`, request, { observe: 'response' });
   }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75748

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>
(cherry picked from commit c953b2663a31bd25aa1a86d8bd4f3e528308d0ed)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
	src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
	src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
	src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
