### PR TITLE
cephfs/snapdiff: introduce mask param for file attr changes

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10462,6 +10462,7 @@ int Client::file_blockdiff(struct scan_state_t *state, const UserPerm &perms,
 }
 
 int Client::readdir_snapdiff(dir_result_t* d1, snapid_t snap2,
+                             unsigned diff_mask,
                              struct dirent* out_de,
                              snapid_t* out_snap)
 {
@@ -10499,6 +10500,7 @@ int Client::readdir_snapdiff(dir_result_t* d1, snapid_t snap2,
       } else if (dirp->hash_order()) {
 	req->head.args.snapdiff.offset_hash = dirp->offset_high();
       }
+      req->head.args.snapdiff.mask = diff_mask;
       req->dirp = dirp;
   };
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -443,6 +443,7 @@ public:
    *
    */
   int readdir_snapdiff(dir_result_t* dir1, snapid_t snap2,
+    unsigned diff_mask,
     struct dirent* out_de, snapid_t* out_snap);
 
   int getdir(const char *relpath, std::list<std::string>& names,

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -470,6 +470,19 @@ extern const char *ceph_mds_op_name(int op);
 #define CEPH_SETATTR_KILL_SGID		(1 << 14)
 #endif
 
+// attr mask bits in an int
+#ifndef CEPH_SNAPDIFF_MODE
+#define CEPH_SNAPDIFF_MODE		(1 << 0)
+#define CEPH_SNAPDIFF_UID		(1 << 1)
+#define CEPH_SNAPDIFF_GID		(1 << 2)
+#define CEPH_SNAPDIFF_SIZE		(1 << 3)
+#define CEPH_SNAPDIFF_NLINK		(1 << 4)
+#define CEPH_SNAPDIFF_MTIME		(1 << 5)
+#define CEPH_SNAPDIFF_ATIME		(1 << 6)
+#define CEPH_SNAPDIFF_CTIME		(1 << 7)
+#define CEPH_SNAPDIFF_BTIME		(1 << 8)
+#endif
+
 /*
  * open request flags
  */
@@ -650,6 +663,7 @@ union ceph_mds_request_args {
 		__le16 flags;
                 __le32 offset_hash;
 		__le64 snap_other;
+		__le32 mask;                 /*CEPH_SNAPDIFF_*/
 	} __attribute__ ((packed)) snapdiff;
         struct {
                 // latest scan "pointer"

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -645,6 +645,19 @@ int ceph_readdir_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp,
 int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de,
 		       struct ceph_statx *stx, unsigned want, unsigned flags, struct Inode **out);
 
+/* attr mask bits (up to an int in size) */
+#ifndef CEPH_SNAPDIFF_MODE
+#define CEPH_SNAPDIFF_MODE		(1 << 0)
+#define CEPH_SNAPDIFF_UID		(1 << 1)
+#define CEPH_SNAPDIFF_GID		(1 << 2)
+#define CEPH_SNAPDIFF_SIZE		(1 << 3)
+#define CEPH_SNAPDIFF_NLINK		(1 << 4)
+#define CEPH_SNAPDIFF_MTIME		(1 << 5)
+#define CEPH_SNAPDIFF_ATIME		(1 << 6)
+#define CEPH_SNAPDIFF_CTIME		(1 << 7)
+#define CEPH_SNAPDIFF_BTIME		(1 << 8)
+#endif
+
 struct ceph_snapdiff_info
 {
   struct ceph_mount_info* cmount;
@@ -652,6 +665,7 @@ struct ceph_snapdiff_info
   struct ceph_dir_result* dir_aux; // aux dir entry to identify the second snapshot.
                                    // Can point to the parent dir entry if entry-in-question
                                    // doesn't exist in the second snapshot
+  unsigned mask;                   // snapdiff file metadata mask (CEPH_SNAPDIFF_*)
 };
 
 struct ceph_file_blockdiff_result;
@@ -727,6 +741,7 @@ int ceph_file_blockdiff_finish(struct ceph_file_blockdiff_info* info);
  * @param rel_path subpath under the root to build delta for
  * @param snap1 the first snapshot name
  * @param snap2 the second snapshot name
+ * @param diff_mask file metadata change mask to apply for delta building
  * @param out resulting snapdiff stream handle to be used for snapdiff results
               retrieval via ceph_readdir_snapdiff
  * @returns 0 on success and negative error code otherwise
@@ -736,6 +751,7 @@ int ceph_open_snapdiff(struct ceph_mount_info* cmount,
                        const char* rel_path,
                        const char* snap1,
                        const char* snap2,
+                       unsigned diff_mask,
                        struct ceph_snapdiff_info* out);
 /**
  * Get the next snapshot delta entry.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -853,6 +853,7 @@ extern "C" int ceph_open_snapdiff(struct ceph_mount_info* cmount,
                                   const char* rel_path,
                                   const char* snap1,
                                   const char* snap2,
+				  unsigned diff_mask,
                                   struct ceph_snapdiff_info* out)
 {
   if (!cmount->is_mounted()) {
@@ -867,6 +868,7 @@ extern "C" int ceph_open_snapdiff(struct ceph_mount_info* cmount,
   }
   out->cmount = cmount;
   out->dir1 = out->dir_aux = nullptr;
+  out->mask = diff_mask;
 
   char full_path1[PATH_MAX];
   char snapdir[PATH_MAX];
@@ -939,6 +941,7 @@ extern "C" int ceph_readdir_snapdiff(struct ceph_snapdiff_info* snapdiff,
   int r = snapdiff->cmount->get_client()->readdir_snapdiff(
     d1,
     d2->inode->snapid,
+    snapdiff->mask,
     &(out->dir_entry),
     &snapid);
   if (r >= 0) {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5495,7 +5495,6 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
     respond_to_request(mdr, -EPERM);
     return;
   }
-
   __u32 mask = req->head.args.setattr.mask;
   __u32 access_mask = MAY_WRITE;
 
@@ -12677,6 +12676,7 @@ void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)
   // which frag?
   frag_t fg = (__u32)req->head.args.snapdiff.frag;
   unsigned req_flags = (__u32)req->head.args.snapdiff.flags;
+  unsigned diff_mask = (__u32)req->head.args.snapdiff.mask;
   string offset_str = req->get_path2();
 
   __u32 offset_hash = 0;
@@ -12739,6 +12739,7 @@ void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)
   dout(10) << __func__
     << " snap " << mdr->snapid
     << " vs. snap " << mdr->snapid_diff_other
+    << " input mask 0x" << diff_mask
     << dendl;
 
   if (mdr->snapid_diff_other == mdr->snapid ||
@@ -12785,6 +12786,7 @@ void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)
     offset_str,
     offset_hash,
     req_flags,
+    diff_mask,
     dirbl);
 }
 
@@ -12831,6 +12833,7 @@ void Server::_readdir_diff(
   const string& offset_str,
   uint32_t offset_hash,
   unsigned req_flags,
+  unsigned diff_mask,
   bufferlist& dirbl)
 {
   // build dir contents
@@ -12863,6 +12866,7 @@ void Server::_readdir_diff(
     from_the_beginning ? nullptr : & skip_key,
     snapid_prev,
     snapid,
+    diff_mask,
     dnbl,
     [&](CDentry* dn, CInode* in, bool exists) {
       string name;
@@ -12946,18 +12950,51 @@ bool Server::build_snap_diff(
   dentry_key_t* skip_key,
   snapid_t snapid_prev,
   snapid_t snapid,
+  unsigned diff_mask,
   const bufferlist& dnbl,
   std::function<bool (CDentry*, CInode*, bool)> add_result_cb)
 {
-  client_t client = mdr->client_request->get_source().num();
-
   struct EntryInfo {
     CDentry* dn = nullptr;
     CInode* in = nullptr;
-    utime_t mtime;
 
     void reset() {
       *this = EntryInfo();
+    }
+    EntryInfo() {}
+    EntryInfo(CDentry* _dn, CInode* _in) : dn(_dn), in(_in) {}
+
+    bool valid() const {
+      return in != nullptr && dn != nullptr;
+    }
+    bool meta_differs(const CInode* _in, unsigned mask, unsigned& res_mask) const {
+      ceph_assert(in);
+      ceph_assert(_in);
+
+      auto my = in->get_inode();
+      auto oth = _in->get_inode();
+      ceph_assert(my);
+      ceph_assert(oth);
+      res_mask = 0;
+      if ((mask & CEPH_SNAPDIFF_MODE) && (my->mode != oth->mode))
+	res_mask |= CEPH_SNAPDIFF_MODE;
+      if ((mask & CEPH_SNAPDIFF_UID) && (my->uid != oth->uid))
+	res_mask |= CEPH_SNAPDIFF_UID;
+      if ((mask & CEPH_SNAPDIFF_GID) && (my->gid != oth->gid))
+	res_mask |= CEPH_SNAPDIFF_GID;
+      if ((mask & CEPH_SNAPDIFF_SIZE) && (my->size != oth->size))
+	res_mask |= CEPH_SNAPDIFF_SIZE;
+      if ((mask & CEPH_SNAPDIFF_NLINK) && (my->nlink != oth->nlink))
+	res_mask |= CEPH_SNAPDIFF_NLINK;
+      if ((mask & CEPH_SNAPDIFF_MTIME) && (my->mtime != oth->mtime))
+	res_mask |= CEPH_SNAPDIFF_MTIME;
+      if ((mask & CEPH_SNAPDIFF_ATIME) && (my->atime != oth->atime))
+	res_mask |= CEPH_SNAPDIFF_ATIME;
+      if ((mask & CEPH_SNAPDIFF_CTIME) && (my->ctime != oth->ctime))
+	res_mask |= CEPH_SNAPDIFF_CTIME;
+      if ((mask & CEPH_SNAPDIFF_BTIME) && (my->btime != oth->btime))
+	res_mask |= CEPH_SNAPDIFF_BTIME;
+      return res_mask != 0;
     }
   } before;
 
@@ -12968,9 +13005,11 @@ bool Server::build_snap_diff(
     ei.reset();
     return r;
   };
+  client_t client = mdr->client_request->get_source().num();
 
   auto it = !skip_key ? dir->begin() : dir->upper_bound(*skip_key);
 
+  diff_mask = diff_mask != 0 ? diff_mask : CEPH_SNAPDIFF_MTIME; // to preserve backward compatibility with the original impl.
   while(it != dir->end()) {
     CDentry* dn = it->second;
     dout(20) << __func__ << " " << it->first << "->" << *dn << dendl;
@@ -13027,7 +13066,6 @@ bool Server::build_snap_diff(
     }
     ceph_assert(in);
 
-    utime_t mtime = in->get_inode()->mtime;
     if (in->is_dir()) {
 
       // we need to maintain the order of entries (determined by their name hashes)
@@ -13063,9 +13101,7 @@ bool Server::build_snap_diff(
 	  << dn->first << "/" << dn->last << dendl;
 	continue;
       }
-      string_view name_before =
-        before.dn ? string_view(before.dn->get_name()) : string_view();
-      if (before.dn && dn->get_name() != name_before) {
+      if (before.valid() && before.dn->get_name() != dn->get_name()) {
         if (!insert_deleted(before)) {
           break;
         }
@@ -13074,33 +13110,32 @@ bool Server::build_snap_diff(
       if (snapid_prev >= dn->first && snapid_prev <= dn->last) {
 	dout(30) << __func__ << " dn_before " << dn->get_name() << " "
 	  << dn->first << "/" << dn->last << dendl;
-	before = EntryInfo {dn, in, mtime};
+	before = EntryInfo {dn, in};
 	continue;
       } else {
-	if (before.dn && dn->get_name() == name_before) {
+	if (before.valid() && before.dn->get_name() == dn->get_name()) {
 	  if (before.in->ino() != in->ino()) {
 	    dout(30) << __func__ << " inode changed " << dn->get_name() << " "
 		     << dn->first << "/" << dn->last
-		     << " " << before.mtime << " vs. " << mtime
 		     << dendl;
 	    if (!insert_deleted(before)) {
 	      break;
 	    }
 	    before.reset();
 	  } else {
-	    if (mtime == before.mtime) {
-	      dout(30) << __func__ << " timestamp not changed " << dn->get_name() << " "
-		       << dn->first << "/" << dn->last
-		       << " " << mtime
-		       << dendl;
+	    unsigned res_mask = 0;
+	    if (before.meta_differs(in, diff_mask, res_mask) ) {
+	      dout(0) << __func__ << " attrs changed " << dn->get_name() << " "
+		<< dn->first << "/" << dn->last
+		<< " result mask: 0x" << std::hex << res_mask << std::dec
+		<< dendl;
+	      before.reset();
+	    } else {
+	      dout(0) << __func__ << " attrs not changed " << dn->get_name() << " "
+		<< dn->first << "/" << dn->last
+		<< dendl;
 	      before.reset();
 	      continue;
-	    } else {
-	      dout(30) << __func__ << " timestamp changed " << dn->get_name() << " "
-		       << dn->first << "/" << dn->last
-		       << " " << before.mtime << " vs. " << mtime
-		       << dendl;
-	      before.reset();
 	    }
 	  }
 	}

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -572,6 +572,7 @@ private:
     const std::string& offset_str,
     uint32_t offset_hash,
     unsigned req_flags,
+    unsigned diff_mask,
     bufferlist& dirbl);
   bool build_snap_diff(
     const MDRequestRef& mdr,
@@ -580,6 +581,7 @@ private:
     dentry_key_t* skip_key,
     snapid_t snapid_before,
     snapid_t snapid,
+    unsigned diff_mask,
     const bufferlist& dnbl,
     std::function<bool(CDentry*, CInode*, bool)> add_result_cb);
 

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -161,6 +161,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
                            const char *rel_path,
                            const char *snap1,
                            const char *snap2,
+                           unsigned snapdiff_mask,
                            ceph_snapdiff_info *out)
     int ceph_readdir_snapdiff(ceph_snapdiff_info *snapdiff, ceph_snapdiff_entry_t *out);
     int ceph_close_snapdiff(ceph_snapdiff_info *snapdiff)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -69,6 +69,16 @@ CEPH_SETATTR_SIZE  = 0x20
 CEPH_SETATTR_CTIME = 0x40
 CEPH_SETATTR_BTIME = 0x200
 
+CEPH_SNAPDIFF_MODE = 0x1
+CEPH_SNAPDIFF_UID = 0x2
+CEPH_SNAPDIFF_GID = 0x4
+CEPH_SNAPDIFF_SIZE = 0x8
+CEPH_SNAPDIFF_NLINK = 0x10
+CEPH_SNAPDIFF_MTIME = 0x20
+CEPH_SNAPDIFF_ATIME = 0x40
+CEPH_SNAPDIFF_CTIME = 0x80
+CEPH_SNAPDIFF_BTIME = 0x100
+
 CEPH_NOSNAP = -2
 
 # XXX: errno definitions, hard-coded numbers here are errnos defined by Linux
@@ -1063,7 +1073,7 @@ cdef class LibCephFS(object):
 
         return handle.close()
 
-    def opensnapdiff(self, root_path, rel_path, snap1name, snap2name) -> SnapDiffHandle:
+    def opensnapdiff(self, root_path, rel_path, snap1name, snap2name, diff_mask) -> SnapDiffHandle:
         """
         Open the given directory.
 
@@ -1083,8 +1093,9 @@ cdef class LibCephFS(object):
             char* _relp = relp
             char* _snap1 = snap1
             char* _snap2 = snap2
+            unsigned _diff_mask = diff_mask
         with nogil:
-            ret = ceph_open_snapdiff(self.cluster, _root, _relp, _snap1, _snap2, &h.handle);
+            ret = ceph_open_snapdiff(self.cluster, _root, _relp, _snap1, _snap2, _diff_mask, &h.handle);
         if ret < 0:
             raise make_ex(ret, "open_snapdiff failed for {} vs. {}"
                 .format(snap1.decode('utf-8'), snap2.decode('utf-8')))

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -222,7 +222,7 @@ cdef nogil:
         pass
     dirent * ceph_readdir(ceph_mount_info *cmount, ceph_dir_result *dirp):
         pass
-    int ceph_open_snapdiff(ceph_mount_info *cmount, const char *root_path, const char *rel_path, const char *snap1path, const char *snap2root, ceph_snapdiff_info *out):
+    int ceph_open_snapdiff(ceph_mount_info *cmount, const char *root_path, const char *rel_path, const char *snap1path, const char *snap2root, unsigned mask, ceph_snapdiff_info *out):
         pass
     int ceph_readdir_snapdiff(ceph_snapdiff_info *snapdiff, ceph_snapdiff_entry_t *out):
         pass

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -19,6 +19,8 @@
 #include "include/ceph_assert.h"
 #include "include/object.h"
 #include "include/stringify.h"
+#include "include/utime.h"
+#include "common/Clock.h"
 #include "common/ceph_context.h"
 #include "common/config_proxy.h"
 #include "common/JSONFormatter.h"
@@ -46,8 +48,9 @@ class TestMount {
   const uint64_t BLOCK_SIZE_FACTOR = 1*1024*1024;
   const uint64_t BLOCK_SIZE=4*BLOCK_SIZE_FACTOR;
 
+  unsigned diff_mask = 0;
 public:
-  TestMount( const char* root_dir_name = "dir0") {
+  TestMount( const char* root_dir_name = "dir0", unsigned mask = 0) : diff_mask(mask) {
     ceph_create(&cmount, NULL);
     ceph_conf_read_file(cmount, NULL);
     ceph_conf_parse_env(cmount, NULL);
@@ -64,7 +67,9 @@ public:
     ceph_rmdir(cmount, dir_path);
     ceph_shutdown(cmount);
   }
-
+  void set_diff_mask(unsigned mask) {
+    diff_mask = mask;
+  }
   int conf_get(const char *option, char *buf, size_t len) {
     return ceph_conf_get(cmount, option, buf, len);
   }
@@ -240,6 +245,26 @@ public:
     auto target_path = make_file_path(target);
     return ceph_symlink(cmount, target_path.c_str(), src_path.c_str());
   }
+  int chmod(const char* relpath, int mode)
+  {
+    auto file_path = make_file_path(relpath);
+    return ceph_chmod(cmount, file_path.c_str(), mode);
+  }
+  int utimes(const char* relpath, struct timeval times[2])
+  {
+    auto file_path = make_file_path(relpath);
+    return ceph_utimes(cmount, file_path.c_str(), times);
+  }
+
+  int statx(const char* relpath, struct ceph_statx *stx, unsigned int want, unsigned int flags)
+  {
+    auto file_path = make_file_path(relpath);
+    return ceph_statx(cmount, file_path.c_str(), stx, want, flags);
+  }
+  int sync()
+  {
+    return ceph_sync_fs(cmount);
+  }
 
   int test_open(const char* relpath)
   {
@@ -333,6 +358,7 @@ public:
                                relpath,
                                s1.c_str(),
                                s2.c_str(),
+                               diff_mask,
                                &info);
     if (r != 0) {
       std::cerr << " Failed to open snapdiff, ret:" << r << std::endl;
@@ -2190,6 +2216,74 @@ TEST(LibCephFS, SnapDiffDeletionRecreation) {
     }
   }
   test_mount.verify_snap_diff(expected, "bulk", "snap1", "snap2");
+
+  test_mount.rmsnap("snap1");
+  test_mount.rmsnap("snap2");
+}
+
+TEST(LibCephFS, SnapDiffStatDelta) {
+  TestMount test_mount("");
+
+  ASSERT_EQ(0, test_mount.mkdir("diffstat_delta"));
+  string path1("diffstat_delta/1");
+  test_mount.write_full(path1.c_str(), path1.c_str());
+
+  string path2("diffstat_delta/2");
+  test_mount.write_full(path2.c_str(), path2.c_str());
+
+  ASSERT_EQ(0, test_mount.mksnap("snap1"));
+  // creation of snap1 done
+
+  {
+    //update path1 ctime/mtime
+    sleep(2);
+    struct timeval times[2];
+    utime_t _now = ceph_clock_now();
+    _now.copy_to_timeval(&times[0]);
+    _now.copy_to_timeval(&times[1]);
+    ASSERT_EQ(0, test_mount.utimes(path1.c_str(), times));
+  }
+  test_mount.chmod(path2.c_str(), 0600);
+  test_mount.sync();
+
+  ASSERT_EQ(0, test_mount.mksnap("snap2"));
+
+  uint64_t snapid1;
+  uint64_t snapid2;
+
+  // learn snapshot ids and do basic verification
+  ASSERT_EQ(0, test_mount.get_snapid("snap1", &snapid1));
+  ASSERT_EQ(0, test_mount.get_snapid("snap2", &snapid2));
+  {
+    vector <pair <string, uint64_t>> expected;
+    expected.push_back({"1", snapid2});
+    test_mount.verify_snap_diff(expected, "diffstat_delta", "snap1", "snap2");
+  }
+  {
+    test_mount.set_diff_mask(CEPH_SNAPDIFF_MODE);
+    vector <pair <string, uint64_t>> expected;
+    expected.push_back({"2", snapid2});
+    test_mount.verify_snap_diff(expected, "diffstat_delta", "snap1", "snap2");
+  }
+  {
+    test_mount.set_diff_mask(CEPH_SNAPDIFF_MODE | CEPH_SNAPDIFF_CTIME);
+    vector <pair <string, uint64_t>> expected;
+    expected.push_back({ "1", snapid2 });
+    expected.push_back({ "2", snapid2 });
+    test_mount.verify_snap_diff(expected, "diffstat_delta", "snap1", "snap2");
+  }
+  {
+    test_mount.set_diff_mask(CEPH_SNAPDIFF_CTIME);
+    vector <pair <string, uint64_t>> expected;
+    expected.push_back({"1", snapid2});
+    expected.push_back({"2", snapid2 });
+    test_mount.verify_snap_diff(expected, "diffstat_delta", "snap1", "snap2");
+  }
+  {
+    test_mount.set_diff_mask(CEPH_SNAPDIFF_UID | CEPH_SNAPDIFF_GID);
+    vector <pair <string, uint64_t>> expected;
+    test_mount.verify_snap_diff(expected, "diffstat_delta", "snap1", "snap2");
+  }
 
   test_mount.rmsnap("snap1");
   test_mount.rmsnap("snap2");

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -812,7 +812,8 @@ def test_snapdiff(testdir):
     cephfs.mksnap("/snapdiff_test", "snap2", 0o755)
     snap1id = cephfs.snap_info(b"/snapdiff_test/.snap/snap1")['id']
     snap2id = cephfs.snap_info(b"/snapdiff_test/.snap/snap2")['id']
-    diff = cephfs.opensnapdiff(b"/snapdiff_test", b"/", b"snap2", b"snap1")
+    diff = cephfs.opensnapdiff(b"/snapdiff_test", b"/", b"snap2", b"snap1",
+     libcephfs.CEPH_SNAPDIFF_CTIME | libcephfs.CEPH_SNAPDIFF_MTIME)
     cnt = 0
     e = diff.readdir()
     while e is not None:

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1475,7 +1475,7 @@ int PeerReplayer::SnapDiffSync::init_sync() {
 
   ceph_snapdiff_info info;
   r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), ".",
-                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
+                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), 0, &info);
   if (r != 0) {
     derr << ": failed to open snapdiff for " << m_dir_root << ": r=" << r << dendl;
     return r;
@@ -1507,7 +1507,7 @@ int PeerReplayer::SnapDiffSync::init_directory(const std::string &epath,
 
     ceph_snapdiff_info info;
     r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), epath.c_str(),
-                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
+                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), 0, &info);
     if (r != 0) {
       derr << ": failed to open snapdiff for " << m_dir_root << ", r=" << r << dendl;
       return r;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75705





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
