### PR TITLE
tentacle: qa/rgw/upgrade: symlinks are explicit about distro versions

### DIFF
--- a/qa/suites/rgw/upgrade/1-install/reef/distro$/centos_9.stream.yaml
+++ b/qa/suites/rgw/upgrade/1-install/reef/distro$/centos_9.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/centos_9.stream.yaml

--- a/qa/suites/rgw/upgrade/1-install/reef/distro$/centos_latest.yaml
+++ b/qa/suites/rgw/upgrade/1-install/reef/distro$/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/rgw/upgrade/1-install/reef/distro$/ubuntu_22.04.yaml
+++ b/qa/suites/rgw/upgrade/1-install/reef/distro$/ubuntu_22.04.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_22.04.yaml

--- a/qa/suites/rgw/upgrade/1-install/reef/distro$/ubuntu_latest.yaml
+++ b/qa/suites/rgw/upgrade/1-install/reef/distro$/ubuntu_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/rgw/upgrade/1-install/squid/distro$/centos_9.stream.yaml
+++ b/qa/suites/rgw/upgrade/1-install/squid/distro$/centos_9.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/centos_9.stream.yaml

--- a/qa/suites/rgw/upgrade/1-install/squid/distro$/centos_latest.yaml
+++ b/qa/suites/rgw/upgrade/1-install/squid/distro$/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/rgw/upgrade/1-install/squid/distro$/ubuntu_22.04.yaml
+++ b/qa/suites/rgw/upgrade/1-install/squid/distro$/ubuntu_22.04.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_22.04.yaml

--- a/qa/suites/rgw/upgrade/1-install/squid/distro$/ubuntu_latest.yaml
+++ b/qa/suites/rgw/upgrade/1-install/squid/distro$/ubuntu_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75740

---

backport of https://github.com/ceph/ceph/pull/68001
parent tracker: https://tracker.ceph.com/issues/75717

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh