### PR TITLE
mgr/dashboard: carbonize top-level RGW config modal fields

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
@@ -41,79 +41,61 @@
       </div>
 
       <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-        <div class="form-group row">
-          <label class="cd-col-form-label required"
-                 for="kms_provider"
-                 i18n>Key management service provider</label>
-          <div class="cd-col-form-input">
-            <select id="kms_provider"
-                    class="form-select"
-                    (change)="setKmsProvider()"
-                    formControlName="kms_provider">
-              <option *ngIf="kmsProviders !== null && kmsProviders.length === 0"
-                      ngValue="null"
-                      i18n>-- No kms providers available --</option>
-              <option *ngIf="kmsProviders !== null && kmsProviders.length > 0"
-                      ngValue=""
-                      i18n>-- Select a provider --</option>
-              <option *ngFor="let provider of kmsProviders"
-                      [value]="provider">{{ provider }}</option>
-            </select>
-            <cd-help-text>
-              <span i18n>Where the encryption keys are stored.
-              </span>
-            </cd-help-text>
-            <span class="invalid-feedback"
-                  *ngIf="configForm.showError('kms_provider', frm, 'required')"
-                  i18n>This field is required.</span>
-          </div>
+        <div class="form-item">
+          <cds-select id="kms_provider"
+                      formControlName="kms_provider"
+                      label="Key management service provider"
+                      helperText="Where the encryption keys are stored."
+                      invalidText="This field is required."
+                      i18n-label
+                      i18n-helperText
+                      i18n-invalidText
+                      [invalid]="configForm.showError('kms_provider', frm, 'required')"
+                      (change)="setKmsProvider()">
+            <option *ngIf="kmsProviders !== null && kmsProviders.length === 0"
+                    ngValue="null"
+                    i18n>-- No kms providers available --</option>
+            <option *ngIf="kmsProviders !== null && kmsProviders.length > 0"
+                    ngValue=""
+                    i18n>-- Select a provider --</option>
+            <option *ngFor="let provider of kmsProviders"
+                    [value]="provider">{{ provider }}</option>
+          </cds-select>
         </div>
       </div>
 
       <div *ngIf="kmsProviders.length !== 0 && configForm.getValue('kms_provider') !== ''">
         <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label class="cd-col-form-label required"
-                   for="auth"
-                   i18n>Authentication Method</label>
-            <div class="cd-col-form-input">
-              <select class="form-select"
-                      id="auth"
-                      formControlName="auth">
-                <option *ngFor="let auth of authMethods"
-                        [value]="auth">{{ auth }}</option>
-              </select>
-              <cd-help-text>
-                <span i18n>Type of authentication method to be used with Vault
-                </span>
-              </cd-help-text>
-              <span class="invalid-feedback"
-                    *ngIf="configForm.showError('auth', frm, 'required')"
-                    i18n>This field is required.</span>
-            </div>
+          <div class="form-item">
+            <cds-select id="auth"
+                        formControlName="auth"
+                        label="Authentication Method"
+                        helperText="Type of authentication method to be used with Vault"
+                        invalidText="This field is required."
+                        i18n-label
+                        i18n-helperText
+                        i18n-invalidText
+                        [invalid]="configForm.showError('auth', frm, 'required')">
+              <option *ngFor="let auth of authMethods"
+                      [value]="auth">{{ auth }}</option>
+            </cds-select>
           </div>
         </div>
 
         <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label class="cd-col-form-label required"
-                   for="secret_engine"
-                   i18n>Secret Engine</label>
-            <div class="cd-col-form-input">
-              <select class="form-select"
-                      id="secret_engine"
-                      formControlName="secret_engine">
-                <option *ngFor="let secret_engine of secretEngines"
-                        [value]="secret_engine">{{ secret_engine }}</option>
-              </select>
-              <cd-help-text>
-                <span i18n>Vault Secret Engine to be used to retrieve encryption keys.
-                </span>
-              </cd-help-text>
-              <span class="invalid-feedback"
-                    *ngIf="configForm.showError('secret_engine', frm, 'required')"
-                    i18n>This field is required.</span>
-            </div>
+          <div class="form-item">
+            <cds-select id="secret_engine"
+                        formControlName="secret_engine"
+                        label="Secret Engine"
+                        helperText="Vault Secret Engine to be used to retrieve encryption keys."
+                        invalidText="This field is required."
+                        i18n-label
+                        i18n-helperText
+                        i18n-invalidText
+                        [invalid]="configForm.showError('secret_engine', frm, 'required')">
+              <option *ngFor="let secret_engine of secretEngines"
+                      [value]="secret_engine">{{ secret_engine }}</option>
+            </cds-select>
           </div>
         </div>
 
@@ -161,34 +143,21 @@
         </div>
 
         <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label  class="cd-col-form-label required"
-                    for="addr">
-              <span i18n
-                    *ngIf="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT">Vault Address
-              </span>
-              <span i18n
-                    *ngIf="configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP">KMIP Address
-              </span>
-            </label>
-            <div class="cd-col-form-input">
-              <input  class="form-control"
-                      id="addr"
-                      formControlName="addr"
-                      placeholder="http://127.0.0.1:8000"
-                      i18n>
-                <cd-help-text >
-                  <span *ngIf="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT"
-                        i18n>Vault server base address.
-                  </span>
-                  <span *ngIf="configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
-                        i18n>Kmip server base address.
-                  </span>
-                </cd-help-text>
-              <span class="invalid-feedback"
-                    *ngIf="configForm.showError('addr', frm, 'required')"
-                    i18n>This field is required.</span>
-            </div>
+          <div class="form-item">
+            <cds-text-label [label]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault Address' : 'KMIP Address'"
+                            for="addr"
+                            [invalid]="configForm.showError('addr', frm, 'required')"
+                            invalidText="This field is required."
+                            [helperText]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault server base address.' : 'Kmip server base address.'"
+                            i18n-invalidText
+                            i18n-helperText>
+              <input cdsText
+                     id="addr"
+                     formControlName="addr"
+                     placeholder="http://127.0.0.1:8000"
+                     i18n-placeholder
+                     [invalid]="configForm.showError('addr', frm, 'required')">
+            </cds-text-label>
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
@@ -1,333 +1,267 @@
-<cd-modal [modalRef]="activeModal">
-  <ng-container i18n="form title"
-                class="modal-title">{{ action | titlecase }} RGW Encryption Configurations</ng-container>
+<cds-modal size="lg"
+           [open]="open"
+           [hasScrollingContent]="true"
+           (overlaySelected)="closeModal()">
+  <cds-modal-header (closeSelect)="closeModal()">
+    <h3 cdsModalHeaderHeading
+        i18n>{{ action | titlecase }} RGW Encryption Configurations</h3>
+    <cd-help-text [formAllFieldsRequired]="true"></cd-help-text>
+  </cds-modal-header>
 
-  <ng-container class="modal-content">
-    <form name="configForm"
-          #frm="ngForm"
-          [formGroup]="configForm">
-    <div class="modal-body">
-      <div class="form-group row">
-        <label class="cd-col-form-label required"
-               for="encryptionType"
+  <form name="configForm"
+        #frm="ngForm"
+        [formGroup]="configForm"
+        novalidate>
+    <div cdsModalContent>
+      <div class="form-item">
+        <label class="cds--label fw-bold"
                i18n>Encryption Type</label>
-        <div class="col-md-auto custom-checkbox form-check-inline ms-3">
-          <input class="form-check-input"
-                 formControlName="encryptionType"
-                 id="s3Enabled"
-                 type="radio"
-                 (change)="checkKmsProviders()"
-                 [attr.disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_S3 ? true : null"
-                 [value]="ENCRYPTION_TYPE.SSE_S3">
-          <label class="custom-check-label"
-                 [ngClass]="{'text-muted': editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_S3}"
-                 for="s3Enabled"
-                 i18n>SSE-S3</label>
-        </div>
-
-        <div class="col-md-auto custom-checkbox form-check-inline">
-          <input class="form-check-input"
-                 formControlName="encryptionType"
-                 id="kmsEnabled"
-                 (change)="checkKmsProviders()"
-                 [value]="ENCRYPTION_TYPE.SSE_KMS"
-                 [attr.disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_KMS ? true : null"
-                 type="radio">
-          <label class="custom-check-label"
-                 [ngClass]="{'text-muted': editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_KMS}"
-                 for="kmsEnabled"
-                 i18n>SSE-KMS</label>
-        </div>
+        <cds-radio-group formControlName="encryptionType"
+                         orientation="horizontal"
+                         helperText="Choose which encryption workflow this configuration should enable."
+                         i18n-helperText>
+          <cds-radio [value]="ENCRYPTION_TYPE.SSE_S3"
+                     [disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_S3"
+                     (change)="checkKmsProviders()"
+                     i18n>SSE-S3</cds-radio>
+          <cds-radio [value]="ENCRYPTION_TYPE.SSE_KMS"
+                     [disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_KMS"
+                     (change)="checkKmsProviders()"
+                     i18n>SSE-KMS</cds-radio>
+        </cds-radio-group>
       </div>
 
-      <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-        <div class="form-item">
-          <cds-select id="kms_provider"
-                      formControlName="kms_provider"
-                      label="Key management service provider"
-                      helperText="Where the encryption keys are stored."
+      <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+           class="form-item">
+        <cds-select id="kms_provider"
+                    formControlName="kms_provider"
+                    label="Key management service provider"
+                    helperText="Where the encryption keys are stored."
+                    invalidText="This field is required."
+                    i18n-label
+                    i18n-helperText
+                    i18n-invalidText
+                    [invalid]="configForm.showError('kms_provider', frm, 'required')"
+                    (change)="setKmsProvider()">
+          <option *ngIf="kmsProviders !== null && kmsProviders.length === 0"
+                  ngValue="null"
+                  i18n>-- No kms providers available --</option>
+          <option *ngIf="kmsProviders !== null && kmsProviders.length > 0"
+                  ngValue=""
+                  i18n>-- Select a provider --</option>
+          <option *ngFor="let provider of kmsProviders"
+                  [value]="provider">{{ provider }}</option>
+        </cds-select>
+      </div>
+
+      <div *ngIf="kmsProviders.length !== 0 && configForm.getValue('kms_provider') !== ''">
+        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-select id="auth"
+                      formControlName="auth"
+                      label="Authentication Method"
+                      helperText="Type of authentication method to be used with Vault."
                       invalidText="This field is required."
                       i18n-label
                       i18n-helperText
                       i18n-invalidText
-                      [invalid]="configForm.showError('kms_provider', frm, 'required')"
-                      (change)="setKmsProvider()">
-            <option *ngIf="kmsProviders !== null && kmsProviders.length === 0"
-                    ngValue="null"
-                    i18n>-- No kms providers available --</option>
-            <option *ngIf="kmsProviders !== null && kmsProviders.length > 0"
-                    ngValue=""
-                    i18n>-- Select a provider --</option>
-            <option *ngFor="let provider of kmsProviders"
-                    [value]="provider">{{ provider }}</option>
+                      [invalid]="configForm.showError('auth', frm, 'required')">
+            <option *ngFor="let auth of authMethods"
+                    [value]="auth">{{ auth }}</option>
           </cds-select>
         </div>
-      </div>
 
-      <div *ngIf="kmsProviders.length !== 0 && configForm.getValue('kms_provider') !== ''">
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-item">
-            <cds-select id="auth"
-                        formControlName="auth"
-                        label="Authentication Method"
-                        helperText="Type of authentication method to be used with Vault"
-                        invalidText="This field is required."
-                        i18n-label
-                        i18n-helperText
-                        i18n-invalidText
-                        [invalid]="configForm.showError('auth', frm, 'required')">
-              <option *ngFor="let auth of authMethods"
-                      [value]="auth">{{ auth }}</option>
-            </cds-select>
-          </div>
+        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-select id="secret_engine"
+                      formControlName="secret_engine"
+                      label="Secret Engine"
+                      helperText="Vault Secret Engine to be used to retrieve encryption keys."
+                      invalidText="This field is required."
+                      i18n-label
+                      i18n-helperText
+                      i18n-invalidText
+                      [invalid]="configForm.showError('secret_engine', frm, 'required')">
+            <option *ngFor="let secret_engine of secretEngines"
+                    [value]="secret_engine">{{ secret_engine }}</option>
+          </cds-select>
         </div>
 
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-item">
-            <cds-select id="secret_engine"
-                        formControlName="secret_engine"
-                        label="Secret Engine"
-                        helperText="Vault Secret Engine to be used to retrieve encryption keys."
-                        invalidText="This field is required."
-                        i18n-label
-                        i18n-helperText
-                        i18n-invalidText
-                        [invalid]="configForm.showError('secret_engine', frm, 'required')">
-              <option *ngFor="let secret_engine of secretEngines"
-                      [value]="secret_engine">{{ secret_engine }}</option>
-            </cds-select>
-          </div>
+        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-text-label for="secret_path"
+                          helperText="Vault secret URL prefix, which can be used to restrict access to a particular subset of the Vault secret space."
+                          i18n
+                          i18n-helperText>Secret Path
+            <input cdsText
+                   type="text"
+                   id="secret_path"
+                   placeholder="/v1/secret/data"
+                   i18n-placeholder
+                   formControlName="secret_path">
+          </cds-text-label>
         </div>
 
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label class="cd-col-form-label"
-                   for="secret_path"
-                   i18n>Secret Path
-            </label>
-            <div class="cd-col-form-input">
-              <input  class="form-control"
-                      type="text"
-                      id="secret_path"
-                      formControlName="secret_path"
-                      placeholder="/v1/secret/data">
-                <cd-help-text>
-                  <span i18n>Vault secret URL prefix, which can be used to restrict access to a particular subset of the Vault secret space.
-                  </span>
-                </cd-help-text>
-              <span class="invalid-feedback"
-                    *ngIf="configForm.showError('secret_path', frm, 'required')"
-                    i18n>This field is required.</span>
-            </div>
-          </div>
+        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-text-label for="namespace"
+                          helperText="Vault Namespace to be used to select your tenant."
+                          i18n
+                          i18n-helperText>Namespace
+            <input cdsText
+                   type="text"
+                   id="namespace"
+                   placeholder="tenant1"
+                   formControlName="namespace">
+          </cds-text-label>
         </div>
 
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') == KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label class="cd-col-form-label"
-                   for="namespace"
-                   i18n>Namespace
-            </label>
-            <div class="cd-col-form-input">
-              <input  class="form-control"
-                      id="namespace"
-                      type="text"
-                      placeholder="tenant1"
-                      formControlName="namespace">
-              <cd-help-text>
-                <span i18n>Vault Namespace to be used to select your tenant.
-                </span>
-              </cd-help-text>
-            </div>
-          </div>
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-text-label for="addr"
+                          [invalid]="configForm.showError('addr', frm, 'required')"
+                          [invalidText]="addressError"
+                          [helperText]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault server base address.' : 'Kmip server base address.'">
+            {{ configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault Address' : 'KMIP Address' }}
+            <input cdsText
+                   id="addr"
+                   formControlName="addr"
+                   placeholder="http://127.0.0.1:8000"
+                   i18n-placeholder
+                   [invalid]="configForm.showError('addr', frm, 'required')">
+          </cds-text-label>
+          <ng-template #addressError>
+            <span class="invalid-feedback"
+                  *ngIf="configForm.showError('addr', frm, 'required')"
+                  i18n>This field is required.</span>
+          </ng-template>
         </div>
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-item">
-            <cds-text-label [label]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault Address' : 'KMIP Address'"
-                            for="addr"
-                            [invalid]="configForm.showError('addr', frm, 'required')"
-                            invalidText="This field is required."
-                            [helperText]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault server base address.' : 'Kmip server base address.'"
-                            i18n-invalidText
-                            i18n-helperText>
-              <input cdsText
-                     id="addr"
-                     formControlName="addr"
-                     placeholder="http://127.0.0.1:8000"
-                     i18n-placeholder
-                     [invalid]="configForm.showError('addr', frm, 'required')">
-            </cds-text-label>
-          </div>
-        </div>
-
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT)|| configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div  *ngIf="configForm.getValue('auth') === 'token'"
-                class="form-group row">
-          <label  class="cd-col-form-label required"
-                  for="token">
-          <span i18n>Token</span>
-          <cd-helper i18n>
-            The token authentication method expects a Vault token to be present in a plaintext file.
-          </cd-helper>
-          </label>
-          <div class="cd-col-form-input">
-            <input  type="file"
-                    id="token"
-                    formControlName="token"
-                    (change)="fileUpload($event.target.files, 'token')">
-              <cd-help-text>
-                <span i18n>If authentication method is 'token', provide a path to the token file.
-                </span>
-              </cd-help-text>
+        <div *ngIf="((configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) && configForm.getValue('auth') === 'token'"
+             class="form-item">
+          <cds-text-label for="token"
+                          [invalid]="configForm.showError('token', frm, 'required')"
+                          [invalidText]="tokenError"
+                          helperText="Provide the path to the Vault token file on the RGW host."
+                          i18n
+                          i18n-helperText>Token file path
+            <input cdsText
+                   type="text"
+                   id="token"
+                   placeholder="/path/to/token"
+                   i18n-placeholder
+                   formControlName="token"
+                   [invalid]="configForm.showError('token', frm, 'required')">
+          </cds-text-label>
+          <ng-template #tokenError>
             <span class="invalid-feedback"
                   *ngIf="configForm.showError('token', frm, 'required')"
                   i18n>This field is required.</span>
-          </div>
-          </div>
+          </ng-template>
         </div>
 
-      <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP">
-        <div class="form-group row">
-          <label  class="cd-col-form-label"
-                  for="kms_key_template"
-                  i18n>KMS Key Template
-          </label>
-          <div class="cd-col-form-input">
-            <input  class="form-control"
-                    id="kms_key_template"
-                    placeholder="$keyid"
-                    formControlName="kms_key_template">
-            <cd-help-text>
-              <span i18n>sse-kms; kmip key names
-              </span>
-            </cd-help-text>
-          </div>
-        </div>
-        <div class="form-group row">
-          <label  class="cd-col-form-label"
-                  for="s3_key_template"
-                  i18n>S3 Key Template
-          </label>
-          <div class="cd-col-form-input">
-            <input  class="form-control"
-                    id="s3_key_template"
-                    placeholder="$keyid"
-                    formControlName="s3_key_template">
-            <cd-help-text>
-              <span i18n>sse-s3; kmip key template
-              </span>
-            </cd-help-text>
-          </div>
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
+             class="form-item">
+          <cds-text-label for="kms_key_template"
+                          helperText="sse-kms; kmip key names"
+                          i18n
+                          i18n-helperText>KMS Key Template
+            <input cdsText
+                   id="kms_key_template"
+                   placeholder="$keyid"
+                   formControlName="kms_key_template">
+          </cds-text-label>
         </div>
 
-        <div class="form-group row">
-          <label  class="cd-col-form-label"
-                  for="username"
-                  i18n>Username
-          </label>
-          <div class="cd-col-form-input">
-            <input  id="username"
-                    class="form-control"
-                    [attr.disabled]="configForm.getValue('kms_provider') !== KMS_PROVIDER.KMIP ? true : null"
-                    formControlName="username">
-            <cd-help-text>
-              <span i18n>When authenticating via username
-              </span>
-            </cd-help-text>
-          </div>
-        </div>
-        <div class="form-group row">
-          <label  class="cd-col-form-label"
-                  for="password"
-                  i18n>Password
-          </label>
-          <div class="cd-col-form-input">
-            <input  id="password"
-                    class="form-control"
-                    type="password"
-                    [attr.disabled]="configForm.getValue('kms_provider') != KMS_PROVIDER.KMIP"
-                    formControlName="password">
-            <cd-help-text>
-              <span i18n>optional w/ username
-              </span>
-            </cd-help-text>
-          </div>
-        </div>
-      </div>
-
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label class="cd-col-form-label"
-                   for="ssl_cert">
-            <span i18n>CA Certificate Path</span>
-            <cd-helper i18n>The SSL certificate in PEM format. Please provide file path to the RGW host.</cd-helper>
-            </label>
-            <div class="cd-col-form-input">
-            <input  type="text"
-                    id="ssl_cert"
-                    class="form-control"
-                    formControlName="ssl_cert"
-                    placeholder="/path/to/ca_cert.pem">
-            <cd-help-text>
-              <span i18n>
-                Path for custom ca certificate for accessing server
-              </span>
-            </cd-help-text>
-            </div>
-          </div>
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
+             class="form-item">
+          <cds-text-label for="s3_key_template"
+                          helperText="sse-s3; kmip key template"
+                          i18n
+                          i18n-helperText>S3 Key Template
+            <input cdsText
+                   id="s3_key_template"
+                   placeholder="$keyid"
+                   formControlName="s3_key_template">
+          </cds-text-label>
         </div>
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label class="cd-col-form-label"
-                   for="client_cert">
-            <span i18n>Client Certificate Path</span>
-            <cd-helper i18n>The Client certificate in PEM format. Please provide file path to the RGW host.</cd-helper>
-            </label>
-            <div class="cd-col-form-input">
-              <input  type="text"
-                      id="client_cert"
-                      class="form-control"
-                      formControlName="client_cert"
-                      placeholder="/path/to/client_cert.pem">
-              <cd-help-text>
-                <span i18n>
-                  Path for custom client certificate for accessing server
-                </span>
-              </cd-help-text>
-            </div>
-          </div>
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
+             class="form-item">
+          <cds-text-label for="username"
+                          helperText="When authenticating via username."
+                          i18n
+                          i18n-helperText>Username
+            <input cdsText
+                   id="username"
+                   formControlName="username">
+          </cds-text-label>
         </div>
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3">
-          <div class="form-group row">
-            <label class="cd-col-form-label"
-                   for="client_key">
-            <span i18n>Client Private Key Path</span>
-            <cd-helper i18n>The Client Private Key in PEM format. Please provide file path to the RGW host.</cd-helper>
-            </label>
-            <div class="cd-col-form-input">
-              <input  type="text"
-                      id="client_key"
-                      formControlName="client_key"
-                      placeholder="/path/to/client_key.pem"
-                      class="form-control">
-              <cd-help-text>
-                <span i18n>
-                  Path for private key required for client cert
-                </span>
-              </cd-help-text>
-            </div>
-          </div>
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
+             class="form-item">
+          <cds-password-label for="password"
+                              helperText="Optional with username."
+                              i18n
+                              i18n-helperText>Password
+            <input cdsPassword
+                   id="password"
+                   type="password"
+                   label="Password"
+                   formControlName="password">
+          </cds-password-label>
+        </div>
+
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-text-label for="ssl_cert"
+                          helperText="Path for custom CA certificate used when accessing the server."
+                          i18n
+                          i18n-helperText>CA Certificate Path
+            <input cdsText
+                   type="text"
+                   id="ssl_cert"
+                   formControlName="ssl_cert"
+                   placeholder="/path/to/ca_cert.pem"
+                   i18n-placeholder>
+          </cds-text-label>
+        </div>
+
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-text-label for="client_cert"
+                          helperText="Path for the client certificate used when accessing the server."
+                          i18n
+                          i18n-helperText>Client Certificate Path
+            <input cdsText
+                   type="text"
+                   id="client_cert"
+                   formControlName="client_cert"
+                   placeholder="/path/to/client_cert.pem"
+                   i18n-placeholder>
+          </cds-text-label>
+        </div>
+
+        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
+             class="form-item">
+          <cds-text-label for="client_key"
+                          helperText="Path for the private key required for the client certificate."
+                          i18n
+                          i18n-helperText>Client Private Key Path
+            <input cdsText
+                   type="text"
+                   id="client_key"
+                   formControlName="client_key"
+                   placeholder="/path/to/client_key.pem"
+                   i18n-placeholder>
+          </cds-text-label>
         </div>
       </div>
     </div>
-    <div class="modal-footer">
-      <cd-form-button-panel (submitActionEvent)="onSubmit()"
-                            [submitText]="actionLabels.SUBMIT"
-                            [form]="configForm"></cd-form-button-panel>
-    </div>
-    </form>
-  </ng-container>
-</cd-modal>
+
+    <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                          [form]="configForm"
+                          [submitText]="actionLabels.SUBMIT"
+                          [modalForm]="true"></cd-form-button-panel>
+  </form>
+</cds-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
@@ -15,6 +15,7 @@
     <div cdsModalContent>
       <div class="form-item">
         <label class="cds--label fw-bold"
+               cdRequiredField="Encryption Type"
                i18n>Encryption Type</label>
         <cds-radio-group formControlName="encryptionType"
                          orientation="horizontal"
@@ -37,6 +38,7 @@
         <cds-select id="kms_provider"
                     formControlName="kms_provider"
                     label="Key management service provider"
+                    cdRequiredField="Key management service provider"
                     helperText="Where the encryption keys are stored."
                     invalidText="This field is required."
                     i18n-label
@@ -67,6 +69,7 @@
           <cds-select id="auth"
                       formControlName="auth"
                       label="Authentication Method"
+                      cdRequiredField="Authentication Method"
                       helperText="Type of authentication method to be used with Vault."
                       invalidText="This field is required."
                       i18n-label
@@ -87,6 +90,7 @@
           <cds-select id="secret_engine"
                       formControlName="secret_engine"
                       label="Secret Engine"
+                      cdRequiredField="Secret Engine"
                       helperText="Vault Secret Engine to be used to retrieve encryption keys."
                       invalidText="This field is required."
                       i18n-label
@@ -105,6 +109,7 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="secret_path"
+                          cdOptionalField="Secret Path"
                           helperText="Vault secret URL prefix, which can be used to restrict access to a particular subset of the Vault secret space."
                           i18n
                           i18n-helperText>Secret Path
@@ -123,6 +128,7 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="namespace"
+                          cdOptionalField="Namespace"
                           helperText="Vault Namespace to be used to select your tenant."
                           i18n
                           i18n-helperText>Namespace
@@ -139,6 +145,7 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="addr"
+                          [cdRequiredField]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault Address' : 'KMIP Address'"
                           [invalid]="addressRef.isInvalid"
                           [invalidText]="addressError"
                           [helperText]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault server base address.' : 'Kmip server base address.'">
@@ -170,6 +177,7 @@
         configForm.getValue('auth') === 'token') {
         <div class="form-item">
           <cds-text-label for="token"
+                          cdRequiredField="Token file path"
                           [invalid]="tokenRef.isInvalid"
                           [invalidText]="tokenError"
                           helperText="Provide the path to the Vault token file on the RGW host."
@@ -198,6 +206,7 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-text-label for="kms_key_template"
+                          cdOptionalField="KMS Key Template"
                           helperText="sse-kms; kmip key names"
                           i18n
                           i18n-helperText>KMS Key Template
@@ -213,6 +222,7 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-text-label for="s3_key_template"
+                          cdOptionalField="S3 Key Template"
                           helperText="sse-s3; kmip key template"
                           i18n
                           i18n-helperText>S3 Key Template
@@ -228,6 +238,7 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-text-label for="username"
+                          cdOptionalField="Username"
                           helperText="When authenticating via username."
                           i18n
                           i18n-helperText>Username
@@ -242,6 +253,7 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-password-label for="password"
+                              cdOptionalField="Password"
                               helperText="Optional with username."
                               i18n
                               i18n-helperText>Password
@@ -258,6 +270,7 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="ssl_cert"
+                          cdOptionalField="CA Certificate Path"
                           helperText="Path for custom CA certificate used when accessing the server."
                           i18n
                           i18n-helperText>CA Certificate Path
@@ -275,6 +288,7 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="client_cert"
+                          cdOptionalField="Client Certificate Path"
                           helperText="Path for the client certificate used when accessing the server."
                           i18n
                           i18n-helperText>Client Certificate Path
@@ -292,6 +306,7 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="client_key"
+                          cdOptionalField="Client Private Key Path"
                           helperText="Path for the private key required for the client certificate."
                           i18n
                           i18n-helperText>Client Private Key Path

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
@@ -5,7 +5,8 @@
   <cds-modal-header (closeSelect)="closeModal()">
     <h3 cdsModalHeaderHeading
         i18n>{{ action | titlecase }} RGW Encryption Configurations</h3>
-    <cd-help-text [formAllFieldsRequired]="true"></cd-help-text>
+    <cd-help-text [formAllFieldsRequired]="false"
+                  i18n>Fields marked with * are required.</cd-help-text>
   </cds-modal-header>
 
   <form name="configForm"
@@ -23,11 +24,9 @@
                          i18n-helperText>
           <cds-radio [value]="ENCRYPTION_TYPE.SSE_S3"
                      [disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_S3"
-                     (change)="onEncryptionTypeChange()"
                      i18n>SSE-S3</cds-radio>
           <cds-radio [value]="ENCRYPTION_TYPE.SSE_KMS"
                      [disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_KMS"
-                     (change)="onEncryptionTypeChange()"
                      i18n>SSE-KMS</cds-radio>
         </cds-radio-group>
       </div>
@@ -44,8 +43,7 @@
                     i18n-label
                     i18n-helperText
                     i18n-invalidText
-                    [invalid]="configForm.showError('kms_provider', frm, 'required')"
-                    (change)="onKmsProviderChange()">
+                    [invalid]="configForm.showError('kms_provider', frm, 'required')">
           @if (kmsProviders !== null && kmsProviders.length === 0) {
           <option ngValue="null"
                   i18n>-- No kms providers available --</option>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
@@ -31,8 +31,9 @@
         </cds-radio-group>
       </div>
 
-      <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-           class="form-item">
+      @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS ||
+      configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+      <div class="form-item">
         <cds-select id="kms_provider"
                     formControlName="kms_provider"
                     label="Key management service provider"
@@ -43,20 +44,26 @@
                     i18n-invalidText
                     [invalid]="configForm.showError('kms_provider', frm, 'required')"
                     (change)="setKmsProvider()">
-          <option *ngIf="kmsProviders !== null && kmsProviders.length === 0"
-                  ngValue="null"
+          @if (kmsProviders !== null && kmsProviders.length === 0) {
+          <option ngValue="null"
                   i18n>-- No kms providers available --</option>
-          <option *ngIf="kmsProviders !== null && kmsProviders.length > 0"
-                  ngValue=""
+          }
+          @if (kmsProviders !== null && kmsProviders.length > 0) {
+          <option ngValue=""
                   i18n>-- Select a provider --</option>
-          <option *ngFor="let provider of kmsProviders"
-                  [value]="provider">{{ provider }}</option>
+          }
+          @for (provider of kmsProviders; track provider) {
+          <option [value]="provider">{{ provider }}</option>
+          }
         </cds-select>
       </div>
+      }
 
-      <div *ngIf="kmsProviders.length !== 0 && configForm.getValue('kms_provider') !== ''">
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+      @if (kmsProviders.length !== 0 && configForm.getValue('kms_provider') !== '') {
+        @if ((configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-select id="auth"
                       formControlName="auth"
                       label="Authentication Method"
@@ -66,13 +73,17 @@
                       i18n-helperText
                       i18n-invalidText
                       [invalid]="configForm.showError('auth', frm, 'required')">
-            <option *ngFor="let auth of authMethods"
-                    [value]="auth">{{ auth }}</option>
+            @for (auth of authMethods; track auth) {
+            <option [value]="auth">{{ auth }}</option>
+            }
           </cds-select>
         </div>
+        }
 
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+        @if ((configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-select id="secret_engine"
                       formControlName="secret_engine"
                       label="Secret Engine"
@@ -82,13 +93,17 @@
                       i18n-helperText
                       i18n-invalidText
                       [invalid]="configForm.showError('secret_engine', frm, 'required')">
-            <option *ngFor="let secret_engine of secretEngines"
-                    [value]="secret_engine">{{ secret_engine }}</option>
+            @for (secret_engine of secretEngines; track secret_engine) {
+            <option [value]="secret_engine">{{ secret_engine }}</option>
+            }
           </cds-select>
         </div>
+        }
 
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+        @if ((configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-text-label for="secret_path"
                           helperText="Vault secret URL prefix, which can be used to restrict access to a particular subset of the Vault secret space."
                           i18n
@@ -101,9 +116,12 @@
                    formControlName="secret_path">
           </cds-text-label>
         </div>
+        }
 
-        <div *ngIf="(configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+        @if ((configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-text-label for="namespace"
                           helperText="Vault Namespace to be used to select your tenant."
                           i18n
@@ -115,53 +133,70 @@
                    formControlName="namespace">
           </cds-text-label>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-text-label for="addr"
-                          [invalid]="configForm.showError('addr', frm, 'required')"
+                          [invalid]="addressRef.isInvalid"
                           [invalidText]="addressError"
                           [helperText]="configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault server base address.' : 'Kmip server base address.'">
             {{ configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT ? 'Vault Address' : 'KMIP Address' }}
             <input cdsText
+                   cdValidate
                    id="addr"
+                   #addressRef="cdValidate"
                    formControlName="addr"
                    placeholder="http://127.0.0.1:8000"
                    i18n-placeholder
-                   [invalid]="configForm.showError('addr', frm, 'required')">
+                   [invalid]="addressRef.isInvalid">
           </cds-text-label>
           <ng-template #addressError>
+            @if (configForm.showError('addr', frm, 'required')) {
             <span class="invalid-feedback"
-                  *ngIf="configForm.showError('addr', frm, 'required')"
                   i18n>This field is required.</span>
+            } @else if (configForm.showError('addr', frm, 'invalidURL')) {
+            <span class="invalid-feedback"
+                  i18n>Please enter a valid URL.</span>
+            }
           </ng-template>
         </div>
+        }
 
-        <div *ngIf="((configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) && configForm.getValue('auth') === 'token'"
-             class="form-item">
+        @if (((configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.VAULT) ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) &&
+        configForm.getValue('auth') === 'token') {
+        <div class="form-item">
           <cds-text-label for="token"
-                          [invalid]="configForm.showError('token', frm, 'required')"
+                          [invalid]="tokenRef.isInvalid"
                           [invalidText]="tokenError"
                           helperText="Provide the path to the Vault token file on the RGW host."
                           i18n
                           i18n-helperText>Token file path
             <input cdsText
+                   cdValidate
                    type="text"
                    id="token"
+                   #tokenRef="cdValidate"
                    placeholder="/path/to/token"
                    i18n-placeholder
                    formControlName="token"
-                   [invalid]="configForm.showError('token', frm, 'required')">
+                   [invalid]="tokenRef.isInvalid">
           </cds-text-label>
           <ng-template #tokenError>
+            @if (configForm.showError('token', frm, 'required')) {
             <span class="invalid-feedback"
-                  *ngIf="configForm.showError('token', frm, 'required')"
                   i18n>This field is required.</span>
+            }
           </ng-template>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
+        <div class="form-item">
           <cds-text-label for="kms_key_template"
                           helperText="sse-kms; kmip key names"
                           i18n
@@ -172,9 +207,11 @@
                    formControlName="kms_key_template">
           </cds-text-label>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
+        <div class="form-item">
           <cds-text-label for="s3_key_template"
                           helperText="sse-s3; kmip key template"
                           i18n
@@ -185,9 +222,11 @@
                    formControlName="s3_key_template">
           </cds-text-label>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
+        <div class="form-item">
           <cds-text-label for="username"
                           helperText="When authenticating via username."
                           i18n
@@ -197,9 +236,11 @@
                    formControlName="username">
           </cds-text-label>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS && configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS &&
+        configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
+        <div class="form-item">
           <cds-password-label for="password"
                               helperText="Optional with username."
                               i18n
@@ -211,9 +252,11 @@
                    formControlName="password">
           </cds-password-label>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-text-label for="ssl_cert"
                           helperText="Path for custom CA certificate used when accessing the server."
                           i18n
@@ -226,9 +269,11 @@
                    i18n-placeholder>
           </cds-text-label>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-text-label for="client_cert"
                           helperText="Path for the client certificate used when accessing the server."
                           i18n
@@ -241,9 +286,11 @@
                    i18n-placeholder>
           </cds-text-label>
         </div>
+        }
 
-        <div *ngIf="configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS || configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3"
-             class="form-item">
+        @if (configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_KMS ||
+        configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
+        <div class="form-item">
           <cds-text-label for="client_key"
                           helperText="Path for the private key required for the client certificate."
                           i18n
@@ -256,7 +303,8 @@
                    i18n-placeholder>
           </cds-text-label>
         </div>
-      </div>
+        }
+      }
     </div>
 
     <cd-form-button-panel (submitActionEvent)="onSubmit()"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.html
@@ -23,11 +23,11 @@
                          i18n-helperText>
           <cds-radio [value]="ENCRYPTION_TYPE.SSE_S3"
                      [disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_S3"
-                     (change)="checkKmsProviders()"
+                     (change)="onEncryptionTypeChange()"
                      i18n>SSE-S3</cds-radio>
           <cds-radio [value]="ENCRYPTION_TYPE.SSE_KMS"
                      [disabled]="editing && configForm.getValue('encryptionType') !== ENCRYPTION_TYPE.SSE_KMS"
-                     (change)="checkKmsProviders()"
+                     (change)="onEncryptionTypeChange()"
                      i18n>SSE-KMS</cds-radio>
         </cds-radio-group>
       </div>
@@ -45,7 +45,7 @@
                     i18n-helperText
                     i18n-invalidText
                     [invalid]="configForm.showError('kms_provider', frm, 'required')"
-                    (change)="setKmsProvider()">
+                    (change)="onKmsProviderChange()">
           @if (kmsProviders !== null && kmsProviders.length === 0) {
           <option ngValue="null"
                   i18n>-- No kms providers available --</option>
@@ -109,7 +109,6 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="secret_path"
-                          cdOptionalField="Secret Path"
                           helperText="Vault secret URL prefix, which can be used to restrict access to a particular subset of the Vault secret space."
                           i18n
                           i18n-helperText>Secret Path
@@ -128,7 +127,6 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="namespace"
-                          cdOptionalField="Namespace"
                           helperText="Vault Namespace to be used to select your tenant."
                           i18n
                           i18n-helperText>Namespace
@@ -206,7 +204,6 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-text-label for="kms_key_template"
-                          cdOptionalField="KMS Key Template"
                           helperText="sse-kms; kmip key names"
                           i18n
                           i18n-helperText>KMS Key Template
@@ -222,7 +219,6 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-text-label for="s3_key_template"
-                          cdOptionalField="S3 Key Template"
                           helperText="sse-s3; kmip key template"
                           i18n
                           i18n-helperText>S3 Key Template
@@ -238,7 +234,6 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-text-label for="username"
-                          cdOptionalField="Username"
                           helperText="When authenticating via username."
                           i18n
                           i18n-helperText>Username
@@ -253,7 +248,6 @@
         configForm.getValue('kms_provider') === KMS_PROVIDER.KMIP) {
         <div class="form-item">
           <cds-password-label for="password"
-                              cdOptionalField="Password"
                               helperText="Optional with username."
                               i18n
                               i18n-helperText>Password
@@ -270,7 +264,6 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="ssl_cert"
-                          cdOptionalField="CA Certificate Path"
                           helperText="Path for custom CA certificate used when accessing the server."
                           i18n
                           i18n-helperText>CA Certificate Path
@@ -288,7 +281,6 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="client_cert"
-                          cdOptionalField="Client Certificate Path"
                           helperText="Path for the client certificate used when accessing the server."
                           i18n
                           i18n-helperText>Client Certificate Path
@@ -306,7 +298,6 @@
         configForm.getValue('encryptionType') === ENCRYPTION_TYPE.SSE_S3) {
         <div class="form-item">
           <cds-text-label for="client_key"
-                          cdOptionalField="Client Private Key Path"
                           helperText="Path for the private key required for the client certificate."
                           i18n
                           i18n-helperText>Client Private Key Path

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
@@ -3,9 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
-import { InputModule, SelectModule } from 'carbon-components-angular';
+import { InputModule, ModalModule, RadioModule, SelectModule } from 'carbon-components-angular';
 
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
@@ -24,9 +23,10 @@ describe('RgwConfigModalComponent', () => {
       HttpClientTestingModule,
       ToastrModule.forRoot(),
       InputModule,
+      ModalModule,
+      RadioModule,
       SelectModule
-    ],
-    providers: [NgbActiveModal]
+    ]
   });
 
   beforeEach(() => {
@@ -39,10 +39,31 @@ describe('RgwConfigModalComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render carbonized top-level controls', () => {
+  it('should render a fully carbonized modal shell and form controls', () => {
     const nativeElement = fixture.nativeElement as HTMLElement;
 
+    expect(nativeElement.querySelector('cds-modal')).toBeTruthy();
+    expect(nativeElement.querySelector('cds-radio-group')).toBeTruthy();
     expect(nativeElement.querySelectorAll('cds-select').length).toBeGreaterThanOrEqual(3);
+    expect(nativeElement.querySelector('cds-text-label[for="token"]')).toBeTruthy();
+    expect(nativeElement.querySelector('cds-text-label[for="ssl_cert"]')).toBeTruthy();
+    expect(nativeElement.querySelector('cds-text-label[for="client_key"]')).toBeTruthy();
+    expect(nativeElement.querySelectorAll('.form-group.row').length).toBe(0);
     expect(nativeElement.querySelector('cds-text-label[for="addr"]')).toBeTruthy();
+  });
+
+  it('should render carbonized KMIP-specific fields when the provider is kmip', () => {
+    component.configForm.patchValue({
+      encryptionType: component.ENCRYPTION_TYPE.SSE_KMS,
+      kms_provider: component.KMS_PROVIDER.KMIP
+    });
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+
+    expect(nativeElement.querySelector('cds-text-label[for="kms_key_template"]')).toBeTruthy();
+    expect(nativeElement.querySelector('cds-text-label[for="s3_key_template"]')).toBeTruthy();
+    expect(nativeElement.querySelector('cds-text-label[for="username"]')).toBeTruthy();
+    expect(nativeElement.querySelector('cds-password-label[for="password"]')).toBeTruthy();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
+import { InputModule, SelectModule } from 'carbon-components-angular';
 
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
@@ -21,7 +22,9 @@ describe('RgwConfigModalComponent', () => {
       ReactiveFormsModule,
       RouterTestingModule,
       HttpClientTestingModule,
-      ToastrModule.forRoot()
+      ToastrModule.forRoot(),
+      InputModule,
+      SelectModule
     ],
     providers: [NgbActiveModal]
   });
@@ -34,5 +37,12 @@ describe('RgwConfigModalComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render carbonized top-level controls', () => {
+    const nativeElement = fixture.nativeElement as HTMLElement;
+
+    expect(nativeElement.querySelectorAll('cds-select').length).toBeGreaterThanOrEqual(3);
+    expect(nativeElement.querySelector('cds-text-label[for="addr"]')).toBeTruthy();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
@@ -72,12 +72,11 @@ describe('RgwConfigModalComponent', () => {
       encryptionType: component.ENCRYPTION_TYPE.SSE_KMS,
       kms_provider: component.KMS_PROVIDER.KMIP
     });
-    component.onKmsProviderChange();
+    fixture.detectChanges();
 
     component.configForm.patchValue({
       encryptionType: component.ENCRYPTION_TYPE.SSE_S3
     });
-    component.onEncryptionTypeChange();
     fixture.detectChanges();
 
     expect(component.kmsProviders).toEqual([component.KMS_PROVIDER.VAULT]);
@@ -86,7 +85,6 @@ describe('RgwConfigModalComponent', () => {
     component.configForm.patchValue({
       encryptionType: component.ENCRYPTION_TYPE.SSE_KMS
     });
-    component.onEncryptionTypeChange();
     fixture.detectChanges();
 
     expect(component.kmsProviders).toEqual([

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
@@ -66,4 +66,22 @@ describe('RgwConfigModalComponent', () => {
     expect(nativeElement.querySelector('cds-text-label[for="username"]')).toBeTruthy();
     expect(nativeElement.querySelector('cds-password-label[for="password"]')).toBeTruthy();
   });
+
+  it('should reset unsupported provider when switching from SSE-KMS to SSE-S3', () => {
+    component.configForm.patchValue({
+      encryptionType: component.ENCRYPTION_TYPE.SSE_KMS,
+      kms_provider: component.KMS_PROVIDER.KMIP
+    });
+
+    component.configForm.patchValue({
+      encryptionType: component.ENCRYPTION_TYPE.SSE_S3
+    });
+
+    component.checkKmsProviders();
+    fixture.detectChanges();
+
+    expect(component.kmsProviders).toEqual([component.KMS_PROVIDER.VAULT]);
+    expect(component.configForm.getValue('kms_provider')).toBe(component.KMS_PROVIDER.VAULT);
+    expect((fixture.nativeElement as HTMLElement).querySelector('cds-select#kms_provider')).toBeTruthy();
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
@@ -67,21 +67,32 @@ describe('RgwConfigModalComponent', () => {
     expect(nativeElement.querySelector('cds-password-label[for="password"]')).toBeTruthy();
   });
 
-  it('should reset unsupported provider when switching from SSE-KMS to SSE-S3', () => {
+  it('should restore the last SSE-KMS provider when switching back from SSE-S3', () => {
     component.configForm.patchValue({
       encryptionType: component.ENCRYPTION_TYPE.SSE_KMS,
       kms_provider: component.KMS_PROVIDER.KMIP
     });
+    component.onKmsProviderChange();
 
     component.configForm.patchValue({
       encryptionType: component.ENCRYPTION_TYPE.SSE_S3
     });
-
-    component.checkKmsProviders();
+    component.onEncryptionTypeChange();
     fixture.detectChanges();
 
     expect(component.kmsProviders).toEqual([component.KMS_PROVIDER.VAULT]);
     expect(component.configForm.getValue('kms_provider')).toBe(component.KMS_PROVIDER.VAULT);
-    expect((fixture.nativeElement as HTMLElement).querySelector('cds-select#kms_provider')).toBeTruthy();
+
+    component.configForm.patchValue({
+      encryptionType: component.ENCRYPTION_TYPE.SSE_KMS
+    });
+    component.onEncryptionTypeChange();
+    fixture.detectChanges();
+
+    expect(component.kmsProviders).toEqual([
+      component.KMS_PROVIDER.VAULT,
+      component.KMS_PROVIDER.KMIP
+    ]);
+    expect(component.configForm.getValue('kms_provider')).toBe(component.KMS_PROVIDER.KMIP);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
-import { AbstractControl, Validators } from '@angular/forms';
+import { Validators } from '@angular/forms';
 
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { BaseModal } from 'carbon-components-angular';
 import _ from 'lodash';
 
 import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
@@ -25,7 +25,7 @@ import { KmipConfig, VaultConfig } from '~/app/shared/models/rgw-encryption-conf
   styleUrls: ['./rgw-config-modal.component.scss'],
   standalone: false
 })
-export class RgwConfigModalComponent implements OnInit {
+export class RgwConfigModalComponent extends BaseModal implements OnInit {
   kmsProviders: string[];
 
   configForm: CdFormGroup;
@@ -44,11 +44,11 @@ export class RgwConfigModalComponent implements OnInit {
   KMS_PROVIDER = KMS_PROVIDER;
   constructor(
     private formBuilder: CdFormBuilder,
-    public activeModal: NgbActiveModal,
     public actionLabels: ActionLabelsI18n,
     private rgwBucketService: RgwBucketService,
     private notificationService: NotificationService
   ) {
+    super();
     this.createForm();
   }
   ngOnInit(): void {
@@ -170,18 +170,6 @@ export class RgwConfigModalComponent implements OnInit {
     });
   }
 
-  fileUpload(files: FileList, controlName: string) {
-    const file: File = files[0];
-    const reader = new FileReader();
-    reader.addEventListener('load', () => {
-      const control: AbstractControl = this.configForm.get(controlName);
-      control.setValue(file);
-      control.markAsDirty();
-      control.markAsTouched();
-      control.updateValueAndValidity();
-    });
-  }
-
   onSubmit() {
     const values = this.configForm.getRawValue();
     let encryptionData: VaultConfig | KmipConfig;
@@ -229,7 +217,7 @@ export class RgwConfigModalComponent implements OnInit {
         this.configForm.setErrors({ cdSubmitButton: true });
       },
       complete: () => {
-        this.activeModal.close();
+        this.closeModal();
         this.table?.refreshBtn();
       }
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
@@ -93,6 +93,10 @@ export class RgwConfigModalComponent extends BaseModal implements OnInit {
       selectedEncryptionType === ENCRYPTION_TYPE.SSE_KMS
         ? [KMS_PROVIDER.VAULT, KMS_PROVIDER.KMIP]
         : [KMS_PROVIDER.VAULT];
+    const currentProvider = this.configForm.get('kms_provider').value;
+    if (!this.kmsProviders.includes(currentProvider)) {
+      this.configForm.get('kms_provider').setValue(this.kmsProviders.length ? this.kmsProviders[0] : '');
+    }
   }
   checkKmsProviders() {
     if (!this.editing) {
@@ -123,10 +127,8 @@ export class RgwConfigModalComponent extends BaseModal implements OnInit {
         this.kmsProviders = this.kmsProviders.filter((provider) => !s3Backends.includes(provider));
       }
     }
-    if (!this.editing) {
-      if (this.kmsProviders.length > 0) {
-        this.configForm.get('kms_provider').setValue(this.kmsProviders[0]);
-      }
+    if (!this.editing && this.kmsProviders.length === 0) {
+      this.configForm.get('kms_provider').setValue('');
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
@@ -1,5 +1,6 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { Validators } from '@angular/forms';
+import { Subscription } from 'rxjs';
 
 import { BaseModal } from 'carbon-components-angular';
 import _ from 'lodash';
@@ -25,12 +26,13 @@ import { KmipConfig, VaultConfig } from '~/app/shared/models/rgw-encryption-conf
   styleUrls: ['./rgw-config-modal.component.scss'],
   standalone: false
 })
-export class RgwConfigModalComponent extends BaseModal implements OnInit {
+export class RgwConfigModalComponent extends BaseModal implements OnInit, OnDestroy {
   kmsProviders: string[];
   selectedProviderByEncryptionType: Record<string, string> = {
     [ENCRYPTION_TYPE.SSE_KMS]: KMS_PROVIDER.VAULT,
     [ENCRYPTION_TYPE.SSE_S3]: KMS_PROVIDER.VAULT
   };
+  private formSubscriptions = new Subscription();
 
   configForm: CdFormGroup;
 
@@ -89,7 +91,22 @@ export class RgwConfigModalComponent extends BaseModal implements OnInit {
       this.selectedProviderByEncryptionType[patchValues.encryptionType] = patchValues.kms_provider;
       this.configForm.get('kms_provider').disable();
     }
+    this.formSubscriptions.add(
+      this.configForm.get('encryptionType').valueChanges.subscribe(() => this.syncKmsProviders())
+    );
+    this.formSubscriptions.add(
+      this.configForm.get('kms_provider').valueChanges.subscribe((provider) => {
+        const encryptionType = this.configForm.get('encryptionType').value;
+        if (!this.editing && provider) {
+          this.selectedProviderByEncryptionType[encryptionType] = provider;
+        }
+      })
+    );
     this.syncKmsProviders();
+  }
+
+  ngOnDestroy(): void {
+    this.formSubscriptions.unsubscribe();
   }
 
   private getProvidersForEncryptionType(selectedEncryptionType: string) {
@@ -137,18 +154,6 @@ export class RgwConfigModalComponent extends BaseModal implements OnInit {
       if (nextProvider) {
         this.selectedProviderByEncryptionType[selectedEncryptionType] = nextProvider;
       }
-    }
-  }
-
-  onEncryptionTypeChange() {
-    this.syncKmsProviders();
-  }
-
-  onKmsProviderChange() {
-    const encryptionType = this.configForm.get('encryptionType').value;
-    const provider = this.configForm.get('kms_provider').value;
-    if (provider) {
-      this.selectedProviderByEncryptionType[encryptionType] = provider;
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
@@ -27,6 +27,10 @@ import { KmipConfig, VaultConfig } from '~/app/shared/models/rgw-encryption-conf
 })
 export class RgwConfigModalComponent extends BaseModal implements OnInit {
   kmsProviders: string[];
+  selectedProviderByEncryptionType: Record<string, string> = {
+    [ENCRYPTION_TYPE.SSE_KMS]: KMS_PROVIDER.VAULT,
+    [ENCRYPTION_TYPE.SSE_S3]: KMS_PROVIDER.VAULT
+  };
 
   configForm: CdFormGroup;
 
@@ -82,26 +86,23 @@ export class RgwConfigModalComponent extends BaseModal implements OnInit {
             : this.selectedEncryptionConfigValues['client_key']
       };
       this.configForm.patchValue(patchValues);
+      this.selectedProviderByEncryptionType[patchValues.encryptionType] = patchValues.kms_provider;
       this.configForm.get('kms_provider').disable();
     }
-    this.checkKmsProviders();
+    this.syncKmsProviders();
   }
 
-  setKmsProvider() {
-    const selectedEncryptionType = this.configForm.get('encryptionType').value;
-    this.kmsProviders =
+  private getProvidersForEncryptionType(selectedEncryptionType: string) {
+    return (
       selectedEncryptionType === ENCRYPTION_TYPE.SSE_KMS
         ? [KMS_PROVIDER.VAULT, KMS_PROVIDER.KMIP]
-        : [KMS_PROVIDER.VAULT];
-    const currentProvider = this.configForm.get('kms_provider').value;
-    if (!this.kmsProviders.includes(currentProvider)) {
-      this.configForm.get('kms_provider').setValue(this.kmsProviders.length ? this.kmsProviders[0] : '');
-    }
+        : [KMS_PROVIDER.VAULT]
+    );
   }
-  checkKmsProviders() {
-    if (!this.editing) {
-      this.setKmsProvider();
-    }
+
+  syncKmsProviders() {
+    const selectedEncryptionType = this.configForm.get('encryptionType').value;
+    this.kmsProviders = this.getProvidersForEncryptionType(selectedEncryptionType);
 
     if (
       this.allEncryptionConfigValues &&
@@ -127,8 +128,27 @@ export class RgwConfigModalComponent extends BaseModal implements OnInit {
         this.kmsProviders = this.kmsProviders.filter((provider) => !s3Backends.includes(provider));
       }
     }
-    if (!this.editing && this.kmsProviders.length === 0) {
-      this.configForm.get('kms_provider').setValue('');
+    if (!this.editing) {
+      const rememberedProvider = this.selectedProviderByEncryptionType[selectedEncryptionType];
+      const nextProvider = this.kmsProviders.includes(rememberedProvider)
+        ? rememberedProvider
+        : this.kmsProviders[0] || '';
+      this.configForm.get('kms_provider').setValue(nextProvider, { emitEvent: false });
+      if (nextProvider) {
+        this.selectedProviderByEncryptionType[selectedEncryptionType] = nextProvider;
+      }
+    }
+  }
+
+  onEncryptionTypeChange() {
+    this.syncKmsProviders();
+  }
+
+  onKmsProviderChange() {
+    const encryptionType = this.configForm.get('encryptionType').value;
+    const provider = this.configForm.get('kms_provider').value;
+    if (provider) {
+      this.selectedProviderByEncryptionType[encryptionType] = provider;
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwConfigurationPageComponent } from './rgw-configuration-page.component';
-import { NgbActiveModal, NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SharedModule } from '~/app/shared/shared.module';
 import { RgwModule } from '../rgw.module';
@@ -14,7 +14,6 @@ describe('RgwConfigurationPageComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [RgwConfigurationPageComponent],
-      providers: [NgbActiveModal],
       imports: [HttpClientTestingModule, SharedModule, NgbNavModule, RgwModule, RouterTestingModule]
     }).compileComponents();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 
-import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
 import { Permissions } from '~/app/shared/models/permissions';
@@ -14,10 +13,10 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ListWithDetails } from '~/app/shared/classes/list-with-details.class';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { ModalService } from '~/app/shared/services/modal.service';
 import { RgwConfigModalComponent } from '../rgw-config-modal/rgw-config-modal.component';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { ENCRYPTION_TYPE } from '../models/rgw-bucket-encryption';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import {
   KmipConfig,
   VaultConfig,
@@ -49,18 +48,16 @@ export class RgwConfigurationPageComponent extends ListWithDetails implements On
   authMethods: string[];
   secretEngines: string[];
   tableActions: CdTableAction[];
-  bsModalRef: NgbModalRef;
   filteredEncryptionConfigValues: {};
   excludeProps: any[] = [];
   disableCreate = true;
   allEncryptionValues: any;
 
   constructor(
-    public activeModal: NgbActiveModal,
     public actionLabels: ActionLabelsI18n,
     private rgwBucketService: RgwBucketService,
     public authStorageService: AuthStorageService,
-    private modalService: ModalService
+    private modalService: ModalCdsService
   ) {
     super();
     this.permissions = this.authStorageService.getPermissions();
@@ -115,22 +112,16 @@ export class RgwConfigurationPageComponent extends ListWithDetails implements On
 
   openRgwConfigModal(edit: boolean) {
     if (edit) {
-      const initialState = {
+      this.modalService.show(RgwConfigModalComponent, {
         action: 'edit',
         editing: true,
         selectedEncryptionConfigValues: this.selection.first(),
         table: this.table
-      };
-      this.bsModalRef = this.modalService.show(RgwConfigModalComponent, initialState, {
-        size: 'lg'
       });
     } else {
-      const initialState = {
+      this.modalService.show(RgwConfigModalComponent, {
         action: 'create',
         allEncryptionConfigValues: this.allEncryptionValues
-      };
-      this.bsModalRef = this.modalService.show(RgwConfigModalComponent, initialState, {
-        size: 'lg'
       });
     }
   }


### PR DESCRIPTION


This is a targeted Carbon follow-up for the RGW encryption configuration create
modal at `#/rgw/configuration`.

The patch intentionally keeps the scope small:

- preserves the existing `cd-modal` shell and modal service wiring
- preserves the existing reactive form logic and submit flow
- carbonizes the top visible configuration controls that define the main create
  path
- adds a focused unit test for the updated controls

Updated controls:

- `kms_provider`
- `auth`
- `secret_engine`
- `addr`

The encryption type radio inputs and the deeper provider-specific sections are
left functionally unchanged in this patch to avoid a larger modal/service
rewrite.

## Why This Scope

The goal here is to improve Carbon alignment for the most visible and
highest-traffic part of the RGW configuration create modal without introducing a
large behavioral refactor.

This keeps the PR reviewable because:

- the modal service contract is unchanged
- conditional field logic is unchanged
- provider-specific sections are not rewritten
- the diff stays limited to one template and one focused spec update

## Validation

Focused unit test:

```bash
cd src/pybind/mgr/dashboard/frontend
npx jest --runInBand \
  src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.spec.ts
```

Result:

- 1 test suite passed
- 2 tests passed

The updated spec verifies that the Carbonized top-level controls render in the
modal template.

## Manual Validation

Validated locally through the dashboard UI after starting a local RGW-enabled
`vstart` environment and opening:

- `#/rgw/configuration`
- `Object -> Configuration -> Create`

Manual checks:

- the create modal opens successfully
- the top-level select controls render with Carbon components
- the address field renders with Carbon text input styling
- existing form behavior remains intact for the untouched lower sections

## Screenshots
<img width="2880" height="1536" alt="Screenshot from 2026-03-28 08-58-55" src="https://github.com/user-attachments/assets/87cfbcd1-28af-4cb3-aac2-4415c271dfca" />
<img width="2880" height="1531" alt="Screenshot from 2026-03-28 08-58-44" src="https://github.com/user-attachments/assets/2883c240-5b4e-47e9-8fae-9a2b8ee390b9" />
<img width="2880" height="1531" alt="Screenshot from 2026-03-28 08-58-40" src="https://github.com/user-attachments/assets/f1ad8d93-0f4a-44a6-9cc3-e92154b9bf67" />



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
