### PR TITLE
tentacle: qa: fixing the qa test in mon/misc.sh after adding beacon-diff feature 

### DIFF
--- a/qa/standalone/mon/misc.sh
+++ b/qa/standalone/mon/misc.sh
@@ -281,7 +281,10 @@ function TEST_mon_features() {
     jq_success "$jqinput" "$jqfilter" "squid" || return 1
     jqfilter='.monmap.features.persistent[]|select(. == "tentacle")'
     jq_success "$jqinput" "$jqfilter" "tentacle" || return 1
-    jqfilter='.monmap.features.persistent | length == 12'
+    #nvmeof_beacon_diff
+    jqfilter='.monmap.features.persistent[]|select(. == "nvmeof_beacon_diff")'
+    jq_success "$jqinput" "$jqfilter" "nvmeof_beacon_diff" || return 1
+    jqfilter='.monmap.features.persistent | length == 13'
     jq_success "$jqinput" "$jqfilter" || return 1
 
     CEPH_ARGS=$CEPH_ARGS_orig


### PR DESCRIPTION
This is a backport of #67307 to the `tentacle` branch. It resolves the `TEST_mon_features` failure in `qa/standalone/mon/misc.sh` which was caused by a hardcoded feature count that did not account for the recently added `nvmeof_beacon_diff`.

**Cherry-picked from commit:** 0b418393c1f3605a8a8eca061659a32ae31769fa

### Conflicts
- **qa/standalone/mon/misc.sh**: 
    - Adjusted the persistent feature `length` check to **13** (baseline 12 + nvmeof_beacon_diff).

### Checklist
- Tracker (select at least one)
  - [x] References tracker ticket: https://tracker.ceph.com/issues/74827
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/) - This PR fixes an existing standalone test.