### PR TITLE
rgw: enable runtime toggle for dynamic resharding thread

### DIFF
--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -188,6 +188,29 @@ in the future. This command allows administrators to set a per-bucket
 minimum. This does not, however, prevent administrators from manually
 resharding to a lower number of shards.
 
+Runtime Toggle
+---------------
+
+To temporarily disable dynamic resharding (without restart):
+
+.. code-block:: bash
+
+   # Capture current settings for later restoration
+   ORIGINAL_MAX_SHARDS=$(ceph config get client.rgw rgw_max_dynamic_shards)
+   ORIGINAL_MAY_REDUCE=$(ceph config get client.rgw rgw_dynamic_resharding_may_reduce)
+   
+   # Disable dynamic resharding
+   ceph config set client.rgw rgw_dynamic_resharding_may_reduce false
+   ceph config set client.rgw rgw_max_dynamic_shards 1
+
+To re-enable dynamic resharding with original settings:
+
+.. code-block:: bash
+
+   # Restore original settings
+   ceph config set client.rgw rgw_max_dynamic_shards "$ORIGINAL_MAX_SHARDS"
+   ceph config set client.rgw rgw_dynamic_resharding_may_reduce "$ORIGINAL_MAY_REDUCE"
+
 Troubleshooting
 ===============
 

--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -56,6 +56,7 @@ Configuration
 .. confval:: rgw_max_dynamic_shards
 .. confval:: rgw_dynamic_resharding_may_reduce
 .. confval:: rgw_dynamic_resharding_reduction_wait
+.. confval:: rgw_dynamic_resharding_work_time
 .. confval:: rgw_reshard_bucket_lock_duration
 .. confval:: rgw_reshard_thread_interval
 .. confval:: rgw_reshard_num_logs
@@ -210,6 +211,41 @@ To re-enable dynamic resharding with original settings:
    # Restore original settings
    ceph config set client.rgw rgw_max_dynamic_shards "$ORIGINAL_MAX_SHARDS"
    ceph config set client.rgw rgw_dynamic_resharding_may_reduce "$ORIGINAL_MAY_REDUCE"
+
+Dynamic Resharding Work Time Window
+-----------------------------------
+
+The :confval:`rgw_dynamic_resharding_work_time` option controls when the
+dynamic resharding maintenance thread is allowed to process resharding work.
+This lets administrators confine automatic resharding activity to a preferred
+local-time window.
+
+Format
+~~~~~~
+
+Set this option as a local-time range in 24-hour format:
+
+::
+
+    HH:MM-HH:MM
+
+For example:
+
+- ``00:00-06:00`` allows dynamic resharding from midnight to 06:00.
+- ``22:00-23:59`` allows dynamic resharding late at night.
+- ``00:00-23:59`` allows dynamic resharding all day (default).
+
+Behavior
+~~~~~~~~
+
+- Inside the configured time window, the maintenance thread can process
+   queued dynamic resharding work.
+- Outside the window, queued work remains pending until the next allowed
+   period.
+
+This option applies to automatic dynamic resharding maintenance activity,
+and is useful when operators want to avoid background resharding impact
+during peak client workloads.
 
 Troubleshooting
 ===============

--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -59,6 +59,15 @@ Request Entities
 +-------------------------------+-----------+-----------------------------------------------------------------+
 | ``LocationConstraint``        | String    | A zonegroup API name, with optional :ref:`s3_bucket_placement`. |
 +-------------------------------+-----------+-----------------------------------------------------------------+
+| ``BucketIndex``               | Container | Ceph RGW extension to customize bucket index layout.            |
++-------------------------------+-----------+-----------------------------------------------------------------+
+| ``BucketIndex/Type``          | String    | Bucket index type: ``Normal`` or ``Indexless``.                |
++-------------------------------+-----------+-----------------------------------------------------------------+
+| ``BucketIndex/NumShards``     | Integer   | Initial shard count for ``Normal`` bucket index type; value     |
+|                               |           | must be greater than ``0``. Limited by                          |
+|                               |           | :confval:`rgw_create_bucket_max_shards` (if that config is      |
+|                               |           | ``0``, no upper limit is enforced).                             |
++-------------------------------+-----------+-----------------------------------------------------------------+
 
 
 HTTP Response

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3548,6 +3548,32 @@ options:
   - rgw_dynamic_resharding
   - rgw_max_objs_per_shard
   min: 1
+- name: rgw_create_bucket_max_shards
+  type: uint
+  level: advanced
+  desc: Maximum shard count allowed in a CreateBucket request
+  long_desc: This is the maximum number of bucket index shards that a CreateBucket
+    request may set via BucketIndex/NumShards. A value of 0 means unlimited.
+  default: 1999
+  services:
+  - rgw
+  see_also:
+  - rgw_max_dynamic_shards
+  min: 0
+- name: rgw_dynamic_resharding_work_time
+  type: str
+  level: advanced
+  desc: Dynamic resharding allowed work time
+  long_desc: Local time window in which the dynamic resharding maintenance thread
+    can work. It expects 24-hour time notation. For example, "00:00-06:00"
+    allows dynamic resharding work from midnight to 06:00 local time.
+  default: 00:00-23:59
+  services:
+  - rgw
+  see_also:
+  - rgw_dynamic_resharding
+  - rgw_max_dynamic_shards
+  - rgw_reshard_thread_interval
 - name: rgw_reshard_thread_interval
   type: uint
   level: advanced

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -4,6 +4,7 @@
 #include <limits>
 #include <sstream>
 #include <chrono>
+#include <ctime>
 
 #include "rgw_zone.h"
 #include "driver/rados/rgw_bucket.h"
@@ -36,6 +37,61 @@ const string bucket_instance_lock_name = "bucket_instance_lock";
 // key reduction values; NB maybe expose some in options
 constexpr uint64_t default_min_objs_per_shard = 10000;
 constexpr uint32_t min_dynamic_shards = 11;
+
+namespace {
+
+constexpr int hours_in_a_day = 24;
+constexpr int secs_in_a_day = 60 * 60 * 24;
+
+bool should_reshard_work_now(const std::string& worktime, const utime_t& now)
+{
+  int start_hour = 0;
+  int start_minute = 0;
+  int end_hour = 23;
+  int end_minute = 59;
+  std::sscanf(worktime.c_str(), "%d:%d-%d:%d", &start_hour, &start_minute,
+              &end_hour, &end_minute);
+
+  struct tm bdt;
+  time_t tt = now.sec();
+  localtime_r(&tt, &bdt);
+
+  // next-day adjustment if the configured end_hour is less than start_hour
+  if (end_hour < start_hour) {
+    bdt.tm_hour = bdt.tm_hour > end_hour ? bdt.tm_hour : bdt.tm_hour + hours_in_a_day;
+    end_hour += hours_in_a_day;
+  }
+
+  return ((bdt.tm_hour * 60 + bdt.tm_min >= start_hour * 60 + start_minute) &&
+          (bdt.tm_hour * 60 + bdt.tm_min <= end_hour * 60 + end_minute));
+}
+
+int schedule_next_reshard_start_time(const std::string& worktime,
+                                     const utime_t& now)
+{
+  int start_hour = 0;
+  int start_minute = 0;
+  int end_hour = 23;
+  int end_minute = 59;
+  std::sscanf(worktime.c_str(), "%d:%d-%d:%d", &start_hour, &start_minute,
+              &end_hour, &end_minute);
+
+  struct tm bdt;
+  time_t tt = now.sec();
+  time_t nt;
+  localtime_r(&tt, &bdt);
+
+  bdt.tm_hour = start_hour;
+  bdt.tm_min = start_minute;
+  bdt.tm_sec = 0;
+
+  nt = mktime(&bdt);
+  int secs = int(nt - tt);
+
+  return secs > 0 ? secs : secs + secs_in_a_day;
+}
+
+} // anonymous namespace
 
 /* All primes up to 2000 used to attempt to make dynamic sharding use
  * a prime numbers of shards. Note: this list also includes 1 for when
@@ -1818,8 +1874,14 @@ void *RGWReshard::ReshardWorker::entry() {
   }
 
   do {
-    utime_t start = ceph_clock_now();
-    reshard->process_all_logshards(this, null_yield);
+    int secs = 0;
+    const auto now = ceph_clock_now();
+    const auto worktime = cct->_conf.get_val<std::string>("rgw_dynamic_resharding_work_time");
+    const bool should_work = (debug_interval > 0) || should_reshard_work_now(worktime, now);
+
+    if (should_work) {
+      utime_t start = now;
+      reshard->process_all_logshards(this, null_yield);
 
     if (reshard->going_down()) {
       break;
@@ -1828,7 +1890,7 @@ void *RGWReshard::ReshardWorker::entry() {
     utime_t end = ceph_clock_now();
     utime_t elapsed = end - start;
 
-    int secs = cct->_conf.get_val<uint64_t>("rgw_reshard_thread_interval");
+    secs = cct->_conf.get_val<uint64_t>("rgw_reshard_thread_interval");
     secs = std::max(1, int(secs * interval_factor));
 
     if (secs <= elapsed.sec()) {
@@ -1836,6 +1898,12 @@ void *RGWReshard::ReshardWorker::entry() {
     }
 
     secs -= elapsed.sec();
+    } else {
+      secs = schedule_next_reshard_start_time(worktime, now);
+      ldpp_dout(this, 20) << "outside rgw_dynamic_resharding_work_time=" << worktime
+                          << ", sleeping " << secs << " seconds until next window"
+                          << dendl;
+    }
 
     // note: this will likely wait for the intended period of
     // time, but could wait for less

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -74,6 +74,7 @@
 #include "rgw_sts.h"
 #ifdef WITH_RADOSGW_RADOS
 #include "rgw_sal_rados.h"
+#include "driver/rados/rgw_tools.h"
 #endif
 #include "rgw_cksum_pipe.h"
 #include "rgw_s3select.h"
@@ -2712,7 +2713,7 @@ int RGWCreateBucket_ObjStore_S3::get_params(optional_yield y)
           s->err.message = "NumShards must be greater than 0";
           return -EINVAL;
         }
-        const auto limit = s->cct->_conf.get_val<uint64_t>("rgw_max_dynamic_shards");
+        const uint32_t limit = static_cast<uint32_t>(rgw_shards_max());
         if (*val > limit) {
           s->err.message = fmt::format("NumShards cannot exceed {}", limit);
           return -EINVAL;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -74,7 +74,6 @@
 #include "rgw_sts.h"
 #ifdef WITH_RADOSGW_RADOS
 #include "rgw_sal_rados.h"
-#include "driver/rados/rgw_tools.h"
 #endif
 #include "rgw_cksum_pipe.h"
 #include "rgw_s3select.h"
@@ -2713,8 +2712,8 @@ int RGWCreateBucket_ObjStore_S3::get_params(optional_yield y)
           s->err.message = "NumShards must be greater than 0";
           return -EINVAL;
         }
-        const uint32_t limit = static_cast<uint32_t>(rgw_shards_max());
-        if (*val > limit) {
+        const auto limit = s->cct->_conf.get_val<uint64_t>("rgw_create_bucket_max_shards");
+        if (limit > 0 && *val > limit) {
           s->err.message = fmt::format("NumShards cannot exceed {}", limit);
           return -EINVAL;
         }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/73984

Also manual shards is now limited by RGW_SHARDS_PRIME_1 as mentioned in documentation rather than the rgw_max_dynamic_shards.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
