### PR TITLE
mgr/dashboard: show table action icons for non-primary actions

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -74,20 +74,20 @@ export class IscsiTargetListComponent extends ListWithDetails implements OnInit,
     this.tableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         routerLink: () => '/block/iscsi/targets/create',
         name: this.actionLabels.CREATE
       },
       {
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         routerLink: () => `/block/iscsi/targets/edit/${this.selection.first().target_iqn}`,
         name: this.actionLabels.EDIT,
         disable: () => this.getEditDisableDesc()
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteIscsiTargetModal(),
         name: this.actionLabels.DELETE,
         disable: () => this.getDeleteDisableDesc()

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
@@ -48,7 +48,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
 
     const createBootstrapAction: CdTableAction = {
       permission: 'update',
-      icon: 'document--add',
+      icon: 'documentAdd',
       click: () => this.createBootstrapModal(),
       name: $localize`Create Bootstrap Token`,
       canBePrimary: () => true,
@@ -57,7 +57,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
     };
     const importBootstrapAction: CdTableAction = {
       permission: 'update',
-      icon: 'document--import',
+      icon: 'documentImport',
       click: () => this.importBootstrapModal(),
       name: $localize`Import Bootstrap Token`,
       disable: () => false,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
@@ -7,7 +7,6 @@ import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
 import { TableStatusViewCache } from '~/app/shared/classes/table-status-view-cache';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { URLVerbs } from '~/app/shared/constants/app.constants';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -56,14 +55,14 @@ export class PoolListComponent implements OnInit, OnDestroy {
 
     const editModeAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       click: () => this.editModeModal(),
       name: $localize`Edit Mode`,
       canBePrimary: () => true
     };
     const addPeerAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       name: $localize`Add Peer`,
       click: () => this.editPeersModal('add'),
       disable: () => !this.selection.first() || this.selection.first().mirror_mode === 'disabled',
@@ -72,14 +71,14 @@ export class PoolListComponent implements OnInit, OnDestroy {
     };
     const editPeerAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.exchange,
+      icon: 'exchange',
       name: $localize`Edit Peer`,
       click: () => this.editPeersModal('edit'),
       visible: () => !!this.getPeerUUID()
     };
     const deletePeerAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       name: $localize`Delete Peer`,
       click: () => this.deletePeersModal(),
       visible: () => !!this.getPeerUUID()

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
@@ -107,7 +107,7 @@ export class NvmeofGatewayGroupComponent implements OnInit {
     ];
     const createAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       disable: () => (this.nodesAvailable ? false : $localize`Gateway nodes are not available`),
       routerLink: () => this.urlBuilder.getCreate(),
       name: this.actionLabels.CREATE,
@@ -116,7 +116,7 @@ export class NvmeofGatewayGroupComponent implements OnInit {
 
     const viewAction: CdTableAction = {
       permission: 'read',
-      icon: Icons.eye,
+      icon: 'eye',
       click: () => this.getViewDetails(),
       name: $localize`View details`,
       canBePrimary: (selection: CdTableSelection) => selection.hasMultiSelection
@@ -124,7 +124,7 @@ export class NvmeofGatewayGroupComponent implements OnInit {
 
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteGatewayGroupModal(),
       name: this.actionLabels.DELETE,
       canBePrimary: (selection: CdTableSelection) => selection.hasMultiSelection

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.ts
@@ -146,7 +146,7 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
     this.tableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.addGateway(),
         name: $localize`Add`,
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection,
@@ -154,7 +154,7 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.removeGateway(),
         name: $localize`Remove`,
         disable: (selection: CdTableSelection) => !selection.hasSelection

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
@@ -4,7 +4,6 @@ import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -90,7 +89,7 @@ export class NvmeofInitiatorsListComponent implements OnInit {
       {
         name: this.actionLabels.ADD,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () =>
           this.router.navigate([{ outlets: { modal: [URLVerbs.ADD, 'initiator'] } }], {
             queryParams: { group: this.group },
@@ -102,7 +101,7 @@ export class NvmeofInitiatorsListComponent implements OnInit {
       {
         name: $localize`Edit host key`,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.editHostKeyModal(),
         disable: () => this.selection.selected.length !== 1,
         canBePrimary: (selection: CdTableSelection) => selection.selected.length === 1
@@ -110,7 +109,7 @@ export class NvmeofInitiatorsListComponent implements OnInit {
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.removeInitiatorModal(),
         disable: () => !this.selection.hasSelection,
         canBePrimary: (selection: CdTableSelection) => selection.hasSelection

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
@@ -4,7 +4,7 @@ import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons, EMPTY_STATE_IMAGE } from '~/app/shared/enum/icons.enum';
+import { EMPTY_STATE_IMAGE } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -88,7 +88,7 @@ export class NvmeofListenersListComponent implements OnInit {
       {
         name: this.actionLabels.ADD,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () =>
           this.router.navigate([{ outlets: { modal: [URLVerbs.ADD, 'listener'] } }], {
             queryParams: { group: this.group },
@@ -101,7 +101,7 @@ export class NvmeofListenersListComponent implements OnInit {
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteListenerModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
@@ -4,7 +4,6 @@ import { NvmeofService, GroupsComboboxItem } from '~/app/shared/api/nvmeof.servi
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -95,7 +94,7 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => {
           this.router.navigate(['block/nvmeof/namespaces/create'], {
             queryParams: {
@@ -110,7 +109,7 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
       {
         name: $localize`Expand`,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: (row: NvmeofSubsystemNamespace) => {
           const namespace = row || this.selection.first();
           this.ngZone.run(() => {
@@ -134,7 +133,7 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteNamespaceModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-namespaces-list/nvmeof-subsystem-namespaces-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-namespaces-list/nvmeof-subsystem-namespaces-list.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -105,7 +104,7 @@ export class NvmeofSubsystemNamespacesListComponent implements OnInit, OnDestroy
       {
         name: this.actionLabels.ADD,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () =>
           this.router.navigate(['block/nvmeof/namespaces/create'], {
             queryParams: {
@@ -119,7 +118,7 @@ export class NvmeofSubsystemNamespacesListComponent implements OnInit, OnDestroy
       {
         name: $localize`Expand`,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: (row: NvmeofSubsystemNamespace) => {
           const namespace = row || this.selection.first();
           this.router.navigate(
@@ -141,7 +140,7 @@ export class NvmeofSubsystemNamespacesListComponent implements OnInit, OnDestroy
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteNamespaceModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
@@ -13,7 +13,6 @@ import { ListWithDetails } from '~/app/shared/classes/list-with-details.class';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { NvmeofSubsystemAuthType } from '~/app/shared/enum/nvmeof.enum';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -114,7 +113,7 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () =>
           this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.CREATE] } }], {
             queryParams: { group: this.group }
@@ -125,7 +124,7 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteSubsystemModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -141,14 +141,14 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
       ).toStringEncoded();
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => this.urlBuilder.getCreate(),
       canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection,
       name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       routerLink: () => this.urlBuilder.getEdit(getImageUri()),
       name: this.actionLabels.EDIT,
       disable: (selection: CdTableSelection) =>
@@ -156,7 +156,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteRbdModal(),
       name: this.actionLabels.DELETE,
       title: RBDActionHelpers.delete,
@@ -164,7 +164,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
     };
     const moveAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.trash,
+      icon: 'trash',
       title: RBDActionHelpers.moveToTrash,
       click: () => this.trashRbdModal(),
       name: this.actionLabels.TRASH,
@@ -175,7 +175,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
     };
     const resyncAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.refresh,
+      icon: 'refresh',
       click: () => this.resyncRbdModal(),
       name: this.actionLabels.RESYNC,
       disable: (selection: CdTableSelection) => this.getResyncDisableDesc(selection)
@@ -187,7 +187,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         this.getRemovingStatusDesc(selection) ||
         this.getInvalidNameDisable(selection) ||
         !!selection.first().cdExecuting,
-      icon: Icons.copy,
+      icon: 'copy',
       routerLink: () => `/block/rbd/copy/${getImageUri()}`,
       name: this.actionLabels.COPY,
       title: RBDActionHelpers.copy
@@ -199,7 +199,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         this.getInvalidNameDisable(selection) ||
         selection.first().cdExecuting ||
         !selection.first().parent,
-      icon: Icons.flatten,
+      icon: 'flatten',
       click: () => this.flattenRbdModal(),
       name: this.actionLabels.FLATTEN,
       title: RBDActionHelpers.flatten
@@ -207,7 +207,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
 
     const removeSchedulingAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       click: () => this.removeSchedulingModal(),
       name: this.actionLabels.REMOVE_SCHEDULING,
       disable: (selection: CdTableSelection) =>
@@ -217,7 +217,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
     };
     const promoteAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       click: () => this.actionPrimary(true),
       name: this.actionLabels.PROMOTE,
       visible: () => this.selection.first() != null && !this.selection.first().primary,
@@ -226,7 +226,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
     };
     const demoteAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       click: () => this.actionPrimary(false),
       name: this.actionLabels.DEMOTE,
       visible: () => this.selection.first() != null && this.selection.first().primary,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-list/rbd-namespace-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-list/rbd-namespace-list.component.ts
@@ -7,7 +7,6 @@ import { PoolService } from '~/app/shared/api/pool.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
@@ -45,13 +44,13 @@ export class RbdNamespaceListComponent implements OnInit {
     this.permission = this.authStorageService.getPermissions().rbdImage;
     const createAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       click: () => this.createModal(),
       name: this.actionLabels.CREATE
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteModal(),
       name: this.actionLabels.DELETE,
       disable: () => this.getDeleteDisableDesc()

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
@@ -1,6 +1,5 @@
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 
@@ -28,19 +27,19 @@ export class RbdSnapshotActionsModel {
 
     this.create = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       name: actionLabels.CREATE
     };
     this.rename = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       name: actionLabels.RENAME,
       disable: (selection: CdTableSelection) =>
         this.disableForMirrorSnapshot(selection) || !selection.hasSingleSelection
     };
     this.protect = {
       permission: 'update',
-      icon: Icons.lock,
+      icon: 'lock',
       visible: (selection: CdTableSelection) =>
         selection.hasSingleSelection && !selection.first().is_protected,
       name: actionLabels.PROTECT,
@@ -50,7 +49,7 @@ export class RbdSnapshotActionsModel {
     };
     this.unprotect = {
       permission: 'update',
-      icon: Icons.unlock,
+      icon: 'unlock',
       visible: (selection: CdTableSelection) =>
         selection.hasSingleSelection && selection.first().is_protected,
       name: actionLabels.UNPROTECT,
@@ -61,7 +60,7 @@ export class RbdSnapshotActionsModel {
       canBePrimary: (selection: CdTableSelection) => selection.hasSingleSelection,
       disable: (selection: CdTableSelection) =>
         this.getCloneDisableDesc(selection) || this.disableForMirrorSnapshot(selection),
-      icon: Icons.clone,
+      icon: 'clone',
       name: actionLabels.CLONE
     };
     this.copy = {
@@ -71,19 +70,19 @@ export class RbdSnapshotActionsModel {
         !selection.hasSingleSelection ||
         selection.first().cdExecuting ||
         this.disableForMirrorSnapshot(selection),
-      icon: Icons.copy,
+      icon: 'copy',
       name: actionLabels.COPY
     };
     this.rollback = {
       permission: 'update',
-      icon: Icons.undo,
+      icon: 'undo',
       name: actionLabels.ROLLBACK,
       disable: (selection: CdTableSelection) =>
         this.disableForMirrorSnapshot(selection) || !selection.hasSingleSelection
     };
     this.deleteSnap = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       disable: (selection: CdTableSelection) => {
         const first = selection.first();
         return (

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.ts
@@ -68,13 +68,13 @@ export class RbdTrashListComponent implements OnInit {
     this.permission = this.authStorageService.getPermissions().rbdImage;
     const restoreAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.undo,
+      icon: 'undo',
       click: () => this.restoreModal(),
       name: this.actionLabels.RESTORE
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteModal(),
       name: this.actionLabels.DELETE
     };

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.ts
@@ -7,7 +7,6 @@ import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { TableStatusViewCache } from '~/app/shared/classes/table-status-view-cache';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
@@ -55,7 +54,7 @@ export class CephfsClientsComponent extends BaseModal implements OnInit {
     this.permission = this.authStorageService.getPermissions().cephfs;
     const evictAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.signOut,
+      icon: 'signOut',
       click: () => this.evictClientModal(),
       name: this.actionLabels.EVICT
     };

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
@@ -147,7 +147,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
       tableActions: [
         {
           name: this.actionLabels.SET,
-          icon: Icons.edit,
+          icon: 'edit',
           permission: 'update',
           visible: (selection) =>
             !selection.hasSelection || (selection.first() && selection.first().dirValue === 0),
@@ -155,14 +155,14 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
         },
         {
           name: this.actionLabels.UPDATE,
-          icon: Icons.edit,
+          icon: 'edit',
           permission: 'update',
           visible: (selection) => selection.first() && selection.first().dirValue > 0,
           click: () => this.updateQuotaModal()
         },
         {
           name: this.actionLabels.UNSET,
-          icon: Icons.destroy,
+          icon: 'destroy',
           permission: 'update',
           disable: (selection) =>
             !selection.hasSelection || (selection.first() && selection.first().dirValue === 0),
@@ -200,7 +200,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
       tableActions: [
         {
           name: this.actionLabels.CREATE,
-          icon: Icons.add,
+          icon: 'add',
           permission: 'create',
           canBePrimary: (selection) => !selection.hasSelection,
           click: () => this.createSnapshot(),
@@ -208,7 +208,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
         },
         {
           name: this.actionLabels.DELETE,
-          icon: Icons.destroy,
+          icon: 'destroy',
           permission: 'delete',
           click: () => this.deleteSnapshotModal()
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.ts
@@ -91,33 +91,33 @@ export class CephfsListComponent extends ListWithDetails implements OnInit {
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.router.navigate([this.urlBuilder.getCreate()]),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () =>
           this.router.navigate([this.urlBuilder.getEdit(String(this.selection.first().id))])
       },
       {
         name: this.actionLabels.AUTHORIZE,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.authorizeModal()
       },
       {
         name: this.actionLabels.ATTACH,
         permission: 'read',
-        icon: Icons.bars,
+        icon: 'bars',
         disable: () => !this.selection?.hasSelection,
         click: () => this.showAttachInfo()
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.removeVolumeModal(),
         name: this.actionLabels.REMOVE,
         disable: this.getDisableDesc.bind(this)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -10,7 +10,6 @@ import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
 import { Daemon, MirroringRow } from '~/app/shared/models/cephfs.model';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { Permission } from '~/app/shared/models/permissions';
 
@@ -57,7 +56,7 @@ export class CephfsMirroringListComponent implements OnInit {
 
     const createAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => this.urlBuilder.getCreate(),
       name: this.actionLabels.CREATE,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-list/cephfs-snapshotschedule-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-list/cephfs-snapshotschedule-list.component.ts
@@ -91,19 +91,19 @@ export class CephfsSnapshotscheduleListComponent
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.openModal(false)
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.openModal(true)
       },
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
-        icon: Icons.trash,
+        icon: 'trash',
         click: () => this.deleteSnapshotSchedule()
       }
     ];
@@ -172,7 +172,7 @@ export class CephfsSnapshotscheduleListComponent
       {
         name: isActive ? this.actionLabels.DEACTIVATE : this.actionLabels.ACTIVATE,
         permission: 'update',
-        icon: isActive ? Icons.warning : Icons.success,
+        icon: isActive ? 'warning' : 'success',
         click: () =>
           isActive ? this.deactivateSnapshotSchedule() : this.activateSnapshotSchedule()
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-group/cephfs-subvolume-group.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-group/cephfs-subvolume-group.component.ts
@@ -113,27 +113,27 @@ export class CephfsSubvolumeGroupComponent implements OnInit, OnChanges {
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.openModal(),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.openModal(true)
       },
       {
         name: this.actionLabels.NFS_EXPORT,
         permission: 'create',
-        icon: Icons.nfsExport,
+        icon: 'nfsExport',
         routerLink: () => ['/cephfs/nfs/create', this.fsName, this.selection?.first()?.name],
         disable: () => !this.selection.hasSingleSelection
       },
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.removeSubVolumeModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.ts
@@ -147,26 +147,26 @@ export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnCh
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.openModal()
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.openModal(true)
       },
       {
         name: this.actionLabels.ATTACH,
         permission: 'read',
-        icon: Icons.bars,
+        icon: 'bars',
         disable: () => !this.selection?.hasSelection,
         click: () => this.showAttachInfo()
       },
       {
         name: this.actionLabels.NFS_EXPORT,
         permission: 'create',
-        icon: Icons.nfsExport,
+        icon: 'nfsExport',
         routerLink: () => [
           '/cephfs/nfs/create',
           this.fsName,
@@ -178,7 +178,7 @@ export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnCh
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.removeSubVolumeModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
@@ -5,7 +5,6 @@ import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-g
 import { CephfsSubvolumeService } from '~/app/shared/api/cephfs-subvolume.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
@@ -106,20 +105,20 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.openModal()
       },
       {
         name: this.actionLabels.CLONE,
         permission: 'create',
-        icon: Icons.clone,
+        icon: 'clone',
         disable: () => !this.selection.hasSingleSelection,
         click: () => this.cloneModal()
       },
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         disable: () => !this.selection.hasSingleSelection,
         click: () => this.deleteSnapshot()
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -125,7 +125,7 @@ export class ConfigurationComponent extends ListWithDetails implements OnInit {
       this.selection.first() && `${encodeURIComponent(this.selection.first().name)}`;
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       routerLink: () => `/configuration/edit/${getConfigOptUri()}`,
       name: this.actionLabels.EDIT,
       disable: () => !this.isEditable(this.selection)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -142,7 +142,7 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
         name: this.actionLabels.ADD_STORAGE,
         permission: 'create',
         buttonKind: 'secondary',
-        icon: Icons.expand,
+        icon: 'expand',
         routerLink: '/add-storage',
         disable: (selection: CdTableSelection) => this.getDisable('add', selection),
         visible: () => this.showExpandClusterBtn
@@ -152,7 +152,7 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
       {
         name: this.actionLabels.ADD,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () =>
           this.router.url.includes('/hosts')
             ? this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.ADD] } }])
@@ -164,35 +164,35 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.editAction(),
         disable: (selection: CdTableSelection) => this.getDisable('edit', selection)
       },
       {
         name: this.actionLabels.START_DRAIN,
         permission: 'update',
-        icon: Icons.exit,
+        icon: 'exit',
         click: () => this.hostDrain(),
         visible: () => !this.showGeneralActionsOnly && !this.draining
       },
       {
         name: this.actionLabels.STOP_DRAIN,
         permission: 'update',
-        icon: Icons.exit,
+        icon: 'exit',
         click: () => this.hostDrain(true),
         visible: () => !this.showGeneralActionsOnly && this.draining
       },
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteAction(),
         disable: (selection: CdTableSelection) => this.getDisable('remove', selection)
       },
       {
         name: this.actionLabels.ENTER_MAINTENANCE,
         permission: 'update',
-        icon: Icons.enter,
+        icon: 'enter',
         click: () => this.hostMaintenance(),
         disable: (selection: CdTableSelection) =>
           this.getDisable('maintenance', selection) ||
@@ -203,7 +203,7 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
       {
         name: this.actionLabels.EXIT_MAINTENANCE,
         permission: 'update',
-        icon: Icons.exit,
+        icon: 'exit',
         click: () => this.hostMaintenance(),
         disable: (selection: CdTableSelection) =>
           this.getDisable('maintenance', selection) ||

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
@@ -96,7 +96,7 @@ export class InventoryDevicesComponent implements OnInit, OnDestroy {
     this.tableActions = [
       {
         permission: 'update',
-        icon: Icons.show,
+        icon: 'show',
         click: () => this.identifyDevice(),
         name: $localize`Identify`,
         disable: (selection: CdTableSelection) => this.getDisable('identify', selection),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
@@ -4,7 +4,6 @@ import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { ListWithDetails } from '~/app/shared/classes/list-with-details.class';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
@@ -69,21 +68,21 @@ export class MgrModuleListComponent extends ListWithDetails {
           return Object.values(this.selection.first().options).length === 0;
         },
         routerLink: () => `/mgr-modules/edit/${getModuleUri()}`,
-        icon: Icons.edit
+        icon: 'edit'
       },
       {
         name: $localize`Enable`,
         permission: 'update',
         click: () => this.updateModuleState(),
         disable: () => this.isTableActionDisabled('enabled'),
-        icon: Icons.start
+        icon: 'start'
       },
       {
         name: $localize`Disable`,
         permission: 'update',
         click: () => this.updateModuleState(),
         disable: () => this.getTableActionDisabledDesc(),
-        icon: Icons.stop
+        icon: 'stop'
       }
     ];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-list/multi-cluster-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-list/multi-cluster-list.component.ts
@@ -69,28 +69,28 @@ export class MultiClusterListComponent extends ListWithDetails implements OnInit
     this.tableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         name: this.actionLabels.CONNECT,
         disable: (selection: CdTableSelection) => this.getDisable('Connect', selection),
         routerLink: () => this.urlBuilder.getConnect()
       },
       {
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         name: this.actionLabels.EDIT,
         disable: (selection: CdTableSelection) => this.getDisable('edit', selection),
         routerLink: () => this.urlBuilder.getEdit(this.selection.first().name)
       },
       {
         permission: 'update',
-        icon: Icons.refresh,
+        icon: 'refresh',
         name: this.actionLabels.RECONNECT,
         disable: (selection: CdTableSelection) => this.getDisable('reconnect', selection),
         routerLink: () => this.urlBuilder.getReconnect(this.selection.first().name)
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         name: this.actionLabels.DISCONNECT,
         disable: (selection: CdTableSelection) => this.getDisable('disconnect', selection),
         click: () => this.openDeleteClusterModal()

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -124,7 +124,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.router.navigate([this.urlBuilder.getCreate()]),
         disable: (selection: CdTableSelection) => this.getDisable('create', selection),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
@@ -132,20 +132,20 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.editAction()
       },
       {
         name: this.actionLabels.FLAGS,
         permission: 'update',
-        icon: Icons.flag,
+        icon: 'flag',
         click: () => this.configureFlagsIndivAction(),
         disable: () => !this.hasOsdSelected
       },
       {
         name: this.actionLabels.SCRUB,
         permission: 'update',
-        icon: Icons.analyse,
+        icon: 'analyse',
         click: () => this.scrubAction(false),
         disable: () => !this.hasOsdSelected,
         canBePrimary: (selection: CdTableSelection) => selection.hasSelection
@@ -153,7 +153,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
       {
         name: this.actionLabels.DEEP_SCRUB,
         permission: 'update',
-        icon: Icons.deepCheck,
+        icon: 'deepCheck',
         click: () => this.scrubAction(true),
         disable: () => !this.hasOsdSelected
       },
@@ -162,28 +162,28 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
         permission: 'update',
         click: () => this.reweight(),
         disable: () => !this.hasOsdSelected || !this.selection.hasSingleSelection,
-        icon: Icons.reweight
+        icon: 'reweight'
       },
       {
         name: this.actionLabels.MARK_OUT,
         permission: 'update',
         click: () => this.showConfirmationModal($localize`out`, this.osdService.markOut),
         disable: () => this.isNotSelectedOrInState('out'),
-        icon: Icons.left
+        icon: 'left'
       },
       {
         name: this.actionLabels.MARK_IN,
         permission: 'update',
         click: () => this.showConfirmationModal($localize`in`, this.osdService.markIn),
         disable: () => this.isNotSelectedOrInState('in'),
-        icon: Icons.right
+        icon: 'right'
       },
       {
         name: this.actionLabels.MARK_DOWN,
         permission: 'update',
         click: () => this.showConfirmationModal($localize`down`, this.osdService.markDown),
         disable: () => this.isNotSelectedOrInState('down'),
-        icon: Icons.down
+        icon: 'down'
       },
       {
         name: this.actionLabels.MARK_LOST,
@@ -200,7 +200,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
             this.osdService.markLost
           ),
         disable: () => this.isNotSelectedOrInState('up'),
-        icon: Icons.flatten
+        icon: 'flatten'
       },
       {
         name: this.actionLabels.PURGE,
@@ -220,7 +220,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
             }
           ),
         disable: () => this.isNotSelectedOrInState('up'),
-        icon: Icons.erase
+        icon: 'erase'
       },
       {
         name: this.actionLabels.DESTROY,
@@ -240,14 +240,14 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
             }
           ),
         disable: () => this.isNotSelectedOrInState('up'),
-        icon: Icons.clearFilters
+        icon: 'clearFilters'
       },
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
         click: () => this.delete(),
         disable: (selection: CdTableSelection) => this.getDisable('delete', selection),
-        icon: Icons.destroy
+        icon: 'destroy'
       }
     ];
   }
@@ -256,21 +256,21 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
     this.clusterWideActions = [
       {
         name: $localize`Flags`,
-        icon: Icons.flag,
+        icon: 'flag',
         click: () => this.configureFlagsAction(),
         permission: 'read',
         visible: () => this.permissions.osd.read
       },
       {
         name: $localize`Recovery Priority`,
-        icon: Icons.deepCheck,
+        icon: 'deepCheck',
         click: () => this.configureQosParamsAction(),
         permission: 'read',
         visible: () => this.permissions.configOpt.read
       },
       {
         name: $localize`PG scrub`,
-        icon: Icons.analyse,
+        icon: 'analyse',
         click: () => this.configurePgScrubAction(),
         permission: 'read',
         visible: () => this.permissions.configOpt.read

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
@@ -84,7 +84,7 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
         canBePrimary: (selection: CdTableSelection) => selection.hasSingleSelection,
         disable: (selection: CdTableSelection) =>
           !selection.hasSingleSelection || selection.first().cdExecuting,
-        icon: Icons.add,
+        icon: 'add',
         routerLink: () =>
           '/monitoring' + this.urlBuilder.getCreateFrom(this.selection.first().fingerprint),
         name: $localize`Create Silence`

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-list/silence-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-list/silence-list.component.ts
@@ -9,7 +9,6 @@ import { PrometheusService } from '~/app/shared/api/prometheus.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n, SucceededActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { AlertmanagerSilence } from '~/app/shared/models/alertmanager-silence';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
@@ -73,7 +72,7 @@ export class SilenceListComponent extends PrometheusListHelper {
     this.tableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         routerLink: () => this.urlBuilder.getCreate(),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection,
         name: this.actionLabels.CREATE
@@ -87,13 +86,13 @@ export class SilenceListComponent extends PrometheusListHelper {
           selection.first().cdExecuting ||
           (selection.first().cdExecuting && selectionExpired(selection)) ||
           !selectionExpired(selection),
-        icon: Icons.copy,
+        icon: 'copy',
         routerLink: () => this.urlBuilder.getRecreate(this.selection.first().id),
         name: this.actionLabels.RECREATE
       },
       {
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         canBePrimary: (selection: CdTableSelection) =>
           selection.hasSingleSelection && !selectionExpired(selection),
         disable: (selection: CdTableSelection) =>
@@ -106,7 +105,7 @@ export class SilenceListComponent extends PrometheusListHelper {
       },
       {
         permission: 'delete',
-        icon: Icons.trash,
+        icon: 'trash',
         canBePrimary: (selection: CdTableSelection) =>
           selection.hasSingleSelection && !selectionExpired(selection),
         disable: (selection: CdTableSelection) =>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
@@ -117,28 +117,28 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
     this.tableActions = [
       {
         permission: 'update',
-        icon: Icons.start,
+        icon: 'start',
         click: () => this.daemonAction('start'),
         name: this.actionLabels.START,
         disable: () => this.actionDisabled('start')
       },
       {
         permission: 'update',
-        icon: Icons.stop,
+        icon: 'stop',
         click: () => this.daemonAction('stop'),
         name: this.actionLabels.STOP,
         disable: () => this.actionDisabled('stop')
       },
       {
         permission: 'update',
-        icon: Icons.restart,
+        icon: 'restart',
         click: () => this.daemonAction('restart'),
         name: this.actionLabels.RESTART,
         disable: () => this.actionDisabled('restart')
       },
       {
         permission: 'update',
-        icon: Icons.deploy,
+        icon: 'deploy',
         click: () => this.daemonAction('redeploy'),
         name: this.actionLabels.REDEPLOY,
         disable: () => this.actionDisabled('redeploy')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -105,7 +105,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
     this.tableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.openModal(),
         name: this.actionLabels.CREATE,
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
@@ -113,14 +113,14 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       },
       {
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () => this.openModal(true),
         name: this.actionLabels.EDIT,
         disable: (selection: CdTableSelection) => this.getDisable('update', selection)
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteAction(),
         name: this.actionLabels.DELETE,
         disable: (selection: CdTableSelection) => this.getDisable('delete', selection)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -11,7 +11,6 @@ import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { ViewCacheStatus } from '~/app/shared/enum/view-cache-status.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
@@ -100,7 +99,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
 
     const createAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => `/${prefix}/nfs/create`,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection,
       name: this.actionLabels.CREATE
@@ -108,7 +107,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
 
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       routerLink: () => [
         `/${prefix}/nfs/edit/${getNfsUri()}`,
         {
@@ -123,7 +122,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
 
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteNfsModal(),
       name: this.actionLabels.DELETE
     };

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -13,7 +13,6 @@ import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { ViewCacheStatus } from '~/app/shared/enum/view-cache-status.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
@@ -82,20 +81,20 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
     this.tableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         routerLink: () => this.urlBuilder.getCreate(),
         name: this.actionLabels.CREATE
       },
       {
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         routerLink: () =>
           this.urlBuilder.getEdit(encodeURIComponent(this.selection.first().pool_name)),
         name: this.actionLabels.EDIT
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deletePoolModal(),
         name: this.actionLabels.DELETE,
         disable: this.getDisableDesc.bind(this)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-lifecycle-list/rgw-bucket-lifecycle-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-lifecycle-list/rgw-bucket-lifecycle-list.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angu
 import { Bucket } from '../models/rgw-bucket';
 import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -72,20 +71,20 @@ export class RgwBucketLifecycleListComponent implements OnInit {
     ];
     const createAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       click: () => this.openTieringModal(this.actionLabels.CREATE),
       name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       disable: () => this.selection.hasMultiSelection,
       click: () => this.openTieringModal(this.actionLabels.EDIT),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteAction(),
       disable: () => !this.selection.hasSelection,
       name: this.actionLabels.DELETE,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -9,7 +9,6 @@ import { ListWithDetails } from '~/app/shared/classes/list-with-details.class';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
@@ -117,20 +116,20 @@ export class RgwBucketListComponent extends ListWithDetails implements OnInit, O
       )}`;
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => this.urlBuilder.getCreate(),
       name: this.actionLabels.CREATE,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       routerLink: () => this.urlBuilder.getEdit(getBucketUri()),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       title: $localize`Bucket is not empty. Remove all objects before deletion.`,
       click: () => this.deleteAction(),
       disable: () => this.selection.first()?.num_objects > 0,
@@ -138,7 +137,7 @@ export class RgwBucketListComponent extends ListWithDetails implements OnInit, O
     };
     const tieringAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       click: () => this.openTieringModal(),
       disable: () => !this.selection.hasSelection,
       name: this.actionLabels.TIERING

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-notification-list/rgw-bucket-notification-list.component.ts
@@ -28,7 +28,6 @@ import { TopicConfiguration } from '~/app/shared/models/notification-configurati
 import { RgwNotificationFormComponent } from '../rgw-notification-form/rgw-notification-form.component';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 
 const BASE_URL = 'rgw/bucket';
 @Component({
@@ -95,20 +94,20 @@ export class RgwBucketNotificationListComponent extends ListWithDetails implemen
 
     const createAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       click: () => this.openNotificationModal(this.actionLabels.CREATE),
       name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       disable: () => this.selection.hasMultiSelection,
       click: () => this.openNotificationModal(this.actionLabels.EDIT),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteAction(),
       disable: () => !this.selection.hasSelection,
       name: this.actionLabels.DELETE,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.ts
@@ -13,7 +13,6 @@ import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ListWithDetails } from '~/app/shared/classes/list-with-details.class';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { RgwConfigModalComponent } from '../rgw-config-modal/rgw-config-modal.component';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
@@ -87,14 +86,14 @@ export class RgwConfigurationPageComponent extends ListWithDetails implements On
     this.tableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         name: this.actionLabels.CREATE,
         click: () => this.openRgwConfigModal(false),
         disable: () => this.disableCreate
       },
       {
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         name: this.actionLabels.EDIT,
         click: () => this.openRgwConfigModal(true)
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
@@ -237,14 +237,14 @@ export class RgwMultisiteDetailsComponent extends CdForm implements OnDestroy, O
     this.createTableActions = [
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         name: this.actionLabels.CREATE + ' Realm',
         click: () => this.openModal('realm'),
         visible: () => !this.showMigrateAndReplicationActions
       },
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         name: this.actionLabels.CREATE + ' Zonegroup',
         click: () => this.openModal('zonegroup'),
         disable: () => this.getDisable(),
@@ -252,21 +252,21 @@ export class RgwMultisiteDetailsComponent extends CdForm implements OnDestroy, O
       },
       {
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         name: this.actionLabels.CREATE + ' Zone',
         click: () => this.openModal('zone'),
         visible: () => !this.showMigrateAndReplicationActions
       },
       {
         permission: 'create',
-        icon: Icons.download,
+        icon: 'download',
         name: this.actionLabels.IMPORT,
         click: () => this.openImportModal(),
         disable: () => this.getDisableImport()
       },
       {
         permission: 'create',
-        icon: Icons.upload,
+        icon: 'upload',
         name: this.actionLabels.EXPORT,
         click: () => this.openExportModal(),
         disable: () => this.getDisableExport()
@@ -275,7 +275,7 @@ export class RgwMultisiteDetailsComponent extends CdForm implements OnDestroy, O
     this.migrateTableAction = [
       {
         permission: 'create',
-        icon: Icons.wrench,
+        icon: 'wrench',
         name: this.actionLabels.MIGRATE,
         click: () => this.openMigrateModal()
       }
@@ -283,7 +283,7 @@ export class RgwMultisiteDetailsComponent extends CdForm implements OnDestroy, O
     this.multisiteReplicationActions = [
       {
         permission: 'create',
-        icon: Icons.wrench,
+        icon: 'wrench',
         name: this.actionLabels.SETUP_MULTISITE_REPLICATION,
         click: () =>
           this.router.navigate([BASE_URL, { outlets: { modal: 'setup-multisite-replication' } }])

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges, TemplateRef, ViewChild } from '@angular/core';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -116,20 +115,20 @@ export class RgwMultisiteSyncPolicyDetailsComponent implements OnChanges {
     ];
     const symAddAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       name: this.actionLabels.CREATE,
       click: () => this.openModal(FlowType.symmetrical),
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
     const symEditAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       name: this.actionLabels.EDIT,
       click: () => this.openModal(FlowType.symmetrical, true)
     };
     const symDeleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       disable: () => !this.symFlowSelection.hasSelection,
       name: this.actionLabels.DELETE,
       click: () => this.deleteFlow(FlowType.symmetrical),
@@ -138,14 +137,14 @@ export class RgwMultisiteSyncPolicyDetailsComponent implements OnChanges {
     this.symFlowTableActions = [symAddAction, symEditAction, symDeleteAction];
     const dirAddAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       name: this.actionLabels.CREATE,
       click: () => this.openModal(FlowType.directional),
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
     const dirDeleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       // TODO: disabling 'delete' as we are not getting flow_id from backend which is needed for deletion
       disable: () =>
         'Deleting the directional flow is disabled in the UI. Please use CLI to delete the directional flow',
@@ -156,20 +155,20 @@ export class RgwMultisiteSyncPolicyDetailsComponent implements OnChanges {
     this.dirFlowTableActions = [dirAddAction, dirDeleteAction];
     const pipeAddAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       name: this.actionLabels.CREATE,
       click: () => this.openPipeModal(),
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
     const pipeEditAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       name: this.actionLabels.EDIT,
       click: () => this.openPipeModal(true)
     };
     const pipeDeleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       disable: () => !this.pipeSelection.hasSelection,
       name: this.actionLabels.DELETE,
       click: () => this.deletePipe(),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy/rgw-multisite-sync-policy.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy/rgw-multisite-sync-policy.component.ts
@@ -9,7 +9,6 @@ import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
@@ -118,20 +117,20 @@ export class RgwMultisiteSyncPolicyComponent extends ListWithDetails implements 
     };
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       click: () => this.router.navigate([BASE_URL, { outlets: { modal: URLVerbs.CREATE } }]),
       name: this.actionLabels.CREATE,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       click: () => this.router.navigate([BASE_URL, { outlets: { modal: getEditURL() } }]),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteAction(),
       disable: () => !this.selection.hasSelection,
       name: this.actionLabels.DELETE,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-list/rgw-storage-class-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-list/rgw-storage-class-list.component.ts
@@ -13,7 +13,6 @@ import {
 } from '../models/rgw-storage-class.model';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { FinishedTask } from '~/app/shared/models/finished-task';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
 import { RgwZoneService } from '~/app/shared/api/rgw-zone.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
@@ -108,20 +107,20 @@ export class RgwStorageClassListComponent extends ListWithDetails implements OnI
       {
         name: this.actionLabels.CREATE,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.router.navigate([this.urlBuilder.getCreate()]),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         routerLink: () => [`/${BASE_URL}/edit/${getStorageUri()}`]
       },
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.removeStorageClassModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.ts
@@ -13,7 +13,6 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { RgwTopicService } from '~/app/shared/api/rgw-topic.service';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -83,7 +82,7 @@ export class RgwTopicListComponent extends ListWithDetails implements OnInit {
       this.selection.first() && `${encodeURIComponent(this.selection.first().key)}`;
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => this.urlBuilder.getCreate(),
       name: this.actionLabels.CREATE,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
@@ -91,14 +90,14 @@ export class RgwTopicListComponent extends ListWithDetails implements OnInit {
 
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       routerLink: () => this.urlBuilder.getEdit(getBucketUri()),
       name: this.actionLabels.EDIT
     };
 
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteAction(),
       disable: () => !this.selection.hasSelection,
       name: this.actionLabels.DELETE,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts/rgw-user-accounts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts/rgw-user-accounts.component.ts
@@ -11,7 +11,6 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { Account } from '../models/rgw-user-accounts';
 import { RgwUserAccountsService } from '~/app/shared/api/rgw-user-accounts.service';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { Router } from '@angular/router';
 import { ListWithDetails } from '~/app/shared/classes/list-with-details.class';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
@@ -135,20 +134,20 @@ export class RgwUserAccountsComponent extends ListWithDetails implements OnInit 
     };
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       click: () => this.router.navigate([`${BASE_URL}/${URLVerbs.CREATE}`]),
       name: this.actionLabels.CREATE,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       click: () => this.router.navigate([`${BASE_URL}/${getEditURL()}`]),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteAction(),
       name: this.actionLabels.DELETE
     };

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.ts
@@ -71,7 +71,7 @@ export class RgwUserDetailsComponent implements OnChanges, OnInit {
         name: $localize`Show`,
         permission: 'read',
         click: () => this.showKeyModal(),
-        icon: Icons.show
+        icon: 'show'
       }
     ];
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
@@ -141,20 +141,20 @@ export class RgwUserListComponent extends ListWithDetails implements OnInit {
       this.selection.first() && `${encodeURIComponent(this.selection.first().uid)}`;
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => this.urlBuilder.getCreate(),
       name: this.actionLabels.CREATE,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       routerLink: () => this.urlBuilder.getEdit(getUserUri()),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteAction(),
       disable: () => !this.selection.hasSelection,
       name: this.actionLabels.DELETE

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.ts
@@ -15,7 +15,6 @@ import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { SmbService } from '~/app/shared/api/smb.service';
 import { SMBCluster } from '../smb.model';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
@@ -74,20 +73,20 @@ export class SmbClusterListComponent extends ListWithDetails implements OnInit {
       {
         name: `${this.actionLabels.CREATE} cluster`,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         routerLink: () => this.urlBuilder.getCreate(),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         routerLink: () =>
           this.selection.first() && this.urlBuilder.getEdit(this.selection.first().cluster_id)
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.removeSMBClusterModal(),
         name: this.actionLabels.DELETE
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-list/smb-join-auth-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-list/smb-join-auth-list.component.ts
@@ -10,7 +10,6 @@ import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { SMBJoinAuth } from '../smb.model';
 import { Router } from '@angular/router';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
@@ -72,21 +71,21 @@ export class SmbJoinAuthListComponent implements OnInit {
       {
         name: `${this.actionLabels.CREATE} AD`,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.router.navigate([this.urlBuilder.getCreate()]),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () =>
           this.router.navigate([this.urlBuilder.getEdit(String(this.selection.first().auth_id))])
       },
       {
         name: this.actionLabels.DELETE,
         permission: 'update',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.openDeleteModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-list/smb-share-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-list/smb-share-list.component.ts
@@ -11,7 +11,6 @@ import { SmbService } from '~/app/shared/api/smb.service';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -119,14 +118,14 @@ export class SmbShareListComponent implements OnInit {
       {
         name: `${this.actionLabels.CREATE}`,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         routerLink: () => [`/${SHARE_PATH}/${URLVerbs.CREATE}`, this.clusterId],
         canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         routerLink: () => [
           `/${SHARE_PATH}/${URLVerbs.EDIT}`,
           this.clusterId,
@@ -135,7 +134,7 @@ export class SmbShareListComponent implements OnInit {
       },
       {
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.deleteShareModal(),
         name: this.actionLabels.DELETE
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-list/smb-usersgroups-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-list/smb-usersgroups-list.component.ts
@@ -15,7 +15,6 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { SmbService } from '~/app/shared/api/smb.service';
 import { SMBUsersGroups } from '../smb.model';
 import { Router } from '@angular/router';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
@@ -86,14 +85,14 @@ export class SmbUsersgroupsListComponent extends ListWithDetails implements OnIn
       {
         name: `${this.actionLabels.CREATE} standalone`,
         permission: 'create',
-        icon: Icons.add,
+        icon: 'add',
         click: () => this.router.navigate([this.urlBuilder.getCreate()]),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
-        icon: Icons.edit,
+        icon: 'edit',
         click: () =>
           this.router.navigate([
             this.urlBuilder.getEdit(String(this.selection.first().users_groups_id))
@@ -102,7 +101,7 @@ export class SmbUsersgroupsListComponent extends ListWithDetails implements OnIn
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
-        icon: Icons.destroy,
+        icon: 'destroy',
         click: () => this.openDeleteModal()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
@@ -10,7 +10,6 @@ import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete
 import { FormModalComponent } from '~/app/shared/components/form-modal/form-modal.component';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
-import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
@@ -55,20 +54,20 @@ export class RoleListComponent extends ListWithDetails implements OnInit {
     this.permission = this.authStorageService.getPermissions().user;
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => this.urlBuilder.getCreate(),
       name: this.actionLabels.CREATE
     };
     const cloneAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.clone,
+      icon: 'clone',
       name: this.actionLabels.CLONE,
       disable: () => !this.selection.hasSingleSelection,
       click: () => this.cloneRole()
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       disable: () => !this.selection.hasSingleSelection || this.selection.first().system,
       routerLink: () =>
         this.selection.first() && this.urlBuilder.getEdit(this.selection.first().name),
@@ -76,7 +75,7 @@ export class RoleListComponent extends ListWithDetails implements OnInit {
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       disable: () => !this.selection.hasSingleSelection || this.selection.first().system,
       click: () => this.deleteRoleModal(),
       name: this.actionLabels.DELETE

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -61,20 +61,20 @@ export class UserListComponent implements OnInit {
     this.permission = this.authStorageService.getPermissions().user;
     const addAction: CdTableAction = {
       permission: 'create',
-      icon: Icons.add,
+      icon: 'add',
       routerLink: () => this.urlBuilder.getCreate(),
       name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
-      icon: Icons.edit,
+      icon: 'edit',
       routerLink: () =>
         this.selection.first() && this.urlBuilder.getEdit(this.selection.first().username),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
-      icon: Icons.destroy,
+      icon: 'destroy',
       click: () => this.deleteUserModal(),
       name: this.actionLabels.DELETE
     };

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/datatable.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/datatable.module.ts
@@ -31,6 +31,37 @@ import ArrowDown from '@carbon/icons/es/caret--down/16';
 import ChevronDwon from '@carbon/icons/es/chevron--down/16';
 import CheckMarkIcon from '@carbon/icons/es/checkmark/32';
 import CubeIcon from '@carbon/icons/es/cube/32';
+import TrashCanIcon from '@carbon/icons/es/trash-can/16';
+import LockedIcon from '@carbon/icons/es/locked/16';
+import UnlockedIcon from '@carbon/icons/es/unlocked/16';
+import ReplicateIcon from '@carbon/icons/es/replicate/16';
+import UndoIcon from '@carbon/icons/es/undo/16';
+import PlayFilledIcon from '@carbon/icons/es/play--filled/16';
+import StopFilledIcon from '@carbon/icons/es/stop--filled/16';
+import StethoscopeIcon from '@carbon/icons/es/stethoscope/16';
+import SettingsIcon from '@carbon/icons/es/settings/16';
+import ScalesIcon from '@carbon/icons/es/scales/16';
+import ArrowLeftIcon from '@carbon/icons/es/arrow--left/16';
+import ArrowRightIcon from '@carbon/icons/es/arrow--right/16';
+import ArrowDownIcon from '@carbon/icons/es/arrow--down/16';
+import EraseIcon from '@carbon/icons/es/erase/16';
+import UnlinkIcon from '@carbon/icons/es/unlink/16';
+import ArrowsHorizontalIcon from '@carbon/icons/es/arrows--horizontal/16';
+import ViewIcon from '@carbon/icons/es/view/16';
+import CloseFilledIcon from '@carbon/icons/es/close--filled/16';
+import DownloadIcon from '@carbon/icons/es/download/16';
+import UploadIcon from '@carbon/icons/es/upload/16';
+import ToolsIcon from '@carbon/icons/es/tools/16';
+import LoginIcon from '@carbon/icons/es/login/16';
+import LogoutIcon from '@carbon/icons/es/logout/16';
+import FlagIcon from '@carbon/icons/es/flag/16';
+import RestartIcon from '@carbon/icons/es/restart/16';
+import ListIcon from '@carbon/icons/es/list/16';
+import ExportIcon from '@carbon/icons/es/export/16';
+import EditIcon from '@carbon/icons/es/edit/16';
+import CopyIcon from '@carbon/icons/es/copy/16';
+import DocumentAddIcon from '@carbon/icons/es/document--add/16';
+import DocumentImportIcon from '@carbon/icons/es/document--import/16';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule } from '@ngx-formly/core';
@@ -148,7 +179,38 @@ export class DataTableModule {
       ArrowDown,
       ChevronDwon,
       CheckMarkIcon,
-      CubeIcon
+      CubeIcon,
+      TrashCanIcon,
+      LockedIcon,
+      UnlockedIcon,
+      ReplicateIcon,
+      UndoIcon,
+      PlayFilledIcon,
+      StopFilledIcon,
+      StethoscopeIcon,
+      SettingsIcon,
+      ScalesIcon,
+      ArrowLeftIcon,
+      ArrowRightIcon,
+      ArrowDownIcon,
+      EraseIcon,
+      UnlinkIcon,
+      ArrowsHorizontalIcon,
+      ViewIcon,
+      CloseFilledIcon,
+      DownloadIcon,
+      UploadIcon,
+      ToolsIcon,
+      LoginIcon,
+      LogoutIcon,
+      FlagIcon,
+      RestartIcon,
+      ListIcon,
+      ExportIcon,
+      EditIcon,
+      CopyIcon,
+      DocumentAddIcon,
+      DocumentImportIcon
     ]);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.html
@@ -10,9 +10,9 @@
           [preserveFragment]="currentAction.preserveFragment ? '' : null"
           data-testid="primary-action">
     <span i18n>{{ currentAction.name }}</span>
-    <svg class="cds--btn__icon"
-         cdsIcon="add"
-         size="16"></svg>
+    <cd-icon class="cds--btn__icon"
+             [useDefault]="true"
+             [type]="currentAction.icon"></cd-icon>
   </button>
   <ng-container *ngIf="primaryDropDown">
     <button class="primary-dropdown-btn"
@@ -36,6 +36,8 @@
                                   data-testid="table-action-option-btn"
                                   i18n>
         {{ action.name }}
+        <cd-icon class="action-icon"
+                 [type]="action.icon"></cd-icon>
         </cds-overflow-menu-option>
       </ng-container>
     </ng-template>
@@ -68,6 +70,8 @@
                                 data-testid="table-action-option-btn"
                                 i18n>
       {{ action.name }}
+      <cd-icon class="action-icon"
+               [type]="action.icon"></cd-icon>
       </cds-overflow-menu-option>
     </ng-container>
   </cds-overflow-menu>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.scss
@@ -10,10 +10,6 @@ button.dropdown-item:hover {
   background-color: vv.$gray-300;
 }
 
-.action-icon {
-  padding-right: 1.5rem;
-}
-
 .action-label {
   font-weight: bold;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.spec.ts
@@ -29,18 +29,18 @@ describe('TableActionsComponent', () => {
   beforeEach(() => {
     addAction = {
       permission: 'create',
-      icon: 'fa-plus',
+      icon: 'add',
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection,
       name: 'Add'
     };
     editAction = {
       permission: 'update',
-      icon: 'fa-pencil',
+      icon: 'edit',
       name: 'Edit'
     };
     copyAction = {
       permission: 'create',
-      icon: 'fa-copy',
+      icon: 'copy',
       canBePrimary: (selection: CdTableSelection) => selection.hasSingleSelection,
       disable: (selection: CdTableSelection) =>
         !selection.hasSingleSelection || selection.first().cdExecuting,
@@ -48,7 +48,7 @@ describe('TableActionsComponent', () => {
     };
     deleteAction = {
       permission: 'delete',
-      icon: 'fa-times',
+      icon: 'destroy',
       canBePrimary: (selection: CdTableSelection) => selection.hasSelection,
       disable: (selection: CdTableSelection) =>
         !selection.hasSelection || selection.first().cdExecuting,
@@ -56,14 +56,14 @@ describe('TableActionsComponent', () => {
     };
     protectAction = {
       permission: 'update',
-      icon: 'fa-lock',
+      icon: 'lock',
       canBePrimary: () => false,
       visible: (selection: CdTableSelection) => selection.hasSingleSelection,
       name: 'Protect'
     };
     unprotectAction = {
       permission: 'update',
-      icon: 'fa-unlock',
+      icon: 'unlock',
       canBePrimary: () => false,
       visible: (selection: CdTableSelection) => !selection.hasSingleSelection,
       name: 'Unprotect'
@@ -208,7 +208,7 @@ describe('TableActionsComponent', () => {
     it('should return a description if disable method returns a string', () => {
       const deleteWithDescAction: CdTableAction = {
         permission: 'delete',
-        icon: 'fa-times',
+        icon: 'destroy',
         canBePrimary: (selection: CdTableSelection) => selection.hasSelection,
         disable: () => {
           return 'Delete action disabled description';
@@ -229,7 +229,7 @@ describe('TableActionsComponent', () => {
   describe('useClickAction', () => {
     const editClickAction: CdTableAction = {
       permission: 'update',
-      icon: 'fa-pencil',
+      icon: 'edit',
       name: 'Edit',
       click: () => {
         return 'Edit action click';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -289,6 +289,8 @@
                                 data-testid="table-action-option-btn"
                                 i18n>
         {{ action.name }}
+        <cd-icon class="action-icon"
+                 [type]="action.icon"></cd-icon>
       </cds-overflow-menu-option>
     </ng-container>
   </cds-overflow-menu>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -12,12 +12,12 @@ export enum Icons {
   trash = 'trash-can', // Move to trash
   lock = 'locked', // Protect
   unlock = 'unlocked', // Unprotect
-  clone = 'fa fa-clone', // clone
-  undo = 'fa fa-undo', // Rollback, Restore
+  clone = 'replicate', // clone
+  undo = 'undo', // Rollback, Restore
   search = 'search', // Search
-  start = 'fa fa-play', // Enable
-  stop = 'fa fa-stop', // Disable
-  analyse = 'fa fa-stethoscope', // Scrub
+  start = 'play--filled', // Enable
+  stop = 'stop--filled', // Disable
+  analyse = 'stethoscope', // Scrub
   deepCheck = 'settings', // Deep Scrub, Setting, Configuration
   cogs = 'fa fa-cogs', // Multiple Settings, Configurations
   reweight = 'scales', // Reweight
@@ -25,7 +25,7 @@ export enum Icons {
   left = 'arrow--left', // Mark out
   right = 'arrow--right', // Mark in
   down = 'arrow--down', // Mark Down
-  erase = 'fa fa-eraser', // Purge  color: bd.$white;
+  erase = 'erase', // Purge
   expand = 'maximize', // Expand cluster
   user = 'user', // User, Initiators
   users = 'user--multiple', // Users, Groups
@@ -52,34 +52,36 @@ export enum Icons {
   server = 'fa fa-server', // Server, Portal
   filter = 'filter', // Filter
   lineChart = 'analytics', // Line chart
-  signOut = 'fa fa-sign-out', // Sign Out
+  signOut = 'logout', // Sign Out
   circle = 'dot-mark', // Circle
   bell = 'notification', // Notification
   mute = 'notification--off', // Mute or silence
   leftArrow = 'caret--left', // Left facing angle
   rightArrow = 'caret--right', // Right facing angle
   downArrow = 'caret--down',
-  flag = 'fa fa-flag', // OSD configuration
+  flag = 'flag', // OSD configuration
   clearFilters = 'close--filled', // Clear filters, solid x
   download = 'download', // Download
-  upload = 'fa fa-upload', // Upload
+  upload = 'upload', // Upload
   code = 'code', // JSON file
   document = 'document', // Text file
   wrench = 'tools', // Configuration Error
-  enter = 'fa fa-sign-in', // Enter
-  exit = 'fa fa-sign-out', // Exit
-  restart = 'fa fa-history', // Restart
+  enter = 'login', // Enter
+  exit = 'logout', // Exit
+  restart = 'restart', // Restart
   deploy = 'cube', // Deploy, Redeploy
   cubes = 'fa fa-cubes', // Object storage
   sitemap = 'fa fa-sitemap', // Cluster, network, connections
   database = 'fa fa-database', // Database, Block storage
-  bars = 'fa fa-bars', // Stack, bars
+  bars = 'list', // Stack, bars
   navicon = 'fa fa-navicon', // Navigation
   areaChart = 'fa fa-area-chart', // Area Chart, dashboard
-  eye = 'fa fa-eye', // Observability
+  eye = 'view', // Observability
   calendar = 'fa fa-calendar',
   externalUrl = 'fa fa-external-link', // links to external page
-  nfsExport = 'fa fa-server', // NFS export
+  nfsExport = 'export', // NFS export
+  documentAdd = 'document--add', // Create Bootstrap Token
+  documentImport = 'document--import', // Import Bootstrap Token
   launch = 'launch',
   parentChild = 'parent-child',
   dataTable = 'data-table',
@@ -170,7 +172,40 @@ export const ICON_TYPE = {
   arrowUpRight: ' arrow--up-right',
   inProgress: 'in-progress',
   arrowDown: 'arrow--down',
-  destroy: 'close'
+  destroy: 'close',
+  trash: 'trash',
+  lock: 'lock',
+  unlock: 'unlock',
+  clone: 'clone',
+  undo: 'undo',
+  start: 'start',
+  stop: 'stop',
+  analyse: 'analyse',
+  deepCheck: 'deepCheck',
+  reweight: 'reweight',
+  left: 'left',
+  right: 'right',
+  down: 'down',
+  erase: 'erase',
+  expand: 'expand',
+  flatten: 'flatten',
+  refresh: 'refresh',
+  exchange: 'exchange',
+  show: 'show',
+  clearFilters: 'clearFilters',
+  download: 'download',
+  upload: 'upload',
+  wrench: 'wrench',
+  enter: 'enter',
+  exit: 'exit',
+  signOut: 'signOut',
+  flag: 'flag',
+  restart: 'restart',
+  eye: 'eye',
+  bars: 'bars',
+  nfsExport: 'nfsExport',
+  documentAdd: 'documentAdd',
+  documentImport: 'documentImport'
 } as const;
 
 export const EMPTY_STATE_IMAGE = {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-action.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-action.ts
@@ -1,3 +1,4 @@
+import { ICON_TYPE } from '~/app/shared/enum/icons.enum';
 import { CdTableSelection } from './cd-table-selection';
 
 export class CdTableAction {
@@ -16,8 +17,8 @@ export class CdTableAction {
   // The name of the action
   name: string;
 
-  // The font awesome icon that will be used
-  icon: string;
+  // The icon type key used with cd-icon component
+  icon: keyof typeof ICON_TYPE;
 
   // For adding the default tooltip
   title?: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
@@ -6,7 +6,6 @@ import { of as observableOf } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
-import { Icons } from '~/app/shared/enum/icons.enum';
 
 /**
  * This service checks if a route can be activated by executing a
@@ -90,7 +89,7 @@ export class ModuleStatusGuardService {
               navigate_to: config.navigate_to,
               uiConfig: config.uiConfig,
               uiApiPath: config.uiApiPath,
-              icon: Icons.wrench,
+              icon: 'wrench',
               component: config.component
             }
           });

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -139,6 +139,18 @@ Overflow menu
   box-shadow: none;
 }
 
+// Align action icons to the trailing edge of the overflow menu option, per
+// Carbon's menu anatomy guidance (https://carbondesignsystem.com/components/menu/usage/#anatomy).
+.cds--overflow-menu-options__option-content {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.cds--overflow-menu-options__option-content > .action-icon {
+  margin-inline-start: auto;
+}
+
 /******************************************
 Forms
 ******************************************/


### PR DESCRIPTION
mgr/dashboard: show table action icons also for non-primary actions

Currently only the primary table actions get shown with icons, but in the table action configuration icon data is passed for each action. This change renders the icon alongside the action name in all overflow menu dropdown options.

Fixes: https://tracker.ceph.com/issues/75755
Signed-off-by: Amir Ali Tariq <amiralitariq@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
