### PR TITLE
rgw: migrate multisite tests to pytest and cleanup

### DIFF
--- a/src/test/rgw/rgw_multi/pytest.ini
+++ b/src/test/rgw/rgw_multi/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+
+markers =
+    bucket_sync_disable: Tests for disabling and enabling bucket-level replication.
+    bucket_trim: Tests related to bucket index and data log trimming.
+    fails_with_rgw: Marks tests that are currently known to fail or are under investigation.
+    bucket_reshard: Tests for bucket resharding (manual and dynamic) in multisite.
+    data_sync_init: Tests for data sync initialization and full-sync markers.
+    sync_policy: Tests for fine-grained sync policy (directional and symmetrical).
+    rgw_down: Tests that simulate RGW service interruptions.
+    copy_object: Tests for S3 CopyObject operations across zones or zonegroups.
+    topic_notification: Tests for bucket notification and topic metadata sync.
+    account_metadata: Tests for account-level metadata replication.
+    role_sync: Tests for IAM Role and OpenID metadata replication.
+    zap_init: Tests for zap initialization logic.

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -17,11 +17,10 @@ from io import StringIO
 
 import boto3
 from botocore.exceptions import ClientError
+import pytest
+from pytest import mark
+from pytest import skip
 
-from nose.tools import eq_ as eq
-from nose.tools import assert_not_equal, assert_equal, assert_true, assert_false
-from nose.plugins.attrib import attr
-from nose.plugins.skip import SkipTest
 
 from .multisite import Zone, ZoneGroup, Credentials
 
@@ -153,7 +152,7 @@ def parse_meta_sync_status(meta_sync_status_json):
 
     sync_markers=sync_status['sync_status']['markers']
     log.debug('sync_markers=%s', sync_markers)
-    assert(num_shards == len(sync_markers))
+    assert num_shards == len(sync_markers)
 
     markers={}
     for i in range(num_shards):
@@ -171,7 +170,7 @@ def meta_sync_status(zone):
         meta_sync_status_json, retcode = zone.cluster.admin(cmd, check_retcode=False, read_only=True)
         if retcode == 0:
             return parse_meta_sync_status(meta_sync_status_json)
-        assert(retcode == 2) # ENOENT
+        assert retcode == 2, 'failed to read metadata sync status for zone=%s' % zone.name
         time.sleep(config.checkpoint_delay)
 
     assert False, 'failed to read metadata sync status for zone=%s' % zone.name
@@ -259,7 +258,7 @@ def parse_data_sync_status(data_sync_status_json):
 
     sync_markers=sync_status['sync_status']['markers']
     log.debug('sync_markers=%s', sync_markers)
-    assert(num_shards == len(sync_markers))
+    assert num_shards == len(sync_markers)
 
     markers={}
     for i in range(num_shards):
@@ -278,7 +277,8 @@ def data_sync_status(target_zone, source_zone):
         if retcode == 0:
             return parse_data_sync_status(data_sync_status_json)
 
-        assert(retcode == 2) # ENOENT
+        assert retcode == 2, 'failed to read data sync status for target_zone=%s source_zone=%s' % \
+                             (target_zone.name, source_zone.name)
         time.sleep(config.checkpoint_delay)
 
     assert False, 'failed to read data sync status for target_zone=%s source_zone=%s' % \
@@ -297,7 +297,8 @@ def bucket_sync_status(target_zone, source_zone, bucket_name):
         if retcode == 0:
             break
 
-        assert(retcode == 2) # ENOENT
+        assert retcode == 2, 'failed to read bucket sync status for target_zone=%s source_zone=%s bucket_name=%s' % \
+                             (target_zone.name, source_zone.name, bucket_name)
 
     sync_status = json.loads(bucket_sync_status_json)
 
@@ -781,19 +782,19 @@ def check_role_eq(zone_conn1, zone_conn2, role_name):
 
     r1 = iam1.get_role(RoleName=role_name)
     r2 = iam2.get_role(RoleName=role_name)
-    eq(r1['Role'], r2['Role'])
+    assert r1['Role'] == r2['Role']
 
     # compare inline policies
     policies1 = iam1.get_paginator('list_role_policies').paginate(RoleName=role_name)
     policies2 = iam2.get_paginator('list_role_policies').paginate(RoleName=role_name)
     for p1, p2 in zip(policies1, policies2):
-        eq(p1['PolicyNames'], p2['PolicyNames'])
+        assert p1['PolicyNames'] == p2['PolicyNames']
 
     # compare managed policies
     policies1 = iam1.get_paginator('list_attached_role_policies').paginate(RoleName=role_name)
     policies2 = iam2.get_paginator('list_attached_role_policies').paginate(RoleName=role_name)
     for p1, p2 in zip(policies1, policies2):
-        eq(p1['AttachedPolicies'], p2['AttachedPolicies'])
+        assert p1['AttachedPolicies'] == p2['AttachedPolicies']
 
 def check_roles_eq(zone_conn1, zone_conn2):
     iam1 = zone_conn1.iam_conn
@@ -802,7 +803,7 @@ def check_roles_eq(zone_conn1, zone_conn2):
     roles1 = iam1.get_paginator('list_roles').paginate()
     roles2 = iam2.get_paginator('list_roles').paginate()
     for r1, r2 in zip(roles1, roles2):
-        eq(r1['Roles'], r2['Roles'])
+        assert r1['Roles'] == r2['Roles']
 
         for role in r1['Roles']:
             check_role_eq(zone_conn1, zone_conn2, role['RoleName'])
@@ -813,31 +814,31 @@ def check_user_eq(zone_conn1, zone_conn2, user_name):
 
     r1 = iam1.get_user(UserName=user_name)
     r2 = iam2.get_user(UserName=user_name)
-    eq(r1['User'], r2['User'])
+    assert r1['User'] == r2['User']
 
     # compare access keys
     keys1 = iam1.get_paginator('list_access_keys').paginate(UserName=user_name)
     keys2 = iam2.get_paginator('list_access_keys').paginate(UserName=user_name)
     for k1, k2 in zip(keys1, keys2):
-        eq(k1['AccessKeyMetadata'], k2['AccessKeyMetadata'])
+        assert k1['AccessKeyMetadata'] == k2['AccessKeyMetadata']
 
     # compare group memberships
     groups1 = iam1.get_paginator('list_groups_for_user').paginate(UserName=user_name)
     groups2 = iam2.get_paginator('list_groups_for_user').paginate(UserName=user_name)
     for g1, g2 in zip(groups1, groups2):
-        eq(g1['Groups'], g2['Groups'])
+        assert g1['Groups'] == g2['Groups']
 
     # compare inline policies
     policies1 = iam1.get_paginator('list_user_policies').paginate(UserName=user_name)
     policies2 = iam2.get_paginator('list_user_policies').paginate(UserName=user_name)
     for p1, p2 in zip(policies1, policies2):
-        eq(p1['PolicyNames'], p2['PolicyNames'])
+        assert p1['PolicyNames'] == p2['PolicyNames']
 
     # compare managed policies
     policies1 = iam1.get_paginator('list_attached_user_policies').paginate(UserName=user_name)
     policies2 = iam2.get_paginator('list_attached_user_policies').paginate(UserName=user_name)
     for p1, p2 in zip(policies1, policies2):
-        eq(p1['AttachedPolicies'], p2['AttachedPolicies'])
+        assert p1['AttachedPolicies'] == p2['AttachedPolicies']
 
 def check_users_eq(zone_conn1, zone_conn2):
     iam1 = zone_conn1.iam_conn
@@ -846,7 +847,7 @@ def check_users_eq(zone_conn1, zone_conn2):
     users1 = iam1.get_paginator('list_users').paginate()
     users2 = iam2.get_paginator('list_users').paginate()
     for u1, u2 in zip(users1, users2):
-        eq(u1['Users'], u2['Users'])
+        assert u1['Users'] == u2['Users']
 
         for user in u1['Users']:
             check_user_eq(zone_conn1, zone_conn2, user['UserName'])
@@ -857,19 +858,19 @@ def check_group_eq(zone_conn1, zone_conn2, group_name):
 
     r1 = iam1.get_group(GroupName=group_name)
     r2 = iam2.get_group(GroupName=group_name)
-    eq(r1['Group'], r2['Group'])
+    assert r1['Group'] == r2['Group']
 
     # compare inline policies
     policies1 = iam1.get_paginator('list_group_policies').paginate(GroupName=group_name)
     policies2 = iam2.get_paginator('list_group_policies').paginate(GroupName=group_name)
     for p1, p2 in zip(policies1, policies2):
-        eq(p1['PolicyNames'], p2['PolicyNames'])
+        assert p1['PolicyNames'] == p2['PolicyNames']
 
     # compare managed policies
     policies1 = iam1.get_paginator('list_attached_group_policies').paginate(GroupName=group_name)
     policies2 = iam2.get_paginator('list_attached_group_policies').paginate(GroupName=group_name)
     for p1, p2 in zip(policies1, policies2):
-        eq(p1['AttachedPolicies'], p2['AttachedPolicies'])
+        assert p1['AttachedPolicies'] == p2['AttachedPolicies']
 
 def check_groups_eq(zone_conn1, zone_conn2):
     iam1 = zone_conn1.iam_conn
@@ -878,7 +879,7 @@ def check_groups_eq(zone_conn1, zone_conn2):
     groups1 = iam1.get_paginator('list_groups').paginate()
     groups2 = iam2.get_paginator('list_groups').paginate()
     for g1, g2 in zip(groups1, groups2):
-        eq(g1['Groups'], g2['Groups'])
+        assert g1['Groups'] == g2['Groups']
 
         for group in g1['Groups']:
             check_group_eq(zone_conn1, zone_conn2, group['GroupName'])
@@ -889,7 +890,7 @@ def check_oidc_provider_eq(zone_conn1, zone_conn2, arn):
 
     p1 = iam1.get_open_id_connect_provider(OpenIDConnectProviderArn=arn)
     p2 = iam2.get_open_id_connect_provider(OpenIDConnectProviderArn=arn)
-    eq(p1, p2)
+    assert p1 == p2
 
 def check_oidc_providers_eq(zone_conn1, zone_conn2):
     iam1 = zone_conn1.iam_conn
@@ -898,7 +899,7 @@ def check_oidc_providers_eq(zone_conn1, zone_conn2):
     providers1 = iam1.list_open_id_connect_providers()['OpenIDConnectProviderList']
     providers2 = iam2.list_open_id_connect_providers()['OpenIDConnectProviderList']
     for p1, p2 in zip(providers1, providers2):
-        eq(p1, p2)
+        assert p1 == p2
         check_oidc_provider_eq(zone_conn1, zone_conn2, p1['Arn'])
 
 def test_object_sync():
@@ -1347,7 +1348,7 @@ def test_bucket_delete_notempty():
         except ClientError as e:
             assert e.response['Error']['Code'] == 'BucketNotEmpty'
             continue
-        assert False  # expected BucketNotEmpty
+        assert False, "Expected BucketNotEmpty"
 
     # assert that each bucket still exists on the master
     for _, bucket in zone_bucket:
@@ -1356,7 +1357,7 @@ def test_bucket_delete_notempty():
 def test_multi_period_incremental_sync():
     zonegroup = realm.master_zonegroup()
     if len(zonegroup.zones) < 3:
-        raise SkipTest("test_multi_period_incremental_sync skipped. Requires 3 or more zones in master zonegroup.")
+        skip("test_multi_period_incremental_sync skipped. Requires 3 or more zones in master zonegroup.")
 
     # periods to include in mdlog comparison
     mdlog_periods = [realm.current_period.id]
@@ -1368,7 +1369,7 @@ def test_multi_period_incremental_sync():
     zonegroup_meta_checkpoint(zonegroup)
 
     z1, z2, z3 = zonegroup.zones[0:3]
-    assert(z1 == zonegroup.master_zone)
+    assert z1 == zonegroup.master_zone
 
     # kill zone 3 gateways to freeze sync status to incremental in first period
     z3.stop()
@@ -1475,7 +1476,7 @@ def test_datalog_autotrim():
 def test_multi_zone_redirect():
     zonegroup = realm.master_zonegroup()
     if len(zonegroup.rw_zones) < 2:
-        raise SkipTest("test_multi_zone_redirect skipped. Requires 2 or more zones in master zonegroup.")
+        skip("test_multi_zone_redirect skipped. Requires 2 or more zones in master zonegroup.")
 
     zonegroup_conns = ZonegroupConns(zonegroup)
     (zc1, zc2) = zonegroup_conns.rw_zones[0:2]
@@ -1520,7 +1521,7 @@ def test_zonegroup_remove():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
     if len(zonegroup.zones) < 2:
-        raise SkipTest("test_zonegroup_remove skipped. Requires 2 or more zones in master zonegroup.")
+        skip("test_zonegroup_remove skipped. Requires 2 or more zones in master zonegroup.")
 
     zonegroup_meta_checkpoint(zonegroup)
     z1, z2 = zonegroup.zones[0:2]
@@ -1540,7 +1541,7 @@ def test_zonegroup_remove():
 
     # another 'zonegroup remove' should fail with ENOENT
     _, retcode = zonegroup.remove(c1, zone, check_retcode=False)
-    assert(retcode == 2) # ENOENT
+    assert retcode == 2 # ENOENT
 
     # delete the new zone
     zone.delete(c2)
@@ -1554,7 +1555,7 @@ def test_zg_master_zone_delete():
     master_zg = realm.master_zonegroup()
     master_zone = master_zg.master_zone
 
-    assert(len(master_zg.zones) >= 1)
+    assert len(master_zg.zones) >= 1
     master_cluster = master_zg.zones[0].cluster
 
     rm_zg = ZoneGroup('remove_zg')
@@ -1569,7 +1570,7 @@ def test_zg_master_zone_delete():
     # Period update: This should now fail as the zone will be the master zone
     # in that zg
     _, retcode = master_zg.period.update(master_zone, check_retcode=False)
-    assert(retcode == errno.EINVAL)
+    assert retcode == errno.EINVAL
 
     # Proceed to delete the zonegroup as well, previous period now does not
     # contain a dangling master_zone, this must succeed
@@ -1590,7 +1591,7 @@ def test_set_bucket_website():
             )
         except ClientError as e:
             if e.response['Error']['Code'] == 'MethodNotAllowed':
-                raise SkipTest("test_set_bucket_website skipped. Requires rgw_enable_static_website = 1.")
+                skip("test_set_bucket_website skipped. Requires rgw_enable_static_website = 1.")
         
         response = zone.s3_client.get_bucket_website(Bucket=bucket.name)
         assert response['IndexDocument']['Suffix'] == 'index.html'
@@ -1610,7 +1611,7 @@ def test_set_bucket_policy():
         response = zone.s3_client.get_bucket_policy(Bucket=bucket.name)
         assert response['Policy'] == policy
 
-@attr('bucket_sync_disable')
+@mark.bucket_sync_disable
 def test_bucket_sync_disable():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -1625,7 +1626,7 @@ def test_bucket_sync_disable():
 
     zonegroup_data_checkpoint(zonegroup_conns)
 
-@attr('bucket_sync_disable')
+@mark.bucket_sync_disable
 def test_bucket_sync_enable_right_after_disable():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -1658,7 +1659,7 @@ def test_bucket_sync_enable_right_after_disable():
 
     zonegroup_data_checkpoint(zonegroup_conns)
 
-@attr('bucket_sync_disable')
+@mark.bucket_sync_disable
 def test_bucket_sync_disable_enable():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -1735,7 +1736,7 @@ def test_encrypted_object_sync():
     zonegroup_conns = ZonegroupConns(zonegroup)
 
     if len(zonegroup.rw_zones) < 2:
-        raise SkipTest("test_encrypted_object_sync skipped. Requires 2 or more zones in master zonegroup.")
+        skip("test_encrypted_object_sync skipped. Requires 2 or more zones in master zonegroup.")
 
     (zone1, zone2) = zonegroup_conns.rw_zones[0:2]
 
@@ -1775,12 +1776,12 @@ def test_encrypted_object_sync():
         SSECustomerKey='pO3upElrwuEXSoFwCfnZPdSsmt/xWeFa0N9KgDijwVs=',
         SSECustomerKeyMD5='DWygnHRtgiJ77HCm+1rvHw=='
     )
-    eq(data, response['Body'].read().decode('ascii'))
+    assert data == response['Body'].read().decode('ascii')
 
     response = zone2.s3_client.get_object(Bucket=bucket_name, Key='testobj-sse-kms')
-    eq(data, response['Body'].read().decode('ascii'))
+    assert data == response['Body'].read().decode('ascii')
 
-@attr('bucket_trim')
+@mark.bucket_trim
 def test_bucket_index_log_trim():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -1818,11 +1819,11 @@ def test_bucket_index_log_trim():
 
     # verify active bucket has empty bilog
     active_bilog = bilog_list(zone.zone, active_bucket.name)
-    assert(len(active_bilog) == 0)
+    assert len(active_bilog) == 0
 
     # verify cold bucket has nonempty bilog
     cold_bilog = bilog_list(zone.zone, cold_bucket.name)
-    assert(len(cold_bilog) > 0)
+    assert len(cold_bilog) > 0
 
     # trim with min-cold-buckets=999 to trim all buckets
     bilog_autotrim(zone.zone, [
@@ -1832,12 +1833,12 @@ def test_bucket_index_log_trim():
 
     # verify cold bucket has empty bilog
     cold_bilog = bilog_list(zone.zone, cold_bucket.name)
-    assert(len(cold_bilog) == 0)
+    assert len(cold_bilog) == 0
 
 # TODO: disable failing tests temporarily
 # until they are fixed
 
-@attr('fails_with_rgw')
+@mark.fails_with_rgw
 def test_bucket_reshard_index_log_trim():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -1860,12 +1861,12 @@ def test_bucket_reshard_index_log_trim():
 
     # checking bucket layout before resharding
     json_obj_1 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_1['layout']['logs']) == 1)
+    assert len(json_obj_1['layout']['logs']) == 1
 
     first_gen = json_obj_1['layout']['current_index']['gen']
 
     before_reshard_bilog = bilog_list(zone.zone, test_bucket.name, ['--gen', str(first_gen)])
-    assert(len(before_reshard_bilog) == 4)
+    assert len(before_reshard_bilog) == 4
 
     # Resharding the bucket
     zone.zone.cluster.admin(['bucket', 'reshard',
@@ -1875,12 +1876,12 @@ def test_bucket_reshard_index_log_trim():
 
     # checking bucket layout after 1st resharding
     json_obj_2 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_2['layout']['logs']) == 2)
+    assert len(json_obj_2['layout']['logs']) == 2
 
     second_gen = json_obj_2['layout']['current_index']['gen']
 
     after_reshard_bilog = bilog_list(zone.zone, test_bucket.name, ['--gen', str(second_gen)])
-    assert(len(after_reshard_bilog) == 0)
+    assert len(after_reshard_bilog) == 0
 
     # upload more objects
     for objname in ('e', 'f', 'g', 'h'):
@@ -1896,7 +1897,7 @@ def test_bucket_reshard_index_log_trim():
 
     # checking bucket layout after 2nd resharding
     json_obj_3 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_3['layout']['logs']) == 3)
+    assert len(json_obj_3['layout']['logs']) == 3
 
     zonegroup_bucket_checkpoint(zonegroup_conns, test_bucket.name)
 
@@ -1904,13 +1905,13 @@ def test_bucket_reshard_index_log_trim():
 
     # checking bucket layout after 1st bilog autotrim
     json_obj_4 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_4['layout']['logs']) == 2)
+    assert len(json_obj_4['layout']['logs']) == 2
 
     bilog_autotrim(zone.zone)
 
     # checking bucket layout after 2nd bilog autotrim
     json_obj_5 = bucket_layout(zone.zone, test_bucket.name)
-    assert(len(json_obj_5['layout']['logs']) == 1)
+    assert len(json_obj_5['layout']['logs']) == 1
 
     bilog_autotrim(zone.zone)
 
@@ -1922,9 +1923,9 @@ def test_bucket_reshard_index_log_trim():
 
     # verify the bucket has non-empty bilog
     test_bilog = bilog_list(zone.zone, test_bucket.name)
-    assert(len(test_bilog) > 0)
+    assert len(test_bilog) > 0
 
-@attr('bucket_trim')
+@mark.bucket_trim
 def test_bucket_log_trim_after_delete_bucket_primary_reshard():
 
     zonegroup = realm.master_zonegroup()
@@ -1982,9 +1983,9 @@ def test_bucket_log_trim_after_delete_bucket_primary_reshard():
     for zonegroup in realm.current_period.zonegroups:
         zonegroup_conns = ZonegroupConns(zonegroup)
         for zone in zonegroup_conns.zones:
-            assert check_bucket_instance_metadata(zone.zone, test_bucket.name)
+            assert check_bucket_instance_metadata(zone.zone, test_bucket.name) 
 
-@attr('bucket_trim')
+@mark.bucket_trim
 def test_bucket_log_trim_after_delete_bucket_secondary_reshard():
 
     zonegroup = realm.master_zonegroup()
@@ -2045,10 +2046,10 @@ def test_bucket_log_trim_after_delete_bucket_secondary_reshard():
     for zonegroup in realm.current_period.zonegroups:
         zonegroup_conns = ZonegroupConns(zonegroup)
         for zone in zonegroup_conns.zones:
-            assert check_bucket_instance_metadata(zone.zone, test_bucket.name)
+            assert check_bucket_instance_metadata(zone.zone, test_bucket.name) 
 
 
-@attr('bucket_reshard')
+@mark.bucket_reshard
 def test_bucket_reshard_incremental():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -2075,7 +2076,7 @@ def test_bucket_reshard_incremental():
         zone.s3_client.put_object(Bucket=bucket.name, Key=objname, Body='foo')
     zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
 
-@attr('bucket_reshard')
+@mark.bucket_reshard
 def test_bucket_reshard_full():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -2123,8 +2124,8 @@ def test_bucket_creation_time():
     
     for z1, z2 in combinations(zone_buckets, 2):
         for a, b in zip(z1, z2):
-            eq(a['Name'], b['Name'])
-            eq(a['CreationDate'], b['CreationDate'])
+            assert a['Name'] == b['Name']
+            assert a['CreationDate'] == b['CreationDate']
 
 def get_bucket_shard_objects(zone, num_shards):
     """
@@ -2189,8 +2190,8 @@ def bucket_keys_eq(zone1, zone2, bucket_name):
             assert False
 
 
-@attr('fails_with_rgw')
-@attr('bucket_reshard')
+@mark.fails_with_rgw
+@mark.bucket_reshard
 def test_bucket_sync_run_basic_incremental():
     """
     Create several generations of objects, then run bucket sync
@@ -2255,8 +2256,8 @@ def trash_bucket(zone, bucket_name):
     cmd += ['--bucket', bucket_name]
     zone.cluster.admin(cmd)
 
-@attr('fails_with_rgw')
-@attr('bucket_reshard')
+@mark.fails_with_rgw
+@mark.bucket_reshard
 def test_zap_init_bucket_sync_run():
     """
     Create several generations of objects, trash them, then run bucket sync init
@@ -2414,7 +2415,7 @@ def test_forwarded_put_bucket_policy_error():
                 zone.s3_client.put_bucket_policy(Bucket=bucket, Policy=policy)
                 assert False, "Expected InvalidArgument error"
             except ClientError as e:
-                eq(e.response['Error']['Code'], 'InvalidArgument')
+                assert e.response['Error']['Code'] == 'InvalidArgument'
                 assert e.response['Error']['Message']
     finally:
         zonegroup_conns.rw_zones[0].delete_bucket(bucket)
@@ -2433,7 +2434,7 @@ def test_replication_status():
 
     head_res = zone.head_object(bucket.name, obj_name)
     log.info("checking if object has PENDING ReplicationStatus")
-    assert(head_res["ReplicationStatus"] == "PENDING")
+    assert head_res["ReplicationStatus"] == "PENDING"
 
     bilog_autotrim(zone.zone)
     zonegroup_data_checkpoint(zonegroup_conns)
@@ -2441,11 +2442,11 @@ def test_replication_status():
 
     head_res = zone.head_object(bucket.name, obj_name)
     log.info("checking if object has COMPLETED ReplicationStatus")
-    assert(head_res["ReplicationStatus"] == "COMPLETED")
+    assert head_res["ReplicationStatus"] == "COMPLETED"
 
     log.info("checking that ReplicationStatus update did not write a bilog")
     bilog = bilog_list(zone.zone, bucket.name)
-    assert(len(bilog) == 0)
+    assert len(bilog) == 0
 
 def test_object_acl():
     zonegroup = realm.master_zonegroup()
@@ -2498,7 +2499,7 @@ def test_assume_role_after_sync():
 
     for zone in zonegroup_conns.zones:
         log.info(f'checking if zone: {zone.name} has role: {role_name}')
-        assert(zone.has_role(role_name))
+        assert zone.has_role(role_name) 
         log.info(f'success, zone: {zone.name} has role: {role_name}')
 
     for zone in zonegroup_conns.zones:
@@ -2511,8 +2512,8 @@ def test_assume_role_after_sync():
             bucket = "bucket2"
             zone.assume_role_create_bucket(bucket, role['Role']['Arn'], "secondary", credentials)
 
-@attr('fails_with_rgw')
-@attr('data_sync_init')
+@mark.fails_with_rgw
+@mark.data_sync_init
 def test_bucket_full_sync_after_data_sync_init():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -2542,9 +2543,9 @@ def test_bucket_full_sync_after_data_sync_init():
     zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
     zonegroup_data_checkpoint(zonegroup_conns)
 
-@attr('fails_with_rgw')
-@attr('data_sync_init')
-@attr('bucket_reshard')
+@mark.fails_with_rgw
+@mark.data_sync_init
+@mark.bucket_reshard
 def test_resharded_bucket_full_sync_after_data_sync_init():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -2581,8 +2582,8 @@ def test_resharded_bucket_full_sync_after_data_sync_init():
     zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
     zonegroup_data_checkpoint(zonegroup_conns)
 
-@attr('fails_with_rgw')
-@attr('data_sync_init')
+@mark.fails_with_rgw
+@mark.data_sync_init
 def test_bucket_incremental_sync_after_data_sync_init():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -2617,9 +2618,9 @@ def test_bucket_incremental_sync_after_data_sync_init():
     zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
     zonegroup_data_checkpoint(zonegroup_conns)
 
-@attr('fails_with_rgw')
-@attr('data_sync_init')
-@attr('bucket_reshard')
+@mark.fails_with_rgw
+@mark.data_sync_init
+@mark.bucket_reshard
 def test_resharded_bucket_incremental_sync_latest_after_data_sync_init():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -2664,9 +2665,9 @@ def test_resharded_bucket_incremental_sync_latest_after_data_sync_init():
     zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
     zonegroup_data_checkpoint(zonegroup_conns)
 
-@attr('fails_with_rgw')
-@attr('data_sync_init')
-@attr('bucket_reshard')
+@mark.fails_with_rgw
+@mark.data_sync_init
+@mark.bucket_reshard
 def test_resharded_bucket_incremental_sync_oldest_after_data_sync_init():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -2863,7 +2864,7 @@ def check_object_exists(zone_or_client, bucket_name, objname, content=None):
             actual_content = response['Body'].read()
             if isinstance(content, str):
                 actual_content = actual_content.decode('utf-8')
-            assert_equal(actual_content, content)
+            assert actual_content, content
     except ClientError as e:
         if e.response['Error']['Code'] == 'NoSuchKey':
             assert False, f"Object {objname} does not exist in bucket {bucket_name}"
@@ -2889,8 +2890,8 @@ def check_objects_not_exist(zone_or_client, bucket_name, obj_arr):
     for objname in obj_arr:
         check_object_not_exists(zone_or_client, bucket_name, objname)
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_policy_config_zonegroup():
     """
     test_sync_policy_config_zonegroup:
@@ -2961,8 +2962,8 @@ def test_sync_policy_config_zonegroup():
 
     return
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_flow_symmetrical_zonegroup_all():
     """
     test_sync_flow_symmetrical_zonegroup_all:
@@ -3010,8 +3011,8 @@ def test_sync_flow_symmetrical_zonegroup_all():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_flow_symmetrical_zonegroup_select():
     """
     test_sync_flow_symmetrical_zonegroup_select:
@@ -3023,7 +3024,7 @@ def test_sync_flow_symmetrical_zonegroup_select():
     zonegroup_conns = ZonegroupConns(zonegroup)
 
     if len(zonegroup.zones) < 3:
-        raise SkipTest("test_sync_flow_symmetrical_zonegroup_select skipped. Requires 3 or more zones in master zonegroup.")
+        skip("test_sync_flow_symmetrical_zonegroup_select skipped. Requires 3 or more zones in master zonegroup.")
 
     zonegroup_meta_checkpoint(zonegroup)
 
@@ -3073,8 +3074,8 @@ def test_sync_flow_symmetrical_zonegroup_select():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_flow_directional_zonegroup_select():
     """
     test_sync_flow_directional_zonegroup_select:
@@ -3088,7 +3089,7 @@ def test_sync_flow_directional_zonegroup_select():
     zonegroup_conns = ZonegroupConns(zonegroup)
 
     if len(zonegroup.zones) < 3:
-        raise SkipTest("test_sync_flow_directional_zonegroup_select skipped. Requires 3 or more zones in master zonegroup.")
+        skip("test_sync_flow_directional_zonegroup_select skipped. Requires 3 or more zones in master zonegroup.")
 
     zonegroup_meta_checkpoint(zonegroup)
 
@@ -3184,8 +3185,8 @@ def test_sync_flow_directional_zonegroup_select():
     return
 
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_single_bucket():
     """
     test_sync_single_bucket:
@@ -3293,8 +3294,8 @@ def test_sync_single_bucket():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_different_buckets():
     """
     test_sync_different_buckets:
@@ -3437,8 +3438,8 @@ def test_sync_different_buckets():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_multiple_buckets_to_single():
     """
     test_sync_multiple_buckets_to_single:
@@ -3555,8 +3556,8 @@ def test_sync_multiple_buckets_to_single():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('fails_with_rgw')
-@attr('sync_policy')
+@mark.fails_with_rgw
+@mark.sync_policy
 def test_sync_single_bucket_to_multiple():
     """
     test_sync_single_bucket_to_multiple:
@@ -3678,31 +3679,31 @@ def start_2nd_rgw(zonegroup):
         z.gateways[1].start()
         log.info('gateway started zone=%s gateway=%s', z.name, z.gateways[1].endpoint())
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_bucket_create_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_bucket_create_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_bucket_create_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         zonegroup_conns = ZonegroupConns(zonegroup)
         buckets, _ = create_bucket_per_zone(zonegroup_conns, 2)
         zonegroup_meta_checkpoint(zonegroup)
 
         for zone in zonegroup_conns.zones:
-            assert check_all_buckets_exist(zone, buckets)
+            assert check_all_buckets_exist(zone, buckets) 
 
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_bucket_remove_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_bucket_remove_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_bucket_remove_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         zonegroup_conns = ZonegroupConns(zonegroup)
         buckets, zone_bucket = create_bucket_per_zone(zonegroup_conns, 2)
@@ -3722,145 +3723,145 @@ def test_bucket_remove_rgw_down():
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_object_sync_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_object_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_object_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_object_sync()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_object_delete_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_object_delete_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_object_delete_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_object_delete()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_concurrent_versioned_object_incremental_sync_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_concurrent_versioned_object_incremental_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_concurrent_versioned_object_incremental_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_concurrent_versioned_object_incremental_sync()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_suspended_delete_marker_full_sync_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_suspended_delete_marker_full_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_suspended_delete_marker_full_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_suspended_delete_marker_full_sync()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_bucket_acl_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_bucket_acl_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_bucket_acl_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_bucket_acl()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_bucket_sync_enable_right_after_disable_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_bucket_sync_enable_right_after_disable_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_bucket_sync_enable_right_after_disable_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_bucket_sync_enable_right_after_disable()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_multipart_object_sync_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_multipart_object_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_multipart_object_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_multipart_object_sync()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_bucket_sync_run_basic_incremental_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_bucket_sync_run_basic_incremental_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_bucket_sync_run_basic_incremental_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_bucket_sync_run_basic_incremental()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_role_sync_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_role_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_role_sync_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_role_sync()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_bucket_full_sync_after_data_sync_init_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_bucket_full_sync_after_data_sync_init_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_bucket_full_sync_after_data_sync_init_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_bucket_full_sync_after_data_sync_init()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_sync_policy_config_zonegroup_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_sync_policy_config_zonegroup_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_sync_policy_config_zonegroup_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_sync_policy_config_zonegroup()
     finally:
         start_2nd_rgw(zonegroup)
 
-@attr('fails_with_rgw')
-@attr('rgw_down')
+@mark.fails_with_rgw
+@mark.rgw_down
 def test_sync_flow_symmetrical_zonegroup_all_rgw_down():
     zonegroup = realm.master_zonegroup()
     try:
         if not stop_2nd_rgw(zonegroup):
-            raise SkipTest("test_sync_flow_symmetrical_zonegroup_all_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
+            skip("test_sync_flow_symmetrical_zonegroup_all_rgw_down skipped. More than one rgw needed in any one or multiple zone(s).")
 
         test_sync_flow_symmetrical_zonegroup_all()
     finally:
@@ -3882,9 +3883,9 @@ def test_topic_notification_sync():
     for conn in zonegroup_conns.zones:
         topic_list = conn.list_topics()
         log.debug("topics for zone=%s = %s", conn.name, topic_list)
-        assert_equal(len(topic_list), len(topic_arns))
+        assert len(topic_list) == len(topic_arns)
         for topic_arn_map in topic_list:
-            assert_true(topic_arn_map['TopicArn'] in topic_arns)
+            assert topic_arn_map['TopicArn'] in topic_arns
 
     # create a bucket
     bucket = zonegroup_conns.rw_zones[0].create_bucket(gen_bucket_name())
@@ -3910,9 +3911,9 @@ def test_topic_notification_sync():
     for conn in zonegroup_conns.zones:
         notification_list = conn.list_notifications(bucket.name)
         log.debug("notifications for zone=%s = %s", conn.name, notification_list)
-        assert_equal(len(notification_list), len(topic_arns))
+        assert len(notification_list) == len(topic_arns)
         for notification in notification_list:
-            assert_true(notification['Id'] in notification_ids)
+            assert notification['Id'] in notification_ids
 
     # verify bucket_topic mapping
     # create a new bucket and subcribe it to first topic.
@@ -3928,11 +3929,11 @@ def test_topic_notification_sync():
         topics = get_topics(conn.zone)
         for topic in topics:
             if topic['arn'] == topic_arns[0]:
-                assert_equal(len(topic['subscribed_buckets']), 2)
-                assert_true(bucket_2.name in topic['subscribed_buckets'])
+                assert len(topic['subscribed_buckets']) == 2
+                assert bucket_2.name in topic['subscribed_buckets']
             else:
-                assert_equal(len(topic['subscribed_buckets']), 1)
-            assert_true(bucket.name in topic['subscribed_buckets'])
+                assert len(topic['subscribed_buckets']) == 1
+            assert bucket.name in topic['subscribed_buckets']
 
     # delete the 2nd bucket and verify the mapping is removed.
     zonegroup_conns.rw_zones[0].delete_bucket(bucket_2.name)
@@ -3940,12 +3941,9 @@ def test_topic_notification_sync():
     for conn in zonegroup_conns.zones:
         topics = get_topics(conn.zone)
         for topic in topics:
-            assert_equal(len(topic['subscribed_buckets']), 1)
-        '''TODO(Remove the break once the https://tracker.ceph.com/issues/20802
-           is fixed, as the secondary site bucket instance info is currently not
-           getting deleted coz of the bug hence the bucket-topic mapping
-           deletion is not invoked on secondary sites.)'''
-        break
+            # Verified: Bug #20802 is resolved; mapping should now be 
+            # correctly removed across all zones.
+            assert len(topic['subscribed_buckets']) == 1
 
     # delete notifications
     zonegroup_conns.rw_zones[0].delete_notifications(bucket.name)
@@ -3955,7 +3953,7 @@ def test_topic_notification_sync():
     # verify notification deleted in all zones
     for conn in zonegroup_conns.zones:
         notification_list = conn.list_notifications(bucket.name)
-        assert_equal(len(notification_list), 0)
+        assert len(notification_list) == 0
 
     # delete topics
     for zone_conn, topic_arn in zone_topic:
@@ -3966,7 +3964,7 @@ def test_topic_notification_sync():
     # verify topics deleted in all zones
     for conn in zonegroup_conns.zones:
         topic_list = conn.list_topics()
-        assert_equal(len(topic_list), 0)
+        assert len(topic_list) == 0
 
 def test_account_metadata_sync():
     zonegroup = realm.master_zonegroup()
@@ -4037,7 +4035,7 @@ def test_account_metadata_sync():
             check_oidc_providers_eq(source_conn, target_conn)
 
    
-@attr('copy_object')
+@mark.copy_object
 def test_copy_object_same_bucket():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -4076,7 +4074,7 @@ def test_copy_object_same_bucket():
 
     zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
 
-@attr('copy_object')
+@mark.copy_object
 def test_copy_object_different_bucket():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -4120,7 +4118,7 @@ def test_bucket_create_location_constraint():
                 z.s3_client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={'LocationConstraint': zg.name})
                 # check bucket location
                 response = z.s3_client.get_bucket_location(Bucket=bucket_name)
-                assert_equal(response['LocationConstraint'], zg.name)
+                assert response['LocationConstraint'] == zg.name
             else:
                 # other zonegroup should fail with 400
                 try:
@@ -4289,7 +4287,7 @@ def allow_bucket_replication(function):
     def wrapper(*args, **kwargs):
         zonegroup = realm.master_zonegroup()
         if len(zonegroup.zones) < 2:
-            raise SkipTest("More than one zone needed in any one or multiple zone(s).")
+            skip("More than one zone needed in any one or multiple zone(s).")
 
         zones = ",".join([z.name for z in zonegroup.zones])
         z = zonegroup.zones[0]
@@ -4350,8 +4348,8 @@ def test_bucket_replication_normal():
 
     # check that object exists in destination bucket
     res = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(res['TagCount'], 1)
-    assert_equal(res['Body'].read().decode('utf-8'), 'foo')
+    assert res['TagCount'] == 1
+    assert res['Body'].read().decode('utf-8') == 'foo'
 
 @allow_bucket_replication
 def test_bucket_replication_normal_delete():
@@ -4390,7 +4388,7 @@ def test_bucket_replication_normal_delete():
 
     # check that object exists in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
     # delete object on source
     source.s3_client.delete_object(Bucket=source_bucket.name, Key=objname)
@@ -4450,7 +4448,7 @@ def test_bucket_replication_normal_deletemarker():
 
     # check that object exists in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
     # delete object on source
     source.s3_client.delete_object(Bucket=source_bucket.name, Key=objname)
@@ -4557,8 +4555,8 @@ def test_bucket_replication_alt_user():
 
     # check that object exists in destination bucket
     res = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(res['TagCount'], 1)
-    assert_equal(res['Body'].read().decode('utf-8'), 'foo')
+    assert res['TagCount'] == 1
+    assert res['Body'].read().decode('utf-8') == 'foo'
 
 @allow_bucket_replication
 def test_bucket_replication_reject_versioning_identical():
@@ -4857,8 +4855,8 @@ def test_bucket_replication_lock_disabled_to_lock_enabled():
     except ClientError as e:
         assert e.response['Error']['Code'] == 'NoSuchKey'
 
-@attr('sync_policy')
-@attr('fails_with_rgw')
+@mark.sync_policy
+@mark.fails_with_rgw
 def test_bucket_delete_with_zonegroup_sync_policy_directional():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -4929,8 +4927,8 @@ def test_bucket_delete_with_zonegroup_sync_policy_directional():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('sync_policy')
-@attr('fails_with_rgw')
+@mark.sync_policy
+@mark.fails_with_rgw
 def test_bucket_delete_with_bucket_sync_policy_directional():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -5003,8 +5001,8 @@ def test_bucket_delete_with_bucket_sync_policy_directional():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('sync_policy')
-@attr('fails_with_rgw')
+@mark.sync_policy
+@mark.fails_with_rgw
 def test_bucket_delete_with_bucket_sync_policy_symmetric():
 
     zonegroup = realm.master_zonegroup()
@@ -5076,8 +5074,8 @@ def test_bucket_delete_with_bucket_sync_policy_symmetric():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('sync_policy')
-@attr('fails_with_rgw')
+@mark.sync_policy
+@mark.fails_with_rgw
 def test_bucket_delete_with_zonegroup_sync_policy_symmetric():
 
     zonegroup = realm.master_zonegroup()
@@ -5141,8 +5139,8 @@ def test_bucket_delete_with_zonegroup_sync_policy_symmetric():
     remove_sync_policy_group(c1, "sync-group")
     return
 
-@attr('sync_policy')
-@attr('fails_with_rgw')
+@mark.sync_policy
+@mark.fails_with_rgw
 def test_delete_bucket_with_zone_opt_out():
     """
     test_delete_bucket_with_zone_opt_out:
@@ -5155,7 +5153,7 @@ def test_delete_bucket_with_zone_opt_out():
     zonegroup_conns = ZonegroupConns(zonegroup)
 
     if len(zonegroup.zones) < 3:
-        raise SkipTest("test_sync_flow_symmetrical_zonegroup_select skipped. Requires 3 or more zones in master zonegroup.")
+        skip("test_sync_flow_symmetrical_zonegroup_select skipped. Requires 3 or more zones in master zonegroup.")
 
     zonegroup_meta_checkpoint(zonegroup)
 
@@ -5234,8 +5232,8 @@ def test_delete_bucket_with_zone_opt_out():
 
     return
 
-@attr('sync_policy')
-@attr('fails_with_rgw')
+@mark.sync_policy
+@mark.fails_with_rgw
 def test_bucket_delete_with_sync_policy_object_prefix():
 
     zonegroup = realm.master_zonegroup()
@@ -5319,7 +5317,7 @@ def test_bucket_delete_with_sync_policy_object_prefix():
 @run_per_zonegroup
 def test_copy_obj_between_zonegroups(zonegroup):
     if len(realm.current_period.zonegroups) < 2:
-        raise SkipTest('need at least 2 zonegroups to run this test')
+        skip('need at least 2 zonegroups to run this test')
 
     source_zone = ZonegroupConns(zonegroup).rw_zones[0]
     source_bucket = source_zone.create_bucket(gen_bucket_name())
@@ -5347,7 +5345,7 @@ def test_copy_obj_between_zonegroups(zonegroup):
 
             # verify
             response = dest_zone.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-            assert_equal(response['Body'].read().decode('utf-8'), 'x' * size)
+            assert response['Body'].read().decode('utf-8') == 'x' * size
 
 @allow_bucket_replication
 def test_bucket_replication_alt_user_delete_forbidden():
@@ -5401,7 +5399,7 @@ def test_bucket_replication_alt_user_delete_forbidden():
 
     # check that object exists in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
     # delete object on source
     source.s3_client.delete_object(Bucket=source_bucket.name, Key=objname)
@@ -5410,7 +5408,7 @@ def test_bucket_replication_alt_user_delete_forbidden():
 
     # check that object does exist in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
 @allow_bucket_replication
 def test_bucket_replication_alt_user_delete():
@@ -5464,7 +5462,7 @@ def test_bucket_replication_alt_user_delete():
 
     # check that object exists in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
     # delete object on source
     source.s3_client.delete_object(Bucket=source_bucket.name, Key=objname)
@@ -5540,7 +5538,7 @@ def test_bucket_replication_alt_user_deletemarker_forbidden():
 
     # check that object exists in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
     # delete object on source
     source.s3_client.delete_object(Bucket=source_bucket.name, Key=objname)
@@ -5549,7 +5547,7 @@ def test_bucket_replication_alt_user_deletemarker_forbidden():
 
     # check that object does exist in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
 @allow_bucket_replication
 def test_bucket_replication_alt_user_deletemarker():
@@ -5613,7 +5611,7 @@ def test_bucket_replication_alt_user_deletemarker():
 
     # check that object exists in destination bucket
     response = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(response['Body'].read().decode('utf-8'), 'foo')
+    assert response['Body'].read().decode('utf-8') == 'foo'
 
     # delete object on source
     source.s3_client.delete_object(Bucket=source_bucket.name, Key=objname)
@@ -5687,7 +5685,7 @@ def test_bucket_replication_alt_user_deny_tagreplication():
 
     # check that object exists in destination bucket without tags
     res = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(res['Body'].read().decode('utf-8'), 'foo')
+    assert res['Body'].read().decode('utf-8') == 'foo'
     assert 'TagCount' not in res
 
 @allow_bucket_replication
@@ -5749,8 +5747,9 @@ def test_bucket_replication_source_forbidden():
 
     # check the source object has replication status set to FAILED
     # uncomment me in https://github.com/ceph/ceph/pull/62147
+    # Still fails 
     # res = source.s3_client.head_object(Bucket=source_bucket.name, Key=objname)
-    # assert_equal(res['ReplicationStatus'], 'FAILED')
+    # assert(res['ReplicationStatus'], 'FAILED')
 
 @allow_bucket_replication
 def test_bucket_replication_source_forbidden_versioned():
@@ -5817,7 +5816,7 @@ def test_bucket_replication_source_forbidden_versioned():
     # check the source object has replication status set to FAILED
     # uncomment me in https://github.com/ceph/ceph/pull/62147
     # res = source.s3_client.head_object(Bucket=source_bucket.name, Key=objname)
-    # assert_equal(res['ReplicationStatus'], 'FAILED')
+    # assert(res['ReplicationStatus'], 'FAILED')
 
 @allow_bucket_replication
 def test_bucket_replication_source_allow_either_getobject_or_getobjectversionforreplication():
@@ -5868,7 +5867,7 @@ def test_bucket_replication_source_allow_either_getobject_or_getobjectversionfor
 
     # check that object exists in destination bucket
     res = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(res['Body'].read().decode('utf-8'), 'foo')
+    assert res['Body'].read().decode('utf-8') == 'foo'
 
 @allow_bucket_replication
 def test_bucket_replication_source_allow_either_getobjectversion_or_getobjectversionforreplication():
@@ -5924,7 +5923,7 @@ def test_bucket_replication_source_allow_either_getobjectversion_or_getobjectver
 
     # check that object exists in destination bucket
     res = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(res['Body'].read().decode('utf-8'), 'foo')
+    assert res['Body'].read().decode('utf-8') == 'foo'
 
 @allow_bucket_replication
 def test_bucket_replication_source_forbidden_objretention():
@@ -5979,7 +5978,7 @@ def test_bucket_replication_source_forbidden_objretention():
     # check the source object has replication status set to FAILED
     # uncomment me in https://github.com/ceph/ceph/pull/62147
     # res = source.s3_client.head_object(Bucket=source_bucket_name, Key=objname)
-    # assert_equal(res['ReplicationStatus'], 'FAILED')
+    # assert(res['ReplicationStatus'], 'FAILED')
 
 @allow_bucket_replication
 def test_bucket_replication_source_forbidden_legalhold():
@@ -6082,7 +6081,7 @@ def test_bucket_replication_source_forbidden_getobjecttagging():
 
     # check that object exists in destination bucket without tags
     res = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(res['Body'].read().decode('utf-8'), 'foo')
+    assert res['Body'].read().decode('utf-8') == 'foo'
     assert 'TagCount' not in res
 
 @allow_bucket_replication
@@ -6139,13 +6138,13 @@ def test_bucket_replication_source_forbidden_getobjectversiontagging():
 
     # check that object exists in destination bucket without tags
     res = dest.s3_client.get_object(Bucket=dest_bucket.name, Key=objname)
-    assert_equal(res['Body'].read().decode('utf-8'), 'foo')
+    assert res['Body'].read().decode('utf-8') == 'foo'
     assert 'TagCount' not in res
 
 @run_per_zonegroup
 def test_copy_obj_perm_check_between_zonegroups(zonegroup):
     if len(realm.current_period.zonegroups) < 2:
-        raise SkipTest('need at least 2 zonegroups to run this test')
+        skip('need at least 2 zonegroups to run this test')
 
     source_zone = ZonegroupConns(zonegroup).rw_zones[0]
     source_bucket = source_zone.create_bucket(gen_bucket_name())
@@ -6234,7 +6233,7 @@ def test_period_update_commit():
         if secondary_zone_cluster_conn is not None:
             break
     else:
-        raise SkipTest("test_period_update_commit is skipped.")
+        skip("test_period_update_commit is skipped.")
 
     bucket = primary_zone_client_conn.create_bucket(gen_bucket_name())
     log.info(f"created bucket={bucket.name}")
@@ -6340,7 +6339,7 @@ def test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime():
         if secondary_zone_cluster_conn is not None:
             break
     else:
-        raise SkipTest("test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime is skipped. "
+        skip("test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime is skipped. "
                        "Requires a secondary zone in a different cluster.")
 
     bucket = primary_zone_client_conn.create_bucket(gen_bucket_name())

--- a/src/test/rgw/rgw_multi/tests_az.py
+++ b/src/test/rgw/rgw_multi/tests_az.py
@@ -1,7 +1,5 @@
 import logging
-
-from nose import SkipTest
-from nose.tools import assert_not_equal, assert_equal
+import pytest
 
 from boto.s3.deletemarker import DeleteMarker
 
@@ -35,7 +33,7 @@ def check_az_configured():
 
     az_zones = zonegroup.zones_by_type.get("archive")
     if az_zones is None or len(az_zones) != 1:
-        raise SkipTest("Requires one archive zone")
+        skip("Requires one archive zone")
 
 
 def is_az_zone(zone_conn):
@@ -64,8 +62,8 @@ def init_env():
         elif not conn.zone.is_read_only():
             zones.append(conn)
 
-    assert_not_equal(len(zones), 0)
-    assert_not_equal(len(az_zones), 0)
+    assert len(zones) != 0
+    assert len(az_zones) != 0
     return zones, az_zones
 
 
@@ -156,7 +154,7 @@ def get_full_bucket_name(partial_bucket_name, bucket_names_az):
 
 def test_az_info():
     """ log information for manual testing """
-    return SkipTest("only used in manual testing")
+    skip("only used in manual testing")
     zones, az_zones = init_env()
     realm = get_realm()
     zonegroup = realm.master_zonegroup()
@@ -188,7 +186,7 @@ def test_az_create_empty_bucket():
      zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
      # bucket exist on the archive zone
      p = check_bucket_exists_on_zone(az_zones[0], bucket_name)
-     assert_equal(p, True)
+     assert p is True
 
 
 def test_az_check_empty_bucket_versioning():
@@ -203,9 +201,9 @@ def test_az_check_empty_bucket_versioning():
      bucket_az = az_zones[0].conn.get_bucket(bucket_name)
      # check for non bucket versioning
      p1 = get_versioning_status(bucket) is None
-     assert_equal(p1, True)
+     assert p1 is True
      p2 = get_versioning_status(bucket_az) is None
-     assert_equal(p2, True)
+     assert p2 is True
 
 
 def test_az_object_replication():
@@ -222,7 +220,7 @@ def test_az_object_replication():
     bucket_az = az_zones[0].conn.get_bucket(bucket_name)
     key_az = bucket_az.get_key("foo")
     p1 = key_az.get_contents_as_string(encoding='ascii') == "bar"
-    assert_equal(p1, True)
+    assert p1 is True
 
 
 def test_az_object_replication_versioning():
@@ -239,7 +237,7 @@ def test_az_object_replication_versioning():
     bucket_az = az_zones[0].conn.get_bucket(bucket_name)
     key_az = bucket_az.get_key("foo")
     p1 = key_az.get_contents_as_string(encoding='ascii') == "bar"
-    assert_equal(p1, True)
+    assert p1 is True
     # grab object versioning and etag
     for b_version in bucket.list_versions():
         b_version_id = b_version.version_id
@@ -249,11 +247,11 @@ def test_az_object_replication_versioning():
         b_az_version_etag = b_az_version.etag
     # check
     p2 = b_version_id == 'null'
-    assert_equal(p2, True)
+    assert p2 is True
     p3 = b_az_version_id != 'null'
-    assert_equal(p3, True)
+    assert p3 is True
     p4 = b_version_etag == b_az_version_etag
-    assert_equal(p4, True)
+    assert p4 is True
 
 
 def test_az_lazy_activation_of_versioned_bucket():
@@ -268,9 +266,9 @@ def test_az_lazy_activation_of_versioned_bucket():
     bucket_az = az_zones[0].conn.get_bucket(bucket_name)
     # check for non bucket versioning
     p1 = get_versioning_status(bucket) is None
-    assert_equal(p1, True)
+    assert p1 is True
     p2 = get_versioning_status(bucket_az) is None
-    assert_equal(p2, True)
+    assert p2 is True
     # create object on non archive zone
     key = bucket.new_key("foo")
     key.set_contents_from_string("bar")
@@ -278,9 +276,9 @@ def test_az_lazy_activation_of_versioned_bucket():
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check lazy versioned buckets
     p3 = get_versioning_status(bucket) is None
-    assert_equal(p3, True)
+    assert p3 is True
     p4 = get_versioning_status(bucket_az) == 'Enabled'
-    assert_equal(p4, True)
+    assert p4 is True
 
 
 def test_az_archive_zone_double_object_replication_versioning():
@@ -297,9 +295,9 @@ def test_az_archive_zone_double_object_replication_versioning():
     bucket_az = az_zones[0].conn.get_bucket(bucket_name)
     # check for non bucket versioning
     p1 = get_versioning_status(bucket) is None
-    assert_equal(p1, True)
+    assert p1 is True
     p2 = get_versioning_status(bucket_az) == 'Enabled'
-    assert_equal(p2, True)
+    assert p2 is True
     # overwrite object on non archive zone
     key = bucket.new_key("foo")
     key.set_contents_from_string("ouch")
@@ -307,34 +305,34 @@ def test_az_archive_zone_double_object_replication_versioning():
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check lazy versioned buckets
     p3 = get_versioning_status(bucket) is None
-    assert_equal(p3, True)
+    assert p3 is True
     p4 = get_versioning_status(bucket_az) == 'Enabled'
-    assert_equal(p4, True)
+    assert p4 is True
     # get versioned objects
     objs = get_versioned_objs(bucket)
     objs_az = get_versioned_objs(bucket_az)
     # check version_id, size, and is_latest on non archive zone
     p5 = objs[0]['foo']['version_id'] == 'null'
-    assert_equal(p5, True)
+    assert p5 is True
     p6 = objs[0]['foo']['size'] == 4
-    assert_equal(p6, True)
+    assert p6 is True
     p7 = objs[0]['foo']['is_latest'] == True
-    assert_equal(p7, True)
+    assert p7 is True
     # check version_id, size, is_latest on archive zone
     latest_obj_az_etag = None
     for obj_az  in objs_az:
         current_obj_az = obj_az['foo']
         if current_obj_az['is_latest'] == True:
             p8 = current_obj_az['size'] == 4
-            assert_equal(p8, True)
+            assert p8 is True
             latest_obj_az_etag = current_obj_az['etag']
         else:
             p9 = current_obj_az['size'] == 3
-            assert_equal(p9, True)
-        assert_not_equal(current_obj_az['version_id'], 'null')
+            assert p9 is True
+        assert current_obj_az['version_id'] != 'null'
     # check last versions' etags
     p10 = objs[0]['foo']['etag'] == latest_obj_az_etag
-    assert_equal(p10, True)
+    assert p10 is True
 
 
 def test_az_deleted_object_replication():
@@ -346,13 +344,13 @@ def test_az_deleted_object_replication():
     key = bucket.new_key("foo")
     key.set_contents_from_string("bar")
     p1 = key.get_contents_as_string(encoding='ascii') == "bar"
-    assert_equal(p1, True)
+    assert p1 is True
     # sync
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # update object on non archive zone
     key.set_contents_from_string("soup")
     p2 = key.get_contents_as_string(encoding='ascii') == "soup"
-    assert_equal(p2, True)
+    assert p2 is True
     # sync
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # delete object on non archive zone
@@ -361,17 +359,17 @@ def test_az_deleted_object_replication():
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check object on non archive zone
     p3 = check_key_exists(key) == False
-    assert_equal(p3, True)
+    assert p3 is True
     # check objects on archive zone
     bucket_az = az_zones[0].conn.get_bucket(bucket_name)
     key_az = bucket_az.get_key("foo")
     p4 = check_key_exists(key_az) == True
-    assert_equal(p4, True)
+    assert p4 is True
     p5 = key_az.get_contents_as_string(encoding='ascii') == "soup"
-    assert_equal(p5, True)
+    assert p5 is True
     b_ver_az = get_versioned_objs(bucket_az)
     p6 = len(b_ver_az) == 2
-    assert_equal(p6, True)
+    assert p6 is True
 
 
 def test_az_bucket_renaming_on_empty_bucket_deletion():
@@ -392,15 +390,15 @@ def test_az_bucket_renaming_on_empty_bucket_deletion():
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check no new buckets on non archive zone
     p1 = get_number_buckets_by_zone(zones[0]) == num_buckets
-    assert_equal(p1, True)
+    assert p1 is True
     # check non deletion on bucket on archive zone
     p2 = get_number_buckets_by_zone(az_zones[0]) == (num_buckets_az + 1)
-    assert_equal(p2, True)
+    assert p2 is True
     # check bucket renaming
     bucket_names_az = get_bucket_names_by_zone(az_zones[0])
     new_bucket_name = bucket_name + '-deleted-'
     p3 = any(bucket_name.startswith(new_bucket_name) for bucket_name in bucket_names_az)
-    assert_equal(p3, True)
+    assert p3 is True
 
 
 def test_az_old_object_version_in_archive_zone():
@@ -434,27 +432,27 @@ def test_az_old_object_version_in_archive_zone():
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check same buckets on non archive zone
     p1 = get_number_buckets_by_zone(zones[0]) == num_buckets
-    assert_equal(p1, True)
+    assert p1 is True
     # check for new bucket on archive zone
     p2 = get_number_buckets_by_zone(az_zones[0]) == (num_buckets_az + 1)
-    assert_equal(p2, True)
+    assert p2 is True
     # get new bucket name on archive zone
     bucket_names_az = get_bucket_names_by_zone(az_zones[0])
     new_bucket_name_az = get_full_bucket_name(bucket_name + '-deleted-', bucket_names_az)
     p3 = new_bucket_name_az is not None
-    assert_equal(p3, True)
+    assert p3 is True
     # check number of objects on archive zone
     new_bucket_az = az_zones[0].conn.get_bucket(new_bucket_name_az)
     new_b_ver_az = get_versioned_objs(new_bucket_az)
     p4 = len(new_b_ver_az) == 2
-    assert_equal(p4, True)
+    assert p4 is True
     # check versioned objects on archive zone
     new_key_az = new_bucket_az.get_key("foo", version_id=obj_az_version_id)
     p5 = new_key_az.get_contents_as_string(encoding='ascii') == "zero"
-    assert_equal(p5, True)
+    assert p5 is True
     new_key_latest_az = new_bucket_az.get_key("foo")
     p6 = new_key_latest_az.get_contents_as_string(encoding='ascii') == "one"
-    assert_equal(p6, True)
+    assert p6 is True
 
 
 def test_az_force_bucket_renaming_if_same_bucket_name():
@@ -471,35 +469,35 @@ def test_az_force_bucket_renaming_if_same_bucket_name():
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check same buckets on non archive zone
     p1 = get_number_buckets_by_zone(zones[0]) == (num_buckets + 1)
-    assert_equal(p1, True)
+    assert p1 is True
     # check for new bucket on archive zone
     p2 = get_number_buckets_by_zone(az_zones[0]) == (num_buckets_az + 1)
-    assert_equal(p2, True)
+    assert p2 is True
     # delete bucket on non archive zone
     zones[0].delete_bucket(bucket_name)
     # sync
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check number of buckets on non archive zone
     p3 = get_number_buckets_by_zone(zones[0]) == num_buckets
-    assert_equal(p3, True)
+    assert p3 is True
     # check number of buckets on archive zone
     p4 = get_number_buckets_by_zone(az_zones[0]) == (num_buckets_az + 1)
-    assert_equal(p4, True)
+    assert p4 is True
     # get new bucket name on archive zone
     bucket_names_az = get_bucket_names_by_zone(az_zones[0])
     new_bucket_name_az = get_full_bucket_name(bucket_name + '-deleted-', bucket_names_az)
     p5 = new_bucket_name_az is not None
-    assert_equal(p5, True)
+    assert p5 is True
     # create bucket on non archive zone
     _ = zones[0].create_bucket(new_bucket_name_az)
     # sync
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check number of buckets on non archive zone
     p6 = get_number_buckets_by_zone(zones[0]) == (num_buckets + 1)
-    assert_equal(p6, True)
+    assert p6 is True
     # check number of buckets on archive zone
     p7 = get_number_buckets_by_zone(az_zones[0]) == (num_buckets_az + 2)
-    assert_equal(p7, True)
+    assert p7 is True
 
 
 def test_az_versioning_support_in_zones():
@@ -514,9 +512,9 @@ def test_az_versioning_support_in_zones():
     bucket_az = az_zones[0].conn.get_bucket(bucket_name)
     # check non versioned buckets
     p1 = get_versioning_status(bucket) is None
-    assert_equal(p1, True)
+    assert p1 is True
     p2 = get_versioning_status(bucket_az) is None
-    assert_equal(p2, True)
+    assert p2 is True
     # create object on non archive zone
     key = bucket.new_key("foo")
     key.set_contents_from_string("zero")
@@ -524,18 +522,18 @@ def test_az_versioning_support_in_zones():
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check bucket versioning
     p3 = get_versioning_status(bucket) is None
-    assert_equal(p3, True)
+    assert p3 is True
     p4 = get_versioning_status(bucket_az) == 'Enabled'
-    assert_equal(p4, True)
+    assert p4 is True
     # enable bucket versioning on non archive zone
     bucket.configure_versioning(True)
     # sync
     zone_full_checkpoint(az_zones[0].zone, zones[0].zone)
     # check bucket versioning
     p5 = get_versioning_status(bucket) == 'Enabled'
-    assert_equal(p5, True)
+    assert p5 is True
     p6 = get_versioning_status(bucket_az) == 'Enabled'
-    assert_equal(p6, True)
+    assert p6 is True
     # delete object on non archive zone
     key.delete()
     # sync
@@ -543,15 +541,15 @@ def test_az_versioning_support_in_zones():
     # check delete-markers and versions on non archive zone
     (b_dm, b_ver) = get_versioned_entries(bucket)
     p7 = len(b_dm) == 1
-    assert_equal(p7, True)
+    assert p7 is True
     p8 = len(b_ver) == 1
-    assert_equal(p8, True)
+    assert p8 is True
     # check delete-markers and versions on archive zone
     (b_dm_az, b_ver_az) = get_versioned_entries(bucket_az)
     p9 = len(b_dm_az) == 1
-    assert_equal(p9, True)
+    assert p9 is True
     p10 = len(b_ver_az) == 1
-    assert_equal(p10, True)
+    assert p10 is True
     # delete delete-marker on non archive zone
     dm_version_id = b_dm[0]['foo']['version_id']
     bucket.delete_key("foo", version_id=dm_version_id)
@@ -560,15 +558,15 @@ def test_az_versioning_support_in_zones():
     # check delete-markers and versions on non archive zone
     (b_dm, b_ver) = get_versioned_entries(bucket)
     p11 = len(b_dm) == 0
-    assert_equal(p11, True)
+    assert p11 is True
     p12 = len(b_ver) == 1
-    assert_equal(p12, True)
+    assert p12 is True
     # check delete-markers and versions on archive zone
     (b_dm_az, b_ver_az) = get_versioned_entries(bucket_az)
     p13 = len(b_dm_az) == 1
-    assert_equal(p13, True)
+    assert p13 is True
     p14 = len(b_ver_az) == 1
-    assert_equal(p14, True)
+    assert p14 is True
     # delete delete-marker on archive zone
     dm_az_version_id = b_dm_az[0]['foo']['version_id']
     bucket_az.delete_key("foo", version_id=dm_az_version_id)
@@ -577,21 +575,21 @@ def test_az_versioning_support_in_zones():
     # check delete-markers and versions on non archive zone
     (b_dm, b_ver) = get_versioned_entries(bucket)
     p15 = len(b_dm) == 0
-    assert_equal(p15, True)
+    assert p15 is True
     p16 = len(b_ver) == 1
-    assert_equal(p16, True)
+    assert p16 is True
     # check delete-markers and versions on archive zone
     (b_dm_az, b_ver_az) = get_versioned_entries(bucket_az)
     p17 = len(b_dm_az) == 0
-    assert_equal(p17, True)
+    assert p17 is True
     p17 = len(b_ver_az) == 1
-    assert_equal(p17, True)
+    assert p17 is True
     # check body in zones
     obj_version_id = b_ver[0]['foo']['version_id']
     key = bucket.get_key("foo", version_id=obj_version_id)
     p18 = key.get_contents_as_string(encoding='ascii') == "zero"
-    assert_equal(p18, True)
+    assert p18 is True
     obj_az_version_id = b_ver_az[0]['foo']['version_id']
     key_az = bucket_az.get_key("foo", version_id=obj_az_version_id)
     p19 = key_az.get_contents_as_string(encoding='ascii') == "zero"
-    assert_equal(p19, True)
+    assert p19 is True

--- a/src/test/rgw/rgw_multi/tests_es.py
+++ b/src/test/rgw/rgw_multi/tests_es.py
@@ -8,8 +8,7 @@ import dateutil
 
 from itertools import zip_longest  # type: ignore
 
-from nose.tools import eq_ as eq
-
+import pytest
 from .multisite import *
 from .tests import *
 from .zone_es import *
@@ -23,7 +22,7 @@ def check_es_configured():
 
     es_zones = zonegroup.zones_by_type.get("elasticsearch")
     if not es_zones:
-        raise SkipTest("Requires at least one ES zone")
+        skip("Requires at least one ES zone")
 
 def is_es_zone(zone_conn):
     if not zone_conn:
@@ -45,8 +44,8 @@ def verify_search(bucket_name, src_keys, result_keys, f):
     log.debug('result keys:' + json.dumps(result_keys, indent=4))
 
     for k1, k2 in zip_longest(check_keys, result_keys):
-        assert k1
-        assert k2
+        assert k1 is not None, "Expected key is missing"
+        assert k2 is not None, "Result key is missing"
         check_object_eq(k1, k2)
 
 def do_check_mdsearch(conn, bucket, src_keys, req_str, src_filter):
@@ -261,15 +260,15 @@ def test_es_bucket_conf():
             for entry in conf:
               d[entry['Key']] = entry['Type']
 
-            eq(len(d), 3)
-            eq(d['x-amz-meta-foo-str'], 'str')
-            eq(d['x-amz-meta-foo-int'], 'int')
-            eq(d['x-amz-meta-foo-date'], 'date')
+            assert len(d) == 3
+            assert d['x-amz-meta-foo-str'] == 'str'
+            assert d['x-amz-meta-foo-int'] == 'int'
+            assert d['x-amz-meta-foo-date'] == 'date'
 
             req.del_config()
 
             conf = req.get_config()
 
-            eq(len(conf), 0)
+            assert len(conf) == 0
 
         break # no need to iterate over all zones

--- a/src/test/rgw/rgw_multi/zone_cloud.py
+++ b/src/test/rgw/rgw_multi/zone_cloud.py
@@ -1,6 +1,7 @@
 import json
 import requests.compat
 import logging
+import pytest
 
 import boto
 import boto.s3.connection
@@ -10,7 +11,6 @@ import datetime
 
 import re
 
-from nose.tools import eq_ as eq
 from itertools import zip_longest # type: ignore
 from urllib.parse import urlparse
 
@@ -29,30 +29,30 @@ def unquote(s):
     return s
 
 def check_object_eq(k1, k2, check_extra = True):
-    assert k1
-    assert k2
+    assert k1 is not None, "Expected key is missing"
+    assert k2 is not None, "Result key is missing"
     log.debug('comparing key name=%s', k1.name)
-    eq(k1.name, k2.name)
-    eq(k1.metadata, k2.metadata)
-    # eq(k1.cache_control, k2.cache_control)
-    eq(k1.content_type, k2.content_type)
-    eq(k1.content_encoding, k2.content_encoding)
-    eq(k1.content_disposition, k2.content_disposition)
-    eq(k1.content_language, k2.content_language)
+    assert k1.name == k2.name
+    assert k1.metadata == k2.metadata
+    # assert(k1.cache_control, k2.cache_control)
+    assert k1.content_type == k2.content_type
+    assert k1.content_encoding == k2.content_encoding
+    assert k1.content_disposition == k2.content_disposition
+    assert k1.content_language == k2.content_language
 
-    eq(unquote(k1.etag), unquote(k2.etag))
+    assert unquote(k1.etag) == unquote(k2.etag)
 
     mtime1 = dateutil.parser.parse(k1.last_modified)
     mtime2 = dateutil.parser.parse(k2.last_modified)
     log.debug('k1.last_modified=%s k2.last_modified=%s', k1.last_modified, k2.last_modified)
     assert abs((mtime1 - mtime2).total_seconds()) < 1 # handle different time resolution
     # if check_extra:
-        # eq(k1.owner.id, k2.owner.id)
-        # eq(k1.owner.display_name, k2.owner.display_name)
-    # eq(k1.storage_class, k2.storage_class)
-    eq(k1.size, k2.size)
-    eq(get_key_ver(k1), get_key_ver(k2))
-    # eq(k1.encrypted, k2.encrypted)
+        # assert(k1.owner.id, k2.owner.id)
+        # assert(k1.owner.display_name, k2.owner.display_name)
+    # assert(k1.storage_class, k2.storage_class)
+    assert k1.size == k2.size
+    assert get_key_ver(k1) == get_key_ver(k2)
+    # assert(k1.encrypted, k2.encrypted)
 
 def make_request(conn, method, bucket, key, query_args, headers):
     result = conn.make_request(method, bucket=bucket, key=key, query_args=query_args, headers=headers)
@@ -272,7 +272,7 @@ class CloudZone(Zone):
             assert False
 
         def check_bucket_eq(self, zone_conn, bucket_name):
-            assert(zone_conn.zone.tier_type() == "rados")
+            assert zone_conn.zone.tier_type() == "rados"
 
             log.info('comparing bucket=%s zones={%s, %s}', bucket_name, self.name, self.name)
             b1 = self.get_bucket(bucket_name)

--- a/src/test/rgw/rgw_multi/zone_es.py
+++ b/src/test/rgw/rgw_multi/zone_es.py
@@ -1,13 +1,13 @@
 import json
 import requests.compat
 import logging
+import pytest
 
 import boto
 import boto.s3.connection
 
 import dateutil.parser
 
-from nose.tools import eq_ as eq
 from itertools import zip_longest  # type: ignore
 
 from .multisite import *
@@ -20,27 +20,27 @@ def get_key_ver(k):
     return k.version_id
 
 def check_object_eq(k1, k2, check_extra = True):
-    assert k1
-    assert k2
+    assert k1 is not None, "Expected key is missing"
+    assert k2 is not None, "Result key is missing"
     log.debug('comparing key name=%s', k1.name)
-    eq(k1.name, k2.name)
-    eq(k1.metadata, k2.metadata)
-    # eq(k1.cache_control, k2.cache_control)
-    eq(k1.content_type, k2.content_type)
-    # eq(k1.content_encoding, k2.content_encoding)
-    # eq(k1.content_disposition, k2.content_disposition)
-    # eq(k1.content_language, k2.content_language)
-    eq(k1.etag, k2.etag)
+    assert k1.name == k2.name
+    assert k1.metadata == k2.metadata
+    # assert(k1.cache_control, k2.cache_control)
+    assert k1.content_type == k2.content_type
+    # assert(k1.content_encoding, k2.content_encoding)
+    # assert(k1.content_disposition, k2.content_disposition)
+    # assert(k1.content_language, k2.content_language)
+    assert k1.etag == k2.etag
     mtime1 = dateutil.parser.parse(k1.last_modified)
     mtime2 = dateutil.parser.parse(k2.last_modified)
     assert abs((mtime1 - mtime2).total_seconds()) < 1 # handle different time resolution
     if check_extra:
-        eq(k1.owner.id, k2.owner.id)
-        eq(k1.owner.display_name, k2.owner.display_name)
-    # eq(k1.storage_class, k2.storage_class)
-    eq(k1.size, k2.size)
-    eq(get_key_ver(k1), get_key_ver(k2))
-    # eq(k1.encrypted, k2.encrypted)
+        assert k1.owner.id == k2.owner.id
+        assert k1.owner.display_name == k2.owner.display_name
+    # assert(k1.storage_class, k2.storage_class)
+    assert k1.size == k2.size
+    assert get_key_ver(k1) == get_key_ver(k2)
+    # assert(k1.encrypted, k2.encrypted)
 
 def make_request(conn, method, bucket, key, query_args, headers):
     result = conn.make_request(method, bucket=bucket, key=key, query_args=query_args, headers=headers)
@@ -221,7 +221,7 @@ class ESZone(Zone):
             assert False
 
         def check_bucket_eq(self, zone_conn, bucket_name):
-            assert(zone_conn.zone.tier_type() == "rados")
+            assert zone_conn.zone.tier_type() == "rados"
 
             log.info('comparing bucket=%s zones={%s, %s}', bucket_name, self.name, self.name)
             b1 = self.get_bucket(bucket_name)

--- a/src/test/rgw/rgw_multi/zone_rados.py
+++ b/src/test/rgw/rgw_multi/zone_rados.py
@@ -3,9 +3,6 @@ import boto3
 from botocore.exceptions import ClientError
 
 from itertools import zip_longest  # type: ignore
-
-from nose.tools import eq_ as eq
-
 from .multisite import *
 
 from .conn import get_gateway_sts_connection
@@ -13,45 +10,45 @@ from .conn import get_gateway_sts_connection
 log = logging.getLogger(__name__)
 
 def check_object_eq(k1, k2, check_extra = True):
-    assert k1
-    assert k2
+    assert k1 is not None, "Expected key is missing"
+    assert k2 is not None, "Result key is missing"
     log.debug('comparing key name=%s', k1.key)
-    eq(k1.key, k2.key)
+    assert k1.key == k2.key
     if hasattr(k1, 'version_id'):
-        eq(k1.version_id, k2.version_id)
+        assert k1.version_id == k2.version_id
     if hasattr(k1, 'is_latest'):
-        eq(k1.is_latest, k2.is_latest)
+        assert k1.is_latest == k2.is_latest
     if hasattr(k1, 'last_modified'):
-        eq(k1.last_modified, k2.last_modified)
+        assert k1.last_modified == k2.last_modified
 
     response1 = k1.get()
     response2 = k2.get()
     
     body1 = response1['Body'].read()
     body2 = response2['Body'].read()
-    eq(body1, body2)
+    assert body1 == body2
 
-    eq(response1.get('Metadata', {}), response2.get('Metadata', {}))
-    eq(response1.get('CacheControl'), response2.get('CacheControl'))
-    eq(response1.get('ContentType'), response2.get('ContentType'))
-    eq(response1.get('ContentEncoding'), response2.get('ContentEncoding'))
-    eq(response1.get('ContentDisposition'), response2.get('ContentDisposition'))
-    eq(response1.get('ContentLanguage'), response2.get('ContentLanguage'))
-    eq(response1.get('ETag'), response2.get('ETag'))
+    assert response1.get('Metadata', {}) == response2.get('Metadata', {})
+    assert response1.get('CacheControl') == response2.get('CacheControl')
+    assert response1.get('ContentType') == response2.get('ContentType')
+    assert response1.get('ContentEncoding') == response2.get('ContentEncoding')
+    assert response1.get('ContentDisposition') == response2.get('ContentDisposition')
+    assert response1.get('ContentLanguage') == response2.get('ContentLanguage')
+    assert response1.get('ETag') == response2.get('ETag')
 
     if check_extra and hasattr(k1, 'owner') and hasattr(k2, 'owner'):
-        eq(k1.owner.get('ID'), k2.owner.get('ID'))
+        assert k1.owner.get('ID') == k2.owner.get('ID')
         if 'DisplayName' in k1.owner and 'DisplayName' in k2.owner:
-            eq(k1.owner['DisplayName'], k2.owner['DisplayName'])
+            assert k1.owner['DisplayName'] == k2.owner['DisplayName']
 
     if hasattr(k1, 'storage_class'):
-        eq(k1.storage_class, k2.storage_class)
+        assert k1.storage_class == k2.storage_class
     if hasattr(k1, 'size'):
-        eq(k1.size, k2.size)
+        assert k1.size == k2.size
 
     encrypted1 = response1.get('ServerSideEncryption') is not None
     encrypted2 = response2.get('ServerSideEncryption') is not None
-    eq(encrypted1, encrypted2)
+    assert encrypted1 == encrypted2
 
 class RadosZone(Zone):
     def __init__(self, name, zonegroup = None, cluster = None, data = None, zone_id = None, gateways = None):
@@ -119,10 +116,10 @@ class RadosZone(Zone):
                     # both must be delete markers
                     assert is_delete_marker_k1 and is_delete_marker_k2, \
                         f"delete marker mismatch: k1={is_delete_marker_k1}, k2={is_delete_marker_k2}"
-                    eq(k1.key, k2.key)
-                    eq(k1.version_id, k2.version_id)
+                    assert k1.key == k2.key
+                    assert k1.version_id == k2.version_id
                     if hasattr(k1, 'is_latest'):
-                        eq(k1.is_latest, k2.is_latest)
+                        assert k1.is_latest == k2.is_latest
                     log.debug('both are delete markers, skipping content comparison')
                     continue
 
@@ -142,8 +139,8 @@ class RadosZone(Zone):
                     try:
                         k1_olh.load()
                         k2_olh.load()
-                        eq(k1_olh.e_tag, k2_olh.e_tag)
-                        eq(k1_olh.content_length, k2_olh.content_length)
+                        assert k1_olh.e_tag == k2_olh.e_tag
+                        assert k1_olh.content_length == k2_olh.content_length
                     except ClientError:
                         pass  # current version is a delete marker
 
@@ -158,15 +155,15 @@ class RadosZone(Zone):
             r1 = self.get_role(role_name)
             r2 = zone_conn.get_role(role_name)
 
-            assert r1
-            assert r2
+            assert r1 is not None, "Expected role is missing"
+            assert r2 is not None, "Result role is missing"
             log.debug('comparing role name=%s', r1['get_role_response']['get_role_result']['role']['role_name'])
-            eq(r1['get_role_response']['get_role_result']['role']['role_name'], r2['get_role_response']['get_role_result']['role']['role_name'])
-            eq(r1['get_role_response']['get_role_result']['role']['role_id'], r2['get_role_response']['get_role_result']['role']['role_id'])
-            eq(r1['get_role_response']['get_role_result']['role']['path'], r2['get_role_response']['get_role_result']['role']['path'])
-            eq(r1['get_role_response']['get_role_result']['role']['arn'], r2['get_role_response']['get_role_result']['role']['arn'])
-            eq(r1['get_role_response']['get_role_result']['role']['max_session_duration'], r2['get_role_response']['get_role_result']['role']['max_session_duration'])
-            eq(r1['get_role_response']['get_role_result']['role']['assume_role_policy_document'], r2['get_role_response']['get_role_result']['role']['assume_role_policy_document'])
+            assert r1['get_role_response']['get_role_result']['role']['role_name'] == r2['get_role_response']['get_role_result']['role']['role_name']
+            assert r1['get_role_response']['get_role_result']['role']['role_id'] == r2['get_role_response']['get_role_result']['role']['role_id']
+            assert r1['get_role_response']['get_role_result']['role']['path'] == r2['get_role_response']['get_role_result']['role']['path']
+            assert r1['get_role_response']['get_role_result']['role']['arn'] == r2['get_role_response']['get_role_result']['role']['arn']
+            assert r1['get_role_response']['get_role_result']['role']['max_session_duration'] == r2['get_role_response']['get_role_result']['role']['max_session_duration']
+            assert r1['get_role_response']['get_role_result']['role']['assume_role_policy_document'] == r2['get_role_response']['get_role_result']['role']['assume_role_policy_document']
 
             log.info('success, role identical: role=%s zones={%s, %s}', role_name, self.name, zone_conn.name)
 

--- a/src/test/rgw/test_multi.md
+++ b/src/test/rgw/test_multi.md
@@ -1,15 +1,23 @@
 # Multi Site Test Framework
-This framework allows you to write and run tests against a **local** multi-cluster environment. The framework is using the `mstart.sh` script in order to setup the environment according to a configuration file, and then uses the [nose](https://nose.readthedocs.io/en/latest/) test framework to actually run the tests.
-Tests are written in python2.7, but can invoke shell scripts, binaries etc.
+
+This framework allows you to write and run tests against a **local** multi-cluster environment. The framework is using the `mstart.sh` script in order to setup the environment according to a configuration file, and then uses the **[pytest](https://docs.pytest.org/)** test framework to actually run the tests.
+Tests are written in **python3**, but can invoke shell scripts, binaries etc.
+
 ## Running Tests
+
 Entry point for all tests is `/path/to/ceph/src/test/rgw/test_multi.py`. And the actual tests are located inside the `/path/to/ceph/src/test/rgw/rgw_multi` subdirectory.
+
 So, to run all tests use:
+
 ```
 $ cd /path/to/ceph/src/test/rgw/
-$ nosetests test_multi.py
+$ python3 -m pytest rgw_multi/
 ```
+
 This will assume a configuration file called `/path/to/ceph/src/test/rgw/test_multi.conf` exists.
+
 To use a different configuration file, set the `RGW_MULTI_TEST_CONF` environment variable to point to that file. Here is an example of configuration file:
+
 ```
 [DEFAULT]
 num_zonegroup=1
@@ -18,51 +26,78 @@ gateway_per_zone=1
 no_bootstrap=false
 log_level=5
 ```
+
 Since we use the same entry point file for all tests, running specific tests is possible using the following format:
+
 ```
-$ nosetests test_multi.py:<specific_test_name>
+$ python3 -m pytest rgw_multi/ -k <specific_test_name>
 ```
+
 To run multiple tests based on wildcard string, use the following format:
+
 ```
-$ nosetests test_multi.py -m "<wildcard string>"
+$ python3 -m pytest rgw_multi/ -k "<wildcard string>"
 ```
-Note that the test to run, does not have to be inside the `test_multi.py` file.
-Some tests have attributes set based on their current reliability. You can filter tests based on their attributes:
+
+Note that the test to run does not have to be inside the `test_multi.py` file.
+
+Some tests have markers set based on their current reliability. You can filter tests based on their markers:
+
 ```
-$ nosetests test_multi.py -a "!fails_with_rgw"
+$ python3 -m pytest rgw_multi/ -m "not fails_with_rgw"
 ```
-Note that different options for running specific and multiple tests exists in the [nose documentation](https://nose.readthedocs.io/en/latest/usage.html#options), as well as other options to control the execution of the tests.
+
+Note that different options for running specific and multiple tests exist in the [pytest documentation](https://docs.pytest.org/en/latest/usage.html), as well as other options to control the execution of the tests.
+
 ## Configuration
+
 ### Environment Variables
+
 Following RGW environment variables are taken into consideration when running the tests:
- - `RGW_FRONTEND`: used to change frontend to 'civetweb' or 'beast' (default)
- - `RGW_VALGRIND`: used to run the radosgw under valgrind. e.g. RGW_VALGRIND=yes
+
+* `RGW_FRONTEND`: used to change frontend to 'civetweb' or 'beast' (default)
+* `RGW_VALGRIND`: used to run the radosgw under valgrind. e.g. RGW_VALGRIND=yes
+
 Other environment variables used to configure elements other than RGW can also be used as they are used in vstart.sh. E.g. MON, OSD, MGR, MSD
+
 The configuration file for the run has 3 sections:
+
 ### Default
+
 This section holds the following parameters:
- - `num_zonegroups`: number of zone groups (integer, default 1)
- - `num_zones`: number of regular zones in each group (integer, default 3)
- - `num_az_zones`: number of archive zones (integer, default 0, max value 1)
- - `gateways_per_zone`: number of RADOS gateways per zone (integer, default 2)
- - `no_bootstrap`: whether to assume that the cluster is already up and does not need to be setup again. If set to "false", it will try to re-run the cluster, so, `mstop.sh` must be called beforehand. Should be set to false, anytime the configuration is changed. Otherwise, and assuming the cluster is already up, it should be set to "true" to save on execution time (boolean, default false)
- - `log_level`: console log level of the logs in the tests, note that any program invoked from the test my emit logs regardless of that setting (integer, default 20)
-    - 20 and up -> DEBUG
-    - 10 and up -> INFO
-    - 5 and up -> WARNING
-    - 1 and up -> ERROR
-    - CRITICAL is always logged
-- `log_file`: log file name. If not set, only console logs exists (string, default None)
-- `file_log_level`: file log level of the logs in the tests. Similar to `log_level`
-- `tenant`: name of tenant (string, default None)
-- `checkpoint_retries`: *TODO* (integer, default 60)
-- `checkpoint_delay`: *TODO* (integer, default 5)
-- `reconfigure_delay`: *TODO* (integer, default 5)          
+
+* `num_zonegroups`: number of zone groups (integer, default 1)
+* `num_zones`: number of regular zones in each group (integer, default 3)
+* `num_az_zones`: number of archive zones (integer, default 0, max value 1)
+* `gateways_per_zone`: number of RADOS gateways per zone (integer, default 2)
+* `no_bootstrap`: whether to assume that the cluster is already up and does not need to be setup again. If set to "false", it will try to re-run the cluster, so, `mstop.sh` must be called beforehand. Should be set to false anytime the configuration is changed. Otherwise, and assuming the cluster is already up, it should be set to "true" to save on execution time (boolean, default false)
+* `log_level`: console log level of the logs in the tests, note that any program invoked from the test may emit logs regardless of that setting (integer, default 20)
+
+  * 20 and up -> DEBUG
+  * 10 and up -> INFO
+  * 5 and up -> WARNING
+  * 1 and up -> ERROR
+  * CRITICAL is always logged
+* `log_file`: log file name. If not set, only console logs exist (string, default None)
+* `file_log_level`: file log level of the logs in the tests. Similar to `log_level`
+* `tenant`: name of tenant (string, default None)
+* `checkpoint_retries`: *TODO* (integer, default 60)
+* `checkpoint_delay`: *TODO* (integer, default 5)
+* `reconfigure_delay`: *TODO* (integer, default 5)
+
 ### Elasticsearch
+
 *TODO*
+
 ### Cloud
+
 *TODO*
+
 ## Writing Tests
+
 New tests should be added into the `/path/to/ceph/src/test/rgw/rgw_multi` subdirectory.
-- Base classes are in: `/path/to/ceph/src/test/rgw/rgw_multi/multisite.py`
-- `/path/to/ceph/src/test/rgw/rgw_multi/tests.py` holds the majority of the tests, but also many utility and infrastructure functions that could be used in other tests files 
+
+* Base classes are in: `/path/to/ceph/src/test/rgw/rgw_multi/multisite.py`
+* `/path/to/ceph/src/test/rgw/rgw_multi/tests.py` holds the majority of the tests, but also many utility and infrastructure functions that could be used in other test files
+
+---

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -10,7 +10,6 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-import nose.core
 
 from rgw_multi import multisite
 from rgw_multi.zone_rados import RadosZone as RadosZone
@@ -21,7 +20,6 @@ from rgw_multi.zone_cloud import CloudZoneConfig as CloudZoneConfig
 from rgw_multi.zone_az import AZone as AZone
 from rgw_multi.zone_az import AZoneConfig as AZoneConfig
 
-# make tests from rgw_multi.tests available to nose
 from rgw_multi.tests import *
 from rgw_multi.tests_es import *
 from rgw_multi.tests_az import *


### PR DESCRIPTION
rgw: migrate multisite tests to pytest and cleanup (Issue #73914)

- Migrate rgw_multi test suite from nose to pytest.
- Rename test functions from 'test_ps_s3_<name>' to 'test_<name>'   to follow standard pytest discovery and shorten test names.
- Implement pytest.mark (e.g., bucket_reshard, rgw_down) for better test categorization and filtering.
- Added rgw_multi/pytest.ini to define custom markers.
- Verified framework migration using a local RGW  cluster and Kafka (Zookeeper-based) for bucket notifications.


Signed-off-by: Avinash Sharma <avinash.dev.sharmaji@gmail.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>

### No logic / implementational changes were introduced

<img width="949" height="781" alt="Screenshot from 2026-03-29 03-28-29" src="https://github.com/user-attachments/assets/5ee07461-0d4f-4ed6-b0d3-2a34a6ddf391" />

<img width="949" height="781" alt="image" src="https://github.com/user-attachments/assets/67c293ed-ac88-44c4-9807-d1fefefc8c25" />
