### PR TITLE
osd: fix ASAN ODR violations in denc-mod-osd

### DIFF
--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -42,11 +42,9 @@ using ceph::timespan_str;
 using result_t = Scrub::SnapMapReaderI::result_t;
 using code_t = Scrub::SnapMapReaderI::result_t::code_t;
 
-
-const string SnapMapper::MAPPING_PREFIX = "SNA_";
-const string SnapMapper::OBJECT_PREFIX = "OBJ_";
-
-const char *SnapMapper::PURGED_SNAP_PREFIX = "PSN_";
+static const std::string MAPPING_PREFIX = "SNA_";
+static const std::string OBJECT_PREFIX = "OBJ_";
+static const char *PURGED_SNAP_PREFIX = "PSN_";
 
 /*
 

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -181,12 +181,6 @@ public:
     }
   };
 
-  static const std::string LEGACY_MAPPING_PREFIX;
-  static const std::string MAPPING_PREFIX;
-  static const std::string OBJECT_PREFIX;
-  static const char *PURGED_SNAP_EPOCH_PREFIX;
-  static const char *PURGED_SNAP_PREFIX;
-
 #ifndef WITH_CRIMSON
   struct Scrubber {
     CephContext *cct;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1584,10 +1584,6 @@ ostream& operator<<(ostream& out, const pool_opts_t& opts)
 
 // -- pg_pool_t --
 
-const char *pg_pool_t::APPLICATION_NAME_CEPHFS("cephfs");
-const char *pg_pool_t::APPLICATION_NAME_RBD("rbd");
-const char *pg_pool_t::APPLICATION_NAME_RGW("rgw");
-
 void pg_pool_t::dump(Formatter *f) const
 {
   f->dump_stream("create_time") << get_create_time();
@@ -4874,8 +4870,6 @@ void ObjectModDesc::decode(ceph::buffer::list::const_iterator &_bl)
   bl.reassign_to_mempool(mempool::mempool_osd_pglog);
   DECODE_FINISH(_bl);
 }
-
-std::atomic<uint32_t> ObjectCleanRegions::max_num_intervals = {10};
 
 void ObjectCleanRegions::set_max_num_intervals(uint32_t num)
 {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1278,9 +1278,9 @@ class OSDMap;
  * pg_pool
  */
 struct pg_pool_t {
-  static const char *APPLICATION_NAME_CEPHFS;
-  static const char *APPLICATION_NAME_RBD;
-  static const char *APPLICATION_NAME_RGW;
+  inline static constexpr const char *APPLICATION_NAME_CEPHFS = "cephfs";
+  inline static constexpr const char *APPLICATION_NAME_RBD = "rbd";
+  inline static constexpr const char *APPLICATION_NAME_RGW = "rgw";
 
   enum {
     TYPE_REPLICATED = 1,     // replication
@@ -4270,7 +4270,7 @@ private:
   bool new_object;
   bool clean_omap;
   interval_set<uint64_t> clean_offsets;
-  static std::atomic<uint32_t> max_num_intervals;
+  inline static std::atomic<uint32_t> max_num_intervals{10};
 
   /**
    * trim the number of intervals if clean_offsets.num_intervals()


### PR DESCRIPTION
When building ceph-dencoder with ASAN (-DWITH_ASAN=ON), loading denc-mod-osd.so triggered ODR (One Definition Rule) violations because several static class members were defined both in libceph-common.so and denc-mod-osd.so.

Fix each case appropriately:

- pg_pool_t::APPLICATION_NAME_{CEPHFS,RBD,RGW}: used across many translation units; convert to inline static constexpr in the header and remove the out-of-line definitions from osd_types.cc.

- ObjectCleanRegions::max_num_intervals: used in osd_types.cc and OSD.cc; convert to inline static in the header and remove the out-of-line definition from osd_types.cc.

- SnapMapper::{MAPPING_PREFIX,OBJECT_PREFIX,PURGED_SNAP_PREFIX}: only used within SnapMapper.cc; remove from the class entirely and move to file-local static constants in SnapMapper.cc.

- SnapMapper::{LEGACY_MAPPING_PREFIX,PURGED_SNAP_EPOCH_PREFIX}: never used anywhere; remove the dead declarations from SnapMapper.h.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
