### PR TITLE
tentacle: mgr/cephadm: Add KMIP server support for NVMeoF gateway

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nvmeof.py
+++ b/src/cephadm/cephadmlib/daemons/nvmeof.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from typing import Dict, List, Optional, Tuple, Union
+from pathlib import Path
 
 from ..container_daemon_form import ContainerDaemonForm, daemon_to_container
 from ..container_types import CephContainer
@@ -81,6 +82,8 @@ class CephNvmeof(ContainerDaemonForm):
         mounts[log_dir] = '/var/log/ceph:z'
         if mtls_dir:
             mounts[mtls_dir] = '/src/mtls:z'
+        if Path('/etc/kmip').is_dir():
+            mounts['/etc/kmip'] = '/src/certs/kmip:z'
         return mounts
 
     def _get_huge_pages_mounts(self, files: Dict[str, str]) -> Dict[str, str]:

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -80,6 +80,11 @@ server_cert = /server.cert
 client_cert = /client.cert
 root_ca_cert = /root.ca.cert
 
+{% if spec.kmip_cert_dir %}
+[kmip]
+cert_dir = {{ spec.kmip_cert_dir }}
+{% endif %}
+
 [spdk]
 tgt_path = {{ spec.tgt_path }}
 rpc_socket_dir = {{ spec.rpc_socket_dir }}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -429,6 +429,9 @@ server_cert = /server.cert
 client_cert = /client.cert
 root_ca_cert = /root.ca.cert
 
+[kmip]
+cert_dir = ./certs/kmip/{{server_name}}
+
 [spdk]
 tgt_path = /usr/local/bin/nvmf_tgt
 rpc_socket_dir = /var/tmp/

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1465,6 +1465,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  monitor_timeout: Optional[float] = 1.0,
                  enable_monitor_client: bool = True,
                  monitor_client_log_file_dir: Optional[str] = '',
+                 kmip_cert_dir: Optional[str] = './certs/kmip/{server_name}',
                  placement: Optional[PlacementSpec] = None,
                  unmanaged: bool = False,
                  preview_only: bool = False,
@@ -1668,6 +1669,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.enable_monitor_client = enable_monitor_client
         #: ``monitor_client_log_file_dir`` the monitor client log output file file directory
         self.monitor_client_log_file_dir = monitor_client_log_file_dir
+        #: ``kmip_cert_dir`` directory for KMIP servers keys and certificates
+        self.kmip_cert_dir = kmip_cert_dir
 
     def get_port_start(self) -> List[int]:
         return [self.port, 4420, self.discovery_port, self.prometheus_port]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75774

---

backport of https://github.com/ceph/ceph/pull/68030
parent tracker: https://tracker.ceph.com/issues/75739

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh