### PR TITLE
mgr/dashboard: refresh feedback modal after module enable

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -92,6 +92,25 @@ describe('FeedbackComponent', () => {
 
     expect(refreshSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('should retry feedback state refresh after module update until backend is ready', fakeAsync(() => {
+    const mgrModuleService = TestBed.inject(MgrModuleService);
+    spyOn(feedbackService, 'isKeyExist').and.returnValues(
+      throwError(() => ({ status: 400 })), // initial ngOnInit check
+      throwError(() => ({ status: 400 })), // first refresh after updateCompleted$
+      of(false) // retry succeeds
+    );
+
+    fixture.detectChanges();
+    expect(component.isFeedbackEnabled).toBe(false);
+
+    mgrModuleService.updateCompleted$.next();
+    tick(1000);
+
+    expect(component.isFeedbackEnabled).toBe(true);
+    expect(component.feedbackForm.enabled).toBe(true);
+    expect(component.isAPIKeySet).toBe(false);
+  }));
 
   it('should test invalid api-key', () => {
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
@@ -80,6 +80,19 @@ describe('FeedbackComponent', () => {
     expect(component.isAPIKeySet).toBe(false);
   });
 
+  it('should always refresh feedback state after module updates complete', () => {
+    const mgrModuleService = TestBed.inject(MgrModuleService);
+    const refreshSpy = spyOn<any>(component, 'refreshFeedbackModuleState').and.callThrough();
+    spyOn(feedbackService, 'isKeyExist').and.returnValue(of(true));
+
+    fixture.detectChanges();
+    refreshSpy.calls.reset();
+
+    mgrModuleService.updateCompleted$.next();
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('should test invalid api-key', () => {
     fixture.detectChanges();
     formHelper = new FormHelper(component.feedbackForm);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
@@ -8,6 +8,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { throwError } from 'rxjs';
 
 import { FeedbackService } from '~/app/shared/api/feedback.service';
+import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { configureTestBed, FormHelper } from '~/testing/unit-test-helper';
 import { FeedbackComponent } from './feedback.component';
@@ -37,32 +38,53 @@ describe('FeedbackComponent', () => {
     fixture = TestBed.createComponent(FeedbackComponent);
     component = fixture.componentInstance;
     feedbackService = TestBed.inject(FeedbackService);
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should open the form in a modal', () => {
+    fixture.detectChanges();
     const nativeEl = fixture.debugElement.nativeElement;
     expect(nativeEl.querySelector('cds-modal')).not.toBe(null);
   });
 
   it('should redirect to mgr-modules if feedback module is not enabled', () => {
-    spyOn(feedbackService, 'isKeyExist').and.returnValue(throwError({ status: 400 }));
+    spyOn(feedbackService, 'isKeyExist').and.returnValue(throwError(() => ({ status: 400 })));
 
-    component.ngOnInit();
+    fixture.detectChanges();
 
     expect(component.isFeedbackEnabled).toEqual(false);
     expect(component.feedbackForm.disabled).toBeTruthy();
   });
 
+  it('should refresh feedback state after enabling the module', () => {
+    const mgrModuleService = TestBed.inject(MgrModuleService);
+    spyOn(feedbackService, 'isKeyExist').and.returnValues(
+      throwError(() => ({ status: 400 })),
+      of(false)
+    );
+    spyOn(mgrModuleService, 'updateModuleState').and.callFake(() => {
+      mgrModuleService.updateCompleted$.next();
+    });
+
+    fixture.detectChanges();
+    expect(component.isFeedbackEnabled).toBe(false);
+
+    component.enableFeedbackModule();
+
+    expect(component.isFeedbackEnabled).toBe(true);
+    expect(component.feedbackForm.enabled).toBe(true);
+    expect(component.isAPIKeySet).toBe(false);
+  });
+
   it('should test invalid api-key', () => {
-    component.ngOnInit();
+    fixture.detectChanges();
     formHelper = new FormHelper(component.feedbackForm);
 
-    spyOn(feedbackService, 'createIssue').and.returnValue(throwError({ status: 400 }));
+    spyOn(feedbackService, 'createIssue').and.returnValue(throwError(() => ({ status: 400 })));
 
     formHelper.setValue('api_key', 'invalidkey');
     formHelper.setValue('project', 'dashboard');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.spec.ts
@@ -112,6 +112,29 @@ describe('FeedbackComponent', () => {
     expect(component.isAPIKeySet).toBe(false);
   }));
 
+  it('should stop retry state after all module-refresh attempts fail', fakeAsync(() => {
+    const mgrModuleService = TestBed.inject(MgrModuleService);
+    spyOn(feedbackService, 'isKeyExist').and.returnValues(
+      throwError(() => ({ status: 400 })), // initial ngOnInit check
+      throwError(() => ({ status: 400 })), // first refresh after updateCompleted$
+      throwError(() => ({ status: 400 })), // retry 1
+      throwError(() => ({ status: 400 })), // retry 2
+      throwError(() => ({ status: 400 })), // retry 3
+      throwError(() => ({ status: 400 })), // retry 4
+      throwError(() => ({ status: 400 })) // retry 5
+    );
+
+    fixture.detectChanges();
+    mgrModuleService.updateCompleted$.next();
+
+    tick(5000);
+
+    expect(component.pendingModuleRefreshRetries).toBe(0);
+    expect(component.moduleRefreshTimeoutId).toBeNull();
+    expect(component.isFeedbackEnabled).toBe(false);
+    expect(component.feedbackForm.disabled).toBe(true);
+  }));
+
   it('should test invalid api-key', () => {
     fixture.detectChanges();
     formHelper = new FormHelper(component.feedbackForm);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
@@ -17,6 +17,9 @@ import { NotificationService } from '~/app/shared/services/notification.service'
   standalone: false
 })
 export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
+  private readonly MODULE_REFRESH_RETRY_ATTEMPTS = 5;
+  private readonly MODULE_REFRESH_RETRY_DELAY_MS = 1000;
+
   title = 'Feedback';
   projects: any = [
     'dashboard',
@@ -32,6 +35,8 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
   api_key: string;
   keySub: Subscription;
   moduleUpdateSub: Subscription;
+  moduleRefreshTimeoutId: number;
+  pendingModuleRefreshRetries = 0;
   submit: string;
   feedbackForm: CdFormGroup;
   isAPIKeySet = false;
@@ -49,18 +54,24 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.createForm();
-    this.refreshFeedbackModuleState();
+    this.refreshFeedbackModuleState(false);
     this.moduleUpdateSub = this.mgrModuleService.updateCompleted$.subscribe(() => {
-      this.refreshFeedbackModuleState();
+      this.pendingModuleRefreshRetries = this.MODULE_REFRESH_RETRY_ATTEMPTS;
+      this.refreshFeedbackModuleState(true);
     });
   }
 
-  private refreshFeedbackModuleState() {
+  private refreshFeedbackModuleState(retryOnError: boolean) {
     this.keySub?.unsubscribe();
     this.keySub = this.feedbackService.isKeyExist().subscribe({
       next: (data: boolean) => {
         this.isFeedbackEnabled = true;
         this.feedbackForm.enable();
+        this.pendingModuleRefreshRetries = 0;
+        if (this.moduleRefreshTimeoutId) {
+          clearTimeout(this.moduleRefreshTimeoutId);
+          this.moduleRefreshTimeoutId = null;
+        }
         this.isAPIKeySet = data;
         if (this.isAPIKeySet) {
           this.feedbackForm.get('api_key').clearValidators();
@@ -72,6 +83,12 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
       error: () => {
         this.isFeedbackEnabled = false;
         this.feedbackForm.disable();
+        if (retryOnError && this.pendingModuleRefreshRetries > 0) {
+          this.pendingModuleRefreshRetries--;
+          this.moduleRefreshTimeoutId = window.setTimeout(() => {
+            this.refreshFeedbackModuleState(true);
+          }, this.MODULE_REFRESH_RETRY_DELAY_MS);
+        }
       }
     });
   }
@@ -89,6 +106,9 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.keySub?.unsubscribe();
     this.moduleUpdateSub?.unsubscribe();
+    if (this.moduleRefreshTimeoutId) {
+      clearTimeout(this.moduleRefreshTimeoutId);
+    }
   }
 
   onSubmit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
@@ -61,17 +61,21 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
     });
   }
 
+  private stopModuleRefreshRetryState() {
+    this.pendingModuleRefreshRetries = 0;
+    if (this.moduleRefreshTimeoutId) {
+      clearTimeout(this.moduleRefreshTimeoutId);
+      this.moduleRefreshTimeoutId = null;
+    }
+  }
+
   private refreshFeedbackModuleState(retryOnError: boolean) {
     this.keySub?.unsubscribe();
     this.keySub = this.feedbackService.isKeyExist().subscribe({
       next: (data: boolean) => {
         this.isFeedbackEnabled = true;
         this.feedbackForm.enable();
-        this.pendingModuleRefreshRetries = 0;
-        if (this.moduleRefreshTimeoutId) {
-          clearTimeout(this.moduleRefreshTimeoutId);
-          this.moduleRefreshTimeoutId = null;
-        }
+        this.stopModuleRefreshRetryState();
         this.isAPIKeySet = data;
         if (this.isAPIKeySet) {
           this.feedbackForm.get('api_key').clearValidators();
@@ -88,6 +92,8 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
           this.moduleRefreshTimeoutId = window.setTimeout(() => {
             this.refreshFeedbackModuleState(true);
           }, this.MODULE_REFRESH_RETRY_DELAY_MS);
+        } else {
+          this.stopModuleRefreshRetryState();
         }
       }
     });
@@ -106,9 +112,7 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.keySub?.unsubscribe();
     this.moduleUpdateSub?.unsubscribe();
-    if (this.moduleRefreshTimeoutId) {
-      clearTimeout(this.moduleRefreshTimeoutId);
-    }
+    this.stopModuleRefreshRetryState();
   }
 
   onSubmit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
@@ -51,9 +51,7 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
     this.createForm();
     this.refreshFeedbackModuleState();
     this.moduleUpdateSub = this.mgrModuleService.updateCompleted$.subscribe(() => {
-      if (!this.isFeedbackEnabled) {
-        this.refreshFeedbackModuleState();
-      }
+      this.refreshFeedbackModuleState();
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/feedback/feedback.component.ts
@@ -31,6 +31,7 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
   tracker: string[] = ['bug', 'feature'];
   api_key: string;
   keySub: Subscription;
+  moduleUpdateSub: Subscription;
   submit: string;
   feedbackForm: CdFormGroup;
   isAPIKeySet = false;
@@ -48,12 +49,27 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.createForm();
+    this.refreshFeedbackModuleState();
+    this.moduleUpdateSub = this.mgrModuleService.updateCompleted$.subscribe(() => {
+      if (!this.isFeedbackEnabled) {
+        this.refreshFeedbackModuleState();
+      }
+    });
+  }
+
+  private refreshFeedbackModuleState() {
+    this.keySub?.unsubscribe();
     this.keySub = this.feedbackService.isKeyExist().subscribe({
       next: (data: boolean) => {
+        this.isFeedbackEnabled = true;
+        this.feedbackForm.enable();
         this.isAPIKeySet = data;
         if (this.isAPIKeySet) {
           this.feedbackForm.get('api_key').clearValidators();
+        } else {
+          this.feedbackForm.get('api_key').setValidators(Validators.required);
         }
+        this.feedbackForm.get('api_key').updateValueAndValidity();
       },
       error: () => {
         this.isFeedbackEnabled = false;
@@ -73,7 +89,8 @@ export class FeedbackComponent extends CdForm implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.keySub.unsubscribe();
+    this.keySub?.unsubscribe();
+    this.moduleUpdateSub?.unsubscribe();
   }
 
   onSubmit() {


### PR DESCRIPTION



 The feedback modal only checked whether the `feedback` mgr module was enabled during initialization. If the
  module was disabled, the modal showed the enable prompt and disabled the form, but after clicking `Enable`
  it never refreshed its local state. That allowed the same enable prompt to reappear even though the module
  had already been enabled.

  This change refreshes the feedback modal state when the module enable flow completes, rechecks the API-key
  status, reenables the form, and restores the correct validator state.

  Fixes: https://tracker.ceph.com/issues/75734
   
  The feedback submission flow stayed blocked after enabling the `feedback` mgr module because the modal did
  not refresh its internal enabled state once the module toggle completed. As a result, users could still be
  prevented from submitting feedback even though the backend module had been enabled successfully.

  This change refreshes the modal after module enable, so the report form becomes usable immediately without
  requiring the modal to be reopened.

  Fixes: https://tracker.ceph.com/issues/75733



  ## Validation

  Focused unit tests were updated and rerun locally:

  ```bash
  cd src/pybind/mgr/dashboard/frontend
  npm run env_build
  npx jest --runInBand \
    src/app/ceph/shared/feedback/feedback.component.spec.ts

  Result:

  - 1 test suite passed
  - 5 tests passed
```
<img width="2880" height="1432" alt="image" src="https://github.com/user-attachments/assets/2227709d-75e9-4a55-b030-da1422083d36" />


<img width="2880" height="1532" alt="image" src="https://github.com/user-attachments/assets/3cd1646c-5044-4ca1-bf90-355df7bbf96e" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
