### PR TITLE
src: fix 'occured' typo across codebase

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -4319,7 +4319,7 @@ void MDSRank::inmemory_logger() {
   if (client_eviction_dump ||
       beacon.missed_beacon_ack_dump ||
       beacon.missed_internal_heartbeat_dump) {
-    //dump the in-memory logs if any of these events occured recently
+    //dump the in-memory logs if any of these events occurred recently
     dout(0) << __func__ << " client_eviction_dump "<< client_eviction_dump
             << ", missed_beacon_ack_dump " << beacon.missed_beacon_ack_dump
             << ", missed_internal_heartbeat_dump " << beacon.missed_internal_heartbeat_dump

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -480,7 +480,7 @@ void AsyncConnection::process() {
     case STATE_CONNECTION_ESTABLISHED: {
       if (pendingReadLen) {
         ssize_t r = read(*pendingReadLen, read_buffer, readCallback);
-        if (r <= 0) { // read all bytes, or an error occured
+        if (r <= 0) { // read all bytes, or an error occurred
           pendingReadLen.reset();
           char *buf_tmp = read_buffer;
           read_buffer = nullptr;

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -3360,7 +3360,7 @@ class RmtreeDir:
         # or unlink() for them.
         self.de_ignore_list = []
 
-        # Indicates whether an error occured during call to readdir().
+        # Indicates whether an error occurred during call to readdir().
         self.has_readdir_failed = False
 
         # If a dir entry has been removed and readdir() returns None,
@@ -3420,7 +3420,7 @@ class RmtreeDir:
 
                     de = self.fs.readdir(self.handle)
         except Error as e:
-            log.error(f'Exception occured: "{e}"')
+            log.error(f'Exception occurred: "{e}"')
             self.set_readdir_error()
 
     def try_rmdir(self, suppress_errors=False):
@@ -3443,7 +3443,7 @@ class RmtreeDir:
             # XXX: push this dir to stack, done in the caller method
             raise
         except Error as e:
-            log.error('Following exception occured while calling rmdir() for '
+            log.error('Following exception occurred while calling rmdir() for '
                       f'dir "{self.name}": "{e}"')
             self.add_to_de_ignore_list(self.name)
 
@@ -3458,7 +3458,7 @@ class RmtreeDir:
             self.fs.unlinkat(self.fd, de_name, 0)
             self.de_has_been_removed = True
         except Error as e:
-            log.error('Following exception occured while calling unlink() for '
+            log.error('Following exception occurred while calling unlink() for '
                       f'file "{de_name}": "{e}"')
             self.add_to_de_ignore_list(de_name)
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1363,7 +1363,7 @@ bool PeerReplayer::SyncMechanism::pop_dataq_entry(SyncEntry &out_entry) {
     // predicate true
     if (ready)
       break;
-    // otherwise timeout occured, nothing to do - loop again
+    // otherwise timeout occurred, nothing to do - loop again
   }
   dout(20) << ": snapshot data replayer woke up to process m_syncm_dataq, syncm=" << this
            << " crawl_finished=" << m_crawl_finished << dendl;
@@ -2413,7 +2413,7 @@ void PeerReplayer::run_datasync(SnapshotDataSyncThread *data_replayer) {
           mark_and_notify_syncms_to_backoff(-EBLOCKLISTED);
           break;
         }
-        // otherwise timeout occured, nothing to do - loop again
+        // otherwise timeout occurred, nothing to do - loop again
       }
 
       if (shutdown || blocklist) {


### PR DESCRIPTION
Fix misspelling of "occurred" (spelled as "occured") in comments and log messages
across multiple components:

- `src/tools/cephfs_mirror/PeerReplayer.cc` — comments (2 occurrences)
- `src/msg/async/AsyncConnection.cc` — comment
- `src/mds/MDSRank.cc` — comment
- `src/pybind/cephfs/cephfs.pyx` — comment + log.error messages (4 occurrences)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests