### PR TITLE
src: fix miscellaneous typos in comments

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -334,7 +334,7 @@ int md_config_t::set_mon_vals(CephContext *cct,
 		  << " cleared (was " << Option::to_str(config->second) << ")"
 		  << dendl;
     values.rm_val(name, CONF_MON);
-    // if this is a debug option, it needs to propagate to teh subsys;
+    // if this is a debug option, it needs to propagate to the subsys;
     // this isn't covered by update_legacy_vals() below.  similarly,
     // we want to trigger a config notification for these items.
     const Option *o = find_option(name);

--- a/src/common/io_exerciser/EcIoSequence.h
+++ b/src/common/io_exerciser/EcIoSequence.h
@@ -23,7 +23,7 @@ class EcIoSequence : public IoSequence {
 
   EcIoSequence(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
-  // Writes cannot be sent to injected on shard zero, so selections seperated
+  // Writes cannot be sent to injected on shard zero, so selections separated
   // out
   void select_random_data_shard_to_inject_read_error(
       std::optional<std::pair<int, int>> km,

--- a/src/include/platform_errno.h
+++ b/src/include/platform_errno.h
@@ -14,7 +14,7 @@
 
 /* XXX: This definitions are placed here so that it's easy to import them into
  * CephFS python bindings. Otherwise, entire src/include/types.h would needed to
- * be imported, which is unneccessary and also complicated.
+ * be imported, which is unnecessary and also complicated.
  */
 
 #pragma once

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3732,7 +3732,7 @@ public:
           if (r < 0) {
             ldpp_dout(dpp, 4) << "failed to read part lengths from the manifest" << dendl;
           } else {
-            // store the encoded part lenghts in RGW_ATTR_CRYPT_PARTS
+            // store the encoded part lengths in RGW_ATTR_CRYPT_PARTS
             bufferlist parts_bl;
             encode(parts_len, parts_bl);
             src_attrs[RGW_ATTR_CRYPT_PARTS] = std::move(parts_bl);
@@ -5470,7 +5470,7 @@ int fixup_manifest_to_parts_len(const DoutPrefixProvider *dpp, rgw::sal::Attrs &
       ldpp_dout(dpp, 0) << "failed to read part lengths from the manifest r=" << r << dendl;
       return r;
     }
-    // store the encoded part lenghts in RGW_ATTR_CRYPT_PARTS
+    // store the encoded part lengths in RGW_ATTR_CRYPT_PARTS
     bufferlist parts_bl;
     encode(parts_len, parts_bl);
     src_attrs[RGW_ATTR_CRYPT_PARTS] = std::move(parts_bl);

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1273,7 +1273,7 @@ int RGWBucketReshard::execute(int num_shards,
   if (ret < 0) {
     return ret;
   }
-  // TODO: release the lock when purging the old index shards or unsucessful new index shards
+  // TODO: release the lock when purging the old index shards or unsuccessful new index shards
   auto unlock = make_scope_guard([this] { reshard_lock.unlock(); });
 
   if (reshard_log) {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -3204,7 +3204,7 @@ TEST(bluestore_blob_t, unused) {
     // _do_write_small 0x2a000~1000
     // and 0x1d000~1000
     uint64_t unused_granularity = 0x3000;
-    // offsets and lenght below are selected to
+    // offsets and length below are selected to
     // be aligned with unused_granularity
     uint64_t offset0 = 0x2a000;
     uint64_t offset = 0x1d000;

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -481,7 +481,7 @@ TEST_F(OSDMapTest, Features) {
   ASSERT_TRUE(features & CEPH_FEATURE_OSDHASHPSPOOL);
   ASSERT_TRUE(features & CEPH_FEATURE_OSD_PRIMARY_AFFINITY);
 
-  // remove teh EC pool, but leave the rule.  add primary affinity.
+  // remove the EC pool, but leave the rule.  add primary affinity.
   {
     OSDMap::Incremental new_pool_inc(osdmap.get_epoch() + 1);
     new_pool_inc.old_pools.insert(osdmap.lookup_pg_pool_name("ec"));

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -2367,7 +2367,7 @@ def test_copy_after_dedup():
 
         # At this point the original obejcts are all removed
         # Objects created by server-side-copy should keep the tail in place
-        # because of teh refcount
+        # because of the refcount
         verify_objects_copy(bucket_cp, files, conn, expected_results, config)
 
     finally:


### PR DESCRIPTION
Fix various misspellings in code comments across the codebase:

- `src/common/config.cc` — "teh" → "the"
- `src/common/io_exerciser/EcIoSequence.h` — "seperated" → "separated"
- `src/include/platform_errno.h` — "unneccessary" → "unnecessary"
- `src/test/objectstore/test_bluestore_types.cc` — "lenght" → "length"
- `src/test/osd/TestOSDMap.cc` — "teh" → "the"
- `src/rgw/driver/rados/rgw_reshard.cc` — "unsucessful" → "unsuccessful"
- `src/rgw/driver/rados/rgw_rados.cc` — "lenghts" → "lengths" (2 occurrences)
- `src/test/rgw/dedup/test_dedup.py` — "teh" → "the"

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests