### PR TITLE
mgr/prometheus: cleanup the smb share processing logs

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1961,15 +1961,16 @@ class Module(MgrModule, OrchestratorClientMixin):
             try:
                 smb_data = json.loads(out)
 
+                self.log.info("Processing SMB share resource")
                 for resource in smb_data.get('resources', []):
                     if resource.get('resource_type') == 'ceph.smb.share':
-                        self.log.info("Processing SMB share resource")
                         cluster_id = resource.get('cluster_id')
                         if not cluster_id:
                             self.log.debug("Skipping share with missing cluster_id")
                             continue
 
                         share_id = resource.get('share_id', '')
+                        self.log.debug(f"Processing SMB share resource: {share_id} in cluster {cluster_id}")
                         cephfs = resource.get('cephfs', {})
                         cephfs_volume = cephfs.get('volume', '')
                         cephfs_subvolumegroup = cephfs.get('subvolumegroup', '_nogroup')


### PR DESCRIPTION
It logs the same output for as many share exists in the cluster. Instead creating a debug log if we want to see the share that's being processed and moving the generic message outside the for loop.

Currently, the logs look like this if you have lot of shares
```
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
Mar 28 04:43:11 ceph-node-00 ceph-mgr[2272]: [prometheus INFO prometheus] Processing SMB share resource
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
