### PR TITLE
qa,src: replace deprecated egrep/fgrep with grep -E/grep -F

### DIFF
--- a/qa/standalone/mon/osd-crush.sh
+++ b/qa/standalone/mon/osd-crush.sh
@@ -40,7 +40,7 @@ function TEST_crush_rule_create_simple() {
     run_mon $dir a || return 1
 
     ceph --format xml osd crush rule dump replicated_rule | \
-        egrep '<op>take</op><item>[^<]+</item><item_name>default</item_name>' | \
+        grep -E '<op>take</op><item>[^<]+</item><item_name>default</item_name>' | \
         grep '<op>choose_firstn</op><num>0</num><type>osd</type>' || return 1
     local rule=rule0
     local root=host1
@@ -50,7 +50,7 @@ function TEST_crush_rule_create_simple() {
     ceph osd crush rule create-simple $rule $root $failure_domain 2>&1 | \
         grep "$rule already exists" || return 1
     ceph --format xml osd crush rule dump $rule | \
-        egrep '<op>take</op><item>[^<]+</item><item_name>'$root'</item_name>' | \
+        grep -E '<op>take</op><item>[^<]+</item><item_name>'$root'</item_name>' | \
         grep '<op>choose_firstn</op><num>0</num><type>'$failure_domain'</type>' || return 1
     ceph osd crush rule rm $rule || return 1
 }
@@ -96,7 +96,7 @@ function TEST_crush_rule_create_erasure() {
     ceph osd crush rule create-erasure $rule 2>&1 | \
         grep "$rule already exists" || return 1
     ceph --format xml osd crush rule dump $rule | \
-        egrep '<op>take</op><item>[^<]+</item><item_name>default</item_name>' | \
+        grep -E '<op>take</op><item>[^<]+</item><item_name>default</item_name>' | \
         grep '<op>chooseleaf_indep</op><num>0</num><type>host</type>' || return 1
     ceph osd crush rule rm $rule || return 1
     ! ceph osd crush rule ls | grep $rule || return 1

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -1028,7 +1028,7 @@ function list_missing_erasure_coded() {
 
     for i in $(seq 0 120) ; do
         [ $i -lt 60 ] || return 1
-        matches=$(ceph pg $pg list_unfound | egrep "MOBJ0|MOBJ1" | wc -l)
+        matches=$(ceph pg $pg list_unfound | grep -E "MOBJ0|MOBJ1" | wc -l)
         [ $matches -eq 2 ] && break
     done
 }

--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -57,4 +57,4 @@ tasks:
 - ceph.healthy:
 - exec:
     osd.0:
-      - egrep '(defer backfill|defer recovery)' /var/log/ceph/ceph-osd.*.log
+      - grep -E '(defer backfill|defer recovery)' /var/log/ceph/ceph-osd.*.log

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1901,7 +1901,7 @@ def task(ctx, config):
 
     By default, the cluster log is checked for errors and warnings,
     and the run marked failed if any appear. You can ignore log
-    entries by giving a list of egrep compatible regexes, i.e.:
+    entries by giving a list of grep -E compatible regexes, i.e.:
 
         tasks:
         - ceph:

--- a/qa/tasks/rook.py
+++ b/qa/tasks/rook.py
@@ -223,12 +223,12 @@ def ceph_log(ctx, config):
             """
             args = [
                 'sudo',
-                'egrep', pattern,
+                'grep -E', pattern,
                 f'{log_dir}/ceph.log',
             ]
             if excludes:
                 for exclude in excludes:
-                    args.extend([run.Raw('|'), 'egrep', '-v', exclude])
+                    args.extend([run.Raw('|'), 'grep -E', '-v', exclude])
             args.extend([
                 run.Raw('|'), 'head', '-n', '1',
             ])

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1042,17 +1042,17 @@ test_migration() {
     rbd snap create test1@snap2
     rbd clone test1@snap1 clone_v1 --rbd_default_clone_format=1
     rbd clone test1@snap2 clone_v2 --rbd_default_clone_format=2
-    rbd info clone_v1 | fgrep 'parent: rbd/test1@snap1'
-    rbd info clone_v2 | fgrep 'parent: rbd/test1@snap2'
+    rbd info clone_v1 | grep -F 'parent: rbd/test1@snap1'
+    rbd info clone_v2 | grep -F 'parent: rbd/test1@snap2'
     rbd info clone_v2 |grep 'op_features: clone-child'
     test "$(rbd export clone_v1 - | md5sum)" = "${md5sum}"
     test "$(rbd export clone_v2 - | md5sum)" = "${md5sum}"
     test "$(rbd children test1@snap1)" = "rbd/clone_v1"
     test "$(rbd children test1@snap2)" = "rbd/clone_v2"
     rbd migration prepare test1 rbd2/test2
-    rbd info clone_v1 | fgrep 'parent: rbd2/test2@snap1'
-    rbd info clone_v2 | fgrep 'parent: rbd2/test2@snap2'
-    rbd info clone_v2 | fgrep 'op_features: clone-child'
+    rbd info clone_v1 | grep -F 'parent: rbd2/test2@snap1'
+    rbd info clone_v2 | grep -F 'parent: rbd2/test2@snap2'
+    rbd info clone_v2 | grep -F 'op_features: clone-child'
     test "$(rbd children rbd2/test2@snap1)" = "rbd/clone_v1"
     test "$(rbd children rbd2/test2@snap2)" = "rbd/clone_v2"
     rbd migration execute test1
@@ -1061,9 +1061,9 @@ test_migration() {
     test "$(rbd export clone_v1 - | md5sum)" = "${md5sum}"
     test "$(rbd export clone_v2 - | md5sum)" = "${md5sum}"
     rbd migration prepare rbd2/test2 test1
-    rbd info clone_v1 | fgrep 'parent: rbd/test1@snap1'
-    rbd info clone_v2 | fgrep 'parent: rbd/test1@snap2'
-    rbd info clone_v2 | fgrep 'op_features: clone-child'
+    rbd info clone_v1 | grep -F 'parent: rbd/test1@snap1'
+    rbd info clone_v2 | grep -F 'parent: rbd/test1@snap2'
+    rbd info clone_v2 | grep -F 'op_features: clone-child'
     test "$(rbd children test1@snap1)" = "rbd/clone_v1"
     test "$(rbd children test1@snap2)" = "rbd/clone_v2"
     rbd migration execute test1
@@ -1185,7 +1185,7 @@ test_trash_purge_schedule() {
     rbd namespace create rbd2/ns1
 
     test "$(ceph rbd trash purge schedule list)" = "{}"
-    ceph rbd trash purge schedule status | fgrep '"scheduled": []'
+    ceph rbd trash purge schedule status | grep -F '"scheduled": []'
 
     expect_fail rbd trash purge schedule ls
     test "$(rbd trash purge schedule ls -R --format json)" = "[]"
@@ -1373,7 +1373,7 @@ test_trash_purge_schedule_staggering() {
 
     # Initial empty check
     test "$(ceph rbd trash purge schedule list)" = "{}"
-    ceph rbd trash purge schedule status | fgrep '"scheduled": []'
+    ceph rbd trash purge schedule status | grep -F '"scheduled": []'
 
     # Create 80 namespaces
     for i in {1..80}; do
@@ -1517,7 +1517,7 @@ test_mirror_snapshot_schedule() {
     rbd mirror pool peer add rbd2 cluster1
 
     test "$(ceph rbd mirror snapshot schedule list)" = "{}"
-    ceph rbd mirror snapshot schedule status | fgrep '"scheduled_images": []'
+    ceph rbd mirror snapshot schedule status | grep -F '"scheduled_images": []'
 
     expect_fail rbd mirror snapshot schedule ls
     test "$(rbd mirror snapshot schedule ls -R --format json)" = "[]"
@@ -1702,7 +1702,7 @@ test_mirror_snapshot_schedule_staggering() {
 
     # Initial empty check
     test "$(ceph rbd mirror snapshot schedule list)" = "{}"
-    ceph rbd mirror snapshot schedule status | fgrep '"scheduled_images": []'
+    ceph rbd mirror snapshot schedule status | grep -F '"scheduled_images": []'
 
     # Create 80 images
     for i in {1..80}; do
@@ -1969,9 +1969,9 @@ test_mirror_pool_peer_bootstrap_create() {
     test "$TOKEN_FSID" = "$(ceph fsid)"
     test "$TOKEN_KEY" = "$(ceph auth get-key client.$TOKEN_CLIENT_ID)"
     for addr in "${MON_ADDRS[@]}"; do
-        fgrep "$addr" <<< "$TOKEN_MON_HOST"
+        grep -F "$addr" <<< "$TOKEN_MON_HOST"
     done
-    expect_fail fgrep "$BAD_MON_ADDR" <<< "$TOKEN_MON_HOST"
+    expect_fail grep -F "$BAD_MON_ADDR" <<< "$TOKEN_MON_HOST"
 
     # check that the token does not change, including across pools
     test "$(rbd mirror pool peer bootstrap create \

--- a/qa/workunits/rbd/journal.sh
+++ b/qa/workunits/rbd/journal.sh
@@ -70,9 +70,9 @@ test_rbd_journal()
     save_commit_position ${journal}
     rbd bench --io-type write ${image} --io-size 4096 --io-threads 1 \
 	--io-total $((4096 * count)) --io-pattern seq
-    rbd journal status --image ${image} | fgrep "tid=$((count - 1))"
+    rbd journal status --image ${image} | grep -F "tid=$((count - 1))"
     restore_commit_position ${journal}
-    rbd journal status --image ${image} | fgrep "positions=[]"
+    rbd journal status --image ${image} | grep -F "positions=[]"
     local count1=$(rbd journal inspect --verbose ${journal} |
 			  grep -c 'event_type.*AioWrite')
     test "${count}" -eq "${count1}"

--- a/qa/workunits/rbd/kernel.sh
+++ b/qa/workunits/rbd/kernel.sh
@@ -18,7 +18,7 @@ function get_device_dir {
 	local POOL=$1
 	local IMAGE=$2
 	local SNAP=$3
-	rbd device list | tail -n +2 | egrep "\s+$POOL\s+$IMAGE\s+$SNAP\s+" |
+	rbd device list | tail -n +2 | grep -E "\s+$POOL\s+$IMAGE\s+$SNAP\s+" |
 	    awk '{print $1;}'
 }
 

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -74,7 +74,7 @@ $(printf %x $IMAGE_SIZE)
 EOF
     [[ $(rados -p rbd ls | grep -c rbd_data.$IMAGE_ID) -eq $num_objects_expected ]]
     for ((i = 0; i < $num_objects_expected; i++)); do
-        rados -p rbd stat rbd_data.$IMAGE_ID.$(printf %016x $i) | egrep "(size $((OBJECT_SIZE / 2)))|(size 0)"
+        rados -p rbd stat rbd_data.$IMAGE_ID.$(printf %016x $i) | grep -E "(size $((OBJECT_SIZE / 2)))|(size 0)"
     done
 }
 

--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -412,7 +412,7 @@ function test_migration_open_clone_chain() {
 }
 
 function get_nbd_device_paths {
-  rbd device list -t nbd | tail -n +2 | egrep "\s+rbd\s+testimg" | awk '{print $5;}'
+  rbd device list -t nbd | tail -n +2 | grep -E "\s+rbd\s+testimg" | awk '{print $5;}'
 }
 
 function clean_up_cryptsetup() {

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -67,7 +67,7 @@ function cleanup()
 
     set +e
 
-    mount | fgrep ${TEMPDIR}/mnt && _sudo umount -f ${TEMPDIR}/mnt
+    mount | grep -F ${TEMPDIR}/mnt && _sudo umount -f ${TEMPDIR}/mnt
 
     rm -Rf ${TEMPDIR}
     if [ -n "${DEV}" ]

--- a/qa/workunits/rbd/test_admin_socket.sh
+++ b/qa/workunits/rbd/test_admin_socket.sh
@@ -122,8 +122,8 @@ rbd_cache_flush="rbd cache flush ${pool}/${image}"
 rbd_cache_invalidate="rbd cache invalidate ${pool}/${image}"
 
 rbd_watch_start ${image}
-${ceph_admin} help | fgrep "${rbd_cache_flush}"
-${ceph_admin} help | fgrep "${rbd_cache_invalidate}"
+${ceph_admin} help | grep -F "${rbd_cache_flush}"
+${ceph_admin} help | grep -F "${rbd_cache_invalidate}"
 rbd_watch_end ${image}
 
 # test rbd cache commands with disabled and enabled cache

--- a/qa/workunits/rgw/test_rgw_d4n.py
+++ b/qa/workunits/rgw/test_rgw_d4n.py
@@ -54,7 +54,7 @@ def exec_cmd(cmd):
         return False
 
 def get_radosgw_endpoint():
-    out = exec_cmd('sudo ss -nltp | egrep "rados|valgr|memcheck-"')  # short for radosgw/valgrind
+    out = exec_cmd('sudo ss -nltp | grep -E "rados|valgr|memcheck-"')  # short for radosgw/valgrind
     x = out.decode('utf8').split(" ")
     port = [i for i in x if ':' in i][0].split(':')[1]
     log.info('radosgw port: %s' % port)

--- a/qa/workunits/rgw/test_rgw_datacache.py
+++ b/qa/workunits/rgw/test_rgw_datacache.py
@@ -80,7 +80,7 @@ def exec_cmd(cmd):
         return False
 
 def get_radosgw_endpoint():
-    out = exec_cmd('sudo ss -nltp | egrep "rados|valgr|memcheck-"')  # short for radosgw/valgrind
+    out = exec_cmd('sudo ss -nltp | grep -E "rados|valgr|memcheck-"')  # short for radosgw/valgrind
     x = out.decode('utf8').split(" ")
     port = [i for i in x if ':' in i][0].split(':')[1]
     log.info('radosgw port: %s' % port)

--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -184,10 +184,10 @@ get_name_list() {
     # extract list of monitors, mdss, osds, mgrs defined in startup.conf
     allconf=$(for entity in \
       $local \
-      `$CCONF -c $conf -l mon | egrep -v '^mon$' || true` \
-      `$CCONF -c $conf -l mds | egrep -v '^mds$' || true` \
-      `$CCONF -c $conf -l mgr | egrep -v '^mgr$' || true` \
-      `$CCONF -c $conf -l osd | egrep -v '^osd$' || true`; do
+      `$CCONF -c $conf -l mon | grep -E -v '^mon$' || true` \
+      `$CCONF -c $conf -l mds | grep -E -v '^mds$' || true` \
+      `$CCONF -c $conf -l mgr | grep -E -v '^mgr$' || true` \
+      `$CCONF -c $conf -l osd | grep -E -v '^osd$' || true`; do
       echo $entity
     done | sort -u)
 
@@ -209,7 +209,7 @@ get_name_list() {
 		done
 		;;
 	    *)
-		if ! echo " " $allconf $local " " | egrep -q "( $type$id | $type.$id )"; then
+		if ! echo " " $allconf $local " " | grep -E -q "( $type$id | $type.$id )"; then
 		    echo "$0: $type.$id not found ($conf defines" $allconf", /var/lib/ceph defines" $local")"
 		    exit 1
 		fi

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -414,10 +414,10 @@ for name in $what; do
 		do_root_cmd_okfail "mkdir -p $fs_path"
 		if [ "$fs_type" = "btrfs" ]; then
 		    echo Mounting Btrfs on $host:$fs_path
-		    do_root_cmd_okfail "modprobe btrfs ; btrfs device scan || btrfsctl -a ; egrep -q '^[^ ]+ $fs_path ' /proc/mounts && umount $fs_path ; mount -t btrfs $fs_opt $first_dev $fs_path"
+		    do_root_cmd_okfail "modprobe btrfs ; btrfs device scan || btrfsctl -a ; grep -E -q '^[^ ]+ $fs_path ' /proc/mounts && umount $fs_path ; mount -t btrfs $fs_opt $first_dev $fs_path"
 		else
 		    echo Mounting $fs_type on $host:$fs_path
-		    do_root_cmd_okfail "modprobe $fs_type ; egrep -q '^[^ ]+ $fs_path ' /proc/mounts && umount $fs_path ; mount -t $fs_type $fs_opt $first_dev $fs_path"
+		    do_root_cmd_okfail "modprobe $fs_type ; grep -E -q '^[^ ]+ $fs_path ' /proc/mounts && umount $fs_path ; mount -t $fs_type $fs_opt $first_dev $fs_path"
 		fi
 		if [ "$ERR" != "0" ]; then
 		    EXIT_STATUS=$ERR

--- a/src/rgw/rgw-orphan-list
+++ b/src/rgw/rgw-orphan-list
@@ -161,10 +161,10 @@ rados_ls() {
 
     # check for locators (w/o namespace); we identify them by skipping
     # past the empty namespace (i.e., one TAB), skipping past the oid,
-    # then looking for a TAB; note we use egrep to get the '+' character
+    # then looking for a TAB; note we use grep -E to get the '+' character
     # and the $ in front of the ' allows the \t to be interpreted as a TAB
     log "Checking for locators"
-    egrep --text $'^\t[[:graph:]]+\t' "$rados_out" >>"$rados_odd"
+    grep -E --text $'^\t[[:graph:]]+\t' "$rados_out" >>"$rados_odd"
     if [ "${PIPESTATUS[0]}" -eq 0 ] ;then
         log "Locator found"
         locator_found=1


### PR DESCRIPTION
`egrep` and `fgrep` are deprecated and emit warnings on modern systems:

    egrep: warning: egrep is obsolescent; using grep -E

Replace all occurrences across the ceph/ceph repository:
- `egrep` → `grep -E` (22 occurrences in 13 files)
- `fgrep` → `grep -F` (19 occurrences in 4 files)

Affected areas: qa/workunits, qa/standalone, qa/tasks, qa/suites, src/init-ceph.in, src/ceph_common.sh, src/rgw/rgw-orphan-list

These are POSIX-defined equivalences with identical behavior. All modified shell scripts pass `bash -n` syntax checking.

Fixes: https://tracker.ceph.com/issues/75776
Related: https://tracker.ceph.com/issues/74259 (same issue in teuthology repo)

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests