### PR TITLE
isa-l: enable on RISC-V

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -244,7 +244,7 @@ endif()
 
 # Set WITH_EC_ISA_PLUGIN early so it's available when processing common/options
 # This must be set before add_subdirectory(common) is called
-if(HAVE_NASM_X64_AVX2 OR HAVE_ARMV8_SIMD OR HAS_ALTIVEC)
+if(HAVE_NASM_X64_AVX2 OR HAVE_ARMV8_SIMD OR HAS_ALTIVEC OR HAVE_RISCV_RVV)
   set(WITH_EC_ISA_PLUGIN TRUE CACHE BOOL "")
 endif()
 

--- a/src/arch/riscv.c
+++ b/src/arch/riscv.c
@@ -6,8 +6,13 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+int ceph_arch_riscv_rvv = 0;
 int ceph_arch_riscv_zbc = 0;
 int ceph_arch_riscv_zvbc = 0;
+
+#ifndef RISCV_HWPROBE_IMA_V
+#define RISCV_HWPROBE_IMA_V (1ULL << 2)
+#endif
 
 #ifndef RISCV_HWPROBE_EXT_ZBC
 #define RISCV_HWPROBE_EXT_ZBC (1ULL << 7)
@@ -30,6 +35,7 @@ void ceph_arch_riscv_probe(void)
 
     if (do_hwprobe(pairs, 1) == 0) {
         unsigned long long ext = pairs[0].value;
+        ceph_arch_riscv_rvv  = (ext & RISCV_HWPROBE_IMA_V);
         ceph_arch_riscv_zbc  = (ext & RISCV_HWPROBE_EXT_ZBC);
         ceph_arch_riscv_zvbc = (ext & RISCV_HWPROBE_EXT_ZVBC);
     }

--- a/src/arch/riscv.h
+++ b/src/arch/riscv.h
@@ -13,6 +13,7 @@
 extern "C" {
 #endif
 
+extern int ceph_arch_riscv_rvv;
 extern int ceph_arch_riscv_zbc;
 extern int ceph_arch_riscv_zvbc;
 

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -82,6 +82,36 @@ elseif(HAVE_ARMV8_SIMD)
     COMPILE_DEFINITIONS "__ASSEMBLY__"
     INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/src/isa-l/igzip;${PROJECT_SOURCE_DIR}/src/isa-l/igzip/aarch64"
   )
+elseif(HAVE_RISCV_RVV)
+  set(zlib_asm_sources
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/riscv64/igzip_multibinary_riscv64.S
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/riscv64/igzip_isal_adler32_rvv.S
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/riscv64/igzip_isal_adler32_rvv128.S
+  )
+  set(zlib_sources
+    CompressionPluginZlib.cc
+    ZlibCompressor.cc
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/hufftables_c.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_base.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_icf_base.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/adler32_base.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/flatten_ll.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/encode_df.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_icf_body.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_inflate.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/huff_codes.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/proc_heap_base.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/crc/crc_base_aliases.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/crc/crc_base.c
+    ${CMAKE_SOURCE_DIR}/src/isa-l/crc/crc64_base.c
+    ${zlib_asm_sources}
+  )
+  set_source_files_properties(${zlib_asm_sources} PROPERTIES
+    COMPILE_DEFINITIONS "__ASSEMBLY__"
+    INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/src/isa-l/igzip;${PROJECT_SOURCE_DIR}/src/isa-l/igzip/riscv64"
+  )
 else()
   set(zlib_sources
     CompressionPluginZlib.cc

--- a/src/compressor/zlib/CompressionPluginZlib.h
+++ b/src/compressor/zlib/CompressionPluginZlib.h
@@ -19,6 +19,7 @@
 #include "arch/probe.h"
 #include "arch/intel.h"
 #include "arch/arm.h"
+#include "arch/riscv.h"
 #include "common/ceph_context.h"
 #include "compressor/CompressionPlugin.h"
 #include "ZlibCompressor.h"
@@ -46,6 +47,11 @@ public:
     if (cct->_conf->compressor_zlib_isal) {
       ceph_arch_probe();
       isal = (ceph_arch_aarch64_pmull && ceph_arch_neon);
+    }
+#elif defined(HAVE_RISCV_RVV)
+    if (cct->_conf->compressor_zlib_isal) {
+      ceph_arch_probe();
+      isal = ceph_arch_riscv_rvv;
     }
 #endif
     if (compressor == 0 || has_isal != isal) {

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -72,6 +72,7 @@ ZlibCompressor::ZlibCompressor(CephContext *cct, bool isal)
 
 #if (__x86_64__ && defined(HAVE_NASM_X64_AVX2))
 #elif defined(__aarch64__)
+#elif defined(HAVE_RISCV_RVV)
 #else
   if (isal_enabled) {
     derr << "WARN: ISA-L enabled (compressor_zlib_isal=true) but not supported"
@@ -154,7 +155,7 @@ int ZlibCompressor::zlib_compress(const bufferlist &in, bufferlist &out, std::op
   return 0;
 }
 
-#if (__x86_64__ && defined(HAVE_NASM_X64_AVX2)) || defined(__aarch64__)
+#if (__x86_64__ && defined(HAVE_NASM_X64_AVX2)) || defined(__aarch64__) || defined(HAVE_RISCV_RVV)
 int ZlibCompressor::isal_compress(const bufferlist &in, bufferlist &out, std::optional<int32_t> &compressor_message)
 {
   int ret;
@@ -219,7 +220,7 @@ int ZlibCompressor::compress(const bufferlist &in, bufferlist &out, std::optiona
   if (uadk_enabled)
     return uadk_accel.compress(in, out);
 #endif
-#if (__x86_64__ && defined(HAVE_NASM_X64_AVX2)) || defined(__aarch64__)
+#if (__x86_64__ && defined(HAVE_NASM_X64_AVX2)) || defined(__aarch64__) || defined(HAVE_RISCV_RVV)
   if (isal_enabled)
     return isal_compress(in, out, compressor_message);
   else

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -70,7 +70,9 @@ ZlibCompressor::ZlibCompressor(CephContext *cct, bool isal)
   : Compressor(COMP_ALG_ZLIB, "zlib"), isal_enabled(isal), cct(cct)
 {
 
-#if !(__x86_64__ && defined(HAVE_NASM_X64_AVX2)) || defined(__aarch64__)
+#if (__x86_64__ && defined(HAVE_NASM_X64_AVX2))
+#elif defined(__aarch64__)
+#else
   if (isal_enabled) {
     derr << "WARN: ISA-L enabled (compressor_zlib_isal=true) but not supported"
          << dendl;

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -402,7 +402,7 @@ INSTANTIATE_TEST_SUITE_P(
 #ifdef HAVE_LZ4
     "lz4",
 #endif
-#if defined(__x86_64__) || defined(__aarch64__)
+#if defined(__x86_64__) || defined(__aarch64__) || defined(HAVE_RISCV_RVV)
     "zlib/isal",
 #endif
     "zlib/noisal",
@@ -412,7 +412,7 @@ INSTANTIATE_TEST_SUITE_P(
 #endif
     "zstd"));
 
-#if defined(__x86_64__) || defined(__aarch64__)
+#if defined(__x86_64__) || defined(__aarch64__) || defined(HAVE_RISCV_RVV)
 
 TEST(ZlibCompressor, zlib_isal_compatibility)
 {
@@ -477,7 +477,7 @@ TEST(CompressionPlugin, all)
   }
 }
 
-#if defined(__x86_64__) || defined(__aarch64__)
+#if defined(__x86_64__) || defined(__aarch64__) || defined(HAVE_RISCV_RVV)
 
 TEST(ZlibCompressor, isal_compress_zlib_decompress_random)
 {


### PR DESCRIPTION
ISA-L v2.32.0 added RISC-V support. This pr enables ISA-L on RISC-V.
  
  ## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests