### PR TITLE
tentacle: rgw/sts: correct error code to 400 (from 403)

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -143,6 +143,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ECANCELED, {409, "ConcurrentModification"}},
     { EDQUOT, {507, "InsufficientCapacity"}},
     { ENOSPC, {507, "InsufficientCapacity"}},
+    { ERR_EXPIRED_TOKEN, {400, "ExpiredToken"}},
 });
 
 rgw_http_errors rgw_http_swift_errors({

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -362,7 +362,8 @@ inline constexpr const char* RGW_REST_STS_XMLNS =
 #define ERR_ACCOUNT_EXISTS 2403
 
 #define ERR_RESTORE_ALREADY_IN_PROGRESS 2500
-    
+#define ERR_EXPIRED_TOKEN 2501
+
 #ifndef UINT32_MAX
 #define UINT32_MAX (0xffffffffu)
 #endif

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -7140,7 +7140,7 @@ rgw::auth::s3::STSEngine::authenticate(
         real_clock::time_point now = real_clock::now();
         if (now >= *exp) {
           ldpp_dout(dpp, 0) << "ERROR: Token expired" << dendl;
-          return result_t::reject(-EPERM);
+          return result_t::reject(-ERR_EXPIRED_TOKEN);
         }
       } else {
         ldpp_dout(dpp, 0) << "ERROR: Invalid expiration: " << expiration << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75721

---

backport of https://github.com/ceph/ceph/pull/65847
parent tracker: https://tracker.ceph.com/issues/73441

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh