### PR TITLE
tentacle: mgr/dashboard: fix subvolume group corruption from smb share form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
@@ -174,16 +174,21 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
       const subvolGroup = this.smbShareForm.getValue('subvolume_group') || ''; // Default to empty if not present
       const subvol = this.smbShareForm.getValue('subvolume');
 
-      this.subvolService
-        .info(fsName, subvol, subvolGroup)
-        .pipe(map((data: any) => data['path']))
-        .subscribe(
-          (path: string) => {
-            this.updatePath(path);
-            resolve();
-          },
-          (error: any) => reject(error)
-        );
+      if (subvol) {
+        this.subvolService
+          .info(fsName, subvol, subvolGroup)
+          .pipe(map((data: any) => data['path']))
+          .subscribe(
+            (path: string) => {
+              this.updatePath(path);
+              resolve();
+            },
+            (error: any) => reject(error)
+          );
+      } else {
+        this.updatePath(`/volumes/${subvolGroup}/`);
+        resolve();
+      }
     });
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75783

---

backport of https://github.com/ceph/ceph/pull/68066
parent tracker: https://tracker.ceph.com/issues/75771

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh