### PR TITLE
tentacle: ceph-volume: skip cdrom devices in inverntory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -345,6 +345,27 @@ class TestGetDevices(object):
         assert result[sda_path]['actuators'] == fake_actuator_nb
 
 
+class TestGetBlockDevsSysfs(object):
+    def test_optical_device_is_skipped(self, fake_filesystem):
+        # sr0 is a CDROM (IPMI/BMC virtual media),not a usable disk.
+        fake_filesystem.create_file('/dev/sr0')
+        fake_filesystem.create_dir('/sys/dev/block')
+        fake_filesystem.create_dir('/sys/block/sr0/holders')
+        fake_filesystem.create_dir('/sys/block/sr0/device')
+        fake_filesystem.create_file('/sys/block/sr0/device/type', contents='5\n')
+
+        assert disk.get_block_devs_sysfs(device='sr0') == []
+
+    def test_regular_device_is_not_skipped(self, fake_filesystem):
+        # normal disk should still be reported.
+        fake_filesystem.create_file('/dev/sda')
+        fake_filesystem.create_dir('/sys/dev/block')
+        fake_filesystem.create_dir('/sys/block/sda/holders')
+
+        result = disk.get_block_devs_sysfs(device='sda')
+        assert result == [['/dev/sda', '/dev/sda', 'disk', '/dev/sda']]
+
+
 class TestSizeCalculations(object):
 
     @pytest.mark.parametrize('aliases', [

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -715,6 +715,12 @@ def get_block_devs_sysfs(_sys_block_path: str = '/sys/block', _sys_dev_block_pat
         name = kname = pname = os.path.join("/dev", dev)
         if not os.path.exists(name):
             continue
+        # Exclude any CDROM devices (ex: IPMI devices)
+        # The linux kernel reports these as SCSI device type 5 under /sys/block/<dev>/device/type
+        # and they appear as /dev/sr* (ex: /dev/sr0)
+        # These are not physical disks and are not valid OSD targets, so skip them.
+        if get_file_contents(os.path.join(_sys_block_path, dev, 'device/type'), '').strip() == '5':
+            continue
         type_: str = 'disk'
         holders: List[str] = os.listdir(os.path.join(_sys_block_path, dev, 'holders'))
         if holder_inner_loop():


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75791

---

backport of https://github.com/ceph/ceph/pull/67624
parent tracker: https://tracker.ceph.com/issues/75281

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh