### PR TITLE
mgr/volumes: add validation to arguments

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -342,7 +342,7 @@ class CephString(CephArgtype):
     def valid(self, s: str, partial: bool = False) -> None:
         sset = set(s)
         if self.goodset and not sset <= self.goodset:
-            raise ArgumentFormat("invalid chars {0} in {1}".
+            raise ArgumentFormat("invalid chars '{0}' in '{1}'".
                                  format(''.join(sset - self.goodset), s))
         self.val = s
 
@@ -1042,8 +1042,14 @@ def validate_one(word: str,
             desc.instance.valid(part, partial)
             vals.append(desc.instance.val)
     else:
-        desc.instance.valid(word, partial)
-        vals.append(desc.instance.val)
+        try:
+            desc.instance.valid(word, partial)
+            vals.append(desc.instance.val)
+        except ArgumentError as e:
+            l = list(e.args)
+            l[0] += f" for argument {desc.name}"
+            e.args = tuple(l)
+            raise
     desc.numseen += 1
     if desc.N:
         desc.n = desc.numseen + 1

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -734,7 +734,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     # places and modifying it can will lead to unnecessary disturbances in all
     # those places.
     # See: https://github.com/ceph/ceph/pull/60534#discussion_r2228436110
-    def _is_name_valid(self, name):
+    def _is_name_valid(self, name, nameof):
+        '''
+        Return "Success" if name is valid and if it's invalid return the string
+        that should be printed in stdout.
+        '''
+        if not name:
+            stdout_str = (f"{nameof} name is blank which is not allowed, "
+                          f"choose a better {nameof} name")
         # leading dot in name of subvolume groups and subvolumes
         # will make them hidden dirs, which doesn't seem like a
         # sensible thing to have
@@ -743,29 +750,30 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         # NOTE:
         # we only accept goodchars set of characters, so the input parsing
         # logic does all the heavy lifting of input validation
-        if name.startswith('.'):
-            return False
+        elif name.startswith('.'):
+            stdout_str = (f"{nameof} name starting with a dot which is not "
+                          f"allowed, choose a better {nameof} name")
         # don't allow names starting with a digit. For example, names like "2",
         # "3cephfs", "7subvol".
         elif name[0].isdigit():
-            return False
-        return True
+            stdout_str = (f"{nameof} name starting with a digit which is not "
+                          f"allowed, choose a better {nameof} name")
+        else:
+            stdout_str = None
+
+        if stdout_str:
+            return (-errno.EINVAL, "", stdout_str)
+        else:
+            return (0, "", "Success")
 
     def _is_vol_name_valid(self, name):
-        if not name or not self._is_name_valid(name):
-            return -errno.EINVAL, "", "choose a better volume name"
-        return 0, "", "Success"
+        return self._is_name_valid(name, 'volume')
 
     def _is_group_name_valid(self, name):
-        if not name or self._is_name_valid(name):
-            # for None ... e.g. we're okay when group_name is None
-            return 0, "", "Success"
-        return -errno.EINVAL, "", "choose a better subvolume group name"
+        return self._is_name_valid(name, 'subvolume group')
 
     def _is_subvol_name_valid(self, name):
-        if not name or not self._is_name_valid(name):
-            return -errno.EINVAL, "", "choose a better subvolume name"
-        return 0, "", "Success"
+        return self._is_name_valid(name, 'subvolume')
 
     def handle_command(self, inbuf, cmd):
         handler_name = "_cmd_" + cmd['prefix'].replace(" ", "_")

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -729,13 +729,18 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                             self.vc.cloner.resume()
 
 
+    # XXX: these checks can be done through modifying goodchars regex string but
+    # that is deliberately being avoided as it is also being used in many other
+    # places and modifying it can will lead to unnecessary disturbances in all
+    # those places.
+    # See: https://github.com/ceph/ceph/pull/60534#discussion_r2228436110
     def _is_name_valid(self, name):
         # leading dot in name of subvolume groups and subvolumes
         # will make them hidden dirs, which doesn't seem like a
         # sensible thing to have
         # we also don't want strings with path separators or spaces or
         # non-printable characters
-        # Note:
+        # NOTE:
         # we only accept goodchars set of characters, so the input parsing
         # logic does all the heavy lifting of input validation
         if name.startswith('.'):

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -745,6 +745,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         # logic does all the heavy lifting of input validation
         if name.startswith('.'):
             return False
+        # don't allow names starting with a digit. For example, names like "2",
+        # "3cephfs", "7subvol".
+        elif name[0].isdigit():
+            return False
         return True
 
     def _is_vol_name_valid(self, name):

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -60,7 +60,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs volume rm '
-                   'name=vol_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
                    'name=yes-i-really-mean-it,type=CephString,req=false ',
             'desc': "Delete a FS volume by passing --yes-i-really-mean-it flag",
             'perm': 'rw'
@@ -75,20 +75,20 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs volume info '
-                   'name=vol_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
                    'name=human_readable,type=CephBool,req=false ',
             'desc': "Get the information of a CephFS volume",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolumegroup ls '
-            'name=vol_name,type=CephString ',
+            f'name=vol_name,type=CephString,goodchars={goodchars} ',
             'desc': "List subvolumegroups",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolumegroup create '
-                   'name=vol_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
                    f'name=group_name,type=CephString,goodchars={goodchars} '
                    'name=size,type=CephInt,req=false '
                    'name=pool_layout,type=CephString,req=false '
@@ -103,23 +103,23 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolumegroup rm '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars} '
                    'name=force,type=CephBool,req=false ',
             'desc': "Delete a CephFS subvolume group in a volume",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolumegroup info '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars} ',
             'desc': "Get the metadata of a CephFS subvolume group in a volume, ",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolumegroup resize '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars} '
                    'name=new_size,type=CephString,req=true '
                    'name=no_shrink,type=CephBool,req=false ',
             'desc': "Resize a CephFS subvolume group",
@@ -127,23 +127,23 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolumegroup exist '
-                   'name=vol_name,type=CephString ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} ',
             'desc': "Check a volume for the existence of subvolumegroup",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume ls '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "List subvolumes",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume create '
-                   'name=vol_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
                    f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=size,type=CephInt,req=false '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=pool_layout,type=CephString,req=false '
                    'name=uid,type=CephInt,req=false '
                    'name=gid,type=CephInt,req=false '
@@ -161,9 +161,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume rm '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=force,type=CephBool,req=false '
                    'name=retain_snapshots,type=CephBool,req=false ',
             'desc': "Delete a CephFS subvolume in a volume, and optionally, "
@@ -173,10 +173,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume authorize '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=auth_id,type=CephString '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=access_level,type=CephString,req=false '
                    'name=tenant_id,type=CephString,req=false '
                    'name=allow_existing_id,type=CephBool,req=false ',
@@ -185,99 +185,99 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume deauthorize '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=auth_id,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Deny a cephx auth ID access to a subvolume",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume authorized_list '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "List auth IDs that have access to a subvolume",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume evict '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=auth_id,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Evict clients based on auth IDs and subvolume mounted",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolumegroup getpath '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars} ',
             'desc': "Get the mountpath of a CephFS subvolume group in a volume",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume getpath '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Get the mountpath of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume info '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Get the information of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume exist '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Check a volume for the existence of a subvolume, "
                     "optionally in a specified subvolume group",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume metadata set '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=key_name,type=CephString '
                    'name=value,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Set custom metadata (key-value) for a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume metadata get '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=key_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Get custom metadata associated with the key of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume metadata ls '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "List custom metadata (key-value pairs) of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume metadata rm '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=key_name,type=CephString '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=force,type=CephBool,req=false ',
             'desc': "Remove custom metadata (key-value) associated with the key of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
@@ -285,26 +285,26 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume earmark get '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Get earmark for a subvolume",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume earmark set '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=earmark,type=CephString ',
             'desc': "Set earmark for a subvolume",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume earmark rm '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Remove earmark from a subvolume",
             'perm': 'rw'
         },
@@ -335,7 +335,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs quiesce '
-                   'name=vol_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
                    'name=members,type=CephString,n=N,req=false '
                    '-- '
                    'name=set_id,type=CephString,req=false '
@@ -351,7 +351,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=query,type=CephBool,req=false '
                    'name=all,type=CephBool,req=false '
                    'name=cancel,type=CephBool,req=false '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=leader,type=CephBool,req=false '
                    'name=with_leader,type=CephInt,range=0,req=false ',
             'desc': "Manage quiesce sets of subvolumes",
@@ -359,8 +359,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolumegroup pin'
-                   ' name=vol_name,type=CephString'
-                   ' name=group_name,type=CephString,req=true'
+                   f' name=vol_name,type=CephString,goodchars={goodchars}'
+                   f' name=group_name,type=CephString,req=true,goodchars={goodchars}'
                    ' name=pin_type,type=CephChoices,strings=export|distributed|random'
                    ' name=pin_setting,type=CephString,req=true',
             'desc': "Set MDS pinning policy for subvolumegroup",
@@ -393,23 +393,23 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
         {
             'cmd': 'fs subvolumegroup snapshot ls '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars} ',
             'desc': "List subvolumegroup snapshots",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolumegroup snapshot create '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString ',
             'desc': "Create a snapshot of a CephFS subvolume group in a volume",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolumegroup snapshot rm '
-                   'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
                    'name=force,type=CephBool,req=false ',
                    'desc': "Delete a snapshot of a CephFS subvolume group in a volume",
@@ -417,72 +417,72 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume snapshot ls '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "List subvolume snapshots",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume snapshot create '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Create a snapshot of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume snapshot info '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Get the information of a CephFS subvolume snapshot "
                     "and optionally, in a specific subvolume group",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume snapshot metadata set '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
                    'name=key_name,type=CephString '
                    'name=value,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Set custom metadata (key-value) for a CephFS subvolume snapshot in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume snapshot metadata get '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
                    'name=key_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Get custom metadata associated with the key of a CephFS subvolume snapshot in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume snapshot metadata ls '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "List custom metadata (key-value pairs) of a CephFS subvolume snapshot in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'r'
         },
         {
             'cmd': 'fs subvolume snapshot metadata rm '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
                    'name=key_name,type=CephString '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=force,type=CephBool,req=false ',
             'desc': "Remove custom metadata (key-value) associated with the key of a CephFS subvolume snapshot in a volume, "
                     "and optionally, in a specific subvolume group",
@@ -490,10 +490,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume snapshot rm '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=force,type=CephBool,req=false ',
             'desc': "Delete a snapshot of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
@@ -512,21 +512,21 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume resize '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=new_size,type=CephString,req=true '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=no_shrink,type=CephBool,req=false ',
             'desc': "Resize a CephFS subvolume",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume pin'
-                   ' name=vol_name,type=CephString'
-                   ' name=sub_name,type=CephString'
+                   f' name=vol_name,type=CephString,goodchars={goodchars}'
+                   f' name=sub_name,type=CephString,goodchars={goodchars}'
                    ' name=pin_type,type=CephChoices,strings=export|distributed|random'
                    ' name=pin_setting,type=CephString,req=true'
-                   ' name=group_name,type=CephString,req=false',
+                   f' name=group_name,type=CephString,req=false,goodchars={goodchars}',
             'desc': "Set MDS pinning policy for subvolume",
             'perm': 'rw'
         },
@@ -559,49 +559,49 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolume snapshot protect '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "(deprecated) Protect snapshot of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume snapshot unprotect '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "(deprecated) Unprotect a snapshot of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume snapshot clone '
-                   'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars} '
                    'name=snap_name,type=CephString '
                    'name=target_sub_name,type=CephString '
                    'name=pool_layout,type=CephString,req=false '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} '
                    'name=target_group_name,type=CephString,req=false ',
             'desc': "Clone a snapshot to target subvolume",
             'perm': 'rw'
         },
         {
             'cmd': 'fs clone status '
-                   'name=vol_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
                    'name=clone_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Get status on a cloned subvolume.",
             'perm': 'r'
         },
         {
             'cmd': 'fs clone cancel '
-                   'name=vol_name,type=CephString '
+                   f'name=vol_name,type=CephString,goodchars={goodchars} '
                    'name=clone_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars} ',
             'desc': "Cancel an pending or ongoing clone operation.",
             'perm': 'r'
         },
@@ -729,6 +729,35 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                             self.vc.cloner.resume()
 
 
+    def _is_name_valid(self, name):
+        # leading dot in name of subvolume groups and subvolumes
+        # will make them hidden dirs, which doesn't seem like a
+        # sensible thing to have
+        # we also don't want strings with path separators or spaces or
+        # non-printable characters
+        # Note:
+        # we only accept goodchars set of characters, so the input parsing
+        # logic does all the heavy lifting of input validation
+        if name.startswith('.'):
+            return False
+        return True
+
+    def _is_vol_name_valid(self, name):
+        if not name or not self._is_name_valid(name):
+            return -errno.EINVAL, "", "choose a better volume name"
+        return 0, "", "Success"
+
+    def _is_group_name_valid(self, name):
+        if not name or self._is_name_valid(name):
+            # for None ... e.g. we're okay when group_name is None
+            return 0, "", "Success"
+        return -errno.EINVAL, "", "choose a better subvolume group name"
+
+    def _is_subvol_name_valid(self, name):
+        if not name or not self._is_name_valid(name):
+            return -errno.EINVAL, "", "choose a better subvolume name"
+        return 0, "", "Success"
+
     def handle_command(self, inbuf, cmd):
         handler_name = "_cmd_" + cmd['prefix'].replace(" ", "_")
         try:
@@ -740,6 +769,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_volume_create(self, inbuf, cmd):
+        _errno, out, err = self._is_vol_name_valid(cmd['name'])
+        if _errno < 0:
+            return _errno, out, err
         vol_id = cmd['name']
         placement = cmd.get('placement', '')
         data_pool = cmd.get('data_pool', None)
@@ -750,6 +782,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_fs_volume_rm(self, inbuf, cmd):
         vol_name = cmd['vol_name']
         confirm = cmd.get('yes-i-really-mean-it', None)
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.delete_fs_volume(vol_name, confirm)
 
     @mgr_cmd_wrap
@@ -758,12 +793,21 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_volume_rename(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, "choose a name amongst the old volumes"
+        errno, out, err = self._is_vol_name_valid(cmd['new_vol_name'])
+        if errno < 0:
+            return errno, out, "choose a better name for the new volume"
         return self.vc.rename_fs_volume(cmd['vol_name'],
                                         cmd['new_vol_name'],
                                         cmd.get('yes_i_really_mean_it', False))
 
     @mgr_cmd_wrap
     def _cmd_fs_volume_info(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.volume_info(vol_name=cmd['vol_name'],
                                    human_readable=cmd.get('human_readable', False))
 
@@ -772,6 +816,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), empty string(str), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.create_subvolume_group(
             vol_name=cmd['vol_name'], group_name=cmd['group_name'], size=cmd.get('size', None),
             pool_layout=cmd.get('pool_layout', None), mode=cmd.get('mode', '755'),
@@ -784,17 +834,35 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), empty string(str), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.remove_subvolume_group(vol_name=cmd['vol_name'],
                                               group_name=cmd['group_name'],
                                               force=cmd.get('force', False))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_info(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolumegroup_info(vol_name=cmd['vol_name'],
                                            group_name=cmd['group_name'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_resize(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.resize_subvolume_group(vol_name=cmd['vol_name'],
                                               group_name=cmd['group_name'],
                                               new_size=cmd['new_size'],
@@ -802,10 +870,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_ls(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.list_subvolume_groups(vol_name=cmd['vol_name'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_exist(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_group_exists(vol_name=cmd['vol_name'])
 
     @mgr_cmd_wrap
@@ -813,6 +887,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), empty string(str), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.create_subvolume(vol_name=cmd['vol_name'],
                                         sub_name=cmd['sub_name'],
                                         group_name=cmd.get('group_name', None),
@@ -832,6 +915,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), empty string(str), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.remove_subvolume(vol_name=cmd['vol_name'],
                                         sub_name=cmd['sub_name'],
                                         group_name=cmd.get('group_name', None),
@@ -843,6 +935,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), secret key(str), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.authorize_subvolume(vol_name=cmd['vol_name'],
                                            sub_name=cmd['sub_name'],
                                            auth_id=cmd['auth_id'],
@@ -856,6 +957,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), empty string(str), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.deauthorize_subvolume(vol_name=cmd['vol_name'],
                                              sub_name=cmd['sub_name'],
                                              auth_id=cmd['auth_id'],
@@ -866,6 +976,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), list of authids(json), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.authorized_list(vol_name=cmd['vol_name'],
                                        sub_name=cmd['sub_name'],
                                        group_name=cmd.get('group_name', None))
@@ -875,6 +994,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         :return: a 3-tuple of return code(int), empyt string(str), error message (str)
         """
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.evict(vol_name=cmd['vol_name'],
                              sub_name=cmd['sub_name'],
                              auth_id=cmd['auth_id'],
@@ -882,33 +1010,79 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_ls(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.list_subvolumes(vol_name=cmd['vol_name'],
                                        group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_getpath(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.getpath_subvolume_group(
             vol_name=cmd['vol_name'], group_name=cmd['group_name'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_getpath(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_getpath(vol_name=cmd['vol_name'],
                                          sub_name=cmd['sub_name'],
                                          group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_info(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_info(vol_name=cmd['vol_name'],
                                       sub_name=cmd['sub_name'],
                                       group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_exist(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
         return self.vc.subvolume_exists(vol_name=cmd['vol_name'],
                                         group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_metadata_set(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.set_user_metadata(vol_name=cmd['vol_name'],
                                       sub_name=cmd['sub_name'],
                                       key_name=cmd['key_name'],
@@ -917,6 +1091,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_metadata_get(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.get_user_metadata(vol_name=cmd['vol_name'],
                                       sub_name=cmd['sub_name'],
                                       key_name=cmd['key_name'],
@@ -924,12 +1107,30 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_metadata_ls(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.list_user_metadata(vol_name=cmd['vol_name'],
                                       sub_name=cmd['sub_name'],
                                       group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_metadata_rm(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.remove_user_metadata(vol_name=cmd['vol_name'],
                                       sub_name=cmd['sub_name'],
                                       key_name=cmd['key_name'],
@@ -938,12 +1139,30 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_earmark_get(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.get_earmark(vol_name=cmd['vol_name'],
                                    sub_name=cmd['sub_name'],
                                    group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_earmark_set(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.set_earmark(vol_name=cmd['vol_name'],
                                       sub_name=cmd['sub_name'],
                                       group_name=cmd.get('group_name', None),
@@ -951,6 +1170,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_earmark_rm(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.clear_earmark(vol_name=cmd['vol_name'],
                                       sub_name=cmd['sub_name'],
                                       group_name=cmd.get('group_name', None))
@@ -976,39 +1204,81 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_quiesce(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.quiesce(cmd)
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_pin(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.pin_subvolume_group(vol_name=cmd['vol_name'],
                                            group_name=cmd['group_name'], pin_type=cmd['pin_type'],
                                            pin_setting=cmd['pin_setting'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_charmap_set(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_group_charmap_set(vol_name=cmd['vol_name'],
                                                    group_name=cmd['group_name'],
                                                    setting=cmd['setting'],
                                                    value=cmd['value'])
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_charmap_rm(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_group_charmap_rm(vol_name=cmd['vol_name'],
                                                    group_name=cmd['group_name'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_charmap_get(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_group_charmap_get(vol_name=cmd['vol_name'],
                                                    group_name=cmd['group_name'],
                                                    setting=cmd.get('setting', 'charmap'))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_snapshot_create(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.create_subvolume_group_snapshot(vol_name=cmd['vol_name'],
                                                        group_name=cmd['group_name'],
                                                        snap_name=cmd['snap_name'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_snapshot_rm(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.remove_subvolume_group_snapshot(vol_name=cmd['vol_name'],
                                                        group_name=cmd['group_name'],
                                                        snap_name=cmd['snap_name'],
@@ -1016,11 +1286,26 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_snapshot_ls(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.list_subvolume_group_snapshots(vol_name=cmd['vol_name'],
                                                       group_name=cmd['group_name'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_create(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.create_subvolume_snapshot(vol_name=cmd['vol_name'],
                                                  sub_name=cmd['sub_name'],
                                                  snap_name=cmd['snap_name'],
@@ -1028,6 +1313,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_rm(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.remove_subvolume_snapshot(vol_name=cmd['vol_name'],
                                                  sub_name=cmd['sub_name'],
                                                  snap_name=cmd['snap_name'],
@@ -1036,6 +1330,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_info(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_snapshot_info(vol_name=cmd['vol_name'],
                                                sub_name=cmd['sub_name'],
                                                snap_name=cmd['snap_name'],
@@ -1043,6 +1346,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_metadata_set(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.set_subvolume_snapshot_metadata(vol_name=cmd['vol_name'],
                                                sub_name=cmd['sub_name'],
                                                snap_name=cmd['snap_name'],
@@ -1052,6 +1364,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_metadata_get(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.get_subvolume_snapshot_metadata(vol_name=cmd['vol_name'],
                                                sub_name=cmd['sub_name'],
                                                snap_name=cmd['snap_name'],
@@ -1060,6 +1381,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_metadata_ls(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.list_subvolume_snapshot_metadata(vol_name=cmd['vol_name'],
                                                sub_name=cmd['sub_name'],
                                                snap_name=cmd['snap_name'],
@@ -1067,6 +1397,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_metadata_rm(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.remove_subvolume_snapshot_metadata(vol_name=cmd['vol_name'],
                                                sub_name=cmd['sub_name'],
                                                snap_name=cmd['snap_name'],
@@ -1076,12 +1415,30 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_ls(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.list_subvolume_snapshots(vol_name=cmd['vol_name'],
                                                 sub_name=cmd['sub_name'],
                                                 group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_getpath(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_snapshot_getpath(vol_name=cmd['vol_name'],
                                                   sub_name=cmd['sub_name'],
                                                   snap_name=cmd['snap_name'],
@@ -1089,12 +1446,30 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_resize(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.resize_subvolume(vol_name=cmd['vol_name'], sub_name=cmd['sub_name'],
                                         new_size=cmd['new_size'], group_name=cmd.get('group_name', None),
                                         no_shrink=cmd.get('no_shrink', False))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_pin(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_pin(vol_name=cmd['vol_name'],
                                      sub_name=cmd['sub_name'], pin_type=cmd['pin_type'],
                                      pin_setting=cmd['pin_setting'],
@@ -1102,6 +1477,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_charmap_set(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_charmap_set(vol_name=cmd['vol_name'],
                                              sub_name=cmd['sub_name'],
                                              setting=cmd['setting'],
@@ -1110,12 +1494,30 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_charmap_rm(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_charmap_rm(vol_name=cmd['vol_name'],
                                              sub_name=cmd['sub_name'],
                                              group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_charmap_get(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.subvolume_charmap_get(vol_name=cmd['vol_name'],
                                              sub_name=cmd['sub_name'],
                                              setting=cmd.get('setting', 'charmap'),
@@ -1123,16 +1525,43 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_protect(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.protect_subvolume_snapshot(vol_name=cmd['vol_name'], sub_name=cmd['sub_name'],
                                                   snap_name=cmd['snap_name'], group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_unprotect(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.unprotect_subvolume_snapshot(vol_name=cmd['vol_name'], sub_name=cmd['sub_name'],
                                                     snap_name=cmd['snap_name'], group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_clone(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_subvol_name_valid(cmd['sub_name'])
+        if errno < 0:
+            return errno, out, err
         return self.vc.clone_subvolume_snapshot(
             vol_name=cmd['vol_name'], sub_name=cmd['sub_name'], snap_name=cmd['snap_name'],
             group_name=cmd.get('group_name', None), pool_layout=cmd.get('pool_layout', None),
@@ -1140,11 +1569,23 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_clone_status(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.clone_status(
             vol_name=cmd['vol_name'], clone_name=cmd['clone_name'], group_name=cmd.get('group_name', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_clone_cancel(self, inbuf, cmd):
+        errno, out, err = self._is_vol_name_valid(cmd['vol_name'])
+        if errno < 0:
+            return errno, out, err
+        errno, out, err = self._is_group_name_valid(cmd.get('group_name', None))
+        if errno < 0:
+            return errno, out, err
         return self.vc.clone_cancel(
             vol_name=cmd['vol_name'], clone_name=cmd['clone_name'], group_name=cmd.get('group_name', None))
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/68687
Fixes: https://tracker.ceph.com/issues/74177






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>