### PR TITLE
mgr/dashboard: fix schedule_info.name for inherited mirroring schedules

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -171,7 +171,8 @@ class Pool(RESTController):
             cluster_interval = RbdMirroringService.get_schedule_interval('')
             if cluster_interval:
                 pool[0]['schedule_info'] = {
-                    'name': '',
+                    'name': pool_schedule_spec,
+                    'schedule_source': '',
                     'schedule_interval': cluster_interval,
                     'schedule_time': None,
                     'inherited': 'cluster'

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.model.ts
@@ -27,6 +27,7 @@ export class RbdFormModel {
 
 export class ScheduleInfo {
   image: string;
+  schedule_source: string;
   schedule_time: string;
   schedule_interval: ScheduleInterval[];
 }

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -343,7 +343,8 @@ class RbdService(object):
 
                     if pool_interval:
                         stat['schedule_info'] = {
-                            'name': pool_schedule_spec,
+                            'name': image_schedule_spec,
+                            'schedule_source': pool_schedule_spec,
                             'schedule_interval': pool_interval,
                             'schedule_time': image_schedule_time,
                             'inherited': 'pool'
@@ -352,7 +353,8 @@ class RbdService(object):
                         cluster_interval = RbdMirroringService.get_schedule_interval('')
                         if cluster_interval:
                             stat['schedule_info'] = {
-                                'name': '',
+                                'name': image_schedule_spec,
+                                'schedule_source': '',
                                 'schedule_interval': cluster_interval,
                                 'schedule_time': image_schedule_time,
                                 'inherited': 'cluster'


### PR DESCRIPTION
When querying an RBD image's mirroring schedule via the dashboard API,
the `schedule_info.name` field should always identify the queried image.
For inherited schedules (pool-level or cluster-level), the `name` field
was incorrectly set to the schedule source identifier (pool spec or
empty string) instead of the image's own `pool/image` spec.

This fix sets the `name` field to the image spec and introduces a new
`schedule_source` field that preserves the original source-level
identifier, so consumers can still determine where the schedule was
inherited from. The same fix is applied to the pool controller for
cluster-inherited pool schedules.

Fixes: https://tracker.ceph.com/issues/75098

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests