### PR TITLE
crimson/os/seastore: Prepare no invalidation to LBA user txns

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -512,7 +512,6 @@ struct FixedKVInternalNode
   }
 
   void merge_content_to_pending_versions(Transaction &t) {
-    ceph_assert(is_rewrite_transaction(t.get_src()));
     this->for_each_copy_dest_set(t, [this, &t](auto &copy_dests) {
       this->merge_content_to(t, copy_dests.dests_by_key);
     });

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -942,11 +942,13 @@ void Cache::commit_retire_extent(
   invalidate_extent(t, *ref);
 }
 
-void Cache::prepare_rewrite_publish_to_prior(
+void Cache::stage_visibility_handoff(
     Transaction& t,
     CachedExtentRef next,
     CachedExtentRef prev)
 {
+  LOG_PREFIX(Cache::stage_visibility_handoff);
+  SUBDEBUGT(seastore_t, "", t);
   assert(next->get_paddr() == prev->get_paddr() ||
          // prev is being rewritten by a trim_dirty
          // or cleaner transaction
@@ -954,21 +956,23 @@ void Cache::prepare_rewrite_publish_to_prior(
   assert(next->get_paddr().is_absolute() || next->get_paddr().is_root());
   assert(next->version == prev->version + 1);
   const auto t_src = t.get_src();
-  assert(is_rewrite_transaction(t_src));
+  ceph_assert(should_use_no_conflict_publish(t_src, next->get_type()));
 
   bool was_stable_dirty = prev->is_stable_dirty();
   if (!was_stable_dirty) {
     pinboard->remove(*prev);
   }
+
+  // Block prev/prior into an io-wait state so anyone waiting on
+  // it will not proceed while we are preparing/publishing the new view.
   prev->set_io_wait(CachedExtent::extent_state_t::DIRTY, true);
   ceph_assert(next->committer);
   ceph_assert(prev->committer);
   ceph_assert(next->committer == prev->committer);
-  auto &committer = *next->committer;
-  committer.commit_state();
-  if (is_lba_backref_node(next->get_type())) {
-    committer.sync_checksum();
-  }
+
+  // commit_state() is called afer commit, a CLEAN prior may still have NULL_TIME.
+  prev->set_modify_time(next->get_modify_time());
+
   if (!was_stable_dirty) {
     add_to_dirty(prev, &t_src);
   }
@@ -1367,8 +1371,7 @@ record_t Cache::prepare_record(
       DEBUGT("invalid mutated extent -- {}", t, *i);
       continue;
     }
-    if (is_rewrite_transaction(t.get_src()) &&
-        !is_root_type(i->get_type())) {
+    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
       i->new_committer(t);
       i->committer->block_trans(t);
     }
@@ -1484,21 +1487,25 @@ record_t Cache::prepare_record(
    * - prepare_commit()
    */
   for (auto &i: t.mutated_block_list) {
-    if (i->is_valid()) {
-      if (i->is_mutation_pending()) {
-        i->set_io_wait(CachedExtent::extent_state_t::DIRTY,
-                       is_rewrite_transaction(t.get_src()));
-        if (is_rewrite_transaction(t.get_src())) {
-          prepare_rewrite_publish_to_prior(t, i, i->prior_instance);
-        } else {
-          commit_replace_extent(t, i, i->prior_instance);
-        }
-      } // else, is_exist_mutation_pending():
-        // - it doesn't have prior_instance to replace
-        // - and add_extent() atomically below
-        // - set_io_wait(DIRTY) atomically below
+    if (!i->is_valid()) {
+      continue;
     }
-  }
+
+    if (i->is_mutation_pending()) {
+      const bool use_no_conflict = should_use_no_conflict_publish(t.get_src(), i->get_type());
+      // Block the new extent readers until the journal commit completes.
+      i->set_io_wait(CachedExtent::extent_state_t::DIRTY, use_no_conflict);
+
+      if (use_no_conflict) {
+        stage_visibility_handoff(t, i, i->prior_instance);
+      } else {
+        commit_replace_extent(t, i, i->prior_instance);
+      }
+      // else, is_exist_mutation_pending():
+      // - it doesn't have prior_instance to replace
+      // - handled by add_extent() atomically below
+      }
+    }
 
   // Transaction is now a go, set up in-memory cache state
   // invalidate now invalid blocks
@@ -1514,7 +1521,10 @@ record_t Cache::prepare_record(
     retire_stat.increment(extent->get_length());
     DEBUGT("retired and remove extent {}~0x{:x} -- {}",
 	   t, extent->get_paddr(), extent->get_length(), *extent);
-    if (is_rewrite_transaction(t.get_src())) {
+    if (should_use_no_conflict_publish(t.get_src(), extent->get_type())) {
+      // avoid extent invalidation on retirement
+      // only adjust dirty bookkeeping
+      // we would invalidate them in complete_commit final stage
       assert(extent->is_stable());
       if (extent->is_stable_dirty()) {
         remove_from_dirty(extent, &trans_src);
@@ -1635,24 +1645,19 @@ record_t Cache::prepare_record(
 	  i->get_type()));
     }
     i->set_io_wait(CachedExtent::extent_state_t::CLEAN,
-                   is_rewrite_transaction(t.get_src()));
+                   should_use_no_conflict_publish(t.get_src(), i->get_type()));
     // Note, paddr is known until complete_commit(),
     // so add_extent() later.
-    if (is_rewrite_transaction(t.get_src())) {
+    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
       assert(i->get_prior_instance());
       assert(!i->committer);
       assert(!i->get_prior_instance()->committer);
       i->new_committer(t);
       assert(i->committer);
       auto &committer = *i->committer;
-      // this must have been a rewriten extent
-      committer.commit_state();
-      if (is_lba_backref_node(i->get_type())) {
-        committer.sync_checksum();
-      }
       committer.block_trans(t);
       i->get_prior_instance()->set_io_wait(
-        CachedExtent::extent_state_t::CLEAN, true);
+        CachedExtent::extent_state_t::CLEAN, should_use_no_conflict_publish(t.get_src(), i->get_type()));
     }
   }
 
@@ -1677,7 +1682,7 @@ record_t Cache::prepare_record(
 	  i->get_length(),
 	  i->get_type()));
     }
-    if (is_rewrite_transaction(t.get_src())) {
+    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
       assert(i->get_prior_instance());
       assert(!i->committer);
       assert(!i->get_prior_instance()->committer);
@@ -1685,20 +1690,14 @@ record_t Cache::prepare_record(
       assert(i->committer);
       i->get_prior_instance()->committer = i->committer;
       auto &committer = *i->committer;
-      // this must have been a rewriten extent
-      committer.commit_state();
-      if (is_lba_backref_node(i->get_type())) {
-        committer.sync_checksum();
-      }
       committer.block_trans(t);
       i->get_prior_instance()->set_io_wait(
         CachedExtent::extent_state_t::CLEAN, true);
     }
     i->set_io_wait(CachedExtent::extent_state_t::CLEAN,
-                   is_rewrite_transaction(t.get_src()));
+                   should_use_no_conflict_publish(t.get_src(), i->get_type()));
     // Note, paddr is (can be) known until complete_commit(),
     // so add_extent() later.
-
   }
 
   for (auto &i: t.inplace_ool_block_list) {
@@ -1745,7 +1744,7 @@ record_t Cache::prepare_record(
     } else {
       assert(i->is_exist_mutation_pending());
       i->set_io_wait(CachedExtent::extent_state_t::DIRTY,
-                     is_rewrite_transaction(t.get_src()));
+                     should_use_no_conflict_publish(t.get_src(), i->get_type()));
     }
 
     // exist mutation pending extents must be in t.mutated_block_list
@@ -1980,7 +1979,9 @@ void Cache::complete_commit(
   for (auto &i: t.retired_set) {
     auto &extent = i.extent;
     auto trans_src = t.get_src();
-    if (is_rewrite_transaction(trans_src)) {
+    if (should_use_no_conflict_publish(trans_src, extent->get_type())) {
+     // retired extents should remain valid through complete_commit().
+     // We only free space post-commit *AFTER* handoff.
       assert(extent->is_valid());
     }
     epm.mark_space_free(extent->get_paddr(), extent->get_length());
@@ -2008,7 +2009,7 @@ void Cache::complete_commit(
     i->pending_for_transaction = TRANS_ID_NULL;
     i->on_initial_write();
     const auto t_src = t.get_src();
-    if (is_rewrite_transaction(t_src)) {
+    if (should_use_no_conflict_publish(t_src, i->get_type())) {
       ceph_assert(i->committer);
       auto &committer = *i->committer;
       auto &prior = *i->get_prior_instance();
@@ -2017,6 +2018,8 @@ void Cache::complete_commit(
              "existing, inline={} -- {}, prior={}",
              t, is_inline, *i, prior);
       prior.pending_for_transaction = TRANS_ID_NULL;
+      committer.commit_state();
+      committer.sync_checksum();
       committer.commit_and_share_paddr();
       if (is_lba_backref_node(i->get_type())) {
         committer.commit_data();
@@ -2086,7 +2089,7 @@ void Cache::complete_commit(
     if (i->version == 1 || is_root_type(i->get_type())) {
       i->dirty_from = start_seq;
       DEBUGT("commit extent done, become dirty -- {}", t, *i);
-      if (is_rewrite_transaction(t.get_src()) && !is_root_type(i->get_type())) {
+      if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
         auto &prior = *i->get_prior_instance();
         prior.dirty_from = start_seq;
         ceph_assert(i->committer);
@@ -2097,12 +2100,13 @@ void Cache::complete_commit(
       DEBUGT("commit extent done -- {}", t, *i);
     }
     i->on_delta_write(final_block_start);
-    if (is_rewrite_transaction(t.get_src()) &&
-        !is_root_type(i->get_type())) {
+    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
       TRACET("committing paddr to prior for {}, prior={}",
         t, *i, *i->prior_instance);
       assert(i->committer);
       auto &committer = *i->committer;
+      committer.commit_state();
+      committer.sync_checksum();
       committer.unblock_trans(t);
       auto &prior = *i->prior_instance;
       prior.pending_for_transaction = TRANS_ID_NULL;
@@ -2141,14 +2145,15 @@ void Cache::complete_commit(
     commit_backref_entries(std::move(backref_entries), start_seq);
   }
 
-  if (is_rewrite_transaction(t.get_src())) {
-    t.for_each_finalized_fresh_block([&t](const CachedExtentRef &i) {
+  t.for_each_finalized_fresh_block([&t](const CachedExtentRef &i) {
+    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
       i->set_invalid(t);
-    });
-    for (auto &i: t.mutated_block_list) {
-      if (i->get_type() != extent_types_t::ROOT) {
+    }
+  });
+
+  for (auto &i: t.mutated_block_list) {
+    if (should_use_no_conflict_publish(t.get_src(), i->get_type())) {
         i->set_invalid(t);
-      }
     }
   }
 }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -942,7 +942,7 @@ void Cache::commit_retire_extent(
   invalidate_extent(t, *ref);
 }
 
-void Cache::commit_replace_extent(
+void Cache::prepare_rewrite_publish_to_prior(
     Transaction& t,
     CachedExtentRef next,
     CachedExtentRef prev)
@@ -954,8 +954,37 @@ void Cache::commit_replace_extent(
   assert(next->get_paddr().is_absolute() || next->get_paddr().is_root());
   assert(next->version == prev->version + 1);
   const auto t_src = t.get_src();
-  bool t_rewrite = is_rewrite_transaction(t_src);
-  if (booting && !t_rewrite) {
+  assert(is_rewrite_transaction(t_src));
+
+  bool was_stable_dirty = prev->is_stable_dirty();
+  if (!was_stable_dirty) {
+    pinboard->remove(*prev);
+  }
+  prev->set_io_wait(CachedExtent::extent_state_t::DIRTY, true);
+  ceph_assert(next->committer);
+  ceph_assert(prev->committer);
+  ceph_assert(next->committer == prev->committer);
+  auto &committer = *next->committer;
+  committer.commit_state();
+  if (is_lba_backref_node(next->get_type())) {
+    committer.sync_checksum();
+  }
+  if (!was_stable_dirty) {
+    add_to_dirty(prev, &t_src);
+  }
+}
+
+void Cache::commit_replace_extent(
+    Transaction& t,
+    CachedExtentRef next,
+    CachedExtentRef prev)
+{
+  assert(next->get_paddr() == prev->get_paddr());
+  assert(next->get_paddr().is_absolute() || next->get_paddr().is_root());
+  assert(next->version == prev->version + 1);
+  const auto t_src = t.get_src();
+
+  if (booting) {
     extents_index.replace(*next, *prev);
   }
 
@@ -965,23 +994,6 @@ void Cache::commit_replace_extent(
     // add the new dirty root to front
     remove_from_dirty(prev, nullptr/* exclude root */);
     add_to_dirty(next, nullptr/* exclude root */);
-  } else if (t_rewrite) {
-    bool was_stable_dirty = prev->is_stable_dirty();
-    if (!was_stable_dirty) {
-      pinboard->remove(*prev);
-    }
-    prev->set_io_wait(CachedExtent::extent_state_t::DIRTY, true);
-    ceph_assert(next->committer);
-    ceph_assert(prev->committer);
-    ceph_assert(next->committer == prev->committer);
-    auto &committer = *next->committer;
-    committer.commit_state();
-    if (is_lba_backref_node(next->get_type())) {
-      committer.sync_checksum();
-    }
-    if (!was_stable_dirty) {
-      add_to_dirty(prev, &t_src);
-    }
   } else if (prev->is_stable_dirty()) {
     replace_dirty(next, prev, t_src);
   } else {
@@ -989,9 +1001,8 @@ void Cache::commit_replace_extent(
     add_to_dirty(next, &t_src);
   }
 
-  if (!t_rewrite || is_root_type(prev->get_type())) {
-    invalidate_extent(t, *prev);
-  }
+  invalidate_extent(t, *prev);
+
 }
 
 void Cache::invalidate_extent(
@@ -1477,7 +1488,11 @@ record_t Cache::prepare_record(
       if (i->is_mutation_pending()) {
         i->set_io_wait(CachedExtent::extent_state_t::DIRTY,
                        is_rewrite_transaction(t.get_src()));
-        commit_replace_extent(t, i, i->prior_instance);
+        if (is_rewrite_transaction(t.get_src())) {
+          prepare_rewrite_publish_to_prior(t, i, i->prior_instance);
+        } else {
+          commit_replace_extent(t, i, i->prior_instance);
+        }
       } // else, is_exist_mutation_pending():
         // - it doesn't have prior_instance to replace
         // - and add_extent() atomically below

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1948,8 +1948,27 @@ private:
   /// Retire extent
   void commit_retire_extent(Transaction& t, CachedExtentRef ref);
 
-  /// Replace prev with next
+  /**
+  * commit_replace_extent()
+  * replace-and-invalidate path (to be deprecated..)
+  *
+  * Invalidates `prev` for readers (conflict-and-retry) and replaces it with `next`.
+  */
   void commit_replace_extent(Transaction& t, CachedExtentRef next, CachedExtentRef prev);
+
+  /**
+  * prepare_rewrite_publish_to_prior()
+  * Rewrite (background) pre-commit staging: publish state to prior.
+  *
+  * For background rewrite paths (TRIM_DIRTY / CLEANER_*).
+  * i.e is_rewrite_transaction().
+  *
+  * Prepares `prev` (the shared prior) to carry the committed state
+  * before commit, so readers don’t get invalidated.
+  */
+  void Cache::prepare_rewrite_publish_to_prior(Transaction& t,
+                                               CachedExtentRef next,
+                                               CachedExtentRef prev);
 
   /// Invalidate extent and mark affected transactions
   void invalidate_extent(Transaction& t, CachedExtent& extent);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1957,18 +1957,17 @@ private:
   void commit_replace_extent(Transaction& t, CachedExtentRef next, CachedExtentRef prev);
 
   /**
-  * prepare_rewrite_publish_to_prior()
-  * Rewrite (background) pre-commit staging: publish state to prior.
-  *
-  * For background rewrite paths (TRIM_DIRTY / CLEANER_*).
-  * i.e is_rewrite_transaction().
-  *
-  * Prepares `prev` (the shared prior) to carry the committed state
-  * before commit, so readers don’t get invalidated.
-  */
-  void Cache::prepare_rewrite_publish_to_prior(Transaction& t,
-                                               CachedExtentRef next,
-                                               CachedExtentRef prev);
+   * stage_visibility_handoff()
+   * pre-commit staging: publish state to prior (No conflict path).
+   *
+   * Used for should_use_no_conflict_publish transactions.
+   *
+   * Sets up committer + readers of `prev` (the shared prior) so that publish (state/data + paddr share)
+   * can be applied atomically later in complete_commit(). Avoiding readers invalidatation.
+ */
+void stage_visibility_handoff(Transaction& t,
+                              CachedExtentRef next,
+                              CachedExtentRef prev);
 
   /// Invalidate extent and mark affected transactions
   void invalidate_extent(Transaction& t, CachedExtent& extent);

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -506,7 +506,7 @@ void ExtentCommitter::block_trans(Transaction &t) {
   for (auto &item : prior.read_transactions) {
     TRACET("blocking trans {} for rewriting {}",
       t, item.t->get_trans_id(), *item.ref);
-    item.t->need_wait_rewrite = true;
+    item.t->need_wait_visibility = true;
   }
 }
 
@@ -516,7 +516,7 @@ void ExtentCommitter::unblock_trans(Transaction &t) {
   for (auto &item : prior.read_transactions) {
     TRACET("unblocking trans {} for rewriting {}",
       t, item.t->get_trans_id(), *item.ref);
-    item.t->need_wait_rewrite = false;
+    item.t->need_wait_visibility = false;
   }
 }
 

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -492,7 +492,7 @@ void ExtentCommitter::_share_prior_data_to_pending_versions()
 }
 
 void CachedExtent::new_committer(Transaction &t) {
-  ceph_assert(is_rewrite_transaction(t.get_src()));
+  ceph_assert(should_use_no_conflict_publish(t.get_src(), this->get_type()));
   ceph_assert(!committer);
   committer = new ExtentCommitter(*this, t);
   assert(prior_instance);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -655,7 +655,7 @@ public:
 
   /// Returns true iff extent is stable and not io-pending
   bool is_stable_ready() const {
-    return is_stable() && (!is_pending_io() || io_wait->rewriting);
+    return is_stable() && (!is_pending_io() || io_wait->stable_view);
   }
 
   /// Returns true if extent can not be mutated,
@@ -963,15 +963,22 @@ private:
   std::optional<paddr_t> prior_poffset = std::nullopt;
 
   struct io_wait_t {
-    seastar::shared_promise<> pr;
-    extent_state_t from_state;
-    bool rewriting = false;
+    seastar::shared_promise<> pr;  /// completes when the I/O finishes
+    extent_state_t from_state;     /// state before entering the wait
+
+    /**
+      * If true, treat the extent as "stable-ready" for visibility checks
+      * even while I/O is pending. Used by:
+      *  See: stage_visibility_handoff()
+      */
+    bool stable_view = false;
   };
+
   std::optional<io_wait_t> io_wait;
 
-  void set_io_wait(extent_state_t new_state, bool rewriting) {
+  void set_io_wait(extent_state_t new_state, bool stable_view) {
     ceph_assert(!io_wait);
-    io_wait.emplace(seastar::shared_promise<>(), state, rewriting);
+    io_wait.emplace(seastar::shared_promise<>(), state, stable_view);
     state = new_state;
     assert(is_data_stable());
   }

--- a/src/crimson/os/seastore/lba/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba/lba_btree_node.h
@@ -381,7 +381,6 @@ struct LBALeafNode
   }
 
   void merge_content_to_pending_versions(Transaction &t) {
-    ceph_assert(is_rewrite_transaction(t.get_src()));
     this->for_each_copy_dest_set(t, [this, &t](auto &copy_dests) {
 #ifndef NDEBUG
       for (auto &copy_dest : copy_dests.dests_by_key) {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2282,6 +2282,34 @@ constexpr bool is_modify_transaction(transaction_type_t type) {
       is_background_transaction(type));
 }
 
+/**
+ * should_use_no_conflict_publish()
+ *
+ * Returns true when this (transaction source, extent type) pair should take
+ * the no-conflict publish path (i.e avoid invalidate-and-retry and use the
+ * committer + visibility hand-off).
+ *
+ * Currently true for:
+ *  - rewrite (background) transactions, for any non-root extent
+ *
+ *  To be expanded to:
+ *  - user (txn_manager) transactions that mutate LBA nodes
+ *  - Onode/Omap nodes
+ */
+constexpr bool should_use_no_conflict_publish(transaction_type_t txn_type,
+                                              extent_types_t ext_type) {
+  // keep classic handling for ROOT
+  if (is_root_type(ext_type)) {
+    return false;
+  }
+
+  // TODO: Extend this as support grows (e.g. Onode/OMAP nodes).
+  //       is_user_transaction(txn_type) && is_lba_node(ext_type)
+
+  return is_rewrite_transaction(txn_type);
+}
+
+
 // Note: It is possible to statically introduce structs for OOL, which must be
 // more efficient, but that requires to specialize the RecordSubmitter as well.
 // Let's delay this optimization until necessary.

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -572,7 +572,7 @@ public:
     ool_write_stats = {};
     rewrite_stats = {};
     conflicted = false;
-    need_wait_rewrite = false;
+    need_wait_visibility = false;
     assert(backref_entries.empty());
     if (!has_reset) {
       has_reset = true;
@@ -690,7 +690,8 @@ public:
   }
 
   btree_cursor_stats_t cursor_stats;
-  bool need_wait_rewrite = false;
+
+ bool need_wait_visibility = false;
 
 private:
   friend class Cache;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -544,7 +544,7 @@ TransactionManager::do_submit_transaction(
     tref.get_handle().enter(write_pipeline.prepare)
   );
 
-  while (tref.need_wait_rewrite) {
+  while (tref.need_wait_visibility) {
     co_await trans_intr::make_interruptible(seastar::yield());
   }
   if (trim_alloc_to && *trim_alloc_to != JOURNAL_SEQ_NULL) {


### PR DESCRIPTION
This is a preparation to the suggested alternative in: https://github.com/ceph/ceph/pull/67755
See: https://github.com/ceph/ceph/pull/67755#issuecomment-4133720702

Key commit:
```
Generalize prepare_rewrite_publish_to_prior() into stage_visibility_handoff().

* introduce should_use_no_conflict_publish

* Replace is_rewrite_transaction() checks with should_use_no_conflict_publish(),
  so adding new no-conflict users becomes straightforward.

* Stop committing metadata (commit_state + sync_checksum) during prepare_record()
  (pre-commit). While it is correct for rewrite, doing it pre-commit doesn't buy
  us anything today because readers are still blocked until the publish finishes.

  Moving metadata commit to the after commit phase would also make future
  non-rewrite users easier to support.

This is a prep step for expanding no-conflict publish coverage.
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
