### PR TITLE
rgw: avoid doubled ARN in GetBucketReplication for pre-existing data

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1449,7 +1449,17 @@ struct ReplicationConfiguration {
       }
 
       if (pipe.dest.bucket) {
-        destination.bucket = ARN(*pipe.dest.bucket).to_string();
+        // The bucket name may already contain the full ARN from data
+        // written before commit b8f89327e1a ("rgw: handle destination
+        // bucket as an ARN in ReplicationConfiguration").  Detect this
+        // to avoid producing a doubled ARN like
+        // "arn:aws:s3:::arn:aws:s3:::bucket".
+        auto existing = ARN::parse(pipe.dest.bucket->name);
+        if (existing && existing->service == rgw::Service::s3) {
+          destination.bucket = existing->to_string();
+        } else {
+          destination.bucket = ARN(*pipe.dest.bucket).to_string();
+        }
       }
 
       filter.emplace();


### PR DESCRIPTION
Before commit b8f89327e1a ("rgw: handle destination bucket as an ARN
in ReplicationConfiguration"), `PutBucketReplication` stored the full
ARN string (e.g. `arn:aws:s3:::bucket`) as the bucket name in the sync
policy.  After that commit, `GetBucketReplication` wraps the stored
bucket name in a new ARN via `ARN(rgw_bucket).to_string()`, which
produces a doubled prefix like `arn:aws:s3:::arn:aws:s3:::bucket` for
buckets whose replication was configured before the fix.

This makes the GET-then-PUT workflow impossible — the doubled ARN is
rejected as invalid input on subsequent PUT requests.

The fix detects whether the stored bucket name is already a valid S3
ARN and uses it directly, avoiding the double-wrapping.  New data
written after b8f89327e1a stores only the bare bucket name, so the
else branch handles that case unchanged.

## How to reproduce

1. On a **squid** (or older) cluster, set up a realm with endpoints and
   a zonegroup-level sync group so the S3 Replication API is enabled.
2. Create two buckets, enable versioning on the source, and call
   `PutBucketReplication` with destination `arn:aws:s3:::dest-bucket`.
3. Verify the sync policy stores the full ARN as the bucket name:
   ```
   radosgw-admin metadata get bucket.instance:<source>:<id>
   ```
   shows `dest.bucket = "arn:aws:s3:::dest-bucket"` in `sync_policy`.
4. Upgrade to **tentacle/main** (which includes b8f89327e1a).
5. Call `GetBucketReplication` — the destination bucket ARN is now
   `arn:aws:s3:::arn:aws:s3:::dest-bucket`.

Verified on a squid 19.2.2 cluster.

Fixes: https://tracker.ceph.com/issues/75770

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests