### PR TITLE
tentacle: test/rgw/notification: do not use netstat in the code

### DIFF
--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -1531,7 +1531,7 @@ def test_ps_s3_notification_push_amqp_idleness_check():
     print('waiting for 40sec for checking idleness')
     time.sleep(40)
 
-    os.system("netstat -nnp | grep 5672");
+    os.system("ss -tnp | grep 5672")
 
     # do the process of uploading an object and checking for notification again
     number_of_objects = 10
@@ -1574,7 +1574,7 @@ def test_ps_s3_notification_push_amqp_idleness_check():
     # check amqp receiver 1 for deletions
     receiver1.verify_s3_events(keys, exact_match=True, deletions=True)
 
-    os.system("netstat -nnp | grep 5672");
+    os.system("ss -tnp | grep 5672")
 
     # cleanup
     stop_amqp_receiver(receiver1, task1)
@@ -2969,12 +2969,15 @@ def test_ps_s3_persistent_cleanup():
 
 def check_http_server(http_port):
     str_port = str(http_port)
-    cmd = 'netstat -tlnnp | grep python | grep '+str_port
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-    out = proc.communicate()[0]
-    assert len(out) > 0, 'http python server NOT listening on port '+str_port
-    log.info("http python server listening on port "+str_port)
-    log.info(out.decode('utf-8'))
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.settimeout(1)
+        s.connect((get_ip(), http_port))
+        log.info("http server listening on port "+str_port)
+    except (socket.error, socket.timeout):
+        assert False, 'http server NOT listening on port '+str_port
+    finally:
+        s.close()
 
 
 def wait_for_queue_to_drain(topic_name, tenant=None, account=None, http_port=None):
@@ -3503,7 +3506,7 @@ def test_ps_s3_notification_kafka_idle_behaviour():
     while not is_idle:
         print('waiting for 10sec for checking idleness')
         time.sleep(10)
-        cmd = "netstat -nnp | grep 9092 | grep radosgw"
+        cmd = "ss -tnp | grep 9092 | grep radosgw"
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
         out = proc.communicate()[0]
         if len(out) == 0:


### PR DESCRIPTION
* net-tools are deprecated in fedora and ubuntu
* using netstat -p (used to verify that the http server is listening on a port) requires root privilages, which may fail in some tests environments

Fixes: https://tracker.ceph.com/issues/75820


(cherry picked from commit 5e204e17684ec6d2ab5b44e114be6cc4dfcf10b9)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
