### PR TITLE
tentacle: qa: Add nvmeof upgrade from v20.2.0 and tentacle

### DIFF
--- a/qa/suites/nvmeof/upgrade/0-clusters/4-gateways-1-initiator.yaml
+++ b/qa/suites/nvmeof/upgrade/0-clusters/4-gateways-1-initiator.yaml
@@ -26,7 +26,3 @@ roles:
   - client.4
   - ceph.nvmeof.nvmeof.d
 
-tasks:
-- install:
-    extra_packages:
-        - nvme-cli

--- a/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-v20.2.0.yaml
+++ b/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-v20.2.0.yaml
@@ -3,7 +3,7 @@ os_version: "9.stream"
 
 tasks:
 - install:
-    branch: squid-nvmeof
+    tag: v20.2.0
     exclude_packages:
       - ceph-volume
       - ceph-osd-classic
@@ -13,8 +13,7 @@ tasks:
 - print: "**** done install task..."
 
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:squid-nvmeof
-    compiled_cephadm_branch: squid-nvmeof
+    image: quay.io/ceph/ceph:v20.2.0
 
 - nvmeof:
     installer: host.a


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75542

---

backport of https://github.com/ceph/ceph/pull/67742
parent tracker: https://tracker.ceph.com/issues/75453

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh