### PR TITLE
doc/man: fix spelling etc errors (1 of 2)

### DIFF
--- a/doc/man/8/ceph-authtool.rst
+++ b/doc/man/8/ceph-authtool.rst
@@ -32,7 +32,7 @@ possibly an associated capability specification. Each key is
 associated with an entity name, of the form
 ``{client,mon,mds,osd}.name``.
 
-**WARNING** Ceph provides authentication and protection against
+**WARNING:** Ceph provides authentication and protection against
 man-in-the-middle attacks once secret keys are in place.  However,
 data over the wire is not encrypted, which may include the messages
 used to configure said keys. The system is primarily intended to be
@@ -85,7 +85,7 @@ Options
 
 .. option:: --mode *mode*
 
-   will set the desired file mode to the keyring e.g: 0644, defaults to 0600
+   will set the desired file mode to the keyring e.g.: 0644, defaults to 0600
 
 
 Capabilities
@@ -95,7 +95,7 @@ The subsystem is the name of a Ceph subsystem: ``mon``, ``mds``, or
 ``osd``.
 
 The capability is a string describing what the given user is allowed
-to do. This takes the form of a comma separated list of allow
+to do. This takes the form of a comma-separated list of allow
 clauses with a permission specifier containing one or more of rwx for
 read, write, and execute permission. The ``allow *`` grants full
 superuser permissions for the given subsystem.

--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -54,7 +54,7 @@ Commands
 
 :command:`fsck` [ --deep ] *(on|off) or (yes|no) or (1|0) or (true|false)*
 
-   run consistency check on BlueStore metadata.  If *--deep* is specified, also read all object data and verify checksums.
+   Run a consistency check on BlueStore metadata.  If *--deep* is specified, also read all object data and verify checksums.
 
 :command:`repair`
 
@@ -62,11 +62,11 @@ Commands
 
 :command:`qfsck`
 
-   run consistency check on BlueStore metadata comparing allocator data (from RocksDB CFB when exists and if not uses allocation-file) with ONodes state.
+   Run a consistency check on BlueStore metadata comparing allocator data (from RocksDB CFB when exists; and if not, uses allocation-file) with ONodes state.
 
 :command:`allocmap`
 
-   performs the same check done by qfsck and then stores a new allocation-file (command is disabled by default and requires a special build)
+   Performs the same check done by qfsck and then stores a new allocation-file (command is disabled by default and requires a special build).
 
 :command:`restore_cfb`
 
@@ -144,8 +144,8 @@ Commands
 
 :command:`reshard` --path *osd path* --sharding *new sharding* [ --resharding-ctrl *control string* ]
 
-   Changes sharding of BlueStore's RocksDB. Sharding is build on top of RocksDB column families.
-   This option allows to test performance of *new sharding* without need to redeploy OSD.
+   Changes sharding of BlueStore's RocksDB. Sharding is built on top of RocksDB column families.
+   This option allows to test the performance of *new sharding* without the need to redeploy OSD.
    Resharding is usually a long process, which involves walking through entire RocksDB key space
    and moving some of them to different column families.
    Option --resharding-ctrl provides performance control over resharding process.
@@ -157,18 +157,18 @@ Commands
 
    Show sharding that is currently applied to BlueStore's RocksDB.
 
-:command: `trim` --path *osd path*
+:command:`trim` --path *osd path*
 
    An SSD that has been used heavily may experience performance degradation.
    This operation uses TRIM / discard to free unused blocks from BlueStore and BlueFS block devices,
    and allows the drive to perform more efficient internal housekeeping.
    If BlueStore runs with discard enabled, this option may not be useful.
 
-:command: `zap-device` --dev *dev path*
+:command:`zap-device` --dev *dev path*
 
    Zeros all device label locations. This effectively makes device appear empty.
 
-:command: `revert-wal-to-plain` --path *osd path*
+:command:`revert-wal-to-plain` --path *osd path*
 
    Changes WAL files from envelope mode to the legacy plain mode.
    Useful for downgrades, or if you might want to disable this new feature (bluefs_wal_envelope_mode).
@@ -190,8 +190,8 @@ Options
 
 .. option:: -i *osd_id*
 
-   Operate as OSD *osd_id*. Connect to monitor for OSD specific options.
-   If monitor is unavailable, add --no-mon-config to read from ceph.conf instead.
+   Operate as OSD *osd_id*. Connect to Monitors for OSD-specific options.
+   If Monitor is unavailable, add --no-mon-config to read from ceph.conf instead.
 
 .. option:: --devs-source *device*
 
@@ -228,7 +228,7 @@ Options
 
 .. option:: --resharding-ctrl *control string*
 
-   Provides control over resharding process. Specifies how often refresh RocksDB iterator,
+   Provides control over the resharding process. Specifies how often to refresh RocksDB iterator,
    and how large should commit batch be before committing to RocksDB. Option format is:
    <iterator_refresh_bytes>/<iterator_refresh_keys>/<batch_commit_bytes>/<batch_commit_keys>
    Default: 10000000/10000/1000000/1000
@@ -237,13 +237,13 @@ Additional ceph.conf options
 ============================
 
 Any configuration option that is accepted by OSD can be also passed to **ceph-bluestore-tool**.
-Useful to provide necessary configuration options when access to monitor/ceph.conf is impossible and -i option cannot be used.
+Useful to provide necessary configuration options when access to the Monitors or ceph.conf is impossible and the -i option cannot be used.
 
 Device labels
 =============
 
 Every BlueStore block device has a block label at the beginning of the device.
-Main device might optionaly have additional labels at different locations
+The main device might optionally have additional labels at different locations
 for the sake of OSD robustness.
 You can dump the contents of the label with::
 
@@ -280,7 +280,7 @@ It is advised to first check if rescue process would be successful::
   ceph-bluestore-tool fsck --path *osd path* \
   --bluefs_replay_recovery=true --bluefs_replay_recovery_disable_compact=true
 
-If above fsck is successful fix procedure can be applied.
+If above fsck is successful, the fix procedure can be applied.
 
 Availability
 ============

--- a/doc/man/8/ceph-conf.rst
+++ b/doc/man/8/ceph-conf.rst
@@ -20,22 +20,22 @@ Synopsis
 Description
 ===========
 
-**ceph-conf** is a utility for getting information from a ceph
+**ceph-conf** is a utility for getting information from a Ceph
 configuration file. As with most Ceph programs, you can specify which
 Ceph configuration file to use with the ``-c`` flag.
 
-Note that unlike other ceph tools, **ceph-conf** will *only* read from
+Note that unlike other Ceph tools, **ceph-conf** will *only* read from
 config files (or return compiled-in default values)--it will *not*
-fetch config values from the monitor cluster.  For this reason it is
+fetch config values from the Monitor cluster.  For this reason it is
 recommended that **ceph-conf** only be used in legacy environments
 that are strictly config-file based.  New deployments and tools should
-instead rely on either querying the monitor explicitly for
+instead rely on either querying the Monitors' central config store explicitly for
 configuration (e.g., ``ceph config get <daemon> <option>``) or use
 daemons themselves to fetch effective config options (e.g.,
 ``ceph-osd -i 123 --show-config-value osd_data``).  The latter option
 has the advantages of drawing from compiled-in defaults (which
-occasionally vary between daemons), config files, and the monitor's
-config database, providing the exact value that that daemon would be
+occasionally vary between daemons), config files, and the Monitors'
+config database, providing the exact value that a daemon would be
 using if it were started.
 
 Actions
@@ -94,7 +94,7 @@ Options
 .. option:: -r, --resolve-search
 
    search for the first file that exists and can be opened in the resulted
-   comma delimited search list.
+   comma-delimited search list.
 
 .. option:: -s, --section
 
@@ -124,7 +124,7 @@ To list all sections::
 
 To print the path of the "keyring" used by "client.0"::
 
-       ceph-conf --name client.0 -r -l keyring
+        ceph-conf --name client.0 -r -l keyring
 
 
 Files
@@ -146,4 +146,4 @@ information.
 See also
 ========
 
-:doc:`ceph <ceph>`\(8),
+:doc:`ceph <ceph>`\(8)

--- a/doc/man/8/ceph-create-keys.rst
+++ b/doc/man/8/ceph-create-keys.rst
@@ -16,9 +16,9 @@ Description
 ===========
 
 :program:`ceph-create-keys` is a utility to generate bootstrap keyrings using
-the given monitor when it is ready.
+the given Monitor when it is ready.
 
-It creates following auth entities (or users)
+It creates the following auth entities (or users)
 
 ``client.admin``
 
@@ -42,11 +42,11 @@ Options
 
 .. option:: -t
 
-   time out after **seconds** (default: 600) waiting for a response from the monitor
+   time out after **seconds** (default: 600) waiting for a response from the Monitor
 
 .. option:: -i, --id
 
-   id of a ceph-mon that is coming up. **ceph-create-keys** will wait until it joins quorum.
+   ID of a ceph-mon that is coming up. **ceph-create-keys** will wait until it joins quorum.
 
 .. option:: -v, --verbose
 

--- a/doc/man/8/ceph-debugpack.rst
+++ b/doc/man/8/ceph-debugpack.rst
@@ -19,9 +19,9 @@ Description
 useful for debugging crashes. The resulting tarball can be shared with
 Ceph developers when debugging a problem.
 
-The tarball will include the binaries for ceph-mds, ceph-osd, and ceph-mon, radosgw, any
-log files, the ceph.conf configuration file, any core files we can
-find, and (if the system is running) dumps of the current cluster state
+The tarball will include the binaries for ceph-mds, ceph-osd, ceph-mon, and radosgw; any
+log files; the ceph.conf configuration file; any core files we can
+find; and (if the system is running) dumps of the current cluster state
 as reported by 'ceph report'.
 
 
@@ -31,7 +31,7 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during
    startup.
 
 

--- a/doc/man/8/ceph-dencoder.rst
+++ b/doc/man/8/ceph-dencoder.rst
@@ -15,7 +15,7 @@ Synopsis
 Description
 ===========
 
-**ceph-dencoder** is a utility to encode, decode, and dump ceph data
+**ceph-dencoder** is a utility to encode, decode, and dump Ceph data
 structures.  It is used for debugging and for testing inter-version
 compatibility.
 

--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -18,7 +18,7 @@ Description
 ===========
 
 **ceph-fuse** is a FUSE ("Filesystem in USErspace") client for Ceph
-distributed file system. It will mount a ceph file system specified via the -m
+distributed file system. It will mount a Ceph file system specified via the -m
 option or described by ceph.conf (see below) at the specific mount point. See
 `Mount CephFS using FUSE`_ for detailed information.
 
@@ -41,19 +41,19 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through ceph.conf).
+   Connect to specified Monitor (instead of looking through ceph.conf).
 
 .. option:: -n client.{cephx-username}
 
-   Pass the name of CephX user whose secret key is be to used for mounting.
+   Pass the name of CephX user whose secret key is to be used for mounting.
 
 .. option:: --id <client-id>
 
-   Pass the name of CephX user whose secret key is be to used for mounting.
+   Pass the name of CephX user whose secret key is to be used for mounting.
    ``--id`` takes just the ID of the client in contrast to ``-n``. For
    example, ``--id 0`` for using ``client.0``.
 

--- a/doc/man/8/ceph-immutable-object-cache.rst
+++ b/doc/man/8/ceph-immutable-object-cache.rst
@@ -17,15 +17,15 @@ Description
 
 :program:`ceph-immutable-object-cache` is a daemon for object cache of RADOS
 objects among Ceph clusters. It will promote the objects to a local directory
-upon promote requests and future reads will be serviced from these cached
+upon promote requests, and future reads will be serviced from these cached
 objects.
 
 It connects to local clusters via the RADOS protocol, relying on
-default search paths to find ceph.conf files, monitor addresses and
+default search paths to find ceph.conf files, Monitor addresses and
 authentication information for them, i.e. ``/etc/ceph/$cluster.conf``,
 ``/etc/ceph/$cluster.keyring``, and
 ``/etc/ceph/$cluster.$name.keyring``, where ``$cluster`` is the
-human-friendly name of the cluster, and ``$name`` is the rados user to
+human-friendly name of the cluster, and ``$name`` is the RADOS user to
 connect as, e.g. ``client.ceph-immutable-object-cache``.
 
 
@@ -35,11 +35,11 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use ``ceph.conf`` configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through ``ceph.conf``).
+   Connect to specified Monitor (instead of looking through ``ceph.conf``).
 
 .. option:: -i ID, --id ID
 
@@ -47,7 +47,7 @@ Options
 
 .. option:: -n TYPE.ID, --name TYPE.ID
 
-   Set the rados user name for the gateway (eg. client.ceph-immutable-object-cache)
+   Set the RADOS user name for the gateway (e.g. client.ceph-immutable-object-cache)
 
 .. option:: --cluster NAME
 

--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -21,7 +21,7 @@ RocksDB's data (like OSD's omap) offline.
 Commands
 ========
 
-:program:`ceph-kvstore-tool` utility uses many commands for debugging purpose
+:program:`ceph-kvstore-tool` utility uses many commands for debugging purposes
 which are as follows:
 
 :command:`list [prefix]`
@@ -82,7 +82,7 @@ which are as follows:
 
 :command:`stats`
     Prints statistics from underlying key-value database. This is only for informative purposes.
-    Format and information content may vary between releases. For RocksDB information includes
+    Format and information content may vary between releases. For RocksDB, information includes
     compactions stats, performance counters, memory usage and internal RocksDB stats. 
 
 :command:`histogram`

--- a/doc/man/8/ceph-mds.rst
+++ b/doc/man/8/ceph-mds.rst
@@ -24,7 +24,7 @@ system namespace, coordinating access to the shared OSD cluster.
 Each ceph-mds daemon instance should have a unique name. The name is used
 to identify daemon instances in the ceph.conf.
 
-Once the daemon has started, the monitor cluster will normally assign
+Once the daemon has started, the Monitor cluster will normally assign
 it a logical rank, or put it in a standby pool to take over for
 another daemon that crashes. Some of the specified options can cause
 other behaviors.
@@ -57,12 +57,12 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during
    startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through
+   Connect to specified Monitor (instead of looking through
    ``ceph.conf``).
 
 .. option:: --id/-i ID

--- a/doc/man/8/ceph-mon.rst
+++ b/doc/man/8/ceph-mon.rst
@@ -15,13 +15,13 @@ Synopsis
 Description
 ===========
 
-**ceph-mon** is the cluster monitor daemon for the Ceph distributed
+**ceph-mon** is the cluster Monitor daemon for the Ceph distributed
 file system. One or more instances of **ceph-mon** form a Paxos
 part-time parliament cluster that provides extremely reliable and
 durable storage of cluster membership, configuration, and state.
 
 The *mondatapath* refers to a directory on a local file system storing
-monitor data. It is normally specified via the ``mon data`` option in
+Monitor data. It is normally specified via the ``mon data`` option in
 the configuration file.
 
 Options
@@ -50,27 +50,27 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during
    startup.
 
 .. option:: --mkfs
 
    Initialize the ``mon data`` directory with seed information to form
-   and initial ceph file system or to join an existing monitor
+   an initial Ceph file system or to join an existing Monitor
    cluster.  Three pieces of information must be provided:
 
    - The cluster fsid.  This can come from a monmap (``--monmap <path>``) or
      explicitly via ``--fsid <uuid>``.
-   - A list of monitors and their addresses.  This list of monitors
+   - A list of Monitors and their addresses.  This list of Monitors
      can come from a monmap (``--monmap <path>``), the ``mon host``
      configuration value (in *ceph.conf* or via ``-m
      host1,host2,...``), or (for backward compatibility) the deprecated ``mon addr`` lines in *ceph.conf*.  If this
-     monitor is to be part of the initial monitor quorum for a new
+     Monitor is to be part of the initial Monitor quorum for a new
      Ceph cluster, then it must be included in the initial list,
-     matching either the name or address of a monitor in the list.
+     matching either the name or address of a Monitor in the list.
      When matching by address, either the ``public addr`` or ``public
      subnet`` options may be used.
-   - The monitor secret key ``mon.``.  This must be included in the
+   - The Monitor secret key ``mon.``.  This must be included in the
      keyring provided via ``--keyring <path>``.
 
 .. option:: --keyring
@@ -79,7 +79,7 @@ Options
 
 .. option:: --no-config-file
 
-    Signal that we don't want to rely on a *ceph.conf*, either user provided
+    Signal that we don't want to rely on a *ceph.conf*, either user-provided
     or the default, to run the daemon.  This will entail providing all
     necessary options to the daemon as arguments.
 

--- a/doc/man/8/ceph-monstore-tool.rst
+++ b/doc/man/8/ceph-monstore-tool.rst
@@ -40,8 +40,8 @@ Commands
 :command:`get osdmap [-- options]`
     Get osdmap (version VER if specified) (default: last committed).
 
-:command:`get msdmap [-- options]`
-    Get msdmap (version VER if specified) (default: last committed).
+:command:`get mdsmap [-- options]`
+    Get mdsmap (version VER if specified) (default: last committed).
 
 :command:`get mgr [-- options]`
     Get mgrmap (version VER if specified) (default: last committed).
@@ -61,14 +61,14 @@ Commands
 :command:`dump-paxos [-- options]`
     Dump Paxos transactions  (-- -- help for more info).
 
-:command:`dump-trace FILE  [-- options]`
+:command:`dump-trace FILE [-- options]`
     Dump contents of trace file FILE (-- --help for more info).
 
-:command:`replay-trace FILE  [-- options]`
+:command:`replay-trace FILE [-- options]`
     Replay trace from FILE (-- --help for more info).
 
 :command:`random-gen [-- options]`
-    Add randomly genererated ops to the store (-- --help for more info).
+    Add randomly generated ops to the store (-- --help for more info).
 
 :command:`rewrite-crush [-- options]`
     Add a rewrite commit to the store

--- a/doc/man/8/ceph-objectstore-tool.rst
+++ b/doc/man/8/ceph-objectstore-tool.rst
@@ -16,7 +16,7 @@ Possible object operations:
 
 * (get|set)-bytes [file]
 * set-(attr|omap) [file]
-* (get|rm)-attr|omap)
+* (get|rm)-(attr|omap)
 * get-omaphdr
 * set-omaphdr [file]
 * list-attrs
@@ -38,7 +38,7 @@ Description
 | **ceph-objectstore-tool** --data-path *path to osd* [--pgid *$PG_ID* ][--op *command*]
 | **ceph-objectstore-tool** --data-path *path to osd* [ --op *list $OBJECT_ID*]
 
-Possible -op commands::
+Possible --op commands::
 
 * info
 * log
@@ -80,7 +80,7 @@ Examples
 
 Modifying Objects
 -----------------
-These commands modify state of an OSD. The OSD must not be running when ceph-objectstore-tool is used.
+These commands modify the state of an OSD. The OSD must not be running when ceph-objectstore-tool is used.
 
 Listing Objects and Placement Groups
 ------------------------------------
@@ -102,7 +102,7 @@ Identify the placement group (PG) that an object belongs to::
    ceph-objectstore-tool --data-path $PATH_TO_OSD --op list $OBJECT_ID
 
 
-Fixing Lost Objects   
+Fixing Lost Objects
 -------------------
 
 Make sure the OSD is down::
@@ -139,11 +139,11 @@ Manipulating an object's content
    
     ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-bytes > $OBJECT_FILE_NAME
 
-For example::
+   For example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' get-bytes > zone_info.default.backup
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' get-bytes > zone_info.default.backup
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' get-bytes > zone_info.default.working-copy
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' get-bytes > zone_info.default.working-copy
 
 The first command creates the back-up copy, and the second command creates the working copy.
 
@@ -151,11 +151,11 @@ The first command creates the back-up copy, and the second command creates the w
 
 5. Set the bytes of the object::
      
-     ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-bytes < $OBJECT_FILE_NAME
+    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-bytes < $OBJECT_FILE_NAME
 
-For example::
+   For example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' set-bytes < zone_info.default.working-copy
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' set-bytes < zone_info.default.working-copy
  
 
 Removing an Object
@@ -206,41 +206,41 @@ The **ceph-objectstore-tool** utility will output the object map (OMAP) header w
 Prerequisites
 ^^^^^^^^^^^^^
 
-    * Having root access to the Ceph OSD node.
-    * Stopping the ceph-osd daemon. 
+* Having root access to the Ceph OSD node.
+* Stopping the ceph-osd daemon.
 
 Procedure
 ^^^^^^^^^
 
-  Verify that the target OSD is down:
+Verify that the target OSD is down:
 
-  Syntax::
+Syntax::
 
     systemctl status ceph-osd@$OSD_NUMBER
 
-  Example::
+Example::
 
     [root@osd ~]# systemctl status ceph-osd@1
 
-  Get the object map header:
+Get the object map header:
 
-  Syntax::
+Syntax::
 
-        ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr > $OBJECT_MAP_FILE_NAME
+    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr > $OBJECT_MAP_FILE_NAME
 
-  Example::
+Example::
 
-        [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  get-omaphdr > zone_info.default.omaphdr.txt
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  get-omaphdr > zone_info.default.omaphdr.txt
 
-  Set the object map header:
+Set the object map header:
 
-  Syntax::
+Syntax::
 
-        ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr < $OBJECT_MAP_FILE_NAME
+    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr < $OBJECT_MAP_FILE_NAME
 
-  Example::
+Example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  set-omaphdr < zone_info.default.omaphdr.txt
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  set-omaphdr < zone_info.default.omaphdr.txt
 
 
 Manipulating the Object Map Key
@@ -253,8 +253,8 @@ the key in the OMAP.
 Prerequisites
 ^^^^^^^^^^^^^
 
-    * Having root access to the Ceph OSD node.
-    * Stopping the ceph-osd daemon. 
+* Having root access to the Ceph OSD node.
+* Stopping the ceph-osd daemon.
 
 Commands
 ^^^^^^^^
@@ -263,37 +263,37 @@ Run the commands in this section as ``root`` on an OSD node.
 
 * **Getting the object map key**
 
-   Syntax:
+  Syntax:
 
-   .. code-block:: ini 
+  .. code-block:: ini
      
-      ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omap $KEY > $OBJECT_MAP_FILE_NAME
+    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omap $KEY > $OBJECT_MAP_FILE_NAME
 
-   Example::
+  Example::
 
     ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  get-omap "" > zone_info.default.omap.txt
 
 * **Setting the object map key**
 
-   Syntax:
+  Syntax:
 
-   .. code-block:: ini 
+  .. code-block:: ini
 
-      ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-omap $KEY < $OBJECT_MAP_FILE_NAME
+    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-omap $KEY < $OBJECT_MAP_FILE_NAME
 
-   Example::
+  Example::
 
     ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' set-omap "" < zone_info.default.omap.txt
 
 * **Removing the object map key**
 
-   Syntax:
+  Syntax:
 
-   .. code-block:: ini 
+  .. code-block:: ini
 
-      ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-omap $KEY
+    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-omap $KEY
 
-   Example::
+  Example::
 
     ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' rm-omap ""
 
@@ -307,34 +307,34 @@ Note
 Prerequisites
 ^^^^^^^^^^^^^
 
-    * Having root access to the Ceph OSD node.
-    * Stopping the ceph-osd daemon. 
+* Having root access to the Ceph OSD node.
+* Stopping the ceph-osd daemon.
 
 Procedure
 ^^^^^^^^^
 
-   Verify that the target OSD is down:
+Verify that the target OSD is down:
 
-   Syntax::
+Syntax::
 
     systemctl status ceph-osd@$OSD_NUMBER
 
-   Example::
+Example::
 
     [root@osd ~]# systemctl status ceph-osd@1
 
-   List the object's attributes:
+List the object's attributes:
 
-   Syntax::
+Syntax::
 
     ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-attrs
 
-   Example::
+Example::
 
     [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' list-attrs
 
 
-MANIPULATING THE OBJECT ATTRIBUTE KEY
+Manipulating the Object Attribute Key
 -------------------------------------
 
 Use the ceph-objectstore-tool utility to change an object's attributes. To manipulate the object's attributes you need the data and journal paths, the placement group identifier (PG ID), the object, and the key in the object's attribute.
@@ -342,20 +342,20 @@ Note
 
 Prerequisites
 
-    * Having root access to the Ceph OSD node.  
-    * Stopping the ceph-osd daemon. 
+* Having root access to the Ceph OSD node.  
+* Stopping the ceph-osd daemon.
 
 Procedure
 
-    Verify that the target OSD is down.
+ Verify that the target OSD is down.
 
  Syntax::
 
-    systemctl status ceph-osd@$OSD_NUMBER
+   systemctl status ceph-osd@$OSD_NUMBER
 
  Example::
 
-    [root@osd ~]# systemctl status ceph-osd@1
+   [root@osd ~]# systemctl status ceph-osd@1
 
  Get the object's attributes:
 
@@ -483,7 +483,7 @@ Options
 
 Error Codes
 ===========
-"Mount failed with '(11) Resource temporarily unavailable" - This might mean that you have attempted to run **ceph-objectstore-tool** on a running OSD.
+"Mount failed with '(11) Resource temporarily unavailable'" - This might mean that you have attempted to run **ceph-objectstore-tool** on a running OSD.
 
 Availability
 ============

--- a/doc/man/8/ceph-post-file.rst
+++ b/doc/man/8/ceph-post-file.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **ceph-post-file** [-d *description] [-u *user*] *file or dir* ...
+| **ceph-post-file** [-d *description*] [-u *user*] *file or dir* ...
 
 
 Description
@@ -20,9 +20,9 @@ later analysis by Ceph developers.
 
 Each invocation uploads files or directories to a separate directory
 with a unique tag.  That tag can be passed to a developer or
-referenced in a bug report (http://tracker.ceph.com/).  Once the
+referenced in a bug report (https://tracker.ceph.com/).  Once the
 upload completes, the directory is marked non-readable and
-non-writeable to prevent access or modification by other users.
+non-writable to prevent access or modification by other users.
 
 Warning
 =======
@@ -68,4 +68,4 @@ See also
 ========
 
 :doc:`ceph <ceph>`\(8),
-:doc:`ceph-debugpack <ceph-debugpack>`\(8),
+:doc:`ceph-debugpack <ceph-debugpack>`\(8)

--- a/doc/man/8/ceph-syn.rst
+++ b/doc/man/8/ceph-syn.rst
@@ -34,12 +34,12 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during
    startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through
+   Connect to specified Monitor (instead of looking through
    ``ceph.conf``).
 
 .. option:: --num_client num
@@ -58,7 +58,7 @@ Workloads
 Each workload should be preceded by ``--syn`` on the command
 line. This is not a complete list.
 
-:command:`mknap` *path* *snapname*
+:command:`mksnap` *path* *snapname*
   Create a snapshot called *snapname* on *path*.
 
 :command:`rmsnap` *path* *snapname*
@@ -73,7 +73,7 @@ line. This is not a complete list.
 
 :command:`readfile` *sizeinmb* *blocksize*
   Read file, named after our client id, that is *sizeinmb* MB by
-  writing *blocksize* chunks.
+  reading *blocksize* chunks.
 
 :command:`rw` *sizeinmb* *blocksize*
   Write file, then read it back, as above.

--- a/doc/man/8/ceph-volume-systemd.rst
+++ b/doc/man/8/ceph-volume-systemd.rst
@@ -35,7 +35,7 @@ In the case of ``lvm`` a call could look like::
 
 Which in turn will call ``ceph-volume`` in the following way::
 
-    ceph-volume lvm trigger  0-8715BEB4-15C5-49DE-BA6F-401086EC7B41
+    ceph-volume lvm trigger 0-8715BEB4-15C5-49DE-BA6F-401086EC7B41
 
 Any other subcommand will need to have implemented a ``trigger`` command that
 can consume the extra metadata in this format.
@@ -46,10 +46,10 @@ Availability
 
 :program:`ceph-volume-systemd` is part of Ceph, a massively scalable,
 open-source, distributed storage system. Please refer to the documentation at
-http://docs.ceph.com/ for more information.
+https://docs.ceph.com/ for more information.
 
 
 See also
 ========
 
-:doc:`ceph-osd <ceph-osd>`\(8),
+:doc:`ceph-osd <ceph-osd>`\(8)

--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -23,7 +23,7 @@ Synopsis
 Description
 ===========
 
-:program:`ceph-volume` is a single purpose command line tool to deploy logical
+:program:`ceph-volume` is a single-purpose command line tool to deploy logical
 volumes as OSDs, trying to maintain a similar API to ``ceph-disk`` when
 preparing, activating, and creating OSDs.
 
@@ -70,7 +70,7 @@ lvm
 .. program:: ceph-volume lvm
 
 By making use of LVM tags, the ``lvm`` sub-command is able to store and later
-re-discover and query devices associated with OSDs so that they can later
+re-discover and query devices associated with OSDs so that they can later be
 activated.
 
 Subcommands:
@@ -251,7 +251,7 @@ For encrypting an OSD, the ``--dmcrypt`` flag must be added when preparing
 create
 ^^^^^^
 
-Wraps the two-step process to provision a new osd (calling ``prepare`` first
+Wraps the two-step process to provision a new OSD (calling ``prepare`` first
 and then ``activate``) into a single one. The reason to prefer ``prepare`` and
 then ``activate`` is to gradually introduce new OSDs into a cluster, and
 avoiding large amounts of data being rebalanced.
@@ -419,7 +419,7 @@ case it is attached to the OSD replacing one of the source devices. Following
 replacement rules apply (in the order of precedence, stop on the first match):
 
     - if source list has DB volume - target device replaces it.
-    - if source list has WAL volume - target device replace it.
+    - if source list has WAL volume - target device replaces it.
     - if source list has slow volume only - operation is not permitted,
       requires explicit allocation via new-db/new-wal command.
 
@@ -560,10 +560,10 @@ Availability
 ============
 
 :program:`ceph-volume` is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
-the documentation at http://docs.ceph.com/ for more information.
+the documentation at https://docs.ceph.com/ for more information.
 
 
 See also
 ========
 
-:doc:`ceph-osd <ceph-osd>`\(8),
+:doc:`ceph-osd <ceph-osd>`\(8)


### PR DESCRIPTION
Low-hanging spelling, punctuation, and capitalization errors etc.  
Ignore style and other more complex issues.  
Use https for links.  
Fix markup rendered as-is and indentation in 2 files.

GitHub Copilot was used to search for most of these spelling etc. errors.
Everything else including confirming and fixing the errors was done manually.

Fixes syntax errors in `doc/man/8/ceph-bluestore-tool.rst` with markup rendered as-is:
- Original: https://docs.ceph.com/en/latest/man/8/ceph-bluestore-tool/#commands
- Rendered PR: https://ceph--68156.org.readthedocs.build/en/68156/man/8/ceph-bluestore-tool/#commands

Fixes indentation in `doc/man/8/ceph-objectstore-tool.rst`:
- Original: https://docs.ceph.com/en/latest/man/8/ceph-objectstore-tool/#manipulating-an-object-s-content
- Rendered PR: https://ceph--68156.org.readthedocs.build/en/68156/man/8/ceph-objectstore-tool/#manipulating-an-object-s-content
- Original: https://docs.ceph.com/en/latest/man/8/ceph-objectstore-tool/#prerequisites (and all the way to the end of the doc)
- Rendered PR: https://ceph--68156.org.readthedocs.build/en/68156/man/8/ceph-objectstore-tool/#prerequisites (and all the way to the end of the doc)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
