### PR TITLE
Client: MDS return -ESTALE while openning snapped files which is removed in the live fs

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14501,6 +14501,7 @@ void Client::_ll_get(Inode *in)
     if (in->snapid != CEPH_NOSNAP)
       ll_snap_ref[in->snapid]++;
   }
+  in->move_to_pinnned();
   in->ll_get();
   ldout(cct, 20) << __func__ << " " << in << " " << in->ino << " -> " << in->ll_ref << dendl;
 }
@@ -14514,6 +14515,7 @@ int Client::_ll_put(Inode *in, uint64_t num)
       ceph_assert(in->dentries.size() == 1); // dirs can't be hard-linked
       in->get_first_parent()->put(); // unpin dentry
     }
+    in->move_to_unpinned();
     if (in->snapid != CEPH_NOSNAP) {
       auto p = ll_snap_ref.find(in->snapid);
       ceph_assert(p != ll_snap_ref.end());

--- a/src/client/Dentry.h
+++ b/src/client/Dentry.h
@@ -11,8 +11,8 @@
 
 class Dentry : public LRUObject {
 public:
-  explicit Dentry(Dir *_dir, const std::string &_name) :
-    dir(_dir), name(_name), inode_xlist_link(this)
+  explicit Dentry(Dir* _dir, const std::string& _name) :
+    dir(_dir), name(_name), inode_xlist_link(this), pin_tracked_link(this)
   {
     auto r = dir->dentries.insert(make_pair(name, this));
     ceph_assert(r.second);
@@ -44,6 +44,12 @@ public:
   void link(InodeRef in) {
     inode = in;
     inode->dentries.push_back(&inode_xlist_link);
+    if (inode->ll_ref) {
+      inode->pinned_dentries.push_back(&pin_tracked_link);
+      get(); // ll_ref -> dn pin
+    } else {
+      inode->unpinned_dentries.push_back(&pin_tracked_link);
+    }
     if (inode->is_dir()) {
       if (inode->dir)
         get(); // dir -> dn pin
@@ -60,9 +66,27 @@ public:
         put(); // ll_ref -> dn pin
     }
     ceph_assert(inode_xlist_link.get_list() == &inode->dentries);
+
+    if (pin_tracked_link.get_list() == &inode->pinned_dentries ||
+        pin_tracked_link.get_list() == &inode->unpinned_dentries) {
+      if (pin_tracked_link.get_list() == &inode->pinned_dentries) {
+        put();
+      }
+      pin_tracked_link.remove_myself();
+    }
     inode_xlist_link.remove_myself();
     inode.reset();
     dir->num_null_dentries++;
+  }
+
+  void do_pin() {
+    inode->pinned_dentries.push_back(&pin_tracked_link);
+    get();
+  }
+
+  void do_unpin() {
+    inode->unpinned_dentries.push_back(&pin_tracked_link);
+    put();
   }
   void mark_primary() {
     if (inode && inode->dentries.front() != this)
@@ -111,6 +135,7 @@ public:
 
 private:
   xlist<Dentry *>::item inode_xlist_link;
+  xlist<Dentry *>::item pin_tracked_link;
 };
 
 #endif

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -909,3 +909,19 @@ void Inode::set_effective_size(uint64_t size)
 
   *(ceph_le64 *)fscrypt_file.data() = size;
 }
+
+void Inode::move_to_unpinned() {
+  while (!pinned_dentries.empty()) {
+    auto it = pinned_dentries.begin();
+    (*it)->do_unpin();
+  }
+  ceph_assert(pinned_dentries.empty());
+}
+
+void Inode::move_to_pinnned() {
+  while (!unpinned_dentries.empty()) {
+    auto it = unpinned_dentries.begin();
+    (*it)->do_pin();
+  }
+  ceph_assert(unpinned_dentries.empty());
+}

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -266,6 +266,24 @@ struct Inode : RefCountedObject {
 
   uint64_t  ll_ref = 0;   // separate ref count for ll client
   xlist<Dentry *> dentries; // if i'm linked to a dentry.
+  /*
+  For files, the dentry reference count is not incremented because multiple
+  dentries may point to the same inode. Managing dentry reference counting is
+  not straightforward, since in functions such as Client::_ll_get and
+  Client::_ll_put we do not know exactly which dentry is being targeted for
+  increment or decrement. To handle this, we maintain two lists of dentries.
+
+  Initially, at link time, all dentries are placed in the unpinned list.
+  Whenever the inode reference count is incremented, all dentries in the
+  unpinned list are pinned and moved to the file_pinned_dentries list. These
+  dentries remain pinned until the inode's reference count drops to zero.
+
+  This ensures that dentries associated with a file are protected from
+  unintended cache eviction.
+  https://tracker.ceph.com/issues/75825
+  */
+  xlist<Dentry *> pinned_dentries; 
+  xlist<Dentry *> unpinned_dentries;
   std::string    symlink;  // symlink content, if it's a symlink
   std::map<std::string,bufferptr> xattrs;
   std::map<frag_t,int> fragmap;  // known frag -> mds mappings
@@ -280,6 +298,10 @@ struct Inode : RefCountedObject {
     ceph_assert(!dentries.empty());
     return *dentries.begin();
   }
+
+  void move_to_unpinned();
+
+  void move_to_pinnned();
 
   void make_long_path(filepath& p);
   void make_short_path(filepath& p);

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -4611,3 +4611,176 @@ TEST(LibCephFS, ConcurrentWriteAndFsync) {
   ASSERT_EQ(0, ceph_unmount(cmount));
   ceph_shutdown(cmount);
 }
+
+TEST(LibCephFS, SnappedFileOpenTest) {
+  struct InodeDeleter {
+    struct ceph_mount_info* cmount = nullptr;
+    void operator()(Inode* inode) const {
+      if (cmount && inode) {
+        ceph_ll_forget(cmount, inode, 1);
+      }
+    }
+  };
+  struct FhDeleter {
+    struct ceph_mount_info* cmount = nullptr;
+    void operator()(struct Fh* fh) const {
+      if (cmount && fh) {
+        ceph_ll_close(cmount, fh);
+      }
+    }
+  };
+
+  struct DirptrDeleter {
+    struct ceph_mount_info* cmount = nullptr;
+    void operator()(struct ceph_dir_result* dirp) const {
+      if (cmount && dirp) {
+        ceph_ll_releasedir(cmount, dirp);
+      }
+    }
+  };
+
+  using InodePtr = std::unique_ptr<Inode, InodeDeleter>;
+  using FhPtr = std::unique_ptr<struct Fh, FhDeleter>;
+  using DirptrPtr = std::unique_ptr<struct ceph_dir_result, DirptrDeleter>;
+  auto make_inode_ptr = [](struct ceph_mount_info* cmount, Inode* inode) {
+    return InodePtr(inode, InodeDeleter{cmount});
+  };
+  auto make_fh_ptr = [](struct ceph_mount_info* cmount, struct Fh* fh) {
+    return FhPtr(fh, FhDeleter{cmount});
+  };
+  auto make_dirptr_ptr = [](struct ceph_mount_info* cmount, struct ceph_dir_result* dirp) {
+    return DirptrPtr(dirp, DirptrDeleter{cmount});
+  };
+  constexpr int file_count = 2;
+  constexpr int file_size = 1LL << 30;
+  const unsigned stat_flags = AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW;
+  std::string test_dir = "test_dir";
+  std::string snapped_dir = "snapped_dir";
+  std::string snap_name = "snap_before_delete";
+  struct ceph_mount_info *cmount1;
+  auto mount_and_create_files = [&]() {
+    ASSERT_EQ(0, ceph_create(&cmount1, NULL));
+    ASSERT_EQ(0, ceph_conf_read_file(cmount1, NULL));
+    ASSERT_EQ(0, ceph_conf_parse_env(cmount1, NULL));
+    ASSERT_EQ(0, ceph_mount(cmount1, NULL));
+    const UserPerm* perms = ceph_mount_perms(cmount1);
+    Inode* root_raw = nullptr;
+    ASSERT_EQ(0, ceph_ll_lookup_root(cmount1, &root_raw));
+    ASSERT_NE(root_raw, nullptr);
+    auto root = make_inode_ptr(cmount1, root_raw);
+
+    Inode* test_dir_inode_raw = nullptr;
+    struct ceph_statx stx;
+    ASSERT_EQ(0, ceph_ll_mkdir(cmount1, root.get(),
+              test_dir.c_str(), 0777, &test_dir_inode_raw,
+              &stx, 0, stat_flags, perms));
+    ASSERT_NE(test_dir_inode_raw, nullptr);
+    auto test_dir_inode = make_inode_ptr(cmount1, test_dir_inode_raw);
+
+    Inode* snapped_dir_inode_raw = nullptr;
+    ASSERT_EQ(0, ceph_ll_mkdir(cmount1, test_dir_inode.get(),
+              snapped_dir.c_str(), 0777, &snapped_dir_inode_raw,
+              &stx, 0, stat_flags, perms));
+    ASSERT_NE(snapped_dir_inode_raw, nullptr);
+    auto snapped_dir_inode = make_inode_ptr(cmount1, snapped_dir_inode_raw);
+    std::vector<char> random_payload(file_size);
+    for (int i = 0; i < file_size; ++i) {
+      random_payload[i] = static_cast<char>(i % 256);
+    }
+    std::vector <InodePtr> file_inodes;
+    std::vector <FhPtr> file_fhs;
+    for (int i = 0; i < file_count; ++i) {
+      std::string file_name = "file_" + std::to_string(i);
+      Inode* file_inode_raw = nullptr;
+      Fh* file_fh_raw = nullptr;
+      ASSERT_EQ(0, ceph_ll_create(cmount1, snapped_dir_inode.get(),
+                file_name.c_str(), 0644, O_CREAT | O_TRUNC | O_RDWR,
+              &file_inode_raw, &file_fh_raw, &stx, 0, stat_flags, perms));
+      ASSERT_NE(file_inode_raw, nullptr);
+      auto file_inode = make_inode_ptr(cmount1, file_inode_raw);
+      auto file_fh = make_fh_ptr(cmount1, file_fh_raw);
+      size_t bytes_written = ceph_ll_write(cmount1, file_fh.get(), 0,
+                random_payload.size(), random_payload.data());
+      ASSERT_EQ(bytes_written, random_payload.size());
+      ASSERT_EQ(0, ceph_ll_fsync(cmount1, file_fh.get(), 0));
+      file_inodes.push_back(std::move(file_inode));
+      file_fhs.push_back(std::move(file_fh));
+    }
+    
+    Inode* snap_dir_inode_raw = nullptr;
+    ASSERT_EQ(0, ceph_ll_lookup(cmount1, snapped_dir_inode.get(),
+                                ".snap", &snap_dir_inode_raw, &stx,
+                                0, stat_flags, perms));
+    ASSERT_NE(snap_dir_inode_raw, nullptr);
+    InodePtr snap_dir_inode = make_inode_ptr(cmount1, snap_dir_inode_raw);
+
+    Inode* snapshot_inode_raw = nullptr;
+    ASSERT_EQ(0, ceph_ll_mkdir(cmount1, snap_dir_inode.get(),
+              snap_name.c_str(), 0777, &snapshot_inode_raw,
+              &stx, 0, stat_flags, perms));
+    ASSERT_NE(snap_dir_inode_raw, nullptr);
+    auto snapshot_inode = make_inode_ptr(cmount1, snapshot_inode_raw);
+
+    for (int i = 0; i < file_count; ++i) {
+      std::string file_name = "file_" + std::to_string(i);
+      ASSERT_EQ(0, ceph_ll_unlink(cmount1, snapped_dir_inode.get(),
+              file_name.c_str(), perms));
+    }
+  };
+  mount_and_create_files();
+  ASSERT_EQ(0, ceph_unmount(cmount1));
+  ceph_shutdown(cmount1);
+  std::this_thread::sleep_for(std::chrono::seconds(30));
+  struct ceph_mount_info *cmount2;
+  auto mount_and_open_snapped_files = [&]() {
+    ASSERT_EQ(0, ceph_create(&cmount2, NULL));
+    ASSERT_EQ(0, ceph_conf_read_file(cmount2, NULL));
+    ASSERT_EQ(0, ceph_conf_parse_env(cmount2, NULL));
+    ASSERT_EQ(0, ceph_conf_set(cmount2, "client_cache_size", "0"));
+    ASSERT_EQ(0, ceph_mount(cmount2, NULL));
+    const UserPerm* perms = ceph_mount_perms(cmount2);
+    struct ceph_statx stx;
+    Inode* root_raw = nullptr;
+    ASSERT_EQ(0, ceph_ll_lookup_root(cmount2, &root_raw));
+    auto root = make_inode_ptr(cmount2, root_raw);
+    Inode* snaphost_inode_raw = nullptr;
+    std::string snap_path = test_dir + "/" + snapped_dir + "/.snap/" + snap_name;
+    ASSERT_EQ(0, ceph_ll_lookup(cmount2, root.get(), snap_path.c_str(),
+              &snaphost_inode_raw, &stx, 0, stat_flags, perms));
+    auto snaphost_inode = make_inode_ptr(cmount2, snaphost_inode_raw);
+    struct ceph_dir_result* dirp_raw = nullptr;
+    ASSERT_EQ(0, ceph_ll_opendir(cmount2, snaphost_inode.get(), &dirp_raw, perms));
+    auto dirp = make_dirptr_ptr(cmount2, dirp_raw);
+    std::vector <std::string> file_names;
+    std::vector <InodePtr> file_inodes;
+    while (true) {
+      struct dirent de{};
+      Inode* entry_raw = nullptr;
+      int r = ceph_readdirplus_r(cmount2, dirp.get(), &de, &stx, CEPH_STATX_MODE |
+                                CEPH_STATX_UID | CEPH_STATX_GID | CEPH_STATX_SIZE
+                                | CEPH_STATX_MTIME, stat_flags, &entry_raw);
+      ASSERT_TRUE(r >= 0);
+      if (r == 0) {
+        break;
+      }
+      auto entry_inode = make_inode_ptr(cmount2, entry_raw);
+      std::string name = de.d_name;
+      if (name == "." || name == "..") {
+        continue;
+      }
+      file_names.push_back(name);
+      file_inodes.push_back(std::move(entry_inode));
+    }
+    dirp = nullptr; // release dirp before unmounting
+    std::vector <FhPtr> openned_fh;
+    for (int i = 0; i < file_inodes.size(); ++i) {
+      Fh* fh_raw = nullptr;
+      ASSERT_EQ(0, ceph_ll_open(cmount2, file_inodes[i].get(), O_RDONLY, &fh_raw, perms));
+      auto fh = make_fh_ptr(cmount2, fh_raw);
+      openned_fh.push_back(std::move(fh));
+    }
+  };
+  mount_and_open_snapped_files();
+  ASSERT_EQ(0, ceph_unmount(cmount2));
+  ceph_shutdown(cmount2);
+}


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75825
Signed-off-by: Md Mahamudur Rahaman Sajib <mahamudur.sajib@croit.io>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
