### PR TITLE
mgr/cephadm: set default prometheus template in config-key store unless overridden by the user

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -627,6 +627,28 @@ class PrometheusService(CephadmService):
         files = {
             'prometheus.yml': self.mgr.template.render('services/prometheus/prometheus.yml.j2', context)
         }
+
+        # check if the prometheus.yml already exists in the config-key store,
+        # if not we need to set the initial config-key with the default template content.
+        # If it already exists, we need not override user config changes.
+        r, outs, err = self.mgr.mon_command({
+            'prefix': 'config-key get',
+            'key': 'mgr/cephadm/services/prometheus/prometheus.yml'
+        })
+        if r == -errno.ENOENT:
+            loader = self.mgr.template.engine.env.loader
+            assert loader is not None
+
+            raw_template, _, _ = loader.get_source(
+                self.mgr.template.engine.env,
+                'services/prometheus/prometheus.yml.j2'
+            )
+            self.mgr.check_mon_command({
+                'prefix': 'config-key set',
+                'key': 'mgr/cephadm/services/prometheus/prometheus.yml',
+                'val': raw_template
+            })
+
         r: Dict[str, Any] = {
             'files': files,
             'retention_time': retention_time,

--- a/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
@@ -1867,3 +1867,67 @@ spec:
                         error_ok=True,
                         use_current_daemon_image=False,
                     )
+
+    @patch("cephadm.services.monitoring.PrometheusService.get_dependencies", lambda *a, **k: [])
+    def test_prometheus_config_sets_default_when_missing(self, cephadm_module):
+
+        svc = PrometheusService(cephadm_module)
+
+        daemon_spec = Mock()
+        daemon_spec.daemon_type = 'prometheus'
+        daemon_spec.service_name = 'prometheus'
+        daemon_spec.host = 'test'
+
+        cephadm_module.mon_command = Mock(return_value=(-2, '', ''))
+        cephadm_module.check_mon_command = Mock()
+
+        loader = Mock()
+        loader.get_source.return_value = ("raw_template_content", None, None)
+        cephadm_module.template.engine.env.loader = loader
+
+        cephadm_module.template.render = Mock(return_value="rendered_config")
+
+        cephadm_module._get_security_config = Mock(return_value=(False, False, False))
+        cephadm_module._get_alertmanager_credentials = Mock(return_value=(None, None))
+        cephadm_module._get_mgr_ips = Mock(return_value=['127.0.0.1'])
+
+        cephadm_module.spec_store = {
+            'prometheus': Mock()
+        }
+        cephadm_module.spec_store['prometheus'].spec = PrometheusSpec('prometheus')
+
+        svc.generate_config(daemon_spec)
+
+        cephadm_module.check_mon_command.assert_called_once_with({
+            'prefix': 'config-key set',
+            'key': 'mgr/cephadm/services/prometheus/prometheus.yml',
+            'val': "raw_template_content"
+        })
+
+    @patch("cephadm.services.monitoring.PrometheusService.get_dependencies", lambda *a, **k: [])
+    def test_prometheus_config_does_not_override_existing(self, cephadm_module):
+
+        svc = PrometheusService(cephadm_module)
+
+        daemon_spec = Mock()
+        daemon_spec.daemon_type = 'prometheus'
+        daemon_spec.service_name = 'prometheus'
+        daemon_spec.host = 'test'
+
+        cephadm_module.mon_command = Mock(return_value=(0, 'existing', ''))
+        cephadm_module.check_mon_command = Mock()
+
+        cephadm_module.template.render = Mock(return_value="rendered_config")
+
+        cephadm_module._get_security_config = Mock(return_value=(False, False, False))
+        cephadm_module._get_alertmanager_credentials = Mock(return_value=(None, None))
+        cephadm_module._get_mgr_ips = Mock(return_value=['127.0.0.1'])
+
+        cephadm_module.spec_store = {
+            'prometheus': Mock()
+        }
+        cephadm_module.spec_store['prometheus'].spec = PrometheusSpec('prometheus')
+
+        svc.generate_config(daemon_spec)
+
+        cephadm_module.check_mon_command.assert_not_called()


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75826





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
