### PR TITLE
doc/man: fix spelling etc errors (2 of 2)

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -183,7 +183,7 @@ Commands
 add-repo
 --------
 
-configure local package repository to also include the ceph repository.
+configure local package repository to also include the Ceph repository.
 
 Arguments:
 
@@ -215,7 +215,7 @@ Configuration:
 When starting the shell, cephadm looks for configuration in the following order.
 Only the first values found are used:
 
-1. An explicit, user provided path to a config file (``-c/--config`` option)
+1. An explicit, user-provided path to a config file (``-c/--config`` option)
 2. Config file for daemon specified with ``--name`` parameter (``/var/lib/ceph/<fsid>/<daemon-name>/config``)
 3. ``/var/lib/ceph/<fsid>/config/ceph.conf`` if it exists
 4. The config file for a ``mon`` daemon (``/var/lib/ceph/<fsid>/mon.<mon-id>/config``) if it exists
@@ -225,13 +225,13 @@ Only the first values found are used:
 bootstrap
 ---------
 
-Bootstrap a cluster on the local host. It deploys a MON and a MGR and then also automatically
+Bootstrap a cluster on the local host. It deploys a Monitor and a Manager and then also automatically
 deploys the monitoring stack on this host (see --skip-monitoring-stack) and calls
 ``ceph orch host add $(hostname)`` (see --skip-ssh).
 
 Arguments:
 
-* [--config CONFIG, -c CONFIG]    ceph conf file to incorporate
+* [--config CONFIG, -c CONFIG]    Ceph configuration file to incorporate
 * [--mon-id MON_ID]               mon id (default: local hostname)
 * [--mon-addrv MON_ADDRV]         mon IPs (e.g., [v2:localipaddr:3300,v1:localipaddr:6789])
 * [--mon-ip MON_IP]               mon IP
@@ -243,7 +243,7 @@ Arguments:
 * [--output-keyring OUTPUT_KEYRING] location to write keyring file with new cluster admin and mon keys
 * [--output-config OUTPUT_CONFIG] location to write conf file to connect to new cluster
 * [--output-pub-ssh-key OUTPUT_PUB_SSH_KEY] location to write the cluster's public SSH key
-* [--skip-ssh                     skip setup of ssh key on local host
+* [--skip-ssh]                    skip setup of ssh key on local host
 * [--initial-dashboard-user INITIAL_DASHBOARD_USER] Initial user for the dashboard
 * [--initial-dashboard-password INITIAL_DASHBOARD_PASSWORD] Initial password for the initial dashboard user
 * [--ssl-dashboard-port SSL_DASHBOARD_PORT] Port number used to connect with dashboard using SSL
@@ -252,7 +252,7 @@ Arguments:
 * [--ssh-config SSH_CONFIG] SSH config
 * [--ssh-private-key SSH_PRIVATE_KEY] SSH private key
 * [--ssh-public-key SSH_PUBLIC_KEY] SSH public key
-* [--ssh-user SSH_USER]           set user for SSHing to cluster hosts, passwordless sudo will be needed for non-root users'
+* [--ssh-user SSH_USER]           set user for SSHing to cluster hosts, passwordless sudo will be needed for non-root users
 * [--skip-mon-network]            set mon public_network based on bootstrap mon ip
 * [--skip-dashboard]              do not enable the Ceph Dashboard
 * [--dashboard-password-noupdate] stop forced dashboard password change
@@ -264,7 +264,7 @@ Arguments:
 * [--allow-fqdn-hostname]         allow hostname that is fully-qualified (contains ".")
 * [--skip-prepare-host]           Do not prepare host
 * [--orphan-initial-daemons]      Set mon and mgr service to unmanaged and do not create the crash service
-* [--skip-monitoring-stack]       Do not automatically provision monitoring stack] (prometheus, grafana, alertmanager, node-exporter)
+* [--skip-monitoring-stack]       Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter)
 * [--apply-spec APPLY_SPEC]       Apply cluster spec after bootstrap (copy ssh key, add hosts and apply services)
 * [--registry-url REGISTRY_URL]   url of custom registry to login to. e.g. docker.io, quay.io
 * [--registry-username REGISTRY_USERNAME] username of account to login to on custom registry
@@ -280,6 +280,7 @@ Run ceph-volume inside a container::
     cephadm ceph-volume inventory
 
 Positional arguments:
+
 * [command]               command
 
 Arguments:
@@ -343,7 +344,7 @@ Arguments:
 * [--key KEY]                 key for new daemon
 * [--osd-fsid OSD_FSID]       OSD uuid, if creating an OSD container
 * [--skip-firewalld]          Do not configure firewalld
-* [--tcp-ports                List of tcp ports to open in the host firewall
+* [--tcp-ports]               List of TCP ports to open in the host firewall
 * [--reconfig]                Reconfigure a previously deployed daemon
 * [--allow-ptrace]            Allow SYS_PTRACE on daemon container
 
@@ -356,6 +357,7 @@ Run an interactive shell inside a running daemon container::
     cephadm enter --name mgr.myhost.ysubfo
 
 Positional arguments:
+
 * [command]               command
 
 Arguments:
@@ -366,7 +368,7 @@ Arguments:
 install
 -------
 
-install ceph package(s)
+install Ceph package(s)
 
 Positional arguments:
 
@@ -503,7 +505,7 @@ Arguments:
 pull
 ----
 
-Pull the ceph image::
+Pull the Ceph image::
 
     cephadm pull
 
@@ -584,7 +586,7 @@ remove package repository configuration
 run
 ---
 
-run a ceph daemon, in a container, in the foreground
+run a Ceph daemon, in a container, in the foreground
 
 Arguments:
 
@@ -647,18 +649,18 @@ Update the OSD service for specific OSDs
 Arguments:
 
 * [--fsid FSID]                 cluster FSID
-* --osd-ids OSD_IDS             Comma-separated OSD IDs
-* --service-name SERVICE_NAME   OSD service name
+* [--osd-ids OSD_IDS]           Comma-separated OSD IDs
+* [--service-name SERVICE_NAME] OSD service name
 
 
 Availability
 ============
 
 :program:`cephadm` is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
-the documentation at http://docs.ceph.com/ for more information.
+the documentation at https://docs.ceph.com/ for more information.
 
 
 See also
 ========
 
-:doc:`ceph-volume <ceph-volume>`\(8),
+:doc:`ceph-volume <ceph-volume>`\(8)

--- a/doc/man/8/cephfs-mirror.rst
+++ b/doc/man/8/cephfs-mirror.rst
@@ -28,12 +28,12 @@ Options
 
 .. option:: --mon-host monaddress[:port]
 
-   Connect to specified monitor (instead of looking through
+   Connect to specified Monitor (instead of looking through
    ``ceph.conf``).
 
 .. option:: --keyring=<path-to-keyring>
 
-   Provide path to keyring; useful when it's absent in standard locations.
+   Provide path to keyring; useful when it is absent in standard locations.
 
 .. option:: --log-file=<logfile>
 
@@ -46,7 +46,7 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use ``ceph.conf`` configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during startup.
 
 .. option:: -i ID, --id ID
 
@@ -54,7 +54,7 @@ Options
 
 .. option:: -n TYPE.ID, --name TYPE.ID
 
-   Set the rados user name (eg. client.mirror)
+   Set the RADOS user name (e.g. client.mirror)
 
 .. option:: --cluster NAME
 

--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -21,14 +21,14 @@ CephFS Shell provides shell-like commands that directly interact with the
 Ceph File System.
 
 This tool can be used in interactive mode as well as in non-interactive mode.
-In former mode, cephfs-shell opens a shell session and after the given command
+In the former mode, cephfs-shell opens a shell session and after the given command
 is finished, it prints the prompt string and waits indefinitely. When the
-shell session is finished, cephfs-shell quits with the return value of last
+shell session is finished, cephfs-shell quits with the return value of the last
 executed command. In non-interactive mode, cephfs-shell issues a command and
 exits right after the command's execution is complete with the command's
 return value.
 
-Behaviour of CephFS Shell can be tweaked using ``cephfs-shell.conf``. Refer to
+Behavior of CephFS Shell can be tweaked using ``cephfs-shell.conf``. Refer to
 `CephFS Shell Configuration File`_ for details.
 
 Options
@@ -54,12 +54,12 @@ Options
 
     Latest version of the cmd2 module is required for running cephfs-shell.
     If CephFS is installed through source, execute cephfs-shell in the build
-    directory. It can also be executed as following using virtualenv:
+    directory. It can also be executed as follows using virtualenv:
 
-.. code:: bash
+    .. code:: bash
 
-    [build]$ python3 -m venv venv && source venv/bin/activate && pip3 install cmd2 colorama
-    [build]$ source vstart_environment.sh && source venv/bin/activate && python3 ../src/tools/cephfs/shell/cephfs-shell
+        [build]$ python3 -m venv venv && source venv/bin/activate && pip3 install cmd2 colorama
+        [build]$ source vstart_environment.sh && source venv/bin/activate && python3 ../src/tools/cephfs/shell/cephfs-shell
 
 Commands
 ========
@@ -105,12 +105,14 @@ Usage :
     
         put [options] <source_path> <target_path>
 
-* source_path - local file/directory path to be copied to cephfs.
-    * if `.` copies all the file/directories in the local working directory.
-    * if `-`  Reads the input from stdin. 
+* source_path - local file/directory path to be copied to CephFS.
+
+    * If ``.``, copies all the file/directories in the local working directory.
+    * If ``-``, reads the input from stdin.
 
 * target_path - remote directory path where the files/directories are to be copied to.
-    * if `.` files/directories are copied to the remote working directory.
+
+    * If ``.``, files/directories are copied to the remote working directory.
 
 Options :
    -f, --force        Overwrites the destination if it already exists.
@@ -126,11 +128,13 @@ Usage :
     get [options] <source_path> <target_path>
 
 * source_path - remote file/directory path which is to be copied to local file system.
-    * if `.` copies all the file/directories in the remote working directory.
+
+    * If ``.``, copies all the file/directories in the remote working directory.
                     
 * target_path - local directory path where the files/directories are to be copied to.
-    * if `.` files/directories are copied to the local working directory. 
-    * if `-` Writes output to stdout.
+
+    * If ``.``, files/directories are copied to the local working directory.
+    * If ``-``, writes output to stdout.
 
 Options:
   -f, --force        Overwrites the destination if it already exists.
@@ -145,6 +149,7 @@ Usage :
     ls [option] [directory]...
 
 * directory - name of directory whose files/directories are to be listed. 
+
     * By default current working directory's files/directories are listed.
 
 Options:
@@ -194,7 +199,8 @@ Usage :
     cd [directory]
         
 * directory - path/directory name. If no directory is mentioned it is changed to the root directory.
-    * If '.' moves to the parent directory of the current directory.
+
+    * If ``.``, moves to the parent directory of the current directory.
 
 cwd
 ---
@@ -223,7 +229,7 @@ Usage :
 mv
 --
 
-Moves files/Directory from source to destination.
+Moves files/directory from source to destination.
 
 Usage : 
     
@@ -232,16 +238,16 @@ Usage :
 rmdir
 -----
 
-Delete a directory(ies).
+Delete directories.
 
 Usage : 
     
-    rmdir <directory_name>.....
+    rmdir <directory_name>...
 
 rm
 --
 
-Remove a file(es).
+Remove files.
 
 Usage : 
     
@@ -251,7 +257,7 @@ Usage :
 write
 -----
 
-Create and Write a file.
+Create and write a file.
 
 Usage : 
         
@@ -262,11 +268,11 @@ Usage :
 lls
 ---
 
-Lists all files and directories in the specified directory.Current local directory files and directories are listed if no     path is mentioned
+Lists all files and directories in the specified directory. Current local directory files and directories are listed if no path is mentioned
 
 Usage: 
     
-    lls <path>.....
+    lls <path>...
 
 lcd
 ---
@@ -311,7 +317,7 @@ Usage:
 run_pyscript
 ------------
 
-Runs a python script file inside the console
+Runs a Python script file inside the console
 
 Usage: 
     
@@ -327,12 +333,13 @@ Usage:
 py
 --
 
-Invoke python command, shell, or script
+Invoke Python command, shell, or script
 
-Usage : 
+Usage: 
 
-        py <command>: Executes a Python command.
-        py: Enters interactive Python mode.
+    py <command>: Executes a Python command.
+
+    py: Enters interactive Python mode.
 
 shortcuts
 ---------
@@ -429,7 +436,7 @@ Usage:
 locate
 ------
 
-Find an item in File System
+Find an item in file system
 
 Usage:
 
@@ -454,7 +461,7 @@ Options :
 snap
 ----
 
-Create or Delete Snapshot
+Create or delete a snapshot
 
 Usage:
 
@@ -546,7 +553,7 @@ Options:
 quota
 -----
 
-Quota management for a Directory
+Quota management for a directory
 
 Usage :
 
@@ -596,7 +603,7 @@ Following is a sample ``cephfs-shell.conf``
 Exit Code
 =========
 
-Following exit codes are returned by cephfs shell
+Following exit codes are returned by cephfs-shell
 
 +-----------------------------------------------+-----------+
 | Error Type                                    | Exit Code |

--- a/doc/man/8/cephfs-top.rst
+++ b/doc/man/8/cephfs-top.rst
@@ -15,8 +15,8 @@ Synopsis
 Description
 ===========
 
-**cephfs-top** provides top(1) like functionality for Ceph Filesystem.
-Various client metrics are displayed and updated in realtime.
+**cephfs-top** provides top(1)-like functionality for Ceph Filesystem.
+Various client metrics are displayed and updated in real-time.
 
 Ceph Metadata Servers periodically send client metrics to Ceph Manager.
 ``Stats`` plugin in Ceph Manager provides an interface to fetch these metrics.
@@ -26,7 +26,7 @@ Options
 
 .. option:: --cluster
 
-   Cluster: Ceph cluster to connect. Defaults to ``ceph``.
+   Cluster: Ceph cluster to connect to. Defaults to ``ceph``.
 
 .. option:: --id
 
@@ -34,7 +34,7 @@ Options
 
 .. option:: --selftest
 
-   Perform a selftest. This mode performs a sanity check of ``stats`` module.
+   Perform a self-test. This mode performs a sanity check of ``stats`` module.
 
 .. option:: --conffile [CONFFILE]
 
@@ -127,7 +127,7 @@ Availability
 ============
 
 **cephfs-top** is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to the Ceph documentation at
-http://ceph.com/ for more information.
+https://ceph.com/ for more information.
 
 
 See also

--- a/doc/man/8/crushdiff.rst
+++ b/doc/man/8/crushdiff.rst
@@ -19,12 +19,12 @@ Description
 ===========
 
 **crushdiff** is a utility that lets you test the effect of a crushmap
-change: number of pgs, objects, bytes moved. This is a wrapper around
+change: number of PGs, objects, bytes moved. This is a wrapper around
 :doc:`osdmaptool <osdmaptool>`\(8), relying on its **--test-map-pgs-dump**
-option to get the list of changed pgs. Additionally it uses pg stats
+option to get the list of changed PGs. Additionally, it uses PG stats
 to calculate the numbers of objects and bytes moved.
 
-By default, **crushdiff** will use the cluster current osdmap and pg
+By default, **crushdiff** will use the cluster's current osdmap and PG
 stats, which requires access to the cluster. Though one can use the
 **--osdmap** and **--pg-dump** options to test against previously
 obtained data.
@@ -34,19 +34,19 @@ Options
 
 .. option:: --compiled
 
-   The input/output crushmap is compiled. If the options is not
-   specified the expected/returned crushmap is in txt (decompiled)
+   The input/output CRUSH map is compiled. If the option is not
+   specified, the expected/returned CRUSH map is in txt (decompiled)
    format.
 
 .. option:: --pg-dump <pg-dump>
 
-   JSON output of **ceph pg dump**. If not specified **crushdiff**
-   will try to get data running the command itself.
+   JSON output of **ceph pg dump**. If not specified, **crushdiff**
+   will try to get data by running the command itself.
 
 .. option:: --osdmap <osdmap>
 
    The cluster osdmap, obtained with **ceph osd getmap** command. If
-   not specified **crushdiff** will try to get data running the
+   not specified, **crushdiff** will try to get data by running the
    command itself.
 
 .. option:: --verbose
@@ -58,7 +58,7 @@ Commands
 
 :command:`compare` *crushmap*
   Compare the crushmap from *crushmap* file with the crushmap from
-  the cluster osdmap. The output will show the expected number of pgs,
+  the cluster osdmap. The output will show the expected number of PGs,
   objects, bytes moved when the new crushmap is installed.
 
 :command:`export` *crushmap*
@@ -89,13 +89,13 @@ Check the result::
         730.52Mi/10.55Gi (6.76%) bytes to move
 
 When running with **--verbose** option the output will also contain
-detailed information about the affected pgs, like below::
+detailed information about the affected PGs, like below::
 
         4.3	[0, 2, 1] -> [1, 4, 2]
         4.b	[0, 1, 3] -> [2, 1, 3]
         4.c	[4, 0, 1] -> [4, 1, 2]
 
-i.e. a pg number, and its old and the new osd active sets.
+i.e. a PG number, and its old and the new OSD active sets.
 
 If the result is satisfactory install the updated map::
 
@@ -115,4 +115,4 @@ See also
 
 :doc:`ceph <ceph>`\(8),
 :doc:`crushtool <crushtool>`\(8),
-:doc:`osdmaptool <osdmaptool>`\(8),
+:doc:`osdmaptool <osdmaptool>`\(8)

--- a/doc/man/8/crushtool.rst
+++ b/doc/man/8/crushtool.rst
@@ -16,7 +16,7 @@ Synopsis
 Description
 ===========
 
-**crushtool** is a utility that lets you create, compile, decompile
+**crushtool** is a utility that lets you create, compile, decompile,
 and test CRUSH map files.
 
 CRUSH is a pseudo-random data distribution algorithm that efficiently
@@ -61,11 +61,11 @@ silence all output from the CRUSH subsystem::
 Running tests with --test
 =========================
 
-The test mode will use the input crush map ( as specified with **-i
-map** ) and perform a dry run of CRUSH mapping or random placement
-(if **--simulate** is set ). On completion, two kinds of reports can be
+The test mode will use the input crush map (as specified with **-i
+map**\) and perform a dry run of CRUSH mapping or random placement
+(if **--simulate** is set). On completion, two kinds of reports can be
 created. 
-1) The **--show-...** option outputs human readable information
+1) The **--show-...** option outputs human-readable information
 on stderr. 
 2) The **--output-csv** option creates CSV files that are
 documented by the **--help-output** option.
@@ -157,7 +157,7 @@ pools; it only runs simulations by mapping values in the range
       ..
 
    shows that **95224** mappings succeeded without retries, **3745**
-   mappings succeeded with one attempts, etc. There are as many rows
+   mappings succeeded with one retry attempt, etc. There are as many rows
    as the value of the **--set-choose-total-tries** option.
 
 .. option:: --show-retry-exhaustion
@@ -250,7 +250,7 @@ Example
 
 Suppose we have two rows with two racks each and 20 nodes per rack. Suppose
 each node contains 4 storage devices for Ceph OSD Daemons. This configuration
-allows us to deploy 320 Ceph OSD Daemons. Lets assume a 42U rack with 2U nodes,
+allows us to deploy 320 Ceph OSD Daemons. Let's assume a 42U rack with 2U nodes,
 leaving an extra 2U for a rack switch.
 
 To reflect our hierarchy of devices, nodes, racks and rows, we would execute
@@ -314,7 +314,7 @@ See also
 ========
 
 :doc:`ceph <ceph>`\(8),
-:doc:`osdmaptool <osdmaptool>`\(8),
+:doc:`osdmaptool <osdmaptool>`\(8)
 
 Authors
 =======

--- a/doc/man/8/librados-config.rst
+++ b/doc/man/8/librados-config.rst
@@ -16,7 +16,7 @@ Description
 ===========
 
 **librados-config** is a utility that displays information about the
-  installed ``librados``.
+installed ``librados``.
 
 
 Options

--- a/doc/man/8/monmaptool.rst
+++ b/doc/man/8/monmaptool.rst
@@ -15,17 +15,17 @@ Synopsis
 Description
 ===========
 
-**monmaptool** is a utility to create, view, and modify a monitor
+**monmaptool** is a utility to create, view, and modify a Monitor
 cluster map for the Ceph distributed storage system. The monitor map
 specifies the only fixed addresses in the Ceph distributed system.
 All other daemons bind to arbitrary addresses and register themselves
-with the monitors.
+with the Monitors.
 
 When creating a map with --create, a new monitor map with a new,
 random UUID will be created. It should be followed by one or more
-monitor addresses.
+Monitor addresses.
 
-The default Ceph monitor port for messenger protocol v1 is 6789, and
+The default Ceph Monitor port for messenger protocol v1 is 6789, and
 3300 for protocol v2.
 
 Multiple actions can be performed per invocation.
@@ -43,7 +43,7 @@ Options
 
    list the enabled features as well as the available ones.
 
-   By default, a human readable output is produced.
+   By default, a human-readable output is produced.
 
 .. option:: --create
 
@@ -59,7 +59,7 @@ Options
 .. option:: --generate
 
    generate a new monmap based on the values on the command line or specified
-   in the ceph configuration.  This is, in order of preference,
+   in the Ceph configuration.  This is, in order of preference,
 
       #. ``--monmap filename`` to specify a monmap to load
       #. ``--mon-host 'host1,ip2'`` to specify a list of hosts or ip addresses
@@ -74,18 +74,18 @@ Options
 
 .. option:: --add name ip[:port]
 
-   add a monitor with the specified ip:port to the map.
+   add a Monitor with the specified ip:port to the map.
 
-   If the *nautilus* feature is set, and the port is not, the monitor
+   If the *nautilus* feature is set, and the port is not, the Monitor
    will be added for both messenger protocols.
 
 .. option:: --addv name [protocol:ip:port[,...]]
 
-   add a monitor with the specified version:ip:port to the map.
+   add a Monitor with the specified version:ip:port to the map.
 
 .. option:: --rm name
 
-   remove the monitor with the specified name from the map.
+   remove the Monitor with the specified name from the map.
 
 .. option:: --fsid uuid
 
@@ -110,7 +110,7 @@ Options
 Example
 =======
 
-To create a new map with three monitors (for a fresh Ceph cluster)::
+To create a new map with three Monitors (for a fresh Ceph cluster)::
 
         monmaptool --create --add nodeA 192.168.0.10 --add nodeB 192.168.0.11 \
           --add nodeC 192.168.0.12 --enable-all-features --clobber monmap
@@ -119,7 +119,7 @@ To display the contents of the map::
 
         monmaptool --print monmap
 
-To replace one monitor::
+To replace one Monitor::
 
         monmaptool --rm nodeA monmap
         monmaptool --add nodeA 192.168.0.9 monmap
@@ -137,4 +137,4 @@ See also
 ========
 
 :doc:`ceph <ceph>`\(8),
-:doc:`crushtool <crushtool>`\(8),
+:doc:`crushtool <crushtool>`\(8)

--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -9,23 +9,23 @@
 Synopsis
 ========
 
-| **mount.ceph** *name*@*fsid*.*fs_name*=/[*subdir*] *dir* [-o *options* ]
+| **mount.ceph** *name*\ @\ *fsid*\ .\ *fs_name*\ =/[*subdir*] *dir* [ -o *options* ]
 
 
 Description
 ===========
 
 **mount.ceph** is a helper for mounting the Ceph file system on a Linux host.
-It serves to resolve monitor hostname(s) into IP addresses and read
+It serves to resolve Monitor hostname(s) into IP addresses and read
 authentication keys from disk; the Linux kernel client component does most of
-the real work. To mount a Ceph file system use::
+the real work. To mount a Ceph file system, use::
 
   mount.ceph name@07fe3187-00d9-42a3-814b-72a4d5e7d5be.fs_name=/ /mnt/mycephfs -o mon_addr=1.2.3.4
 
 where "name" is the RADOS client name (referred to hereafter as "RADOS user",
 and meaning any individual or system actor such as an application). 
 
-Mount helper can fill in the cluster FSID by reading the ceph configuration file.
+Mount helper can fill in the cluster FSID by reading the Ceph configuration file.
 It is recommended to call the mount helper via mount(8) as per::
 
   mount -t ceph name@.fs_name=/ /mnt/mycephfs -o mon_addr=1.2.3.4
@@ -36,21 +36,21 @@ The first argument is the device part of the mount command. It includes the
 RADOS user for authentication, the file system name and a path within CephFS
 that will be mounted at the mount point.
 
-Monitor addresses can be passed using ``mon_addr`` mount option. Multiple monitor
+Monitor addresses can be passed using ``mon_addr`` mount option. Multiple Monitor
 addresses can be passed by separating addresses with a slash ("/"). Only one
-monitor is needed to mount successfully; the client will learn about all monitors
-from any responsive monitor. However, it is a good idea to specify more than one
-in case the one happens to be down at the time of mount. Monitor addresses takes
+Monitor is needed to mount successfully; the client will learn about all Monitors
+from any responsive Monitor. However, it is a good idea to specify more than one
+in case the one happens to be down at the time of mount. Monitor addresses take
 the form ip_address[:port]. If the port is not specified, the Ceph default of 6789
 is assumed.
 
-If monitor addresses are not specified, then **mount.ceph** will attempt to determine
-monitor addresses using local configuration files and/or DNS SRV records. In similar
+If Monitor addresses are not specified, then **mount.ceph** will attempt to determine
+Monitor addresses using local configuration files and/or DNS SRV records. In a similar
 way, if authentication is enabled on Ceph cluster (which is done using CephX) and
 options ``secret`` and ``secretfile`` are not specified in the command, the mount
 helper will spawn a child process that will use the standard Ceph library routines
-to find a keyring and fetch the secret from it (including the monitor address and
-FSID if those not specified).
+to find a keyring and fetch the secret from it (including the Monitor address and
+FSID if those are not specified).
 
 A sub-directory of the file system can be mounted by specifying the (absolute)
 path to the sub-directory right after "=" in the device part of the mount command.
@@ -68,7 +68,7 @@ Basic
 
 :command:`conf`
     Path to a ceph.conf file. This is used to initialize the Ceph context
-    for autodiscovery of monitor addresses and auth secrets. The default is
+    for autodiscovery of Monitor addresses and auth secrets. The default is
     to use the standard search path for ceph.conf files.
 
 :command:`mount_timeout`
@@ -262,7 +262,7 @@ Mount only part of the namespace/file system::
 
     mount.ceph fs_user@.mycephfs2=/some/directory/in/cephfs /mnt/mycephfs
 
-Pass the monitor host's IP address, optionally::
+Pass the Monitor host's IP address, optionally::
 
     mount.ceph fs_user@.mycephfs2=/ /mnt/mycephfs -o mon_addr=192.168.0.1
 
@@ -270,7 +270,7 @@ Pass the port along with IP address if it is running on a non-standard port::
 
     mount.ceph fs_user@.mycephfs2=/ /mnt/mycephfs -o mon_addr=192.168.0.1:7000
 
-If there are multiple monitors, pass each address separated by a "/"::
+If there are multiple Monitors, pass each address separated by a "/"::
 
    mount.ceph fs_user@.mycephfs2=/ /mnt/mycephfs -o mon_addr=192.168.0.1/192.168.0.2/192.168.0.3
 

--- a/doc/man/8/mount.fuse.ceph.rst
+++ b/doc/man/8/mount.fuse.ceph.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 ====================================================
- mount.fuse.ceph -- mount ceph-fuse from /etc/fstab.
+ mount.fuse.ceph -- mount ceph-fuse from /etc/fstab
 ====================================================
 
 .. program:: mount.fuse.ceph
@@ -27,7 +27,7 @@ To use mount.fuse.ceph, add an entry in ``/etc/fstab`` like::
   none      /mnt/ceph   fuse.ceph   ceph.id=myuser,ceph.conf=/etc/ceph/foo.conf,_netdev,defaults  0 0
 
 ceph-fuse options are specified in the ``OPTIONS`` column and must begin
-with '``ceph.``' prefix. This way ceph related fs options will be passed to
+with '``ceph.``' prefix. This way Ceph-related file system options will be passed to
 ceph-fuse and others will be ignored by ceph-fuse.
 
 Options

--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -101,11 +101,11 @@ Options
 
 .. option:: --test-map-pg <pgid>
 
-   map a particular placement group(specified by pgid) to the OSDs.
+   map a particular placement group (specified by pgid) to the OSDs.
 
 .. option:: --test-map-object <objectname> [--pool <poolid>]
 
-   map a particular placement group(specified by objectname) to the OSDs.
+   map a particular placement group (specified by objectname) to the OSDs.
 
 .. option:: --test-crush [--range-first <first> --range-last <last>]
 
@@ -365,4 +365,4 @@ See also
 ========
 
 :doc:`ceph <ceph>`\(8),
-:doc:`crushtool <crushtool>`\(8),
+:doc:`crushtool <crushtool>`\(8)

--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -36,13 +36,13 @@ Global Options
 
 .. option:: --pgid
 
-   As an alternative to ``--pool``, ``--pgid`` also allow users to specify the
+   As an alternative to ``--pool``, ``--pgid`` also allows users to specify the
    PG id to which the command will be directed. With this option, certain
    commands like ``ls`` allow users to limit the scope of the command to the given PG.
 
 .. option:: -N namespace, --namespace namespace
 
-   Specify the rados namespace to use for the object.
+   Specify the RADOS namespace to use for the object.
 
 .. option:: --all
 
@@ -65,12 +65,12 @@ Global Options
 .. option:: -i infile
 
    will specify an input file to be passed along as a payload with the
-   command to the monitor cluster. This is only used for specific
-   monitor commands.
+   command to the Monitor cluster. This is only used for specific
+   Monitor commands.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through ceph.conf).
+   Connect to specified Monitor (instead of looking through ceph.conf).
 
 .. option:: -b block_size
 
@@ -78,9 +78,9 @@ Global Options
 
 .. option:: --striper
 
-   Uses the striping API of rados rather than the default one.
+   Uses the striping API of RADOS rather than the default one.
    Available for stat, stat2, get, put, append, truncate, rm, ls
-   and all xattr related operation.
+   and all xattr-related operation.
 
 .. option:: -O object_size, --object-size object_size
 
@@ -142,7 +142,7 @@ Load gen options
 
 .. option:: --min-object-size
 
-  Min object size.
+   Min object size.
 
 .. option:: --max-object-size
 
@@ -314,10 +314,10 @@ Pool specific commands
   Remove *attr* from the extended attributes of an object.
 
 :command:`stat` *name*
-   Get stat (ie. mtime, size) of given object
+  Get stat (i.e. mtime, size) of given object
 
 :command:`stat2` *name*
-   Get stat (similar to stat, but with high precision time) of given object
+  Get stat (similar to stat, but with high precision time) of given object
 
 :command:`listomapkeys` *name*
   List all the keys stored in the object map of object name.
@@ -346,7 +346,7 @@ Pool specific commands
   Set the value of the object map header of object name.
 
 :command:`export` *filename*
-  Serialize pool contents to a file or standard output.\n"
+  Serialize pool contents to a file or standard output.
 
 :command:`import` [--dry-run] [--no-overwrite] < filename | - >
   Load pool contents from a file or standard input

--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -152,7 +152,7 @@ as follows:
 
 :command:`object rm`
   Remove an S3/Swift object. Include "--yes-i-really-mean-it" to remove object's
-  entry from bucket index, for example if it's damaged.
+  entry from bucket index, for example if it is damaged.
 
 :command:`object stat`
   Stat an S3/Swift object for its metadata.
@@ -366,7 +366,7 @@ as follows:
 
 :command:`log show`
   Dump a log from specific object or (bucket + date + bucket-id).
-  (NOTE: required to specify formatting of date to "YYYY-MM-DD-hh")
+  (NOTE: required to specify formatting of the date as "YYYY-MM-DD-hh")
 
 :command:`log rm`
   Remove log object.
@@ -519,12 +519,12 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use ``ceph.conf`` configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during
    startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of selecting one
+   Connect to specified Monitor (instead of selecting one
    from ceph.conf).
 
 .. option:: --tenant=<tenant>
@@ -566,7 +566,7 @@ Options
 
 .. option:: --generate-key
 
-    create user with or without credentials.
+    Create user with or without credentials.
     If this option set to false, then user cannot set --gen-access-key/--gen-secret/--secret-key/--access-key.
     If this option set to true, then user cannot set  --secret-key/--access-key and bypass options for --gen-secret/--gen-access-key.
     Default is true.
@@ -609,7 +609,7 @@ Options
 .. option:: --pool=<pool>
 
    Specify the pool name.
-   Also used with `orphans find` as data pool to scan for leaked rados objects.
+   Also used with `orphans find` as data pool to scan for leaked RADOS objects.
 
 .. option:: --object=object
 
@@ -652,7 +652,7 @@ Options
 .. option:: --purge-keys
 
    When specified, subuser removal will also purge the subuser' keys.
-   
+
 .. option:: --purge-objects
 
    When specified, the bucket removal will also purge all objects in it.
@@ -858,7 +858,7 @@ Options
 
 .. option:: --categories=<list>
 
-    Comma separated list of categories, used in usage show.
+    Comma-separated list of categories, used in usage show.
 
 .. option:: --caps=<caps>
 
@@ -910,11 +910,11 @@ Options
 
 .. option:: --restore-status
 
-   Filter objects return by the 'restore list' command by status.
+   Filter objects returned by the 'restore list' command by status.
 
 .. option:: --show-restore-stats
 
-   Shows restore stats in a bucket stat command. Here the bucket name need be provided.
+   Shows restore stats in a bucket stat command. The bucket name needs to be provided.
 
 Quota Options
 =============
@@ -942,7 +942,7 @@ Orphans Search Options
 .. option:: --orphan-stale-secs
 
    Number of seconds to wait before declaring an object to be an orphan.
-   The efault is 86400 (24 hours).
+   The default is 86400 (24 hours).
 
 .. option:: --job-id
 
@@ -988,7 +988,7 @@ Role Options
 
 Bucket Notifications/PubSub Options
 ===================================
-.. option:: --topic                   
+.. option:: --topic
 
    The bucket notifications/pubsub topic name.
 
@@ -1084,5 +1084,5 @@ https://docs.ceph.com for more information.
 See also
 ========
 
-:doc:`ceph <ceph>`\(8)
+:doc:`ceph <ceph>`\(8),
 :doc:`radosgw <radosgw>`\(8)

--- a/doc/man/8/radosgw.rst
+++ b/doc/man/8/radosgw.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 ===============================
- radosgw -- rados REST gateway
+ radosgw -- RADOS REST gateway
 ===============================
 
 .. program:: radosgw
@@ -27,19 +27,19 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use ``ceph.conf`` configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through ``ceph.conf``).
+   Connect to specified Monitor (instead of looking through ``ceph.conf``).
 
 .. option:: -i ID, --id ID
 
-   Set the ID portion of name for radosgw
+   Set the ID portion of the name for radosgw
 
 .. option:: -n TYPE.ID, --name TYPE.ID
 
-   Set the rados user name for the gateway (eg. client.radosgw.gateway)
+   Set the RADOS user name for the gateway (e.g. client.radosgw.gateway)
 
 .. option:: --cluster NAME
 
@@ -77,13 +77,13 @@ or process management may be available in the FastCGI application framework
 in use.
 
 ``Apache`` must be configured in a way that enables ``mod_proxy_fcgi`` to be
-used with localhost tcp.
+used with localhost TCP.
 
-The following steps show the configuration in Ceph's configuration file i.e,
+The following steps show the configuration in Ceph's configuration file i.e.,
 ``/etc/ceph/ceph.conf`` and the gateway configuration file i.e,
 ``/etc/httpd/conf.d/rgw.conf`` (RPM-based distros) or
 ``/etc/apache2/conf-available/rgw.conf`` (Debian-based distros) with localhost
-tcp:
+TCP:
 
 #. For distros with Apache 2.2 and early versions of Apache 2.4 that use
    localhost TCP, append the following contents to ``/etc/ceph/ceph.conf``::
@@ -139,29 +139,6 @@ tcp:
 
 		</VirtualHost>
 
-#. Add the following content in the gateway configuration file:
-
-   For CentOS/RHEL add in ``/etc/httpd/conf.d/rgw.conf``::
-
-		<VirtualHost *:80>
-		ServerName localhost
-		DocumentRoot /var/www/html
-
-		ErrorLog /var/log/httpd/rgw_error.log
-		CustomLog /var/log/httpd/rgw_access.log combined
-
-		# LogLevel debug
-
-		RewriteEngine On
-
-		RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
-
-		SetEnv proxy-nokeepalive 1
-
-		ProxyPass / unix:///var/run/ceph/ceph.radosgw.gateway.fastcgi.sock|fcgi://localhost:9000/
-
-		</VirtualHost>
-
 #. Generate a key for radosgw to use for authentication with the cluster. ::
 
 	ceph-authtool -C -n client.radosgw.gateway --gen-key /etc/ceph/keyring.radosgw.gateway
@@ -207,10 +184,10 @@ Following is an example configuration::
 
 
 The total number of shards determines how many total objects hold the
-usage log information. The per-user number of shards specify how many
+usage log information. The per-user number of shards specifies how many
 objects hold usage information for a single user. The tick interval
 configures the number of seconds between log flushes, and the flush
-threshold specify how many entries can be kept before resorting to
+threshold specifies how many entries can be kept before resorting to
 synchronous flush.
 
 .. warning:: All RGW instances and ``radosgw-admin`` commands must use the
@@ -234,5 +211,5 @@ more information.
 See also
 ========
 
-:doc:`ceph <ceph>`\(8)
+:doc:`ceph <ceph>`\(8),
 :doc:`radosgw-admin <radosgw-admin>`\(8)

--- a/doc/man/8/rbd-fuse.rst
+++ b/doc/man/8/rbd-fuse.rst
@@ -15,7 +15,7 @@ Synopsis
 Note
 ====
 
-**rbd-fuse** is not recommended for any production or high performance workloads.
+**rbd-fuse** is not recommended for any production or high-performance workloads.
 
 Description
 ===========
@@ -40,7 +40,7 @@ Any options not recognized by rbd-fuse will be passed on to libfuse.
 .. option:: -c ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during startup.
 
 .. option:: -p pool
 

--- a/doc/man/8/rbd-ggate.rst
+++ b/doc/man/8/rbd-ggate.rst
@@ -18,7 +18,7 @@ Description
 
 **rbd-ggate** is a client for RADOS block device (rbd) images. It will
 map a rbd image to a ggate (FreeBSD GEOM Gate class) device, allowing
-access it as regular local block device.
+access to it as a regular local block device.
 
 Commands
 ========
@@ -75,5 +75,5 @@ https://docs.ceph.com for more information.
 See also
 ========
 
-:doc:`rbd <rbd>`\(8)
+:doc:`rbd <rbd>`\(8),
 :doc:`ceph <ceph>`\(8)

--- a/doc/man/8/rbd-mirror.rst
+++ b/doc/man/8/rbd-mirror.rst
@@ -20,11 +20,11 @@ block device (rbd) images among Ceph clusters. It replays changes to
 images in remote clusters in a local cluster, for disaster recovery.
 
 It connects to remote clusters via the RADOS protocol, relying on
-default search paths to find ceph.conf files, monitor addresses and
+default search paths to find ceph.conf files, Monitor addresses and
 authentication information for them, i.e. ``/etc/ceph/$cluster.conf``,
 ``/etc/ceph/$cluster.keyring``, and
 ``/etc/ceph/$cluster.$name.keyring``, where ``$cluster`` is the
-human-friendly name of the cluster, and ``$name`` is the rados user to
+human-friendly name of the cluster, and ``$name`` is the RADOS user to
 connect as, e.g. ``client.rbd-mirror``.
 
 
@@ -34,11 +34,11 @@ Options
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use ``ceph.conf`` configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through ``ceph.conf``).
+   Connect to specified Monitor (instead of looking through ``ceph.conf``).
 
 .. option:: -i ID, --id ID
 
@@ -46,7 +46,7 @@ Options
 
 .. option:: -n TYPE.ID, --name TYPE.ID
 
-   Set the rados user name for the gateway (eg. client.rbd-mirror)
+   Set the RADOS user name for rbd-mirror (e.g. client.rbd-mirror)
 
 .. option:: --cluster NAME
 

--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -19,8 +19,8 @@ Description
 ===========
 
 **rbd-nbd** is a client for RADOS block device (rbd) images like rbd kernel module.
-It will map a rbd image to a nbd (Network Block Device) device, allowing access it
-as regular local block device.
+It will map an rbd image to an nbd (Network Block Device) device, allowing access to it
+as a regular local block device.
 
 Options
 =======
@@ -28,7 +28,7 @@ Options
 .. option:: -c ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
-   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+   ``/etc/ceph/ceph.conf`` to determine Monitor addresses during startup.
 
 .. option:: --read-only
 
@@ -37,7 +37,7 @@ Options
 .. option:: --nbds_max *limit*
 
    Override the parameter nbds_max of NBD kernel module when modprobe, used to
-   limit the count of nbd device.
+   limit the count of nbd devices.
 
 .. option:: --max_part *limit*
 
@@ -67,7 +67,7 @@ Options
 
 .. option:: --reattach-timeout *seconds*
 
-   Specify timeout for the kernel to wait for a new rbd-nbd process is
+   Specify timeout for the kernel to wait for a new rbd-nbd process to be
    attached after the old process is detached. The default is 30
    second.
 

--- a/doc/man/8/rbd-replay-many.rst
+++ b/doc/man/8/rbd-replay-many.rst
@@ -15,7 +15,7 @@ Synopsis
 Description
 ===========
 
-**rbd-replay-many** is a utility for replaying a rados block device (RBD) workload on several clients.
+**rbd-replay-many** is a utility for replaying a RADOS block device (RBD) workload on several clients.
 Although all clients use the same workload, they replay against separate images.
 This matches normal use of librbd, where each original client is a VM with its own image.
 

--- a/doc/man/8/rbd-replay-prep.rst
+++ b/doc/man/8/rbd-replay-prep.rst
@@ -15,7 +15,7 @@ Synopsis
 Description
 ===========
 
-**rbd-replay-prep** processes raw rados block device (RBD) traces to prepare them for **rbd-replay**.
+**rbd-replay-prep** processes raw RADOS block device (RBD) traces to prepare them for **rbd-replay**.
 
 
 Options
@@ -31,7 +31,7 @@ Options
 
 .. option:: --verbose
 
-   Print all processed events to console
+   Prints all processed events to the console.
 
 Examples
 ========

--- a/doc/man/8/rbd-replay.rst
+++ b/doc/man/8/rbd-replay.rst
@@ -15,7 +15,7 @@ Synopsis
 Description
 ===========
 
-**rbd-replay** is a utility for replaying rados block device (RBD) workloads.
+**rbd-replay** is a utility for replaying RADOS block device (RBD) workloads.
 
 
 Options
@@ -24,7 +24,7 @@ Options
 .. option:: -c ceph.conf, --conf ceph.conf
 
    Use ceph.conf configuration file instead of the default /etc/ceph/ceph.conf to
-   determine monitor addresses during startup.
+   determine Monitor addresses during startup.
 
 .. option:: -p pool, --pool pool
 
@@ -46,7 +46,7 @@ Options
 .. option:: --dump-perf-counters
 
    **Experimental**
-   Dump performance counters to standard out before an image is closed.
+   Dump performance counters to stdout before an image is closed.
    Performance counters may be dumped multiple times if multiple images are closed,
    or if the same image is opened and closed multiple times.
    Performance counters and their meaning may change between versions.

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -16,7 +16,7 @@ Synopsis
 Description
 ===========
 
-**rbd** is a utility for manipulating rados block device (RBD) images,
+**rbd** is a utility for manipulating RADOS block device (RBD) images,
 used by the Linux rbd driver and the rbd storage driver for QEMU/KVM.
 RBD images are simple block devices that are striped over objects and
 stored in a RADOS object store. The size of the objects the image is
@@ -29,11 +29,11 @@ Options
 .. option:: -c ceph.conf, --conf ceph.conf
 
    Use ceph.conf configuration file instead of the default /etc/ceph/ceph.conf to
-   determine monitor addresses during startup.
+   determine Monitor addresses during startup.
 
 .. option:: -m monaddress[:port]
 
-   Connect to specified monitor (instead of looking through ceph.conf).
+   Connect to specified Monitor (instead of looking through ceph.conf).
 
 .. option:: --cluster cluster-name
 
@@ -45,7 +45,7 @@ Options
 
 .. option:: --namespace namespace-name
 
-   Use a pre-defined image namespace within a pool
+   Use a predefined image namespace within a pool
 
 .. option:: --no-progress
 
@@ -77,7 +77,7 @@ Parameters
 
 .. option:: --object-size size-in-B/K/M
 
-   Specifies the object size in B/K/M.  Object size will be rounded up the
+   Specifies the object size in B/K/M.  Object size will be rounded up to the
    nearest power of two; if no suffix is given, unit B is assumed.  The default
    object size is 4M, smallest is 4K and maximum is 32M.
 
@@ -263,7 +263,7 @@ Commands
   (default) or other supported device (*nbd* or *ubbd* on Linux or *ggate* on
   FreeBSD).
 
-  The --options argument is a comma separated list of device type
+  The --options argument is a comma-separated list of device type
   specific options (opt1,opt2=val,...).
 
 :command:`device unmap` [-t | --device-type *device-type*] [-o | --options *device-options*] [--snap-id *snap-id*] *image-spec* | *snap-spec* | *device-path*
@@ -303,7 +303,7 @@ Commands
   If the RBD fast-diff feature is not enabled on images, this operation will
   require querying the OSDs for every potential object within the image.
 
-  The --merge-snapshots will merge snapshots used space into their parent images.
+  The --merge-snapshots option will merge snapshots' used space into their parent images.
 
 :command:`encryption format` *image-spec* *format* *passphrase-file* [--cipher-alg *alg*]
   Formats image to an encrypted format.
@@ -313,8 +313,8 @@ Commands
 
 :command:`export` [--export-format *format (1 or 2)*] (*image-spec* | *snap-spec*) [*dest-path*]
   Export image to dest path (use - for stdout).
-  The --export-format accepts '1' or '2' currently. Format 2 allow us to export not only the content
-  of image, but also the snapshots and other properties, such as image_order, features.
+  The --export-format accepts '1' or '2' currently. Format 2 allows us to export not only the content
+  of the image, but also the snapshots and other properties, such as image_order and features.
 
 :command:`export-diff` [--from-snap *snap-name*] [--whole-object] (*image-spec* | *snap-spec*) *dest-path*
   Export an incremental diff for an image to dest path (use - for stdout).  If
@@ -390,7 +390,7 @@ Commands
   Remove metadata key with the value.
 
 :command:`image-meta set` *image-spec* *key* *value*
-  Set metadata key with the value. They will displayed in `image-meta list`.
+  Set metadata key with the value. They will be displayed in `image-meta list`.
 
 :command:`import` [--export-format *format (1 or 2)*] [--image-format *format-id*] [--object-size *size-in-B/K/M*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*] [--estimated-size *size-in-M/G/T*]... [--image-shared] *src-path* [*image-spec*]
   Create a new image and import its data from path (use - for
@@ -401,15 +401,15 @@ Commands
   The --stripe-unit and --stripe-count arguments are optional, but must be
   used together.
 
-  The --export-format accepts '1' or '2' currently. Format 2 allow us to import not only the content
-  of image, but also the snapshots and other properties, such as image_order, features.
+  The --export-format accepts '1' or '2' currently. Format 2 allows us to import not only the content
+  of image, but also the snapshots and other properties, such as image_order and features.
 
 :command:`import-diff` *src-path* *image-spec*
   Import an incremental diff of an image and apply it to the current image.  If the diff
   was generated relative to a start snapshot, we verify that snapshot already exists before
   continuing.  If there was an end snapshot we verify it does not already exist before
   applying the changes, and create the snapshot when we are done.
-  
+
 :command:`info` *image-spec* | *snap-spec*
   Will dump information (such as size and object size) about a specific rbd image.
   If the image is a clone, information about its parent is also displayed.
@@ -419,7 +419,7 @@ Commands
   Flag image journal client as disconnected.
 
 :command:`journal export` [--verbose] [--no-error] *src-journal-spec* *path-name*
-  Export image journal to path (use - for stdout). It can be make a backup
+  Export image journal to path (use - for stdout). It can be used to make a backup
   of the image journal especially before attempting dangerous operations.
 
   Note that this command may not always work if the journal is badly corrupted.
@@ -462,11 +462,11 @@ Commands
 
 :command:`merge-diff` *first-diff-path* *second-diff-path* *merged-diff-path*
   Merge two continuous incremental diffs of an image into one single diff. The
-  first diff's end snapshot must be equal with the second diff's start snapshot.
+  first diff's end snapshot must be equal to the second diff's start snapshot.
   The first diff could be - for stdin, and merged diff could be - for stdout, which
   enables multiple diff files to be merged using something like
   'rbd merge-diff first second - | rbd merge-diff - third result'. Note this command
-  currently only support the source incremental diff with stripe-count == 1
+  currently only supports the source incremental diff with stripe-count == 1
 
 :command:`migration abort` *image-spec*
   Cancel image migration. This step may be run after successful or
@@ -492,9 +492,9 @@ Commands
   by its destination spec.
 
   An image can also be migrated from a read-only import source by adding the
-  *--import-only* optional and providing a JSON-encoded *--source-spec* or a
+  *--import-only* option and providing a JSON-encoded *--source-spec* or a
   path to a JSON-encoded source-spec file using the *--source-spec-path*
-  optionals.
+  option.
 
 :command:`mirror image demote` *image-spec*
   Demote a primary image to non-primary for RBD mirroring.
@@ -564,7 +564,7 @@ Commands
 :command:`mirror pool peer set` [*pool-name*] *uuid* *key* *value*
   Update mirroring peer settings.
   The key can be either ``client`` or ``cluster``, and the value
-  is corresponding to remote client name or remote cluster name.
+  corresponds to remote client name or remote cluster name.
 
 :command:`mirror pool promote` [--force] [*pool-name*]
   Promote all non-primary images within a pool or namespace to primary.
@@ -667,7 +667,7 @@ Commands
 :command:`sparsify` [--sparse-size *sparse-size*] *image-spec*
   Reclaim space for zeroed image extents. The default sparse size is
   4096 bytes and can be changed via --sparse-size option with the
-  following restrictions: it should be power of two, not less than
+  following restrictions: it should be a power of two, not less than
   4096, and not larger than image object size.
 
 :command:`status` *image-spec*
@@ -680,7 +680,7 @@ Commands
   Move an image to the trash. Images, even ones actively in-use by 
   clones, can be moved to the trash and deleted at a later time. Use
   ``--expires-at`` to set the expiration time of an image after which
-  it's allowed to be removed.
+  it is allowed to be removed.
 
 :command:`trash purge` [*pool-name*]
   Remove all expired images from trash.
@@ -738,7 +738,7 @@ The striping is controlled by three parameters:
 
 .. option:: object-size
 
-  The size of objects we stripe over is a power of two. It will be rounded up the nearest power of two.
+  The size of objects we stripe over is a power of two. It will be rounded up to the nearest power of two.
   The default object size is 4 MB, smallest is 4K and maximum is 32M.
 
 .. option:: stripe-unit
@@ -832,7 +832,7 @@ Per mapping (block device) `rbd device map` options:
   manually zeroing.
 
 * abort_on_full - Fail write requests with -ENOSPC when the cluster is full or
-  the data pool reaches its quota (since 5.0).  The default behaviour is to
+  the data pool reaches its quota (since 5.0).  The default behavior is to
   block until the full condition is cleared.
 
 * alloc_size - Minimum allocation unit of the underlying OSD object store
@@ -857,7 +857,7 @@ Per mapping (block device) `rbd device map` options:
   Each key-value pair stands on its own: "myrack" doesn't need to reside in
   "mydc", which in turn doesn't need to reside in "myregion".  The location
   is not a path to the root of the hierarchy but rather a set of nodes that
-  are matched independently, owning to the fact that bucket names are unique
+  are matched independently, owing to the fact that bucket names are unique
   within a CRUSH map.  "Multipath" locations are supported, so it is possible
   to indicate locality for multiple parallel hierarchies::
 
@@ -919,8 +919,8 @@ Per mapping (block device) `rbd device map` options:
   mode, agree to 'crc' mode.
 
 * rxbounce - Use a bounce buffer when receiving data (since 5.17).  The default
-  behaviour is to read directly into the destination buffer.  A bounce buffer
-  is needed if the destination buffer isn't guaranteed to be stable (i.e. remain
+  behavior is to read directly into the destination buffer.  A bounce buffer
+  is needed if the destination buffer is not guaranteed to be stable (i.e. remain
   unchanged while it is being read to).  In particular this is the case for
   Windows where a system-wide "dummy" (throwaway) page may be mapped into the
   destination buffer in order to generate a single large I/O.  Otherwise,
@@ -982,7 +982,7 @@ To map an image via the kernel with cephx enabled::
 
        rbd device map mypool/myimage --id admin --keyfile secretfile
 
-To map an image via the kernel with different cluster name other than default *ceph*::
+To map an image via the kernel with a cluster name other than the default *ceph*::
 
        rbd device map mypool/myimage --cluster cluster-name
 

--- a/doc/man/8/rbdmap.rst
+++ b/doc/man/8/rbdmap.rst
@@ -94,7 +94,7 @@ commands::
 
     rbd map foopool/bar1 --id admin --keyring /etc/ceph/ceph.client.admin.keyring
     rbd map foopool/bar2 --id admin --keyring /etc/ceph/ceph.client.admin.keyring
-    rbd map foopool/bar2 --id admin --keyring /etc/ceph/ceph.client.admin.keyring --options lock_on_read,queue_depth=1024
+    rbd map foopool/bar3 --id admin --keyring /etc/ceph/ceph.client.admin.keyring --options lock_on_read,queue_depth=1024
 
 If the images had XFS file systems on them, the corresponding ``/etc/fstab``
 entries might look like this::
@@ -127,4 +127,4 @@ https://docs.ceph.com for more information.
 See also
 ========
 
-:doc:`rbd <rbd>`\(8),
+:doc:`rbd <rbd>`\(8)

--- a/doc/man/8/rgw-gap-list.rst
+++ b/doc/man/8/rgw-gap-list.rst
@@ -77,5 +77,5 @@ https://docs.ceph.com for more information.
 See also
 ========
 
-:doc:`radosgw-admin <radosgw-admin>`\(8)
+:doc:`radosgw-admin <radosgw-admin>`\(8),
 :doc:`rgw-orphan-list <rgw-orphan-list>`\(8)

--- a/doc/man/8/rgw-orphan-list.rst
+++ b/doc/man/8/rgw-orphan-list.rst
@@ -15,13 +15,13 @@ Description
 ===========
 
 :program:`rgw-orphan-list` is an *EXPERIMENTAL* RADOS gateway user
-administration utility. It produces a listing of rados objects that
+administration utility. It produces a listing of RADOS objects that
 are not directly or indirectly referenced through the bucket indexes
 on a pool. It places the results and intermediate files on the local
-filesystem rather than on the ceph cluster itself, and therefore will
+filesystem rather than on the Ceph cluster itself, and therefore will
 not itself consume additional cluster storage.
 
-In theory orphans should not exist. However because ceph evolves
+In theory orphans should not exist. However because Ceph evolves
 rapidly, bugs do crop up, and they may result in orphans that are left
 behind.
 
@@ -58,12 +58,12 @@ Launch the tool::
 Availability
 ============
 
-:program:`radosgw-admin` is part of Ceph, a massively scalable, open-source,
+:program:`rgw-orphan-list` is part of Ceph, a massively scalable, open-source,
 distributed storage system.  Please refer to the Ceph documentation at
 https://docs.ceph.com for more information.
 
 See also
 ========
 
-:doc:`radosgw-admin <radosgw-admin>`\(8)
+:doc:`radosgw-admin <radosgw-admin>`\(8),
 :doc:`ceph-diff-sorted <ceph-diff-sorted>`\(8)

--- a/doc/man/8/rgw-policy-check.rst
+++ b/doc/man/8/rgw-policy-check.rst
@@ -21,13 +21,13 @@ and determines if it is syntactically correct.
 It does not check to see if the policy makes sense;
 it only checks to see if the file would be accepted
 by the policy parsing logic inside
-:program:`radsogw`.
+:program:`radosgw`.
 
 More than one filename may be specified.  If no files are
 given, the program will read from stdin.
 
 On success, the program will say nothing.  On failure,
-the program will emit a error message indicating the
+the program will emit an error message indicating the
 problem.  The program will terminate with non-zero exit
 status if one or more policies could not be read or parsed.
 

--- a/doc/man/8/rgw-restore-bucket-index.rst
+++ b/doc/man/8/rgw-restore-bucket-index.rst
@@ -18,11 +18,11 @@ Description
 user administration utility. It scans the data pool for objects that
 belong to a given bucket and tries to add those objects back to the
 bucket index. It's intended as a **last resort** after a
-**catastrophic** loss of a bucket index. Please thorougly review the
+**catastrophic** loss of a bucket index. Please review thoroughly the
 *Warnings* listed below.
 
 The utility works with regular (i.e., un-versioned) buckets, versioned
-buckets, and buckets were versioning has been suspended.
+buckets, and buckets where versioning has been suspended.
 
 Warnings
 ========
@@ -34,13 +34,13 @@ active use while this utility is running.
 
 The results are unpredictable if only some bucket's objects are
 missing from the bucket index. In such a case, consider using the
-"object reindex" subcommand of `radosgw-admin` to restore object's to
+"object reindex" subcommand of `radosgw-admin` to restore objects to
 the bucket index one-by-one.
 
 For objects in versioned buckets, if the latest version is a delete
 marker, it will be restored. If a delete marker has been written over
 with a new version, then that delete marker will not be restored. This
-should have minimal impact on results in that the it recovers the
+should have minimal impact on results in that it recovers the
 latest version and previous versions are all accessible.
 
 Command-Line Arguments


### PR DESCRIPTION
Low-hanging spelling, punctuation, and capitalization errors etc.  
Ignore style and other more complex issues.  
Use https for links.  
Fixes markup rendered as-is in `mount.ceph.rst`.

GitHub Copilot was used to search for most of these spelling etc. errors. Unfortunately GitHub Copilot does not archive chat logs for a long time, the prompt was similar to `List spelling errors in files <list of files touched by this PR>`.
Everything else including confirming and fixing the errors was done manually.

Assisted-by: Claude Sonnet 4.6 / GitHub Copilot







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
