### PR TITLE
ceph-volume: add seastore secondary device support

### DIFF
--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -83,5 +83,6 @@ and ``ceph-disk`` is fully disabled. Encryption is fully supported.
    simple/activate
    simple/scan
    simple/systemd
+   seastore
    zfs/index
    zfs/inventory

--- a/doc/ceph-volume/seastore.rst
+++ b/doc/ceph-volume/seastore.rst
@@ -1,0 +1,335 @@
+.. _ceph-volume-seastore:
+
+SeaStore Support in ceph-volume
+================================
+
+.. note::
+   SeaStore is the native object store for Crimson OSD and is currently in
+   technology preview. It requires Crimson to be enabled in your Ceph cluster.
+
+Overview
+--------
+
+SeaStore is designed with a different architecture than BlueStore:
+
+**BlueStore Architecture** (Classic OSD):
+  - Primary device (``block``): Stores object data
+  - Optional ``block.db``: RocksDB metadata
+  - Optional ``block.wal``: Write-ahead log
+  - One OSD process per device set
+
+**SeaStore Architecture** (Crimson OSD):
+  - Primary device (``block``): Hot-tier data and journal combined
+  - Optional secondary devices (``block.<TYPE>.<ID>/block``): Slower-tier for cold data migration
+  - No separate DB/WAL devices
+  - One OSD process per OSD ID, using N Seastar reactor threads (``crimson_cpu_num``)
+
+Device Naming Convention
+------------------------
+
+SeaStore uses a different naming scheme for secondary devices.  Each secondary
+is a **directory** named ``block.<TYPE>.<ID>`` containing a ``block`` symlink
+pointing to the device — matching the layout that ``SegmentManager`` opens as
+``path + "/block"`` (``segment_manager.cc``)::
+
+    /var/lib/ceph/osd/<cluster>-<id>/block                  # Primary device symlink
+    /var/lib/ceph/osd/<cluster>-<id>/block.HDD.1/           # Secondary device directory
+    /var/lib/ceph/osd/<cluster>-<id>/block.HDD.1/block      # Secondary device symlink
+    /var/lib/ceph/osd/<cluster>-<id>/block.SSD.2/           # Secondary device directory
+    /var/lib/ceph/osd/<cluster>-<id>/block.SSD.2/block      # Secondary device symlink
+
+Valid device types for secondary devices:
+
+* ``HDD`` - Hard disk drives (for cold data)
+* ``SSD`` - Solid state drives
+* ``ZBD`` - Zoned block devices (ZNS SSD or SMR HDD)
+* ``RANDOM_BLOCK_SSD`` - Random block SSD
+
+.. important::
+   Secondary devices should **NOT be faster** than the primary device.
+   When secondary devices are slower (e.g., HDD), SeaStore automatically
+   migrates cold data from the fast primary device to slower secondary devices.
+
+Preparing OSDs with LVM
+------------------------
+
+Simple Single-Device Setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For a basic SeaStore OSD with only a primary device:
+
+.. prompt:: bash #
+
+   ceph-volume lvm prepare --osd-type crimson --objectstore seastore --data /dev/nvme0n1
+
+Or using an existing logical volume:
+
+.. prompt:: bash #
+
+   ceph-volume lvm prepare --osd-type crimson --objectstore seastore --data vg/lv-osd
+
+Multi-Device Setup with Tiering
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For performance optimization with hot/cold tiering:
+
+.. prompt:: bash #
+
+   ceph-volume lvm prepare \
+       --osd-type crimson \
+       --objectstore seastore \
+       --data /dev/nvme0n1 \
+       --seastore-secondary /dev/sdb:HDD \
+       --seastore-secondary /dev/sdc:HDD
+
+This creates:
+
+* Primary device: NVMe SSD for hot data
+* Two cold-tier HDDs for infrequently accessed data
+
+Using LVM for all devices::
+
+    # Create logical volumes first
+    lvcreate -L 500G -n osd-primary vg-fast
+    lvcreate -L 2T -n osd-cold-1 vg-slow
+    lvcreate -L 2T -n osd-cold-2 vg-slow
+
+    # Prepare with SeaStore
+    ceph-volume lvm prepare \
+        --osd-type crimson \
+        --objectstore seastore \
+        --data vg-fast/osd-primary \
+        --seastore-secondary vg-slow/osd-cold-1:HDD \
+        --seastore-secondary vg-slow/osd-cold-2:HDD
+
+Preparing OSDs with RAW
+------------------------
+
+Simple Single-Device Setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. prompt:: bash #
+
+   ceph-volume raw prepare --osd-type crimson --objectstore seastore --data /dev/nvme0n1
+
+Multi-Device Setup with Tiering
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. prompt:: bash #
+
+   ceph-volume raw prepare \
+       --osd-type crimson \
+       --objectstore seastore \
+       --data /dev/nvme0n1 \
+       --seastore-secondary /dev/sdb:HDD \
+       --seastore-secondary /dev/sdc:HDD
+
+Encryption Support
+------------------
+
+SeaStore supports encryption via dm-crypt, similar to BlueStore:
+
+.. prompt:: bash #
+
+   ceph-volume lvm prepare \
+       --osd-type crimson \
+       --objectstore seastore \
+       --dmcrypt \
+       --data /dev/nvme0n1 \
+       --seastore-secondary /dev/sdb:HDD
+
+TPM2 enrollment is also supported:
+
+.. prompt:: bash #
+
+   ceph-volume raw prepare \
+       --osd-type crimson \
+       --objectstore seastore \
+       --dmcrypt \
+       --with-tpm \
+       --data /dev/nvme0n1
+
+.. note::
+   Currently, only the primary device is encrypted. Secondary device
+   encryption support may be added in the future.
+
+Activating OSDs
+---------------
+
+LVM backend
+^^^^^^^^^^^
+
+Activation works the same as BlueStore: OSD identity is read from LVM
+tags, so no per-OSD arguments are required.
+
+.. prompt:: bash #
+
+   ceph-volume lvm activate <osd-id> <osd-fsid>
+
+.. prompt:: bash #
+
+   ceph-volume lvm activate --all
+
+RAW backend
+^^^^^^^^^^^
+
+.. important::
+   For the RAW backend, ``ceph-volume raw activate`` **cannot auto-discover**
+   SeaStore OSDs: BlueStore's ``ceph-bluestore-tool show-label`` does not
+   understand SeaStore's on-disk format.  Until
+   ``crimson-objectstore-tool`` gains a ``dump-superblock`` command
+   (tracker `#68106 <https://tracker.ceph.com/issues/68106>`_), every raw
+   activate call must supply ``--device``, ``--osd-id``, and
+   ``--osd-uuid`` explicitly.  ``ceph-volume raw activate --all`` is
+   **not supported** for SeaStore.
+
+.. prompt:: bash #
+
+   ceph-volume raw activate \
+       --objectstore seastore \
+       --device /dev/nvme0n1 \
+       --osd-id <osd-id> \
+       --osd-uuid <osd-fsid>
+
+If the OSD has secondary devices, they must also be re-supplied on every
+activate, because the secondary device paths are not persisted outside
+the primary device's superblock:
+
+.. prompt:: bash #
+
+   ceph-volume raw activate \
+       --objectstore seastore \
+       --device /dev/nvme0n1 \
+       --osd-id <osd-id> \
+       --osd-uuid <osd-fsid> \
+       --seastore-secondary /dev/sdb:HDD \
+       --seastore-secondary /dev/sdc:HDD
+
+Listing OSDs
+------------
+
+LVM backend:
+
+.. prompt:: bash #
+
+   ceph-volume lvm list
+
+RAW backend:
+
+.. prompt:: bash #
+
+   ceph-volume raw list
+
+The output will show SeaStore OSDs with their primary and secondary devices.
+
+Migration from BlueStore
+------------------------
+
+.. warning::
+   Direct migration from BlueStore to SeaStore is **not supported**.
+   SeaStore uses a completely different on-disk format.
+
+To migrate:
+
+1. Create new SeaStore OSDs
+2. Let Ceph backfill data to new OSDs
+3. Remove old BlueStore OSDs
+4. Decommission old devices
+
+Troubleshooting
+---------------
+
+OSD Fails to Start
+^^^^^^^^^^^^^^^^^^
+
+Check that Crimson is enabled in your cluster:
+
+.. prompt:: bash #
+
+   ceph config get global enable_experimental_unrecoverable_data_corrupting_features
+
+The output should include ``crimson``.
+
+.. prompt:: bash #
+
+   ceph osd dump | grep flags
+
+The output should include ``allow_crimson``.
+
+Invalid Secondary Device Type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ensure you're using valid device types::
+
+    Valid: HDD, SSD, ZBD, RANDOM_BLOCK_SSD
+    Invalid: hdd, nvme, sata (case-sensitive, must be uppercase)
+
+Example error::
+
+    RuntimeError: Invalid secondary device type: hdd. Valid types: HDD, SSD, ZBD, RANDOM_BLOCK_SSD
+
+Secondary Device Not Detected
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Check symlinks in the OSD directory:
+
+.. prompt:: bash #
+
+   ls -la /var/lib/ceph/osd/ceph-0/
+
+The output should include ``block -> /dev/nvme0n1`` (primary device symlink)
+and ``block.HDD.1/`` (secondary device directory).
+
+.. prompt:: bash #
+
+   ls -la /var/lib/ceph/osd/ceph-0/block.HDD.1/
+
+The output should include ``block -> /dev/sdb`` (secondary device symlink
+inside the directory).
+
+If the directory or inner symlink is missing, the OSD may not have been prepared correctly.
+
+Crimson CPU Allocation
+----------------------
+
+.. warning::
+   ``crimson_cpu_num`` (or ``crimson_cpu_set``) **must** be configured before
+   running ``ceph-volume``.  ``crimson-osd`` reads this value from the Monitor
+   during startup and calls ``ceph_abort()`` if neither option is set, causing
+   ``ceph-volume``'s ``--mkfs`` step to fail immediately.
+
+Configure CPU allocation before deploying:
+
+.. prompt:: bash #
+
+   ceph config set osd crimson_cpu_num 8
+
+The value is baked into the device superblock at ``--mkfs`` time — SeaStore
+partitions the device into ``crimson_cpu_num`` equal shards — and cannot be
+changed after deployment without reformatting the device.
+
+When deploying via cephadm, include ``crimson_cpu_num`` in the OSD service
+spec's ``config`` block so cephadm pushes it to the Monitor before invoking
+``ceph-volume``:
+
+.. code-block:: yaml
+
+    service_type: osd
+    service_id: my-crimson-osds
+    placement:
+      host_pattern: '*'
+    osd_type: crimson
+    objectstore: seastore
+    config:
+      crimson_cpu_num: "8"
+    spec:
+      data_devices:
+        paths:
+          - /dev/nvme0n1
+
+See Also
+--------
+
+* :ref:`crimson_doc` - Crimson OSD overview
+* :ref:`seastore` - SeaStore design documentation
+* :ref:`ceph-volume-lvm` - LVM backend documentation

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -155,11 +155,24 @@ bluestore_args: Dict[str, Any] = {
 }
 
 
+seastore_args: Dict[str, Any] = {
+    '--seastore-secondary': {
+        'dest': 'seastore_secondary',
+        'help': 'Secondary device for seastore in DEVICE:TYPE format '
+                '(TYPE is one of HDD, SSD, ZBD, RANDOM_BLOCK_SSD). '
+                'May be specified multiple times.',
+        'action': 'append',
+        'default': [],
+        'type': arg_validators.ValidSeastoreSecondary(),
+    },
+}
+
+
 def get_default_args() -> Dict[str, Any]:
     defaults = {}
     def format_name(name: str) -> str:
         return name.strip('-').replace('-', '_').replace('.', '_')
-    for argset in (common_args, bluestore_args):
+    for argset in (common_args, bluestore_args, seastore_args):
         defaults.update({format_name(name): val.get('default', None) for name, val in argset.items()})
     return defaults
 
@@ -176,12 +189,16 @@ def common_parser(prog: str, description: str) -> argparse.ArgumentParser:
     )
 
     bluestore_group = parser.add_argument_group('bluestore')
+    seastore_group = parser.add_argument_group('seastore')
 
     for name, kwargs in common_args.items():
         parser.add_argument(name, **kwargs)
 
     for name, kwargs in bluestore_args.items():
         bluestore_group.add_argument(name, **kwargs)
+
+    for name, kwargs in seastore_args.items():
+        seastore_group.add_argument(name, **kwargs)
 
     # Do not parse args, so that consumers can do something before the args get
     # parsed triggering argparse behavior

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -3,6 +3,7 @@ import logging
 import argparse
 from textwrap import dedent
 from ceph_volume import objectstore
+from ceph_volume.util.arg_validators import validate_objectstore_args
 from .common import prepare_parser
 from typing import List, Optional
 
@@ -58,6 +59,7 @@ class Prepare(object):
             self.args = parser.parse_args(self.argv)
         if self.args.bluestore:
             self.args.objectstore = 'bluestore'
+        validate_objectstore_args(self.args)
         self.objectstore = objectstore.mapping['LVM'][self.args.objectstore](args=self.args)
         if self.objectstore is not None:
             self.objectstore.safe_prepare()

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -78,4 +78,14 @@ def create_parser(prog: str, description: str) -> argparse.ArgumentParser:
         choices=['classic', 'crimson'],
         type=str,
     )
+    parser.add_argument(
+        '--seastore-secondary',
+        dest='seastore_secondary',
+        help='Secondary device for seastore in DEVICE:TYPE format '
+             '(TYPE is one of HDD, SSD, ZBD, RANDOM_BLOCK_SSD). '
+             'May be specified multiple times.',
+        action='append',
+        default=[],
+        type=arg_validators.ValidSeastoreSecondary(),
+    )
     return parser

--- a/src/ceph-volume/ceph_volume/devices/raw/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/prepare.py
@@ -3,6 +3,7 @@ import logging
 import os
 from textwrap import dedent
 from ceph_volume import terminal, objectstore
+from ceph_volume.util.arg_validators import validate_objectstore_args
 from .common import create_parser
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ class Prepare(object):
         self.args = parser.parse_args(self.argv)
         if self.args.bluestore:
             self.args.objectstore = 'bluestore'
+        validate_objectstore_args(self.args)
         if self.args.dmcrypt:
             if not self.args.with_tpm and not os.getenv('CEPH_VOLUME_DMCRYPT_SECRET'):
                 terminal.error('encryption was requested (--dmcrypt) but environment variable ' \

--- a/src/ceph-volume/ceph_volume/objectstore/__init__.py
+++ b/src/ceph-volume/ceph_volume/objectstore/__init__.py
@@ -1,5 +1,6 @@
 from . import lvm
 from . import raw
+from .seastore_lvm import SeastoreLvm
 from typing import Any, Dict
 from enum import Enum
 
@@ -11,7 +12,7 @@ class ObjectStore(str, Enum):
 mapping: Dict[str, Any] = {
     'LVM': {
         ObjectStore.bluestore: lvm.Lvm,
-        ObjectStore.seastore: lvm.Lvm
+        ObjectStore.seastore: SeastoreLvm,
     },
     'RAW': {
         ObjectStore.bluestore: raw.Raw

--- a/src/ceph-volume/ceph_volume/objectstore/__init__.py
+++ b/src/ceph-volume/ceph_volume/objectstore/__init__.py
@@ -1,6 +1,7 @@
 from . import lvm
 from . import raw
 from .seastore_lvm import SeastoreLvm
+from .seastore_raw import SeastoreRaw
 from typing import Any, Dict
 from enum import Enum
 
@@ -15,6 +16,7 @@ mapping: Dict[str, Any] = {
         ObjectStore.seastore: SeastoreLvm,
     },
     'RAW': {
-        ObjectStore.bluestore: raw.Raw
+        ObjectStore.bluestore: raw.Raw,
+        ObjectStore.seastore: SeastoreRaw,
     }
 }

--- a/src/ceph-volume/ceph_volume/objectstore/seastore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/seastore.py
@@ -1,0 +1,32 @@
+"""
+Shared helpers for seastore objectstore backends (LVM and raw).
+"""
+import os
+from ceph_volume.util import prepare as prepare_utils
+
+
+class SeastoreMixin:
+    """Methods shared by SeastoreLvm and SeastoreRaw.
+
+    Mixed into each concrete class alongside its storage-specific base
+    (Lvm or Raw).  Every method here overrides a BlueStore-oriented
+    default from BaseObjectStore.
+    """
+
+    def add_objectstore_opts(self) -> None:
+        affinity = self.get_osdspec_affinity()
+        if affinity:
+            self.osd_mkfs_cmd.extend(['--osdspec-affinity', affinity])
+
+    def prepare_osd_req(self, tmpfs: bool = True) -> None:
+        super().prepare_osd_req(tmpfs=tmpfs)
+        for i, (device, dtype) in enumerate(
+                getattr(self.args, 'seastore_secondary', [])):
+            prepare_utils.link_seastore_secondary(
+                device, dtype, i + 1, self.osd_id)
+
+    def unlink_bs_symlinks(self) -> None:
+        block_path = os.path.join(self.osd_path, 'block')
+        if os.path.exists(block_path):
+            os.unlink(block_path)
+        prepare_utils.unlink_seastore_secondaries(self.osd_path)

--- a/src/ceph-volume/ceph_volume/objectstore/seastore_lvm.py
+++ b/src/ceph-volume/ceph_volume/objectstore/seastore_lvm.py
@@ -1,67 +1,48 @@
-import logging
 import os
-from ceph_volume import conf, terminal, process
+from typing import List, Optional
+
+from ceph_volume import conf, configuration, process, terminal
 from ceph_volume.api import lvm as api
+from ceph_volume.systemd import systemctl
 from ceph_volume.util import prepare as prepare_utils
 from ceph_volume.util import system
-from ceph_volume.systemd import systemctl
-from ceph_volume import configuration
 from .lvm import Lvm
-from typing import List, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import argparse
-
-logger = logging.getLogger(__name__)
+from .seastore import SeastoreMixin
 
 
-class SeastoreLvm(Lvm):
+class SeastoreLvm(SeastoreMixin, Lvm):
     """
     LVM-backed seastore OSD.  Inherits the full prepare/activate machinery from
-    Lvm but overrides the parts that are BlueStore-specific.
+    Lvm but overrides the parts that are BlueStore-specific via SeastoreMixin.
     """
-
-    def add_objectstore_opts(self) -> None:
-        # Seastore does not use --bluestore-block-wal/db-path.
-        affinity = self.get_osdspec_affinity()
-        if affinity:
-            self.osd_mkfs_cmd.extend(['--osdspec-affinity', affinity])
 
     def setup_metadata_devices(self) -> None:
         """
         Record secondary device metadata in LVM tags on the block LV.
-        Secondaries are raw devices — no new LVs are created for them.
+        Secondaries are raw devices -- no new LVs are created for them.
         Tag keys: ceph.seastore_secondary_{i}_{count,device,type,id}
         """
-        secondaries = getattr(self.args, 'seastore_secondary', []) or []
+        secondaries = getattr(self.args, 'seastore_secondary', [])
         self.tags['ceph.seastore_secondary_count'] = len(secondaries)
         for i, (device, dtype) in enumerate(secondaries):
             self.tags['ceph.seastore_secondary_%d_device' % i] = device
             self.tags['ceph.seastore_secondary_%d_type' % i] = dtype
             self.tags['ceph.seastore_secondary_%d_id' % i] = i + 1
 
-    def prepare_osd_req(self, tmpfs: bool = True) -> None:
-        super().prepare_osd_req(tmpfs=tmpfs)
-        secondaries = getattr(self.args, 'seastore_secondary', []) or []
-        for i, (device, dtype) in enumerate(secondaries):
-            prepare_utils.link_seastore_secondary(device, dtype, i + 1, self.osd_id)
+    @staticmethod
+    def _find_block_lv(osd_lvs: List[api.Volume]) -> Optional[api.Volume]:
+        """Return the block LV from a list of OSD LVs, or None."""
+        for lv in osd_lvs:
+            if lv.tags.get('ceph.type') == 'block':
+                return lv
+        return None
 
-    def unlink_bs_symlinks(self) -> None:
-        block_path = os.path.join(self.osd_path, 'block')
-        if os.path.exists(block_path):
-            os.unlink(block_path)
-        prepare_utils.unlink_seastore_secondaries(self.osd_path)
-
-    def _get_secondaries_from_lvs(self, osd_lvs: List[api.Volume]):
+    def _get_secondaries_from_lvs(self, osd_lvs: List[api.Volume]) -> list:
         """
         Reconstruct the list of (device, dtype, dev_id) tuples from LVM tags
         stored on the block LV.
         """
-        osd_block_lv = None
-        for lv in osd_lvs:
-            if lv.tags.get('ceph.type') == 'block':
-                osd_block_lv = lv
-                break
+        osd_block_lv = self._find_block_lv(osd_lvs)
         if osd_block_lv is None:
             return []
 
@@ -86,11 +67,8 @@ class SeastoreLvm(Lvm):
                   osd_lvs: List[api.Volume],
                   no_systemd: bool = False,
                   no_tmpfs: bool = False) -> None:
-        for lv in osd_lvs:
-            if lv.tags.get('ceph.type') == 'block':
-                osd_block_lv = lv
-                break
-        else:
+        osd_block_lv = self._find_block_lv(osd_lvs)
+        if osd_block_lv is None:
             raise RuntimeError('could not find a seastore OSD to activate')
 
         osd_id = osd_block_lv.tags['ceph.osd_id']
@@ -105,10 +83,9 @@ class SeastoreLvm(Lvm):
 
         self.unlink_bs_symlinks()
 
-        osd_lv_path = osd_block_lv.lv_path
-        system.chown(self.osd_path)
-        process.run(['ln', '-snf', osd_lv_path, os.path.join(self.osd_path, 'block')])
-        system.chown(os.path.join(self.osd_path, 'block'))
+        block_path = os.path.join(self.osd_path, 'block')
+        process.run(['ln', '-snf', osd_block_lv.lv_path, block_path])
+        system.chown(block_path)
         system.chown(self.osd_path)
 
         for device, dtype, dev_id in self._get_secondaries_from_lvs(osd_lvs):

--- a/src/ceph-volume/ceph_volume/objectstore/seastore_lvm.py
+++ b/src/ceph-volume/ceph_volume/objectstore/seastore_lvm.py
@@ -1,0 +1,125 @@
+import logging
+import os
+from ceph_volume import conf, terminal, process
+from ceph_volume.api import lvm as api
+from ceph_volume.util import prepare as prepare_utils
+from ceph_volume.util import system
+from ceph_volume.systemd import systemctl
+from ceph_volume import configuration
+from .lvm import Lvm
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+logger = logging.getLogger(__name__)
+
+
+class SeastoreLvm(Lvm):
+    """
+    LVM-backed seastore OSD.  Inherits the full prepare/activate machinery from
+    Lvm but overrides the parts that are BlueStore-specific.
+    """
+
+    def add_objectstore_opts(self) -> None:
+        # Seastore does not use --bluestore-block-wal/db-path.
+        affinity = self.get_osdspec_affinity()
+        if affinity:
+            self.osd_mkfs_cmd.extend(['--osdspec-affinity', affinity])
+
+    def setup_metadata_devices(self) -> None:
+        """
+        Record secondary device metadata in LVM tags on the block LV.
+        Secondaries are raw devices — no new LVs are created for them.
+        Tag keys: ceph.seastore_secondary_{i}_{count,device,type,id}
+        """
+        secondaries = getattr(self.args, 'seastore_secondary', []) or []
+        self.tags['ceph.seastore_secondary_count'] = len(secondaries)
+        for i, (device, dtype) in enumerate(secondaries):
+            self.tags['ceph.seastore_secondary_%d_device' % i] = device
+            self.tags['ceph.seastore_secondary_%d_type' % i] = dtype
+            self.tags['ceph.seastore_secondary_%d_id' % i] = i + 1
+
+    def prepare_osd_req(self, tmpfs: bool = True) -> None:
+        super().prepare_osd_req(tmpfs=tmpfs)
+        secondaries = getattr(self.args, 'seastore_secondary', []) or []
+        for i, (device, dtype) in enumerate(secondaries):
+            prepare_utils.link_seastore_secondary(device, dtype, i + 1, self.osd_id)
+
+    def unlink_bs_symlinks(self) -> None:
+        block_path = os.path.join(self.osd_path, 'block')
+        if os.path.exists(block_path):
+            os.unlink(block_path)
+        prepare_utils.unlink_seastore_secondaries(self.osd_path)
+
+    def _get_secondaries_from_lvs(self, osd_lvs: List[api.Volume]):
+        """
+        Reconstruct the list of (device, dtype, dev_id) tuples from LVM tags
+        stored on the block LV.
+        """
+        osd_block_lv = None
+        for lv in osd_lvs:
+            if lv.tags.get('ceph.type') == 'block':
+                osd_block_lv = lv
+                break
+        if osd_block_lv is None:
+            return []
+
+        try:
+            count = int(osd_block_lv.tags.get('ceph.seastore_secondary_count', 0))
+        except (ValueError, TypeError):
+            return []
+
+        secondaries = []
+        for i in range(count):
+            device = osd_block_lv.tags.get('ceph.seastore_secondary_%d_device' % i)
+            dtype = osd_block_lv.tags.get('ceph.seastore_secondary_%d_type' % i)
+            try:
+                dev_id = int(osd_block_lv.tags.get('ceph.seastore_secondary_%d_id' % i, i + 1))
+            except (ValueError, TypeError):
+                dev_id = i + 1
+            if device and dtype:
+                secondaries.append((device, dtype, dev_id))
+        return secondaries
+
+    def _activate(self,
+                  osd_lvs: List[api.Volume],
+                  no_systemd: bool = False,
+                  no_tmpfs: bool = False) -> None:
+        for lv in osd_lvs:
+            if lv.tags.get('ceph.type') == 'block':
+                osd_block_lv = lv
+                break
+        else:
+            raise RuntimeError('could not find a seastore OSD to activate')
+
+        osd_id = osd_block_lv.tags['ceph.osd_id']
+        conf.cluster = osd_block_lv.tags['ceph.cluster_name']
+        osd_fsid = osd_block_lv.tags['ceph.osd_fsid']
+        configuration.load_ceph_conf_path(osd_block_lv.tags['ceph.cluster_name'])
+        configuration.load()
+
+        self.osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+        if not system.path_is_mounted(self.osd_path):
+            prepare_utils.create_osd_path(osd_id, tmpfs=not no_tmpfs)
+
+        self.unlink_bs_symlinks()
+
+        osd_lv_path = osd_block_lv.lv_path
+        system.chown(self.osd_path)
+        process.run(['ln', '-snf', osd_lv_path, os.path.join(self.osd_path, 'block')])
+        system.chown(os.path.join(self.osd_path, 'block'))
+        system.chown(self.osd_path)
+
+        for device, dtype, dev_id in self._get_secondaries_from_lvs(osd_lvs):
+            sec_dir = os.path.join(self.osd_path, 'block.%s.%s' % (dtype, dev_id))
+            os.makedirs(sec_dir, exist_ok=True)
+            system.chown(device)
+            process.run(['ln', '-snf', device, os.path.join(sec_dir, 'block')])
+            system.chown(sec_dir)
+
+        if not no_systemd:
+            systemctl.enable_volume(osd_id, osd_fsid, 'lvm')
+            systemctl.enable_osd(osd_id)
+            systemctl.start_osd(osd_id)
+        terminal.success("ceph-volume lvm activate successful for osd ID: %s" % osd_id)

--- a/src/ceph-volume/ceph_volume/objectstore/seastore_raw.py
+++ b/src/ceph-volume/ceph_volume/objectstore/seastore_raw.py
@@ -1,0 +1,79 @@
+import logging
+
+from ceph_volume import terminal, conf, decorators
+from ceph_volume.util import system
+from ceph_volume.util import prepare as prepare_utils
+from .raw import Raw
+from .seastore import SeastoreMixin
+
+logger = logging.getLogger(__name__)
+
+
+class SeastoreRaw(SeastoreMixin, Raw):
+    """
+    Raw-device seastore OSD.  Inherits the full prepare/activate machinery
+    from Raw but overrides the parts that are BlueStore-specific via
+    SeastoreMixin.
+    """
+
+    @decorators.needs_root
+    def activate(self) -> None:
+        """Activate a SeaStore OSD on raw devices.
+
+        Unlike ``Raw.activate`` which discovers OSDs via
+        ``ceph-bluestore-tool show-label``, SeaStore devices have a
+        different on-disk format and cannot be discovered that way.
+        Until ``crimson-objectstore-tool`` gains a ``dump-superblock``
+        command (tracker #68106), the user must supply ``--device``,
+        ``--osd-id``, and ``--osd-uuid`` explicitly on every activate.
+        ``--all`` is not supported for SeaStore on the raw backend.
+
+        Secondary device symlinks must also be re-supplied via
+        ``--seastore-secondary`` on each activate because the secondary
+        device paths are not persisted outside the primary device's
+        superblock.
+        """
+        if not self.devices:
+            raise RuntimeError(
+                'ceph-volume raw activate --objectstore seastore requires '
+                '--device (discovery via --all is not yet supported for '
+                'SeaStore). See doc/ceph-volume/seastore.rst.'
+            )
+        if not self.osd_id:
+            raise RuntimeError(
+                'ceph-volume raw activate --objectstore seastore requires '
+                '--osd-id. SeaStore OSDs cannot be discovered from the '
+                'device label; the OSD ID must be supplied explicitly.'
+            )
+        if not self.osd_fsid:
+            raise RuntimeError(
+                'ceph-volume raw activate --objectstore seastore requires '
+                '--osd-uuid. SeaStore OSDs cannot be discovered from the '
+                'device label; the OSD FSID must be supplied explicitly.'
+            )
+
+        # ``Raw.__init__`` populates ``block_device_path`` from
+        # ``args.data``, which doesn't exist on the raw activate command
+        # line.  Use the first entry in ``self.devices`` (which folds in
+        # both ``--device`` and ``--devices`` from the parser).
+        self.block_device_path = self.devices[0]
+        logger.info(
+            f'Activating osd.{self.osd_id} uuid {self.osd_fsid} '
+            f'on {self.block_device_path}'
+        )
+        self._activate(self.osd_id, self.osd_fsid)
+
+    def _activate(self, osd_id: str, osd_fsid: str) -> None:
+        self.osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+        if not system.path_is_mounted(self.osd_path):
+            prepare_utils.create_osd_path(osd_id, tmpfs=not self.args.no_tmpfs)
+
+        self.unlink_bs_symlinks()
+        prepare_utils.link_block(self.block_device_path, osd_id)
+
+        for i, (device, dtype) in enumerate(
+                getattr(self.args, 'seastore_secondary', [])):
+            prepare_utils.link_seastore_secondary(device, dtype, i + 1, osd_id)
+
+        system.chown(self.osd_path)
+        terminal.success("ceph-volume raw activate successful for osd ID: %s" % osd_id)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -1,4 +1,5 @@
 import pytest
+from argparse import Namespace
 from ceph_volume.devices import lvm
 from unittest.mock import patch
 
@@ -43,6 +44,33 @@ class TestPrepare(object):
     def test_invalid_osd_id_passed(self, m_create_key):
         with pytest.raises(SystemExit):
             lvm.prepare.Prepare(argv=['--osd-id', 'foo']).main()
+
+    def test_seastore_rejects_block_db(self, m_create_key):
+        p = lvm.prepare.Prepare([])
+        p.args = Namespace(objectstore='seastore', bluestore=False,
+                           block_db='/dev/sdb', block_wal=None,
+                           seastore_secondary=[])
+        with pytest.raises(RuntimeError) as exc:
+            p.main()
+        assert '--block.db cannot be used with --objectstore seastore' in str(exc.value)
+
+    def test_seastore_rejects_block_wal(self, m_create_key):
+        p = lvm.prepare.Prepare([])
+        p.args = Namespace(objectstore='seastore', bluestore=False,
+                           block_db=None, block_wal='/dev/sdc',
+                           seastore_secondary=[])
+        with pytest.raises(RuntimeError) as exc:
+            p.main()
+        assert '--block.wal cannot be used with --objectstore seastore' in str(exc.value)
+
+    def test_bluestore_rejects_seastore_secondary(self, m_create_key):
+        p = lvm.prepare.Prepare([])
+        p.args = Namespace(objectstore='bluestore', bluestore=False,
+                           block_db=None, block_wal=None,
+                           seastore_secondary=[('/dev/sdb', 'HDD')])
+        with pytest.raises(RuntimeError) as exc:
+            p.main()
+        assert '--seastore-secondary cannot be used with --objectstore bluestore' in str(exc.value)
 
 
 class TestActivate(object):

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
@@ -1,4 +1,5 @@
 import pytest
+from argparse import Namespace
 from ceph_volume.devices import raw
 from unittest.mock import patch, MagicMock
 from ceph_volume.objectstore.raw import Raw
@@ -115,3 +116,37 @@ class TestPrepare(object):
         with pytest.raises(Exception):
             raw.prepare.Prepare(argv=['--bluestore', '--data', '/dev/foo']).main()
         m_rollback_osd.assert_called()
+
+    @patch('ceph_volume.devices.raw.prepare.create_parser')
+    def test_seastore_rejects_block_db(self, m_parser, m_create_key):
+        m_parser.return_value.parse_args.return_value = Namespace(
+            objectstore='seastore', bluestore=False,
+            block_db='/dev/sdb', block_wal=None,
+            seastore_secondary=[], dmcrypt=False, with_tpm=False)
+        p = raw.prepare.Prepare(['--dummy'])
+        with pytest.raises(RuntimeError) as exc:
+            p.main()
+        assert '--block.db cannot be used with --objectstore seastore' in str(exc.value)
+
+    @patch('ceph_volume.devices.raw.prepare.create_parser')
+    def test_seastore_rejects_block_wal(self, m_parser, m_create_key):
+        m_parser.return_value.parse_args.return_value = Namespace(
+            objectstore='seastore', bluestore=False,
+            block_db=None, block_wal='/dev/sdc',
+            seastore_secondary=[], dmcrypt=False, with_tpm=False)
+        p = raw.prepare.Prepare(['--dummy'])
+        with pytest.raises(RuntimeError) as exc:
+            p.main()
+        assert '--block.wal cannot be used with --objectstore seastore' in str(exc.value)
+
+    @patch('ceph_volume.devices.raw.prepare.create_parser')
+    def test_bluestore_rejects_seastore_secondary(self, m_parser, m_create_key):
+        m_parser.return_value.parse_args.return_value = Namespace(
+            objectstore='bluestore', bluestore=False,
+            block_db=None, block_wal=None,
+            seastore_secondary=[('/dev/sdb', 'HDD')],
+            dmcrypt=False, with_tpm=False)
+        p = raw.prepare.Prepare(['--dummy'])
+        with pytest.raises(RuntimeError) as exc:
+            p.main()
+        assert '--seastore-secondary cannot be used with --objectstore bluestore' in str(exc.value)

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_seastore_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_seastore_lvm.py
@@ -1,0 +1,298 @@
+import pytest
+from argparse import Namespace
+from unittest.mock import patch, Mock, MagicMock
+from ceph_volume.objectstore.seastore_lvm import SeastoreLvm
+from ceph_volume.api.lvm import Volume
+from ceph_volume.util import system
+
+
+class TestSeastoreLvm:
+    @patch('ceph_volume.objectstore.lvm.prepare_utils.create_key',
+           Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
+    def setup_method(self, m_create_key):
+        args = Namespace(dmcrypt_format_opts=None, dmcrypt_open_opts=None)
+        self.lvm = SeastoreLvm(args)
+
+    @patch('ceph_volume.conf.cluster', 'ceph')
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    @patch('ceph_volume.objectstore.lvm.prepare_utils.create_id', Mock(return_value='111'))
+    def test_pre_prepare_lv(self, m_get_single_lv, factory):
+        args = factory(objectstore='seastore',
+                       cluster_fsid='abcd',
+                       osd_fsid='abc123',
+                       crush_device_class='ssd',
+                       osd_id='111',
+                       data='vg_foo/lv_foo')
+        m_get_single_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='fake-uuid')
+        self.lvm.encrypted = False
+        self.lvm.with_tpm = 0
+        self.lvm.args = args
+        self.lvm.objectstore = 'seastore'
+        self.lvm.pre_prepare()
+        assert self.lvm.osd_id == '111'
+        assert self.lvm.block_device_path == '/fake-path'
+
+
+    def test_add_objectstore_opts_no_bluestore_paths(self):
+        """SeastoreLvm must not add --bluestore-block-wal-path / --bluestore-block-db-path."""
+        self.lvm.osd_mkfs_cmd = ['ceph-osd', '--mkfs']
+        self.lvm.wal_device_path = '/dev/sdb'
+        self.lvm.db_device_path = '/dev/sdc'
+        self.lvm.add_objectstore_opts()
+        cmd = ' '.join(self.lvm.osd_mkfs_cmd)
+        assert '--bluestore-block-wal-path' not in cmd
+        assert '--bluestore-block-db-path' not in cmd
+
+    @patch.dict('os.environ', {'CEPH_VOLUME_OSDSPEC_AFFINITY': 'my-spec'})
+    def test_add_objectstore_opts_with_affinity(self):
+        self.lvm.osd_mkfs_cmd = ['ceph-osd', '--mkfs']
+        self.lvm.add_objectstore_opts()
+        assert '--osdspec-affinity' in self.lvm.osd_mkfs_cmd
+        assert 'my-spec' in self.lvm.osd_mkfs_cmd
+
+
+    def test_setup_metadata_devices_no_secondaries(self, factory):
+        args = factory(seastore_secondary=[])
+        self.lvm.args = args
+        self.lvm.tags = {}
+        self.lvm.setup_metadata_devices()
+        assert self.lvm.tags['ceph.seastore_secondary_count'] == 0
+
+    def test_setup_metadata_devices_one_secondary(self, factory):
+        args = factory(seastore_secondary=[('/dev/sdb', 'HDD')])
+        self.lvm.args = args
+        self.lvm.tags = {}
+        self.lvm.setup_metadata_devices()
+        assert self.lvm.tags['ceph.seastore_secondary_count'] == 1
+        assert self.lvm.tags['ceph.seastore_secondary_0_device'] == '/dev/sdb'
+        assert self.lvm.tags['ceph.seastore_secondary_0_type'] == 'HDD'
+        assert self.lvm.tags['ceph.seastore_secondary_0_id'] == 1
+
+    def test_setup_metadata_devices_two_secondaries(self, factory):
+        args = factory(seastore_secondary=[('/dev/sdb', 'HDD'), ('/dev/sdc', 'SSD')])
+        self.lvm.args = args
+        self.lvm.tags = {}
+        self.lvm.setup_metadata_devices()
+        assert self.lvm.tags['ceph.seastore_secondary_count'] == 2
+        assert self.lvm.tags['ceph.seastore_secondary_1_device'] == '/dev/sdc'
+        assert self.lvm.tags['ceph.seastore_secondary_1_type'] == 'SSD'
+        assert self.lvm.tags['ceph.seastore_secondary_1_id'] == 2
+
+    def test_setup_metadata_devices_missing_attr(self):
+        # args without seastore_secondary attribute at all (e.g. old code paths)
+        self.lvm.args = Namespace()  # no seastore_secondary attribute
+        self.lvm.tags = {}
+        self.lvm.setup_metadata_devices()
+        assert self.lvm.tags['ceph.seastore_secondary_count'] == 0
+
+
+    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.prepare_osd_req')
+    def test_prepare_osd_req_no_secondaries(self, m_super, m_link, factory):
+        args = factory(seastore_secondary=[])
+        self.lvm.args = args
+        self.lvm.osd_id = '0'
+        self.lvm.prepare_osd_req()
+        m_super.assert_called_once()
+        m_link.assert_not_called()
+
+    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.prepare_osd_req')
+    def test_prepare_osd_req_with_secondaries(self, m_super, m_link, factory):
+        args = factory(seastore_secondary=[('/dev/sdb', 'HDD'), ('/dev/sdc', 'SSD')])
+        self.lvm.args = args
+        self.lvm.osd_id = '0'
+        self.lvm.prepare_osd_req()
+        assert m_link.call_count == 2
+        m_link.assert_any_call('/dev/sdb', 'HDD', 1, '0')
+        m_link.assert_any_call('/dev/sdc', 'SSD', 2, '0')
+
+
+    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.unlink_seastore_secondaries')
+    def test_unlink_bs_symlinks_no_block(self, m_unlink, fake_filesystem):
+        osd_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(osd_path)
+        self.lvm.osd_path = osd_path
+        self.lvm.unlink_bs_symlinks()
+        m_unlink.assert_called_once_with(osd_path)
+
+    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.unlink_seastore_secondaries')
+    def test_unlink_bs_symlinks_removes_block(self, m_unlink, fake_filesystem):
+        osd_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(osd_path)
+        fake_filesystem.create_file(osd_path + '/block')
+        self.lvm.osd_path = osd_path
+        self.lvm.unlink_bs_symlinks()
+        assert not fake_filesystem.exists(osd_path + '/block')
+        m_unlink.assert_called_once_with(osd_path)
+
+
+    def test_get_secondaries_from_lvs_empty(self):
+        lvs = [Volume(lv_name='block', lv_path='/dev/vg/lv',
+                      vg_name='vg', lv_tags='ceph.type=block',
+                      lv_uuid='uuid1')]
+        assert self.lvm._get_secondaries_from_lvs(lvs) == []
+
+    def test_get_secondaries_from_lvs_one(self):
+        tags = ('ceph.type=block,ceph.seastore_secondary_count=1,'
+                'ceph.seastore_secondary_0_device=/dev/sdb,'
+                'ceph.seastore_secondary_0_type=HDD,'
+                'ceph.seastore_secondary_0_id=1')
+        lvs = [Volume(lv_name='block', lv_path='/dev/vg/lv',
+                      vg_name='vg', lv_tags=tags, lv_uuid='uuid1')]
+        result = self.lvm._get_secondaries_from_lvs(lvs)
+        assert result == [('/dev/sdb', 'HDD', 1)]
+
+    def test_get_secondaries_from_lvs_two(self):
+        tags = ('ceph.type=block,ceph.seastore_secondary_count=2,'
+                'ceph.seastore_secondary_0_device=/dev/sdb,'
+                'ceph.seastore_secondary_0_type=HDD,'
+                'ceph.seastore_secondary_0_id=1,'
+                'ceph.seastore_secondary_1_device=/dev/sdc,'
+                'ceph.seastore_secondary_1_type=SSD,'
+                'ceph.seastore_secondary_1_id=2')
+        lvs = [Volume(lv_name='block', lv_path='/dev/vg/lv',
+                      vg_name='vg', lv_tags=tags, lv_uuid='uuid1')]
+        result = self.lvm._get_secondaries_from_lvs(lvs)
+        assert result == [('/dev/sdb', 'HDD', 1), ('/dev/sdc', 'SSD', 2)]
+
+    def test_get_secondaries_from_lvs_no_block_lv(self):
+        lvs = [Volume(lv_name='other', lv_path='/dev/vg/lv',
+                      vg_name='vg', lv_tags='ceph.type=db', lv_uuid='uuid1')]
+        assert self.lvm._get_secondaries_from_lvs(lvs) == []
+
+
+    @patch('ceph_volume.objectstore.seastore_lvm.os.makedirs')
+    @patch('ceph_volume.objectstore.seastore_lvm.SeastoreLvm.unlink_bs_symlinks')
+    @patch('ceph_volume.objectstore.lvm.prepare_utils.create_osd_path')
+    @patch('ceph_volume.terminal.success')
+    def test__activate_no_secondaries(self,
+                                      m_success, m_create_osd_path,
+                                      m_unlink, m_makedirs,
+                                      monkeypatch, fake_run, fake_call,
+                                      conf_ceph_stub, patch_udevdata):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
+        m_create_osd_path.return_value = MagicMock()
+        m_success.return_value = MagicMock()
+
+        lvs = [Volume(lv_name='lv_foo-block',
+                      lv_path='/fake-block-path',
+                      vg_name='vg_foo',
+                      lv_tags=('ceph.type=block,ceph.osd_id=0,ceph.osd_fsid=abcd,'
+                               'ceph.cluster_name=ceph,ceph.encrypted=0,'
+                               'ceph.seastore_secondary_count=0'),
+                      lv_uuid='fake-block-uuid')]
+        self.lvm._activate(lvs)
+
+        # prime-osd-dir must NOT be called for seastore
+        run_cmds = [c['args'][0][0] for c in fake_run.calls]
+        assert 'ceph-bluestore-tool' not in run_cmds
+
+        # block symlink must be created
+        block_ln_calls = [c['args'][0] for c in fake_run.calls
+                          if c['args'][0][0] == 'ln'
+                          and c['args'][0][2] == '/fake-block-path']
+        assert block_ln_calls
+
+        assert m_success.called
+
+    @patch('ceph_volume.objectstore.seastore_lvm.os.makedirs')
+    @patch('ceph_volume.objectstore.seastore_lvm.SeastoreLvm.unlink_bs_symlinks')
+    @patch('ceph_volume.objectstore.lvm.prepare_utils.create_osd_path')
+    @patch('ceph_volume.terminal.success')
+    def test__activate_with_secondaries(self,
+                                        m_success, m_create_osd_path,
+                                        m_unlink, m_makedirs,
+                                        monkeypatch, fake_run, fake_call,
+                                        conf_ceph_stub, patch_udevdata):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
+        m_create_osd_path.return_value = MagicMock()
+        m_success.return_value = MagicMock()
+
+        lvs = [Volume(lv_name='lv_foo-block',
+                      lv_path='/fake-block-path',
+                      vg_name='vg_foo',
+                      lv_tags=('ceph.type=block,ceph.osd_id=0,ceph.osd_fsid=abcd,'
+                               'ceph.cluster_name=ceph,ceph.encrypted=0,'
+                               'ceph.seastore_secondary_count=1,'
+                               'ceph.seastore_secondary_0_device=/dev/sdb,'
+                               'ceph.seastore_secondary_0_type=HDD,'
+                               'ceph.seastore_secondary_0_id=1'),
+                      lv_uuid='fake-block-uuid')]
+        self.lvm._activate(lvs)
+
+        # secondary directory block.HDD.1 must be created via makedirs
+        m_makedirs.assert_called_once_with(
+            '/var/lib/ceph/osd/ceph-0/block.HDD.1', exist_ok=True)
+
+        # secondary block symlink must be created
+        secondary_ln_calls = [c['args'][0] for c in fake_run.calls
+                               if c['args'][0][0] == 'ln'
+                               and 'block.HDD.1' in c['args'][0][-1]]
+        assert secondary_ln_calls
+        assert secondary_ln_calls[0][2] == '/dev/sdb'
+
+    @patch('ceph_volume.objectstore.seastore_lvm.os.makedirs')
+    @patch('ceph_volume.objectstore.seastore_lvm.SeastoreLvm.unlink_bs_symlinks')
+    @patch('ceph_volume.objectstore.lvm.prepare_utils.create_osd_path')
+    @patch('ceph_volume.terminal.success')
+    def test__activate_with_two_secondaries(self,
+                                            m_success, m_create_osd_path,
+                                            m_unlink, m_makedirs,
+                                            monkeypatch, fake_run, fake_call,
+                                            conf_ceph_stub, patch_udevdata):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
+        m_create_osd_path.return_value = MagicMock()
+        m_success.return_value = MagicMock()
+
+        lvs = [Volume(lv_name='lv_foo-block',
+                      lv_path='/fake-block-path',
+                      vg_name='vg_foo',
+                      lv_tags=('ceph.type=block,ceph.osd_id=0,ceph.osd_fsid=abcd,'
+                               'ceph.cluster_name=ceph,ceph.encrypted=0,'
+                               'ceph.seastore_secondary_count=2,'
+                               'ceph.seastore_secondary_0_device=/dev/sdb,'
+                               'ceph.seastore_secondary_0_type=HDD,'
+                               'ceph.seastore_secondary_0_id=1,'
+                               'ceph.seastore_secondary_1_device=/dev/sdc,'
+                               'ceph.seastore_secondary_1_type=SSD,'
+                               'ceph.seastore_secondary_1_id=2'),
+                      lv_uuid='fake-block-uuid')]
+        self.lvm._activate(lvs)
+
+        # both secondary directories must be created
+        assert m_makedirs.call_count == 2
+        m_makedirs.assert_any_call(
+            '/var/lib/ceph/osd/ceph-0/block.HDD.1', exist_ok=True)
+        m_makedirs.assert_any_call(
+            '/var/lib/ceph/osd/ceph-0/block.SSD.2', exist_ok=True)
+
+        # both secondary block symlinks must be created with correct targets
+        ln_calls = {c['args'][0][-1]: c['args'][0][2]
+                    for c in fake_run.calls
+                    if c['args'][0][0] == 'ln' and 'block.' in c['args'][0][-1]}
+        assert ln_calls['/var/lib/ceph/osd/ceph-0/block.HDD.1/block'] == '/dev/sdb'
+        assert ln_calls['/var/lib/ceph/osd/ceph-0/block.SSD.2/block'] == '/dev/sdc'
+
+    def test__activate_raises_exception_no_block_lv(self):
+        lvs = [Volume(lv_name='lv_foo-db',
+                      lv_path='/fake-path',
+                      vg_name='vg_foo',
+                      lv_tags='ceph.type=db',
+                      lv_uuid='fake-db-uuid')]
+        with pytest.raises(RuntimeError) as error:
+            self.lvm._activate(lvs)
+        assert 'could not find a seastore OSD to activate' in str(error.value)

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_seastore_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_seastore_lvm.py
@@ -1,6 +1,6 @@
 import pytest
 from argparse import Namespace
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock
 from ceph_volume.objectstore.seastore_lvm import SeastoreLvm
 from ceph_volume.api.lvm import Volume
 from ceph_volume.util import system
@@ -90,7 +90,7 @@ class TestSeastoreLvm:
         assert self.lvm.tags['ceph.seastore_secondary_count'] == 0
 
 
-    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.link_seastore_secondary')
     @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.prepare_osd_req')
     def test_prepare_osd_req_no_secondaries(self, m_super, m_link, factory):
         args = factory(seastore_secondary=[])
@@ -100,7 +100,7 @@ class TestSeastoreLvm:
         m_super.assert_called_once()
         m_link.assert_not_called()
 
-    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.link_seastore_secondary')
     @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.prepare_osd_req')
     def test_prepare_osd_req_with_secondaries(self, m_super, m_link, factory):
         args = factory(seastore_secondary=[('/dev/sdb', 'HDD'), ('/dev/sdc', 'SSD')])
@@ -112,7 +112,7 @@ class TestSeastoreLvm:
         m_link.assert_any_call('/dev/sdc', 'SSD', 2, '0')
 
 
-    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.unlink_seastore_secondaries')
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.unlink_seastore_secondaries')
     def test_unlink_bs_symlinks_no_block(self, m_unlink, fake_filesystem):
         osd_path = '/var/lib/ceph/osd/ceph-0'
         fake_filesystem.create_dir(osd_path)
@@ -120,7 +120,7 @@ class TestSeastoreLvm:
         self.lvm.unlink_bs_symlinks()
         m_unlink.assert_called_once_with(osd_path)
 
-    @patch('ceph_volume.objectstore.seastore_lvm.prepare_utils.unlink_seastore_secondaries')
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.unlink_seastore_secondaries')
     def test_unlink_bs_symlinks_removes_block(self, m_unlink, fake_filesystem):
         osd_path = '/var/lib/ceph/osd/ceph-0'
         fake_filesystem.create_dir(osd_path)
@@ -179,8 +179,6 @@ class TestSeastoreLvm:
         monkeypatch.setattr(system, 'chown', lambda path: 0)
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
-        m_create_osd_path.return_value = MagicMock()
-        m_success.return_value = MagicMock()
 
         lvs = [Volume(lv_name='lv_foo-block',
                       lv_path='/fake-block-path',
@@ -216,8 +214,6 @@ class TestSeastoreLvm:
         monkeypatch.setattr(system, 'chown', lambda path: 0)
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
-        m_create_osd_path.return_value = MagicMock()
-        m_success.return_value = MagicMock()
 
         lvs = [Volume(lv_name='lv_foo-block',
                       lv_path='/fake-block-path',
@@ -255,8 +251,6 @@ class TestSeastoreLvm:
         monkeypatch.setattr(system, 'chown', lambda path: 0)
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
-        m_create_osd_path.return_value = MagicMock()
-        m_success.return_value = MagicMock()
 
         lvs = [Volume(lv_name='lv_foo-block',
                       lv_path='/fake-block-path',

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_seastore_raw.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_seastore_raw.py
@@ -1,0 +1,206 @@
+import pytest
+from argparse import Namespace
+from unittest.mock import patch, Mock
+from ceph_volume.objectstore.seastore_raw import SeastoreRaw
+from ceph_volume.util import system
+
+
+class TestSeastoreRaw:
+    @patch('ceph_volume.objectstore.raw.prepare_utils.create_key',
+           Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
+    def setup_method(self, m_create_key):
+        args = Namespace(no_tmpfs=False, seastore_secondary=[])
+        self.raw = SeastoreRaw(args)
+
+
+    def test_add_objectstore_opts_no_bluestore_paths(self):
+        self.raw.osd_mkfs_cmd = ['ceph-osd', '--mkfs']
+        self.raw.wal_device_path = '/dev/sdb'
+        self.raw.db_device_path = '/dev/sdc'
+        self.raw.add_objectstore_opts()
+        cmd = ' '.join(self.raw.osd_mkfs_cmd)
+        assert '--bluestore-block-wal-path' not in cmd
+        assert '--bluestore-block-db-path' not in cmd
+
+    @patch.dict('os.environ', {'CEPH_VOLUME_OSDSPEC_AFFINITY': 'my-spec'})
+    def test_add_objectstore_opts_with_affinity(self):
+        self.raw.osd_mkfs_cmd = ['ceph-osd', '--mkfs']
+        self.raw.add_objectstore_opts()
+        assert '--osdspec-affinity' in self.raw.osd_mkfs_cmd
+        assert 'my-spec' in self.raw.osd_mkfs_cmd
+
+
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.prepare_osd_req')
+    def test_prepare_osd_req_no_secondaries(self, m_super, m_link):
+        self.raw.osd_id = '0'
+        self.raw.prepare_osd_req()
+        m_super.assert_called_once()
+        m_link.assert_not_called()
+
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.prepare_osd_req')
+    def test_prepare_osd_req_with_secondaries(self, m_super, m_link):
+        self.raw.osd_id = '0'
+        self.raw.args.seastore_secondary = [('/dev/sdb', 'HDD'), ('/dev/sdc', 'SSD')]
+        self.raw.prepare_osd_req()
+        assert m_link.call_count == 2
+        m_link.assert_any_call('/dev/sdb', 'HDD', 1, '0')
+        m_link.assert_any_call('/dev/sdc', 'SSD', 2, '0')
+
+
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.unlink_seastore_secondaries')
+    def test_unlink_bs_symlinks_no_block(self, m_unlink, fake_filesystem):
+        osd_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(osd_path)
+        self.raw.osd_path = osd_path
+        self.raw.unlink_bs_symlinks()
+        m_unlink.assert_called_once_with(osd_path)
+
+    @patch('ceph_volume.objectstore.seastore.prepare_utils.unlink_seastore_secondaries')
+    def test_unlink_bs_symlinks_removes_block(self, m_unlink, fake_filesystem):
+        osd_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(osd_path)
+        fake_filesystem.create_file(osd_path + '/block')
+        self.raw.osd_path = osd_path
+        self.raw.unlink_bs_symlinks()
+        assert not fake_filesystem.exists(osd_path + '/block')
+        m_unlink.assert_called_once_with(osd_path)
+
+
+    @patch('ceph_volume.objectstore.seastore_raw.SeastoreRaw.unlink_bs_symlinks')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.create_osd_path')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.link_block')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.terminal.success')
+    def test__activate_no_secondaries(self,
+                                      m_success, m_link_sec, m_link_block,
+                                      m_create_osd_path, m_unlink,
+                                      monkeypatch, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
+
+        self.raw.block_device_path = '/dev/sda'
+        self.raw.args.seastore_secondary = []
+        self.raw._activate('0', 'abcd-1234')
+
+        m_link_block.assert_called_once_with('/dev/sda', '0')
+        m_link_sec.assert_not_called()
+        m_success.assert_called_once()
+
+    @patch('ceph_volume.objectstore.seastore_raw.SeastoreRaw.unlink_bs_symlinks')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.create_osd_path')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.link_block')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.terminal.success')
+    def test__activate_with_secondaries(self,
+                                        m_success, m_link_sec, m_link_block,
+                                        m_create_osd_path, m_unlink,
+                                        monkeypatch, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
+
+        self.raw.block_device_path = '/dev/sda'
+        self.raw.args.seastore_secondary = [('/dev/sdb', 'HDD'), ('/dev/sdc', 'SSD')]
+        self.raw._activate('0', 'abcd-1234')
+
+        m_link_block.assert_called_once_with('/dev/sda', '0')
+        assert m_link_sec.call_count == 2
+        m_link_sec.assert_any_call('/dev/sdb', 'HDD', 1, '0')
+        m_link_sec.assert_any_call('/dev/sdc', 'SSD', 2, '0')
+
+    @patch('ceph_volume.objectstore.seastore_raw.SeastoreRaw.unlink_bs_symlinks')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.create_osd_path')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.link_block')
+    @patch('ceph_volume.terminal.success')
+    def test__activate_skips_bluestore_tool(self,
+                                            m_success, m_link_block,
+                                            m_create_osd_path, m_unlink,
+                                            monkeypatch, conf_ceph_stub, fake_run):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
+
+        self.raw.block_device_path = '/dev/sda'
+        self.raw.args.seastore_secondary = []
+        self.raw._activate('0', 'abcd-1234')
+
+        run_cmds = [c['args'][0][0] for c in fake_run.calls]
+        assert 'ceph-bluestore-tool' not in run_cmds
+
+    # ------------------------------------------------------------------
+    # Tests for the activate() override that bypasses direct_report().
+    # SeaStore devices cannot be discovered via ceph-bluestore-tool
+    # show-label, so the raw activate path must accept explicit
+    # --device / --osd-id / --osd-uuid from the caller.
+    # ------------------------------------------------------------------
+
+    def _setup_activate(self, monkeypatch, **overrides):
+        """Populate self.raw with args and matching instance attrs for activate()."""
+        defaults = dict(
+            no_tmpfs=False,
+            seastore_secondary=[],
+            devices=['/dev/sda'],
+            osd_id='0',
+            osd_fsid='abcd-1234',
+        )
+        defaults.update(overrides)
+        monkeypatch.setenv('CEPH_VOLUME_SKIP_NEEDS_ROOT', '1')
+        self.raw.args = Namespace(**defaults)
+        self.raw.devices = self.raw.args.devices
+        self.raw.osd_id = self.raw.args.osd_id
+        self.raw.osd_fsid = self.raw.args.osd_fsid
+
+    @patch('ceph_volume.objectstore.seastore_raw.SeastoreRaw._activate')
+    def test_activate_calls__activate_with_explicit_ids(self,
+                                                         m_activate,
+                                                         monkeypatch):
+        self._setup_activate(monkeypatch)
+        self.raw.activate()
+        m_activate.assert_called_once_with('0', 'abcd-1234')
+        assert self.raw.block_device_path == '/dev/sda'
+
+    def test_activate_requires_devices(self, monkeypatch):
+        self._setup_activate(monkeypatch, devices=[])
+        with pytest.raises(RuntimeError, match=r'--device'):
+            self.raw.activate()
+
+    def test_activate_requires_osd_id(self, monkeypatch):
+        self._setup_activate(monkeypatch, osd_id='')
+        with pytest.raises(RuntimeError, match=r'--osd-id'):
+            self.raw.activate()
+
+    def test_activate_requires_osd_fsid(self, monkeypatch):
+        self._setup_activate(monkeypatch, osd_fsid='')
+        with pytest.raises(RuntimeError, match=r'--osd-uuid'):
+            self.raw.activate()
+
+    @patch('ceph_volume.objectstore.seastore_raw.SeastoreRaw.unlink_bs_symlinks')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.create_osd_path')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.link_block')
+    @patch('ceph_volume.objectstore.seastore_raw.prepare_utils.link_seastore_secondary')
+    @patch('ceph_volume.terminal.success')
+    def test_activate_propagates_secondaries_to__activate(self,
+                                                           m_success,
+                                                           m_link_sec,
+                                                           m_link_block,
+                                                           m_create_path,
+                                                           m_unlink,
+                                                           monkeypatch,
+                                                           conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted',
+                            lambda path: False)
+        self._setup_activate(
+            monkeypatch,
+            seastore_secondary=[('/dev/sdb', 'HDD'), ('/dev/sdc', 'SSD')],
+        )
+        self.raw.activate()
+
+        m_link_block.assert_called_once_with('/dev/sda', '0')
+        assert m_link_sec.call_count == 2
+        m_link_sec.assert_any_call('/dev/sdb', 'HDD', 1, '0')
+        m_link_sec.assert_any_call('/dev/sdc', 'SSD', 2, '0')

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -336,6 +336,48 @@ class TestValidBatchDataDevice(object):
         assert self.validator('/dev/foo')
 
 
+class TestValidSeastoreSecondary(object):
+
+    def setup_method(self):
+        self.validator = arg_validators.ValidSeastoreSecondary()
+
+    def test_valid_hdd(self):
+        result = self.validator('/dev/sdb:HDD')
+        assert result == ('/dev/sdb', 'HDD')
+
+    def test_valid_ssd(self):
+        result = self.validator('/dev/sdc:SSD')
+        assert result == ('/dev/sdc', 'SSD')
+
+    def test_valid_zbd(self):
+        result = self.validator('/dev/sdd:ZBD')
+        assert result == ('/dev/sdd', 'ZBD')
+
+    def test_valid_random_block_ssd(self):
+        result = self.validator('/dev/nvme0n1:RANDOM_BLOCK_SSD')
+        assert result == ('/dev/nvme0n1', 'RANDOM_BLOCK_SSD')
+
+    def test_invalid_type(self):
+        with pytest.raises(argparse.ArgumentError) as exc:
+            self.validator('/dev/sdb:FLOPPY')
+        assert 'Invalid seastore secondary device type' in str(exc.value)
+
+    def test_missing_colon(self):
+        with pytest.raises(argparse.ArgumentError) as exc:
+            self.validator('/dev/sdb')
+        assert 'DEVICE:TYPE format' in str(exc.value)
+
+    def test_empty_device(self):
+        with pytest.raises(argparse.ArgumentError) as exc:
+            self.validator(':HDD')
+        assert 'device path cannot be empty' in str(exc.value)
+
+    def test_extra_colon(self):
+        with pytest.raises(argparse.ArgumentError) as exc:
+            self.validator('/dev/sdb:HDD:extra')
+        assert 'DEVICE:TYPE format' in str(exc.value)
+
+
 class TestValidFraction(object):
 
     def setup_method(self):

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -323,3 +323,50 @@ class TestMkfs(object):
             '--osd-uuid', 'asdf-1234',
             '--setuser', 'ceph', '--setgroup', 'ceph'])
         assert expected in str(error.value)
+
+
+class TestLinkSeastoreSecondary(object):
+
+    def test_creates_directory_and_symlink(self, fake_run, monkeypatch, fake_filesystem):
+        conf.cluster = 'ceph'
+        monkeypatch.setattr('ceph_volume.util.prepare.system.chown', lambda x: True)
+        fake_filesystem.create_dir('/var/lib/ceph/osd/ceph-0')
+        prepare.link_seastore_secondary('/dev/sdb', 'HDD', 1, '0')
+        sec_dir = fake_filesystem.get_object('/var/lib/ceph/osd/ceph-0/block.HDD.1')
+        assert sec_dir.st_mode & 0o40000  # is a directory
+        assert fake_run.calls
+        ln_cmd = fake_run.calls[0]['args'][0]
+        assert ln_cmd[0] == 'ln'
+        assert ln_cmd[1] == '-s'
+        assert ln_cmd[2] == '/dev/sdb'
+        assert ln_cmd[3] == '/var/lib/ceph/osd/ceph-0/block.HDD.1/block'
+
+    def test_uses_correct_type_and_id(self, fake_run, monkeypatch, fake_filesystem):
+        conf.cluster = 'ceph'
+        monkeypatch.setattr('ceph_volume.util.prepare.system.chown', lambda x: True)
+        fake_filesystem.create_dir('/var/lib/ceph/osd/ceph-5')
+        prepare.link_seastore_secondary('/dev/nvme0n1', 'RANDOM_BLOCK_SSD', 3, '5')
+        ln_cmd = fake_run.calls[0]['args'][0]
+        assert ln_cmd[3] == '/var/lib/ceph/osd/ceph-5/block.RANDOM_BLOCK_SSD.3/block'
+
+
+class TestUnlinkSeastoreSecondaries(object):
+
+    def test_removes_secondary_dirs(self, fake_filesystem):
+        osd_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(osd_path + '/block.HDD.1')
+        fake_filesystem.create_file(osd_path + '/block.HDD.1/block')
+        fake_filesystem.create_dir(osd_path + '/block.SSD.2')
+        fake_filesystem.create_file(osd_path + '/block')
+        prepare.unlink_seastore_secondaries(osd_path)
+        assert not fake_filesystem.exists(osd_path + '/block.HDD.1')
+        assert not fake_filesystem.exists(osd_path + '/block.SSD.2')
+        # non-secondary files are untouched
+        assert fake_filesystem.exists(osd_path + '/block')
+
+    def test_no_secondaries_is_noop(self, fake_filesystem):
+        osd_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(osd_path)
+        fake_filesystem.create_file(osd_path + '/block')
+        prepare.unlink_seastore_secondaries(osd_path)
+        assert fake_filesystem.exists(osd_path + '/block')

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -260,6 +260,23 @@ class ValidFraction(object):
         return fraction_float
 
 
+def validate_objectstore_args(args):
+    """Reject flag combinations that cross objectstore boundaries.
+
+    Seastore does not use --block.db / --block.wal, and bluestore does
+    not use --seastore-secondary.  Call this after argument parsing in
+    every prepare/create path.
+    """
+    if args.objectstore == 'seastore':
+        if getattr(args, 'block_db', None):
+            raise RuntimeError('--block.db cannot be used with --objectstore seastore')
+        if getattr(args, 'block_wal', None):
+            raise RuntimeError('--block.wal cannot be used with --objectstore seastore')
+    elif args.objectstore == 'bluestore':
+        if getattr(args, 'seastore_secondary', None):
+            raise RuntimeError('--seastore-secondary cannot be used with --objectstore bluestore')
+
+
 VALID_SEASTORE_SECONDARY_TYPES = {'HDD', 'SSD', 'ZBD', 'RANDOM_BLOCK_SSD'}
 
 

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -258,3 +258,35 @@ class ValidFraction(object):
         if math.isnan(fraction_float) or fraction_float <= 0.0 or fraction_float > 1.0:
             raise argparse.ArgumentError(None, 'Fraction %f not in (0,1.0]' % fraction_float)
         return fraction_float
+
+
+VALID_SEASTORE_SECONDARY_TYPES = {'HDD', 'SSD', 'ZBD', 'RANDOM_BLOCK_SSD'}
+
+
+class ValidSeastoreSecondary(object):
+    """
+    Validate and parse a seastore secondary device specification of the form
+    DEVICE:TYPE where TYPE is one of HDD, SSD, ZBD, RANDOM_BLOCK_SSD.
+    Returns a (device, type) tuple.
+    """
+
+    def __call__(self, value):
+        parts = value.split(':')
+        if len(parts) != 2:
+            raise argparse.ArgumentError(
+                None,
+                '--seastore-secondary must be in DEVICE:TYPE format, got: %s' % value
+            )
+        device, dtype = parts
+        if not device:
+            raise argparse.ArgumentError(
+                None,
+                '--seastore-secondary device path cannot be empty'
+            )
+        if dtype not in VALID_SEASTORE_SECONDARY_TYPES:
+            raise argparse.ArgumentError(
+                None,
+                'Invalid seastore secondary device type %r, must be one of: %s' % (
+                    dtype, ', '.join(sorted(VALID_SEASTORE_SECONDARY_TYPES)))
+            )
+        return device, dtype

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -5,6 +5,8 @@ may want to change some part of the process, while others might want to consume
 the single-call helper
 """
 import os
+import re
+import shutil
 import logging
 import json
 from ceph_volume import process, conf, terminal
@@ -346,6 +348,39 @@ def _validate_bluestore_device(device, excepted_device_type, osd_uuid):
 
 def link_block(block_device, osd_id):
     _link_device(block_device, 'block', osd_id)
+
+
+def link_seastore_secondary(device, dtype, dev_id, osd_id):
+    """
+    Create the directory-and-symlink structure for a seastore secondary device.
+
+    Seastore expects secondary devices at ``{osd_dir}/block.{TYPE}.{ID}/block``
+    (i.e. a directory containing a ``block`` symlink), as opposed to BlueStore
+    which uses flat symlinks.  This matches the layout produced by vstart.sh and
+    read by SegmentManager::get_segment_manager() in segment_manager.cc.
+    """
+    osd_dir = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+    sec_dir = os.path.join(osd_dir, 'block.%s.%s' % (dtype, dev_id))
+    os.makedirs(sec_dir, exist_ok=True)
+    _link_device(device, 'block.%s.%s/block' % (dtype, dev_id), osd_id)
+
+
+_SEASTORE_SECONDARY_RE = re.compile(r'^block\.[A-Z_]+\.\d+$')
+
+
+def unlink_seastore_secondaries(osd_path):
+    """
+    Remove all seastore secondary device directories (block.TYPE.ID/) from
+    ``osd_path``.
+    """
+    # TODO: once ceph/ceph#68106 (crimson-objectstore-tool dump-superblock) is
+    # merged, call it with --dev-path <primary_device> and remove exactly the
+    # directories listed in config.secondary_devices[] rather than enumerating.
+    # The caller already holds the primary device path before invoking
+    # unlink_bs_symlinks(), so it can be threaded through here.
+    for entry in os.listdir(osd_path):
+        if _SEASTORE_SECONDARY_RE.match(entry):
+            shutil.rmtree(os.path.join(osd_path, entry))
 
 
 def link_wal(wal_device, osd_id, osd_uuid=None):


### PR DESCRIPTION
This series teaches ceph-volume how to prepare and activate SeaStore with secondary devices for hot/cold tiering.                                                                                                         

SeaStore expects a different on-disk layout from BlueStore: secondary devices are directories (`block.HDD.1/`) containing a `block` symlink, rather than flat `block.db/block.wal` symlinks. The `--seastore-secondary DEVICE:TYPE`                                                                                                                                                                                                                           flag can be specified multiple times to attach slower-tier devices to a primary NVMe.                                                                                                                                                                                                                                                                                        
                                                                                                                            
The approach adds `SeastoreLvm` and `SeastoreRaw` subclasses that overrideonly the BlueStore-specific parts (`add_objectstore_opts`, `prepare_osd_req`, `unlink_bs_symlinks`, `_activate`), sharing common behavior through a                                                                                                                                                                                                                                    
`SeastoreMixin`. The existing BlueStore code paths are untouched.   

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
