### PR TITLE
rgw/admin: enhance bucket list --marker to support versioned bucket pagination

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -3,6 +3,10 @@
   very large namespaces.
 * RGW: Bucket Logging suppports creating log buckets in EC pools.
   Implicit logging object commits are now performed asynchronously.
+* RGW: radosgw-admin bucket list now supports pagination for versioned buckets by using
+  both --marker and --object-version options together (e.g., ``--marker=obj1 --object-version=abc123``).
+  This enables proper pagination through versioned bucket listings without duplicates or
+  infinite loops. For non-versioned buckets, use only --marker as before (backward compatible).
 * RGW: OpenSSL engine support is deprecated in favor of provider support.
   - Removed the `openssl_engine_opts` configuration option. OpenSSL engine configuration in string format is no longer supported.
   - Added the `openssl_conf` configuration option for loading specified providers as default providers.

--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -83,6 +83,10 @@ as follows:
   list its objects. Adding --allow-unordered
   removes the ordering requirement, possibly generating results more
   quickly for buckets with large number of objects.
+  Use --marker to paginate through object listings (requires ordered listing;
+  do not use with --allow-unordered). For versioned buckets, also specify
+  --object-version with the instance/version ID to resume from a specific version
+  (e.g., ``--marker=obj1 --object-version=abc123``).
 
 :command:`bucket limit check`
   Show bucket sharding stats.

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -516,6 +516,51 @@ def task(ctx, config):
     assert len(out) >= 1
     assert bucket_name in out;
 
+    # TESTCASE 'bucket-list-versioned','bucket','list','versioned bucket with --object-version marker','succeeds'
+    versioned_bucket_name = bucket_name + '-' + 'versioned'
+    connection.create_bucket(Bucket=versioned_bucket_name)
+    connection.put_bucket_versioning(
+        Bucket=versioned_bucket_name,
+        VersioningConfiguration={'Status': 'Enabled'}
+    )
+
+    # Create exactly 3 versions of a unique object
+    unique_obj_key = 'test-versioned-obj-' + str(int(time.time()))
+    connection.put_object(Bucket=versioned_bucket_name, Key=unique_obj_key, Body=b'version1')
+    connection.put_object(Bucket=versioned_bucket_name, Key=unique_obj_key, Body=b'version2')
+    connection.put_object(Bucket=versioned_bucket_name, Key=unique_obj_key, Body=b'version3')
+
+    # List with marker (name only) and max-entries=3, should get exactly 3 versions
+    (err, out) = rgwadmin(ctx, client, [
+            'bucket', 'list', '--bucket', versioned_bucket_name,
+            '--marker', unique_obj_key,
+            '--max-entries', '3'], check_status=True)
+    assert len(out) == 3, f"Expected exactly 3 versions, got {len(out)}"
+    assert all(v['name'] == unique_obj_key for v in out), "All entries should have the same object name"
+
+    # Now use --marker with --object-version to paginate from the second entry
+    # This should return only the third entry
+    second_instance = out[1]['instance']
+    (err, out2) = rgwadmin(ctx, client, [
+            'bucket', 'list', '--bucket', versioned_bucket_name,
+            '--marker', unique_obj_key,
+            '--object-version', second_instance,
+            '--max-entries', '1'], check_status=True)
+
+    # Should get exactly 1 result, and it should be the third entry from the first list
+    assert len(out2) == 1, f"Expected exactly 1 result, got {len(out2)}"
+    assert out2[0]['name'] == out[2]['name'], "Result should match third entry name"
+    assert out2[0]['instance'] == out[2]['instance'], "Result should match third entry instance"
+
+    # Clean up: delete all versions and the versioned bucket
+    versions = connection.list_object_versions(Bucket=versioned_bucket_name)
+    to_delete = []
+    for v in versions.get('Versions', []):
+        to_delete.append({'Key': v['Key'], 'VersionId': v['VersionId']})
+    if to_delete:
+        connection.delete_objects(Bucket=versioned_bucket_name, Delete={'Objects': to_delete})
+    connection.delete_bucket(Bucket=versioned_bucket_name)
+
     # TESTCASE 'max-bucket-limit,'bucket','create','4 buckets','5th bucket fails due to max buckets == 4'
     connection.create_bucket(Bucket=bucket_name + '2')
     connection.create_bucket(Bucket=bucket_name + '3')

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -551,7 +551,11 @@ void usage()
   cout << "                                 additionally rados objects for incomplete multipart uploads will not be output\n";
   cout << "\nBucket list objects options:\n";
   cout << "   --max-entries                 max number of entries listed (default 1000)\n";
-  cout << "   --marker                      the marker used to specify on which entry the listing begins, default none (i.e., very first entry)\n";
+  cout << "   --marker                      object name marker to specify where listing begins (default: start from beginning)\n";
+  cout << "                                 requires ordered listing (do not use with --allow-unordered)\n";
+  cout << "   --object-version              for versioned buckets: specify the version/instance ID to start from\n";
+  cout << "                                 use together with --marker to paginate through versioned buckets\n";
+  cout << "                                 example: --marker=obj1 --object-version=abc123def456\n";
   cout << "   --show-restore-stats          if the flag is in present it will show restores stats in the bucket stats command\n";
   cout << "\n";
   generic_client_usage();
@@ -7625,7 +7629,14 @@ int main(int argc, const char **argv)
 
       params.prefix = prefix;
       params.delim = delim;
-      params.marker = rgw_obj_key(marker);
+      // Support pagination for versioned buckets using --marker and --object-version
+      // For versioned buckets: use both --marker (name) and --object-version (instance)
+      // For non-versioned buckets: use only --marker (name)
+      if (!object_version.empty()) {
+        params.marker = rgw_obj_key(marker, object_version);
+      } else {
+        params.marker = rgw_obj_key(marker);
+      }
       params.ns = ns;
       params.enforce_ns = false;
       params.list_versions = true;

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -423,7 +423,11 @@
   
   Bucket list objects options:
      --max-entries                 max number of entries listed (default 1000)
-     --marker                      the marker used to specify on which entry the listing begins, default none (i.e., very first entry)
+     --marker                      object name marker to specify where listing begins (default: start from beginning)
+                                   requires ordered listing (do not use with --allow-unordered)
+     --object-version              for versioned buckets: specify the version/instance ID to start from
+                                   use together with --marker to paginate through versioned buckets
+                                   example: --marker=obj1 --object-version=abc123def456
      --show-restore-stats          if the flag is in present it will show restores stats in the bucket stats command
   
     --conf/-c FILE    read configuration from the given configuration file


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/75831


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
