### PR TITLE
cephadm: add get_dependencies to smb service class 

### DIFF
--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -1,7 +1,19 @@
+import enum
 import errno
+import hashlib
 import ipaddress
 import logging
-from typing import Any, Dict, List, Tuple, cast, Optional, Iterable, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    TYPE_CHECKING,
+    Tuple,
+    Union,
+    cast,
+)
 
 from mgr_module import HandleCommandResult
 
@@ -20,6 +32,9 @@ from .cephadmservice import (
     simplified_keyring,
 )
 from ..schedule import DaemonPlacement
+
+if TYPE_CHECKING:
+    from ..module import CephadmOrchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +226,8 @@ class SMBService(CephService):
 
         logger.debug('smb generate_config: %r', config_blobs)
         self._configure_cluster_meta(smb_spec, daemon_spec)
-        return config_blobs, []
+        deps = self.get_dependencies(self.mgr, smb_spec)
+        return config_blobs, deps
 
     def _cert_or_uri(self, data: Optional[str]) -> Optional[str]:
         if data is None:
@@ -426,6 +442,26 @@ class SMBService(CephService):
             )
         return ip
 
+    @classmethod
+    def get_dependencies(
+        cls,
+        mgr: 'CephadmOrchestrator',
+        spec: Optional[ServiceSpec] = None,
+        daemon_type: Optional[str] = None,
+    ) -> List[str]:
+        if not spec:
+            return []
+        assert cls.TYPE == spec.service_type
+        smb_spec = cast(SMBSpec, spec)
+        # NOTE: to be very explicit and do a little future proofing our
+        # 'dependencies' that are not the names of other services will be
+        # "namespaced" using the Dep enum.
+        out = []
+        for ccc in smb_spec.ceph_cluster_configs or []:
+            value = _hash_ceph_cluster_config(ccc)
+            out.append(Dep.META(f'ceph_cluster_config.{ccc.alias}', value))
+        return out
+
 
 Network = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
@@ -469,3 +505,19 @@ def _to_keyring(ext_cluster: SMBExternalCephCluster) -> str:
             '',
         ]
     )
+
+
+def _hash_ceph_cluster_config(spec: SMBExternalCephCluster) -> str:
+    _fields = ['alias', 'fsid', 'mon_host', 'user', 'key']
+    fdg = hashlib.sha256()
+    for field_name in _fields:
+        fdg.update(getattr(spec, field_name, '').encode())
+    return f'sha256:{fdg.hexdigest()}'
+
+
+class Dep(enum.Enum):
+    META = 'smb+meta'  # multiple fields as a digest
+    FIELD = 'smb+field'  # a single field and unmanged value
+
+    def __call__(self, key: str, value: str) -> str:
+        return f'{self.value}:{key}={value}'

--- a/src/pybind/mgr/cephadm/tests/services/test_smb.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_smb.py
@@ -1,7 +1,7 @@
 import json
 from unittest.mock import patch
 
-from cephadm.services.smb import SMBSpec
+from cephadm.services.smb import SMBSpec, SMBExternalCephCluster
 from cephadm.module import CephadmOrchestrator
 from cephadm.tests.fixtures import with_host, with_service, async_side_effect
 
@@ -148,3 +148,35 @@ class TestSMB:
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+
+def test_smb_get_dependencies(cephadm_module):
+    from cephadm.services.smb import SMBService
+
+    spec = SMBSpec(
+        cluster_id='foxtrot',
+        features=['domain'],
+        config_uri='rados://.smb/foxtrot/config2.json',
+        join_sources=[
+            'rados:mon-config-key:smb/config/foxtrot/join2.json',
+        ],
+        include_ceph_users=[
+            'client.smb.fs.cephfs.share1',
+            'client.smb.fs.cephfs.share2',
+            'client.smb.fs.fs2.share3',
+        ],
+        ceph_cluster_configs=[
+            SMBExternalCephCluster(
+                alias="exo",
+                fsid='cf05db31-3d4e-4ffd-85ad-753434d5add1',
+                mon_host='[v2:192.168.76.200:3300/0,v1:192.168.76.200:6789/0]',
+                user='client.smb.remote1',
+                key='AQBAAK9ptYayIRAAQ1Bcpti9yMvX2Gl0KMmc4Q=='
+            )
+        ]
+    )
+
+    deps = SMBService.get_dependencies(cephadm_module, spec, spec.service_type)
+    assert deps == [
+        'smb+meta:ceph_cluster_config.exo=sha256:859b001f76df4d184b858b9c3e323ca8ff85a311414d0405f4484d17aa481ef3'
+    ]


### PR DESCRIPTION


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
