### PR TITLE
mgr/dashboard: NVMeoF namespace create form should show subsystem selection first

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.html
@@ -20,17 +20,56 @@
         </cd-help-text>
       </div>
 
+      <!-- Subsystem -->
+      <div cdsRow
+           class="form-item">
+        <div cdsCol>
+          <cds-select
+            formControlName="subsystem"
+            cdValidate
+            #subsystemRef="cdValidate"
+            label="Select subsystem"
+            [invalid]="subsystemRef.isInvalid"
+            invalidText="This field is required"
+            i18n-label
+            i18n-invalidText>
+            @if (!subsystems) {
+            <option
+              [ngValue]="null"
+              disabled>Loading...</option>
+            }
+            @if (subsystems && subsystems.length === 0) {
+            <option
+              [ngValue]="null"
+              disabled>-- No subsystems available --</option>
+            }
+            @if (subsystems && subsystems.length > 0) {
+            <option
+              selectionFeedback="top-after-reopen"
+              value=""
+              selected>Select a subsystem</option>
+            }
+            @for (subsystem of subsystems; track subsystem.nqn) {
+            <option
+              [value]="subsystem.nqn">{{ subsystem.nqn }}</option>
+            }
+          </cds-select>
+        </div>
+      </div>
+
       <!-- Namespace Count (Create only) -->
       <div cdsRow
            class="form-item">
         <div cdsCol>
           <cds-number
             formControlName="nsCount"
+            cdValidate
+            #nsCountRef="cdValidate"
             label="Number of namespaces"
             helperText="No. of namespaces to generate. Value must be between 1 and 5."
             [min]="MIN_NAMESPACE_CREATE"
             [max]="MAX_NAMESPACE_CREATE"
-            [invalid]="nsForm.controls['nsCount'].invalid && (nsForm.controls['nsCount'].dirty || nsForm.controls['nsCount'].touched)"
+            [invalid]="nsCountRef.isInvalid"
             [invalidText]="nsForm.getError('required', 'nsCount') ? requiredInvalidText : nsCountInvalidText"
             i18n-label
             i18n-helperText>
@@ -44,11 +83,13 @@
         <div cdsCol>
           <cds-number
             formControlName="namespace_size"
+            cdValidate
+            #namespaceSizeRef="cdValidate"
             label="Namespace size (GiB)"
             helperText="Specify the size to expose to hosts. Leave blank for full device/file."
             placeholder="e.g. 100"
             [min]="0"
-            [invalid]="nsForm.controls['namespace_size'].invalid && (nsForm.controls['namespace_size'].dirty || nsForm.controls['namespace_size'].touched)"
+            [invalid]="namespaceSizeRef.isInvalid"
             [invalidText]="namespaceSizeError"
             i18n-label
             i18n-helperText>
@@ -126,49 +167,16 @@
       </div>
       }
 
-      <!-- Subsystem -->
-      <div cdsRow
-           class="form-item">
-        <div cdsCol>
-          <cds-select
-            formControlName="subsystem"
-            label="Select subsystem"
-            [invalid]="nsForm.controls['subsystem'].invalid && (nsForm.controls['subsystem'].dirty || nsForm.controls['subsystem'].touched)"
-            invalidText="This field is required"
-            i18n-label
-            i18n-invalidText>
-            @if (subsystems === undefined) {
-            <option
-              [ngValue]="null"
-              disabled>Loading...</option>
-            }
-            @if (subsystems && subsystems.length === 0) {
-            <option
-              [ngValue]="null"
-              disabled>-- No subsystems available --</option>
-            }
-            @if (subsystems && subsystems.length > 0) {
-            <option
-              selectionFeedback="top-after-reopen"
-              value=""
-              selected>Select a subsystem</option>
-            }
-            @for (subsystem of subsystems; track subsystem.nqn) {
-            <option
-              [value]="subsystem.nqn">{{ subsystem.nqn }}</option>
-            }
-          </cds-select>
-        </div>
-      </div>
-
       <!-- Pool -->
       <div cdsRow
            class="form-item">
         <div cdsCol>
           <cds-select
             formControlName="pool"
+            cdValidate
+            #poolRef="cdValidate"
             label="RBD image pool"
-            [invalid]="nsForm.controls['pool'].invalid && (nsForm.controls['pool'].dirty || nsForm.controls['pool'].touched)"
+            [invalid]="poolRef.isInvalid"
             invalidText="This field is required"
             helperText="Pool where the backing Ceph block device resides."
             i18n-label
@@ -237,11 +245,13 @@
               i18n>Image name (optional)</label>
             <cds-text-label
               helperText="Provide a name for the images. For bulk creation, this will be used as the base prefix with numeric suffixes (e.g., img-1, img-2). Leave blank to auto-generate."
-              [invalid]="nsForm.controls['rbd_image_name'].invalid && (nsForm.controls['rbd_image_name'].dirty || nsForm.controls['rbd_image_name'].touched)"
+              [invalid]="rbdImageNameRef.isInvalid"
               [invalidText]="nsForm.getError('rbdImageName', 'rbd_image_name') ? 'Image name contains invalid characters' : ''"
               i18n-helperText
               i18n-invalidText>
               <input cdsText
+                     cdValidate
+                     #rbdImageNameRef="cdValidate"
                      placeholder="Enter a name"
                      formControlName="rbd_image_name" />
             </cds-text-label>
@@ -257,8 +267,10 @@
         <div cdsCol>
           <cds-select
             formControlName="rbd_image_name"
+            cdValidate
+            #rbdImageSelectRef="cdValidate"
             label="RBD Image"
-            [invalid]="nsForm.controls['rbd_image_name'].invalid && (nsForm.controls['rbd_image_name'].dirty || nsForm.controls['rbd_image_name'].touched)"
+            [invalid]="rbdImageSelectRef.isInvalid"
             invalidText="This field is required"
             helperText="Select an existing RBD image from the pool to expose as a namespace."
             i18n-label
@@ -286,19 +298,21 @@
           <cds-text-label
             label="Image size (GiB)"
             helperText="The size of the namespace image."
-            [invalid]="nsForm.controls['image_size'].invalid && (nsForm.controls['image_size'].dirty || nsForm.controls['image_size'].touched)"
+            [invalid]="imageSizeRef.isInvalid"
             [invalidText]="sizeError"
             cdRequiredField="Image Size"
             i18n-label
             i18n-helperText>
             <input cdsText
+                   cdValidate
+                   #imageSizeRef="cdValidate"
                    type="text"
                    placeholder="e.g. 100 GiB"
                    id="image_size"
                    formControlName="image_size"
                    defaultUnit="GiB"
                    [min]="0"
-                   [invalid]="nsForm.controls['image_size'].invalid && (nsForm.controls['image_size'].dirty || nsForm.controls['image_size'].touched)"
+                   [invalid]="imageSizeRef.isInvalid"
                    cdDimlessBinary>
           </cds-text-label>
           <ng-template #sizeError>
@@ -320,4 +334,3 @@
     </div>
   </div>
 </form>
-

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
@@ -45,7 +45,7 @@ export class NvmeofNamespacesFormComponent implements OnInit {
 
   nsForm: CdFormGroup;
   subsystemNQN: string;
-  subsystems: NvmeofSubsystem[] = [];
+  subsystems: NvmeofSubsystem[] | null = null;
   rbdPools: Array<Pool> = null;
   rbdImages: any[] = [];
   initiatorCandidates: { content: string; selected: boolean }[] = [];


### PR DESCRIPTION
mgr/dashboard: NVMeoF namespace create form should show subsystem selection first

Fixes: https://tracker.ceph.com/issues/75846

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

PR Decription : 
## Summary
Reordered the NVMeoF namespace create form to make subsystem selection appear first, improving flow and usability.

## What changed
- Moved "Select subsystem" to the top of the Create Namespace form.
- Kept all existing validation and form behavior unchanged.

## Why
Host-related options depend on the selected subsystem, so showing subsystem first makes the form intuitive and avoids confusion.

Sceenshot : 
<img width="3832" height="2116" alt="image" src="https://github.com/user-attachments/assets/71f17241-0914-4716-b968-c1705d0912c9" />
<img width="3832" height="2116" alt="image" src="https://github.com/user-attachments/assets/2eddcd53-6e5d-4994-be81-1f4c2404a09f" />

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
