### PR TITLE
mgr/dashboard: Add option should be enabled even if allow all host access is enabled in nvme/tcp

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.html
@@ -13,6 +13,7 @@
       #tearsheetStep
                modal-primary-focus
       [group]="group"
+      [allowAllHosts]="allowAllHosts"
       [existingHosts]="existingHosts"></cd-nvmeof-subsystem-step-two>
   </cd-tearsheet-step>
   @if(showAuthStep) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
 
@@ -31,7 +31,7 @@ describe('NvmeofInitiatorsFormComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            queryParams: of({ group: 'test-group' }),
+            queryParamMap: of(convertToParamMap({ group: 'test-group' })),
             params: of({ subsystem_nqn: 'nqn.test' }),
             parent: {
               params: of({ subsystem_nqn: 'nqn.test' })
@@ -57,6 +57,22 @@ describe('NvmeofInitiatorsFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set allowAllHosts to true when disableAllowAll is not set', () => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'getCurrentNavigation').and.returnValue(null);
+    component.ngOnInit();
+    expect(component.allowAllHosts).toBe(true);
+  });
+
+  it('should set allowAllHosts to false when disableAllowAll is true in navigation state', () => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'getCurrentNavigation').and.returnValue({
+      extras: { state: { disableAllowAll: true } }
+    } as any);
+    component.ngOnInit();
+    expect(component.allowAllHosts).toBe(false);
   });
 
   it('should initialize with two steps (Host access control + Authentication optional)', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.ts
@@ -9,7 +9,7 @@ import {
   NvmeofSubsystemInitiator
 } from '~/app/shared/models/nvmeof';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
 
 type InitiatorsFormPayload = Pick<HostStepType, 'hostType' | 'addedHosts'> &
@@ -32,6 +32,7 @@ export class NvmeofInitiatorsFormComponent implements OnInit {
   isSubmitLoading = false;
   existingHosts: string[] = [];
   showAuthStep = true;
+  allowAllHosts = true;
   stepTwoValue: HostStepType = null;
 
   @ViewChild(TearsheetComponent) tearsheet!: TearsheetComponent;
@@ -50,21 +51,26 @@ export class NvmeofInitiatorsFormComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.route.queryParams.subscribe((params) => {
-      this.group = params?.['group'];
+    this.route.queryParamMap.subscribe((params) => {
+      this.group = params.get('group');
     });
-    this.route.parent.params.subscribe((params: any) => {
+    this.allowAllHosts = !this.getDisableAllowAllState();
+    this.route.parent.params.subscribe((params: Params) => {
       if (params.subsystem_nqn) {
         this.subsystemNQN = params.subsystem_nqn;
       }
     });
-    this.route.params.subscribe((params: any) => {
+    this.route.params.subscribe((params: Params) => {
       if (!this.subsystemNQN && params.subsystem_nqn) {
         this.subsystemNQN = params.subsystem_nqn;
       }
       this.fetchExistingHosts();
     });
     this.rebuildSteps();
+  }
+
+  private getDisableAllowAllState(): boolean {
+    return this.router.getCurrentNavigation()?.extras?.state?.['disableAllowAll'] === true;
   }
 
   rebuildSteps() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.html
@@ -1,34 +1,42 @@
-@if (hasAllHostsAllowed()) {
+@if (allowAllHosts) {
   <cd-alert-panel
     class="cds-mb-4"
-    type="warning"
+    type="info"
     [showTitle]="false">
-    <div cdsStack="vertical"
-         gap="1">
-      <strong class="cds-mb-1"
-              i18n>All hosts allowed</strong>
-      <p class="cds-mb-0"
-         i18n>
-        Allowing all hosts grants access to every initiator on the network. Authentication is not supported in this mode, which may expose the subsystem to unauthorized access.
-      </p>
+    <div cdsStack="horizontal"
+         gap="2">
+      <div cdsStack="vertical"
+           gap="2">
+        <strong i18n>Host access: All hosts allowed</strong>
+        <p
+          class="cds-mb-0 cds-mt-1"
+          i18n
+        >
+          Allowing all hosts grants access to every initiator on the network. Authentication is not supported in this mode, which may expose the subsystem to unauthorized access.
+        </p>
+      </div>
+      <a cdsLink
+         class="cds-ml-3"
+         (click)="openAddInitiatorForm(true)"
+         i18n>Edit host access</a>
     </div>
   </cd-alert-panel>
+} @else {
+  <cd-table [data]="initiators"
+            columnMode="flex"
+            (fetchData)="listInitiators()"
+            [columns]="initiatorColumns"
+            selectionType="multiClick"
+            (updateSelection)="updateSelection($event)">
+    <div class="table-actions">
+      <cd-table-actions [permission]="permission"
+                        [selection]="selection"
+                        class="btn-group"
+                        [tableActions]="tableActions">
+      </cd-table-actions>
+    </div>
+  </cd-table>
 }
-
-<cd-table [data]="initiators"
-          columnMode="flex"
-          (fetchData)="listInitiators()"
-          [columns]="initiatorColumns"
-          selectionType="multiClick"
-          (updateSelection)="updateSelection($event)">
-  <div class="table-actions">
-    <cd-table-actions [permission]="permission"
-                      [selection]="selection"
-                      class="btn-group"
-                      [tableActions]="tableActions">
-    </cd-table-actions>
-  </div>
-</cd-table>
 
 <ng-template #hostNqnTpl
              let-row="data.row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
@@ -1,13 +1,14 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
-import { ModalService } from '~/app/shared/services/modal.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { ALLOW_ALL_HOST } from '~/app/shared/models/nvmeof';
 
@@ -15,7 +16,7 @@ import { NvmeofInitiatorsListComponent } from './nvmeof-initiators-list.componen
 
 const mockInitiators = [
   {
-    nqn: ALLOW_ALL_HOST,
+    nqn: 'nqn.2016-06.io.spdk:host1',
     use_dhchap: false
   }
 ];
@@ -23,7 +24,8 @@ const mockInitiators = [
 const mockSubsystem = {
   nqn: 'nqn.2016-06.io.spdk:cnode1',
   serial_number: '12345',
-  has_dhchap_key: false
+  has_dhchap_key: false,
+  allow_any_host: false
 };
 
 class MockNvmeOfService {
@@ -41,26 +43,51 @@ class MockAuthStorageService {
   }
 }
 
-class MockModalService {}
+class MockModalCdsService {}
 
 class MockTaskWrapperService {}
 
 describe('NvmeofInitiatorsListComponent', () => {
   let component: NvmeofInitiatorsListComponent;
   let fixture: ComponentFixture<NvmeofInitiatorsListComponent>;
+  let nvmeofService: NvmeofService;
+  let routeParams$: Subject<any>;
+  let queryParams$: Subject<any>;
+  let routerEvents$: Subject<any>;
 
   beforeEach(async () => {
+    routeParams$ = new Subject<any>();
+    queryParams$ = new Subject<any>();
+    routerEvents$ = new Subject<any>();
+
     await TestBed.configureTestingModule({
       declarations: [NvmeofInitiatorsListComponent],
       imports: [HttpClientModule, RouterTestingModule, SharedModule],
       providers: [
         { provide: NvmeofService, useClass: MockNvmeOfService },
         { provide: AuthStorageService, useClass: MockAuthStorageService },
-        { provide: ModalService, useClass: MockModalService },
-        { provide: TaskWrapperService, useClass: MockTaskWrapperService }
+        { provide: ModalCdsService, useClass: MockModalCdsService },
+        { provide: TaskWrapperService, useClass: MockTaskWrapperService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: { params: routeParams$.asObservable() },
+            queryParams: queryParams$.asObservable()
+          }
+        },
+        {
+          provide: Router,
+          useValue: {
+            events: routerEvents$.asObservable(),
+            navigate: jasmine.createSpy('navigate')
+          }
+        }
       ]
     }).compileComponents();
+  });
 
+  beforeEach(() => {
+    nvmeofService = TestBed.inject(NvmeofService);
     fixture = TestBed.createComponent(NvmeofInitiatorsListComponent);
     component = fixture.componentInstance;
     component.subsystemNQN = 'nqn.2016-06.io.spdk:cnode1';
@@ -84,9 +111,23 @@ describe('NvmeofInitiatorsListComponent', () => {
     expect(component.getDisplayedHostNqn(ALLOW_ALL_HOST)).toBe('Any');
   }));
 
+  it('should default allowAllHosts to false', () => {
+    expect(component.allowAllHosts).toBe(false);
+  });
+
+  it('should set allowAllHosts to true when subsystem allows any host and no initiators', fakeAsync(() => {
+    const allowAllSubsystem = { ...mockSubsystem, allow_any_host: true };
+    spyOn(nvmeofService, 'getInitiators').and.returnValue(of([]));
+    spyOn(nvmeofService, 'getSubsystem').and.returnValue(of(allowAllSubsystem));
+    component.listInitiators();
+    component.getSubsystem();
+    tick();
+    expect(component.allowAllHosts).toBe(true);
+  }));
+
   it('should update authStatus when initiator has dhchap_key', fakeAsync(() => {
     const initiatorsWithKey = [{ nqn: 'nqn1', use_dhchap: true }];
-    spyOn(TestBed.inject(NvmeofService), 'getInitiators').and.returnValue(of(initiatorsWithKey));
+    spyOn(nvmeofService, 'getInitiators').and.returnValue(of(initiatorsWithKey));
     component.listInitiators();
     tick();
     expect(component.authStatus).toBe('Unidirectional');
@@ -96,9 +137,76 @@ describe('NvmeofInitiatorsListComponent', () => {
     const initiatorsWithKey = [{ nqn: 'nqn1', use_dhchap: true }];
     component.initiators = initiatorsWithKey;
     const subsystemWithKey = { ...mockSubsystem, has_dhchap_key: true };
-    spyOn(TestBed.inject(NvmeofService), 'getSubsystem').and.returnValue(of(subsystemWithKey));
+    spyOn(nvmeofService, 'getSubsystem').and.returnValue(of(subsystemWithKey));
     component.getSubsystem();
     tick();
     expect(component.authStatus).toBe('Bi-directional');
+  }));
+
+  it('should fetch only when both route and query params are available', () => {
+    const newFixture = TestBed.createComponent(NvmeofInitiatorsListComponent);
+    const newComponent = newFixture.componentInstance;
+    newComponent.subsystemNQN = undefined;
+    newComponent.group = undefined;
+    const listInitiatorsSpy = spyOn(newComponent, 'listInitiators');
+    const getSubsystemSpy = spyOn(newComponent, 'getSubsystem');
+
+    newComponent.ngOnInit();
+
+    routeParams$.next({ subsystem_nqn: 'nqn.from.route' });
+    expect(listInitiatorsSpy).not.toHaveBeenCalled();
+    expect(getSubsystemSpy).not.toHaveBeenCalled();
+
+    queryParams$.next({ group: 'group-from-query' });
+    expect(listInitiatorsSpy).toHaveBeenCalledTimes(1);
+    expect(getSubsystemSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should refresh on non-modal navigation changes', () => {
+    const newFixture = TestBed.createComponent(NvmeofInitiatorsListComponent);
+    const newComponent = newFixture.componentInstance;
+    newComponent.subsystemNQN = 'nqn.2016-06.io.spdk:cnode1';
+    newComponent.group = 'group1';
+    const listInitiatorsSpy = spyOn(newComponent, 'listInitiators');
+    const getSubsystemSpy = spyOn(newComponent, 'getSubsystem');
+
+    newComponent.ngOnInit();
+    routerEvents$.next(new NavigationEnd(1, '/nvmeof/(modal:add)', '/nvmeof/(modal:add)'));
+    expect(listInitiatorsSpy).toHaveBeenCalledTimes(1);
+    expect(getSubsystemSpy).toHaveBeenCalledTimes(1);
+
+    routerEvents$.next(new NavigationEnd(2, '/nvmeof/subsystem', '/nvmeof/subsystem'));
+    expect(listInitiatorsSpy).toHaveBeenCalledTimes(2);
+    expect(getSubsystemSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should filter ALLOW_ALL_HOST from array response', fakeAsync(() => {
+    spyOn(nvmeofService, 'getInitiators').and.returnValue(
+      of([
+        { nqn: ALLOW_ALL_HOST, use_dhchap: false },
+        { nqn: 'nqn.2016-06.io.spdk:host2', use_dhchap: false }
+      ])
+    );
+
+    component.listInitiators();
+    tick();
+
+    expect(component.initiators).toEqual([{ nqn: 'nqn.2016-06.io.spdk:host2', use_dhchap: false }]);
+  }));
+
+  it('should support hosts-wrapper response from getInitiators', fakeAsync(() => {
+    spyOn(nvmeofService, 'getInitiators').and.returnValue(
+      of({
+        hosts: [
+          { nqn: ALLOW_ALL_HOST, use_dhchap: false },
+          { nqn: 'nqn.2016-06.io.spdk:host3', use_dhchap: true }
+        ]
+      })
+    );
+
+    component.listInitiators();
+    tick();
+
+    expect(component.initiators).toEqual([{ nqn: 'nqn.2016-06.io.spdk:host3', use_dhchap: true }]);
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
@@ -1,5 +1,7 @@
-import { Component, Input, OnInit, TemplateRef, ViewChild } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, Input, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
@@ -28,7 +30,7 @@ import { NvmeofEditHostKeyModalComponent } from '../nvmeof-edit-host-key-modal/n
   styleUrls: ['./nvmeof-initiators-list.component.scss'],
   standalone: false
 })
-export class NvmeofInitiatorsListComponent implements OnInit {
+export class NvmeofInitiatorsListComponent implements OnInit, OnDestroy {
   @Input()
   subsystemNQN: string;
   @Input()
@@ -50,6 +52,9 @@ export class NvmeofInitiatorsListComponent implements OnInit {
   allowAllHost = ALLOW_ALL_HOST;
   yesLabel = $localize`Yes`;
   noLabel = $localize`No`;
+  allowAllHosts = false;
+
+  private subscriptions = new Subscription();
 
   constructor(
     public actionLabels: ActionLabelsI18n,
@@ -78,8 +83,22 @@ export class NvmeofInitiatorsListComponent implements OnInit {
         this.fetchIfReady();
       });
     } else {
+      this.listInitiators();
       this.getSubsystem();
     }
+
+    this.subscriptions.add(
+      this.router.events
+        .pipe(
+          filter(
+            (event): event is NavigationEnd =>
+              event instanceof NavigationEnd && !event.urlAfterRedirects.includes('(modal:')
+          )
+        )
+        .subscribe(() => {
+          this.fetchIfReady();
+        })
+    );
 
     this.initiatorColumns = [
       {
@@ -98,12 +117,9 @@ export class NvmeofInitiatorsListComponent implements OnInit {
         name: this.actionLabels.ADD,
         permission: 'create',
         icon: Icons.add,
-        click: () =>
-          this.router.navigate([{ outlets: { modal: [URLVerbs.ADD, 'initiator'] } }], {
-            queryParams: { group: this.group },
-            relativeTo: this.route.parent
-          }),
-        canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
+        click: () => this.openAddInitiatorForm(),
+        canBePrimary: (selection: CdTableSelection) => !selection.hasSelection,
+        disable: () => this.hasAllHostsAllowed()
       },
       {
         name: $localize`Edit host key`,
@@ -124,6 +140,10 @@ export class NvmeofInitiatorsListComponent implements OnInit {
     ];
   }
 
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+
   private fetchIfReady() {
     if (this.subsystemNQN && this.group) {
       this.listInitiators();
@@ -131,15 +151,31 @@ export class NvmeofInitiatorsListComponent implements OnInit {
     }
   }
 
+  openAddInitiatorForm(disableAllowAll = false) {
+    this.router.navigate([{ outlets: { modal: [URLVerbs.ADD, 'initiator'] } }], {
+      queryParams: { group: this.group },
+      state: { disableAllowAll },
+      relativeTo: this.route.parent
+    });
+  }
+
   editHostKeyModal() {
     const selected = this.selection.selected[0];
     if (!selected) return;
-    this.modalService.show(NvmeofEditHostKeyModalComponent, {
+    const modalRef = this.modalService.show(NvmeofEditHostKeyModalComponent, {
       subsystemNQN: this.subsystemNQN,
       hostNQN: selected.nqn,
       group: this.group,
       dhchapKey: selected.dhchap_key || ''
     });
+    if (modalRef?.closeChange) {
+      this.subscriptions.add(
+        modalRef.closeChange.subscribe(() => {
+          this.listInitiators();
+          this.getSubsystem();
+        })
+      );
+    }
   }
 
   getAllowAllHostIndex() {
@@ -147,7 +183,7 @@ export class NvmeofInitiatorsListComponent implements OnInit {
   }
 
   hasAllHostsAllowed(): boolean {
-    return this.initiators.some((initiator) => initiator.nqn === ALLOW_ALL_HOST);
+    return !!this.subsystem?.allow_any_host && this.initiators.length === 0;
   }
 
   updateSelection(selection: CdTableSelection) {
@@ -159,19 +195,22 @@ export class NvmeofInitiatorsListComponent implements OnInit {
       .getInitiators(this.subsystemNQN, this.group)
       .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
         const initiators = Array.isArray(response) ? response : response?.hosts || [];
-        this.initiators = initiators;
+        this.initiators = initiators.filter((i) => i.nqn !== ALLOW_ALL_HOST);
         this.updateAuthStatus();
       });
   }
 
   getSubsystem() {
-    this.nvmeofService.getSubsystem(this.subsystemNQN, this.group).subscribe((subsystem: any) => {
-      this.subsystem = subsystem;
-      this.updateAuthStatus();
-    });
+    this.nvmeofService
+      .getSubsystem(this.subsystemNQN, this.group)
+      .subscribe((subsystem: NvmeofSubsystem) => {
+        this.subsystem = subsystem;
+        this.updateAuthStatus();
+      });
   }
 
   updateAuthStatus() {
+    this.allowAllHosts = this.hasAllHostsAllowed();
     if (this.subsystem && this.initiators) {
       this.authStatus = getSubsystemAuthStatus(this.subsystem, this.initiators);
     }
@@ -195,7 +234,7 @@ export class NvmeofInitiatorsListComponent implements OnInit {
       itemNames = [...hostNQNs, $localize`Allow any host(*)`];
     }
     const hostName = itemNames[0];
-    this.modalService.show(DeleteConfirmationModalComponent, {
+    const deleteModalRef = this.modalService.show(DeleteConfirmationModalComponent, {
       itemDescription: $localize`host`,
       impact: DeletionImpact.high,
       itemNames,
@@ -215,5 +254,13 @@ export class NvmeofInitiatorsListComponent implements OnInit {
           })
         })
     });
+    if (deleteModalRef?.closeChange) {
+      this.subscriptions.add(
+        deleteModalRef.closeChange.subscribe(() => {
+          this.listInitiators();
+          this.getSubsystem();
+        })
+      );
+    }
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
@@ -31,8 +31,11 @@ const mockNamespaces = [
 ];
 
 class MockNvmeOfService {
+  gatewayGroupsResponse: any = [[{ id: 'g1' }]];
+  namespacesResponse: any = { namespaces: mockNamespaces };
+
   listGatewayGroups() {
-    return of([[{ id: 'g1' }]]);
+    return of(this.gatewayGroupsResponse);
   }
 
   formatGwGroupsList(_response: any) {
@@ -40,7 +43,7 @@ class MockNvmeOfService {
   }
 
   listNamespaces(_group?: string) {
-    return of({ namespaces: mockNamespaces });
+    return of(this.namespacesResponse);
   }
 }
 
@@ -61,6 +64,7 @@ describe('NvmeofNamespacesListComponent', () => {
   let fixture: ComponentFixture<NvmeofNamespacesListComponent>;
 
   let modalService: MockModalCdsService;
+  let nvmeofService: MockNvmeOfService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -81,6 +85,7 @@ describe('NvmeofNamespacesListComponent', () => {
     component.subsystemNQN = 'nqn.2001-07.com.ceph:1721040751436';
     fixture.detectChanges();
     modalService = TestBed.inject(ModalCdsService) as any;
+    nvmeofService = TestBed.inject(NvmeofService) as any;
   });
 
   it('should create', () => {
@@ -116,5 +121,48 @@ describe('NvmeofNamespacesListComponent', () => {
     expect(args.itemNames).toEqual([1]);
     expect(args.itemDescription).toBeDefined();
     expect(typeof args.submitActionObservable).toBe('function');
+  });
+
+  it('should deduplicate namespaces by nsid and subsystem nqn', (done) => {
+    component.group = 'g1';
+    nvmeofService.namespacesResponse = {
+      namespaces: [
+        { nsid: 1, ns_subsystem_nqn: 'sub1' },
+        { nsid: 1, ns_subsystem_nqn: 'sub1' },
+        { nsid: 1, ns_subsystem_nqn: 'sub2' }
+      ]
+    };
+
+    component.namespaces$.pipe(take(1)).subscribe((namespaces) => {
+      expect(namespaces).toEqual([
+        { nsid: 1, ns_subsystem_nqn: 'sub1', unique_id: '1_sub1' },
+        { nsid: 1, ns_subsystem_nqn: 'sub2', unique_id: '1_sub2' }
+      ]);
+      done();
+    });
+
+    component.listNamespaces();
+  });
+
+  it('should default to first group and keep default placeholder when groups exist', () => {
+    component.group = null;
+    component.gwGroups = [{ content: 'g1', selected: false }] as any;
+
+    component.updateGroupSelectionState();
+
+    expect(component.group).toBe('g1');
+    expect(component.gwGroupsEmpty).toBe(false);
+    expect(component.gwGroupPlaceholder).toBe('Enter group name');
+  });
+
+  it('should set error placeholder and call preventDefault on group fetch failure', () => {
+    const preventDefault = jasmine.createSpy('preventDefault');
+
+    component.handleGatewayGroupsError({ preventDefault });
+
+    expect(component.gwGroups).toEqual([]);
+    expect(component.gwGroupsEmpty).toBe(true);
+    expect(component.gwGroupPlaceholder).toBe('Unable to fetch Gateway groups');
+    expect(preventDefault).toHaveBeenCalled();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.html
@@ -23,6 +23,7 @@
           orientation="vertical">
           <cds-radio
             [value]="HOST_TYPE.ALL"
+            [disabled]="!allowAllHosts"
             class="cds-mb-2"
             i18n>Allow all hosts</cds-radio>
           <span class="cds--form__helper-text cds-mb-3"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.ts
@@ -20,6 +20,7 @@ import { TearsheetStep } from '~/app/shared/models/tearsheet-step';
 export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
   @Input() group!: string;
   @Input() existingHosts: string[] = [];
+  @Input() allowAllHosts = true;
   @ViewChild('rightInfluencer', { static: true })
   rightInfluencer?: TemplateRef<any>;
   formGroup: CdFormGroup;
@@ -36,7 +37,6 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
   csvDropText: string = $localize`Drag and drop files here or click to upload`;
   NQN_REGEX = /^nqn\.(19|20)\d\d-(0[1-9]|1[0-2])\.\D{2,3}(\.[A-Za-z0-9-]+)+(:[A-Za-z0-9-\.]+(:[A-Za-z0-9-\.]+)*)$/;
   NQN_REGEX_UUID = /^nqn\.2014-08\.org\.nvmexpress:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-  ALLOW_ALL_HOST = '*';
   uploadedHosts = new Set<string>();
 
   constructor(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
@@ -133,4 +133,39 @@ describe('NvmeofSubsystemsComponent', () => {
   it('should set first group as default initially', () => {
     expect(component.group).toBe(mockGroups[0][0].spec.group);
   });
+
+  it('should mark only current group as selected', () => {
+    component.group = 'foo';
+    component.gwGroups = [{ content: 'default' }, { content: 'foo' }] as any;
+
+    component.updateGroupSelectionState();
+
+    expect(component.gwGroups).toEqual([
+      { content: 'default', selected: false },
+      { content: 'foo', selected: true }
+    ]);
+  });
+
+  it('should clear selected group and refresh subsystem list', () => {
+    component.group = 'default';
+    const getSubsystemsSpy = spyOn(component, 'getSubsystems');
+
+    component.onGroupClear();
+
+    expect(component.group).toBeNull();
+    expect(getSubsystemsSpy).toHaveBeenCalled();
+  });
+
+  it('should set error placeholder and prevent default on groups load error', () => {
+    const preventDefault = jasmine.createSpy('preventDefault');
+    component.context = { error: jasmine.createSpy('error') } as any;
+
+    component.handleGatewayGroupsError({ preventDefault });
+
+    expect(component.gwGroups).toEqual([]);
+    expect(component.gwGroupsEmpty).toBe(true);
+    expect(component.gwGroupPlaceholder).toBe('Unable to fetch Gateway groups');
+    expect(preventDefault).toHaveBeenCalled();
+    expect(component.context.error).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION



https://github.com/user-attachments/assets/037aea57-0520-4a86-baa4-b060f8e380bd



---
Fixes: https://tracker.ceph.com/issues/75509

Signed-off-by: pujaoshahu <pshahu@redhat.com>

---

Summery: 

This PR fixes issues on the NVMe/TCP Initiators page related to the “Allow all hosts” behavior and UI updates.
Added a proper handler for the “Edit host access” link in the alert banner, making it functional.
Ensured that after switching from “Allow all hosts” to restricted access via the Add Initiator form, the initiators table updates immediately and the alert panel is correctly dismissed.
Improved the hasAllHostsAllowed() logic to avoid relying solely on the * wildcard, making the check more reliable even when backend updates are delayed.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
