### PR TITLE
mgr/dashboard: Add option to set motd via api

### DIFF
--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -11183,6 +11183,92 @@ paths:
       summary: Get Monitor Details
       tags:
       - Monitor
+  /api/motd:
+    post:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                expires:
+                  type: string
+                message:
+                  type: string
+                severity:
+                  type: string
+              required:
+              - severity
+              - expires
+              - message
+              type: object
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Resource created.
+        '202':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - Motd
+  /api/motd/clear:
+    delete:
+      parameters: []
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Operation is still executing. Please check the task queue.
+        '204':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Resource deleted.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - Motd
   /api/multi-cluster/auth:
     post:
       parameters: []
@@ -27189,6 +27275,8 @@ tags:
   name: MonPerfCounter
 - description: Get Monitor Details
   name: Monitor
+- description: Message of the day API
+  name: Motd
 - description: Multi-cluster Management API
   name: Multi-cluster
 - description: NFS-Ganesha Cluster Management API

--- a/src/pybind/mgr/dashboard/plugins/motd.py
+++ b/src/pybind/mgr/dashboard/plugins/motd.py
@@ -3,11 +3,12 @@
 import hashlib
 import json
 from enum import Enum
-from typing import Dict, NamedTuple, Optional
+from typing import Dict, NamedTuple, Optional, Union
 
 from ceph.utils import datetime_now, datetime_to_str, parse_timedelta, str_to_datetime
 
 from ..cli import DBCLICommand
+from ..exceptions import DashboardException
 from . import PLUGIN_MANAGER as PM
 from .plugin import SimplePlugin as SP
 
@@ -38,6 +39,35 @@ class Motd(SP):
         )
     ]
 
+    def _normalize_severity(self, severity: Union[MotdSeverity, str]) -> Optional[MotdSeverity]:
+        if isinstance(severity, MotdSeverity):
+            return severity
+        try:
+            return MotdSeverity(severity)
+        except ValueError:
+            return None
+
+    def _set_motd(self, severity: Union[MotdSeverity, str], expires: str, message: str):
+        severity = self._normalize_severity(severity)
+        if severity is None:
+            return 1, '', 'Invalid severity, use "info", "warning" or "danger"'
+
+        if expires != '0':
+            delta = parse_timedelta(expires)
+            if not delta:
+                return 1, '', 'Invalid expires format, use "2h", "10d" or "30s"'
+            expires = datetime_to_str(datetime_now() + delta)
+        else:
+            expires = ''
+        value: str = json.dumps({
+            'message': message,
+            'md5': hashlib.md5(message.encode()).hexdigest(),
+            'severity': severity.value,
+            'expires': expires
+        })
+        self.set_option(self.NAME, value)
+        return 0, 'Message of the day has been set.', ''
+
     @PM.add_hook
     def register_commands(self):
         @DBCLICommand("dashboard {name} get".format(name=self.NAME))
@@ -56,21 +86,7 @@ class Motd(SP):
 
         @DBCLICommand("dashboard {name} set".format(name=self.NAME))
         def _set(_, severity: MotdSeverity, expires: str, message: str):
-            if expires != '0':
-                delta = parse_timedelta(expires)
-                if not delta:
-                    return 1, '', 'Invalid expires format, use "2h", "10d" or "30s"'
-                expires = datetime_to_str(datetime_now() + delta)
-            else:
-                expires = ''
-            value: str = json.dumps({
-                'message': message,
-                'md5': hashlib.md5(message.encode()).hexdigest(),
-                'severity': severity.value,
-                'expires': expires
-            })
-            self.set_option(self.NAME, value)
-            return 0, 'Message of the day has been set.', ''
+            return self._set_motd(severity, expires, message)
 
         @DBCLICommand("dashboard {name} clear".format(name=self.NAME))
         def _clear(_):
@@ -79,7 +95,7 @@ class Motd(SP):
 
     @PM.add_hook
     def get_controllers(self):
-        from ..controllers import RESTController, UIRouter
+        from ..controllers import APIDoc, APIRouter, Endpoint, RESTController, UIRouter
 
         @UIRouter('/motd')
         class MessageOfTheDay(RESTController):
@@ -95,4 +111,21 @@ class Motd(SP):
                         return None
                 return data._asdict()
 
-        return [MessageOfTheDay]
+        @APIRouter('/motd')
+        @APIDoc('Message of the day API', "Motd")
+        class MessageOfTheDayApi(RESTController):
+            def create(_, severity: MotdSeverity, expires: str, message: str):  # pylint: disable=no-self-argument,line-too-long # noqa: E501
+                # pylint: disable=W0212
+                _, _, stderr = self._set_motd(severity, expires, message)
+                if stderr:
+                    raise DashboardException(
+                        code='invalid_motd',
+                        msg="Invalid MOTD input",
+                        component='dashboard'
+                    )
+
+            @Endpoint('DELETE')
+            def clear(_):  # pylint: disable=no-self-argument
+                self.set_option(self.NAME, '')
+
+        return [MessageOfTheDay, MessageOfTheDayApi]


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
