### PR TITLE
test: add RISC-V architecture probe tests

### DIFF
--- a/src/arch/riscv.c
+++ b/src/arch/riscv.c
@@ -36,7 +36,9 @@ void ceph_arch_riscv_probe(void)
     if (do_hwprobe(pairs, 1) == 0) {
         unsigned long long ext = pairs[0].value;
         ceph_arch_riscv_rvv  = (ext & RISCV_HWPROBE_IMA_V);
-        ceph_arch_riscv_zbc  = (ext & RISCV_HWPROBE_EXT_ZBC);
-        ceph_arch_riscv_zvbc = (ext & RISCV_HWPROBE_EXT_ZVBC);
+        ceph_arch_riscv_zbc =
+            (ext & RISCV_HWPROBE_EXT_ZBC) == RISCV_HWPROBE_EXT_ZBC;
+        ceph_arch_riscv_zvbc =
+            (ext & RISCV_HWPROBE_EXT_ZVBC) == RISCV_HWPROBE_EXT_ZVBC;
     }
 }

--- a/src/arch/riscv.c
+++ b/src/arch/riscv.c
@@ -35,8 +35,11 @@ void ceph_arch_riscv_probe(void)
 
     if (do_hwprobe(pairs, 1) == 0) {
         unsigned long long ext = pairs[0].value;
-        ceph_arch_riscv_rvv  = (ext & RISCV_HWPROBE_IMA_V);
-        ceph_arch_riscv_zbc  = (ext & RISCV_HWPROBE_EXT_ZBC);
-        ceph_arch_riscv_zvbc = (ext & RISCV_HWPROBE_EXT_ZVBC);
+        ceph_arch_riscv_rvv =
+            (ext & RISCV_HWPROBE_IMA_V) == RISCV_HWPROBE_IMA_V;
+        ceph_arch_riscv_zbc =
+            (ext & RISCV_HWPROBE_EXT_ZBC) == RISCV_HWPROBE_EXT_ZBC;
+        ceph_arch_riscv_zvbc =
+            (ext & RISCV_HWPROBE_EXT_ZVBC) == RISCV_HWPROBE_EXT_ZVBC;
     }
 }

--- a/src/test/test_arch.cc
+++ b/src/test/test_arch.cc
@@ -20,6 +20,7 @@
 #include "arch/probe.h"
 #include "arch/intel.h"
 #include "arch/arm.h"
+#include "arch/riscv.h"
 #include "global/global_context.h"
 #include "gtest/gtest.h"
 
@@ -81,6 +82,33 @@ TEST(Arch, all)
 
 #endif
 
+#endif
+
+#if __riscv && __linux__
+  char isa[FLAGS_SIZE];
+  FILE *f_isa = popen("grep '^isa[	 ]*:' /proc/cpuinfo | head -1", "r");
+  if (f_isa == NULL || fgets(isa, FLAGS_SIZE - 1, f_isa) == NULL) {
+    if (f_isa)
+      pclose(f_isa);
+    return;
+  }
+  pclose(f_isa);
+  // Replace '_' with ' ' so we can match extensions with strstr(" ext ")
+  for (char *p = isa; *p; p++) {
+    if (*p == '_')
+      *p = ' ';
+  }
+  size_t isa_len = strlen(isa);
+  if (isa_len > 0 && isa[isa_len - 1] == '\n')
+    isa[isa_len - 1] = ' ';
+
+  int expected;
+
+  expected = strstr(isa, " zbc ") ? 1 : 0;
+  EXPECT_EQ(expected, ceph_arch_riscv_zbc);
+
+  expected = strstr(isa, " zvbc ") ? 1 : 0;
+  EXPECT_EQ(expected, ceph_arch_riscv_zvbc);
 #endif
 }
 


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
