### PR TITLE
tentacle: qa/workunits/rbd: drop racy assert in test_tasks_recovery()

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1711,7 +1711,6 @@ test_tasks_recovery() {
        ceph rbd task add flatten rbd2/clone1 && break
        sleep 10
     done
-    test "$(ceph rbd task list)" != "[]"
 
     for i in {1..12}; do
         rbd info rbd2/clone1 | grep 'parent: ' || break


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75654

---

backport of https://github.com/ceph/ceph/pull/67896
parent tracker: https://tracker.ceph.com/issues/75209