### PR TITLE
qa/d4n: Import valkey as redis

### DIFF
--- a/qa/distros/supported-random-distro/ubuntu_22.04.yaml
+++ b/qa/distros/supported-random-distro/ubuntu_22.04.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_22.04.yaml

--- a/qa/suites/rgw/d4n/rpm_latest.yaml
+++ b/qa/suites/rgw/d4n/rpm_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/rpm_latest.yaml

--- a/qa/suites/rgw/d4n/rpm_latest.yaml
+++ b/qa/suites/rgw/d4n/rpm_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/rpm_latest.yaml

--- a/qa/suites/rgw/d4n/supported-random-distro
+++ b/qa/suites/rgw/d4n/supported-random-distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro/

--- a/qa/suites/rgw/d4n/supported-random-distro
+++ b/qa/suites/rgw/d4n/supported-random-distro
@@ -1,0 +1,1 @@
+./.qa/distros/supported-random-distro/

--- a/qa/suites/rgw/d4n/tasks/rgw_d4ntests.yaml
+++ b/qa/suites/rgw/d4n/tasks/rgw_d4ntests.yaml
@@ -2,8 +2,8 @@ tasks:
 - install:
     # extra packages added for the rgw-d4ntests task
     extra_system_packages:
-      deb: ['s3cmd', 'redis']
-      rpm: ['s3cmd', 'redis']
+      deb: ['s3cmd'] # valkey not available by default
+      rpm: ['s3cmd', 'valkey']
 - ceph:
 - redis:
     client.0:

--- a/qa/tasks/redis.py
+++ b/qa/tasks/redis.py
@@ -1,8 +1,10 @@
 import logging
 
+from io import BytesIO
 from teuthology import misc as teuthology
 from teuthology.task import Task
 from teuthology.packaging import remove_package
+from teuthology.orchestra import run
 
 log = logging.getLogger(__name__)
 
@@ -12,7 +14,7 @@ class Redis(Task):
         super(Redis, self).__init__(ctx, config)
         self.log = log
         log.info('Redis Task: __INIT__ ')
-        
+
         clients = ['client.{id}'.format(id=id_)
                    for id_ in teuthology.all_roles_of_type(self.ctx.cluster, 'client')]
         self.all_clients = []
@@ -45,21 +47,79 @@ class Redis(Task):
         for client in self.all_clients:
             self.remove_redis_package(client)
 
+    def valkey_install_for_debian(self):
+        try:
+            for client in self.all_clients:
+                # Taken from https://www.percona.com/blog/new-valkey-packages-by-percona/
+                self.ctx.cluster.only(client).run(
+                    args=[
+                        'curl',
+                        '-O',
+                        'https://repo.percona.com/apt/percona-release_latest.generic_all.deb'
+                    ],
+                )
+                self.ctx.cluster.only(client).run(
+                    args=[
+                        'sudo',
+                        'apt',
+                        'install',
+                        'gnupg2',
+                        'lsb-release',
+                        './percona-release_latest.generic_all.deb',
+                        '-y'
+                    ],
+                )
+                self.ctx.cluster.only(client).run(
+                    args=[
+                        'sudo',
+                        'percona-release',
+                        'enable',
+                        'valkey',
+                        'testing'
+                    ],
+                )
+                self.ctx.cluster.only(client).run(
+                    args=[
+                        'sudo',
+                        'apt',
+                        'update'
+                    ],
+                )
+                self.ctx.cluster.only(client).run(
+                    args=[
+                        'sudo',
+                        'apt',
+                        'install',
+                        'valkey',
+                        '-y'
+                    ],
+                )
+    
+        except Exception as err:
+            log.debug('Redis Task: Error installing valkey package')
+            log.debug(err)
+            raise
+
     def redis_startup(self):
         try:
             for client in self.all_clients:
                 self.ctx.cluster.only(client).run(
                     args=[
                         'sudo',
-                        'redis-server',
+                        'valkey-server',
                         '--daemonize',
                         'yes'
                         ],
                     )
     
+
+        except FileNotFoundError:
+            self.valkey_install_for_debian()
+
         except Exception as err:
             log.debug('Redis Task: Error starting up a Redis server')
             log.debug(err)
+            raise
 
     def redis_shutdown(self):
         try:
@@ -67,7 +127,7 @@ class Redis(Task):
                 self.ctx.cluster.only(client).run(
                     args=[
                         'sudo',
-                        'redis-cli',
+                        'valkey-cli',
                         'shutdown',
                         ],
                     )
@@ -78,6 +138,6 @@ class Redis(Task):
 
     def remove_redis_package(self, client):
         (remote,) = self.ctx.cluster.only(client).remotes.keys()
-        remove_package('redis', remote)
+        remove_package('valkey', remote)
 
 task = Redis

--- a/qa/tasks/redis.py
+++ b/qa/tasks/redis.py
@@ -1,10 +1,8 @@
 import logging
 
-from io import BytesIO
 from teuthology import misc as teuthology
 from teuthology.task import Task
 from teuthology.packaging import remove_package
-from teuthology.orchestra import run
 
 log = logging.getLogger(__name__)
 

--- a/qa/workunits/rgw/run-d4n.sh
+++ b/qa/workunits/rgw/run-d4n.sh
@@ -5,7 +5,7 @@ mydir=`dirname $0`
 python3 -m venv $mydir
 source $mydir/bin/activate
 pip install pip --upgrade
-pip install redis
+pip install valkey
 pip install configobj
 pip install boto3
 

--- a/qa/workunits/rgw/test_rgw_d4n.py
+++ b/qa/workunits/rgw/test_rgw_d4n.py
@@ -23,7 +23,7 @@ import logging as log
 from configobj import ConfigObj
 import botocore
 import boto3
-import redis
+import valkey as redis
 import subprocess
 import os
 import hashlib

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -186,9 +186,14 @@ int SSDDriver::initialize(const DoutPrefixProvider* dpp)
     aio_init(&ainit);
     #endif
 
-    efs::space_info space = efs::space(partition_info.location);
     //currently partition_info.size is unused
-    this->free_space = space.available;
+	try {
+	  efs::space_info space = efs::space(partition_info.location);
+	  this->free_space = space.available;
+	} catch (const efs::filesystem_error& e) {
+	  ldpp_dout(dpp, 0) << "initialize::: ERROR initializing the cache storage space info: " << e.what() << dendl;
+	  //return -EINVAL; Should return error from here?
+	}
 
     return 0;
 }


### PR DESCRIPTION
https://tracker.ceph.com/issues/75711


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
