### PR TITLE
rgw/multi: Recover from future generation sync

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -1412,13 +1412,16 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   rgw_bucket_index_marker_info marker_info;
   BucketIndexShardsManager marker_mgr;
 
+  rgw::bucket_sync::GenHandle gen_state;
+
 public:
   RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                             boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                             const rgw_bucket_shard& source_bs,
                             const RGWSyncTraceNodeRef& _tn_parent,
 			    std::optional<uint64_t> gen,
-                            ceph::real_time* progress);
+                            ceph::real_time* progress,
+			    rgw::bucket_sync::GenHandle gen_state);
 
   int operate(const DoutPrefixProvider *dpp) override;
 };
@@ -1427,6 +1430,7 @@ class RGWDataSyncSingleEntryCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
   rgw::bucket_sync::ShardHandle state; // cached bucket-shard state
+  rgw::bucket_sync::GenHandle gen_state; // cached bucket state
   rgw_data_sync_obligation obligation; // input obligation
   std::optional<rgw_data_sync_obligation> complete; // obligation to complete
   uint32_t obligation_counter = 0;
@@ -1439,13 +1443,14 @@ class RGWDataSyncSingleEntryCR : public RGWCoroutine {
   int sync_status = 0;
 public:
   RGWDataSyncSingleEntryCR(RGWDataSyncCtx *_sc, rgw::bucket_sync::ShardHandle state,
+			   rgw::bucket_sync::GenHandle gen_state,
                            rgw_data_sync_obligation _obligation,
                            RGWDataSyncShardMarkerTrack *_marker_tracker,
                            const rgw_raw_obj& error_repo,
                            boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                            const RGWSyncTraceNodeRef& _tn_parent)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
-      state(std::move(state)), obligation(std::move(_obligation)),
+      state(std::move(state)), gen_state(std::move(gen_state)), obligation(std::move(_obligation)),
       marker_tracker(_marker_tracker), error_repo(error_repo),
       lease_cr(std::move(lease_cr)) {
     set_description() << "data sync single entry (source_zone=" << sc->source_zone << ") " << obligation;
@@ -1487,7 +1492,7 @@ public:
           yield call(new RGWRunBucketSourcesSyncCR(sc, lease_cr,
                                                    state->key.first, tn,
                                                    state->obligation->gen,
-						   &progress));
+						   &progress, gen_state));
           if (retcode < 0) {
             break;
           }
@@ -1642,13 +1647,15 @@ RGWCoroutine* data_sync_single_entry(RGWDataSyncCtx *sc, const rgw_bucket_shard&
                                 ceph::real_time timestamp,
                                 boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                                 boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache,
+                                boost::intrusive_ptr<rgw::bucket_sync::GenCache> bucket_gen_cache,
                                 RGWDataSyncShardMarkerTrack* marker_tracker,
                                 rgw_raw_obj error_repo,
                                 RGWSyncTraceNodeRef& tn,
                                 bool retry) {
   auto state = bucket_shard_cache->get(src, gen);
+  auto gen_state = bucket_gen_cache->get(src.bucket.get_key(), gen);
   auto obligation = rgw_data_sync_obligation{src, gen, marker, timestamp, retry};
-  return new RGWDataSyncSingleEntryCR(sc, std::move(state), std::move(obligation),
+  return new RGWDataSyncSingleEntryCR(sc, std::move(state), std::move(gen_state), std::move(obligation),
                                       &*marker_tracker, error_repo,
                                       lease_cr.get(), tn);
 }
@@ -1675,6 +1682,7 @@ class RGWDataFullSyncSingleEntryCR : public RGWCoroutine {
   ceph::real_time timestamp;
   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
   boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache;
+  boost::intrusive_ptr<rgw::bucket_sync::GenCache> bucket_gen_cache;
   RGWDataSyncShardMarkerTrack* marker_tracker;
   RGWSyncTraceNodeRef tn;
   rgw_bucket_index_marker_info remote_info;
@@ -1690,11 +1698,12 @@ public:
                       const std::string& _key, const rgw_data_sync_status& _sync_status, const rgw_raw_obj& _error_repo,
                       ceph::real_time _timestamp, boost::intrusive_ptr<const RGWContinuousLeaseCR> _lease_cr,
                       boost::intrusive_ptr<rgw::bucket_sync::ShardCache> _bucket_shard_cache,
+                      boost::intrusive_ptr<rgw::bucket_sync::GenCache> _bucket_gen_cache,
                       RGWDataSyncShardMarkerTrack* _marker_tracker,
                       RGWSyncTraceNodeRef& _tn)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env), pool(_pool), source_bs(_source_bs), key(_key),
       sync_status(_sync_status), error_repo(_error_repo), timestamp(_timestamp), lease_cr(std::move(_lease_cr)),
-      bucket_shard_cache(_bucket_shard_cache), marker_tracker(_marker_tracker), tn(_tn) {
+      bucket_shard_cache(_bucket_shard_cache), bucket_gen_cache(_bucket_gen_cache), marker_tracker(_marker_tracker), tn(_tn) {
         error_inject = (sync_env->cct->_conf->rgw_sync_data_full_inject_err_probability > 0);
       }
 
@@ -1740,7 +1749,7 @@ public:
 		timestamp), sc->lcc.adj_concurrency(cct->_conf->rgw_data_sync_spawn_window), std::nullopt);
           } else {
           shard_cr = data_sync_single_entry(sc, source_bs, each->gen, key, timestamp,
-                      lease_cr, bucket_shard_cache, nullptr, error_repo, tn, false);
+					    lease_cr, bucket_shard_cache, bucket_gen_cache, nullptr, error_repo, tn, false);
           tn->log(10, SSTR("full sync: syncing shard_id " << sid << " of gen " << each->gen));
           if (first_shard) {
             first_shard = false;
@@ -1792,6 +1801,7 @@ protected:
   const rgw_data_sync_status& sync_status;
   RGWObjVersionTracker& objv;
   boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache;
+  boost::intrusive_ptr<rgw::bucket_sync::GenCache> bucket_gen_cache;
 
   std::optional<RGWDataSyncShardMarkerTrack> marker_tracker;
   RGWRadosGetOmapValsCR::ResultPtr omapvals;
@@ -1818,12 +1828,13 @@ protected:
     boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
     const rgw_data_sync_status& sync_status,
     RGWObjVersionTracker& objv,
-    const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache)
+    const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache,
+    const boost::intrusive_ptr<rgw::bucket_sync::GenCache>& bucket_gen_cache)
     : RGWCoroutine(_sc->cct), sc(_sc), pool(pool), shard_id(shard_id),
       sync_marker(sync_marker), tn(tn), status_oid(status_oid),
       error_repo(error_repo), lease_cr(std::move(lease_cr)),
       sync_status(sync_status), objv(objv),
-      bucket_shard_cache(bucket_shard_cache) {}
+      bucket_shard_cache(bucket_shard_cache), bucket_gen_cache(bucket_gen_cache) {}
 };
 
 class RGWDataFullSyncShardCR : public RGWDataBaseSyncShardCR {
@@ -1846,10 +1857,11 @@ public:
     const string& status_oid, const rgw_raw_obj& error_repo,
     boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
     const rgw_data_sync_status& sync_status, RGWObjVersionTracker& objv,
-    const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache)
+    const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache,
+    const boost::intrusive_ptr<rgw::bucket_sync::GenCache>& bucket_gen_cache)
     : RGWDataBaseSyncShardCR(sc, pool, shard_id, sync_marker, tn,
 			     status_oid, error_repo, std::move(lease_cr),
-			     sync_status, objv, bucket_shard_cache) {}
+			     sync_status, objv, bucket_shard_cache, bucket_gen_cache) {}
 
   int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
@@ -1905,7 +1917,7 @@ public:
             yield_spawn_window(new RGWDataFullSyncSingleEntryCR(
 				 sc, pool, source_bs, iter->first, sync_status,
 				 error_repo, entry_timestamp, lease_cr,
-				 bucket_shard_cache, &*marker_tracker, tn),
+				 bucket_shard_cache, bucket_gen_cache, &*marker_tracker, tn),
 			       sc->lcc.adj_concurrency(cct->_conf->rgw_data_sync_spawn_window),
              std::nullopt);
           }
@@ -2000,11 +2012,12 @@ public:
     boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
     const rgw_data_sync_status& sync_status, RGWObjVersionTracker& objv,
     const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache,
+    const boost::intrusive_ptr<rgw::bucket_sync::GenCache>& bucket_gen_cache,
     ceph::mutex& inc_lock,
     bc::flat_set<rgw_data_notify_entry>& modified_shards)
     : RGWDataBaseSyncShardCR(sc, pool, shard_id, sync_marker, tn,
 			     status_oid, error_repo, std::move(lease_cr),
-			     sync_status, objv, bucket_shard_cache),
+			     sync_status, objv, bucket_shard_cache, bucket_gen_cache),
       inc_lock(inc_lock), modified_shards(modified_shards) {}
 
   int operate(const DoutPrefixProvider *dpp) override {
@@ -2052,7 +2065,7 @@ public:
 			   << modified_iter->key));
           spawn(data_sync_single_entry(sc, source_bs, modified_iter->gen, {},
 				       ceph::real_time{}, lease_cr,
-				       bucket_shard_cache, &*marker_tracker,
+				       bucket_shard_cache, bucket_gen_cache, &*marker_tracker,
 				       error_repo, tn, false), false);
 	}
 
@@ -2098,7 +2111,7 @@ public:
 			       << " timestamp=" << entry_timestamp));
               spawn(data_sync_single_entry(sc, source_bs, gen, "",
 					   entry_timestamp, lease_cr,
-					   bucket_shard_cache, &*marker_tracker,
+					   bucket_shard_cache, bucket_gen_cache, &*marker_tracker,
 					   error_repo, tn, true), false);
             }
           }
@@ -2152,7 +2165,7 @@ public:
           } else {
             tn->log(1, SSTR("incremental sync on " << log_iter->entry.key  << "shard: " << shard_id << "on gen " << log_iter->entry.gen));
             yield_spawn_window(data_sync_single_entry(sc, source_bs, log_iter->entry.gen, log_iter->log_id,
-                                                 log_iter->log_timestamp, lease_cr,bucket_shard_cache,
+                                                      log_iter->log_timestamp, lease_cr,bucket_shard_cache, bucket_gen_cache,
                                                  &*marker_tracker, error_repo, tn, false),
                                sc->lcc.adj_concurrency(cct->_conf->rgw_data_sync_spawn_window),
                                [&](uint64_t stack_id, int ret) {
@@ -2221,8 +2234,10 @@ class RGWDataSyncShardCR : public RGWCoroutine {
 
   // target number of entries to cache before recycling idle ones
   static constexpr size_t target_cache_size = 256;
-  boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache {
-    rgw::bucket_sync::ShardCache::create(target_cache_size) };
+  boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache{
+      rgw::bucket_sync::ShardCache::create(target_cache_size)};
+  boost::intrusive_ptr<rgw::bucket_sync::GenCache> bucket_gen_cache{
+      rgw::bucket_sync::GenCache::create(target_cache_size)};
 
   boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr;
   boost::intrusive_ptr<RGWCoroutinesStack> lease_stack;
@@ -2290,7 +2305,7 @@ public:
 						sync_marker, tn,
 						status_oid, error_repo,
 						lease_cr, sync_status,
-            objv, bucket_shard_cache));
+						objv, bucket_shard_cache, bucket_gen_cache));
 	  if (retcode < 0) {
 	    if (retcode != -EBUSY) {
 	      tn->log(10, SSTR("full sync failed (retcode=" << retcode << ")"));
@@ -2304,7 +2319,7 @@ public:
 					       sync_marker, tn,
 					       status_oid, error_repo,
 					       lease_cr, sync_status,
-					       objv, bucket_shard_cache,
+					       objv, bucket_shard_cache, bucket_gen_cache,
 					       inc_lock, modified_shards));
 	  if (retcode < 0) {
 	    if (retcode != -EBUSY) {
@@ -5326,6 +5341,7 @@ static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
                                           std::optional<uint64_t> gen,
                                           const RGWSyncTraceNodeRef& tn,
                                           ceph::real_time* progress,
+					  ceph::coarse_mono_time& last_future_generation_recovery,
                                           bool no_lease = false);
 
 RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
@@ -5333,14 +5349,16 @@ RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                                                      const rgw_bucket_shard& source_bs,
                                                      const RGWSyncTraceNodeRef& _tn_parent,
 						     std::optional<uint64_t> gen,
-                                                     ceph::real_time* progress)
+                                                     ceph::real_time* progress,
+						     rgw::bucket_sync::GenHandle gen_state)
   : RGWCoroutine(_sc->env->cct), sc(_sc), sync_env(_sc->env),
     lease_cr(std::move(lease_cr)),
     tn(sync_env->sync_tracer->add_node(
 	 _tn_parent, "bucket_sync_sources",
 	 SSTR( "source=" << source_bs << ":source_zone=" << sc->source_zone))),
     progress(progress),
-    gen(gen)
+    gen(gen),
+    gen_state(std::move(gen_state))
 {
   sync_pair.source_bs = source_bs;
 }
@@ -5375,7 +5393,7 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
 
       yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair,
                                               gen, tn, &*cur_shard_progress,
-                                              false),
+                                              gen_state->last_future_generation_recovery, false),
                          sc->lcc.adj_concurrency(cct->_conf->rgw_bucket_sync_spawn_window),
                          [&](uint64_t stack_id, int ret) {
                            if (ret < 0) {
@@ -5774,16 +5792,21 @@ class RGWSyncBucketCR : public RGWCoroutine {
   rgw_bucket_shard source_bs;
   rgw_pool pool;
   uint64_t current_gen = 0;
+  // In general operation, a reference to a pinned entry in `bucket_gen_cache`
+  ceph::coarse_mono_time& last_future_generation_recovery;
 
   RGWSyncTraceNodeRef tn;
+
+  static constexpr std::chrono::seconds throttle_future_recovery = std::chrono::hours(1);
 
 public:
   RGWSyncBucketCR(RGWDataSyncCtx *_sc,
                   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
-                  const rgw_bucket_sync_pair_info& _sync_pair,
+                  const rgw_bucket_sync_pair_info &_sync_pair,
                   std::optional<uint64_t> gen,
                   const RGWSyncTraceNodeRef& _tn_parent,
                   ceph::real_time* progress,
+                  ceph::coarse_mono_time& last_future_generation_recovery,
                   bool no_lease = false)
     : RGWCoroutine(_sc->cct), sc(_sc), env(_sc->env),
       data_lease_cr(std::move(lease_cr)), sync_pair(_sync_pair),
@@ -5793,7 +5816,7 @@ public:
                  RGWBucketPipeSyncStatusManager::full_status_oid(sc->source_zone,
                                                                  sync_pair.source_bs.bucket,
                                                                  sync_pair.dest_bucket)),
-      no_lease(no_lease),
+      no_lease(no_lease), last_future_generation_recovery(last_future_generation_recovery),
       tn(env->sync_tracer->add_node(_tn_parent, "bucket",
                                     SSTR(bucket_str{_sync_pair.dest_bucket} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
   }
@@ -5807,10 +5830,11 @@ static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
                                           std::optional<uint64_t> gen,
                                           const RGWSyncTraceNodeRef& tn,
                                           ceph::real_time* progress,
+                                          ceph::coarse_mono_time& last_future_generation_recovery,
                                           bool no_lease)
 {
   return new RGWSyncBucketCR(sc, std::move(lease), sync_pair,
-                             gen, tn, progress, no_lease);
+                             gen, tn, progress, last_future_generation_recovery, no_lease);
 }
 
 #define RELEASE_LOCK(cr) \
@@ -6009,29 +6033,46 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
           if (*gen > current_gen) {
 	    /* In case the data log entry is missing for previous gen, it may
 	     * not be marked complete and the sync can get stuck. To avoid it,
-	     * may be we can add this (shardid, gen) to error repo to force
-	     * sync and mark that shard as completed.
+	     * may be we can add an entry for every shard in the previous generation.
 	     */
 	    pool = sc->env->svc->zone->get_zone_params().log_pool;
-            if ((static_cast<std::size_t>(source_bs.shard_id) < bucket_status.shards_done_with_gen.size()) &&
-	       !bucket_status.shards_done_with_gen[source_bs.shard_id]) {
+            if ((ceph::coarse_mono_clock::now() - last_future_generation_recovery) > throttle_future_recovery) {
+	      last_future_generation_recovery = ceph::coarse_mono_clock::now();
 	      // use the error repo and sync status timestamp from the datalog shard corresponding to source_bs
-              error_repo = datalog_oid_for_error_repo(sc, sc->env->driver,
-			   pool, source_bs);
-              yield call(rgw::error_repo::write_cr(sc->env->driver->getRados()->get_rados_handle(), error_repo,
-                                              rgw::error_repo::encode_key(source_bs, current_gen),
-                                              ceph::real_clock::zero()));
-              if (retcode < 0) {
-                tn->log(0, SSTR("ERROR: failed to log prev gen entry (bucket=" << source_bs.bucket << ", shard_id=" << source_bs.shard_id << ", gen=" << current_gen << " in error repo: retcode=" << retcode));
-              } else {
-                tn->log(20, SSTR("logged prev gen entry (bucket=" << source_bs.bucket << ", shard_id=" << source_bs.shard_id << ", gen=" << current_gen << " in error repo: retcode=" << retcode));
+              for (source_bs.shard_id = 0;
+                   source_bs.shard_id < std::ssize(bucket_status.shards_done_with_gen);
+                   ++source_bs.shard_id) {
+		error_repo = datalog_oid_for_error_repo(sc, sc->env->driver,
+							pool, source_bs);
+		tn->log(10, SSTR("writing shard_id " << source_bs.shard_id << " of gen " << current_gen << " to error repo for retry"));
+		yield_spawn_window(
+		    rgw::error_repo::write_cr(
+			sc->env->driver->getRados()->get_rados_handle(),
+			error_repo,
+			rgw::error_repo::encode_key(source_bs, current_gen),
+			ceph::real_clock::zero()),
+		    sc->lcc.adj_concurrency(
+			cct->_conf->rgw_data_sync_spawn_window),
+		    [&](uint64_t stack_id, int ret) {
+		      if (ret < 0) {
+			retcode = ret;
+		      }
+		      return 0;
+		    });
 	      }
+	      drain_all_cb([&](uint64_t stack_id, int ret) {
+		if (ret < 0) {
+		  tn->log(10,
+                        SSTR("writing to error repo returned error: " << ret));
+		}
+		return ret;
+	      });
 	    }
-            retcode = -EAGAIN;
-            tn->log(10, SSTR("ERROR: requested sync of future generation "
-                             << *gen << " > " << current_gen
-                             << ", returning " << retcode << " for later retry"));
-            return set_cr_error(retcode);
+	    retcode = -EAGAIN;
+	    tn->log(10, SSTR("ERROR: requested sync of future generation "
+			     << *gen << " > " << current_gen
+			     << ", returning " << retcode << " for later retry"));
+	    return set_cr_error(retcode);
           } else if (*gen < current_gen) {
             tn->log(10, SSTR("WARNING: requested sync of past generation "
                              << *gen << " < " << current_gen
@@ -6274,11 +6315,14 @@ class ShardCR : public RGWCoroutine {
   ceph::real_time prev_progress;
   ceph::real_time progress;
 
-public:
+  ceph::coarse_mono_time& last_future_generation_recovery;
 
-  ShardCR(RGWDataSyncCtx& sc, const rgw_bucket_sync_pair_info& pair,
-	  const uint64_t gen)
-    : RGWCoroutine(sc.cct), sc(sc), pair(pair), gen(gen) {}
+public:
+  ShardCR(RGWDataSyncCtx &sc, const rgw_bucket_sync_pair_info &pair,
+          const uint64_t gen,
+          ceph::coarse_mono_time &last_future_generation_recovery)
+      : RGWCoroutine(sc.cct), sc(sc), pair(pair), gen(gen),
+        last_future_generation_recovery( last_future_generation_recovery) {}
 
   int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
@@ -6295,6 +6339,7 @@ public:
 	yield call(sync_bucket_shard_cr(&sc, nullptr, pair, gen,
 					sc.env->sync_tracer->root_node,
 					&progress,
+                                        last_future_generation_recovery,
 					true /* no_lease: bucket sync run skips
 					        lock acquisition so it is never
 					        blocked by a background sync process*/));
@@ -6341,6 +6386,10 @@ class GenCR : public RGWShardCollectCR {
   std::vector<rgw_bucket_sync_pair_info> pairs;
   decltype(pairs)::const_iterator iter;
 
+  // We do a manual sync when we're told to do a manual sync. No need
+  // for a cache.
+  ceph::coarse_mono_time last_future_generation_recovery = ceph::coarse_mono_clock::zero();
+
 public:
   GenCR(RGWDataSyncCtx& sc, const rgw_bucket& source, const rgw_bucket& dest,
 	const uint64_t gen, const uint64_t shards,
@@ -6363,7 +6412,7 @@ public:
     if (iter == pairs.cend()) {
       return false;
     }
-    spawn(new ShardCR(sc, *iter, gen), false);
+    spawn(new ShardCR(sc, *iter, gen, last_future_generation_recovery), false);
     ++iter;
     return true;
   }

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -1426,7 +1426,7 @@ public:
 class RGWDataSyncSingleEntryCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::bucket_sync::Handle state; // cached bucket-shard state
+  rgw::bucket_sync::ShardHandle state; // cached bucket-shard state
   rgw_data_sync_obligation obligation; // input obligation
   std::optional<rgw_data_sync_obligation> complete; // obligation to complete
   uint32_t obligation_counter = 0;
@@ -1438,7 +1438,7 @@ class RGWDataSyncSingleEntryCR : public RGWCoroutine {
   ceph::real_time progress;
   int sync_status = 0;
 public:
-  RGWDataSyncSingleEntryCR(RGWDataSyncCtx *_sc, rgw::bucket_sync::Handle state,
+  RGWDataSyncSingleEntryCR(RGWDataSyncCtx *_sc, rgw::bucket_sync::ShardHandle state,
                            rgw_data_sync_obligation _obligation,
                            RGWDataSyncShardMarkerTrack *_marker_tracker,
                            const rgw_raw_obj& error_repo,
@@ -1641,7 +1641,7 @@ RGWCoroutine* data_sync_single_entry(RGWDataSyncCtx *sc, const rgw_bucket_shard&
                                 const std::string marker,
                                 ceph::real_time timestamp,
                                 boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
-                                boost::intrusive_ptr<rgw::bucket_sync::Cache> bucket_shard_cache,
+                                boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache,
                                 RGWDataSyncShardMarkerTrack* marker_tracker,
                                 rgw_raw_obj error_repo,
                                 RGWSyncTraceNodeRef& tn,
@@ -1674,7 +1674,7 @@ class RGWDataFullSyncSingleEntryCR : public RGWCoroutine {
   rgw_raw_obj error_repo;
   ceph::real_time timestamp;
   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
-  boost::intrusive_ptr<rgw::bucket_sync::Cache> bucket_shard_cache;
+  boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache;
   RGWDataSyncShardMarkerTrack* marker_tracker;
   RGWSyncTraceNodeRef tn;
   rgw_bucket_index_marker_info remote_info;
@@ -1689,7 +1689,7 @@ public:
   RGWDataFullSyncSingleEntryCR(RGWDataSyncCtx *_sc, const rgw_pool& _pool, const rgw_bucket_shard& _source_bs,
                       const std::string& _key, const rgw_data_sync_status& _sync_status, const rgw_raw_obj& _error_repo,
                       ceph::real_time _timestamp, boost::intrusive_ptr<const RGWContinuousLeaseCR> _lease_cr,
-                      boost::intrusive_ptr<rgw::bucket_sync::Cache> _bucket_shard_cache,
+                      boost::intrusive_ptr<rgw::bucket_sync::ShardCache> _bucket_shard_cache,
                       RGWDataSyncShardMarkerTrack* _marker_tracker,
                       RGWSyncTraceNodeRef& _tn)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env), pool(_pool), source_bs(_source_bs), key(_key),
@@ -1791,7 +1791,7 @@ protected:
   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
   const rgw_data_sync_status& sync_status;
   RGWObjVersionTracker& objv;
-  boost::intrusive_ptr<rgw::bucket_sync::Cache> bucket_shard_cache;
+  boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache;
 
   std::optional<RGWDataSyncShardMarkerTrack> marker_tracker;
   RGWRadosGetOmapValsCR::ResultPtr omapvals;
@@ -1818,7 +1818,7 @@ protected:
     boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
     const rgw_data_sync_status& sync_status,
     RGWObjVersionTracker& objv,
-    const boost::intrusive_ptr<rgw::bucket_sync::Cache>& bucket_shard_cache)
+    const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache)
     : RGWCoroutine(_sc->cct), sc(_sc), pool(pool), shard_id(shard_id),
       sync_marker(sync_marker), tn(tn), status_oid(status_oid),
       error_repo(error_repo), lease_cr(std::move(lease_cr)),
@@ -1846,7 +1846,7 @@ public:
     const string& status_oid, const rgw_raw_obj& error_repo,
     boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
     const rgw_data_sync_status& sync_status, RGWObjVersionTracker& objv,
-    const boost::intrusive_ptr<rgw::bucket_sync::Cache>& bucket_shard_cache)
+    const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache)
     : RGWDataBaseSyncShardCR(sc, pool, shard_id, sync_marker, tn,
 			     status_oid, error_repo, std::move(lease_cr),
 			     sync_status, objv, bucket_shard_cache) {}
@@ -1999,7 +1999,7 @@ public:
     const string& status_oid, const rgw_raw_obj& error_repo,
     boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
     const rgw_data_sync_status& sync_status, RGWObjVersionTracker& objv,
-    const boost::intrusive_ptr<rgw::bucket_sync::Cache>& bucket_shard_cache,
+    const boost::intrusive_ptr<rgw::bucket_sync::ShardCache>& bucket_shard_cache,
     ceph::mutex& inc_lock,
     bc::flat_set<rgw_data_notify_entry>& modified_shards)
     : RGWDataBaseSyncShardCR(sc, pool, shard_id, sync_marker, tn,
@@ -2221,8 +2221,8 @@ class RGWDataSyncShardCR : public RGWCoroutine {
 
   // target number of entries to cache before recycling idle ones
   static constexpr size_t target_cache_size = 256;
-  boost::intrusive_ptr<rgw::bucket_sync::Cache> bucket_shard_cache {
-    rgw::bucket_sync::Cache::create(target_cache_size) };
+  boost::intrusive_ptr<rgw::bucket_sync::ShardCache> bucket_shard_cache {
+    rgw::bucket_sync::ShardCache::create(target_cache_size) };
 
   boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr;
   boost::intrusive_ptr<RGWCoroutinesStack> lease_stack;

--- a/src/rgw/rgw_bucket_sync_cache.h
+++ b/src/rgw/rgw_bucket_sync_cache.h
@@ -17,13 +17,15 @@
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include "common/intrusive_lru.h"
 #include "rgw_data_sync.h"
+#include "common/ceph_time.h"
 
 namespace rgw::bucket_sync {
 
-// per bucket-shard state cached by DataSyncShardCR
-struct State {
+// per bucket-shard (dimensioned by generation) state cached by DataSyncShardCR
+struct ShardState {
+  using key_type = std::pair<rgw_bucket_shard, std::optional<uint64_t>>;
   // the source bucket shard to sync
-  std::pair<rgw_bucket_shard, std::optional<uint64_t>> key;
+  key_type key;
   // current sync obligation being processed by DataSyncSingleEntry
   std::optional<rgw_data_sync_obligation> obligation;
   // incremented with each new obligation
@@ -31,27 +33,47 @@ struct State {
   // highest timestamp applied by all sources
   ceph::real_time progress_timestamp;
 
-  State(const std::pair<rgw_bucket_shard, std::optional<uint64_t>>& key ) noexcept
-    : key(key) {}
-  State(const rgw_bucket_shard& shard, std::optional<uint64_t> gen) noexcept
+  ShardState(const key_type& key) noexcept
+  : key(key) {}
+  ShardState(const rgw_bucket_shard& shard, std::optional<uint64_t> gen) noexcept
     : key(shard, gen) {}
 };
 
+// per bucket (dimensioned by generation) state cached by DataSyncShardCR
+struct GenState {
+  using key_type = std::pair<std::string, std::optional<uint64_t>>;
+  // the source bucket/generation to sync
+  key_type key;
+  // Last future generation recovery timestamp
+  ceph::coarse_mono_time last_future_generation_recovery = ceph::coarse_mono_clock::zero();
+
+  GenState(const key_type& key) noexcept
+    : key(key) {}
+  GenState(std::string bucket, std::optional<uint64_t> gen) noexcept
+  : key(std::move(bucket), gen) {}
+};
+
+template<typename State>
 struct Entry;
+template<typename State>
 struct EntryToKey;
+template<typename State>
 class Handle;
 
+template<typename State>
 using lru_config = ceph::common::intrusive_lru_config<
-  std::pair<rgw_bucket_shard, std::optional<uint64_t>>, Entry, EntryToKey>;
+    typename State::key_type, Entry<State>, EntryToKey<State>>;
 
 // a recyclable cache entry
-struct Entry : State, ceph::common::intrusive_lru_base<lru_config> {
+template<typename State>
+struct Entry : State, ceph::common::intrusive_lru_base<lru_config<State>> {
   using State::State;
 };
 
+template<typename State>
 struct EntryToKey {
-  using type = std::pair<rgw_bucket_shard, std::optional<uint64_t>>;
-  const type& operator()(const Entry& e) { return e.key; }
+  using type = typename State::key_type;
+  const type& operator()(const Entry<State>& e) { return e.key; }
 };
 
 // use a non-atomic reference count since these aren't shared across threads
@@ -59,9 +81,10 @@ template <typename T>
 using thread_unsafe_ref_counter = boost::intrusive_ref_counter<
     T, boost::thread_unsafe_counter>;
 
-// a state cache for entries within a single datalog shard
-class Cache : public thread_unsafe_ref_counter<Cache> {
-  ceph::common::intrusive_lru<lru_config> cache;
+// A state cache for entries within a single datalog shard
+template<typename State>
+class Cache : public thread_unsafe_ref_counter<Cache<State>> {
+  ceph::common::intrusive_lru<lru_config<State>> cache;
  protected:
   // protected ctor to enforce the use of factory function create()
   explicit Cache(size_t target_size) {
@@ -74,18 +97,19 @@ class Cache : public thread_unsafe_ref_counter<Cache> {
 
   // find or create a cache entry for the given key, and return a Handle that
   // keeps it lru-pinned until destruction
-  Handle get(const rgw_bucket_shard& shard, std::optional<uint64_t> gen);
+  Handle<State> get(const auto& ...args);
 };
 
 // a State handle that keeps the Cache referenced
+template<typename State>
 class Handle {
-  boost::intrusive_ptr<Cache> cache;
-  boost::intrusive_ptr<Entry> entry;
+  boost::intrusive_ptr<Cache<State>> cache;
+  boost::intrusive_ptr<Entry<State>> entry;
  public:
   Handle() noexcept = default;
   ~Handle() = default;
-  Handle(boost::intrusive_ptr<Cache> cache,
-         boost::intrusive_ptr<Entry> entry) noexcept
+  Handle(boost::intrusive_ptr<Cache<State>> cache,
+         boost::intrusive_ptr<Entry<State>> entry) noexcept
     : cache(std::move(cache)), entry(std::move(entry)) {}
   Handle(Handle&&) = default;
   Handle(const Handle&) = default;
@@ -107,10 +131,21 @@ class Handle {
   State* operator->() const noexcept { return entry.get(); }
 };
 
-inline Handle Cache::get(const rgw_bucket_shard& shard, std::optional<uint64_t> gen)
+template<typename State>
+inline Handle<State> Cache<State>::get(const auto& ...args)
 {
-  auto result = cache.get_or_create({ shard, gen });
+  static_assert(
+      std::is_constructible_v<typename State::key_type, decltype(args)...>,
+      "The arguments to Cache<State>::get must be arguments to construct "
+      "State");
+  auto result = cache.get_or_create({args...});
   return {this, std::move(result.first)};
 }
+
+using ShardHandle = Handle<ShardState>;
+using ShardCache = Cache<ShardState>;
+
+using GenHandle = Handle<GenState>;
+using GenCache = Cache<GenState>;
 
 } // namespace rgw::bucket_sync

--- a/src/test/rgw/test_rgw_bucket_sync_cache.cc
+++ b/src/test/rgw/test_rgw_bucket_sync_cache.cc
@@ -12,71 +12,182 @@
  * Foundation.  See file COPYING.
  */
 
-#include "rgw_bucket_sync_cache.h"
+#include <common/ceph_time.h>
 #include <gtest/gtest.h>
+
+#include "rgw_bucket_sync_cache.h"
 
 using namespace rgw::bucket_sync;
 
-// helper function to construct rgw_bucket_shard
-static rgw_bucket_shard make_key(const std::string& tenant,
-                                 const std::string& bucket, int shard)
+using Shard = ShardState;
+using Gen = GenState;
+
+namespace {
+/// Create a key suitable for a given cache
+///
+/// \tparam State One of `Shard` or `Gen`.
+///
+/// \param[in] tenant Owning tenant
+/// \param[in] bucket Bucket name
+/// \param[in] shard Bucket shard, ignored if `State` is `Gen`.
+///
+/// \return A key for the given bucket
+template <typename State>
+auto make_key(const std::string& tenant, const std::string& bucket, int shard) =
+    delete;
+
+template <>
+auto
+make_key<Shard>(const std::string& tenant, const std::string& bucket, int shard)
 {
   auto key = rgw_bucket_key{tenant, bucket};
   return rgw_bucket_shard{std::move(key), shard};
 }
 
-TEST(BucketSyncCache, ReturnCachedPinned)
+template <>
+auto
+make_key<Gen>(
+    const std::string& tenant,
+    const std::string& bucket,
+    // Dummy parameter for overload
+    int)
 {
-  auto cache = Cache::create(0);
-  const auto key = make_key("", "1", 0);
+  auto key = rgw_bucket_key{tenant, bucket};
+  rgw_bucket b{std::move(key)};
+  return b.get_key();
+}
+
+/// Stick an integer into a state
+///
+/// \tparam State One of `Shard` or `Gen`.
+///
+/// \param[inout] state State to modify
+/// \param[in] value Value to store
+template <typename State>
+void mutate(State&, unsigned int value) = delete;
+
+template <>
+void
+mutate<Shard>(ShardState& state, unsigned int value)
+{
+  state.counter = value;
+}
+
+template <>
+void
+mutate<Gen>(GenState& state, unsigned int value)
+{
+  state.last_future_generation_recovery = ceph::coarse_mono_time{
+      ceph::timespan{value}};
+}
+
+/// Retrieve an integer from a state
+///
+/// \note Intended only for values stored with `mutate`, anything else
+/// will be truncated to the capacity of an `unsigned int`.
+///
+/// \tparam State One of `Shard` or `Gen`.
+///
+/// \param[in] state State to modify
+///
+/// \return The integer previously stored in the state
+template <typename State>
+unsigned int extract(const State&) = delete;
+
+template <>
+unsigned int
+extract<Shard>(const Shard& state)
+{
+  return static_cast<unsigned int>(state.counter);
+}
+
+template <>
+unsigned int
+extract<Gen>(const Gen& state)
+{
+  return static_cast<unsigned int>(
+      state.last_future_generation_recovery.time_since_epoch().count());
+}
+} // namespace
+
+template <typename State>
+void
+ReturnCachedPinned()
+{
+  auto cache = Cache<State>::create(0);
+  const auto key = make_key<State>("", "1", 0);
   auto h1 = cache->get(key, std::nullopt); // pin
-  h1->counter = 1;
+  mutate(*h1, 1);
   auto h2 = cache->get(key, std::nullopt);
-  EXPECT_EQ(1, h2->counter);
+  EXPECT_EQ(1, extract(*h2));
 }
 
-TEST(BucketSyncCache, ReturnNewUnpinned)
+TEST(BucketShardSyncCache, ReturnCachedPinned) { ReturnCachedPinned<Shard>(); }
+
+TEST(BucketGenSyncCache, ReturnCachedPinned) { ReturnCachedPinned<Gen>(); }
+
+template <typename State>
+void
+ReturnNewUnpinned()
 {
-  auto cache = Cache::create(0);
-  const auto key = make_key("", "1", 0);
-  cache->get(key, std::nullopt)->counter = 1; // pin+unpin
-  EXPECT_EQ(0, cache->get(key, std::nullopt)->counter);
+  auto cache = Cache<State>::create(0);
+  const auto key = make_key<State>("", "1", 0);
+  mutate(*cache->get(key, std::nullopt), 1); // pin+unpin
+  EXPECT_EQ(0, extract(*cache->get(key, std::nullopt)));
 }
 
-TEST(BucketSyncCache, DistinctTenant)
+TEST(BucketShardSyncCache, ReturnNewUnpinned) { ReturnNewUnpinned<Shard>(); }
+
+TEST(BucketGenSyncCache, ReturnNewUnpinned) { ReturnNewUnpinned<Gen>(); }
+
+template <typename State>
+void
+DistinctTenant()
 {
-  auto cache = Cache::create(2);
-  const auto key1 = make_key("a", "bucket", 0);
-  const auto key2 = make_key("b", "bucket", 0);
+  auto cache = Cache<State>::create(2);
+  const auto key1 = make_key<State>("a", "bucket", 0);
+  const auto key2 = make_key<State>("b", "bucket", 0);
+  mutate(*cache->get(key1, std::nullopt), 1);
+  EXPECT_EQ(0, extract(*cache->get(key2, std::nullopt)));
+}
+
+TEST(BucketShardSyncCache, DistinctTenant) { DistinctTenant<Shard>(); }
+
+TEST(BucketGenSyncCache, DistinctTenant) { DistinctTenant<Gen>(); }
+
+TEST(BucketShardSyncCache, DistinctShards)
+{
+  auto cache = ShardCache::create(2);
+  const auto key1 = make_key<Shard>("", "bucket", 0);
+  const auto key2 = make_key<Shard>("", "bucket", 1);
   cache->get(key1, std::nullopt)->counter = 1;
   EXPECT_EQ(0, cache->get(key2, std::nullopt)->counter);
 }
 
-TEST(BucketSyncCache, DistinctShards)
+template <typename State>
+void
+DistinctGen()
 {
-  auto cache = Cache::create(2);
-  const auto key1 = make_key("", "bucket", 0);
-  const auto key2 = make_key("", "bucket", 1);
-  cache->get(key1, std::nullopt)->counter = 1;
-  EXPECT_EQ(0, cache->get(key2, std::nullopt)->counter);
-}
-
-TEST(BucketSyncCache, DistinctGen)
-{
-  auto cache = Cache::create(2);
-  const auto key = make_key("", "bucket", 0);
+  auto cache = Cache<State>::create(2);
+  const auto key = make_key<State>("", "bucket", 0);
   std::optional<uint64_t> gen1; // empty
   std::optional<uint64_t> gen2 = 5;
-  cache->get(key, gen1)->counter = 1;
-  EXPECT_EQ(0, cache->get(key, gen2)->counter);
+  mutate(*cache->get(key, gen1), 1);
+  EXPECT_EQ(0, extract(*cache->get(key, gen2)));
 }
 
-TEST(BucketSyncCache, DontEvictPinned)
-{
-  auto cache = Cache::create(0);
+TEST(BucketShardSyncCache, DistinctGen) { DistinctGen<Shard>(); }
 
-  const auto key1 = make_key("", "1", 0);
-  const auto key2 = make_key("", "2", 0);
+TEST(BucketGenSyncCache, DistinctGen) { DistinctGen<Gen>(); }
+
+template <typename State>
+void
+DontEvictPinned()
+{
+  auto cache = Cache<State>::create(0);
+
+  const auto key1 = make_key<State>("", "1", 0);
+  const auto key2 = make_key<State>("", "2", 0);
 
   auto h1 = cache->get(key1, std::nullopt);
   EXPECT_EQ(key1, h1->key.first);
@@ -85,46 +196,64 @@ TEST(BucketSyncCache, DontEvictPinned)
   EXPECT_EQ(key1, h1->key.first); // h1 unchanged
 }
 
-TEST(BucketSyncCache, HandleLifetime)
-{
-  const auto key = make_key("", "1", 0);
+TEST(BucketShardSyncCache, DontEvictPinned) { DontEvictPinned<Shard>(); }
 
-  Handle h; // test that handles keep the cache referenced
+TEST(BucketGenSyncCache, DontEvictPinned) { DontEvictPinned<Gen>(); }
+
+template <typename State>
+void
+HandleLifetime()
+{
+  const auto key = make_key<State>("", "1", 0);
+
+  Handle<State> h; // test that handles keep the cache referenced
   {
-    auto cache = Cache::create(0);
+    auto cache = Cache<State>::create(0);
     h = cache->get(key, std::nullopt);
   }
   EXPECT_EQ(key, h->key.first);
 }
 
-TEST(BucketSyncCache, TargetSize)
-{
-  auto cache = Cache::create(2);
+TEST(BucketShardSyncCache, HandleLifetime) { HandleLifetime<Shard>(); }
 
-  const auto key1 = make_key("", "1", 0);
-  const auto key2 = make_key("", "2", 0);
-  const auto key3 = make_key("", "3", 0);
+TEST(BucketGenSyncCache, HandleLifetime) { HandleLifetime<Gen>(); }
+
+template <typename State>
+void
+TargetSize()
+{
+  auto cache = Cache<State>::create(2);
+
+  const auto key1 = make_key<State>("", "1", 0);
+  const auto key2 = make_key<State>("", "2", 0);
+  const auto key3 = make_key<State>("", "3", 0);
 
   // fill cache up to target_size=2
-  cache->get(key1, std::nullopt)->counter = 1;
-  cache->get(key2, std::nullopt)->counter = 2;
+  mutate(*cache->get(key1, std::nullopt), 1);
+  mutate(*cache->get(key2, std::nullopt), 2);
   // test that each unpinned entry is still cached
-  EXPECT_EQ(1, cache->get(key1, std::nullopt)->counter);
-  EXPECT_EQ(2, cache->get(key2, std::nullopt)->counter);
+  EXPECT_EQ(1, extract(*cache->get(key1, std::nullopt)));
+  EXPECT_EQ(2, extract(*cache->get(key2, std::nullopt)));
   // overflow the cache and recycle key1
-  cache->get(key3, std::nullopt)->counter = 3;
+  mutate(*cache->get(key3, std::nullopt), 3);
   // test that the oldest entry was recycled
-  EXPECT_EQ(0, cache->get(key1, std::nullopt)->counter);
+  EXPECT_EQ(0, extract(*cache->get(key1, std::nullopt)));
 }
 
-TEST(BucketSyncCache, HandleMoveAssignEmpty)
+TEST(BucketShardSyncCache, TargetSize) { TargetSize<Shard>(); }
+
+TEST(BucketGenSyncCache, TargetSize) { TargetSize<Gen>(); }
+
+template <typename State>
+void
+HandleMoveAssignEmpty()
 {
-  auto cache = Cache::create(0);
+  auto cache = Cache<State>::create(0);
 
-  const auto key1 = make_key("", "1", 0);
-  const auto key2 = make_key("", "2", 0);
+  const auto key1 = make_key<State>("", "1", 0);
+  const auto key2 = make_key<State>("", "2", 0);
 
-  Handle j1;
+  Handle<State> j1;
   {
     auto h1 = cache->get(key1, std::nullopt);
     j1 = std::move(h1); // assign over empty handle
@@ -134,32 +263,56 @@ TEST(BucketSyncCache, HandleMoveAssignEmpty)
   EXPECT_EQ(key1, j1->key.first); // j1 stays pinned
 }
 
-TEST(BucketSyncCache, HandleMoveAssignExisting)
+TEST(BucketShardSyncCache, HandleMoveAssignEmpty)
 {
-  const auto key1 = make_key("", "1", 0);
-  const auto key2 = make_key("", "2", 0);
+  HandleMoveAssignEmpty<Shard>();
+}
 
-  Handle h1;
+TEST(BucketGenSyncCache, HandleMoveAssignEmpty)
+{
+  HandleMoveAssignEmpty<Gen>();
+}
+
+template <typename State>
+void
+HandleMoveAssignExisting()
+{
+  const auto key1 = make_key<State>("", "1", 0);
+  const auto key2 = make_key<State>("", "2", 0);
+
+  Handle<State> h1;
   {
-    auto cache1 = Cache::create(0);
+    auto cache1 = Cache<State>::create(0);
     h1 = cache1->get(key1, std::nullopt);
-  } // j1 has the last ref to cache1
+  } // h1 has the last ref to cache1
   {
-    auto cache2 = Cache::create(0);
+    auto cache2 = Cache<State>::create(0);
     auto h2 = cache2->get(key2, std::nullopt);
     h1 = std::move(h2); // assign over existing handle
   }
   EXPECT_EQ(key2, h1->key.first);
 }
 
-TEST(BucketSyncCache, HandleCopyAssignEmpty)
+TEST(BucketShardSyncCache, HandleMoveAssignExisting)
 {
-  auto cache = Cache::create(0);
+  HandleMoveAssignExisting<Shard>();
+}
 
-  const auto key1 = make_key("", "1", 0);
-  const auto key2 = make_key("", "2", 0);
+TEST(BucketGenSyncCache, HandleMoveAssignExisting)
+{
+  HandleMoveAssignExisting<Gen>();
+}
 
-  Handle j1;
+template <typename State>
+void
+HandleCopyAssignEmpty()
+{
+  auto cache = Cache<State>::create(0);
+
+  const auto key1 = make_key<State>("", "1", 0);
+  const auto key2 = make_key<State>("", "2", 0);
+
+  Handle<State> j1;
   {
     auto h1 = cache->get(key1, std::nullopt);
     j1 = h1; // assign over empty handle
@@ -169,21 +322,43 @@ TEST(BucketSyncCache, HandleCopyAssignEmpty)
   EXPECT_EQ(key1, j1->key.first); // j1 stays pinned
 }
 
-TEST(BucketSyncCache, HandleCopyAssignExisting)
+TEST(BucketShardSyncCache, HandleCopyAssignEmpty)
 {
-  const auto key1 = make_key("", "1", 0);
-  const auto key2 = make_key("", "2", 0);
+  HandleCopyAssignEmpty<Shard>();
+}
 
-  Handle h1;
+TEST(BucketGenSyncCache, HandleCopyAssignEmpty)
+{
+  HandleCopyAssignEmpty<Gen>();
+}
+
+template <typename State>
+void
+HandleCopyAssignExisting()
+{
+  const auto key1 = make_key<State>("", "1", 0);
+  const auto key2 = make_key<State>("", "2", 0);
+
+  Handle<State> h1;
   {
-    auto cache1 = Cache::create(0);
+    auto cache1 = Cache<State>::create(0);
     h1 = cache1->get(key1, std::nullopt);
-  } // j1 has the last ref to cache1
+  } // h1 has the last ref to cache1
   {
-    auto cache2 = Cache::create(0);
+    auto cache2 = Cache<State>::create(0);
     auto h2 = cache2->get(key2, std::nullopt);
     h1 = h2; // assign over existing handle
     EXPECT_EQ(&*h1, &*h2);
   }
   EXPECT_EQ(key2, h1->key.first);
+}
+
+TEST(BucketShardSyncCache, HandleCopyAssignExisting)
+{
+  HandleCopyAssignExisting<Shard>();
+}
+
+TEST(BucketGenSyncCache, HandleCopyAssignExisting)
+{
+  HandleCopyAssignExisting<Gen>();
 }


### PR DESCRIPTION
On being asked to sync a shard from a future generation, sync all shards from the current generation to help bring it to completion. Add a per-generation bucket cache to keep track of the last generation recovery sync.

Fixes: https://tracker.ceph.com/issues/75786

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
