### PR TITLE
mgr/dashboard: NFS exports created via Dashboard do not inherit RDMA transport from cluster -- RDMA mount fails

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
@@ -2,11 +2,22 @@ export interface NFSBackend {
   hostname: string;
   ip: string;
   port: number;
+  status?: string;
 }
 
 export interface NFSCluster {
   name: string;
-  virtual_ip: number;
-  port: number;
+  virtual_ip: string | null;
+  port?: number;
   backend: NFSBackend[];
+  enable_rdma?: boolean;
+  placement?: Record<string, unknown>;
+  deployment_type?: string;
+  ingress_mode?: string;
+  monitor_port?: number;
+}
+
+export interface NFSClusterOption {
+  cluster_id: string;
+  enable_rdma?: boolean;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.ts
@@ -54,7 +54,7 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
       this.orchStatus = status;
     });
     this.permission = this.authStorageService.getPermissions().nfs;
-    this.clusters$ = this.subject.pipe(switchMap(() => this.nfsService.nfsClusterList()));
+    this.clusters$ = this.subject.pipe(switchMap(() => this.nfsService.listClusters()));
     this.columns = [
       {
         name: $localize`Name`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -725,6 +725,14 @@
           i18n
           >TCP</cds-checkbox
         >
+        <cds-checkbox
+          *ngIf="clusterRdmaEnabled"
+          formControlName="transportRDMA"
+          name="transportRDMA"
+          id="transportRDMA"
+          i18n
+          >RDMA</cds-checkbox
+        >
         <ng-template #transportError>
           <span
             class="invalid-feedback"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -22,6 +22,24 @@ describe('NfsFormComponent', () => {
   let activatedRoute: ActivatedRouteStub;
   let router: Router;
 
+  const nfsClusterListResponse = [
+    {
+      name: 'mynfs',
+      enable_rdma: false,
+      backend: [],
+      virtual_ip: null,
+      placement: {}
+    }
+  ];
+
+  const flushNfsClusterList = () => {
+    const req = httpTesting.expectOne(
+      (request) =>
+        request.url === 'api/nfs-ganesha/cluster' && request.params.get('info') === 'true'
+    );
+    req.flush(nfsClusterListResponse);
+  };
+
   configureTestBed({
     declarations: [NfsFormComponent, NfsFormClientComponent],
     imports: [
@@ -41,7 +59,7 @@ describe('NfsFormComponent', () => {
 
   const matchSquash = (backendSquashValue: string, uiSquashValue: string) => {
     component.ngOnInit();
-    httpTesting.expectOne('api/nfs-ganesha/cluster').flush(['mynfs']);
+    flushNfsClusterList();
     httpTesting.expectOne('ui-api/nfs-ganesha/cephfs/filesystems').flush([{ id: 1, name: 'a' }]);
     httpTesting.expectOne('api/nfs-ganesha/export/mynfs/1').flush({
       fsal: {
@@ -72,7 +90,7 @@ describe('NfsFormComponent', () => {
     RgwHelper.selectDaemon();
     fixture.detectChanges();
 
-    httpTesting.expectOne('api/nfs-ganesha/cluster').flush(['mynfs']);
+    flushNfsClusterList();
     httpTesting.expectOne('ui-api/nfs-ganesha/cephfs/filesystems').flush([{ id: 1, name: 'a' }]);
     httpTesting.verify();
   });
@@ -98,9 +116,40 @@ describe('NfsFormComponent', () => {
       subvolume: '',
       subvolume_group: '_nogroup',
       transportTCP: true,
-      transportUDP: true
+      transportUDP: true,
+      transportRDMA: false
     });
     expect(component.nfsForm.get('cluster_id').disabled).toBeFalsy();
+  });
+
+  it('should hide RDMA transport when cluster does not support it', () => {
+    component.resolveClusters([
+      {
+        name: 'no-rdma-cluster',
+        enable_rdma: false,
+        backend: [],
+        virtual_ip: null,
+        placement: {}
+      }
+    ]);
+    expect(component.clusterRdmaEnabled).toBe(false);
+  });
+
+  it('should show RDMA transport when cluster supports it', () => {
+    component.allClusters = [{ cluster_id: 'rdma-cluster', enable_rdma: true }];
+    component.updateClusterRdmaAvailability('rdma-cluster');
+    expect(component.clusterRdmaEnabled).toBe(true);
+  });
+
+  it('should clear RDMA transport when switching to a non-RDMA cluster', () => {
+    component.allClusters = [
+      { cluster_id: 'rdma-cluster', enable_rdma: true },
+      { cluster_id: 'no-rdma-cluster', enable_rdma: false }
+    ];
+    component.nfsForm.get('transportRDMA').setValue(true);
+    component.updateClusterRdmaAvailability('no-rdma-cluster');
+    expect(component.clusterRdmaEnabled).toBe(false);
+    expect(component.nfsForm.get('transportRDMA').value).toBe(false);
   });
 
   it('should prepare data when selecting an cluster', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -34,6 +34,7 @@ import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-g
 import { RgwUserService } from '~/app/shared/api/rgw-user.service';
 import { RgwExportType } from '../nfs-list/nfs-list.component';
 import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
+import { NFSCluster, NFSClusterOption } from '../models/nfs-cluster-config';
 
 @Component({
   selector: 'cd-nfs-form',
@@ -54,7 +55,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   cluster_id: string = null;
   export_id: string = null;
 
-  allClusters: { cluster_id: string }[] = null;
+  allClusters: NFSClusterOption[] = null;
+  clusterRdmaEnabled = false;
   icons = Icons;
 
   allFsNames: any[] = null;
@@ -177,6 +179,9 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.resolveFsals(data[1]);
       if (data[2]) {
         this.resolveModel(data[2]);
+      }
+      if (this.isEdit) {
+        this.updateClusterRdmaAvailability(this.cluster_id);
       }
       this.loadingReady();
     });
@@ -314,18 +319,25 @@ export class NfsFormComponent extends CdForm implements OnInit {
       squash: new UntypedFormControl(this.nfsSquash[0]),
       transportUDP: new UntypedFormControl(true, {
         validators: [
-          CdValidators.requiredIf({ transportTCP: false }, (value: boolean) => {
-            return !value;
-          })
+          CdValidators.requiredIf(
+            { transportTCP: false, transportRDMA: false },
+            (value: boolean) => {
+              return !value;
+            }
+          )
         ]
       }),
       transportTCP: new UntypedFormControl(true, {
         validators: [
-          CdValidators.requiredIf({ transportUDP: false }, (value: boolean) => {
-            return !value;
-          })
+          CdValidators.requiredIf(
+            { transportUDP: false, transportRDMA: false },
+            (value: boolean) => {
+              return !value;
+            }
+          )
         ]
       }),
+      transportRDMA: new UntypedFormControl(false),
       clients: this.formBuilder.array([]),
       security_label: new UntypedFormControl(false),
 
@@ -368,6 +380,20 @@ export class NfsFormComponent extends CdForm implements OnInit {
         })
       )
     });
+
+    this.nfsForm.get('cluster_id').valueChanges.subscribe((clusterId: string) => {
+      this.updateClusterRdmaAvailability(clusterId);
+    });
+  }
+
+  updateClusterRdmaAvailability(clusterId: string) {
+    const cluster = this.allClusters?.find(
+      (cluster: NFSClusterOption) => cluster.cluster_id === clusterId
+    );
+    this.clusterRdmaEnabled = cluster?.enable_rdma ?? false;
+    if (!this.clusterRdmaEnabled) {
+      this.nfsForm.get('transportRDMA').setValue(false);
+    }
   }
 
   resolveModel(res: any) {
@@ -381,6 +407,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
     res.transportTCP = res.transports.indexOf('TCP') !== -1;
     res.transportUDP = res.transports.indexOf('UDP') !== -1;
+    res.transportRDMA = res.transports.indexOf('RDMA') !== -1;
     delete res.transports;
 
     Object.entries(this.nfsService.nfsSquash).forEach(([key, value]) => {
@@ -430,11 +457,11 @@ export class NfsFormComponent extends CdForm implements OnInit {
     });
   }
 
-  resolveClusters(clusters: string[]) {
-    this.allClusters = [];
-    for (const cluster of clusters) {
-      this.allClusters.push({ cluster_id: cluster });
-    }
+  resolveClusters(clusters: NFSCluster[]) {
+    this.allClusters = clusters.map((cluster) => ({
+      cluster_id: cluster.name,
+      enable_rdma: cluster.enable_rdma ?? false
+    }));
     if (!this.isEdit && this.allClusters.length > 0) {
       this.nfsForm.get('cluster_id').setValue(this.allClusters[0].cluster_id);
     }
@@ -689,6 +716,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
       requestModel.transports.push('UDP');
     }
     delete requestModel.transportUDP;
+    if (requestModel.transportRDMA) {
+      requestModel.transports.push('RDMA');
+    }
+    delete requestModel.transportRDMA;
 
     requestModel.clients.forEach((client: any) => {
       if (_.isString(client.addresses)) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
@@ -87,9 +87,10 @@ export class NfsService extends ApiClient {
     });
   }
 
-  listClusters() {
-    return this.http.get(`${this.apiPath}/cluster`, {
-      headers: { Accept: this.getVersionHeaderValue(0, 1) }
+  listClusters(): Observable<NFSCluster[]> {
+    return this.http.get<NFSCluster[]>(`${this.apiPath}/cluster`, {
+      headers: { Accept: this.getVersionHeaderValue(0, 1) },
+      params: { info: true }
     });
   }
 
@@ -106,12 +107,5 @@ export class NfsService extends ApiClient {
 
   filesystems() {
     return this.http.get(`${this.uiApiPath}/cephfs/filesystems`);
-  }
-
-  nfsClusterList(): Observable<NFSCluster[]> {
-    return this.http.get<NFSCluster[]>(`${this.apiPath}/cluster`, {
-      headers: { Accept: this.getVersionHeaderValue(0, 1) },
-      params: { info: true }
-    });
   }
 }

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -457,6 +457,7 @@ class NFSCluster:
 
         deployment_type = "standalone"
         placement = None
+        enable_rdma = False
 
         nfs_sc = self.mgr.describe_service(
             service_type='nfs',
@@ -466,6 +467,7 @@ class NFSCluster:
         for svc in nfs_services:
             if svc.spec.service_id == cluster_id:
                 placement = svc.spec.placement
+                enable_rdma = getattr(svc.spec, 'enable_rdma', False)
                 break
 
         if ingress_mode:
@@ -481,6 +483,7 @@ class NFSCluster:
             'virtual_ip': virtual_ip,
             'backend': backends,
             'placement': placement.to_json() if placement else {},
+            'enable_rdma': enable_rdma,
         }
 
         if ingress_mode:

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1436,7 +1436,8 @@ EXPORT {
             "deployment_type": "standalone",
             "virtual_ip": None,
             "backend": [],
-            "placement": {}
+            "placement": {},
+            "enable_rdma": False,
         }}
 
     def test_cluster_info(self):


### PR DESCRIPTION


https://github.com/user-attachments/assets/22061966-25b5-4704-9321-d94f61c8fce9


-----------------------------------------------------------------------------------------------------------------------------------------------------------

Testing ->


[ceph: root@ceph-node-00 /]# ceph nfs cluster create rdma-cluster "ceph-node-00" --port 2049 **--enable_rdma --rdma_port 20049**
rdma-cluster cluster already exists
[ceph: root@ceph-node-00 /]# ceph nfs cluster ls                                                                            
[
  "nfs-rdma1",
  "rdmaclustertest",
  **"rdma-cluster"**
]
[ceph: root@ceph-node-00 /]# ceph fs volume create myfs
[ceph: root@ceph-node-00 /]# ceph fs ls
name: cephfs, metadata pool: cephfs.cephfs.meta, data pools: [cephfs.cephfs.data ]
name: myfs, metadata pool: cephfs.myfs.meta, data pools: [cephfs.myfs.data ]
[ceph: root@ceph-node-00 /]# ceph nfs export apply rdma-cluster -i - <<EOF
{
  "pseudo": "/dashboard-export",
  "path": "/",
  "cluster_id": "rdma-cluster",
  "access_type": "RW",
  "squash": "no_root_squash",
  "protocols": [4],
  **"transports": ["TCP", "UDP"],**
  "fsal": {
    "name": "CEPH",
    "fs_name": "myfs"
  }
}
EOF
[
  {
    "pseudo": "/dashboard-export",
    "state": "added"
  }
]
[ceph: root@ceph-node-00 /]# ceph nfs export info rdma-cluster /dashboard-export

{
  "access_type": "RW",
  "clients": [],
  "cluster_id": "rdma-cluster",
  "export_id": 1,
  "fsal": {
    "cmount_path": "/",
    "fs_name": "myfs",
    "name": "CEPH",
    "user_id": "nfs.rdma-cluster.myfs.236cea90"
  },
  "path": "/",
  "protocols": [
    4
  ],
  "pseudo": "/dashboard-export",
  "security_label": true,
  "squash": "no_root_squash",
  **"transports": [
    "RDMA",
    "TCP",
    "UDP"
  ]
}**
[ceph: root@ceph-node-00 /]# ceph nfs cluster create **no-rdma-cluster** "ceph-node-00" --port 2049                                
[ceph: root@ceph-node-00 /]# ceph nfs export apply no-rdma-cluster -i - <<EOF
{
  "pseudo": "/dashboard-export1",
  "path": "/",
  "cluster_id": "no-rdma-cluster",
  "access_type": "RW",
  "squash": "no_root_squash",
  "protocols": [4],
  "transports": ["TCP", "UDP"],
  "fsal": {
    "name": "CEPH",
    "fs_name": "myfs"
  }
}
EOF
[
  {
    "pseudo": "/dashboard-export1",
    "state": "added"
  }
]
[ceph: root@ceph-node-00 /]# ceph nfs export info no-rdma-cluster /dashboard-export1
{
  "access_type": "RW",
  "clients": [],
  "cluster_id": "no-rdma-cluster",
  "export_id": 1,
  "fsal": {
    "cmount_path": "/",
    "fs_name": "myfs",
    "name": "CEPH",
    "user_id": "nfs.no-rdma-cluster.myfs.792e65f0"
  },
  "path": "/",
  "protocols": [
    4
  ],
  "pseudo": "/dashboard-export1",
  "security_label": true,
  "squash": "no_root_squash",
  **"transports": [
    "TCP",
    "UDP"
  ]
}**
[ceph: root@ceph-node-00 /]# no rdma added and its not in cluster level


-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
