### PR TITLE
mgr/orchestrator: added label remove service option

### DIFF
--- a/doc/cephadm/services/index.rst
+++ b/doc/cephadm/services/index.rst
@@ -934,3 +934,69 @@ See Also
 
 * See :ref:`cephadm-osd-declarative` for special handling of unmanaged OSDs.
 * See also :ref:`cephadm-pause`.
+
+
+.. _cephadm-spec-allow-label-remove-service:
+
+Allow Label Placement to Remove All Instances of a Service
+==========================================================
+
+Cephadm supports allowing label placement to remove all instances of a
+service by removing all labels for that service. By default, this feature
+is disabled to protect against users accidentally removing services by
+accident.
+
+
+Allow on Specification Application
+----------------------------------
+
+To allow label placement to remove all instances of a service, set
+``allow_label_remove_service=True`` in :ref:`orchestrator-cli-service-spec` (example.yaml).
+
+``example.yaml``:
+
+.. code-block:: yaml
+
+    service_type: node-exporter
+    placement:
+      label: node-exporter
+    allow_label_remove_service: true
+
+.. prompt:: bash #
+
+    ceph orch apply -i example.yaml
+
+It can also be set using the ``--allow-label-remove-service`` option.
+
+.. prompt:: bash #
+
+    ceph orch apply node-exporter --placement="label:node-exporter" --allow-label-remove-service
+
+
+Allow After Specification Application
+-------------------------------------
+
+To allow label placement to remove all instances of a service after specification
+has been applied, use ``ceph orch set-allow-label-remove-service`` command. The
+commands requires the service name (as reported in ``ceph orch ls``) and boolean
+value as arguments.
+
+.. prompt:: bash #
+
+    ceph orch set-allow-label-remove-service node-exporter true
+
+This will allow the node-exporter service to have all instances removed by label
+placement.
+
+.. prompt:: bash #
+
+    ceph orch set-allow-label-remove-service node-exporter false
+
+This will disallow the node-exporter service to have all instances removed by label
+placement.
+
+.. note::
+    
+  You can use ``ceph orch set-allow-label-remove-service`` on any service, including
+  services that don't have label placement, but it won't have any tangible effect
+  unless the service uses label placement.

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -538,7 +538,7 @@ class SpecStore():
         self._specs[service_name].allow_label_remove_service = value
         self.save(self._specs[service_name])
         return f'Set <allow_label_remove_service> to {str(value)} for service {service_name}'
-    
+
     def needs_configuration(self, name: str) -> bool:
         return self._needs_configuration.get(name, False)
 

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -530,6 +530,15 @@ class SpecStore():
         self.save(self._specs[service_name])
         return f'Set unmanaged to {str(value)} for service {service_name}'
 
+    def set_allow_label_remove_service(self, service_name: str, value: bool) -> str:
+        if service_name not in self._specs:
+            return f'No service of name {service_name} found. Check "ceph orch ls" for all known services'
+        if self._specs[service_name].allow_label_remove_service == value:
+            return f'Service {service_name} already has <allow_label_remove_service> set to {value}. No action taken.'
+        self._specs[service_name].allow_label_remove_service = value
+        self.save(self._specs[service_name])
+        return f'Set <allow_label_remove_service> to {str(value)} for service {service_name}'
+    
     def needs_configuration(self, name: str) -> bool:
         return self._needs_configuration.get(name, False)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4612,6 +4612,10 @@ Then run the following:
         return self.spec_store.set_unmanaged(service_name, value)
 
     @handle_orch_error
+    def set_allow_label_remove_service(self, service_name: str, value: bool) -> str:
+        return self.spec_store.set_allow_label_remove_service(service_name, value)
+
+    @handle_orch_error
     def upgrade_check(self, image: str, version: str) -> str:
         if self.inventory.get_host_with_state("maintenance"):
             raise OrchestratorError("check aborted - you have hosts in maintenance state")

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -284,7 +284,7 @@ class HostAssignment(object):
                 raise OrchestratorValidationError(
                     f'Cannot place {self.spec.one_line_str()}: No matching hosts')
 
-        if self.spec.placement.label:
+        if self.spec.placement.label and not self.spec.allow_label_remove_service:
             label_hosts = self.hosts_by_label(self.spec.placement.label)
             if not label_hosts:
                 raise OrchestratorValidationError(

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -2885,6 +2885,14 @@ Traceback (most recent call last):
         cephadm_module.spec_store.set_unmanaged('crash', False)
         assert not cephadm_module.spec_store._specs['crash'].unmanaged
 
+    def test_set_allow_label_remove_service(self, cephadm_module):
+        cephadm_module.spec_store._specs['node-exporter'] = ServiceSpec('node-exporter', allow_label_remove_service=False)
+        assert not cephadm_module.spec_store._specs['node-exporter'].allow_label_remove_service
+        cephadm_module.spec_store.set_allow_label_remove_service('node-exporter', True)
+        assert cephadm_module.spec_store._specs['node-exporter'].allow_label_remove_service
+        cephadm_module.spec_store.set_allow_label_remove_service('node-exporter', False)
+        assert not cephadm_module.spec_store._specs['node-exporter'].allow_label_remove_service
+
     def test_inventory_known_hostnames(self, cephadm_module):
         cephadm_module.inventory.add_host(HostSpec('host1', '1.2.3.1'))
         cephadm_module.inventory.add_host(HostSpec('host2', '1.2.3.2'))

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -674,7 +674,7 @@ class Orchestrator(object):
         :return: None
         """
         raise NotImplementedError()
-    
+
     def plan(self, spec: Sequence["GenericSpec"]) -> OrchResult[List]:
         """
         Plan (Dry-run, Preview) a List of Specs.

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -667,6 +667,14 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def set_allow_label_remove_service(self, service_name: str, value: bool) -> OrchResult[str]:
+        """
+        Set allow_label_remove_service parameter to True/False for a given service
+
+        :return: None
+        """
+        raise NotImplementedError()
+    
     def plan(self, spec: Sequence["GenericSpec"]) -> OrchResult[List]:
         """
         Plan (Dry-run, Preview) a List of Specs.

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1984,7 +1984,7 @@ Usage:
 
                 if dry_run and not isinstance(spec, HostSpec):
                     spec.preview_only = dry_run
-                    
+
                 if isinstance(spec, TracingSpec) and spec.service_type == 'jaeger-tracing':
                     specs.extend(spec.get_tracing_specs())
                     continue
@@ -1997,7 +1997,7 @@ Usage:
             if not service_type:
                 raise OrchestratorValidationError(usage)
             specs = [ServiceSpec(service_type.value, placement=placementspec,
-                                 unmanaged=unmanaged, preview_only=dry_run, 
+                                 unmanaged=unmanaged, preview_only=dry_run,
                                  allow_label_remove_service=allow_label_remove_service)]
         cmd_result = self._apply_misc(specs, dry_run, format, no_overwrite, continue_on_error)
         if errs:
@@ -2369,7 +2369,7 @@ Usage:
         raise_if_exception(completion)
         out = completion.result_str()
         return HandleCommandResult(stdout=out)
-    
+
     @OrchestratorCLICommand.Write('orch set backend')
     def _set_backend(self, module_name: Optional[str] = None) -> HandleCommandResult:
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2359,6 +2359,17 @@ Usage:
         out = completion.result_str()
         return HandleCommandResult(stdout=out)
 
+    @OrchestratorCLICommand.Write('orch set-allow-label-remove-service')
+    def _set_allow_label_remove_service(self, service_name: str, value: str) -> HandleCommandResult:
+        """Set allow_label_remove_service parameter for the given service name"""
+        if value.lower() not in ("true", "false"):
+            return HandleCommandResult(stderr=f"{value} is not a valid argument, pass 'true' or 'false'", retval=-errno.EINVAL)
+        allow = value.lower() == "true"
+        completion = self.set_allow_label_remove_service(service_name, allow)
+        raise_if_exception(completion)
+        out = completion.result_str()
+        return HandleCommandResult(stdout=out)
+    
     @OrchestratorCLICommand.Write('orch set backend')
     def _set_backend(self, module_name: Optional[str] = None) -> HandleCommandResult:
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1917,11 +1917,12 @@ Usage:
                    unmanaged: bool = False,
                    no_overwrite: bool = False,
                    continue_on_error: bool = False,
-                   inbuf: Optional[str] = None) -> HandleCommandResult:
+                   inbuf: Optional[str] = None,
+                   allow_label_remove_service: bool = False) -> HandleCommandResult:
         """Update the size or placement for a service or apply a large yaml spec"""
         usage = """Usage:
   ceph orch apply -i <yaml spec> [--dry-run]
-  ceph orch apply <service_type> [--placement=<placement_string>] [--unmanaged]
+  ceph orch apply <service_type> [--placement=<placement_string>] [--unmanaged] [--allow-label-remove-service]
         """
         errs: List[str] = []
         if inbuf:
@@ -1983,7 +1984,7 @@ Usage:
 
                 if dry_run and not isinstance(spec, HostSpec):
                     spec.preview_only = dry_run
-
+                    
                 if isinstance(spec, TracingSpec) and spec.service_type == 'jaeger-tracing':
                     specs.extend(spec.get_tracing_specs())
                     continue
@@ -1996,7 +1997,8 @@ Usage:
             if not service_type:
                 raise OrchestratorValidationError(usage)
             specs = [ServiceSpec(service_type.value, placement=placementspec,
-                                 unmanaged=unmanaged, preview_only=dry_run)]
+                                 unmanaged=unmanaged, preview_only=dry_run, 
+                                 allow_label_remove_service=allow_label_remove_service)]
         cmd_result = self._apply_misc(specs, dry_run, format, no_overwrite, continue_on_error)
         if errs:
             # HandleCommandResult is a named tuple, so use

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1008,6 +1008,7 @@ class ServiceSpec(object):
                  ip_addrs: Optional[Dict[str, str]] = None,
                  ssl_ca_cert: Optional[str] = None,
                  termination_grace_period_seconds: Optional[int] = None,
+                 allow_label_remove_service: bool = False,
                  ):
 
         #: See :ref:`orchestrator-cli-placement-spec`.
@@ -1052,6 +1053,13 @@ class ServiceSpec(object):
         self.targets: List[str] = targets or []
         self.remote_write_url = remote_write_url
         self.remote_write_allowed_metrics = remote_write_allowed_metrics
+
+        #: If set to ``true``, a user can remove all instances of a service
+        #: by applying a service spec where no hosts match the label for
+        #: service placement. A user can also, at run time, remove labels from
+        #: hosts to achieve the same effect. This is helpful, for giving users
+        #: the ability to completely remove a service by using labels.
+        self.allow_label_remove_service = allow_label_remove_service
 
         self.config: Optional[Dict[str, str]] = None
         if config:
@@ -1218,6 +1226,8 @@ class ServiceSpec(object):
             ret['unmanaged'] = self.unmanaged
         if self.networks:
             ret['networks'] = self.networks
+        if self.allow_label_remove_service:
+            ret['allow_label_remove_service'] = self.allow_label_remove_service
         if self.extra_container_args:
             ret['extra_container_args'] = ArgumentSpec.map_json(
                 self.extra_container_args
@@ -1424,6 +1434,7 @@ class NFSServiceSpec(ServiceSpec):
                  tls_min_version: Optional[str] = None,
                  tls_ciphers: Optional[str] = None,
                  colocation_ports: Optional[List[Dict[str, int]]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -1432,7 +1443,8 @@ class NFSServiceSpec(ServiceSpec):
             config=config, networks=networks, extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args, custom_configs=custom_configs,
             ip_addrs=ip_addrs, ssl=ssl, ssl_cert=ssl_cert, ssl_key=ssl_key, ssl_ca_cert=ssl_ca_cert,
-            certificate_source=certificate_source, custom_sans=custom_sans)
+            certificate_source=certificate_source, custom_sans=custom_sans,
+            allow_label_remove_service=allow_label_remove_service)
 
         self.port = port
 
@@ -1674,6 +1686,7 @@ class RGWSpec(ServiceSpec):
                  rgw_exit_timeout_secs: int = 120,
                  qat: Optional[Dict[str, str]] = None,
                  d3n_cache: Optional[Dict[str, Any]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'rgw', service_type
 
@@ -1691,7 +1704,7 @@ class RGWSpec(ServiceSpec):
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config, networks=networks,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs)
+            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service)
 
         #: The RGW realm associated with this service. Needs to be manually created
         #: if the spec is being applied directly to cephdam. In case of rgw module
@@ -1950,6 +1963,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'nvmeof'
         super(NvmeofServiceSpec, self).__init__('nvmeof', service_id=service_id,
@@ -1963,7 +1977,8 @@ class NvmeofServiceSpec(ServiceSpec):
                                                 config=config, networks=networks,
                                                 extra_container_args=extra_container_args,
                                                 extra_entrypoint_args=extra_entrypoint_args,
-                                                custom_configs=custom_configs)
+                                                custom_configs=custom_configs,
+                                                allow_label_remove_service=allow_label_remove_service)
 
         #: RADOS pool where ceph-nvmeof config data is stored (use '.nvmeof' as default).
         self.pool = pool or '.nvmeof'
@@ -2369,6 +2384,7 @@ class IscsiServiceSpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'iscsi'
         super(IscsiServiceSpec, self).__init__('iscsi', service_id=service_id,
@@ -2382,7 +2398,8 @@ class IscsiServiceSpec(ServiceSpec):
                                                config=config, networks=networks,
                                                extra_container_args=extra_container_args,
                                                extra_entrypoint_args=extra_entrypoint_args,
-                                               custom_configs=custom_configs)
+                                               custom_configs=custom_configs,
+                                               allow_label_remove_service=allow_label_remove_service)
 
         #: RADOS pool where ceph-iscsi config data is stored.
         self.pool = pool
@@ -2468,6 +2485,7 @@ class IngressSpec(ServiceSpec):
                  monitor_ip_addrs: Optional[Dict[str, str]] = None,
                  use_tcp_mode_over_rgw: bool = False,
                  haproxy_peer_communication_port: Optional[int] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'ingress'
 
@@ -2482,7 +2500,8 @@ class IngressSpec(ServiceSpec):
             custom_sans=custom_sans,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
         )
         self.backend_service = backend_service
         self.frontend_port = frontend_port
@@ -2619,6 +2638,7 @@ class MgmtGatewaySpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'mgmt-gateway'
 
@@ -2634,7 +2654,8 @@ class MgmtGatewaySpec(ServiceSpec):
             preview_only=preview_only,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
         )
         #: Flag to enable or disable HTTPS. By default set to True.
         self.ssl = ssl
@@ -2754,6 +2775,7 @@ class OAuth2ProxySpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'oauth2-proxy'
 
@@ -2768,7 +2790,8 @@ class OAuth2ProxySpec(ServiceSpec):
             custom_sans=custom_sans,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
         )
         #: The address for HTTPS connections, formatted as 'host:port'.
         self.https_address = https_address
@@ -3027,6 +3050,7 @@ class CustomContainerSpec(ServiceSpec):
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
                  init_containers: Optional[List[Union['InitContainerSpec', Dict[str, Any]]]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'container'
         assert service_id is not None
@@ -3038,7 +3062,8 @@ class CustomContainerSpec(ServiceSpec):
             preview_only=preview_only, config=config,
             networks=networks, extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs)
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service)
 
         self.image = image
         self.entrypoint = entrypoint
@@ -3120,6 +3145,7 @@ class MonitoringSpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type in ['grafana', 'node-exporter', 'prometheus', 'alertmanager',
                                 'loki', 'alloy', 'promtail']
@@ -3133,7 +3159,8 @@ class MonitoringSpec(ServiceSpec):
             extra_entrypoint_args=extra_entrypoint_args,
             custom_configs=custom_configs, targets=targets,
             remote_write_url=remote_write_url,
-            remote_write_allowed_metrics=remote_write_allowed_metrics)
+            remote_write_allowed_metrics=remote_write_allowed_metrics,
+            allow_label_remove_service=allow_label_remove_service)
 
         self.service_type = service_type
         self.port = port
@@ -3175,6 +3202,7 @@ class AlertManagerSpec(MonitoringSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'alertmanager'
         super(AlertManagerSpec, self).__init__(
@@ -3183,7 +3211,7 @@ class AlertManagerSpec(MonitoringSpec):
             ssl=ssl, certificate_source=certificate_source,
             preview_only=preview_only, config=config, networks=networks, port=port,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs)
+            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service)
 
         # Custom configuration.
         #
@@ -3236,6 +3264,7 @@ class GrafanaSpec(MonitoringSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'grafana'
         super(GrafanaSpec, self).__init__(
@@ -3244,7 +3273,7 @@ class GrafanaSpec(MonitoringSpec):
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config, networks=networks, port=port,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs)
+            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service)
 
         self.initial_admin_password = initial_admin_password
         self.anonymous_access = anonymous_access
@@ -3311,6 +3340,7 @@ class PrometheusSpec(MonitoringSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'prometheus'
         super(PrometheusSpec, self).__init__(
@@ -3320,7 +3350,8 @@ class PrometheusSpec(MonitoringSpec):
             preview_only=preview_only, config=config, networks=networks, port=port, targets=targets,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
             custom_configs=custom_configs, remote_write_url=remote_write_url,
-            remote_write_allowed_metrics=remote_write_allowed_metrics)
+            remote_write_allowed_metrics=remote_write_allowed_metrics,
+            allow_label_remove_service=allow_label_remove_service)
 
         self.retention_time = retention_time.strip() if retention_time else None
         self.retention_size = retention_size.strip() if retention_size else None
@@ -3388,6 +3419,7 @@ class SNMPGatewaySpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'snmp-gateway'
 
@@ -3398,7 +3430,8 @@ class SNMPGatewaySpec(ServiceSpec):
             preview_only=preview_only,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs)
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service)
 
         self.service_type = service_type
         self.snmp_version = snmp_version
@@ -3511,6 +3544,7 @@ class MDSSpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'mds'
         super(MDSSpec, self).__init__('mds', service_id=service_id,
@@ -3520,7 +3554,8 @@ class MDSSpec(ServiceSpec):
                                       preview_only=preview_only,
                                       extra_container_args=extra_container_args,
                                       extra_entrypoint_args=extra_entrypoint_args,
-                                      custom_configs=custom_configs)
+                                      custom_configs=custom_configs,
+                                      allow_label_remove_service=allow_label_remove_service)
 
     def validate(self) -> None:
         super(MDSSpec, self).validate()
@@ -3546,6 +3581,7 @@ class MONSpec(ServiceSpec):
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
                  crush_locations: Optional[Dict[str, List[str]]] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'mon'
         super(MONSpec, self).__init__('mon', service_id=service_id,
@@ -3557,7 +3593,8 @@ class MONSpec(ServiceSpec):
                                       networks=networks,
                                       extra_container_args=extra_container_args,
                                       extra_entrypoint_args=extra_entrypoint_args,
-                                      custom_configs=custom_configs)
+                                      custom_configs=custom_configs,
+                                      allow_label_remove_service=allow_label_remove_service)
 
         self.crush_locations = crush_locations
         self.validate()
@@ -3592,7 +3629,8 @@ class TracingSpec(ServiceSpec):
                  networks: Optional[List[str]] = None,
                  placement: Optional[PlacementSpec] = None,
                  unmanaged: bool = False,
-                 preview_only: bool = False
+                 preview_only: bool = False,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type in TracingSpec.SERVICE_TYPES + ['jaeger-tracing']
 
@@ -3600,7 +3638,8 @@ class TracingSpec(ServiceSpec):
             service_type, service_id,
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config,
-            networks=networks)
+            networks=networks,
+            allow_label_remove_service=allow_label_remove_service)
         self.without_query = without_query
         self.es_nodes = es_nodes
 
@@ -3633,7 +3672,8 @@ class TracingSpec(ServiceSpec):
                                      unmanaged=self.unmanaged,
                                      config=self.config,
                                      networks=self.networks,
-                                     preview_only=self.preview_only
+                                     preview_only=self.preview_only,
+                                     allow_label_remove_service=self.allow_label_remove_service
                                      ))
         return specs
 
@@ -3707,6 +3747,7 @@ class CephExporterSpec(ServiceSpec):
                  preview_only: bool = False,
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
+                 allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'ceph-exporter'
 
@@ -3718,7 +3759,8 @@ class CephExporterSpec(ServiceSpec):
             unmanaged=unmanaged,
             preview_only=preview_only,
             extra_container_args=extra_container_args,
-            extra_entrypoint_args=extra_entrypoint_args)
+            extra_entrypoint_args=extra_entrypoint_args,
+            allow_label_remove_service=allow_label_remove_service)
 
         self.service_type = service_type
         self.sock_dir = None
@@ -4123,6 +4165,7 @@ class SMBSpec(ServiceSpec):
         unmanaged: bool = False,
         preview_only: bool = False,
         networks: Optional[List[str]] = None,
+        allow_label_remove_service: bool = False,
         # --- smb specific values ---
         # cluster_id - a name identifying the smb "cluster" this daemon
         # is part of. A cluster may be made up of one or more services
@@ -4216,6 +4259,7 @@ class SMBSpec(ServiceSpec):
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
             custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
         )
         self.cluster_id = cluster_id
         self.features = features or []

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1444,7 +1444,8 @@ class NFSServiceSpec(ServiceSpec):
             extra_entrypoint_args=extra_entrypoint_args, custom_configs=custom_configs,
             ip_addrs=ip_addrs, ssl=ssl, ssl_cert=ssl_cert, ssl_key=ssl_key, ssl_ca_cert=ssl_ca_cert,
             certificate_source=certificate_source, custom_sans=custom_sans,
-            allow_label_remove_service=allow_label_remove_service)
+            allow_label_remove_service=allow_label_remove_service
+        )
 
         self.port = port
 
@@ -1704,7 +1705,8 @@ class RGWSpec(ServiceSpec):
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config, networks=networks,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service)
+            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service
+        )
 
         #: The RGW realm associated with this service. Needs to be manually created
         #: if the spec is being applied directly to cephdam. In case of rgw module
@@ -1966,19 +1968,21 @@ class NvmeofServiceSpec(ServiceSpec):
                  allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'nvmeof'
-        super(NvmeofServiceSpec, self).__init__('nvmeof', service_id=service_id,
-                                                ssl=ssl,
-                                                certificate_source=certificate_source,
-                                                ssl_cert=ssl_cert,
-                                                ssl_key=ssl_key,
-                                                custom_sans=custom_sans,
-                                                placement=placement, unmanaged=unmanaged,
-                                                preview_only=preview_only,
-                                                config=config, networks=networks,
-                                                extra_container_args=extra_container_args,
-                                                extra_entrypoint_args=extra_entrypoint_args,
-                                                custom_configs=custom_configs,
-                                                allow_label_remove_service=allow_label_remove_service)
+        super(NvmeofServiceSpec, self).__init__(
+            'nvmeof', service_id=service_id,
+            ssl=ssl,
+            certificate_source=certificate_source,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+            custom_sans=custom_sans,
+            placement=placement, unmanaged=unmanaged,
+            preview_only=preview_only,
+            config=config, networks=networks,
+            extra_container_args=extra_container_args,
+            extra_entrypoint_args=extra_entrypoint_args,
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
+        )
 
         #: RADOS pool where ceph-nvmeof config data is stored (use '.nvmeof' as default).
         self.pool = pool or '.nvmeof'
@@ -2387,19 +2391,21 @@ class IscsiServiceSpec(ServiceSpec):
                  allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'iscsi'
-        super(IscsiServiceSpec, self).__init__('iscsi', service_id=service_id,
-                                               placement=placement, unmanaged=unmanaged,
-                                               ssl=ssl,
-                                               ssl_cert=ssl_cert,
-                                               ssl_key=ssl_key,
-                                               certificate_source=certificate_source,
-                                               custom_sans=custom_sans,
-                                               preview_only=preview_only,
-                                               config=config, networks=networks,
-                                               extra_container_args=extra_container_args,
-                                               extra_entrypoint_args=extra_entrypoint_args,
-                                               custom_configs=custom_configs,
-                                               allow_label_remove_service=allow_label_remove_service)
+        super(IscsiServiceSpec, self).__init__(
+            'iscsi', service_id=service_id,
+            placement=placement, unmanaged=unmanaged,
+            ssl=ssl,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+            certificate_source=certificate_source,
+            custom_sans=custom_sans,
+            preview_only=preview_only,
+            config=config, networks=networks,
+            extra_container_args=extra_container_args,
+            extra_entrypoint_args=extra_entrypoint_args,
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
+        )
 
         #: RADOS pool where ceph-iscsi config data is stored.
         self.pool = pool
@@ -3063,7 +3069,8 @@ class CustomContainerSpec(ServiceSpec):
             networks=networks, extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
             custom_configs=custom_configs,
-            allow_label_remove_service=allow_label_remove_service)
+            allow_label_remove_service=allow_label_remove_service
+        )
 
         self.image = image
         self.entrypoint = entrypoint
@@ -3211,7 +3218,8 @@ class AlertManagerSpec(MonitoringSpec):
             ssl=ssl, certificate_source=certificate_source,
             preview_only=preview_only, config=config, networks=networks, port=port,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service)
+            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service
+        )
 
         # Custom configuration.
         #
@@ -3273,7 +3281,8 @@ class GrafanaSpec(MonitoringSpec):
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config, networks=networks, port=port,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service)
+            custom_configs=custom_configs, allow_label_remove_service=allow_label_remove_service
+        )
 
         self.initial_admin_password = initial_admin_password
         self.anonymous_access = anonymous_access
@@ -3431,7 +3440,8 @@ class SNMPGatewaySpec(ServiceSpec):
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
             custom_configs=custom_configs,
-            allow_label_remove_service=allow_label_remove_service)
+            allow_label_remove_service=allow_label_remove_service
+        )
 
         self.service_type = service_type
         self.snmp_version = snmp_version
@@ -3547,15 +3557,17 @@ class MDSSpec(ServiceSpec):
                  allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'mds'
-        super(MDSSpec, self).__init__('mds', service_id=service_id,
-                                      placement=placement,
-                                      config=config,
-                                      unmanaged=unmanaged,
-                                      preview_only=preview_only,
-                                      extra_container_args=extra_container_args,
-                                      extra_entrypoint_args=extra_entrypoint_args,
-                                      custom_configs=custom_configs,
-                                      allow_label_remove_service=allow_label_remove_service)
+        super(MDSSpec, self).__init__(
+            'mds', service_id=service_id,
+            placement=placement,
+            config=config,
+            unmanaged=unmanaged,
+            preview_only=preview_only,
+            extra_container_args=extra_container_args,
+            extra_entrypoint_args=extra_entrypoint_args,
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
+        )
 
     def validate(self) -> None:
         super(MDSSpec, self).validate()
@@ -3584,17 +3596,19 @@ class MONSpec(ServiceSpec):
                  allow_label_remove_service: bool = False,
                  ):
         assert service_type == 'mon'
-        super(MONSpec, self).__init__('mon', service_id=service_id,
-                                      placement=placement,
-                                      count=count,
-                                      config=config,
-                                      unmanaged=unmanaged,
-                                      preview_only=preview_only,
-                                      networks=networks,
-                                      extra_container_args=extra_container_args,
-                                      extra_entrypoint_args=extra_entrypoint_args,
-                                      custom_configs=custom_configs,
-                                      allow_label_remove_service=allow_label_remove_service)
+        super(MONSpec, self).__init__(
+            'mon', service_id=service_id,
+            placement=placement,
+            count=count,
+            config=config,
+            unmanaged=unmanaged,
+            preview_only=preview_only,
+            networks=networks,
+            extra_container_args=extra_container_args,
+            extra_entrypoint_args=extra_entrypoint_args,
+            custom_configs=custom_configs,
+            allow_label_remove_service=allow_label_remove_service
+        )
 
         self.crush_locations = crush_locations
         self.validate()
@@ -3639,7 +3653,8 @@ class TracingSpec(ServiceSpec):
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config,
             networks=networks,
-            allow_label_remove_service=allow_label_remove_service)
+            allow_label_remove_service=allow_label_remove_service
+        )
         self.without_query = without_query
         self.es_nodes = es_nodes
 
@@ -3760,7 +3775,8 @@ class CephExporterSpec(ServiceSpec):
             preview_only=preview_only,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
-            allow_label_remove_service=allow_label_remove_service)
+            allow_label_remove_service=allow_label_remove_service
+        )
 
         self.service_type = service_type
         self.sock_dir = None


### PR DESCRIPTION
There was a team that wanted the ability to remove a service by removing all labels associated to that service when placing using label placement. This feature currently doesn't exist and will error when finding that no hosts have that label, this is for good reason, as we do not want people to accidentally remove a whole service because they misspelled a label. I think adding an explicit option ``--allow-label-remove-service`` during spec applying is a safe way to add the feature for those who want it.

Fixes: https://tracker.ceph.com/issues/75867

Signed-off-by: Timothy Q Nguyen <timqn22@gmail.com>



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
