### PR TITLE
rgw: fix crash in RGWWatcher::reinit()

### DIFF
--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -13,6 +13,7 @@
 
 #include "rgw_zone.h"
 
+#include <atomic>
 #include <shared_mutex> // for std::shared_lock
 
 #define dout_subsys ceph_subsys_rgw
@@ -29,6 +30,7 @@ class RGWWatcher : public DoutPrefixProvider , public librados::WatchCtx2 {
   uint64_t watch_handle;
   bool unregister_done{false};
   uint64_t retries = 0;
+  std::atomic<bool> reinit_pending{false};
 
   class C_ReinitWatch : public Context {
     RGWWatcher *watcher;
@@ -48,6 +50,12 @@ class RGWWatcher : public DoutPrefixProvider , public librados::WatchCtx2 {
 public:
   RGWWatcher(CephContext *_cct, RGWSI_Notify *s, int i, rgw_rados_ref o)
     : cct(_cct), svc(s), index(i), obj(std::move(o)), watch_handle(0) {}
+
+  RGWWatcher(RGWWatcher&& rhs) noexcept
+    : cct(rhs.cct), svc(rhs.svc), index(rhs.index),
+      obj(std::move(rhs.obj)), watch_handle(rhs.watch_handle),
+      unregister_done(rhs.unregister_done), retries(rhs.retries),
+      reinit_pending(rhs.reinit_pending.load(std::memory_order_relaxed)) {}
 
   rgw_rados_ref& get_obj() { return obj; }
 
@@ -81,10 +89,15 @@ public:
     ldpp_dout(this, -1) << "RGWWatcher::handle_error cookie " << cookie
 			<< " err " << cpp_strerror(err) << dendl;
     svc->remove_watcher(index);
-    svc->schedule_context(new C_ReinitWatch(this));
+    bool expected = false;
+    if (reinit_pending.compare_exchange_strong(expected, true)) {
+      svc->schedule_context(new C_ReinitWatch(this));
+    }
   }
 
   void reinit() {
+    reinit_pending.store(false);
+
     if (retries > 100) {
       lderr(cct) << "ERROR: Looping in attempt to reinit watch. Halting."
 		 << dendl;
@@ -99,7 +112,9 @@ public:
 	  return;
 	} else {
 	  ++retries;
+	  reinit_pending.store(true);
 	  svc->schedule_context(new C_ReinitWatch(this));
+	  return;
 	}
       }
     }
@@ -107,9 +122,11 @@ public:
     if (ret < 0) {
       ldout(cct, 0) << "ERROR: register_watch() returned ret=" << ret << dendl;
       ++retries;
+      reinit_pending.store(true);
       svc->schedule_context(new C_ReinitWatch(this));
       return;
     }
+    retries = 0;
   }
 
   int unregister_watch(optional_yield y) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/73564

RGWWatcher::reinit() crashes with SIGSEGV or stack smashing (SIGABRT) when OSD watch connections break during normal operation.

Three bugs in the reinit/handle_error interaction:
1. Missing `return` after scheduling a retry when `unregister_watch()` fails. Execution falls through to `register_watch()` with the old watch not cleaned up.                                            
                                                            
2. No guard against duplicate C_ReinitWatch callbacks. Each handle_error() unconditionally schedules a new reinit, so rapid watch failures queue multiple redundant reinit cycles.                                                     
                                                                                                                
3. The `retries` counter is never reset on success, so a watcher that recovers many times over its lifetime eventually hits the retries > 100 abort.

Fix by adding the missing return, using an atomic reinit_pending flag to deduplicate C_ReinitWatch scheduling, and resetting retries after successful re-registration.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
