### PR TITLE
mgr: guard close_section calls in get_perf_schema_python

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1264,8 +1264,10 @@ PyObject* ActivePyModules::get_perf_schema_python(
 		<< dendl;
 	  }
 	}
-	f.close_section();  // close 'counters'
-	f.close_section();  // close 'counter object' section
+	if (!prev_key_name.empty()) {
+	  f.close_section();  // close 'counters'
+	  f.close_section();  // close 'counter object' section
+	}
       });
     }
   } else {


### PR DESCRIPTION
## Problem

`get_perf_schema_python` in `ActivePyModules.cc` crashes with an assertion
failure when iterating daemons that have no perf counters. This happens when
a daemon (e.g. an OSD) was running and registered in the daemon state map,
but is now down or destroyed — its `perf_counters.instances` map is empty.

The function unconditionally calls `f.close_section()` twice after the perf
counter loop to close the `counters` and `counter object` sections. When the
loop never executes (empty instances), no sections were opened, and the close
calls trigger `FAILED ceph_assert(cursor != root)` in `PyFormatter.h:85`.

This was introduced in PR #66824 (perf schema labels rewrite, merged 2026-03-30).

## Fix

Add the same `if (!prev_key_name.empty())` guard that already protects the
`close_section()` calls *inside* the loop (line 1243), so we only close
sections that were actually opened.

## Reproduction

On a vstart dev cluster, stop an OSD so it remains in the daemon state map
with empty perf counters, then call `get_perf_schema("osd", "")` via the
selftest module:

**Before fix** — mgr asserts:
```
[selftest INFO selftest] Testing get_perf_schema for all OSDs...
/home/ubuntu/ceph/src/mgr/PyFormatter.h: 85: FAILED ceph_assert(cursor != root)

 ceph version 18a5c0268d umbrella (dev - Debug)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x129)
 2: (ceph::__ceph_assert_fail(ceph::assert_data const&)+0x1b)
 4: (PyFormatter::close_section()+0x48)
 7: (ActivePyModules::get_perf_schema_python(...)+0x245)
```

**After fix** — succeeds:
```
[selftest INFO selftest] Testing get_perf_schema for all OSDs...
[selftest INFO selftest] get_perf_schema returned 3 entries
```

Tracker: https://tracker.ceph.com/issues/75745

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [x] Includes bug reproducer
  - [ ] No tests