### PR TITLE
rados: deprecate ceph osd pool get threshold

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -290,6 +290,9 @@
   to upgrade all OSDs in the cluster. For more details see tracker:
   https://tracker.ceph.com/issues/73031.
 
+ * RADOS: The `ceph osd pool get threshold` command is deprecated in favor of the
+  `ceph config get mgr mgr/pg_autoscaler/threshold` command.
+
 >=19.2.1
 
 * CephFS: The `fs subvolume create` command now allows tagging subvolumes through option

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -171,6 +171,11 @@ The output will resemble the following::
 
      ceph osd pool get threshold
 
+  .. note::
+
+     The ``ceph osd pool get threshold `` command is deprecated and will be removed in a future release.
+     Use ``ceph config get mgr mgr/pg_autoscaler/threshold `` instead.
+
 - **AUTOSCALE** is the pool's ``pg_autoscale_mode`` and is set to ``on``,
   ``off``, or ``warn``.
 

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -258,7 +258,13 @@ class PgAutoscaler(MgrModule):
         A.K.A. the factor by which the new pg_num must vary
         from the existing pg_num before action is taken
         """
-        return 0, str(self.get_module_option('threshold')), ''
+        threshold = self.get_module_option('threshold')
+
+        return 0, str(threshold), (
+                  "Deprecation warning: 'ceph osd pool get threshold' is deprecated "
+                  "and will be removed in a future release. "
+                  "Use 'ceph config get mgr mgr/pg_autoscaler/threshold' instead."
+        )
 
     def complete_all_progress_events(self) -> None:
         for pool_id in list(self._event):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75871

Before changes:
# ./bin/ceph -c ./ceph.conf -k ./keyring osd pool get threshold
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2.0

After changes:

# ./bin/ceph -c ./ceph.conf -k ./keyring osd pool get threshold
3.0
Deprecation warning: 'ceph osd pool get threshold' is deprecated and will be removed in a future release. Use 'ceph config get mgr mgr/pg_autoscaler/threshold' instead.