### PR TITLE
doc: fix period and zone command names in radosgw-admin man page

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -168,7 +168,7 @@ as follows:
 :command:`objects expire`
   Run expired objects cleanup.
 
-:command:`period rm`
+:command:`period delete`
   Remove a period.
 
 :command:`period get`
@@ -291,7 +291,7 @@ as follows:
 :command:`zone create`
   Create a new zone.
 
-:command:`zone rm`
+:command:`zone delete`
   Remove a zone.
 
 :command:`zone get`
@@ -449,7 +449,7 @@ as follows:
 :command:`role create`
   Create a new role for use with STS (Security Token Service).
 
-:command:`role rm`
+:command:`role delete`
   Remove a role.
 
 :command:`role get`
@@ -470,7 +470,7 @@ as follows:
 :command:`role-policy get`
   Get the specified inline policy document embedded with the given role.
 
-:command:`role-policy rm`
+:command:`role-policy delete`
   Remove the policy attached to a role
 
 :command:`reshard add`


### PR DESCRIPTION
The radosgw-admin man page uses incorrect command names that do not match the actual implementation in radosgw-admin.cc:

- period rm -> period delete (code uses period delete)
- zone rm -> zone delete (code uses zone delete)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an [x] between the brackets: [x].  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests