### PR TITLE
tentacle: doc/rados: fix command syntax in add-or-rm-mons.rst

### DIFF
--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -574,7 +574,10 @@ Example Procedure
    
    .. prompt:: bash #
     
-      ceph orch reconfig osd
+      ceph orch reconfig osd.<service_id>
+
+   The ``<service_id>`` value can be obtained from
+   the output of the command ``ceph orch ls osd``.
 
 *The above procedure was developed by Eugen Block and was successfully tested
 in February 2024 on Ceph version 18.2.1 (Reef).*


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/68234 (generated with ceph-backport-doc.sh)


---

Add the missing `service_id` part to the `ceph orch reconfig` command and note that `ceph orch ls osd` can be used to obtain the `service_id`.



Based on Quincy:

* Spec file calls the added part `service_id`.

* The `ceph orch ls` command help calls the two parts in the label: `service_type.service_name` (`service_name` vs. `service_id`).

* Meanwhile the `ceph orch reconfig` command help lists `service_name` for the whole `service_type.service_id` label and does not spell out that it consists of the two components.



*Go with `service_id` instead of `service_name` because the latter is ambiguous.*  

Open to suggestions if this PR should call it something else or be otherwise updated.



Thanks to Eugen Block for a discussion.



Raised in the [docs bugs pad](https://pad.ceph.com/p/Report_Documentation_Bugs/timeslider#40575).



- Original: https://docs.ceph.com/en/latest/rados/operations/add-or-rm-mons/#example-procedure

- Rendered PR: https://ceph--68234.org.readthedocs.build/en/68234/rados/operations/add-or-rm-mons/#example-procedure
