### PR TITLE
mgr/dashboard: replace oauth2 jwt decoding with headers

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -164,6 +164,11 @@ class Auth(RESTController, ControllerAuthMixin):
     @allow_empty_body
     def logout(self):
         logger.debug('Logout started')
+        if mgr.SSO_DB.protocol == AuthType.OAUTH2:
+            return {
+                'redirect_url': OAuth2.get_logout_redirect_url(),
+                'protocol': OAuth2.get_auth_name()
+            }
         token = JwtManager.get_token(cherrypy.request)
         JwtManager.blocklist_token(token)
         self._delete_token_cookie(token)
@@ -177,18 +182,18 @@ class Auth(RESTController, ControllerAuthMixin):
                  parameters={'token': (str, 'Authentication Token')},
                  responses={201: AUTH_CHECK_SCHEMA})
     def check(self, token):
-        if token:
-            if mgr.SSO_DB.protocol == AuthType.OAUTH2:
-                user = OAuth2.get_user(token)
-            else:
-                user = JwtManager.get_user(token)
-            if user:
-                return {
-                    'username': user.username,
-                    'permissions': user.permissions_dict(),
-                    'sso': BaseAuth.from_db(mgr.SSO_DB).sso,
-                    'pwdUpdateRequired': user.pwd_update_required
-                }
+        user = None
+        if mgr.SSO_DB.protocol == AuthType.OAUTH2:
+            user = OAuth2.get_user_from_headers(cherrypy.request)
+        elif token:
+            user = JwtManager.get_user(token)
+        if user:
+            return {
+                'username': user.username,
+                'permissions': user.permissions_dict(),
+                'sso': BaseAuth.from_db(mgr.SSO_DB).sso,
+                'pwdUpdateRequired': user.pwd_update_required
+            }
         return {
             'login_url': BaseAuth.from_db(mgr.SSO_DB).LOGIN_URL,
             'cluster_status': ClusterModel.from_db().dict()['status']

--- a/src/pybind/mgr/dashboard/controllers/oauth2.py
+++ b/src/pybind/mgr/dashboard/controllers/oauth2.py
@@ -14,19 +14,15 @@ class Oauth2(RESTController):
         if not OAuth2.enabled():
             raise DashboardException(500, msg='Failed to login: SSO OAuth2 is not enabled')
 
-        token = OAuth2.get_token(cherrypy.request)
-        if not token:
-            raise cherrypy.HTTPError()
+        user = OAuth2.get_user_from_headers(cherrypy.request)
+        if not user:
+            raise cherrypy.HTTPError(401, 'Missing proxy authentication headers')
 
-        raise cherrypy.HTTPRedirect(OAuth2.get_login_redirect_url(token))
+        raise cherrypy.HTTPRedirect(OAuth2.get_login_redirect_url())
 
     @Endpoint(json_response=False, version=None)
     def logout(self):
         if not OAuth2.enabled():
             raise DashboardException(500, msg='Failed to logout: SSO OAuth2 is not enabled')
 
-        token = OAuth2.get_token(cherrypy.request)
-        if not token:
-            raise cherrypy.HTTPError()
-
-        raise cherrypy.HTTPRedirect(OAuth2.get_logout_redirect_url(token))
+        raise cherrypy.HTTPRedirect(OAuth2.get_logout_redirect_url())

--- a/src/pybind/mgr/dashboard/services/auth/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth/auth.py
@@ -134,7 +134,6 @@ class JwtManager(object):
 
     @classmethod
     def decode(cls, message, secret):
-        oauth2_sso_protocol = mgr.SSO_DB.protocol == AuthType.OAUTH2
         split_message = message.split(".")
         base64_header = split_message[0]
         base64_message = split_message[1]
@@ -142,23 +141,19 @@ class JwtManager(object):
 
         decoded_header = decode_jwt_segment(base64_header)
 
-        if decoded_header['alg'] != cls.JWT_ALGORITHM and not oauth2_sso_protocol:
+        if decoded_header['alg'] != cls.JWT_ALGORITHM:
             raise InvalidAlgorithmError()
 
-        incoming_secret = ''
-        if decoded_header['alg'] == cls.JWT_ALGORITHM:
-            incoming_secret = base64.urlsafe_b64encode(hmac.new(
-                bytes(secret, 'UTF-8'),
-                msg=bytes(base64_header + "." + base64_message, 'UTF-8'),
-                digestmod=hashlib.sha256
-            ).digest()).decode('UTF-8').replace("=", "")
+        incoming_secret = base64.urlsafe_b64encode(hmac.new(
+            bytes(secret, 'UTF-8'),
+            msg=bytes(base64_header + "." + base64_message, 'UTF-8'),
+            digestmod=hashlib.sha256
+        ).digest()).decode('UTF-8').replace("=", "")
 
-        if base64_secret != incoming_secret and not oauth2_sso_protocol:
+        if base64_secret != incoming_secret:
             raise InvalidTokenError()
 
         decoded_message = decode_jwt_segment(base64_message)
-        if oauth2_sso_protocol:
-            decoded_message['username'] = decoded_message['sub']
         now = int(time.time())
         if decoded_message['exp'] < now:
             raise ExpiredSignatureError()
@@ -192,10 +187,6 @@ class JwtManager(object):
     @classmethod
     # pylint: disable=protected-access
     def get_token(cls, request: cherrypy._ThreadLocalProxy):
-        if mgr.SSO_DB.protocol == AuthType.OAUTH2:
-            # Avoids circular import
-            from .oauth2 import OAuth2
-            return OAuth2.get_token(request)
         auth_cookie_name = 'token'
         try:
             # use cookie
@@ -306,12 +297,20 @@ class AuthManagerTool(cherrypy.Tool):
 
     def _check_authentication(self):
         JwtManager.reset_user()
-        token = JwtManager.get_token(cherrypy.request)
-        if token:
-            user = JwtManager.get_user(token)
+
+        if mgr.SSO_DB.protocol == AuthType.OAUTH2:
+            from .oauth2 import OAuth2  # avoid circular import
+            user = OAuth2.get_user_from_headers(cherrypy.request)
             if user:
                 self._check_authorization(user.username)
                 return
+        else:
+            token = JwtManager.get_token(cherrypy.request)
+            if token:
+                user = JwtManager.get_user(token)
+                if user:
+                    self._check_authorization(user.username)
+                    return
 
         resp_head = cherrypy.response.headers
         req_head = cherrypy.request.headers

--- a/src/pybind/mgr/dashboard/services/auth/oauth2.py
+++ b/src/pybind/mgr/dashboard/services/auth/oauth2.py
@@ -1,22 +1,17 @@
 
-import importlib
 import json
 import logging
-from typing import Dict, List
+import time
+from typing import List, Optional
 from urllib.parse import quote
 
 import cherrypy
 import requests
 
 from ... import mgr
-from ...services.auth import BaseAuth, SSOAuth, decode_jwt_segment
+from ...services.auth import BaseAuth, SSOAuth
 from ...tools import prepare_url_prefix
 from ..access_control import Role, User, UserAlreadyExists
-
-try:
-    jmespath = importlib.import_module("jmespath")
-except ModuleNotFoundError:
-    logging.error("Module 'jmespath' is not installed.")
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +23,11 @@ class OAuth2(SSOAuth):
 
     class OAuth2Config(BaseAuth.Config):
         roles_path: str
+        issuer_url: str
 
-    def __init__(self, roles_path=None):
+    def __init__(self, roles_path=None, issuer_url=None):
         self.roles_path = roles_path
+        self.issuer_url = issuer_url
 
     def get_roles_path(self):
         return self.roles_path
@@ -41,14 +38,15 @@ class OAuth2(SSOAuth):
 
     def to_dict(self) -> 'OAuth2Config':
         return {
-            'roles_path': self.roles_path
+            'roles_path': self.roles_path,
+            'issuer_url': self.issuer_url
         }
 
     @classmethod
     def from_dict(cls, s_dict: OAuth2Config) -> 'OAuth2':
         try:
-            return OAuth2(s_dict['roles_path'])
-        except KeyError:
+            return OAuth2(s_dict.get('roles_path'), s_dict.get('issuer_url'))
+        except (KeyError, AttributeError):
             return OAuth2({})
 
     @classmethod
@@ -56,101 +54,38 @@ class OAuth2(SSOAuth):
         return cls.__name__.lower()
 
     @classmethod
-    # pylint: disable=protected-access
-    def get_token(cls, request: cherrypy._ThreadLocalProxy) -> str:
-        try:
-            return request.cookie['token'].value
-        except KeyError:
-            return request.headers.get('X-Access-Token')
+    def get_user_from_headers(cls, request) -> Optional[User]:
+        username = request.headers.get('X-User', '')
+        if not username:
+            return None
+        email = request.headers.get('X-Email', '')
+        groups = request.headers.get('X-User-Groups', '')
 
-    @classmethod
-    def set_token(cls, token: str):
-        cherrypy.request.jwt = token
-        cherrypy.request.jwt_payload = cls.get_token_payload()
-        cherrypy.request.user = cls.get_user(token)
+        logger.debug("OAuth2 proxy headers — X-User: %s, X-Email: %s, X-User-Groups: '%s'",
+                     username, email, groups)
 
-    @classmethod
-    def get_token_payload(cls) -> Dict:
         try:
-            return cherrypy.request.jwt_payload
-        except AttributeError:
-            pass
-        try:
-            return decode_jwt_segment(cherrypy.request.jwt.split(".")[1])
-        except AttributeError:
-            return {}
-
-    @classmethod
-    def set_token_payload(cls, token):
-        cherrypy.request.jwt_payload = decode_jwt_segment(token.split(".")[1])
-
-    @classmethod
-    def get_user_roles(cls):
-        roles: List[str] = []
-        user_roles: List[Role] = []
-        try:
-            jwt_payload = cherrypy.request.jwt_payload
-        except AttributeError:
-            raise cherrypy.HTTPError(401)
-
-        if jmespath and getattr(mgr.SSO_DB.config, 'roles_path', None):
-            logger.debug("Using 'roles_path' to fetch roles")
-            roles = jmespath.search(mgr.SSO_DB.config.roles_path, jwt_payload)
-        # e.g Keycloak
-        elif 'resource_access' in jwt_payload or 'realm_access' in jwt_payload:
-            logger.debug("Using 'resource_access' or 'realm_access' to fetch roles")
-            roles = jmespath.search(
-                "resource_access.*[?@!='account'].roles[] || realm_access.roles[]",
-                jwt_payload)
-        elif 'roles' in jwt_payload:
-            logger.debug("Using 'roles' to fetch roles")
-            roles = jwt_payload['roles']
-            if isinstance(roles, str):
-                roles = [roles]
-        else:
-            raise cherrypy.HTTPError(403)
-        user_roles = Role.map_to_system_roles(roles or [])
-        return user_roles
-
-    @classmethod
-    def get_user(cls, token: str) -> User:
-        try:
-            return cherrypy.request.user
-        except AttributeError:
-            cls.set_token_payload(token)
-            cls._create_user()
-        return cherrypy.request.user
-
-    @classmethod
-    def _create_user(cls):
-        try:
-            jwt_payload = cherrypy.request.jwt_payload
-        except AttributeError:
-            raise cherrypy.HTTPError()
-        try:
-            user = mgr.ACCESS_CTRL_DB.create_user(
-                jwt_payload['sub'], None, jwt_payload['name'], jwt_payload['email'])
+            user = mgr.ACCESS_CTRL_DB.create_user(username, None, username, email)
         except UserAlreadyExists:
-            logger.debug("User already exists")
-            user = mgr.ACCESS_CTRL_DB.get_user(jwt_payload['sub'])
-        user.set_roles(cls.get_user_roles())
-        # set user last update to token time issued
-        user.last_update = jwt_payload['iat']
-        cherrypy.request.user = user
+            user = mgr.ACCESS_CTRL_DB.get_user(username)
+
+        roles = cls._map_groups_to_roles(groups)
+        logger.debug("OAuth2 mapped roles: %s", [r.name for r in roles])
+        user.set_roles(roles)
+        user.last_update = int(time.time())
+        return user
 
     @classmethod
-    def reset_user(cls):
-        try:
-            mgr.ACCESS_CTRL_DB.delete_user(cherrypy.request.user.username)
-            cherrypy.request.user = None
-        except AttributeError:
-            raise cherrypy.HTTPError()
+    def _map_groups_to_roles(cls, groups_header: str) -> List[Role]:
+        if not groups_header:
+            return []
+        idp_groups = [g.strip() for g in groups_header.split(',') if g.strip()]
+        return Role.map_to_system_roles(idp_groups)
 
     @classmethod
-    def get_token_iss(cls, token=''):
-        if token:
-            cls.set_token_payload(token)
-        return cls.get_token_payload()['iss']
+    def get_login_redirect_url(cls) -> str:
+        url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
+        return f"{url_prefix}/#/login"
 
     @classmethod
     def get_openid_config(cls, iss):
@@ -164,14 +99,13 @@ class OAuth2(SSOAuth):
         return json.loads(response.text)
 
     @classmethod
-    def get_login_redirect_url(cls, token) -> str:
+    def get_logout_redirect_url(cls) -> str:
         url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
-        return f"{url_prefix}/#/login?access_token={token}"
-
-    @classmethod
-    def get_logout_redirect_url(cls, token) -> str:
-        openid_config = OAuth2.get_openid_config(OAuth2.get_token_iss(token))
-        end_session_url = openid_config.get('end_session_endpoint')
-        encoded_end_session_url = quote(end_session_url, safe="")
-        url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
-        return f'{url_prefix}/oauth2/sign_out?rd={encoded_end_session_url}'
+        issuer_url = getattr(mgr.SSO_DB.config, 'issuer_url', None)
+        if issuer_url:
+            openid_config = cls.get_openid_config(issuer_url)
+            end_session_url = openid_config.get('end_session_endpoint')
+            if end_session_url:
+                encoded = quote(end_session_url, safe="")
+                return f'{url_prefix}/oauth2/sign_out?rd={encoded}'
+        return f'{url_prefix}/oauth2/sign_out'

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -96,7 +96,7 @@ def load_sso_db():
 
 
 @DBCLICommand.Write("dashboard sso enable oauth2")
-def enable_sso(_, roles_path: Optional[str] = None):
+def enable_sso(_, roles_path: Optional[str] = None, issuer_url: Optional[str] = None):
     mgr.SSO_DB.protocol = AuthType.OAUTH2
     if jmespath and roles_path:
         try:
@@ -104,6 +104,8 @@ def enable_sso(_, roles_path: Optional[str] = None):
             mgr.SSO_DB.config.roles_path = roles_path
         except (JMESPathError, SyntaxError):
             return HandleCommandResult(stdout='Syntax invalid for "roles_path"')
+    if issuer_url:
+        mgr.SSO_DB.config.issuer_url = issuer_url
     mgr.SSO_DB.save()
     mgr.set_module_option('sso_oauth2', True)
     return HandleCommandResult(stdout='SSO is "enabled" with "OAuth2" protocol.')


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
