### PR TITLE
rgw: Fix shutdown/reload issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ GTAGS
 /src/pybind/mgr/dashboard/frontend/src/environments/environment.prod.ts
 /src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
 
+*_processed.pyx
+
 # mypy cache
 .mypy_cache/
 

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -28,6 +28,10 @@ NEORADOS_TESTS=(
     read_operations snapshots watch_notify write_operations
 )
 
+VALGRIND_TESTS=(
+    neorados_leak_watch_notify
+)
+
 # Note on argument ordering: This script processes arguments sequentially,
 # so the order matters. Arguments must be provided in this specific sequence:
 # 1. --serial OR --crimson (optional)
@@ -102,6 +106,11 @@ if [ $vstart -eq 1 ]; then
         ninja -j$(nproc) ceph_test_neorados_$f
     done
 
+    for f in "${VALGRIND_TESTS[@]}";
+    do
+        ninja -j$(nproc) ceph_test_$f
+    done
+
     echo "Setting up a test cluster..."
     ninja -j$(nproc) vstart
     ../src/vstart.sh --debug --new -x --localhost --bluestore
@@ -133,9 +142,7 @@ do
 done
 
 # Running all tests in ceph_test_neorados
-for f in \
-    cls cmd handler_error io ec_io list ec_list misc pool read_operations snapshots \
-    watch_notify write_operations
+for f in "${NEORADOS_TESTS[@]}"
 do
     executable="ceph_test_neorados_$f"
     if [ $vstart -eq 1 ]; then
@@ -158,6 +165,31 @@ do
         fi
         # If running in serial mode, run the test directly
         if ! timeout $timeout $executable; then
+            echo "ERROR: Test $f timed out after $timeout seconds"
+            echo "Check the logs for failures in $f"
+            ret=1
+        fi
+    fi
+done
+
+# Running all tests in VALGRIND_TESTS
+for f in "${VALGRIND_TESTS[@]}"
+do
+    executable="ceph_test_$f"
+    if [ $vstart -eq 1 ]; then
+        executable="./bin/$executable"
+    fi
+    if [ $parallel -eq 1 ]; then
+        r=$(printf '%25s' "$f")
+        ff=$(echo "$f" | awk '{print $1}')
+        bash -o pipefail -exc "valgrind $executable --error-exitcode=1 --track-origins=yes --leak-check=yes --log-file=valgrind_$ff.log" &
+        pid=$!
+        echo "valgrind test $f on pid $pid"
+        pids[$f]=$pid
+        test_type["$f"]="valgrind" # Store test type for later use in parallel mode
+    else
+        # If running in serial mode, run the test directly
+        if ! timeout "$timeout" valgrind "$executable" --track-origins=yes --error-exitcode=1 --leak-check=yes; then
             echo "ERROR: Test $f timed out after $timeout seconds"
             echo "Check the logs for failures in $f"
             ret=1

--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -139,7 +139,7 @@ add_library(cls_log_client STATIC ${cls_log_client_srcs})
 
 
 # cls_timeindex
-set(cls_timeindex_srcs timeindex/cls_timeindex.cc)
+set(cls_timeindex_srcs timeindex/cls_timeindex.cc timeindex/cls_timeindex_types.cc)
 add_library(cls_timeindex SHARED ${cls_timeindex_srcs})
 set_target_properties(cls_timeindex PROPERTIES
   VERSION "1.0.0"

--- a/src/common/async/concepts.h
+++ b/src/common/async/concepts.h
@@ -21,6 +21,9 @@
 
 #include <boost/asio/disposition.hpp>
 #include <boost/asio/execution_context.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/io_context_strand.hpp>
+#include <boost/asio/strand.hpp>
 
 /// \file common/async/concepts
 ///
@@ -39,4 +42,21 @@ concept execution_context =
 template<typename T>
 concept disposition =
   boost::asio::is_disposition_v<T>;
-}
+
+namespace detail {
+template <typename...>
+struct is_strand : public std::false_type {};
+
+template <boost::asio::execution::executor Executor>
+struct is_strand<boost::asio::strand<Executor>> : public std::true_type {};
+} // namespace detail
+
+/// Type predicate for strands
+template <typename T>
+inline constexpr bool is_strand_v =
+    detail::is_strand<typename std::remove_cv_t<T>>::value;
+
+/// Cocnept requiring a strand
+template <typename T>
+concept strand = is_strand_v<T>;
+} // namespace ceph::async

--- a/src/common/async/context_pool.h
+++ b/src/common/async/context_pool.h
@@ -18,7 +18,6 @@
 #define CEPH_COMMON_ASYNC_CONTEXT_POOL_H
 
 #include <concepts>
-#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -54,7 +53,7 @@ public:
   }
   template<std::invocable<> Init>
   io_context_pool(std::int64_t threadcnt, Init&& init) noexcept {
-    start(threadcnt, std::move(init));
+    start(threadcnt, std::forward<Init>(init));
   }
   ~io_context_pool() {
     stop();
@@ -80,8 +79,8 @@ public:
       ioctx.restart();
       for (std::int16_t i = 0; i < threadcnt; ++i) {
 	threadvec.emplace_back(make_named_thread("io_context_pool",
-						 [this, init=std::move(init)] {
-						   std::move(init)();
+						 [this, init] {
+						   init();
 						   ioctx.run();
 						 }));
       }

--- a/src/common/async/service.h
+++ b/src/common/async/service.h
@@ -65,11 +65,10 @@ class service : public boost::asio::execution_context::service {
   /// Unregister an object
   void remove(IoObject& entry) {
     auto lock = std::scoped_lock{mutex};
-    if (entries.empty()) {
-      // already shut down
-    } else {
+    if (entry.is_linked()) {
       entries.erase(entries.iterator_to(entry));
     }
+    // else: already removed by shutdown() or a previous remove()
   }
 };
 

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -20,8 +20,6 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
 
-#include "acconfig.h"
-
 /// optional-like wrapper for a boost::asio::yield_context. operations that take
 /// an optional_yield argument will, when passed a non-empty yield context,
 /// suspend this coroutine instead of the blocking the thread of execution
@@ -40,6 +38,21 @@ class optional_yield {
 
   /// return a reference to the yield_context. only valid if non-empty
   boost::asio::yield_context& get_yield_context() const noexcept { return *y; }
+
+  using executor_type = boost::asio::any_io_executor;
+
+  /// Return the executor associated with the `yield_context` or a
+  /// strand in the system executor.
+  ///
+  /// \note In the case of `null_yield` this creates a new strand on
+  /// every call. If it is important that two things share an
+  /// executor, copy it rather than calling twice.
+  executor_type
+  get_executor() const
+  {
+    return y ? y->get_executor()
+             : boost::asio::make_strand(boost::asio::system_executor{});
+  }
 };
 
 // type tag object to construct an empty optional_yield

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1494,7 +1494,9 @@ public:
     } else if (capacity && notifications.size() >= capacity) {
       // We are allowed one over, so the client knows where in the
       // sequence of notifications we started losing data.
-      notifications.push({errc::notification_overflow, {}});
+      if (notifications.size() == capacity) {
+        notifications.push({errc::notification_overflow, {}});
+      }
     } else {
       notifications.push({{},
 			  Notification{

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1729,11 +1729,16 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
       ceph_assert(c);
       bc::flat_map<std::pair<uint64_t, uint64_t>, buffer::list> reply_map;
       bc::flat_set<std::pair<uint64_t, uint64_t>> missed_set;
-      auto p = rbl.cbegin();
-      decode(reply_map, p);
-      decode(missed_set, p);
-      asio::dispatch(asio::append(std::move(c), res, std::move(reply_map),
-				  std::move(missed_set)));
+      if (rbl.length() > 0) try {
+          auto p = rbl.cbegin();
+          decode(reply_map, p);
+          decode(missed_set, p);
+      } catch (const std::exception&) {
+        // Swallowing the decode error.
+      }
+      asio::dispatch(
+          asio::append(
+              std::move(c), res, std::move(reply_map), std::move(missed_set)));
     }
   }
 };

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1690,6 +1690,7 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
   bool finished = false;
   bs::error_code res;
   bufferlist rbl;
+  bool cleaned = false;
 
   NotifyHandler(asio::io_context& ioc,
 		Objecter* objecter,
@@ -1724,9 +1725,13 @@ struct NotifyHandler : std::enable_shared_from_this<NotifyHandler> {
 
   // Should be called from strand.
   void maybe_cleanup(bs::error_code ec) {
+    if (cleaned) {
+      return;
+    }
     if (!res && ec)
       res = ec;
     if ((acked && finished) || res) {
+      cleaned = true;
       objecter->linger_cancel(op.get());
       ceph_assert(c);
       bc::flat_map<std::pair<uint64_t, uint64_t>, buffer::list> reply_map;

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1406,12 +1406,23 @@ class Notifier : public async::service_list_base_hook {
   std::shared_ptr<detail::Client> neoref;
 
   void service_shutdown() {
-    if (neoref) {
-      neoref = nullptr;
-    }
-    linger_op.reset();
+    // Ensure neorados object and operation live to the end of the
+    // function.
+    auto localop = std::move(linger_op);
+    [[maybe_unused]] auto localneo = std::move(neoref);
     std::unique_lock l(m);
     handlers.clear();
+    l.unlock();
+    if (localop) {
+      // We are being taken down and will execute no more
+      // handlers. Call `linger_cancel` to clean up properly in
+      // Objecter. (It doesn't call out to the OSD or anything.)
+      //
+      // Removal and decrement are guarded by `linger_op->canceled`
+      // so there's no risk of an underflow.
+      localop->objecter->linger_cancel(localop.get());
+    }
+    // The Notifier object is freed by the `linger_cancel` above.
   }
 
 public:

--- a/src/neorados/cls/fifo.h
+++ b/src/neorados/cls/fifo.h
@@ -136,6 +136,8 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
+
 	   auto e = rados.get_executor();
 	   auto impl = std::make_shared<detail::FIFOImpl>(std::move(rados),
 							  std::move(obj),
@@ -195,6 +197,7 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   auto impl = std::make_shared<detail::FIFOImpl>(std::move(rados),
 							  std::move(obj),

--- a/src/neorados/cls/fifo/detail/fifo.h
+++ b/src/neorados/cls/fifo/detail/fifo.h
@@ -208,6 +208,8 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
+
 	   buffer::list in;
 	   fifo::op::get_meta gm;
 	   gm.version = objv;
@@ -277,6 +279,8 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
+
 	   buffer::list in;
 	   fifo::op::get_part_info gpi;
 	   encode(gpi, in);
@@ -429,6 +433,7 @@ private:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   std::unique_lock l(f->m);
 	   auto head_part_num = f->info.head_part_num;
@@ -494,6 +499,7 @@ private:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   std::unique_lock l(f->m);
 	   auto oid = f->info.part_oid(part_num);
@@ -568,6 +574,7 @@ private:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   std::unique_lock l(f->m);
 	   auto oid = f->info.part_oid(part_num);
@@ -658,6 +665,7 @@ private:
        try {
 	 state.throw_if_cancelled(true);
 	 state.reset_cancellation_state(asio::enable_terminal_cancellation());
+         state.complete_if_cancelled(false);
 
 	 ldpp_dout_fmt(dpp, 20, "read_meta: entering");
 	 auto [info, part_header_size, part_entry_overhead] = co_await get_meta(
@@ -722,6 +730,7 @@ private:
        try {
 	 state.throw_if_cancelled(true);
 	 state.reset_cancellation_state(asio::enable_terminal_cancellation());
+         state.complete_if_cancelled(false);
 
 	 ldpp_dout_fmt(dpp, 20, "update_meta: entering");
 	 auto [ec] = co_await f->update_meta(version, update,
@@ -773,6 +782,7 @@ private:
        try {
 	 state.throw_if_cancelled(true);
 	 state.reset_cancellation_state(asio::enable_terminal_cancellation());
+         state.complete_if_cancelled(false);
 
 	 ldpp_dout_fmt(dpp, 20, "process_journal: entering", __LINE__);
 	 std::vector<fifo::journal_entry> processed;
@@ -915,7 +925,7 @@ private:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
-
+	   state.complete_if_cancelled(false);
 
 	   ldpp_dout_fmt(dpp, 20, "prepare_new_part: entering");
 	   std::unique_lock l(f->m);
@@ -1005,6 +1015,7 @@ private:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   ldpp_dout_fmt(dpp, 20, "prepare_new_head: entering");
 	   std::unique_lock l(f->m);
@@ -1105,6 +1116,8 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
+
 	   ldpp_dout_fmt(dpp, 20, "do_open: entering");
 	   std::tie(f->info, f->part_header_size, f->part_entry_overhead)
 	     = co_await get_meta(f->rados, f->obj, f->ioc, objv,
@@ -1152,6 +1165,8 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
+
 	   ldpp_dout_fmt(dpp, 20, "do_create: entering");
 	   co_await create_meta(f->rados, f->obj, f->ioc, objv, oid_prefix,
 				exclusive, max_part_size, max_entry_size,
@@ -1190,6 +1205,7 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   std::unique_lock l(f->m);
 	   auto max_entry_size = f->info.params.max_entry_size;
@@ -1339,6 +1355,7 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 			      << " entering" << dendl;
@@ -1450,6 +1467,7 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 			      << " entering" << dendl;
@@ -1569,6 +1587,7 @@ public:
 	 try {
 	   state.throw_if_cancelled(true);
 	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   state.complete_if_cancelled(false);
 
 	   co_await f->read_meta(dpp, asio::deferred);
 	   std::unique_lock l(f->m);

--- a/src/rgw/async_utils.h
+++ b/src/rgw/async_utils.h
@@ -964,15 +964,17 @@ private:
   loop(CoroFun coro_fun, std::shared_ptr<timer_t> timer)
   {
     try {
-      while ((co_await boost::asio::this_coro::cancellation_state).cancelled() ==
-             boost::asio::cancellation_type::none) {
+      // GCC 14 has a bug related to parenthesized `co_await` expressions.
+      for (auto state = co_await boost::asio::this_coro::cancellation_state;
+           state.cancelled() == boost::asio::cancellation_type::none;
+           state = co_await boost::asio::this_coro::cancellation_state) {
         auto delay = co_await coro_fun();
         timer->expires_after(delay);
         try {
           co_await timer->async_wait(boost::asio::use_awaitable);
         } catch (boost::system::system_error& e) {
           // If the coroutine has been canceled we'll exit when we hit
-          // the while condition. Otherwise, we've been awoken.
+          // the loop condition. Otherwise, we've been awoken.
           if (e.code() != boost::asio::error::operation_aborted) {
             throw;
           }

--- a/src/rgw/async_utils.h
+++ b/src/rgw/async_utils.h
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <deque>
 #include <exception>
 #include <functional>
 #include <string>
@@ -27,12 +28,20 @@
 #include <variant>
 #include <vector>
 
+#include <boost/asio/execution/executor.hpp>
+
+#include <boost/asio/experimental/cancellation_condition.hpp>
+#include <boost/asio/experimental/parallel_group.hpp>
+
+#include <boost/asio/append.hpp>
+#include <boost/asio/associated_immediate_executor.hpp>
+#include <boost/asio/async_result.hpp>
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/cancellation_signal.hpp>
 #include <boost/asio/cancellation_type.hpp>
 #include <boost/asio/co_spawn.hpp>
+#include <boost/asio/consign.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/asio/execution/executor.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/this_coro.hpp>
@@ -223,7 +232,7 @@ run_coro(
       what);
 }
 
-/// Call a C++ coroutine from a stacful coroutine if we can, but block
+/// Call a C++ coroutine from a stackful coroutine if we can, but block
 /// if we get `null_yield.` handling exceptions by returning negative
 /// error codes and passing out the `what()` string.
 template <
@@ -518,6 +527,9 @@ struct overloads : Ts... {
 using shutdown_promise =
     ::boost::asio::experimental::promise<void(std::exception_ptr)>;
 
+/// Vector to accumulate labeled shutdown promises
+using shutdown_vector = std::vector<std::pair<std::string, shutdown_promise>>;
+
 /// \defgroup TaskHandles Handles for long-running coroutines
 ///
 /// Handles for long-running tasks and background loops that can be
@@ -622,9 +634,7 @@ public:
   /// `join` or `shutdown` have been called, it is a contract
   /// violation.
   void
-  shutdown(
-      std::string label,
-      std::vector<std::pair<std::string, shutdown_promise>>& to_wait)
+  shutdown(std::string label, shutdown_vector& to_wait)
   {
     assert(state() == task_state::running);
     scope_guard _{[this] { runnable.template emplace<std::monostate>(); }};
@@ -1227,6 +1237,100 @@ auto
 membind(T& obj, M U::* pm)
 {
   return std::bind_front(std::mem_fn(pm), std::ref(obj));
+}
+
+template <
+    boost::asio::execution::executor Executor,
+    boost::asio::completion_token_for<void(std::exception_ptr)> CompletionToken>
+auto
+await_shutdowns(
+    const DoutPrefixProvider* dpp,
+    Executor executor,
+    shutdown_vector&& to_wait,
+    CompletionToken&& token)
+{
+  namespace asio = boost::asio;
+  using asio::experimental::make_parallel_group;
+  using asio::experimental::wait_for_all;
+  auto e = asio::get_associated_executor(token, executor);
+  auto consigned = asio::consign(
+      std::forward<CompletionToken>(token), boost::asio::make_work_guard(e));
+  return asio::async_initiate<decltype(consigned), void(std::exception_ptr)>(
+      [e, dpp, to_wait = std::move(to_wait)](auto handler) mutable {
+        if (to_wait.empty()) [[unlikely]] {
+          auto i = asio::get_associated_immediate_executor(handler, e);
+          asio::dispatch(
+              i, asio::append(std::move(handler), std::exception_ptr{}));
+          return;
+        }
+        std::vector<std::string> labels;
+        // Due to reallocation, std::vector won't use a move
+        // constructor that isn't noexcept, and `executor_binder`'s
+        // move constructor isn't, seemingly as an oversight.
+        //
+        // This worked fine with views because `to_vector` knew a size
+        // in advance and so there was no potential reallocation
+        // codepath. Heck Jammy.
+        std::deque<decltype(boost::asio::bind_executor(
+            e, std::declval<shutdown_promise>()))>
+            promises;
+        for (auto&& [label, promise] : to_wait) {
+          labels.emplace_back(std::move(label));
+          // `make_parallel_group` requires `get_executor()` which promises
+          // do not have.
+          promises.emplace_back(asio::bind_executor(e, std::move(promise)));
+        }
+        // This way we can keep it alive and not have all the promises
+        // get canceled.
+        auto pg = std::make_shared<decltype(make_parallel_group(std::move(promises)))>(
+            make_parallel_group(std::move(promises)));
+        pg->async_wait(
+            wait_for_all{},
+            [e, dpp, pg, labels = std::move(labels),
+             handler = std::move(handler)](
+                std::vector<std::size_t> completion_order,
+                std::vector<std::exception_ptr> exceptions) mutable {
+              auto what = [](std::exception_ptr e) {
+                if (e)
+                  try {
+                    std::rethrow_exception(e);
+                  } catch (const std::exception& e) {
+                    return std::string(e.what());
+                  } catch (...) {
+                    return std::string(
+                        "Exception not descended from std::exception.");
+                  }
+                return std::string("No error.");
+              };
+              auto is_cancellation = [](std::exception_ptr e) {
+                if (e)
+                  try {
+                    std::rethrow_exception(e);
+                  } catch (const boost::system::system_error& e) {
+                    return (e.code() == asio::error::operation_aborted);
+                  } catch (...) {
+                  }
+                return false;
+              };
+              std::exception_ptr returned_error;
+              for (auto& idx : completion_order) {
+                auto label = std::move(labels[idx]);
+                auto eptr = std::move(exceptions[idx]);
+                if (eptr && !is_cancellation(eptr)) {
+                  ldpp_dout(dpp, 1)
+                      << "Shutting down " << label << " failed with exception "
+                      << what(eptr) << dendl;
+                  if (!returned_error) {
+                    returned_error = std::move(eptr);
+                  }
+                }
+              }
+              asio::post(
+                  e,
+                  asio::append(std::move(handler), std::move(returned_error)));
+            });
+      },
+      consigned);
 }
 } // namespace rgw
 

--- a/src/rgw/async_utils.h
+++ b/src/rgw/async_utils.h
@@ -41,29 +41,35 @@
 ///
 /// \brief Utilities for asynchrony
 
+
 namespace rgw {
 
-namespace asio = boost::asio;
-namespace async = ceph::async;
+/// \defgroup CoroBridge Corutine bridging
+///
+/// Bridging adaptors between different flavors of coroutines.
+/// @{
+///
 
 /// Call a coroutine and block until it completes, handling exceptions
 /// by returning negative error codes and passing out the `what()`
 /// string.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin
-template<asio::execution::executor Executor,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<Executor, AwaitableExecutor>
-inline int run_coro(
-  const DoutPrefixProvider* dpp, //< In case we're blocking
-  Executor executor, ///< Executor on which to run the coroutine
-  asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
-  std::string* what ///< Where to store the result of `what()` on exception
-  ) noexcept
+template <
+    boost::asio::execution::executor Executor,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<Executor, AwaitableExecutor>
+inline int
+run_coro(
+    const DoutPrefixProvider* dpp, //< In case we're blocking
+    Executor executor, ///< Executor on which to run the coroutine
+    boost::asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
+    std::string* what ///< Where to store the result of `what()` on exception
+    ) noexcept
 {
   std::exception_ptr e;
   maybe_warn_about_blocking(dpp);
-  asio::co_spawn(executor, std::move(coro), async::use_blocked[e]);
+  boost::asio::co_spawn(executor, std::move(coro), ceph::async::use_blocked[e]);
   return ceph::from_exception(e, what);
 }
 
@@ -72,17 +78,20 @@ inline int run_coro(
 /// string.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin
-template<async::execution_context ExecutionContext,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<typename ExecutionContext::executor_type,
-			       AwaitableExecutor>
-inline int run_coro(
-  const DoutPrefixProvider* dpp, //< In case we're blocking
-  ExecutionContext& execution_context, ///< Execution context on which to run
-                                      ///  the coroutine
-  asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
-  std::string* what ///< Where to store the result of `what()` on exception
-  ) noexcept
+template <
+    ceph::async::execution_context ExecutionContext,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<
+      typename ExecutionContext::executor_type,
+      AwaitableExecutor>
+inline int
+run_coro(
+    const DoutPrefixProvider* dpp, //< In case we're blocking
+    ExecutionContext& execution_context, ///< Execution context on which to run
+    ///  the coroutine
+    boost::asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
+    std::string* what ///< Where to store the result of `what()` on exception
+    ) noexcept
 {
   return run_coro(dpp, execution_context.get_executor(), std::move(coro), what);
 }
@@ -93,21 +102,24 @@ inline int run_coro(
 /// other than void.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin.
-template<asio::execution::executor Executor,
-	 typename T,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<Executor, AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, //< In case we're blocking
-  Executor executor, ///< Executor on which to run the coroutine
-  asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
-  T& val, ///< Where to store the returned value
-  std::string* what ///< Where to store the result of `what()`.
-  ) noexcept
+template <
+    boost::asio::execution::executor Executor,
+    typename T,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<Executor, AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, //< In case we're blocking
+    Executor executor, ///< Executor on which to run the coroutine
+    boost::asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
+    T& val, ///< Where to store the returned value
+    std::string* what ///< Where to store the result of `what()`.
+    ) noexcept
 {
   std::exception_ptr e;
   maybe_warn_about_blocking(dpp);
-  val = asio::co_spawn(executor, std::move(coro), async::use_blocked[e]);
+  val = boost::asio::co_spawn(
+      executor, std::move(coro), ceph::async::use_blocked[e]);
   return ceph::from_exception(e, what);
 }
 
@@ -117,20 +129,25 @@ int run_coro(
 /// other than void.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin.
-template<async::execution_context ExecutionContext,
-	 typename T,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<typename ExecutionContext::executor_type,
-			       AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, //< In case we're blocking
-  ExecutionContext& execution_context, ///< Execution context on which to run the coroutine
-  asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
-  T& val, ///< Where to store the returned value
-  std::string* what ///< Where to store the result of `what()`.
-  ) noexcept
+template <
+    ceph::async::execution_context ExecutionContext,
+    typename T,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<
+      typename ExecutionContext::executor_type,
+      AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, //< In case we're blocking
+    ExecutionContext&
+        execution_context, ///< Execution context on which to run the coroutine
+    boost::asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
+    T& val, ///< Where to store the returned value
+    std::string* what ///< Where to store the result of `what()`.
+    ) noexcept
 {
-  return run_coro(dpp, execution_context.get_executor(), std::move(coro), val, what);
+  return run_coro(
+      dpp, execution_context.get_executor(), std::move(coro), val, what);
 }
 
 /// Call a coroutine and block until it completes, handling exceptions
@@ -139,21 +156,25 @@ int run_coro(
 /// values as a tuple.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin.
-template<asio::execution::executor Executor,
-	 asio::execution::executor AwaitableExecutor,
-	 typename ...Ts>
-requires std::is_convertible_v<Executor, AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, //< In case we're blocking
-  Executor executor, ///< Executor on which to run the coroutine
-  asio::awaitable<std::tuple<Ts...>, AwaitableExecutor> coro, ///< The coroutine itself
-  std::tuple<Ts&...>&& vals, ///< Supply with std::tie
-  std::string* what ///< Where to store the result of `what()`.
-  ) noexcept
+template <
+    boost::asio::execution::executor Executor,
+    boost::asio::execution::executor AwaitableExecutor,
+    typename... Ts>
+  requires std::is_convertible_v<Executor, AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, //< In case we're blocking
+    Executor executor, ///< Executor on which to run the coroutine
+    boost::asio::awaitable<std::tuple<Ts...>, AwaitableExecutor>
+        coro, ///< The coroutine itself
+    std::tuple<Ts&...>&& vals, ///< Supply with std::tie
+    std::string* what ///< Where to store the result of `what()`.
+    ) noexcept
 {
   std::exception_ptr e;
   maybe_warn_about_blocking(dpp);
-  vals = asio::co_spawn(executor, std::move(coro), async::use_blocked[e]);
+  vals = boost::asio::co_spawn(
+      executor, std::move(coro), ceph::async::use_blocked[e]);
   return ceph::from_exception(e, what);
 }
 
@@ -163,46 +184,56 @@ int run_coro(
 /// other than void.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin.
-template<async::execution_context ExecutionContext,
-	 typename... Ts,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<typename ExecutionContext::executor_type,
-			       AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, //< In case we're blocking
-  ExecutionContext& execution_context, ///< Execution context on which to run the coroutine
-  asio::awaitable<std::tuple<Ts...>, AwaitableExecutor> coro, ///< The coroutine itself
-  std::tuple<Ts&...>&& vals, ///< Supply with std::tie
-  std::string* what ///< Where to store the result of `what()`.
-  ) noexcept
+template <
+    ceph::async::execution_context ExecutionContext,
+    typename... Ts,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<
+      typename ExecutionContext::executor_type,
+      AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, //< In case we're blocking
+    ExecutionContext&
+        execution_context, ///< Execution context on which to run the coroutine
+    boost::asio::awaitable<std::tuple<Ts...>, AwaitableExecutor>
+        coro, ///< The coroutine itself
+    std::tuple<Ts&...>&& vals, ///< Supply with std::tie
+    std::string* what ///< Where to store the result of `what()`.
+    ) noexcept
 {
-  return run_coro(dpp, execution_context.get_executor(), std::move(coro),
-		  std::move(vals), what);
+  return run_coro(
+      dpp, execution_context.get_executor(), std::move(coro), std::move(vals),
+      what);
 }
 
 /// Call a C++ coroutine from a stacful coroutine if we can, but block
 /// if we get `null_yield.` handling exceptions by returning negative
 /// error codes and passing out the `what()` string.
-template<asio::execution::executor Executor,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<Executor, AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, /// For logging
-  const Executor& executor, ///< Executor on which to run the coroutine
-  asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
-  std::string_view name, ///< Name, for logging errors
-  optional_yield y, /// Stackful coroutine context…hopefully
-  int log_level = 5 /// What level to log at
-  ) noexcept
+template <
+    boost::asio::execution::executor Executor,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<Executor, AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, /// For logging
+    const Executor& executor, ///< Executor on which to run the coroutine
+    boost::asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
+    std::string_view name, ///< Name, for logging errors
+    optional_yield y, /// Stackful coroutine context…hopefully
+    int log_level = 5 /// What level to log at
+    ) noexcept
 {
   std::exception_ptr e;
   if (y) {
     auto& yield = y.get_yield_context();
-    asio::co_spawn(yield.get_executor(), std::move(coro),
-		   async::redirect_error(yield, e));
+    boost::asio::co_spawn(
+        yield.get_executor(), std::move(coro),
+        ceph::async::redirect_error(yield, e));
   } else {
     maybe_warn_about_blocking(dpp);
-    asio::co_spawn(executor, std::move(coro), async::use_blocked[e]);
+    boost::asio::co_spawn(
+        executor, std::move(coro), ceph::async::use_blocked[e]);
   }
   std::string what;
   auto r = ceph::from_exception(e, &what);
@@ -217,51 +248,58 @@ int run_coro(
 /// string.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin
-template<async::execution_context ExecutionContext,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<typename ExecutionContext::executor_type,
-			       AwaitableExecutor>
-inline int run_coro(
-  const DoutPrefixProvider* dpp, /// For logging
-  ExecutionContext& execution_context, ///< Execution context on which to run
-                                      ///  the coroutine
-  asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
-  std::string_view name, ///< Name, for logging errors
-  optional_yield y, /// Stackful coroutine context…hopefully
-  int log_level = 5 /// What level to log at
-  ) noexcept
+template <
+    ceph::async::execution_context ExecutionContext,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<
+      typename ExecutionContext::executor_type,
+      AwaitableExecutor>
+inline int
+run_coro(
+    const DoutPrefixProvider* dpp, /// For logging
+    ExecutionContext& execution_context, ///< Execution context on which to run
+    ///  the coroutine
+    boost::asio::awaitable<void, AwaitableExecutor> coro, ///< The coroutine itself
+    std::string_view name, ///< Name, for logging errors
+    optional_yield y, /// Stackful coroutine context…hopefully
+    int log_level = 5 /// What level to log at
+    ) noexcept
 {
-  return run_coro(dpp, execution_context.get_executor(), std::move(coro), name, y,
-		  log_level);
+  return run_coro(
+      dpp, execution_context.get_executor(), std::move(coro), name, y,
+      log_level);
 }
-
 
 /// Call a C++ coroutine from a stackful coroutine if we can, but block
 /// if we get `null_yield.` handling exceptions by returning negative
 /// error codes and passing out the `what()` string. This overload
 /// supports coroutines that return something other than void.
-template<asio::execution::executor Executor,
-	 typename T,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<Executor, AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, /// For logging
-  Executor executor, ///< Executor on which to run the coroutine
-  asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
-  T& val, ///< Where to store the returned value
-  std::string_view name, ///< Name, for logging errors
-  optional_yield y, /// Stackful coroutine context…hopefully
-  int log_level = 5 /// What level to log at
-  ) noexcept
+template <
+    boost::asio::execution::executor Executor,
+    typename T,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<Executor, AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, /// For logging
+    Executor executor, ///< Executor on which to run the coroutine
+    boost::asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
+    T& val, ///< Where to store the returned value
+    std::string_view name, ///< Name, for logging errors
+    optional_yield y, /// Stackful coroutine context…hopefully
+    int log_level = 5 /// What level to log at
+    ) noexcept
 {
   std::exception_ptr e;
   if (y) {
     auto& yield = y.get_yield_context();
-    val = asio::co_spawn(yield.get_executor(), std::move(coro),
-			 async::redirect_error(yield, e));
+    val = boost::asio::co_spawn(
+        yield.get_executor(), std::move(coro),
+        ceph::async::redirect_error(yield, e));
   } else {
     maybe_warn_about_blocking(dpp);
-    val = asio::co_spawn(executor, std::move(coro), async::use_blocked[e]);
+    val = boost::asio::co_spawn(
+        executor, std::move(coro), ceph::async::use_blocked[e]);
   }
   std::string what;
   auto r = ceph::from_exception(e, &what);
@@ -275,51 +313,61 @@ int run_coro(
 /// by returning negative error codes and passing out the `what()`
 /// string. This overload supports coroutines that return something
 /// other than void.
-template<async::execution_context ExecutionContext,
-	 typename T,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<typename ExecutionContext::executor_type,
-			       AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, /// For logging
-  ExecutionContext& execution_context, ///< Execution context on which to run the coroutine
-  asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
-  T& val, ///< Where to store the returned value
-  std::string_view name, ///< Name, for logging errors
-  optional_yield y, /// Stackful coroutine context…hopefully
-  int log_level = 5 /// What level to log at
-  ) noexcept
+template <
+    ceph::async::execution_context ExecutionContext,
+    typename T,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<
+      typename ExecutionContext::executor_type,
+      AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, /// For logging
+    ExecutionContext&
+        execution_context, ///< Execution context on which to run the coroutine
+    boost::asio::awaitable<T, AwaitableExecutor> coro, ///< The coroutine itself
+    T& val, ///< Where to store the returned value
+    std::string_view name, ///< Name, for logging errors
+    optional_yield y, /// Stackful coroutine context…hopefully
+    int log_level = 5 /// What level to log at
+    ) noexcept
 {
-  return run_coro(dpp, execution_context.get_executor(), std::move(coro), val, name,
-		  y, log_level);
+  return run_coro(
+      dpp, execution_context.get_executor(), std::move(coro), val, name, y,
+      log_level);
 }
 
 /// Call a C++ coroutine from a stackful coroutine if we can, but block
 /// if we get `null_yield.` handling exceptions by returning negative
 /// error codes and passing out the `what()` string. This overload
 /// supports coroutines that return multiple values with a tuple.
-template<asio::execution::executor Executor,
-	 asio::execution::executor AwaitableExecutor,
-	 typename ...Ts>
-requires std::is_convertible_v<Executor, AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, /// For logging
-  Executor executor, ///< Executor on which to run the coroutine
-  asio::awaitable<std::tuple<Ts...>, AwaitableExecutor> coro, ///< The coroutine itself
-  std::tuple<Ts&...>&& vals, ///< Supply with std::tie
-  std::string_view name, ///< Name, for logging errors
-  optional_yield y, /// Stackful coroutine context…hopefully
-  int log_level = 5 /// What level to log at
-  ) noexcept
+template <
+    boost::asio::execution::executor Executor,
+    boost::asio::execution::executor AwaitableExecutor,
+    typename... Ts>
+  requires std::is_convertible_v<Executor, AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, /// For logging
+    Executor executor, ///< Executor on which to run the coroutine
+    boost::asio::awaitable<std::tuple<Ts...>, AwaitableExecutor>
+        coro, ///< The coroutine itself
+    std::tuple<Ts&...>&& vals, ///< Supply with std::tie
+    std::string_view name, ///< Name, for logging errors
+    optional_yield y, /// Stackful coroutine context…hopefully
+    int log_level = 5 /// What level to log at
+    ) noexcept
 {
   std::exception_ptr e;
   if (y) {
     auto& yield = y.get_yield_context();
-    vals = asio::co_spawn(yield.get_executor(), std::move(coro),
-			  async::redirect_error(yield, e));
+    vals = boost::asio::co_spawn(
+        yield.get_executor(), std::move(coro),
+        ceph::async::redirect_error(yield, e));
   } else {
     maybe_warn_about_blocking(dpp);
-    vals = asio::co_spawn(executor, std::move(coro), async::use_blocked[e]);
+    vals = boost::asio::co_spawn(
+        executor, std::move(coro), ceph::async::use_blocked[e]);
   }
   std::string what;
   auto r = ceph::from_exception(e, &what);
@@ -335,22 +383,31 @@ int run_coro(
 /// other than void.
 ///
 /// Intended for use in interactive front-ends, e.g. radosgw-admin.
-template<async::execution_context ExecutionContext,
-	 typename... Ts,
-	 asio::execution::executor AwaitableExecutor>
-requires std::is_convertible_v<typename ExecutionContext::executor_type,
-			       AwaitableExecutor>
-int run_coro(
-  const DoutPrefixProvider* dpp, /// For logging
-  ExecutionContext& execution_context, ///< Execution context on which to run the coroutine
-  asio::awaitable<std::tuple<Ts...>, AwaitableExecutor> coro, ///< The coroutine itself
-  std::tuple<Ts&...>&& vals, ///< Supply with std::tie
-  std::string_view name, ///< Name, for logging errors
-  optional_yield y, /// Stackful coroutine context…hopefully
-  int log_level = 5 /// What level to log at
-  ) noexcept
+template <
+    ceph::async::execution_context ExecutionContext,
+    typename... Ts,
+    boost::asio::execution::executor AwaitableExecutor>
+  requires std::is_convertible_v<
+      typename ExecutionContext::executor_type,
+      AwaitableExecutor>
+int
+run_coro(
+    const DoutPrefixProvider* dpp, /// For logging
+    ExecutionContext&
+        execution_context, ///< Execution context on which to run the coroutine
+    boost::asio::awaitable<std::tuple<Ts...>, AwaitableExecutor>
+        coro, ///< The coroutine itself
+    std::tuple<Ts&...>&& vals, ///< Supply with std::tie
+    std::string_view name, ///< Name, for logging errors
+    optional_yield y, /// Stackful coroutine context…hopefully
+    int log_level = 5 /// What level to log at
+    ) noexcept
 {
-  return run_coro(dpp, execution_context.get_executor(), std::move(coro),
-		  std::move(vals), name, y, log_level);
+  return run_coro(
+      dpp, execution_context.get_executor(), std::move(coro), std::move(vals),
+      name, y, log_level);
 }
+
+/// @}
+
 }

--- a/src/rgw/async_utils.h
+++ b/src/rgw/async_utils.h
@@ -15,22 +15,40 @@
 
 #pragma once
 
+#include <cassert>
+#include <chrono>
 #include <exception>
+#include <functional>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <variant>
+#include <vector>
 
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/execution/executor.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/cancellation_type.hpp>
 #include <boost/asio/co_spawn.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/execution/executor.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/this_coro.hpp>
+
+#include <boost/asio/experimental/promise.hpp>
+#include <boost/asio/experimental/use_promise.hpp>
+
+#include "include/function2.hpp"
+#include "include/scope_guard.h"
 
 #include "common/async/blocked_completion.h"
 #include "common/async/concepts.h"
-#include "common/async/yield_context.h"
 #include "common/async/redirect_error.h"
+#include "common/async/yield_context.h"
 
+#include "common/ceph_time.h"
 #include "common/dout.h"
 #include "common/dout_fmt.h"
 #include "common/error_code.h"
@@ -47,7 +65,6 @@ namespace rgw {
 ///
 /// Bridging adaptors between different flavors of coroutines.
 /// @{
-///
 
 /// Call a coroutine and block until it completes, handling exceptions
 /// by returning negative error codes and passing out the `what()`
@@ -432,16 +449,16 @@ struct oy_completer {
 ///
 /// \warning Errors from calls made using this adaptor will throw.
 ///
-/// \example For neorados,
-/// ```c++
+/// For example, with neorados:
 ///
+/// \code{.cpp}
 /// try {
 ///   rados.execute(o, ioc, std::move(op), oyc(dpp, y));
 /// } catch (sys::system_error& e) {
-///   …
+///   // …
 /// }
 ///
-/// ```
+/// \endcode
 ///
 /// \param[in] dpp Logging for `maybe_warn_about_blocking()`
 /// \param[in] y The yield_context, maybe. Maybe not.
@@ -489,6 +506,727 @@ inline auto
 oyc(const DoutPrefixProvider* dpp, optional_yield y, Disposition& disposition)
 {
   return ceph::async::redirect_error(oyc(dpp, y), disposition);
+}
+
+/// Helper type for visitors, from <https://en.cppreference.com/w/cpp/utility/variant/visit.html>
+template <class... Ts>
+struct overloads : Ts... {
+  using Ts::operator()...;
+};
+
+/// Promise used when shutting down the SAL
+using shutdown_promise =
+    ::boost::asio::experimental::promise<void(std::exception_ptr)>;
+
+/// \defgroup TaskHandles Handles for long-running coroutines
+///
+/// Handles for long-running tasks and background loops that can be
+/// cancelled and joined.
+/// @{
+
+/// Type tag to construct handle with coroutine running
+struct running_t {};
+
+/// Create a handle with the coroutine running
+inline constexpr running_t running{};
+
+/// Current state of a task handle
+enum class task_state {
+  /// Handle is not running but can be run
+  ready,
+  /// Handle is running and may be canceled or joined
+  running,
+  /// Handle is dead and cannot be used
+  dead
+};
+
+namespace detail {
+template <
+    typename CoroType,
+    ceph::async::strand Strand = boost::asio::strand<boost::asio::any_io_executor>>
+class metatask_base {
+public:
+  using coro_type = CoroType;
+  using executor_type = Strand;
+  using value_type = void;
+  using promise_type =
+      boost::asio::experimental::promise<void(std::exception_ptr)>;
+
+  /// Return the executor on which the coroutine will run
+  ///
+  /// \returns The executor for running coroutines, a strand in this
+  /// case
+  executor_type
+  get_executor() const
+  {
+    return strand;
+  }
+
+  /// \brief Return the state of the task
+  ///
+  /// \returns A value of type `task_state`
+  task_state
+  state() const
+  {
+    return std::visit(
+        overloads{
+            [](const coro_type&) { return task_state::ready; },
+            [](const promise_type&) { return task_state::running; },
+            [](const std::monostate&) { return task_state::dead; }},
+        runnable);
+  }
+
+  /// Cancels the currently running coroutine
+  ///
+  /// \note Cancellation is idempotent with the same cancellation
+  /// level
+  ///
+  /// \pre The task must be running. If `run` has not been called, or
+  /// `join` or `shutdown` have been called, it is a contract
+  /// violation.
+  void
+  cancel(
+      boost::asio::cancellation_type cancellation_level =
+          boost::asio::cancellation_type::all)
+  {
+    assert(state() == task_state::running);
+    std::get<promise_type>(runnable).cancel(cancellation_level);
+  }
+
+  /// Joins the currently running coroutine
+  ///
+  /// \param[in] token The Asio completion token
+  ///
+  /// \pre The task must be running. If `run` has not been called, or
+  /// `join` or `shutdown` have been called, it is a contract
+  /// violation.
+  ///
+  /// \returns Value appropriate to the completion token.
+  template<boost::asio::completion_token_for<void(std::exception_ptr)> CompletionToken>
+  auto
+  join(CompletionToken&& token)
+  {
+    assert(state() == task_state::running);
+    scope_guard _{[this] { runnable.template emplace<std::monostate>(); }};
+    // Extending the promise's lifetime through the execution of the handler.
+    auto p = std::make_shared<promise_type>(std::get<promise_type>(std::move(runnable)));
+    return (*p)(boost::asio::consign(std::forward<CompletionToken>(token), p));
+  }
+
+  /// Extracts the completion of the running coroutine for shutdown
+  ///
+  /// \note This function is intended to hook into the SAL shutdown
+  /// flow that accumulates multiple promises to wait on.
+  ///
+  /// \pre The task must be running. If `run` has not been called, or
+  /// `join` or `shutdown` have been called, it is a contract
+  /// violation.
+  void
+  shutdown(
+      std::string label,
+      std::vector<std::pair<std::string, shutdown_promise>>& to_wait)
+  {
+    assert(state() == task_state::running);
+    scope_guard _{[this] { runnable.template emplace<std::monostate>(); }};
+    to_wait.emplace_back(std::move(label), std::get<promise_type>(std::move(runnable)));
+  }
+
+  metatask_base(const metatask_base&) = delete;
+  metatask_base& operator =(const metatask_base&) = delete;
+  metatask_base(metatask_base&&) = delete;
+  metatask_base& operator =(metatask_base&&) = delete;
+
+protected:
+  template <typename... Args>
+  metatask_base(Strand strand, Args&&... args) :
+    strand(strand), runnable(std::forward<Args>(args)...)
+  {}
+
+  Strand strand;
+  std::variant<promise_type, coro_type, std::monostate> runnable;
+};
+
+template <
+    ceph::async::strand Strand = boost::asio::strand<boost::asio::any_io_executor>>
+class task_base : public metatask_base<boost::asio::awaitable<void>, Strand> {
+  using Base = metatask_base<boost::asio::awaitable<void>, Strand>;
+protected:
+  using Base::runnable;
+  using Base::strand;
+public:
+  using typename Base::coro_type;
+  using typename Base::executor_type;
+  using typename Base::value_type;
+  using typename Base::promise_type;
+
+  using Base::get_executor;
+  using Base::state;
+  using Base::cancel;
+  using Base::join;
+  using Base::shutdown;
+
+  /// Starts the coroutine running
+  ///
+  /// \pre The task may not be running and may not have run before. If
+  /// `run()` has been called before or the `running` version of the
+  /// constructor was called, it is a contract violation.
+  void
+  run()
+  {
+    using boost::asio::experimental::use_promise;
+    assert(state() == task_state::ready);
+    runnable.template emplace<promise_type>(boost::asio::co_spawn(
+        strand, std::get<coro_type>(std::move(runnable)),
+        boost::asio::bind_executor(strand, use_promise)));
+    assert(state() == task_state::running);
+  }
+
+  /// \brief Construct a task_base from an awaitable, ready
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro The awaitable for the task
+  task_base(Strand strand, coro_type&& coro) :
+    Base(strand, std::in_place_type<coro_type>, std::move(coro))
+  {}
+
+  /// \brief Construct a task_base from a promise, running
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] promise The promise for the currently running task
+  task_base(Strand strand, promise_type&& promise) :
+    Base(strand, std::in_place_type<promise_type>, std::move(promise))
+  {}
+
+  /// \brief Construct an empty task_base, dead
+  ///
+  /// \param[in] strand The strand on which to run
+  task_base(Strand strand) :
+    Base(strand, std::monostate{})
+  {}
+};
+
+template <
+    ceph::async::strand Strand = boost::asio::strand<boost::asio::any_io_executor>>
+class ytask_base : public metatask_base<fu2::unique_function<void(boost::asio::yield_context)>, Strand> {
+  using Base = metatask_base<fu2::unique_function<void(boost::asio::yield_context)>, Strand>;
+protected:
+  using Base::runnable;
+  using Base::strand;
+public:
+  using typename Base::coro_type;
+  using typename Base::executor_type;
+  using typename Base::value_type;
+  using typename Base::promise_type;
+
+  using Base::get_executor;
+  using Base::state;
+  using Base::cancel;
+  using Base::join;
+  using Base::shutdown;
+
+  /// Starts the coroutine running
+  ///
+  /// \pre The task may not be running and may not have run before. If
+  /// `run()` has been called before or the `start_running` version of
+  /// the constructor was called, it is a contract violation.
+  void
+  run()
+  {
+    using boost::asio::experimental::use_promise;
+    assert(state() == task_state::ready);
+    runnable.template emplace<promise_type>(boost::asio::spawn(
+        boost::asio::any_io_executor{strand},
+        std::get<coro_type>(std::move(runnable)),
+        boost::asio::bind_executor(strand, use_promise)));
+    assert(state() == task_state::running);
+  }
+
+  /// \brief Construct a ytask_base from a function, ready
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro The function for the task
+  ytask_base(Strand strand, coro_type&& coro) :
+    Base(strand, std::in_place_type<coro_type>, std::move(coro))
+  {}
+
+  /// \brief Construct a ytask_base from a promise, running
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] promise The promise for the running task
+  ytask_base(Strand strand, promise_type&& promise) :
+    Base(strand, std::in_place_type<promise_type>, std::move(promise))
+  {}
+
+  /// \brief Construct an empty ytask_base, dead
+  ///
+  /// \param[in] strand The strand on which to run
+  ytask_base(Strand strand) :
+    Base(strand, std::monostate{}) {}
+};
+} // namespace detail
+
+/// \brief Handle for long-running tasks
+///
+/// Example:
+/// ```
+/// rgw::task task{boost::asio::make_strand(co_await boost::asio::this_coro::executor),
+///                some_coroutine(), rgw::running};
+/// do_some();
+/// other_things();
+/// co_await task.join(asio::use_awaitable); // Wait for completion.
+/// ```
+///
+/// \warning This class makes no attempt at serialization. Use a
+/// strand or mutex if you need that.
+template <
+    ceph::async::strand Strand = boost::asio::strand<boost::asio::any_io_executor>>
+class task final : public detail::task_base<Strand> {
+  using Base = detail::task_base<Strand>;
+public:
+  using typename Base::coro_type;
+  using typename Base::executor_type;
+  using typename Base::value_type;
+  using typename Base::promise_type;
+
+  using Base::get_executor;
+  using Base::state;
+  using Base::run;
+  using Base::cancel;
+  using Base::join;
+  using Base::shutdown;
+
+  /// \brief Construct a task from an awaitable, ready to be run
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro The awaitable for the task
+  task(Strand strand, coro_type coro) :
+    Base(strand, std::move(coro))
+  {
+    assert(state() == task_state::ready);
+  }
+
+  /// \brief Construct a task from a coroutine function, ready to be run
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro_fun The coroutine function for the task
+  template <std::invocable<> CoroFun>
+    requires(std::is_same_v<std::invoke_result_t<CoroFun>, coro_type>)
+  task(Strand strand, CoroFun&& coro_fun) :
+    Base(strand, std::invoke(std::forward<CoroFun>(coro_fun)))
+  {
+    assert(state() == task_state::ready);
+  }
+
+  /// \brief Construct a running task from an awaitable
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro The awaitable for the task
+  task(Strand strand, coro_type coro, running_t /**< Type tag */) :
+    Base(strand,
+        boost::asio::co_spawn(
+            strand,
+            std::move(coro),
+            boost::asio::bind_executor(
+                strand,
+                boost::asio::experimental::use_promise)))
+  {
+    assert(state() == task_state::running);
+  }
+
+  /// \brief Construct a running task from a coroutine function
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro_fun The coroutine function for the task
+  template <std::invocable<> CoroFun>
+    requires(std::is_same_v<std::invoke_result_t<CoroFun>, coro_type>)
+  task(Strand strand, CoroFun&& coro_fun, running_t /**< Type tag */) :
+    Base(strand,
+        boost::asio::co_spawn(
+            strand,
+            std::invoke(std::forward<CoroFun>(coro_fun)),
+            boost::asio::bind_executor(
+                strand,
+                boost::asio::experimental::use_promise)))
+  {
+    assert(state() == task_state::running);
+  }
+};
+
+/// \brief Handle for periodic maintenance tasks
+///
+/// The supplied function returns an optional containing its intended
+/// delay. If the optional is empty, the loop will exit.
+///
+/// Example:
+///
+/// ```
+/// asio::awaitable<ceph::timespan>
+/// periodic()
+/// {
+///   co_await maintenance();
+///   co_return 3s;
+/// }
+/// ```
+///
+/// ```
+/// rgw::run_loop loop{boost::asio::make_strand(co_await boost::asio::this_coro::executor),
+///                    &periodic, rgw::running};
+/// co_await make_work();
+/// loop.wake();
+/// other_things();
+/// loop.cancel();
+/// co_await loop.join(asio::use_awaitable); // Wait for completion.
+/// ```
+///
+/// \warning This class makes no attempt at serialization. Use a
+/// strand or mutex if you need that.
+template <
+    typename Rep = ceph::rep,
+    typename Ratio = std::nano,
+    ceph::async::strand Strand = boost::asio::strand<boost::asio::any_io_executor>>
+class run_loop final : public detail::task_base<Strand> {
+  using Base = detail::task_base<Strand>;
+  using Base::runnable;
+  using Base::strand;
+  using timer_t = boost::asio::steady_timer;
+public:
+  using duration = std::chrono::duration<Rep, Ratio>;
+  using coro_type = boost::asio::awaitable<duration>;
+  using typename Base::executor_type;
+  using typename Base::value_type;
+  using typename Base::promise_type;
+
+  using Base::get_executor;
+  using Base::state;
+  using Base::run;
+  using Base::cancel;
+  using Base::join;
+  using Base::shutdown;
+
+  /// \brief Construct a run_loop from a coroutine function, ready to be run
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro_fun The coroutine function for the loop. It must return
+  ///                     its intended delay before being re-run
+  template <std::invocable<> CoroFun>
+    requires(std::is_same_v<std::invoke_result_t<CoroFun>, coro_type>)
+  run_loop(Strand strand, CoroFun&& coro_fun) :
+    Base(strand)
+  {
+    runnable.template emplace<typename Base::coro_type>(loop(std::forward<CoroFun>(coro_fun), timer_));
+    assert(state() == task_state::ready);
+  }
+
+  /// \brief Construct a running run_loop from a coroutine function
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro_fun The coroutine function for the loop. It must return
+  ///                     its intended delay before being re-run
+  template <std::invocable<> CoroFun>
+    requires(std::is_same_v<std::invoke_result_t<CoroFun>, coro_type>)
+  run_loop(Strand strand, CoroFun&& coro_fun, running_t /**< Type tag */) :
+    Base(strand)
+  {
+    runnable.template emplace<promise_type>(boost::asio::co_spawn(
+        strand, loop(std::forward<CoroFun>(coro_fun), timer_),
+        boost::asio::bind_executor(
+            strand, boost::asio::experimental::use_promise)));
+    assert(state() == task_state::running);
+  }
+
+  /// \brief Wake a waiting task
+  ///
+  /// \note This wakes the task only when sleeping in the pause between runs.
+  void
+  wake()
+  {
+    assert(state() == task_state::running);
+    boost::asio::dispatch(strand, [timer = this->timer_] {
+      timer->cancel();
+    });
+  }
+
+private:
+
+  template <std::invocable<> CoroFun>
+    requires(std::is_same_v<std::invoke_result_t<CoroFun>, coro_type>)
+  static boost::asio::awaitable<void>
+  loop(CoroFun coro_fun, std::shared_ptr<timer_t> timer)
+  {
+    try {
+      while ((co_await boost::asio::this_coro::cancellation_state).cancelled() ==
+             boost::asio::cancellation_type::none) {
+        auto delay = co_await coro_fun();
+        timer->expires_after(delay);
+        try {
+          co_await timer->async_wait(boost::asio::use_awaitable);
+        } catch (boost::system::system_error& e) {
+          // If the coroutine has been canceled we'll exit when we hit
+          // the while condition. Otherwise, we've been awoken.
+          if (e.code() != boost::asio::error::operation_aborted) {
+            throw;
+          }
+        }
+      }
+    } catch (boost::system::system_error& e) {
+      // Since cancellation is an expected way to exit, it is not
+      // exceptional.
+      if (e.code() != boost::asio::error::operation_aborted) {
+        throw;
+      }
+    }
+  }
+
+  // This is a shared pointer so the coroutine handle itself can own a
+  // reference and promise cancellation through the `run_loop`
+  // destructor will propagate to the timer properly.
+  std::shared_ptr<timer_t> timer_ = std::make_shared<timer_t>(get_executor());
+};
+
+/// \brief Handle for long-running tasks, stackful version
+///
+/// Example:
+/// ```
+/// rgw::ytask task{boost::asio::make_strand(y.get_executor()),
+///                 &some_coroutine, rgw::running};
+/// do_some();
+/// other_things();
+/// join(y); // Wait for completion.
+/// ```
+///
+/// \warning This class makes no attempt at serialization. Use a
+/// strand or mutex if you need that.
+template <
+    ceph::async::strand Strand = boost::asio::strand<boost::asio::any_io_executor>>
+class ytask final : public detail::ytask_base<Strand> {
+  using Base = detail::ytask_base<Strand>;
+public:
+  using typename Base::coro_type;
+  using typename Base::executor_type;
+  using typename Base::value_type;
+  using typename Base::promise_type;
+
+  using Base::get_executor;
+  using Base::state;
+  using Base::run;
+  using Base::cancel;
+  using Base::join;
+  using Base::shutdown;
+
+  /// \brief Construct a ytask from a stackful coroutine function, ready to be run
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro The stackful coroutine function for the task
+  template <std::invocable<boost::asio::yield_context> Coro>
+    requires(std::is_void_v<
+                std::invoke_result_t<Coro, boost::asio::yield_context>>)
+  ytask(Strand strand, Coro&& coro) :
+    Base(strand, std::forward<Coro>(coro))
+  {
+    assert(state() == task_state::ready);
+  }
+
+  /// \brief Construct a running ytask from a stackful coroutine function
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro The stackful coroutine function for the task
+  template <std::invocable<boost::asio::yield_context> Coro>
+    requires(
+        std::is_void_v<std::invoke_result_t<Coro, boost::asio::yield_context>>)
+  ytask(Strand strand, Coro&& coro, running_t) :
+    Base(
+        strand,
+        boost::asio::spawn(
+            boost::asio::any_io_executor{strand},
+            std::forward<Coro>(coro),
+            boost::asio::bind_executor(
+                strand,
+                boost::asio::experimental::use_promise)))
+  {
+    assert(state() == task_state::running);
+  }
+};
+
+/// \brief Handle for periodic maintenance tasks, stackful version
+///
+/// Example:
+///
+/// ```
+/// ceph::timespan
+/// periodic(asio::yield_context y)
+/// {
+///   maintenance(y);
+///   return 3s;
+/// }
+/// ```
+///
+/// ```
+/// rgw::yrun_loop loop{asio::make_strand(y.get_executor()),
+///                     &periodic, rgw::running};
+/// make_work(y);
+/// loop.wake();
+/// other_things();
+/// loop.cancel();
+/// loop.join(y); // Wait for completion.
+/// ```
+///
+/// \warning This class makes no attempt at serialization. Use a
+/// strand or mutex if you need that.
+template <
+    typename Rep = ceph::rep,
+    typename Ratio = std::nano,
+    ceph::async::strand Strand = boost::asio::strand<boost::asio::any_io_executor>>
+class yrun_loop final : public detail::ytask_base<Strand> {
+  using Base = detail::ytask_base<Strand>;
+  using Base::runnable;
+  using Base::strand;
+  using timer_t = boost::asio::steady_timer;
+public:
+  using duration = std::chrono::duration<Rep, Ratio>;
+  using typename Base::executor_type;
+  using typename Base::value_type;
+  using typename Base::promise_type;
+
+  using Base::get_executor;
+  using Base::state;
+  using Base::run;
+  using Base::cancel;
+  using Base::join;
+  using Base::shutdown;
+
+  /// \brief Construct a yrun_loop from a stackful coroutine, ready to
+  /// be run
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro_fun The coroutine function for the loop. It must return
+  ///                     its intended delay before being re-run
+  template <std::invocable<boost::asio::yield_context> CoroFun>
+    requires(std::is_convertible_v<
+             std::invoke_result_t<CoroFun, boost::asio::yield_context>,
+             duration>)
+  yrun_loop(Strand strand, CoroFun&& coro_fun) :
+    Base(strand)
+  {
+    runnable.template emplace<typename Base::coro_type>(
+        [timer = timer_, coro_fun = std::forward<CoroFun>(coro_fun)](
+            boost::asio::yield_context y) mutable {
+          loop(std::forward<CoroFun>(coro_fun), std::move(timer), y);
+        });
+    assert(state() == task_state::ready);
+  }
+
+  /// \brief Construct a running yrun_loop from a coroutine function
+  ///
+  /// \param[in] strand The strand on which to run
+  /// \param[in] coro_fun The coroutine function for the loop. It must return
+  ///                     its intended delay before being re-run
+  template <std::invocable<boost::asio::yield_context> CoroFun>
+    requires(std::is_convertible_v<
+             std::invoke_result_t<CoroFun, boost::asio::yield_context>,
+             duration>)
+  yrun_loop(Strand strand, CoroFun&& coro_fun, running_t /**< Type tag */) :
+    Base(strand)
+  {
+    runnable.template emplace<promise_type>(boost::asio::spawn(
+        boost::asio::any_io_executor(strand),
+        [timer = timer_, coro_fun = std::forward<CoroFun>(coro_fun)](
+            boost::asio::yield_context y) mutable {
+          loop(std::forward<CoroFun>(coro_fun), std::move(timer), y);
+        },
+        boost::asio::bind_executor(
+            strand, boost::asio::experimental::use_promise)));
+    assert(state() == task_state::running);
+  }
+
+  /// \brief Wake a waiting task
+  ///
+  /// \note This wakes the task only when sleeping in the pause between runs.
+  void
+  wake()
+  {
+    assert(state() == task_state::running);
+    boost::asio::dispatch(strand, [timer = timer_] {
+      timer->cancel();
+    });
+  }
+
+private:
+  template <std::invocable<boost::asio::yield_context> CoroFun>
+    requires(std::is_convertible_v<
+             std::invoke_result_t<CoroFun, boost::asio::yield_context>,
+             duration>)
+  static void
+  loop(
+      CoroFun coro_fun,
+      std::shared_ptr<timer_t> timer,
+      boost::asio::yield_context y)
+  {
+    try {
+      while (y.get_cancellation_state().cancelled() ==
+             boost::asio::cancellation_type::none) {
+        auto delay = coro_fun(y);
+        timer->expires_after(delay);
+        try {
+          timer->async_wait(y);
+        } catch (boost::system::system_error& e) {
+          // If the coroutine has been canceled we'll exit when we hit
+          // the while condition. Otherwise, we've been awoken.
+          if (e.code() != boost::asio::error::operation_aborted) {
+            throw;
+          }
+        }
+      }
+    } catch (boost::system::system_error& e) {
+      // Since cancellation is the only way we exit, it is not
+      // exceptional.
+      if (e.code() != boost::asio::error::operation_aborted) {
+        throw;
+      }
+    }
+  }
+
+  // This is a shared pointer so the coroutine handle itself can own a
+  // reference and promise cancellation through the `run_loop`
+  // destructor will propagate to the timer properly.
+  std::shared_ptr<timer_t> timer_ = std::make_shared<timer_t>(get_executor());
+};
+/// @}
+
+/// \brief Convenience to wait within a C++20 coroutine
+///
+/// @param[in] delay Time to wait
+template <typename Rep, typename Period>
+boost::asio::awaitable<void>
+wait_for(std::chrono::duration<Rep, Period> delay)
+{
+  boost::asio::steady_timer timer{
+      co_await boost::asio::this_coro::executor, delay};
+  co_await timer.async_wait(boost::asio::use_awaitable);
+}
+
+/// \brief Convenience to wait within a stackful coroutine
+///
+/// @param[in] delay Time to wait
+/// @param[in] y Yield context
+template <typename Rep, typename Period>
+void
+wait_for(std::chrono::duration<Rep, Period> delay, boost::asio::yield_context y)
+{
+  boost::asio::steady_timer timer{y.get_executor(), delay};
+  timer.async_wait(y);
+}
+
+/// \brief Return a function object binding a member function to an
+/// object
+///
+/// \param[in] obj The object to bind
+/// \param[in] pm The member function to be bound
+template <typename M, typename T, typename U>
+  requires(std::is_base_of_v<U, T>)
+auto
+membind(T& obj, M U::* pm)
+{
+  return std::bind_front(std::mem_fn(pm), std::ref(obj));
 }
 } // namespace rgw
 

--- a/src/rgw/async_utils.h
+++ b/src/rgw/async_utils.h
@@ -43,8 +43,7 @@
 
 
 namespace rgw {
-
-/// \defgroup CoroBridge Corutine bridging
+/// \defgroup CoroBridge Coroutine bridging
 ///
 /// Bridging adaptors between different flavors of coroutines.
 /// @{
@@ -410,4 +409,106 @@ run_coro(
 
 /// @}
 
+namespace detail {
+/// CompletionToken wrapping an optional_yield and a DoutPrefixProvider*
+///
+/// \note I thought briefly of whether I could justify asserting on
+/// blocking in an asio thread. Unconditionally, since I didn't have a
+/// CephContext* either.
+///
+/// \note Obviously, I could not.
+///
+/// \note ;(
+struct oy_completer {
+  const DoutPrefixProvider* dpp;
+  optional_yield y;
+};
+} // namespace detail
+
+/// Adapt `optional_yield` as a completion token for Asio operations
+///
+/// Rather than `use_blocked`, use this as a completion token when
+/// calling to neorados or similar functions expecting one.
+///
+/// \warning Errors from calls made using this adaptor will throw.
+///
+/// \example For neorados,
+/// ```c++
+///
+/// try {
+///   rados.execute(o, ioc, std::move(op), oyc(dpp, y));
+/// } catch (sys::system_error& e) {
+///   …
+/// }
+///
+/// ```
+///
+/// \param[in] dpp Logging for `maybe_warn_about_blocking()`
+/// \param[in] y The yield_context, maybe. Maybe not.
+///
+/// \note I was originally going to write an `async_result`
+/// specialization for optional_yield.
+inline detail::oy_completer
+oyc(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  return {dpp, y};
 }
+
+/// Adapt `optional_yield` as a completion token for Asio operations,
+/// with error diversion
+///
+/// Rather than `use_blocked`, use this as a completion token when
+/// calling to neorados or similar functions expecting one.
+///
+/// \note This version diverts the error rather than throwing. The
+/// type of the error (the `disposition` in Asio parlance) depends on
+/// the operation. Basic neorados operations use
+/// `boost::system::error_code`. Coroutines use `std::exception_ptr`.
+///
+/// An example for neorados,
+/// \code{.cpp}
+///
+/// boost::system::error_code ec;
+/// rados.execute(o, ioc, std::move(op), oyc(dpp, y, ec));
+///
+/// if (ec) {
+///   …
+/// }
+/// \endcode
+///
+/// \param[in] dpp Logging for `maybe_warn_about_blocking()`
+/// \param[in] y The yield_context, maybe. Maybe not.
+/// \param[in] disposition A disposition to redirect
+///
+/// \note I was going to add an overload to optional_yield for
+/// `operator []` to give ergonomic error redirection. Then I
+/// remembered to add maybe warn about blocking and discovered it
+/// required a DoutPrefixProvider*.
+template<ceph::async::disposition Disposition>
+inline auto
+oyc(const DoutPrefixProvider* dpp, optional_yield y, Disposition& disposition)
+{
+  return ceph::async::redirect_error(oyc(dpp, y), disposition);
+}
+} // namespace rgw
+
+namespace boost::asio {
+template <typename Signature>
+struct async_result<rgw::detail::oy_completer, Signature> {
+  template <typename Initiation, typename RawCompletionToken, typename... Args>
+  static auto
+  initiate(Initiation&& initiation, RawCompletionToken&& token, Args&&... args)
+  {
+    if (token.y) {
+      return async_result<yield_context, Signature>::initiate(
+          std::forward<Initiation>(initiation), token.y.get_yield_context(),
+          std::forward<Args>(args)...);
+    } else {
+      maybe_warn_about_blocking(token.dpp);
+      return async_result<ceph::async::use_blocked_t, Signature>::initiate(
+          std::forward<Initiation>(initiation), ceph::async::use_blocked,
+          std::forward<Args>(args)...);
+    }
+  }
+};
+} // namespace boost::asio

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -1874,7 +1874,7 @@ std::unique_ptr<Writer> D4NFilterDriver::get_atomic_writer(const DoutPrefixProvi
   return std::make_unique<D4NFilterWriter>(std::move(writer), this, obj, dpp, true, y);
 }
 
-void D4NFilterDriver::shutdown()
+void D4NFilterDriver::shutdown(shutdown_vector& to_wait)
 {
   // call cancel() on the connection's executor
   boost::asio::dispatch(conn->get_executor(), [c = conn] { c->cancel(); });
@@ -1885,7 +1885,7 @@ void D4NFilterDriver::shutdown()
   bucketDir.reset();
   policyDriver.reset();
 
-  next->shutdown();
+  next->shutdown(to_wait);
 }
 
 std::unique_ptr<Object::ReadOp> D4NFilterObject::get_read_op()

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -91,7 +91,8 @@ class D4NFilterDriver : public FilterDriver {
     void save_y(optional_yield y) { this->y = y; }
     std::shared_ptr<connection> get_conn() { return conn; }
     std::shared_ptr<rgw::d4n::RedisPool> get_redis_pool() { return redis_pool; }
-    void shutdown() override;
+    void shutdown(
+        std::vector<std::pair<std::string, shutdown_promise>>& to_wait) override;
 };
 
 class D4NFilterUser : public FilterUser {

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -123,6 +123,7 @@ public:
   RGWAsyncRadosProcessor(CephContext *_cct, int num_threads);
   ~RGWAsyncRadosProcessor() {}
   void start();
+  void set_down_flag() { going_down = true; }
   void stop();
   void handle_request(const DoutPrefixProvider *dpp, RGWAsyncRadosRequest *req);
   void queue(RGWAsyncRadosRequest *req);

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -750,6 +750,11 @@ int RGWRemoteDataLog::init(const rgw_zone_id& _source_zone, RGWRESTConn *_conn, 
 
 void RGWRemoteDataLog::finish()
 {
+  // Shut down `http_manager` here so that in-flight requests will
+  // cancel and we can join the sync thread without blocking. This
+  // stops a potential mutual deadlock between two RGWs on the same
+  // cluster on period update.
+  http_manager.stop();
   stop();
 }
 

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -10,7 +10,6 @@
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/bind_cancellation_slot.hpp>
 #include <boost/asio/co_spawn.hpp>
-#include <boost/asio/experimental/awaitable_operators.hpp>
 
 #include <boost/container/flat_set.hpp>
 #include <boost/container/flat_map.hpp>
@@ -21,9 +20,8 @@
 #include "include/fs_types.h"
 #include "include/neorados/RADOS.hpp"
 
-#include "common/async/blocked_completion.h"
+#include "common/async/co_throttle.h"
 #include "common/async/librados_completion.h" // IWYU pragma: keep
-#include "common/async/spawn_group.h"
 #include "common/async/yield_context.h"
 
 #include "common/dout.h"
@@ -448,7 +446,7 @@ void DataLogBackends::handle_empty_to(uint64_t new_tail) {
 int RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
 			     const RGWZone* zone,
 			     const RGWZoneParams& zoneparams,
-			     bool background_tasks) noexcept
+			     bool background_tasks, optional_yield y) noexcept
 {
   log_data = zone->log_data;
   try {
@@ -457,7 +455,7 @@ int RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
 		   start(dpp, zoneparams.log_pool,
 			 background_tasks, background_tasks,
 			 background_tasks),
-		   async::use_blocked);
+		   rgw::oyc(dpp, y));
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		       << ": Failed to start datalog: " << e.what()
@@ -514,12 +512,8 @@ RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
   }
 
   if (renew) {
-    renew_future = asio::co_spawn(
-      renew_strand,
-      renew_run(),
-      asio::bind_cancellation_slot(renew_signal.slot(),
-				   asio::bind_executor(renew_strand,
-						       asio::use_future)));
+    renew_task.emplace(asio::make_strand(executor), rgw::membind(*this, &RGWDataChangesLog::renew_run),
+                       rgw::running);
   }
   if (watch) {
     // Establish watch here so we won't be 'started up' until we're watching.
@@ -529,22 +523,14 @@ RGWDataChangesLog::start(const DoutPrefixProvider *dpp,
       throw sys::system_error{ENOTCONN, sys::generic_category(),
 			      "Unable to establish recovery watch!"};
     }
-    watch_future = asio::co_spawn(
-      watch_strand,
-      watch_loop(),
-      asio::bind_cancellation_slot(watch_signal.slot(),
-				   asio::bind_executor(watch_strand,
-						       asio::use_future)));
+    watch_task.emplace(asio::make_strand(executor), watch_loop(),
+                       rgw::running);
   }
   if (recovery) {
     // Recovery can run concurrent with normal operation, so we don't
     // have to block startup while we do all that I/O.
-    recovery_future = asio::co_spawn(
-      recovery_strand,
-      recover(dpp),
-      asio::bind_cancellation_slot(recovery_signal.slot(),
-				   asio::bind_executor(recovery_strand,
-						       asio::use_future)));
+    recovery_task.emplace(asio::make_strand(executor),
+                          recover(dpp), rgw::running);
   }
   co_return;
 }
@@ -731,7 +717,7 @@ int RGWDataChangesLog::choose_oid(const rgw_bucket_shard& bs) {
 asio::awaitable<void>
 RGWDataChangesLog::renew_entries(const DoutPrefixProvider* dpp)
 {
-  if (!log_data) {
+  if (!log_data || down_flag) {
     co_return;
   }
 
@@ -1031,7 +1017,7 @@ int RGWDataChangesLog::add_entry(const DoutPrefixProvider* dpp,
 		  [this, dpp, &bucket_info, &gen,
 		   &shard_id](asio::yield_context y) {
 		    add_entry(dpp, bucket_info, gen, shard_id, y);
-		  }, async::use_blocked);
+		  }, rgw::oyc(dpp, y));
     }
   } catch (const std::exception&) {
     return ceph::from_exception(std::current_exception());
@@ -1256,105 +1242,59 @@ bool RGWDataChangesLog::going_down() const
   return down_flag;
 }
 
-// Now, if we had an awaitable future…
-asio::awaitable<void> RGWDataChangesLog::async_shutdown()
+void
+RGWDataChangesLog::shutdown(rgw::shutdown_vector& to_wait)
 {
-  DoutPrefix dp{cct, ceph_subsys_rgw, "Datalog Shutdown"};
-  if (down_flag) {
-    co_return;
-  }
-  down_flag = true;
-  if (!ran_background)  {
-    co_return;
-  }
-  renew_stop();
-  // Revisit this later
-  asio::dispatch(renew_strand,
-		 [this]() {
-		   renew_signal.emit(asio::cancellation_type::terminal);
-		 });
-  asio::dispatch(recovery_strand,
-		 [this]() {
-		   recovery_signal.emit(asio::cancellation_type::terminal);
-		 });
-  asio::dispatch(watch_strand,
-		 [this]() {
-		   watch_signal.emit(asio::cancellation_type::terminal);
-		 });
-  if (watchcookie && rados->check_watch(watchcookie)) {
-    auto wc = watchcookie;
-    watchcookie = 0;
-    try {
-      co_await rados->unwatch(wc, loc, asio::use_awaitable);
-    } catch (const std::exception& e) {
-      ldpp_dout(&dp, 2)
-	<< "RGWDataChangesLog::async_shutdown: unwatch failed: " << e.what()
-	<< dendl;
-    }
-  }
-  co_return;
-}
-
-void RGWDataChangesLog::blocking_shutdown()
-{
+  using asio::experimental::use_promise;
   DoutPrefix dp{cct, ceph_subsys_rgw, "Datalog Shutdown"};
   if (down_flag) {
     return;
   }
   down_flag = true;
-  if (ran_background)  {
-    renew_stop();
-    // Revisit this later
-    asio::dispatch(renew_strand,
-		   [this]() {
-		     renew_signal.emit(asio::cancellation_type::terminal);
-		   });
-    try {
-      renew_future.wait();
-    } catch (const std::future_error& e) {
-      if (e.code() != std::future_errc::no_state) {
-	throw;
-      }
+  if (ran_background) {
+    if (renew_task) {
+      renew_task->cancel();
+      renew_task->shutdown("terminating datalog renewal loop", to_wait);
+      renew_task.reset();
     }
-    asio::dispatch(recovery_strand,
-		   [this]() {
-		     recovery_signal.emit(asio::cancellation_type::terminal);
-		   });
-    try {
-      recovery_future.wait();
-    } catch (const std::future_error& e) {
-      if (e.code() != std::future_errc::no_state) {
-	throw;
-      }
+    if (recovery_task) {
+      recovery_task->cancel();
+      recovery_task->shutdown("terminating datalog recovery task", to_wait);
+      recovery_task.reset();
     }
-    asio::dispatch(watch_strand,
-		   [this]() {
-		     watch_signal.emit(asio::cancellation_type::terminal);
-		   });
-    try {
-      watch_future.wait();
-    } catch (const std::future_error& e) {
-      if (e.code() != std::future_errc::no_state) {
-	throw;
-      }
-    }
-    if (watchcookie && rados->check_watch(watchcookie)) {
-      auto wc = watchcookie;
-      watchcookie = 0;
-      try {
-	rados->unwatch(wc, loc, async::use_blocked);
-      } catch (const std::exception& e) {
-	ldpp_dout(&dp, 2)
-	  << "RGWDataChangesLog::blocking_shutdown: unwatch failed: " << e.what()
-	  << dendl;
-      }
+    if (watch_task) {
+      to_wait.emplace_back(
+          "terminating datalog recovery watch",
+          asio::spawn(
+              asio::any_io_executor{watch_task->get_executor()},
+              [this, dp](asio::yield_context y) {
+                if (watch_task) {
+                  watch_task->cancel();
+                  watch_task->join(y);
+                  watch_task.reset();
+                }
+                if (watchcookie && rados->check_watch(watchcookie)) {
+                  auto wc = watchcookie;
+                  watchcookie = 0;
+                  try {
+                    rados->unwatch(wc, loc, y);
+                  } catch (const std::exception& e) {
+                    ldpp_dout(&dp, 2)
+                        << "RGWDataChangesLog::shutdown: unwatch failed: "
+                        << e.what() << dendl;
+                  }
+                }
+              },
+              use_promise));
     }
   }
   if (bes) {
-    bes->shutdown();
-    bes.reset();
+    to_wait.emplace_back(
+        std::string("terminating datalog backend"),
+        asio::spawn(
+            asio::any_io_executor{rados->get_executor()},
+            [this](asio::yield_context y) { bes->shutdown(y); }, use_promise));
   }
-  return;
 }
 
 RGWDataChangesLog::~RGWDataChangesLog() {
@@ -1364,65 +1304,47 @@ RGWDataChangesLog::~RGWDataChangesLog() {
   }
 }
 
-asio::awaitable<void> RGWDataChangesLog::renew_run() {
-  static constexpr auto runs_per_prune = 150;
-  auto run = 0;
-  renew_timer.emplace(co_await asio::this_coro::executor);
+asio::awaitable<ceph::timespan> RGWDataChangesLog::renew_run() {
   std::string_view operation;
   const DoutPrefix dp(cct, dout_subsys, "rgw data changes log: ");
-  for (;;) try {
-      ldpp_dout(&dp, 2) << "RGWDataChangesLog::ChangesRenewThread: start"
-			<< dendl;
-      operation = "RGWDataChangesLog::renew_entries"sv;
-      co_await renew_entries(&dp);
+  try {
+    ldpp_dout(&dp, 2) << "RGWDataChangesLog::renew_run: start" << dendl;
+    operation = "RGWDataChangesLog::renew_entries"sv;
+    co_await renew_entries(&dp);
+    operation = {};
+
+    if (renew_run_counter == runs_per_prune) {
+      std::optional<uint64_t> through;
+      ldpp_dout(&dp, 2)
+          << "RGWDataChangesLog::renew_run: pruning old generations"
+          << dendl;
+      operation = "trim_generations"sv;
+      co_await trim_generations(&dp, through);
       operation = {};
-      if (going_down())
-	break;
-
-      if (run == runs_per_prune) {
-	std::optional<uint64_t> through;
-	ldpp_dout(&dp, 2) << "RGWDataChangesLog::ChangesRenewThread: pruning old generations" << dendl;
-	operation = "trim_generations"sv;
-	co_await trim_generations(&dp, through);
-	operation = {};
-	if (through) {
-	  ldpp_dout(&dp, 2)
-	    << "RGWDataChangesLog::ChangesRenewThread: pruned generations "
-	    << "through " << *through << "." << dendl;
-	} else {
-	  ldpp_dout(&dp, 2)
-	    << "RGWDataChangesLog::ChangesRenewThread: nothing to prune."
-	    << dendl;
-	}
-        run = 0;
+      if (through) {
+        ldpp_dout(&dp, 2)
+            << "RGWDataChangesLog::renew_run: pruned generations "
+            << "through " << *through << "." << dendl;
       } else {
-	++run;
+        ldpp_dout(&dp, 20)
+            << "RGWDataChangesLog::renew_run: nothing to prune."
+            << dendl;
       }
-
-      int interval = cct->_conf->rgw_data_log_window * 3 / 4;
-      renew_timer->expires_after(std::chrono::seconds(interval));
-      co_await renew_timer->async_wait(asio::use_awaitable);
-    } catch (sys::system_error& e) {
-      if (e.code() == asio::error::operation_aborted) {
-	ldpp_dout(&dp, 10)
-	  << "RGWDataChangesLog::renew_entries canceled, going down" << dendl;
-	break;
-      } else {
-	ldpp_dout(&dp, 0)
-	  << "renew_thread: ERROR: "
-	  << (operation.empty() ? operation : "<unknown"sv)
-	  << "threw exception: " << e.what() << dendl;
-	continue;
-      }
+      renew_run_counter = 0;
+    } else {
+      ++renew_run_counter;
     }
-}
-
-void RGWDataChangesLog::renew_stop()
-{
-  std::lock_guard l{lock};
-  if (renew_timer) {
-    renew_timer->cancel();
+  } catch (sys::system_error& e) {
+    if (e.code() == asio::error::operation_aborted) {
+      ldpp_dout(&dp, 10)
+          << "RGWDataChangesLog::renew_entries canceled, going down" << dendl;
+    } else {
+      ldpp_dout(&dp, 0) << "renew_thread: ERROR: "
+                        << (operation.empty() ? "<unknown>"sv : operation)
+                        << "threw exception: " << e.what() << dendl;
+    }
   }
+  co_return std::chrono::seconds(cct->_conf->rgw_data_log_window * 3 / 4);
 }
 
 void RGWDataChangesLog::mark_modified(int shard_id, const rgw_bucket_shard& bs, uint64_t gen)
@@ -1639,17 +1561,12 @@ RGWDataChangesLog::recover_shard(const DoutPrefixProvider* dpp, int index)
 asio::awaitable<void> RGWDataChangesLog::recover(
   const DoutPrefixProvider* dpp)
 {
-  co_await asio::co_spawn(
-    recovery_strand,
-    [this](const DoutPrefixProvider* dpp)-> asio::awaitable<void, strand_t> {
-      auto ex = recovery_strand;
-      auto group = async::spawn_group{ex, static_cast<size_t>(num_shards)};
-      for (auto i = 0; i < num_shards; ++i) {
-	boost::asio::co_spawn(ex, recover_shard(dpp, i), group);
-      }
-      co_await group.wait();
-    }(dpp),
-    asio::use_awaitable);
+  auto ex = co_await asio::this_coro::executor;
+  auto throttle = async::co_throttle{ex, 32};
+  for (auto i = 0; i < num_shards; ++i) {
+    co_await throttle.spawn(recover_shard(dpp, i));
+  }
+  co_await throttle.wait();
 
   std::unique_lock l(lock);
   last_recovery = ceph::mono_clock::now();

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -22,8 +22,8 @@
 #include "include/neorados/RADOS.hpp"
 
 #include "common/async/blocked_completion.h"
-#include "common/async/co_throttle.h"
-#include "common/async/librados_completion.h"
+#include "common/async/librados_completion.h" // IWYU pragma: keep
+#include "common/async/spawn_group.h"
 #include "common/async/yield_context.h"
 
 #include "common/dout.h"
@@ -194,15 +194,15 @@ public:
 			    asio::use_awaitable);
 
       entries = entries.first(lentries.size());
-      std::ranges::transform(lentries, std::begin(entries),
-			     [](const auto& e) {
-			       rgw_data_change_log_entry entry;
-			       entry.log_id = e.id;
-			       entry.log_timestamp = e.timestamp;
-			       auto liter = e.data.cbegin();
-			       decode(entry.entry, liter);
-			       return entry;
-			     });
+      ranges::transform(lentries, std::begin(entries),
+                        [](const auto& e) {
+                          rgw_data_change_log_entry entry;
+                          entry.log_id = e.id;
+                          entry.log_timestamp = e.timestamp;
+                          auto liter = e.data.cbegin();
+                          decode(entry.entry, liter);
+                          return entry;
+                        });
       co_return std::make_tuple(std::move(entries), lmark);
     } catch (const buffer::error& err) {
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
@@ -319,15 +319,15 @@ public:
       auto [lentries, outmark] =
 	co_await fifos[shard].list(dpp, marker, log_entries);
       entries = entries.first(lentries.size());
-      std::ranges::transform(lentries, entries.begin(),
-			     [](const auto& e) {
-			       rgw_data_change_log_entry entry ;
-			       entry.log_id = e.marker;
-			       entry.log_timestamp = e.mtime;
-			       auto liter = e.data.cbegin();
-			       decode(entry.entry, liter);
-			       return entry;
-			     });
+      ::ranges::transform(lentries, entries.begin(),
+                          [](const auto& e) {
+                            rgw_data_change_log_entry entry ;
+                            entry.log_id = e.marker;
+                            entry.log_timestamp = e.mtime;
+                            auto liter = e.data.cbegin();
+                            decode(entry.entry, liter);
+                            return entry;
+                          });
       co_return  std::make_tuple(std::move(entries),
 				 outmark ? std::move(*outmark) : std::string{});
     } catch (const buffer::error& err) {
@@ -1581,7 +1581,6 @@ RGWDataChangesLog::decrement_sems(
   ceph::mono_time fetch_time,
   bc::flat_map<std::string, uint64_t>&& semcount)
 {
-  namespace sem_set = neorados::cls::sem_set;
   while (!semcount.empty()) {
     bc::flat_set<std::string> batch;
     for (auto j = 0u; j < sem_max_keys && !semcount.empty(); ++j) {

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -34,7 +34,7 @@
 #include "common/async/async_cond.h"
 #include "common/async/yield_context.h"
 
-#include "common/ceph_context.h"
+#include "include/common_fwd.h"
 #include "common/ceph_json.h"
 #include "common/ceph_time.h"
 #include "common/Formatter.h"
@@ -47,8 +47,6 @@
 #include "rgw_sync_policy.h"
 #include "rgw_trim_bilog.h"
 #include "rgw_zone.h"
-
-#include "common/async/spawn_group.h"
 
 namespace asio = boost::asio;
 namespace bc = boost::container;

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstdint>
-#include <future>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -15,11 +14,12 @@
 #include <variant>
 #include <vector>
 
-#include <boost/asio/use_future.hpp>
+#include <boost/asio/experimental/promise.hpp>
 #include <boost/asio/steady_timer.hpp>
 
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
+
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
@@ -28,20 +28,23 @@
 #include "include/neorados/RADOS.hpp"
 
 #include "include/buffer.h"
+#include "include/common_fwd.h"
 #include "include/encoding.h"
 #include "include/function2.hpp"
 
 #include "common/async/async_cond.h"
 #include "common/async/yield_context.h"
 
-#include "include/common_fwd.h"
 #include "common/ceph_json.h"
 #include "common/ceph_time.h"
 #include "common/Formatter.h"
 #include "common/lru_map.h"
 
-#include "cls/log/cls_log_types.h"
 #include "neorados/cls/sem_set.h"
+
+#include "cls/log/cls_log_types.h"
+
+#include "async_utils.h"
 #include "rgw_basic_types.h"
 #include "rgw_log_backing.h"
 #include "rgw_sync_policy.h"
@@ -357,16 +360,9 @@ class RGWDataChangesLog {
 
   using executor_t = asio::io_context::executor_type;
   executor_t executor;
-  using strand_t = asio::strand<executor_t>;
-  strand_t renew_strand{executor};
-  asio::cancellation_signal renew_signal = asio::cancellation_signal();
-  std::future<void> renew_future;
-  strand_t watch_strand{executor};
-  asio::cancellation_signal watch_signal = asio::cancellation_signal();
-  std::future<void> watch_future;
-  strand_t recovery_strand{executor};
-  asio::cancellation_signal recovery_signal = asio::cancellation_signal();
-  std::future<void> recovery_future;
+  std::optional<rgw::run_loop<>> renew_task;
+  std::optional<rgw::task<>> watch_task;
+  std::optional<rgw::task<>> recovery_task;
 
   ceph::mono_time last_recovery = ceph::mono_clock::zero();
 
@@ -410,9 +406,9 @@ class RGWDataChangesLog {
 		      uint64_t gen,
 		      ceph::real_time expiration);
 
-  std::optional<asio::steady_timer> renew_timer;
-  asio::awaitable<void> renew_run();
-  void renew_stop();
+  static constexpr auto runs_per_prune = 150;
+  int renew_run_counter = 0;
+  asio::awaitable<ceph::timespan> renew_run();
 
   std::function<bool(const rgw_bucket& bucket, optional_yield y,
                      const DoutPrefixProvider *dpp)> bucket_filter;
@@ -441,8 +437,9 @@ public:
 			      // all off (radosgw-admin)
 			      bool recovery, bool watch, bool renew);
 
-  int start(const DoutPrefixProvider *dpp, const RGWZone* _zone,
-	    const RGWZoneParams& zoneparams, bool background_tasks) noexcept;
+  int start(const DoutPrefixProvider* dpp, const RGWZone* _zone,
+            const RGWZoneParams& zoneparams, bool background_tasks,
+            optional_yield y) noexcept;
   asio::awaitable<bool> establish_watch(const DoutPrefixProvider* dpp,
 					std::string_view oid);
   asio::awaitable<void> process_notification(const DoutPrefixProvider* dpp,
@@ -520,8 +517,7 @@ public:
 		 bc::flat_map<std::string, uint64_t>&& semcount);
   asio::awaitable<void> recover_shard(const DoutPrefixProvider* dpp, int index);
   asio::awaitable<void> recover(const DoutPrefixProvider* dpp);
-  asio::awaitable<void> async_shutdown();
-  void blocking_shutdown();
+  void shutdown(rgw::shutdown_vector& to_wait);
 
   asio::awaitable<void> admin_sem_list(std::optional<int> req_shard,
 				       std::uint64_t max_entries,

--- a/src/rgw/driver/rados/rgw_log_backing.cc
+++ b/src/rgw/driver/rados/rgw_log_backing.cc
@@ -20,6 +20,7 @@
 #include "neorados/cls/version.h"
 #include "neorados/cls/fifo.h"
 
+#include "async_utils.h"
 #include "rgw_log_backing.h"
 #include "rgw_common.h"
 
@@ -224,20 +225,24 @@ asio::awaitable<void> log_remove(
   co_return;
 }
 
-void logback_generations::shutdown() {
-  if (watchcookie > 0) {
-    auto cct = rados.cct();
-    sys::error_code ec;
-    rados.unwatch(watchcookie, loc, async::use_blocked[ec]);
-    if (ec) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << ": failed unwatching oid=" << oid
-		 << ", " << ec.message() << dendl;
-    }
-    watchcookie = 0;
-  }
-}
+void
+logback_generations::shutdown(optional_yield y)
+{
+  auto cct = rados.cct();
+  DoutPrefix dp{cct, ceph_subsys_rgw, "logback_generations::shutdown()"};
 
+  if (watchcookie > 0) {
+    try {
+      rados.unwatch(watchcookie, loc, rgw::oyc(&dp, y));
+    } catch (const std::exception& e) {
+      ldpp_dout(&dp, 1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+                        << ": failed unwatching oid=" << oid << ", " << e.what()
+                        << dendl;
+    }
+  }
+  watchcookie = 0;
+  return;
+}
 
 logback_generations::~logback_generations() {
   auto cct = rados.cct();

--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -24,6 +24,8 @@
 
 #include "cls/version/cls_version_types.h"
 
+#include "common/async/yield_context.h"
+
 #include "common/strtol.h"
 
 #include "neorados/cls/fifo.h"
@@ -227,7 +229,7 @@ public:
   virtual void handle_empty_to(uint64_t new_tail) = 0;
 
   /// If you override this, call the superclass method *at the end*.
-  virtual void shutdown();
+  virtual void shutdown(optional_yield y);
 };
 
 inline std::string gencursor(uint64_t gen_id, std::string_view cursor) {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1068,7 +1068,8 @@ bool RGWIndexCompletionManager::handle_completion(completion_t cb, complete_op_d
   return false;
 }
 
-void RGWRados::finalize()
+void
+RGWRados::shutdown(rgw::shutdown_vector& to_wait)
 {
   if (run_sync_thread) {
     std::lock_guard l{meta_sync_thread_lock};
@@ -1083,12 +1084,19 @@ void RGWRados::finalize()
     }
   }
 
-  /* Before joining any sync threads, drain outstanding requests &
-   * mark the async_processor as going_down() */
+  if (svc.async_processor) {
+    svc.async_processor->set_down_flag();
+  }
+
+  // TODO(Æmerson): Turn threads into Asio threads so we can cancel them.
+}
+
+void RGWRados::finalize()
+{
+  // Before joining any sync threads, drain outstanding requests.
   if (svc.async_processor) {
     svc.async_processor->stop();
   }
-
   if (run_sync_thread) {
     std::lock_guard l{meta_sync_thread_lock};
     meta_sync_processor_thread->stop();

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1324,6 +1324,47 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y, rgw
   auto& zone_params = svc.zone->get_zone_params();
   auto& zone = svc.zone->get_zone();
 
+  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
+  binfo_cache->init(svc.cache);
+
+  topic_cache = new RGWChainedCacheImpl<pubsub_bucket_topics_entry>;
+  topic_cache->init(svc.cache);
+
+  lc = new RGWLC();
+  lc->initialize(cct, this->driver);
+
+  restore = make_unique<rgw::restore::Restore>();
+  ret = restore->initialize(cct, this->driver);
+
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to initialize restore thread" << dendl;
+    return ret;
+  }
+
+  quota_handler = RGWQuotaHandler::generate_handler(dpp, this->driver, quota_threads);
+
+  bucket_index_max_shards = (cct->_conf->rgw_override_bucket_index_max_shards ? cct->_conf->rgw_override_bucket_index_max_shards :
+                             zone.bucket_index_max_shards);
+  if (bucket_index_max_shards > get_max_bucket_shards()) {
+    bucket_index_max_shards = get_max_bucket_shards();
+    ldpp_dout(dpp, 1) << __func__ << " bucket index max shards is too large, reset to value: "
+      << get_max_bucket_shards() << dendl;
+  }
+  ldpp_dout(dpp, 20) << __func__ << " bucket index max shards: " << bucket_index_max_shards << dendl;
+
+  bool need_tombstone_cache = !svc.zone->get_zone_data_notify_to_map().empty(); /* have zones syncing from us */
+
+  if (need_tombstone_cache) {
+    obj_tombstone_cache = new tombstone_cache_t(cct->_conf->rgw_obj_tombstone_cache_size);
+  }
+
+  reshard_wait = std::make_shared<RGWReshardWait>();
+
+  reshard = new RGWReshard(this->driver);
+
+  // disable reshard thread based on zone/zonegroup support
+  run_reshard_thread = run_reshard_thread && svc.zone->can_reshard();
+
   /* no point of running sync thread if we don't have a master zone configured
     or there is no rest_master_conn */
   if (!svc.zone->need_to_sync()) {
@@ -1402,52 +1443,11 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y, rgw
     data_notifier->start();
   }
 
-  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
-  binfo_cache->init(svc.cache);
-
-  topic_cache = new RGWChainedCacheImpl<pubsub_bucket_topics_entry>;
-  topic_cache->init(svc.cache);
-
-  lc = new RGWLC();
-  lc->initialize(cct, this->driver);
-
   if (use_lc_thread)
     lc->start_processor();
 
-  restore = make_unique<rgw::restore::Restore>();
-  ret = restore->initialize(cct, this->driver);
-
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to initialize restore thread" << dendl;
-    return ret;
-  }
-
   if (use_restore_thread)
     restore->start_processor();
-
-  quota_handler = RGWQuotaHandler::generate_handler(dpp, this->driver, quota_threads);
-
-  bucket_index_max_shards = (cct->_conf->rgw_override_bucket_index_max_shards ? cct->_conf->rgw_override_bucket_index_max_shards :
-                             zone.bucket_index_max_shards);
-  if (bucket_index_max_shards > get_max_bucket_shards()) {
-    bucket_index_max_shards = get_max_bucket_shards();
-    ldpp_dout(dpp, 1) << __func__ << " bucket index max shards is too large, reset to value: "
-      << get_max_bucket_shards() << dendl;
-  }
-  ldpp_dout(dpp, 20) << __func__ << " bucket index max shards: " << bucket_index_max_shards << dendl;
-
-  bool need_tombstone_cache = !svc.zone->get_zone_data_notify_to_map().empty(); /* have zones syncing from us */
-
-  if (need_tombstone_cache) {
-    obj_tombstone_cache = new tombstone_cache_t(cct->_conf->rgw_obj_tombstone_cache_size);
-  }
-
-  reshard_wait = std::make_shared<RGWReshardWait>();
-
-  reshard = new RGWReshard(this->driver);
-
-  // disable reshard thread based on zone/zonegroup support
-  run_reshard_thread = run_reshard_thread && svc.zone->can_reshard();
 
   if (run_reshard_thread)  {
     reshard->start_processor();

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1088,6 +1088,10 @@ RGWRados::shutdown(rgw::shutdown_vector& to_wait)
     svc.async_processor->set_down_flag();
   }
 
+  if (use_restore_thread) {
+    restore->stop_processor();
+    restore->shutdown(to_wait);
+  }
   // TODO(Æmerson): Turn threads into Asio threads so we can cancel them.
 }
 
@@ -1341,8 +1345,8 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y, rgw
   lc = new RGWLC();
   lc->initialize(cct, this->driver);
 
-  restore = make_unique<rgw::restore::Restore>();
-  ret = restore->initialize(cct, this->driver);
+  restore = make_unique<rgw::restore::Restore>(driver->get_io_context());
+  ret = restore->initialize(cct, this->driver, y);
 
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to initialize restore thread" << dendl;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -42,6 +42,7 @@
 #include "rgw_pubsub.h"
 #include "rgw_tools.h"
 #include "rgw_restore.h"
+#include "async_utils.h"
 
 struct D3nDataCache;
 struct RGWLCCloudTierCtx;
@@ -617,6 +618,7 @@ public:
   int init_svc(bool raw, const DoutPrefixProvider *dpp, bool background_tasks, const rgw::SiteConfig& site, rgw::sal::ConfigStore* cfgstore);
   virtual int init_rados();
   int init_complete(const DoutPrefixProvider *dpp, optional_yield y, rgw::sal::ConfigStore* cfgstore);
+  void shutdown(rgw::shutdown_vector& to_wait);
   void finalize();
 
   int register_to_service_map(const DoutPrefixProvider *dpp, const std::string& daemon_type, const std::map<std::string, std::string>& meta);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -5,50 +5,46 @@
 
 #include <iostream>
 #include <functional>
+
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
 
 #include "include/rados/librados.hpp"
-#include "include/Context.h"
-#include "include/random.h"
-#include "common/RefCountedObj.h"
+
+#include "common/async/context_pool.h"
+#include "common/ceph_mutex.h"
 #include "common/ceph_time.h"
 #include "common/Timer.h"
-#include "common/async/context_pool.h"
-#include "rgw_common.h"
+
+#include "cls/otp/cls_otp_types.h"
 #include "cls/rgw/cls_rgw_types.h"
 #include "cls/version/cls_version_types.h"
-#include "cls/log/cls_log_types.h"
-#include "cls/timeindex/cls_timeindex_types.h"
-#include "cls/otp/cls_otp_types.h"
-#include "rgw_quota.h"
-#include "rgw_log.h"
-#include "rgw_metadata.h"
-#include "rgw_meta_sync_status.h"
-#include "rgw_period_puller.h"
-#include "rgw_obj_manifest.h"
-#include "rgw_sync_module.h"
-#include "rgw_trim_bilog.h"
-#include "rgw_service.h"
-#include "rgw_sal_store.h"
-#include "rgw_aio.h"
-#include "rgw_d3n_cacherequest.h"
 
 #include "services/svc_bi_rados.h"
-#include "common/Throttle.h"
-#include "common/ceph_mutex.h"
-#include "rgw_cache.h"
-#include "rgw_sal_fwd.h"
-#include "rgw_pubsub.h"
-#include "rgw_tools.h"
-#include "rgw_restore.h"
+#include "services/svc_sys_obj_cache.h"
+
 #include "async_utils.h"
+#include "rgw_aio.h"
+#include "rgw_common.h"
+#include "rgw_d3n_cacherequest.h"
+#include "rgw_log.h"
+#include "rgw_metadata.h"
+#include "rgw_obj_manifest.h"
+#include "rgw_pubsub.h"
+#include "rgw_quota.h"
+#include "rgw_restore.h"
+#include "rgw_sal_fwd.h"
+#include "rgw_sal_store.h"
+#include "rgw_service.h"
+#include "rgw_sync_module.h"
+#include "rgw_tools.h"
+#include "rgw_trim_bilog.h"
 
 struct D3nDataCache;
 struct RGWLCCloudTierCtx;
 
 class RGWWatcher;
-class ACLOwner;
+struct ACLOwner;
 class RGWGC;
 class RGWMetaNotifier;
 class RGWDataNotifier;
@@ -297,9 +293,6 @@ namespace rgw { namespace sal {
 } }
 
 class RGWAsyncRadosProcessor;
-
-template <class T>
-class RGWChainedCacheImpl;
 
 struct bucket_info_entry {
   RGWBucketInfo info;

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2556,8 +2556,11 @@ int RadosStore::meta_remove(const DoutPrefixProvider* dpp, std::string& metadata
   return ctl()->meta.mgr->remove(metadata_key, y, dpp);
 }
 
-void RadosStore::shutdown(void) {
-  svc()->datalog_rados->blocking_shutdown();
+void RadosStore::shutdown(shutdown_vector& to_wait) {
+  svc()->datalog_rados->shutdown(to_wait);
+  if (rados) {
+    rados->shutdown(to_wait);
+  }
   return;
 }
 

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -21,6 +21,8 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <boost/asio/bind_cancellation_slot.hpp>
+
 #include <fmt/core.h>
 
 #include "common/async/blocked_completion.h"

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -75,7 +75,6 @@
 #include "services/svc_mdlog.h"
 #include "services/svc_quota.h"
 #include "services/svc_sys_obj.h"
-#include "services/svc_sys_obj_cache.h"
 #include "services/svc_tier_rados.h"
 #include "services/svc_user.h"
 #include "services/svc_zone.h"
@@ -5026,11 +5025,10 @@ int RadosRestore::initialize(const DoutPrefixProvider* dpp, optional_yield y,
   num_objs = n_objs;
   obj_names = o_names;
 
-  maybe_warn_about_blocking(dpp);
   for (auto i=0; i < num_objs; i++) {
     std::unique_ptr<fifo::FIFO> fifo_tmp;
     try {
-      fifo_tmp = fifo::FIFO::create(dpp, r, obj_names[i], neo_ioctx, ceph::async::use_blocked);
+      fifo_tmp = fifo::FIFO::create(dpp, r, obj_names[i], neo_ioctx, rgw::oyc(dpp, y));
     } catch (const sys::system_error& e) {
       ldpp_dout(dpp, -1) << "creating fifo object for index=" << i
 	   << ", objname=" << obj_names[i] << " failed : " << e.what() << dendl;
@@ -5054,62 +5052,26 @@ void RadosRestore::finalize() {
   fifos.clear();
 }
 
-
 int RadosRestore::add_entries(const DoutPrefixProvider* dpp, optional_yield y,
-		int index, const std::vector<rgw::restore::RestoreEntry>& restore_entries) {
-  std::deque<ceph::buffer::list> ent_list;
-
-  for (auto& entry : restore_entries) {
-    bufferlist bl;
-
-    encode(entry, bl);
-    ent_list.push_back(std::move(bl));
-
-  }
-
-  ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
-		 << "Adding " << restore_entries.size() << " entries to FIFO:"
-		 << obj_names[index] << dendl;
-
-  int ret = push(dpp, y, index, std::move(ent_list));
-
-  if (ret < 0) {
-    ldpp_dout(dpp, -1) << "ERROR: push() returned " << ret << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-int RadosRestore::push(const DoutPrefixProvider *dpp, optional_yield y,
-		int index, std::deque<ceph::buffer::list>&& items) {
-  ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
-		 << "Pushing entries to FIFO:" << obj_names[index] << dendl;
-  maybe_warn_about_blocking(dpp);
+                              int index, const std::vector<rgw::restore::RestoreEntry>& restore_entries) {
   try {
-    fifos[index]->push(dpp, items, ceph::async::use_blocked);
-  } catch (const sys::system_error& e) {
-    ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
-		 << ": unable to push to FIFO: " << obj_names[index]
-		 << ": " << e.what() << dendl;
-    return ceph::from_error_code(e.code());
-  }
-  return 0;
-}
+    std::deque<ceph::buffer::list> ent_list;
 
-int RadosRestore::push(const DoutPrefixProvider *dpp, optional_yield y,
-		int index, ceph::buffer::list&& bl) {
-  ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
-		 << "Pushing entry to FIFO:" << obj_names[index] << dendl;
+    for (const auto& entry : restore_entries) {
+      bufferlist bl;
 
-  maybe_warn_about_blocking(dpp);
-  try {
-    fifos[index]->push(dpp, std::move(bl), ceph::async::use_blocked);
-  } catch (const sys::system_error& e) {
-    ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
-		 << ": unable to push to FIFO: " << obj_names[index]
-		 << ": " << e.what() << dendl;
-    return ceph::from_error_code(e.code());
+      encode(entry, bl);
+      ent_list.push_back(std::move(bl));
+    }
+
+    ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << "Adding "
+                       << restore_entries.size()
+                       << " entries to FIFO:" << obj_names[index] << dendl;
+
+    fifos[index]->push(dpp, std::move(ent_list), rgw::oyc(dpp, y));
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, -1) << "ERROR: push() failed with: " << e.what() << dendl;
+    return ceph::from_exception(std::current_exception());
   }
   return 0;
 }
@@ -5141,10 +5103,10 @@ struct rgw_restore_fifo_entry {
 };
 WRITE_CLASS_ENCODER(rgw_restore_fifo_entry)
 
-int RadosRestore::list(const DoutPrefixProvider *dpp, optional_yield y,
-	       	   int index, const std::string& marker, std::string* out_marker,
-		   uint32_t max_entries, std::vector<rgw::restore::RestoreEntry>& entries,
-		   bool* truncated)
+void RadosRestore::list(const DoutPrefixProvider *dpp,
+                        int index, const std::string& marker, std::string* out_marker,
+                        uint32_t max_entries, std::vector<rgw::restore::RestoreEntry>& entries,
+                        bool* truncated, asio::yield_context yc)
 {
   std::vector<fifo::entry> restore_entries{max_entries};
   std::string omark = {};
@@ -5153,10 +5115,9 @@ int RadosRestore::list(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Listing entries from FIFO:" << obj_names[index] << dendl;
 
-  maybe_warn_about_blocking(dpp);
   try {
-    auto [lentries, lmark] = fifos[index]->list(dpp, marker,
-			  	 restore_entries, ceph::async::use_blocked);
+    auto [lentries, lmark] =
+        fifos[index]->list(dpp, marker, restore_entries, yc);
     entries.clear();
 
     for (const auto& entry : lentries) {
@@ -5175,11 +5136,18 @@ int RadosRestore::list(const DoutPrefixProvider *dpp, optional_yield y,
     }
   } catch (const sys::system_error& e) {
     if (e.code() == sys::errc::no_such_file_or_directory) {
+      entries.clear();
+      if (out_marker) {
+        out_marker->clear();
+      }
+      if (truncated) {
+        *truncated = false;
+      }
     } else {
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": unable to list FIFO: " << obj_names[index]
 		 << ": " << e.what() << dendl;
-      return ceph::from_error_code(e.code());
+      throw;
     }
   }
 
@@ -5197,33 +5165,25 @@ int RadosRestore::list(const DoutPrefixProvider *dpp, optional_yield y,
 		 << (truncated ? *truncated : false) 
 		 << ", out_marker:" << (out_marker ? *out_marker : "") << dendl;
 
-  return 0;
 }
 
-int RadosRestore::trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
-			int index, const std::string_view& marker)
+void
+RadosRestore::trim_entries(
+    const DoutPrefixProvider* dpp,
+    int index,
+    const std::string_view& marker,
+    asio::yield_context yc)
 {
   assert(index < num_objs);
 
-  int ret = trim(dpp, y, index, marker);
-  return ret;
-}
-
-int RadosRestore::trim(const DoutPrefixProvider *dpp, optional_yield y,
-		int index, const std::string_view& marker) {
-  ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
-		 << "Trimming FIFO:" << obj_names[index] << " upto marker:" << marker << dendl;
-
-  maybe_warn_about_blocking(dpp);
   try {
-    fifos[index]->trim(dpp, std::string(marker), false, ceph::async::use_blocked);
+    fifos[index]->trim(dpp, std::string(marker), false, yc);
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
-		 << ": unable to trim FIFO: " << obj_names[index]
-		 << ": " << e.what() << dendl;
-    return ceph::from_error_code(e.code());
+                       << ": unable to trim FIFO: " << obj_names[index] << ": "
+                       << e.what() << dendl;
+    throw;
   }
-  return 0;
 }
 
 int RadosNotification::publish_reserve(const DoutPrefixProvider *dpp, RGWObjTags* obj_tags)
@@ -5347,7 +5307,7 @@ int RadosZoneGroup::get_placement_tier(const rgw_placement_rule& rule,
   }
 
   PlacementTier* t;
-  t = new RadosPlacementTier(store, ttier->second);
+  t = new RadosPlacementTier(ttier->second);
   if (!t)
     return -ENOMEM;
 

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -428,7 +428,8 @@ class RadosStore : public StoreDriver {
     virtual const std::string& get_compression_type(const rgw_placement_rule& rule) override;
     virtual bool valid_placement(const rgw_placement_rule& rule) override;
 
-    virtual void shutdown(void) override;
+    virtual void shutdown(
+        std::vector<std::pair<std::string, shutdown_promise>>& to_wait) override;
 
     virtual void finalize(void) override;
 

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -23,7 +23,6 @@
 #include "rgw_rados.h"
 #include "rgw_notify.h"
 #include "rgw_role.h"
-#include "rgw_multi.h"
 #include "rgw_putobj_processor.h"
 #include "services/svc_tier_rados.h"
 #include "cls/lock/cls_lock_client.h"
@@ -36,18 +35,17 @@ extern const std::string pubsub_oid_prefix; // v1 topic metadata prefix
 extern const std::string pubsub_bucket_oid_infix;  // v1 notification in-fix
 
 class RadosPlacementTier: public StorePlacementTier {
-  RadosStore* store;
   RGWZoneGroupPlacementTier tier;
 public:
-  RadosPlacementTier(RadosStore* _store, const RGWZoneGroupPlacementTier& _tier) : store(_store), tier(_tier) {}
-  virtual ~RadosPlacementTier() = default;
+  RadosPlacementTier(const RGWZoneGroupPlacementTier& _tier) : tier(_tier) {}
+  ~RadosPlacementTier() override = default;
 
-  virtual const std::string& get_tier_type() { return tier.tier_type; }
-  virtual bool is_tier_type_s3() { return (tier.is_tier_type_s3()); }
-  virtual const std::string& get_storage_class() { return tier.storage_class; }
-  virtual bool retain_head_object() { return tier.retain_head_object; }
-  virtual bool allow_read_through() { return tier.allow_read_through; }
-  virtual uint64_t get_read_through_restore_days() { return tier.read_through_restore_days; }
+  const std::string& get_tier_type() override { return tier.tier_type; }
+  bool is_tier_type_s3() override { return (tier.is_tier_type_s3()); }
+  const std::string& get_storage_class() override { return tier.storage_class; }
+  bool retain_head_object() override { return tier.retain_head_object; }
+  bool allow_read_through() override { return tier.allow_read_through; }
+  uint64_t get_read_through_restore_days() override { return tier.read_through_restore_days; }
   RGWZoneGroupPlacementTier& get_rt() { return tier; }
 };
 
@@ -57,37 +55,37 @@ class RadosZoneGroup : public StoreZoneGroup {
   std::string empty;
 public:
   RadosZoneGroup(RadosStore* _store, const RGWZoneGroup& _group) : store(_store), group(_group) {}
-  virtual ~RadosZoneGroup() = default;
+  ~RadosZoneGroup() override = default;
 
-  virtual const std::string& get_id() const override { return group.get_id(); };
-  virtual const std::string& get_name() const override { return group.get_name(); };
-  virtual int equals(const std::string& other_zonegroup) const override {
+  const std::string& get_id() const override { return group.get_id(); };
+  const std::string& get_name() const override { return group.get_name(); };
+  int equals(const std::string& other_zonegroup) const override {
     return group.equals(other_zonegroup);
   };
-  virtual bool placement_target_exists(std::string& target) const override;
-  virtual bool is_master_zonegroup() const override {
+  bool placement_target_exists(std::string& target) const override;
+  bool is_master_zonegroup() const override {
     return group.is_master_zonegroup();
   };
-  virtual const std::string& get_api_name() const override { return group.api_name; };
-  virtual void get_placement_target_names(std::set<std::string>& names) const override;
-  virtual const std::string& get_default_placement_name() const override {
+  const std::string& get_api_name() const override { return group.api_name; };
+  void get_placement_target_names(std::set<std::string>& names) const override;
+  const std::string& get_default_placement_name() const override {
     return group.default_placement.name; };
-  virtual int get_hostnames(std::list<std::string>& names) const override {
+  int get_hostnames(std::list<std::string>& names) const override {
     names = group.hostnames;
     return 0;
   };
-  virtual int get_s3website_hostnames(std::list<std::string>& names) const override {
+  int get_s3website_hostnames(std::list<std::string>& names) const override {
     names = group.hostnames_s3website;
     return 0;
   };
   virtual int get_zone_count() const override {
     return group.zones.size();
   }
-  virtual int get_placement_tier(const rgw_placement_rule& rule, std::unique_ptr<PlacementTier>* tier);
-  virtual int get_zone_by_id(const std::string& id, std::unique_ptr<Zone>* zone) override;
-  virtual int get_zone_by_name(const std::string& name, std::unique_ptr<Zone>* zone) override;
-  virtual int list_zones(std::list<std::string>& zone_ids) override;
-  virtual std::unique_ptr<ZoneGroup> clone() override {
+  int get_placement_tier(const rgw_placement_rule& rule, std::unique_ptr<PlacementTier>* tier) override;
+  int get_zone_by_id(const std::string& id, std::unique_ptr<Zone>* zone) override;
+  int get_zone_by_name(const std::string& name, std::unique_ptr<Zone>* zone) override;
+  int list_zones(std::list<std::string>& zone_ids) override;
+  std::unique_ptr<ZoneGroup> clone() override {
     return std::make_unique<RadosZoneGroup>(store, group);
   }
   const RGWZoneGroup& get_group() const { return group; }
@@ -274,7 +272,7 @@ class RadosStore : public StoreDriver {
 		     uint64_t max, bool need_stats, BucketList& buckets,
 		     optional_yield y) override;
     virtual bool is_meta_master() override;
-    virtual Zone* get_zone() { return zone.get(); }
+    virtual Zone* get_zone() override { return zone.get(); }
     virtual std::string zone_unique_id(uint64_t unique_num) override;
     virtual std::string zone_unique_trans_id(const uint64_t unique_num) override;
     virtual int get_zonegroup(const std::string& id, std::unique_ptr<ZoneGroup>* zonegroup) override;
@@ -373,8 +371,8 @@ class RadosStore : public StoreDriver {
     virtual void meta_list_keys_complete(void* handle) override;
     virtual std::string meta_get_marker(void* handle) override;
     virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) override;
-    virtual const RGWSyncModuleInstanceRef& get_sync_module() { return rados->get_sync_module(); }
-    virtual std::string get_host_id() { return rados->host_id; }
+    virtual const RGWSyncModuleInstanceRef& get_sync_module() override { return rados->get_sync_module(); }
+    virtual std::string get_host_id() override { return rados->host_id; }
     std::unique_ptr<LuaManager> get_lua_manager(const std::string& luarocks_path) override;
     virtual std::unique_ptr<RGWRole> get_role(std::string name,
 					      std::string tenant,
@@ -997,30 +995,23 @@ public:
     finalize();
   }
 
-  virtual int initialize(const DoutPrefixProvider* dpp, optional_yield y,
-		  int n_objs, std::vector<std::string>& obj_names) override;
+  int initialize(const DoutPrefixProvider* dpp, optional_yield y,
+                 int n_objs, std::vector<std::string>& obj_names) override;
   void finalize();  
 
-  virtual int add_entries(const DoutPrefixProvider* dpp, optional_yield y,
-	       int index, const std::vector<rgw::restore::RestoreEntry>& restore_entries) override;
-  virtual int list(const DoutPrefixProvider *dpp, optional_yield y,
-	       	   int index,
-	           const std::string& marker, std::string* out_marker,
-		   uint32_t max_entries, std::vector<rgw::restore::RestoreEntry>& entries,
-		   bool* truncated) override;
-  virtual int trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
-		 	  int index, const std::string_view& marker) override;
-  virtual std::unique_ptr<RestoreSerializer> get_serializer(
-	  				       const std::string& lock_name,
-					       const std::string& oid,
-					       const std::string& cookie) override;
-  /** Below routines deal with actual FIFO */
-  int trim(const DoutPrefixProvider *dpp, optional_yield y,
-		int index, const std::string_view& marker);
-  int push(const DoutPrefixProvider *dpp, optional_yield y,
-		int index, ceph::buffer::list&& bl);
-  int push(const DoutPrefixProvider *dpp, optional_yield y,
-		int index, std::deque<ceph::buffer::list>&& items);
+  int add_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                  int index, const std::vector<rgw::restore::RestoreEntry>& restore_entries) override;
+  void list(const DoutPrefixProvider *dpp, int index,
+            const std::string& marker, std::string* out_marker,
+            uint32_t max_entries, std::vector<rgw::restore::RestoreEntry>& entries,
+            bool* truncated, boost::asio::yield_context yc) override;
+  void trim_entries(const DoutPrefixProvider* dpp, int index,
+                    const std::string_view& marker,
+                    boost::asio::yield_context yc) override;
+  std::unique_ptr<RestoreSerializer> get_serializer(
+      const std::string& lock_name,
+      const std::string& oid,
+      const std::string& cookie) override;
 };
 
 class RadosNotification : public StoreNotification {

--- a/src/rgw/driver/rados/rgw_service.cc
+++ b/src/rgw/driver/rados/rgw_service.cc
@@ -135,7 +135,7 @@ int RGWServices_Def::init(CephContext *cct,
 
     r = datalog_rados->start(dpp, &zone->get_zone(),
 			     zone->get_zone_params(),
-			     background_tasks);
+			     background_tasks, y);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: failed to start datalog_rados service (" << cpp_strerror(-r) << dendl;
       return r;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -1308,7 +1308,7 @@ public:
 			   ceph::async::io_context_pool* pool)
     : driver(_s), pool(pool) {}
   ~StoreDestructor() {
-    driver->shutdown();
+    driver->do_shutdown(dpp(), null_yield);
     pool->finish();
     DriverManager::close_storage(driver);
     rgw_http_client_cleanup();

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -636,7 +636,14 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
     lua_background->shutdown();
   }
 
-  env.driver->shutdown();
+  const DoutPrefix dp(g_ceph_context, dout_subsys, "rgw shutdown: ");
+  int r = env.driver->do_shutdown(&dp, null_yield);
+  if (r < 0) {
+    ldpp_dout(&dp, -1)
+        << "Failed shutting down drivers: r = " << r
+        << " Shutdown may hang, crash, or go wonky." << dendl;
+  }
+
   // Do this before closing storage so requests don't try to call into
   // closed storage.
   context_pool->finish();

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -92,7 +92,7 @@ namespace {
 
 OpsLogFile* rgw::AppMain::ops_log_file;
 
-rgw::AppMain::AppMain(const DoutPrefixProvider* dpp) : dpp(dpp), context_pool_holder(dpp) {}
+rgw::AppMain::AppMain(const DoutPrefixProvider* dpp) : dpp(dpp), context_pool(dpp) {}
 rgw::AppMain::~AppMain() = default;
 
 void rgw::AppMain::init_frontends1(bool nfs) 
@@ -236,7 +236,7 @@ int rgw::AppMain::init_storage()
   DriverManager::Config cfg = DriverManager::get_config(false, g_ceph_context);
   env.driver = DriverManager::get_storage(dpp, dpp->get_cct(),
           cfg,
-          context_pool_holder.get(),
+          *context_pool,
           site,
           run_gc,
           run_lc,
@@ -462,7 +462,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       fe = new RGWLoadGenFrontend(env, config);
     }
     else if (framework == "beast") {
-      fe = new RGWAsioFrontend(env, config, *sched_ctx, context_pool_holder.get());
+      fe = new RGWAsioFrontend(env, config, *sched_ctx, *context_pool);
     }
     else if (framework == "rgw-nfs") {
       fe = new RGWLibFrontend(env, config);
@@ -532,7 +532,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       rgw_pauser->add_pauser(dedup_background.get());
     }
       reloader = std::make_unique<RGWRealmReloader>(
-          env, *implicit_tenant_context, service_map_meta, rgw_pauser.get(), context_pool_holder.get());
+          env, *implicit_tenant_context, service_map_meta, rgw_pauser.get(), *context_pool);
       realm_watcher->add_watcher(RGWRealmNotify::Reload, *reloader);
     }
   }
@@ -639,7 +639,7 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
   env.driver->shutdown();
   // Do this before closing storage so requests don't try to call into
   // closed storage.
-  context_pool_holder.get().finish();
+  context_pool->finish();
 
   cfgstore.reset(); // deletes
   DriverManager::close_storage(env.driver);

--- a/src/rgw/rgw_asio_thread.cc
+++ b/src/rgw/rgw_asio_thread.cc
@@ -23,6 +23,12 @@ thread_local bool is_asio_thread = false;
 
 void maybe_warn_about_blocking(const DoutPrefixProvider* dpp)
 {
+  // This is a logging function, by contract null pointers to logging
+  // functions are a no-op.
+  if (!dpp) {
+    return;
+  }
+
   // work on asio threads should be asynchronous, so warn when they block
   if (!is_asio_thread) {
     return;

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -731,7 +731,15 @@ int RGWCoroutinesManager::run(const DoutPrefixProvider *dpp, list<RGWCoroutinesS
       if (ret < 0) {
        ldout(cct, 5) << "completion_mgr.get_next() returned ret=" << ret << dendl;
       }
-      handle_unblocked_stack(context_stacks, scheduled_stacks, io, &blocked_count, &interval_wait_count);
+      // Without this check, `get_next` will error with -ECANCELED and this loop will never exit.
+      if (going_down) {
+        ldout(cct, 5) << __func__ << "(): was stopped, exiting" << dendl;
+        ret = -ECANCELED;
+        canceled = true;
+        break;
+      }
+      handle_unblocked_stack(context_stacks, scheduled_stacks, io,
+                             &blocked_count, &interval_wait_count);
     }
 
 next:

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -106,9 +106,11 @@ class AppMain {
     IOContextPoolHolder& operator=(const IOContextPoolHolder&) = delete;
 
     ceph::async::io_context_pool& get();
+    ceph::async::io_context_pool& operator*() { return get(); }
+    ceph::async::io_context_pool* operator->() { return std::addressof(get()); }
   };
 
-  IOContextPoolHolder context_pool_holder;
+  IOContextPoolHolder context_pool;
 public:
   AppMain(const DoutPrefixProvider* dpp);
   ~AppMain();

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -3,6 +3,7 @@
 
 #include "rgw_realm_reloader.h"
 
+#include "rgw_asio_thread.h"
 #include "rgw_auth_registry.h"
 #include "rgw_bucket.h"
 #include "rgw_log.h"
@@ -32,12 +33,12 @@ RGWRealmReloader::RGWRealmReloader(RGWProcessEnv& env,
                                    const rgw::auth::ImplicitTenants& implicit_tenants,
                                    std::map<std::string, std::string>& service_map_meta,
                                    Pauser* frontends,
-				   boost::asio::io_context& io_context)
+				   ceph::async::io_context_pool& context_pool)
   : env(env),
     implicit_tenants(implicit_tenants),
     service_map_meta(service_map_meta),
     frontends(frontends),
-    io_context(io_context),
+    context_pool(context_pool),
     timer(env.driver->ctx(), mutex, USE_SAFE_TIMER_CALLBACKS),
     mutex(ceph::make_mutex("RGWRealmReloader")),
     reload_scheduled(nullptr)
@@ -98,9 +99,18 @@ void RGWRealmReloader::reload()
   rgw_log_usage_finalize();
 
   env.driver->shutdown();
+  // Drain outstanding work 
+  context_pool.finish();
   // destroy the existing driver
   DriverManager::close_storage(env.driver);
   env.driver = nullptr;
+
+  // Restart context_pool
+  context_pool.start(cct->_conf->rgw_thread_pool_size,
+		     [] {
+		       // request warnings on synchronous librados calls in this thread
+		       is_asio_thread = true;
+		     });
 
   ldpp_dout(&dp, 1) << "driver closed" << dendl;
   {
@@ -120,7 +130,7 @@ void RGWRealmReloader::reload()
       // recreate and initialize a new driver
       DriverManager::Config cfg = DriverManager::get_config(false, g_ceph_context);
       cfg.filter_name = "none";
-      env.driver = DriverManager::get_storage(&dp, cct, cfg, io_context,
+      env.driver = DriverManager::get_storage(&dp, cct, cfg, context_pool,
 	  *env.site,
           cct->_conf->rgw_enable_gc_threads,
           cct->_conf->rgw_enable_lc_threads,

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -98,8 +98,16 @@ void RGWRealmReloader::reload()
   // TODO: make RGWRados responsible for rgw_log_usage lifetime
   rgw_log_usage_finalize();
 
-  env.driver->shutdown();
-  // Drain outstanding work 
+  auto r = env.driver->do_shutdown(&dp, null_yield);
+
+  if (r < 0) {
+    ldpp_dout(&dp, -1)
+        << "Failed shutting down drivers in realm reloader: r = " << r
+        << " Continuing would leave radosgw in an inconsistent state." << dendl;
+    abort();
+  }
+
+  // Drain outstanding work
   context_pool.finish();
   // destroy the existing driver
   DriverManager::close_storage(env.driver);
@@ -182,7 +190,7 @@ void RGWRealmReloader::reload()
     }
   }
 
-  int r = env.driver->register_to_service_map(&dp, "rgw", service_map_meta);
+  r = env.driver->register_to_service_map(&dp, "rgw", service_map_meta);
   if (r < 0) {
     ldpp_dout(&dp, -1) << "ERROR: failed to register to service map: " << cpp_strerror(-r) << dendl;
 

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -5,6 +5,8 @@
 
 #include <boost/asio/io_context.hpp>
 
+#include "common/async/context_pool.h"
+
 #include "rgw_realm_watcher.h"
 #include "common/Cond.h"
 #include "common/Timer.h"
@@ -39,7 +41,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
   RGWRealmReloader(RGWProcessEnv& env,
                    const rgw::auth::ImplicitTenants& implicit_tenants,
                    std::map<std::string, std::string>& service_map_meta,
-                   Pauser* frontends, boost::asio::io_context& io_context);
+                   Pauser* frontends, ceph::async::io_context_pool& context_pool);
   ~RGWRealmReloader() override;
 
   /// respond to realm notifications by scheduling a reload()
@@ -55,7 +57,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
   const rgw::auth::ImplicitTenants& implicit_tenants;
   std::map<std::string, std::string>& service_map_meta;
   Pauser *const frontends;
-  boost::asio::io_context& io_context;
+  ceph::async::io_context_pool& context_pool;
 
   /// reload() takes a significant amount of time, so we don't want to run
   /// it in the handle_notify() thread. we choose a timer thread instead of a

--- a/src/rgw/rgw_restore.cc
+++ b/src/rgw/rgw_restore.cc
@@ -1,54 +1,39 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
-#include <fmt/chrono.h>
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <map>
-#include <algorithm>
-#include <tuple>
-#include <functional>
+#include <vector>
 
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/asio/cancellation_type.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/this_coro.hpp>
 #include <boost/variant.hpp>
 
-#include "include/scope_guard.h"
-#include "include/function2.hpp"
-#include "common/Clock.h" // for ceph_clock_now()
-#include "common/Formatter.h"
-#include "common/containers.h"
-#include "common/split.h"
-#include <common/errno.h>
+#include <fmt/chrono.h>
+
 #include "include/random.h"
-#include "cls/lock/cls_lock_client.h"
-#include "rgw_perf_counters.h"
+
+#include "common/Formatter.h"
+#include "common/errno.h"
+#include "common/dout.h"
+
+#include "async_utils.h"
 #include "rgw_common.h"
-#include "rgw_bucket.h"
 #include "rgw_restore.h"
 #include "rgw_restore_waiter.h"
-#include "rgw_zone.h"
-#include "rgw_string.h"
-#include "rgw_multi.h"
 #include "rgw_sal.h"
-#include "rgw_lc_tier.h"
 #include "rgw_notify.h"
-#include "common/dout.h"
 
 #include "fmt/format.h"
 
-#include "services/svc_sys_obj.h"
-#include "services/svc_zone.h"
-#include "services/svc_tier_rados.h"
 #include "common/ceph_time.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw_restore
 
-
-constexpr int32_t hours_in_a_day = 24;
-constexpr int32_t secs_in_a_day = hours_in_a_day * 60 * 60;
 static constexpr size_t listing_max_entries = 1000;
 
 using namespace std;
@@ -114,6 +99,12 @@ void RestoreEntry::generate_test_instances(std::list<RestoreEntry*>& l)
 static std::string restore_id = "rgw restore";
 static std::string restore_req_id = "0";
 
+Restore::~Restore()
+{
+  ceph_assert(worker.state() != rgw::task_state::running);
+  finalize();
+}
+
 void Restore::send_notification(const DoutPrefixProvider* dpp,
                               rgw::sal::Driver* driver,
                               rgw::sal::Object* obj,
@@ -148,7 +139,7 @@ void Restore::send_notification(const DoutPrefixProvider* dpp,
   }
 }
 
-int Restore::initialize(CephContext *_cct, rgw::sal::Driver* _driver) {
+int Restore::initialize(CephContext *_cct, rgw::sal::Driver* _driver, optional_yield y) {
   int ret = 0;
   cct = _cct;
   driver = _driver;
@@ -179,7 +170,7 @@ int Restore::initialize(CephContext *_cct, rgw::sal::Driver* _driver) {
     return -EINVAL;
   }
 
-  ret = sal_restore->initialize(this, null_yield, max_objs, obj_names);
+  ret = sal_restore->initialize(this, y, max_objs, obj_names);
 
   if (ret < 0) {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": failed to initialize sal_restore" << dendl;
@@ -217,39 +208,28 @@ static inline std::ostream& operator<<(std::ostream &os, RestoreEntry& ent) {
   return os;
 }
 
-void Restore::RestoreWorker::stop()
-{
-  std::lock_guard l{lock};
-  cond.notify_all();
-}
-
-bool Restore::going_down()
-{
-  return down_flag;
-}
-
 void Restore::start_processor()
 {
-  worker = std::make_unique<Restore::RestoreWorker>(this, cct, this);
-  worker->create("rgw_restore");
+  worker.run();
 }
 
 void Restore::stop_processor()
 {
-  down_flag = true;
-  if (worker) {
-    worker->stop();
-    worker->join();
+  if (worker.state() == rgw::task_state::running) {
+    worker.cancel();
   }
-  worker.reset(nullptr);
+}
+
+void Restore::shutdown(shutdown_vector& to_wait)
+{
+  if (worker.state() == rgw::task_state::running) {
+    worker.shutdown("Restore worker", to_wait);
+  }
 }
 
 void Restore::wake_worker()
 {
-  if (worker) {
-    std::lock_guard lock(worker->lock);
-    worker->cond.notify_one();
-  }
+  worker.wake();
 }
 
 unsigned Restore::get_subsys() const
@@ -270,44 +250,43 @@ int Restore::choose_oid(const RestoreEntry& e) {
   return static_cast<int>(index);
 }
 
-void *Restore::RestoreWorker::entry() {
+ceph::timespan
+Restore::worker_task(asio::yield_context y)
+{
+  ceph::timespan duration;
+  ceph::timespan period;
   do {
-    ceph_timespec start = ceph::real_clock::to_ceph_timespec(real_clock::now());
-    int r = 0;
-    r = restore->process(this, null_yield);
-    if (r < 0) {
-      ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ": ERROR: restore process() returned error r=" << r << dendl;	    
+    auto start = ceph::mono_clock::now();
+    try {
+      process(y);
+    } catch (const sys::system_error& e) {
+      if (e.code() == asio::error::operation_aborted) {
+        throw;
+      }
+      ldpp_dout(this, -1) << "ERROR: restore process() threw exception: "
+                          << e.what() << dendl;
+    } catch (const std::exception& e) {
+      ldpp_dout(this, -1)
+          << "ERROR: restore process() threw exception: " << e.what()
+          << dendl;
     }
-    if (restore->going_down())
-      break;
-    ceph_timespec end = ceph::real_clock::to_ceph_timespec(real_clock::now());
-    auto d = end - start;
-    end = d;
-    int secs = cct->_conf->rgw_restore_processor_period;
+    duration = ceph::mono_clock::now() - start;
+    period = std::chrono::seconds(cct->_conf->rgw_restore_processor_period);
+  } while (period < duration);
 
-    if (secs < d)
-      continue; // next round
-
-    std::unique_lock locker{lock};
-    cond.wait_for(locker, std::chrono::seconds(secs));
-  } while (!restore->going_down());
-
-  return NULL;
-
+  return period;
 }
 
-int Restore::process(RestoreWorker* worker, optional_yield y)
+void Restore::process(asio::yield_context y)
 {
-  int max_secs = cct->_conf->rgw_restore_lock_max_time;
+  std::chrono::seconds max_secs{cct->_conf->rgw_restore_lock_max_time};
 
   const int start = ceph::util::generate_random_number(0, max_objs - 1);
   for (int i = 0; i < max_objs; i++) {
     int index = (i + start) % max_objs;
-    int ret = process(index, max_secs, y);
-    if (ret < 0)
-      return ret;
+    // Exceptions from process are thrown here.
+    process(index, max_secs, y);
   }
-  return 0;
 }
 
 // unique_lock expects an unlock() taking no arguments, but
@@ -316,10 +295,15 @@ int Restore::process(RestoreWorker* worker, optional_yield y)
 struct RestoreLockAdapter {
   rgw::sal::RestoreSerializer& serializer;
   const DoutPrefixProvider* dpp = nullptr;
-  optional_yield y;
+  asio::yield_context y;
 
   void unlock() {
-    serializer.unlock(dpp, y);
+    try {
+      serializer.unlock(dpp, y);
+    } catch (const std::exception& e) {
+      ldpp_dout(dpp, 5) << "restore worker: Error in relinquishing lock: " << e.what() << dendl;
+      // Swallow the exception since this is called from `unique_lock`'s destructor.
+    }
   }
 };
 
@@ -330,39 +314,43 @@ struct RestoreLockAdapter {
  * While processing the entries, if any of their restore operation is still in
  * progress, such entries are added back to the list.
  */ 
-int Restore::process(int index, int max_secs, optional_yield y)
+void Restore::process(int index, std::chrono::seconds max_time, asio::yield_context y)
 {
-  ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": process entered index="	
-		      << index << ", max_secs=" << max_secs << dendl;
+  ldpp_dout(this, 20) << __PRETTY_FUNCTION__
+                      << ": process entered index=" << index
+                      << ", max_time=" << max_time << dendl;
 
   /* list used to gather still IN_PROGRESS */
   std::vector<RestoreEntry> r_entries;
 
-  std::unique_ptr<rgw::sal::RestoreSerializer> serializer =
-  			sal_restore->get_serializer(std::string(restore_index_lock_name),
-				       	std::string(obj_names[index]),
-					worker->thr_name());
-  utime_t end = ceph_clock_now();
-
-  /* max_secs should be greater than zero. We don't want a zero max_secs
+  /* time should be greater than zero. We don't want a zero max_time
    * to be translated as no timeout, since we'd then need to break the
    * lock and that would require a manual intervention. In this case
    * we can just wait it out. */
+  if (max_time <= 0s) {
+    throw sys::system_error{
+        EAGAIN, sys::generic_category(),
+        "Max secs should be greater than zero."};
+  }
+  std::unique_ptr<rgw::sal::RestoreSerializer> serializer =
+  			sal_restore->get_serializer(std::string(restore_index_lock_name),
+				       	std::string(obj_names[index]),
+					"restore_thrd: ");
+  auto end = ceph::mono_clock::now() + max_time;
 
-  if (max_secs <= 0)
-    return -EAGAIN;
-
-  end += max_secs;
-  const ceph::timespan time = std::chrono::seconds(max_secs);
-  int ret = serializer->try_lock(this, time, y);
+  int ret = serializer->try_lock(this, max_time, y);
   if (ret == -EBUSY || ret == -EEXIST) {
     /* already locked by another lc processor */
-    ldpp_dout(this, 0) << __PRETTY_FUNCTION__ << ": failed to acquire lock on "	 
-		       << obj_names[index] << dendl;
-    return -EBUSY;
+    ldpp_dout(this, 0) << __PRETTY_FUNCTION__ << ": failed to acquire lock on "
+                       << obj_names[index] << dendl;
+    throw sys::system_error{
+        EBUSY, sys::generic_category(),
+        "Already locked by another restore processor."};
+  } else if (ret < 0) {
+    // On other errors just go to the next shard and try again next
+    // iteration.
+    return;
   }
-  if (ret < 0)
-    return 0;
 
   auto lock_adapter = RestoreLockAdapter{*serializer, this, y};
   std::unique_lock<RestoreLockAdapter> lock(lock_adapter, std::adopt_lock);
@@ -374,24 +362,27 @@ int Restore::process(int index, int max_secs, optional_yield y)
     int max = 100;
     std::vector<RestoreEntry> entries;
 
-    ret = sal_restore->list(this, y, index, marker, &next_marker, max, entries, &truncated);
-    ldpp_dout(this, 20) << __PRETTY_FUNCTION__ <<
-      ": list on shard:" << obj_names[index] << " returned:" << ret <<
-      ", entries.size=" << entries.size() << ", truncated=" << truncated <<
-      ", marker='" << marker << "'" <<
-      ", next_marker='" << next_marker << "'" << dendl;
-
-    if (ret < 0)
-      goto done;
+    try {
+      sal_restore->list(this, index, marker, &next_marker, max, entries, &truncated, y);
+      ldpp_dout(this, 20) << __PRETTY_FUNCTION__ <<
+        ": list on shard:" << obj_names[index] << " returned success:"
+        ", entries.size=" << entries.size() << ", truncated=" << truncated <<
+        ", marker='" << marker << "'" <<
+        ", next_marker='" << next_marker << "'" << dendl;
+    } catch (const std::exception& e) {
+      ldpp_dout(this, 0) << __PRETTY_FUNCTION__
+                          << ": list on shard:" << obj_names[index]
+                          << " failed:" << e.what() << dendl;
+      throw;
+    }
 
     if (entries.size() == 0) {
       lock.unlock();
-      return 0;
+      return;
     }
 
     marker = next_marker;
-    std::vector<RestoreEntry>::iterator iter;
-    for (iter = entries.begin(); iter != entries.end(); ++iter) {
+    for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
       RestoreEntry entry = *iter;
 
       ret = process_restore_entry(entry, y);
@@ -405,18 +396,12 @@ int Restore::process(int index, int max_secs, optional_yield y)
 
       // Skip the entry of object/bucket which no longer exists
       if (ret < 0 && (ret != -ENOENT))
-        goto done;
+        return;
 
       ///process all entries, trim and re-add
-      utime_t now = ceph_clock_now();
+      auto now = ceph::mono_clock::now();
       if (now >= end) {
-        goto done;
-      }
-
-      if (going_down()) {
- 	// leave early, even if tag isn't removed, it's ok since it
-	// will be picked up next time around
-	goto done;
+        return;
       }
     }
   } while (truncated);
@@ -424,9 +409,12 @@ int Restore::process(int index, int max_secs, optional_yield y)
   ldpp_dout(this, 20) << __PRETTY_FUNCTION__ << ": trimming till marker: '" << marker
 		 	 << "' on shard:"
   	  	         << obj_names[index] << dendl;    
-  ret = sal_restore->trim_entries(this, y, index, marker);
-  if (ret < 0) {
-    ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: failed to trim entries on "	    	  	         << obj_names[index] << dendl;
+  try {
+    sal_restore->trim_entries(this, index, marker, y);
+  } catch (const std::exception& e) {
+    ldpp_dout(this, -1) << __PRETTY_FUNCTION__
+                        << ": ERROR: failed to trim entries on "
+                        << obj_names[index] << ": " << e.what() << dendl;
   }
 
   if (!r_entries.empty()) {
@@ -438,11 +426,6 @@ int Restore::process(int index, int max_secs, optional_yield y)
   }
 
   r_entries.clear();
-
-done:
-  lock.unlock();
-
-  return ret;
 }
 
 int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
@@ -470,7 +453,7 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
 
   // fill in the details from entry
   // bucket, obj, days, state=in_progress
-  ret = driver->load_bucket(this, entry.bucket, &bucket, null_yield);
+  ret = driver->load_bucket(this, entry.bucket, &bucket, y);
   if (ret < 0) {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: get_bucket for "
 	   		<< bucket->get_name()	  
@@ -479,7 +462,7 @@ int Restore::process_restore_entry(RestoreEntry& entry, optional_yield y)
   }
   obj = bucket->get_object(entry.obj_key);
 
-  ret = obj->load_obj_state(this, null_yield, true);
+  ret = obj->load_obj_state(this, y, true);
 
   if (ret < 0) {
     ldpp_dout(this, -1) << __PRETTY_FUNCTION__ << ": ERROR: get_object for "
@@ -585,13 +568,6 @@ done:
   return ret;
 }
 
-time_t Restore::thread_stop_at()
-{
-  uint64_t interval = (cct->_conf->rgw_restore_debug_interval > 0)
-    ? cct->_conf->rgw_restore_debug_interval : secs_in_a_day;
-
-  return time(nullptr) + interval;
-}
 
 int Restore::set_cloud_restore_status(const DoutPrefixProvider* dpp,
 			   rgw::sal::Object* pobj, optional_yield y,

--- a/src/rgw/rgw_restore.h
+++ b/src/rgw/rgw_restore.h
@@ -3,27 +3,26 @@
 
 #pragma once
 
-#include <map>
-#include <array>
-#include <string>
+#include <cstdint>
 #include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
 
-#include "common/debug.h"
+#include <boost/asio/spawn.hpp>
+
+#include "cls/rgw/cls_rgw_types.h"
+
+#include "common/dout.h"
 
 #include "include/types.h"
-#include "include/rados/librados.hpp"
-#include "common/ceph_mutex.h"
-#include "common/Cond.h"
-#include "common/iso_8601.h"
-#include "common/Thread.h"
+
+#include "async_utils.h"
 #include "rgw_common.h"
-#include "cls/rgw/cls_rgw_types.h"
-#include "rgw_sal.h"
 #include "rgw_notify.h"
 #include "rgw_restore_waiter.h"
+#include "rgw_sal.h"
 
-#include <atomic>
-#include <tuple>
 
 #define HASH_PRIME 7877
 #define MAX_ID_LEN 255
@@ -68,71 +67,46 @@ struct RestoreEntry {
 WRITE_CLASS_ENCODER(RestoreEntry)
 
 class Restore : public DoutPrefixProvider {
-  CephContext *cct;
-  rgw::sal::Driver* driver;
+  CephContext *cct = nullptr;
+  boost::asio::io_context& io_context;
+  rgw::sal::Driver* driver = nullptr;
   std::unique_ptr<rgw::sal::Restore> sal_restore;
   int max_objs{0};
   std::vector<std::string> obj_names;
-  std::atomic<bool> down_flag = { false };
   std::shared_ptr<RestoreWaiterRegistry> waiter_registry;
 
-  class RestoreWorker : public Thread
-  {
-    const DoutPrefixProvider *dpp;
-    CephContext *cct;
-    rgw::restore::Restore *restore;
-    ceph::mutex lock = ceph::make_mutex("RestoreWorker");
-    ceph::condition_variable cond;
+  ceph::timespan worker_task(boost::asio::yield_context y);
 
-  public:
-
-    using lock_guard = std::lock_guard<std::mutex>;
-    using unique_lock = std::unique_lock<std::mutex>;
-
-    RestoreWorker(const DoutPrefixProvider* _dpp, CephContext *_cct, rgw::restore::Restore *_restore) : dpp(_dpp), cct(_cct), restore(_restore) {}
-    rgw::restore::Restore* get_restore() { return restore; }
-    std::string thr_name() {
-      return std::string{"restore_thrd: "}; // + std::to_string(ix);
-    }
-    void *entry() override;
-    void stop();
-
-    friend class Restore;
-    friend class RGWRados;
-  }; // RestoreWorker
-
-  std::unique_ptr<Restore::RestoreWorker> worker;
+  rgw::yrun_loop<> worker{
+      boost::asio::make_strand(io_context.get_executor()),
+      rgw::membind(*this, &Restore::worker_task)};
 
 public:
-  ~Restore() {
-    stop_processor();
-    finalize();
-  }
+  ~Restore();
 
   friend class RGWRados;
 
-  Restore() : cct(nullptr), driver(nullptr), max_objs(0) {}
+  Restore(boost::asio::io_context& io_context) : io_context(io_context) {}
 
-  int initialize(CephContext *_cct, rgw::sal::Driver* _driver);
+  int initialize(CephContext *_cct, rgw::sal::Driver* _driver, optional_yield y);
   void finalize();
 
-  bool going_down();
   void start_processor();
   void stop_processor();
+  void shutdown(shutdown_vector& to_wait);
   void wake_worker();
   std::shared_ptr<RestoreWaiterRegistry> get_waiter_registry() const { return waiter_registry; }
 
   CephContext *get_cct() const override { return cct; }
   rgw::sal::Restore* get_restore() const { return sal_restore.get(); }
-  unsigned get_subsys() const;
+  unsigned get_subsys() const override;
 
-  std::ostream& gen_prefix(std::ostream& out) const;
+  std::ostream& gen_prefix(std::ostream& out) const override;
 
-  int process(RestoreWorker* worker, optional_yield y);
   int choose_oid(const rgw::restore::RestoreEntry& e);
-  int process(int index, int max_secs, optional_yield y);
+  void process(int index, std::chrono::seconds time, boost::asio::yield_context y);
+  void process(boost::asio::yield_context y);
   int process_restore_entry(rgw::restore::RestoreEntry& entry, optional_yield y);
-  time_t thread_stop_at();
 
   /** Set the restore status for the given object */
   int set_cloud_restore_status(const DoutPrefixProvider* dpp, rgw::sal::Object* pobj,
@@ -150,7 +124,7 @@ public:
 
   /** Given <bucket, obj>, restore the object from the cloud-tier. In case the
    * object cannot be restored immediately, save that restore state(/entry) 
-   * to be procesed later by RestoreWorker thread. */
+   * to be procesed later by background task. */
   int restore_obj_from_cloud(rgw::sal::Bucket* pbucket, rgw::sal::Object* pobj,
 		  	     rgw::sal::PlacementTier* tier,
 			     std::optional<uint64_t> days,

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -13,11 +13,15 @@
  *
  */
 
+#include <cerrno>
 #include <optional>
 
-#include <errno.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/use_future.hpp>
 
 #include "common/errno.h"
 //#include "common/dout.h"
@@ -56,6 +60,25 @@
 
 #define dout_subsys ceph_subsys_rgw
 //#define dout_context g_ceph_context
+
+namespace rgw::sal {
+
+int
+Driver::do_shutdown(
+    const DoutPrefixProvider* dpp,
+    optional_yield y) noexcept
+{
+  try {
+    shutdown_vector to_wait;
+    shutdown(to_wait);
+    await_shutdowns(dpp, y.get_executor(), std::move(to_wait), rgw::oyc(dpp, y));
+  } catch (const std::exception&) {
+    return ceph::from_exception(std::current_exception());
+  }
+  return 0;
+}
+
+} // namespace rgw::sal
 
 extern "C" {
 #ifdef WITH_RADOSGW_RADOS

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -17,16 +17,25 @@
 
 #include <cstdint>
 #include <optional>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
+
+#include <boost/asio/experimental/promise.hpp>
+
 #include <boost/intrusive_ptr.hpp>
+
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 #include "common/tracer.h"
+
+#include "async_utils.h"
 #include "rgw_cksum.h"
 #include "rgw_sal_fwd.h"
 #include "rgw_lua.h"
 #include "rgw_notify_event_type.h"
 #include "rgw_req_context.h"
-#include "include/random.h"
+
 #include "include/function2.hpp"
 
 // FIXME: following subclass dependencies
@@ -44,17 +53,16 @@ using RGWBucketSyncPolicyHandlerRef = std::shared_ptr<RGWBucketSyncPolicyHandler
 class RGWDataSyncStatusManager;
 class RGWSyncModuleInstance;
 typedef std::shared_ptr<RGWSyncModuleInstance> RGWSyncModuleInstanceRef;
-class RGWCompressionInfo;
+struct RGWCompressionInfo;
 struct rgw_pubsub_topics;
 struct rgw_pubsub_bucket_topics;
-class RGWZonePlacementInfo;
+struct RGWZonePlacementInfo;
 struct rgw_pubsub_topic;
 struct RGWOIDCProviderInfo;
 struct RGWRoleInfo;
 class RGWGetObj_Filter;
 
 using RGWBucketListNameFilter = std::function<bool (const std::string&)>;
-
 
 namespace rgw {
   class Aio;
@@ -152,7 +160,7 @@ namespace rgw { namespace sal {
 
 #define RGW_SAL_VERSION 1
 
-struct MPSerializer;
+class MPSerializer;
 class GCChain;
 class RGWRole;
 
@@ -717,8 +725,21 @@ class Driver {
     /** Check to see if this placement rule is valid */
     virtual bool valid_placement(const rgw_placement_rule& rule) = 0;
 
-    /** Shut down background tasks, to be called while Asio is running. */
-    virtual void shutdown(void) { };
+    /**
+     * @brief Shut down background tasks
+     *
+     * Cancel threads, shut down subsystems. Push promises that should
+     * be waited on onto `to_wait`.
+     *
+     * \warning Do not do blocking joins or similar or you risk
+     * deadlock. Cleanup and cancel and push the promises for
+     * anything you wish to join onto the vector.
+     *
+     * @param[inout] to_wait Vector of promises that will be waited on.
+     */
+    virtual void
+    shutdown(shutdown_vector& to_wait)
+    {}
 
     /** Clean up a driver for termination */
     virtual void finalize(void) = 0;
@@ -728,6 +749,11 @@ class Driver {
 
     /** Register admin APIs unique to this driver */
     virtual void register_admin_apis(RGWRESTMgr* mgr) = 0;
+
+    /** Shut down the SAL, stackful coroutine version */
+    int do_shutdown(
+        const DoutPrefixProvider* dpp,
+        optional_yield y) noexcept;
 }; // class Driver
 
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <optional>
 
-#include <boost/asio/awaitable.hpp>
 #include <boost/asio/io_context.hpp>
 
 #include <boost/asio/experimental/promise.hpp>
@@ -46,7 +45,7 @@ struct RGWBucketEnt;
 class RGWRESTMgr;
 class RGWLC;
 struct rgw_user_bucket;
-class RGWUsageBatch;
+struct RGWUsageBatch;
 class RGWCoroutinesManagerRegistry;
 class RGWBucketSyncPolicyHandler;
 using RGWBucketSyncPolicyHandlerRef = std::shared_ptr<RGWBucketSyncPolicyHandler>;
@@ -1762,17 +1761,24 @@ public:
 		  int n_objs, std::vector<std::string>& obj_names) = 0;  
   /** Add list of restore entries */
   virtual int add_entries(const DoutPrefixProvider* dpp, optional_yield y,
-	       int index, const std::vector<rgw::restore::RestoreEntry>& restore_entries) = 0;
+                          int index, const std::vector<rgw::restore::RestoreEntry>& restore_entries) = 0;
   /** List all known entries given a marker */
-  virtual int list(const DoutPrefixProvider *dpp, optional_yield y,
-	       	   int index,
-	           const std::string& marker, std::string* out_marker,
-		   uint32_t max_entries, std::vector<rgw::restore::RestoreEntry>& entries,
-		   bool* truncated) = 0;
+  virtual void list(
+      const DoutPrefixProvider* dpp,
+      int index,
+      const std::string& marker,
+      std::string* out_marker,
+      uint32_t max_entries,
+      std::vector<rgw::restore::RestoreEntry>& entries,
+      bool* truncated,
+      boost::asio::yield_context y) = 0;
 
-  /** Trim restore entries upto the marker */
-  virtual int trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
-		 	  int index, const std::string_view& marker) = 0;
+  /** Trim restore entries up to the marker */
+  virtual void trim_entries(
+      const DoutPrefixProvider* dpp,
+      int index,
+      const std::string_view& marker,
+      boost::asio::yield_context y) = 0;
 
   /** Get a serializer for restore processing */
   virtual std::unique_ptr<RestoreSerializer> get_serializer(

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -1487,17 +1487,17 @@ int FilterRestore::add_entries(const DoutPrefixProvider* dpp, optional_yield y,
 }
 
 /** List all known entries */
-int FilterRestore::list(const DoutPrefixProvider *dpp, optional_yield y,
+void FilterRestore::list(const DoutPrefixProvider *dpp,
 	       	   int index, const std::string& marker, std::string* out_marker,
 		   uint32_t max_entries, std::vector<rgw::restore::RestoreEntry>& entries,
-		   bool* truncated) {
-  return next->list(dpp, y, index, marker, out_marker, max_entries,
-  		    entries, truncated);
+		   bool* truncated, asio::yield_context y) {
+  return next->list(dpp, index, marker, out_marker, max_entries,
+  		    entries, truncated, y);
 }
 
-int FilterRestore::trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
-		 	        int index, const std::string_view& marker) {
-  return next->trim_entries(dpp, y, index, marker);
+void FilterRestore::trim_entries(const DoutPrefixProvider *dpp,
+                                 int index, const std::string_view& marker, asio::yield_context y) {
+  return next->trim_entries(dpp, index, marker, y);
 }
 
 

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -490,7 +490,11 @@ public:
   virtual const std::string& get_compression_type(const rgw_placement_rule& rule) override;
   virtual bool valid_placement(const rgw_placement_rule& rule) override;
 
-  virtual void shutdown(void) override { next->shutdown(); };
+  virtual void
+  shutdown(shutdown_vector& to_wait) override
+  {
+    next->shutdown(to_wait);
+  }
 
   virtual void finalize(void) override;
 

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -29,11 +29,11 @@ public:
   virtual ~FilterPlacementTier() = default;
 
   virtual const std::string& get_tier_type() override { return next->get_tier_type(); }
-  virtual bool is_tier_type_s3() { return next->is_tier_type_s3(); }
+  virtual bool is_tier_type_s3() override { return next->is_tier_type_s3(); }
   virtual const std::string& get_storage_class() override { return next->get_storage_class(); }
   virtual bool retain_head_object() override { return next->retain_head_object(); }
-  virtual bool allow_read_through() { return next->allow_read_through(); }
-  virtual uint64_t get_read_through_restore_days() { return next->get_read_through_restore_days(); }
+  virtual bool allow_read_through() override { return next->allow_read_through(); }
+  virtual uint64_t get_read_through_restore_days() override { return next->get_read_through_restore_days(); }
 
   /* Internal to Filters */
   PlacementTier* get_next() { return next.get(); }
@@ -719,7 +719,7 @@ public:
   virtual bool operator==(const Bucket& b) const override { return next->operator==(b); }
   virtual bool operator!=(const Bucket& b) const override { return next->operator!=(b); }
 
-  friend class BucketList;
+  friend struct BucketList;
 
   /* Internal to Filters */
   Bucket* get_next() { return next.get(); }
@@ -919,8 +919,8 @@ public:
     return std::make_unique<FilterObject>(*this);
   }
 
-  virtual jspan_context& get_trace() { return next->get_trace(); }
-  virtual void set_trace (jspan_context&& _trace_ctx) { next->set_trace(std::move(_trace_ctx)); }
+  virtual jspan_context& get_trace() override { return next->get_trace(); }
+  virtual void set_trace(jspan_context&& _trace_ctx) override { next->set_trace(std::move(_trace_ctx)); }
 
   virtual void print(std::ostream& out) const override { return next->print(out); }
 
@@ -940,7 +940,7 @@ public:
   virtual uint64_t get_size() override { return next->get_size(); }
   virtual const std::string& get_etag() override { return next->get_etag(); }
   virtual ceph::real_time& get_mtime() override { return next->get_mtime(); }
-  virtual const std::optional<rgw::cksum::Cksum>& get_cksum() {
+  virtual const std::optional<rgw::cksum::Cksum>& get_cksum() override {
     return next->get_cksum();
   }
 };
@@ -1096,13 +1096,14 @@ public:
 	       const std::vector<rgw::restore::RestoreEntry>& restore_entries) override;
 
   /** List all known entries */
-  virtual int list(const DoutPrefixProvider *dpp, optional_yield y,
+  virtual void list(const DoutPrefixProvider *dpp,
 	       	   int index,
 	           const std::string& marker, std::string* out_marker,
 		   uint32_t max_entries, std::vector<rgw::restore::RestoreEntry>& entries,
-		   bool* truncated) override;
-  virtual int trim_entries(const DoutPrefixProvider *dpp, optional_yield y,
-		 	  int index, const std::string_view& marker) override;
+		   bool* truncated, boost::asio::yield_context yc) override;
+  virtual void trim_entries(const DoutPrefixProvider* dpp, int index,
+                            const std::string_view& marker,
+                            boost::asio::yield_context yc) override;
 
   /** Get a serializer for lifecycle */
   virtual std::unique_ptr<RestoreSerializer> get_serializer(
@@ -1137,7 +1138,7 @@ public:
     next(std::move(_next)), obj(_obj) {}
   virtual ~FilterWriter() = default;
 
-  virtual int prepare(optional_yield y) { return next->prepare(y); }
+  virtual int prepare(optional_yield y) override { return next->prepare(y); }
   virtual int process(bufferlist&& data, uint64_t offset) override;
   virtual int complete(size_t accounted_size, const std::string& etag,
                        ceph::real_time *mtime, ceph::real_time set_mtime,

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -17,6 +17,8 @@
 
 #include "rgw_sal.h"
 
+#include "include/random.h"
+
 /**
  * @brief State for a StoreObject
  */

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -11,11 +11,11 @@ class RGWSI_SyncModules;
 class RGWSI_Bucket_Sync;
 
 class RGWRealm;
-class RGWZoneGroup;
-class RGWZone;
-class RGWZoneParams;
+struct RGWZoneGroup;
+struct RGWZone;
+struct RGWZoneParams;
 class RGWPeriod;
-class RGWZonePlacementInfo;
+struct RGWZonePlacementInfo;
 
 class RGWBucketSyncPolicyHandler;
 

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -233,3 +233,10 @@ target_link_libraries(ceph_test_neorados_watch_notify
 install(TARGETS
   ceph_test_neorados_watch_notify
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+add_executable(ceph_test_neorados_leak_watch_notify leak_watch_notify.cc)
+target_link_libraries(ceph_test_neorados_leak_watch_notify global libneorados
+  neoradostest-support ${unittest_libs})
+install(TARGETS
+  ceph_test_neorados_leak_watch_notify
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/neorados/leak_watch_notify.cc
+++ b/src/test/neorados/leak_watch_notify.cc
@@ -1,0 +1,50 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Contributors to the Ceph Project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <iostream>
+#include <optional>
+
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "common_tests.h"
+
+namespace asio = boost::asio;
+
+using boost::system::error_code;
+
+// Intentionally get a watch and don't unwatch it to make sure we call
+// `linger_cancel` and don't leak.
+
+int main()
+{    
+  asio::io_context c;
+  std::string_view oid = "obj";
+
+  std::optional<neorados::RADOS> rados;
+  neorados::IOContext pool;
+  neorados::RADOS::Builder{}.build(c, [&](error_code ec, neorados::RADOS r_) {
+    rados = std::move(r_);
+    create_pool(*rados, get_temp_pool_name(),
+		[&](error_code ec, int64_t poolid) {
+		  pool.set_pool(poolid);
+		  rados->watch(oid, pool, [&](error_code, std::uint64_t cookie) {
+		    std::cout << "Got watch: " << cookie << std::endl;
+		  });
+		});
+  });
+  c.run();
+}

--- a/src/test/neorados/watch_notify.cc
+++ b/src/test/neorados/watch_notify.cc
@@ -10,8 +10,8 @@
  *
  */
 
+#include <boost/asio/detached.hpp>
 #include <boost/system/detail/errc.hpp>
-#include <coroutine>
 #include <cstdint>
 #include <iostream>
 #include <utility>
@@ -36,8 +36,6 @@
 
 #include "gtest/gtest.h"
 
-using std::uint64_t;
-
 namespace asio = boost::asio;
 namespace buffer = ceph::buffer;
 namespace container = boost::container;
@@ -46,7 +44,6 @@ namespace sys = boost::system;
 using namespace std::literals;
 
 using neorados::ReadOp;
-using neorados::WriteOp;
 
 using std::uint64_t;
 
@@ -231,6 +228,31 @@ CORO_TEST_F(NeoRadosWatchNotifyPoll, WatchNotify, NeoRadosTest) {
       throw;
     }
   }
+  co_return;
+}
+
+CORO_TEST_F(NeoRadosWatchNotifyPoll, WatchNotifyOverflow, NeoRadosTest) {
+  static constexpr auto oid = "obj"sv;
+  co_await create_obj(oid);
+  auto handle = co_await rados().watch(oid, pool(), asio::use_awaitable,
+                                       std::nullopt, 1);
+  EXPECT_TRUE(rados().check_watch(handle));
+  // TODO: Write an awaitable future. This should work for testing for now.
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  co_await wait_for(1s);
+  co_await rados().next_notification(handle, asio::use_awaitable);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  co_await expect_error_code(rados().next_notification(handle, asio::use_awaitable),
+                             neorados::errc::notification_overflow);
+  rados().notify(oid, pool(), {}, 1s, asio::detached);
+  co_await rados().next_notification(handle, asio::use_awaitable);
+  co_await rados().unwatch(handle, pool(), asio::use_awaitable);
+  std::cout << "Flushing..." << std::endl;
+  co_await rados().flush_watch(asio::use_awaitable);
+  std::cout << "Flushed..." << std::endl;
   co_return;
 }
 

--- a/src/test/neorados/watch_notify.cc
+++ b/src/test/neorados/watch_notify.cc
@@ -312,6 +312,7 @@ CORO_TEST_F(NeoRadosWatchNotifyPoll, WrongWatchType, NeoRadosTest) {
   co_await expect_error_code(
     rados().next_notification(handle, asio::use_awaitable),
     sys::errc::invalid_argument);
+  co_await rados().unwatch(handle, pool(), asio::use_awaitable);
 }
 
 CORO_TEST_F(NeoRadosWatchNotifyPoll, WatchNotifyCancel, NeoRadosTest) {

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -327,7 +327,7 @@ add_executable(unittest_rgw_sync_trace test_rgw_sync_trace.cc)
 add_ceph_unittest(unittest_rgw_sync_trace)
 target_include_directories(unittest_rgw_sync_trace
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
-target_link_libraries(unittest_rgw_sync_trace)
+target_link_libraries(unittest_rgw_sync_trace rgw_common ${rgw_libs})
 
 if(WITH_RADOSGW_RADOS)
 add_executable(ceph_test_rgw_gc_log test_rgw_gc_log.cc $<TARGET_OBJECTS:unit-main>)

--- a/src/test/rgw/test-rgw-multisite-single-cluster.sh
+++ b/src/test/rgw/test-rgw-multisite-single-cluster.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Set up a single-cluster multisite: one RADOS cluster, one realm,
+# one zonegroup, two zones, two RGW instances on different ports.
+#
+# This matches the teuthology multisite topology where both zones
+# share the same cluster.
+#
+# Usage (from build dir):
+#   ../src/test/rgw/test-rgw-multisite-single-cluster.sh [rgw params...]
+#
+# Example with aggressive sync config:
+#   ../src/test/rgw/test-rgw-multisite-single-cluster.sh \
+#       --rgw-data-sync-poll-interval=5 \
+#       --rgw-meta-sync-poll-interval=5 \
+#       --rgw-sync-log-trim-interval=0 \
+#       --rgw-data-notify-interval-msec=0 \
+#       --debug-rgw=1
+#
+# Cluster: c1
+# Zone z1 (primary):   port 8001
+# Zone z2 (secondary): port 8002
+# System user: zone.user / 1234567890 / pencil
+# Regular user: regular.user / 0987654321 / crayon
+
+set -e
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+root_path=$(cd "$script_dir/../.." && pwd)
+
+mstart="$root_path/mstart.sh"
+mrun="$root_path/mrun"
+mrgw="$root_path/mrgw.sh"
+
+realm="earth"
+zg="zg1"
+zone1="z1"
+zone2="z2"
+port1=8001
+port2=8002
+
+system_access_key="1234567890"
+system_secret="pencil"
+regular_access_key="0987654321"
+regular_secret="crayon"
+
+echo "=== Setting up single-cluster multisite ==="
+echo "Cluster: c1"
+echo "Zone $zone1 (primary):   port $port1"
+echo "Zone $zone2 (secondary): port $port2"
+echo ""
+
+# start one cluster
+MON=1 OSD=3 RGW=0 MDS=0 MGR=1 "$mstart" c1 -n -d
+
+# create realm, zonegroup, primary zone
+"$mrun" c1 radosgw-admin realm create --rgw-realm="$realm" --default
+"$mrun" c1 radosgw-admin zonegroup create --rgw-zonegroup="$zg" \
+    --rgw-realm="$realm" --master --default
+"$mrun" c1 radosgw-admin zone create --rgw-zonegroup="$zg" \
+    --rgw-zone="$zone1" --rgw-realm="$realm" \
+    --access-key="$system_access_key" --secret="$system_secret" \
+    --endpoints="http://localhost:$port1" --master --default
+
+# create secondary zone in the same zonegroup, same cluster
+"$mrun" c1 radosgw-admin zone create --rgw-zonegroup="$zg" \
+    --rgw-zone="$zone2" --rgw-realm="$realm" \
+    --access-key="$system_access_key" --secret="$system_secret" \
+    --endpoints="http://localhost:$port2"
+
+# system user
+"$mrun" c1 radosgw-admin user create --uid=zone.user \
+    --display-name=ZoneUser \
+    --access-key="$system_access_key" --secret="$system_secret" \
+    --system
+
+# commit the period
+"$mrun" c1 radosgw-admin period update --commit
+
+# regular user for S3 operations
+"$mrun" c1 radosgw-admin user create --uid=regular.user \
+    --display-name=RegularUser \
+    --access-key="$regular_access_key" --secret="$regular_secret"
+
+# start two RGW instances on the same cluster, different zones
+"$mrgw" c1 "$port1" 0 --rgw-zone="$zone1" --rgw-zonegroup="$zg" \
+    --rgw-realm="$realm" "$@"
+"$mrgw" c1 "$port2" 0 --rgw-zone="$zone2" --rgw-zonegroup="$zg" \
+    --rgw-realm="$realm" "$@"
+
+echo ""
+echo "=== Single-cluster multisite is up ==="
+echo "Primary zone ($zone1):   http://localhost:$port1"
+echo "Secondary zone ($zone2): http://localhost:$port2"
+echo ""
+echo "System credentials:  $system_access_key / $system_secret"
+echo "Regular credentials: $regular_access_key / $regular_secret"
+echo ""
+echo "To stop: ../src/mstop.sh c1"

--- a/src/test/rgw/test-rgw-period-reload-crash.py
+++ b/src/test/rgw/test-rgw-period-reload-crash.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Reproducer for RGW crash/freeze on realm reload during period update.
+
+Precondition: a 2-zone multisite cluster is already running.
+
+For single-cluster multisite (recommended, matches teuthology topology):
+
+    cd build && ../src/test/rgw/test-rgw-multisite-single-cluster.sh \\
+        --rgw-data-sync-poll-interval=5 \\
+        --rgw-meta-sync-poll-interval=5 \\
+        --rgw-sync-log-trim-interval=0 \\
+        --rgw-data-notify-interval-msec=0 \\
+        --debug-rgw=1
+
+    python3 ../src/test/rgw/test-rgw-period-reload-crash.py \\
+        --port=8001 --cluster=c1 --zone=z2
+
+For multi-cluster multisite (test-rgw-multisite.sh):
+
+    python3 ../src/test/rgw/test-rgw-period-reload-crash.py \\
+        --port=8101 --cluster=c2 --zone=zg1-2
+
+This script:
+  1. Slams the primary zone RGW with concurrent PUT traffic via boto3
+  2. Fires period update --commit from the secondary zone (with a zone config
+     change each time so the period is genuinely new)
+  3. Verifies that realm reloads actually fired (checks the RGW log)
+  4. Checks whether the primary zone RGW crashed or froze
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import (
+    ConnectionClosedError,
+    EndpointConnectionError,
+    ClientError,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MRUN = SCRIPT_DIR / "../../mrun"
+
+# Toggle between these compression types to force a genuine zone config change
+# before each period commit, ensuring the period is actually new and the
+# realm reload fires.
+COMPRESSION_TOGGLE = ["zlib", "snappy"]
+
+
+def mrun(cluster, *cmd):
+    """Run a command via mrun against the given cluster."""
+    result = subprocess.run(
+        [str(MRUN), cluster] + list(cmd),
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def make_s3_client(port, access_key, secret_key):
+    return boto3.client(
+        "s3",
+        endpoint_url=f"http://localhost:{port}",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=Config(
+            retries={"max_attempts": 0},
+            max_pool_connections=50,
+        ),
+    )
+
+
+def process_running(port):
+    """Return True if a radosgw process for this port is alive."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", f"radosgw.*{port}"],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def check_alive(port, access_key, secret_key, retries=6, delay=10):
+    """Return 'ok', 'frozen', or 'crashed'.
+
+    Retries the HTTP check several times to ride out reload pauses.
+    Falls back to checking whether the process is still running.
+    """
+    for attempt in range(retries):
+        try:
+            s3 = make_s3_client(port, access_key, secret_key)
+            s3.list_buckets()
+            return "ok"
+        except Exception:
+            if not process_running(port):
+                return "crashed"
+            if attempt < retries - 1:
+                time.sleep(delay)
+    return "frozen"
+
+
+def put_worker(client, bucket, worker_id, stop_event):
+    """Continuously PUT small objects until told to stop."""
+    body = b"x" * 4096
+    i = 0
+    while not stop_event.is_set():
+        try:
+            client.put_object(
+                Bucket=bucket,
+                Key=f"w{worker_id}-{i:06d}",
+                Body=body,
+            )
+        except (ConnectionClosedError, EndpointConnectionError, ClientError):
+            time.sleep(0.1)
+        except Exception:
+            time.sleep(0.1)
+        i += 1
+
+
+def poke_zone_config(cluster, zone, iteration):
+    """Make a trivial zone config change so the next period commit is genuine."""
+    compression = COMPRESSION_TOGGLE[iteration % len(COMPRESSION_TOGGLE)]
+    rc, _, stderr = mrun(
+        cluster, "radosgw-admin", "zone", "placement", "modify",
+        "--rgw-zone", zone,
+        "--placement-id", "default-placement",
+        "--compression", compression,
+    )
+    if rc != 0:
+        print(f"  warning: zone config tweak failed (rc={rc}): {stderr.strip()}")
+    else:
+        print(f"  toggled compression to {compression} on {zone}")
+
+
+def period_update_commit(cluster):
+    """Run radosgw-admin period update --commit."""
+    return mrun(cluster, "radosgw-admin", "period", "update", "--commit")
+
+
+def check_reload_fired(port, since_line):
+    """Check if a realm reload was triggered since a given line in the RGW log.
+
+    Returns (fired, current_line_count).
+    """
+    rgw_log = Path(f"run/c1/out/radosgw.{port}.log")
+    if not rgw_log.exists():
+        return False, since_line
+
+    lines = rgw_log.read_text().splitlines()
+    current_count = len(lines)
+
+    for line in lines[since_line:]:
+        if "reconfiguration scheduled" in line or "Pausing frontends" in line:
+            return True, current_count
+
+    return False, current_count
+
+
+def report_crash(port):
+    """Print diagnostic info after a crash or freeze."""
+    rgw_log = Path(f"run/c1/out/radosgw.{port}.log")
+    if rgw_log.exists():
+        print(f"\nRGW log: {rgw_log}")
+        print("Last 30 lines:")
+        lines = rgw_log.read_text().splitlines()
+        for line in lines[-30:]:
+            print(f"  {line}")
+
+    cores = sorted(Path(".").glob("core*"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if cores:
+        print(f"\nCore dump found: {cores[0]}")
+        print("Get a backtrace with:")
+        print(f"  gdb bin/radosgw {cores[0]} -ex 'thread apply all bt' -ex quit")
+    else:
+        print("\nNo core dump found. If the process is still running (frozen),")
+        print("get a live backtrace with:")
+        print(f"  gdb -batch -ex 'set pagination off' -ex 'thread apply all bt' "
+              f"-p $(pgrep -f 'radosgw.*{port}') 2>&1 | tee /tmp/rgw-frozen-bt.txt")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--port", type=int, default=8001,
+                        help="Primary zone RGW port (default: 8001 for single-cluster)")
+    parser.add_argument("--cluster", default="c1",
+                        help="Cluster to issue period updates from (default: c1)")
+    parser.add_argument("--zone", default="z2",
+                        help="Secondary zone name to poke config on (default: z2)")
+    parser.add_argument("--access-key", default="0987654321",
+                        help="S3 access key")
+    parser.add_argument("--secret-key", default="crayon",
+                        help="S3 secret key")
+    parser.add_argument("--writers", type=int, default=25,
+                        help="Number of concurrent PUT writer threads")
+    parser.add_argument("--updates", type=int, default=10,
+                        help="Number of period update commits to fire")
+    parser.add_argument("--sleep", type=int, default=15,
+                        help="Seconds to wait between period updates")
+    args = parser.parse_args()
+
+    port = args.port
+    endpoint = f"http://localhost:{port}"
+
+    print("=== RGW period reload crash reproducer ===")
+    print(f"Primary zone RGW: {endpoint}")
+    print(f"Period updates from cluster: {args.cluster}, zone config poke: {args.zone}")
+    print(f"Writers: {args.writers}")
+    print(f"Period updates: {args.updates}")
+    print(f"Sleep between updates: {args.sleep}s")
+    print()
+
+    if check_alive(port, args.access_key, args.secret_key, retries=1, delay=0) != "ok":
+        print(f"FATAL: primary zone RGW is not responding on {endpoint}")
+        sys.exit(1)
+    print("Primary zone RGW is alive.")
+
+    rgw_log = Path(f"run/c1/out/radosgw.{port}.log")
+    log_line = len(rgw_log.read_text().splitlines()) if rgw_log.exists() else 0
+
+    client = make_s3_client(port, args.access_key, args.secret_key)
+    bucket = f"reload-crash-test-{os.getpid()}"
+
+    client.create_bucket(Bucket=bucket)
+    print(f"Created bucket: {bucket}")
+
+    stop_event = threading.Event()
+    threads = []
+    print(f"Starting {args.writers} background PUT writers...")
+    for i in range(args.writers):
+        t = threading.Thread(target=put_worker,
+                             args=(client, bucket, i, stop_event),
+                             daemon=True)
+        t.start()
+        threads.append(t)
+
+    time.sleep(3)
+
+    print()
+    print("=== Firing period update commits ===")
+    crashed = False
+    reloads_confirmed = 0
+    try:
+        for i in range(1, args.updates + 1):
+            print(f"\n--- period update #{i} of {args.updates} ---")
+
+            poke_zone_config(args.cluster, args.zone, i)
+
+            rc, _, stderr = period_update_commit(args.cluster)
+            if rc != 0:
+                print(f"  period update returned {rc} (may be expected if RGW died)")
+                if stderr:
+                    print(f"  stderr: {stderr.strip()}")
+            else:
+                print("  period committed")
+
+            time.sleep(args.sleep)
+
+            fired, log_line = check_reload_fired(port, log_line)
+            if fired:
+                print("  realm reload confirmed in RGW log")
+                reloads_confirmed += 1
+            else:
+                print("  WARNING: no realm reload detected in RGW log!")
+
+            status = check_alive(port, args.access_key, args.secret_key)
+            if status == "crashed":
+                print()
+                print("************************************************************")
+                print(f"* RGW CRASHED after period update #{i}!")
+                print("************************************************************")
+                report_crash(port)
+                crashed = True
+                return
+            elif status == "frozen":
+                print()
+                print("************************************************************")
+                print(f"* RGW FROZEN after period update #{i}!")
+                print(f"* (process alive but not responding after 60s)")
+                print("************************************************************")
+                report_crash(port)
+                crashed = True
+                return
+
+            print(f"RGW still alive after period update #{i}")
+
+        print()
+        print(f"=== All {args.updates} period updates completed without crash ===")
+        print(f"    (reloads confirmed: {reloads_confirmed}/{args.updates})")
+        if reloads_confirmed == 0:
+            print("    WARNING: no reloads were detected! The bug was NOT exercised.")
+        else:
+            print("    (If testing the fix, this is the expected result.)")
+
+    finally:
+        stop_event.set()
+        for t in threads:
+            t.join(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -343,7 +343,7 @@ TEST_F(D4NFilterFixture, PutObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -412,7 +412,7 @@ TEST_F(D4NFilterFixture, GetObjectRead)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver)); 
   }, rethrow);
 
@@ -524,7 +524,7 @@ TEST_F(D4NFilterFixture, CopyNoneObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -612,7 +612,7 @@ TEST_F(D4NFilterFixture, CopyMergeObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -700,7 +700,7 @@ TEST_F(D4NFilterFixture, CopyReplaceObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -771,7 +771,7 @@ TEST_F(D4NFilterFixture, DeleteObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -811,7 +811,7 @@ TEST_F(D4NFilterFixture, PutVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -897,7 +897,7 @@ TEST_F(D4NFilterFixture, GetVersionedObjectRead)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1038,7 +1038,7 @@ TEST_F(D4NFilterFixture, CopyNoneVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1179,7 +1179,7 @@ TEST_F(D4NFilterFixture, CopyMergeVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1320,7 +1320,7 @@ TEST_F(D4NFilterFixture, CopyReplaceVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1411,7 +1411,7 @@ TEST_F(D4NFilterFixture, DeleteVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1526,7 +1526,7 @@ TEST_F(D4NFilterFixture, PutObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1599,7 +1599,7 @@ TEST_F(D4NFilterFixture, GetObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1721,7 +1721,7 @@ TEST_F(D4NFilterFixture, CopyNoneObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1843,7 +1843,7 @@ TEST_F(D4NFilterFixture, CopyMergeObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1965,7 +1965,7 @@ TEST_F(D4NFilterFixture, CopyReplaceObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2048,7 +2048,7 @@ TEST_F(D4NFilterFixture, DeleteObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2205,7 +2205,7 @@ TEST_F(D4NFilterFixture, PutVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
  
@@ -2356,7 +2356,7 @@ TEST_F(D4NFilterFixture, GetVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2577,7 +2577,7 @@ TEST_F(D4NFilterFixture, CopyNoneVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2798,7 +2798,7 @@ TEST_F(D4NFilterFixture, CopyMergeVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3019,7 +3019,7 @@ TEST_F(D4NFilterFixture, CopyReplaceVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3128,7 +3128,7 @@ TEST_F(D4NFilterFixture, DeleteVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3213,7 +3213,7 @@ TEST_F(D4NFilterFixture, SimpleDeleteBeforeCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3327,7 +3327,7 @@ TEST_F(D4NFilterFixture, VersionedDeleteBeforeCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3380,7 +3380,7 @@ TEST_F(D4NFilterFixture, SimpleDeleteAfterCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3477,7 +3477,7 @@ TEST_F(D4NFilterFixture, VersionedDeleteAfterCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3520,7 +3520,7 @@ TEST_F(D4NFilterFixture, ListObjectVersions)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3620,7 +3620,7 @@ TEST_F(D4NFilterFixture, BucketRemoveBeforeCleaning)
     EXPECT_EQ(testBucket->check_empty(env->dpp, yield), 0);
 
     conn->cancel();
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3731,7 +3731,7 @@ TEST_F(D4NFilterFixture, BucketRemoveAfterCleaning)
     EXPECT_EQ(testBucket->check_empty(env->dpp, yield), 0);
 
     conn->cancel();
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3808,7 +3808,7 @@ TEST_F(D4NFilterFixture, BucketRemoveDeleteMarker)
 
     EXPECT_EQ(testBucket->check_empty(env->dpp, yield), 0);
     conn->cancel();
-    driver->shutdown();
+    driver->do_shutdown(nullptr, yield);
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 

--- a/src/test/rgw/test_datalog.cc
+++ b/src/test/rgw/test_datalog.cc
@@ -15,14 +15,20 @@
 
 #include "rgw_datalog.h"
 
+#include <ranges>
 #include <string_view>
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/use_awaitable.hpp>
 
+#include <boost/asio/experimental/parallel_group.hpp>
+#include <boost/asio/experimental/cancellation_condition.hpp>
+#include <boost/asio/experimental/promise.hpp>
+
 #include <boost/system/errc.hpp>
 #include <boost/system/error_code.hpp>
 
+#include <async_utils.h>
 #include <fmt/format.h>
 
 #include "include/neorados/RADOS.hpp"
@@ -32,6 +38,9 @@
 #include "test/neorados/common_tests.h"
 
 #include "gtest/gtest.h"
+
+namespace ranges = std::ranges;
+namespace views = std::views;
 
 namespace asio = boost::asio;
 namespace ss = neorados::cls::sem_set;
@@ -199,8 +208,14 @@ public:
   ~DataLogTestBase() override = default;
 
   /// \brief Delete pool used for testing
-  boost::asio::awaitable<void> CoTearDown() override {
-    co_await datalog->async_shutdown();
+  boost::asio::awaitable<void>
+  CoTearDown() override
+  {
+    rgw::shutdown_vector to_wait;
+    datalog->shutdown(to_wait);
+    co_await rgw::await_shutdowns(
+        nullptr, co_await asio::this_coro::executor, std::move(to_wait),
+        asio::use_awaitable);
     co_await clean_pool();
     co_return;
   }

--- a/src/test/rgw/test_rgw_async_utils.cc
+++ b/src/test/rgw/test_rgw_async_utils.cc
@@ -354,7 +354,7 @@ CORO_TEST_F(Task, Shutdown, Task)
   EXPECT_EQ(strand, task.get_executor());
 
   EXPECT_EQ(rgw::task_state::running, task.state());
-  std::vector<std::pair<std::string, rgw::shutdown_promise>> v;
+  rgw::shutdown_vector v;
   task.shutdown(label, v);
   EXPECT_EQ(rgw::task_state::dead, task.state());
   EXPECT_EQ(1u, v.size());
@@ -430,6 +430,16 @@ CORO_TEST_F(Loop, Wake, Loop)
   co_return;
 }
 
+namespace {
+void
+rethrower(std::exception_ptr e)
+{
+  if (e) {
+    std::rethrow_exception(e);
+  }
+}
+}
+
 // The rest of the base class functionality is already covered in the Task tests.
 
 class YTask : public ::testing::Test {
@@ -448,14 +458,6 @@ public:
   {
     rgw::wait_for(3s, y);
     ++value;
-  }
-
-  static void
-  rethrower(std::exception_ptr e)
-  {
-    if (e) {
-      std::rethrow_exception(e);
-    }
   }
 };
 
@@ -529,7 +531,7 @@ TEST_F(YTask, Shutdown)
         EXPECT_EQ(strand, task.get_executor());
 
         ASSERT_EQ(rgw::task_state::running, task.state());
-        std::vector<std::pair<std::string, rgw::shutdown_promise>> v;
+        rgw::shutdown_vector v;
         task.shutdown(label, v);
         ASSERT_EQ(rgw::task_state::dead, task.state());
         ASSERT_EQ(1u, v.size());
@@ -553,14 +555,6 @@ public:
   {
     ++value;
     return delay;
-  }
-
-  static void
-  rethrower(std::exception_ptr e)
-  {
-    if (e) {
-      std::rethrow_exception(e);
-    }
   }
 };
 
@@ -630,3 +624,125 @@ TEST_F(YLoop, Wake)
 }
 
 // The rest of the base class functionality is already covered in the YTask tests.
+
+namespace {
+rgw::task<>
+thrower(ceph::timespan delay, auto executor, auto exception, bool& executed)
+{
+  return rgw::task{
+      asio::make_strand(executor),
+      [](ceph::timespan delay, auto e, bool& executed) -> asio::awaitable<void> {
+        co_await rgw::wait_for(delay);
+        executed = true;
+        throw e;
+      }(delay, std::forward<decltype(exception)>(exception), executed)};
+}
+} // namespace
+
+CORO_TEST(AwaitShutdowns, AwaitShutdowns)
+{
+  bool ran1 = false;
+  auto task1 = thrower(
+      10us, co_await asio::this_coro::executor, std::logic_error{"Oh no!"},
+      ran1);
+  bool ran2 = false;
+  auto task2 = thrower(
+      500ms, co_await asio::this_coro::executor,
+      std::runtime_error{"O me miserum!"}, ran2);
+  task1.run();
+  task2.run();
+
+  rgw::shutdown_vector to_wait;
+  task1.shutdown("task1", to_wait);
+  task2.shutdown("task2", to_wait);
+
+  EXPECT_THROW(
+      co_await rgw::await_shutdowns(
+          nullptr, co_await asio::this_coro::executor, std::move(to_wait),
+          asio::use_awaitable),
+      std::logic_error);
+  EXPECT_TRUE(ran1);
+  EXPECT_TRUE(ran2);
+}
+
+CORO_TEST(AwaitShutdowns, AwaitShutdownsRev)
+{
+  bool ran1 = false;
+  auto task1 = thrower(
+      10us, co_await asio::this_coro::executor, std::logic_error{"Oh no!"},
+      ran1);
+  bool ran2 = false;
+  auto task2 = thrower(
+      500ms, co_await asio::this_coro::executor,
+      std::runtime_error{"O me miserum!"}, ran2);
+  task2.run();
+  task1.run();
+
+  rgw::shutdown_vector to_wait;
+  task2.shutdown("task2", to_wait);
+  task1.shutdown("task1", to_wait);
+
+  EXPECT_THROW(
+      co_await rgw::await_shutdowns(
+          nullptr, co_await asio::this_coro::executor, std::move(to_wait),
+          asio::use_awaitable),
+      std::logic_error);
+  EXPECT_TRUE(ran1);
+  EXPECT_TRUE(ran2);
+}
+
+TEST(YAwaitShutdowns, AwaitShutdowns)
+{
+  asio::io_context io_context;
+  asio::spawn(
+      io_context,
+      [](asio::yield_context y) {
+        bool ran1 = false;
+        auto task1 =
+            thrower(10us, y.get_executor(), std::logic_error{"Oh no!"}, ran1);
+        bool ran2 = false;
+        auto task2 = thrower(
+            500ms, y.get_executor(), std::runtime_error{"O me miserum!"}, ran2);
+        task1.run();
+        task2.run();
+
+        rgw::shutdown_vector to_wait;
+        task1.shutdown("task1", to_wait);
+        task2.shutdown("task2", to_wait);
+
+        EXPECT_THROW(
+            rgw::await_shutdowns(nullptr, y.get_executor(), std::move(to_wait), y), std::logic_error);
+        EXPECT_TRUE(ran1);
+        EXPECT_TRUE(ran2);
+      },
+      rethrower);
+  io_context.run();
+}
+
+TEST(YAwaitShutdowns, AwaitShutdownsRev)
+{
+  asio::io_context io_context;
+  asio::spawn(
+      io_context,
+      [](asio::yield_context y) {
+        bool ran1 = false;
+        auto task1 =
+            thrower(10us, y.get_executor(), std::logic_error{"Oh no!"}, ran1);
+        bool ran2 = false;
+        auto task2 = thrower(
+            500ms, y.get_executor(), std::runtime_error{"O me miserum!"}, ran2);
+        task2.run();
+        task1.run();
+
+        rgw::shutdown_vector to_wait;
+        task2.shutdown("task2", to_wait);
+        task1.shutdown("task1", to_wait);
+
+        EXPECT_THROW(
+            rgw::await_shutdowns(nullptr, y.get_executor(), std::move(to_wait), y), std::logic_error);
+        EXPECT_TRUE(ran1);
+        EXPECT_TRUE(ran2);
+      },
+      rethrower);
+  io_context.run();
+}

--- a/src/test/rgw/test_rgw_async_utils.cc
+++ b/src/test/rgw/test_rgw_async_utils.cc
@@ -21,6 +21,7 @@
 #include <tuple>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/asio/this_coro.hpp>
 #include <boost/asio/spawn.hpp>
 
@@ -29,15 +30,19 @@
 
 #include <gtest/gtest.h>
 
+#include "include/common_fwd.h"
+
 #include "common/async/context_pool.h"
 #include "common/async/yield_context.h"
+#include "common/dout.h"
 
-#include <common/ceph_context.h>
-#include <common/dout.h>
+#include "test/neorados/common_tests.h"
 
 namespace asio = boost::asio;
 namespace async = ceph::async;
 namespace sys = boost::system;
+
+using namespace std::literals;
 
 static auto cct = std::make_unique<CephContext>(CEPH_ENTITY_TYPE_ANY);
 
@@ -249,3 +254,379 @@ TEST(HybridToken, HybridToken)
       rgw::oyc(&dp, null_yield));
   ASSERT_TRUE(ran);
 }
+
+class Task : public CoroTest {
+protected:
+  int value = 0;
+
+public:
+  asio::awaitable<void>
+  increment()
+  {
+    ++value;
+    co_return;
+  }
+
+  asio::awaitable<void>
+  waitcrement()
+  {
+    co_await rgw::wait_for(3s);
+    ++value;
+    co_return;
+  }
+};
+
+CORO_TEST_F(Task, Run, Task)
+{
+  rgw::task task{
+      asio::make_strand(co_await asio::this_coro::executor), increment()};
+
+  EXPECT_EQ(rgw::task_state::ready, task.state());
+  task.run();
+  EXPECT_EQ(rgw::task_state::running, task.state());
+  co_await task.join(asio::use_awaitable);
+  EXPECT_EQ(rgw::task_state::dead, task.state());
+  EXPECT_EQ(1, value);
+  co_return;
+}
+
+CORO_TEST_F(Task, RunCoroFun, Task)
+{
+  rgw::task task{
+      asio::make_strand(co_await asio::this_coro::executor),
+      rgw::membind(*this, &Task::increment)};
+
+  EXPECT_EQ(rgw::task_state::ready, task.state());
+  task.run();
+  EXPECT_EQ(rgw::task_state::running, task.state());
+  co_await task.join(asio::use_awaitable);
+  EXPECT_EQ(rgw::task_state::dead, task.state());
+  EXPECT_EQ(1, value);
+  co_return;
+}
+
+CORO_TEST_F(Task, Running, Task)
+{
+  rgw::task task{
+      asio::make_strand(co_await asio::this_coro::executor), increment(),
+      rgw::running};
+
+  EXPECT_EQ(rgw::task_state::running, task.state());
+  co_await task.join(asio::use_awaitable);
+  EXPECT_EQ(rgw::task_state::dead, task.state());
+  EXPECT_EQ(1, value);
+  co_return;
+}
+
+CORO_TEST_F(Task, RunningCoroFun, Task)
+{
+  rgw::task task{
+      asio::make_strand(co_await asio::this_coro::executor),
+      rgw::membind(*this, &Task::increment), rgw::running};
+
+  EXPECT_EQ(rgw::task_state::running, task.state());
+  co_await task.join(asio::use_awaitable);
+  EXPECT_EQ(rgw::task_state::dead, task.state());
+  EXPECT_EQ(1, value);
+  co_return;
+}
+
+CORO_TEST_F(Task, Cancel, Task)
+{
+  rgw::task task{
+      asio::make_strand(co_await asio::this_coro::executor), waitcrement(),
+      rgw::running};
+
+  EXPECT_EQ(rgw::task_state::running, task.state());
+  task.cancel();
+  EXPECT_EQ(rgw::task_state::running, task.state());
+  co_await expect_error_code(task.join(asio::use_awaitable), asio::error::operation_aborted);
+  EXPECT_EQ(rgw::task_state::dead, task.state());
+  EXPECT_EQ(0, value);
+  co_return;
+}
+
+CORO_TEST_F(Task, Shutdown, Task)
+{
+  auto strand = asio::make_strand(co_await asio::this_coro::executor);
+  static const std::string label = "Test!";
+  rgw::task task{strand, increment(), rgw::running};
+  EXPECT_EQ(strand, task.get_executor());
+
+  EXPECT_EQ(rgw::task_state::running, task.state());
+  std::vector<std::pair<std::string, rgw::shutdown_promise>> v;
+  task.shutdown(label, v);
+  EXPECT_EQ(rgw::task_state::dead, task.state());
+  EXPECT_EQ(1u, v.size());
+  auto& [l, p] = v.front();
+  EXPECT_EQ(label, l);
+  co_await p(asio::use_awaitable);
+  EXPECT_EQ(1, value);
+  co_return;
+}
+
+class Loop : public CoroTest {
+protected:
+  int value = 0;
+  ceph::timespan delay = 0s;
+
+public:
+  asio::awaitable<ceph::timespan>
+  increment()
+  {
+    ++value;
+    co_return delay;
+  }
+};
+
+CORO_TEST_F(Loop, Looping, Loop)
+{
+  delay = 250ms;
+  rgw::run_loop loop{
+      asio::make_strand(co_await asio::this_coro::executor),
+      rgw::membind(*this, &Loop::increment)};
+
+  EXPECT_EQ(rgw::task_state::ready, loop.state());
+  loop.run();
+  EXPECT_EQ(rgw::task_state::running, loop.state());
+  co_await rgw::wait_for(300ms);
+  loop.cancel();
+  co_await loop.join(asio::use_awaitable);
+  EXPECT_EQ(rgw::task_state::dead, loop.state());
+  EXPECT_EQ(2, value);
+  co_return;
+}
+
+CORO_TEST_F(Loop, Running, Loop)
+{
+  delay = 250ms;
+  rgw::run_loop loop{
+      asio::make_strand(co_await asio::this_coro::executor),
+      rgw::membind(*this, &Loop::increment), rgw::running};
+
+  EXPECT_EQ(rgw::task_state::running, loop.state());
+  co_await rgw::wait_for(300ms);
+  loop.cancel();
+  co_await loop.join(asio::use_awaitable);
+  EXPECT_EQ(rgw::task_state::dead, loop.state());
+  EXPECT_EQ(2, value);
+  co_return;
+}
+
+CORO_TEST_F(Loop, Wake, Loop)
+{
+  delay = 5s;
+  rgw::run_loop loop{
+      asio::make_strand(co_await asio::this_coro::executor),
+      rgw::membind(*this, &Loop::increment), rgw::running};
+
+  EXPECT_EQ(rgw::task_state::running, loop.state());
+  loop.wake();
+  co_await rgw::wait_for(100ms);
+  loop.cancel();
+  co_await loop.join(asio::use_awaitable);
+  EXPECT_EQ(rgw::task_state::dead, loop.state());
+  EXPECT_EQ(2, value);
+  co_return;
+}
+
+// The rest of the base class functionality is already covered in the Task tests.
+
+class YTask : public ::testing::Test {
+public:
+  asio::io_context io_context;
+  int value = 0;
+
+  void
+  increment(asio::yield_context)
+  {
+    ++value;
+  }
+
+  void
+  waitcrement(asio::yield_context y)
+  {
+    rgw::wait_for(3s, y);
+    ++value;
+  }
+
+  static void
+  rethrower(std::exception_ptr e)
+  {
+    if (e) {
+      std::rethrow_exception(e);
+    }
+  }
+};
+
+TEST_F(YTask, Run)
+{
+  asio::spawn(
+      io_context,
+      [this](asio::yield_context y) {
+        rgw::ytask task{
+            asio::make_strand(y.get_executor()),
+            rgw::membind(*this, &YTask::increment)};
+
+        ASSERT_EQ(rgw::task_state::ready, task.state());
+        task.run();
+        ASSERT_EQ(rgw::task_state::running, task.state());
+        task.join(y);
+        ASSERT_EQ(rgw::task_state::dead, task.state());
+        ASSERT_EQ(1, value);
+      },
+      &rethrower);
+  io_context.run();
+}
+
+TEST_F(YTask, Running)
+{
+  asio::spawn(
+      io_context,
+      [this](asio::yield_context y) {
+        rgw::ytask task{
+            asio::make_strand(y.get_executor()),
+            rgw::membind(*this, &YTask::increment), rgw::running};
+
+        ASSERT_EQ(rgw::task_state::running, task.state());
+        task.join(y);
+        ASSERT_EQ(rgw::task_state::dead, task.state());
+        ASSERT_EQ(1, value);
+      },
+      &rethrower);
+  io_context.run();
+}
+
+TEST_F(YTask, Cancel)
+{
+  asio::spawn(
+      io_context,
+      [this](asio::yield_context y) {
+        rgw::ytask task{
+            asio::make_strand(y.get_executor()),
+            rgw::membind(*this, &YTask::waitcrement), rgw::running};
+
+        ASSERT_EQ(rgw::task_state::running, task.state());
+        task.cancel();
+        ASSERT_EQ(rgw::task_state::running, task.state());
+        ASSERT_THROW(task.join(y), sys::system_error);
+        ASSERT_EQ(rgw::task_state::dead, task.state());
+        ASSERT_EQ(0, value);
+      },
+      &rethrower);
+  io_context.run();
+}
+
+TEST_F(YTask, Shutdown)
+{
+  asio::spawn(
+      io_context,
+      [this](asio::yield_context y) {
+        auto strand = asio::make_strand(y.get_executor());
+        rgw::ytask task{
+            strand, rgw::membind(*this, &YTask::increment), rgw::running};
+        static const std::string label = "Test!";
+        EXPECT_EQ(strand, task.get_executor());
+
+        ASSERT_EQ(rgw::task_state::running, task.state());
+        std::vector<std::pair<std::string, rgw::shutdown_promise>> v;
+        task.shutdown(label, v);
+        ASSERT_EQ(rgw::task_state::dead, task.state());
+        ASSERT_EQ(1u, v.size());
+        auto& [l, p] = v.front();
+        ASSERT_EQ(label, l);
+        p(y);
+        ASSERT_EQ(1, value);
+      },
+      &rethrower);
+  io_context.run();
+}
+
+class YLoop : public ::testing::Test {
+public:
+  asio::io_context io_context;
+  int value = 0;
+  ceph::timespan delay = 0s;
+
+  ceph::timespan
+  increment(asio::yield_context)
+  {
+    ++value;
+    return delay;
+  }
+
+  static void
+  rethrower(std::exception_ptr e)
+  {
+    if (e) {
+      std::rethrow_exception(e);
+    }
+  }
+};
+
+TEST_F(YLoop, Looping)
+{
+  asio::spawn(
+      io_context,
+      [this](asio::yield_context y) {
+        delay = 250ms;
+        rgw::yrun_loop loop{asio::make_strand(y.get_executor()),
+                            rgw::membind(*this, &YLoop::increment)};
+
+        ASSERT_EQ(rgw::task_state::ready, loop.state());
+        loop.run();
+        ASSERT_EQ(rgw::task_state::running, loop.state());
+        rgw::wait_for(300ms, y);
+        loop.cancel();
+        loop.join(y);
+        ASSERT_EQ(rgw::task_state::dead, loop.state());
+        ASSERT_EQ(2, value);
+      },
+      &rethrower);
+  io_context.run();
+}
+
+TEST_F(YLoop, Running)
+{
+  asio::spawn(
+      io_context,
+      [this](asio::yield_context y) {
+        delay = 250ms;
+        rgw::yrun_loop loop{
+            asio::make_strand(y.get_executor()),
+            rgw::membind(*this, &YLoop::increment), rgw::running};
+
+        ASSERT_EQ(rgw::task_state::running, loop.state());
+        rgw::wait_for(300ms, y);
+        loop.cancel();
+        loop.join(y);
+        ASSERT_EQ(rgw::task_state::dead, loop.state());
+        ASSERT_EQ(2, value);
+      },
+      &rethrower);
+  io_context.run();
+}
+
+TEST_F(YLoop, Wake)
+{
+  asio::spawn(
+      io_context,
+      [this](asio::yield_context y) {
+        delay = 5s;
+        rgw::yrun_loop loop{
+            asio::make_strand(y.get_executor()),
+            rgw::membind(*this, &YLoop::increment), rgw::running};
+
+        ASSERT_EQ(rgw::task_state::running, loop.state());
+        loop.wake();
+        rgw::wait_for(100ms, y);
+        loop.cancel();
+        loop.join(y);
+        EXPECT_EQ(rgw::task_state::dead, loop.state());
+        EXPECT_EQ(2, value);
+      },
+      &rethrower);
+  io_context.run();
+}
+
+// The rest of the base class functionality is already covered in the YTask tests.

--- a/src/test/rgw/test_rgw_async_utils.cc
+++ b/src/test/rgw/test_rgw_async_utils.cc
@@ -43,15 +43,17 @@ static auto cct = std::make_unique<CephContext>(CEPH_ENTITY_TYPE_ANY);
 
 static NoDoutPrefix dp(cct.get(), ceph_subsys_rgw);
 
+static asio::awaitable<void>
+maybethrow(int code)
+{
+  if (code != 0) {
+    throw sys::system_error{code, sys::generic_category()};
+  }
+  co_return;
+}
+
 TEST(CoSpawn, CoSpawn) {
   async::io_context_pool pool{3};
-
-  auto maybethrow = [](int code) -> asio::awaitable<void> {
-    if (code != 0) {
-      throw sys::system_error{code, sys::generic_category()};
-    }
-    co_return;
-  };
 
   int r = 0;
   r = rgw::run_coro(&dp, pool, maybethrow(ENOENT), nullptr);
@@ -204,4 +206,46 @@ TEST(CoSpawn, CoSpawn) {
   ASSERT_EQ(instr, s);
   ASSERT_TRUE(p);
   ASSERT_EQ(5, *p);
+}
+
+TEST(HybridToken, HybridToken)
+{
+  ceph::async::io_context_pool io_context{3, [] { is_asio_thread = true; }};
+  bool ran = false;
+  asio::spawn(
+      io_context,
+      [&](asio::yield_context yc) {
+        optional_yield y{yc};
+
+        ASSERT_NO_THROW(
+            co_spawn(yc.get_executor(), maybethrow(0), rgw::oyc(&dp, y)));
+        ASSERT_NO_THROW(co_spawn(
+            yc.get_executor(), maybethrow(0), rgw::oyc(&dp, null_yield)));
+
+        ASSERT_THROW(
+            co_spawn(yc.get_executor(), maybethrow(ENOENT), rgw::oyc(&dp, y)),
+            sys::system_error);
+        ASSERT_THROW(
+            co_spawn(
+                yc.get_executor(), maybethrow(ENOENT),
+                rgw::oyc(&dp, null_yield)),
+            sys::system_error);
+
+        {
+          std::exception_ptr eptr;
+          ASSERT_NO_THROW(co_spawn(
+              yc.get_executor(), maybethrow(ENOENT), rgw::oyc(&dp, y, eptr)));
+          ASSERT_EQ(-ENOENT, ceph::from_exception(eptr));
+        }
+        {
+          std::exception_ptr eptr;
+          ASSERT_NO_THROW(co_spawn(
+              yc.get_executor(), maybethrow(ENOENT), rgw::oyc(&dp, null_yield, eptr)));
+          ASSERT_EQ(-ENOENT, ceph::from_exception(eptr));
+        }
+
+        ran = true;
+      },
+      rgw::oyc(&dp, null_yield));
+  ASSERT_TRUE(ran);
 }


### PR DESCRIPTION
Work through issues of shutting down RGW.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
