### PR TITLE
rbd-mirror: Improve group replayer

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2899,6 +2899,7 @@ test_force_promote_before_initial_sync()
   local group_id_before
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}/${group0}"
   start_mirrors "${secondary_cluster}"
   wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
@@ -2913,6 +2914,7 @@ test_force_promote_before_initial_sync()
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}/${group0}"
   start_mirrors "${secondary_cluster}"
   wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
@@ -3355,6 +3357,7 @@ test_odf_failover_failback()
   if [ "${scenario}" = 'resync_on_failback' ]; then
     # request resync - won't happen until other site is marked as primary
     mirror_group_resync "${secondary_cluster}" "${pool}/${group0}" 
+    group_resync_marker_exists "${secondary_cluster}" "${pool}/${group0}"
   fi  
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_after
@@ -3470,6 +3473,7 @@ test_resync_marker()
   # demote primary and request resync on secondary - check that group does not get deleted (due to resync request flag)
   mirror_group_demote "${primary_cluster}" "${pool}/${group0}" 
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}" 
+  group_resync_marker_exists "${secondary_cluster}" "${pool}/${group0}"
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+unknown'
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_after
@@ -3478,6 +3482,7 @@ test_resync_marker()
   test "${image_id_before}" = "${image_id_after}" || fail "image recreated with no primary"
 
   mirror_group_promote "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_removed "${secondary_cluster}" "${pool}/${group0}"
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_after
   test "${group_id_before}" = "${group_id_after}" || fail "group recreated"

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -2671,6 +2671,75 @@ mirror_group_resync()
     run_cmd "rbd --cluster=${cluster} mirror group resync ${group_spec}"
 }
 
+# Return:
+#   0 - group resync marker exists
+#   1 - group resync marker does not exist
+#   2 - failed to determine marker state
+test_group_resync_marker()
+{
+    local cluster=$1
+    local group_spec=$2
+    local group_id
+
+    get_id_from_group_info "${cluster}" "${group_spec}" group_id "try_cmd" || { fail; return 2; }
+
+    local group_header_oid="rbd_group_header.${group_id}"
+    local pool="${group_spec%%/*}"
+    local remainder="${group_spec#*/}"
+    local namespace_args=""
+
+    if [[ "${remainder}" == */* ]]; then
+        namespace_args="--namespace ${remainder%/*}"
+    fi
+
+    local rc=0
+    try_admin_cmd "rados --cluster ${cluster} --pool ${pool} ${namespace_args} getomapval ${group_header_oid} metadata_rbd_group_resync >/dev/null" || rc=$?
+
+    return ${rc}
+}
+
+# Verify that the group resync marker exists.
+# Return:
+#   0 - group resync marker exists
+#   1 - group resync marker does not exist or the check failed
+group_resync_marker_exists()
+{
+    local rc=0
+
+    test_group_resync_marker "$@" || rc=$?
+
+    if [[ ${rc} -eq 0 ]]; then
+        return 0
+    elif [[ ${rc} -eq 1 ]]; then
+        fail "group resync marker is not set"
+        return 1
+    else
+        fail "failed to determine group resync marker state"
+        return 1
+    fi
+}
+
+# Verify that the group resync marker is removed.
+# Return:
+#   0 - group resync marker is removed
+#   1 - group resync marker still exists or the check failed
+group_resync_marker_removed()
+{
+    local rc=0
+
+    test_group_resync_marker "$@" || rc=$?
+
+    if [[ ${rc} -eq 0 ]]; then
+        fail "group resync marker is still set"
+        return 1
+    elif [[ ${rc} -eq 1 ]]; then
+        return 0
+    else
+        fail "failed to determine group resync marker state"
+        return 1
+    fi
+}
+
 test_group_present()
 {
     local cluster=$1
@@ -2738,7 +2807,7 @@ test_group_id_changed()
 
     get_id_from_group_info "${cluster}" "${group_spec}" current_group_id "try_cmd" || { fail; return 1; }
     test "${orig_group_id}" != "${current_group_id}" || { fail; return 1; }
-  }
+}
 
 wait_for_group_id_changed()
 {
@@ -2749,7 +2818,10 @@ wait_for_group_id_changed()
 
     for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
         sleep ${s}
-        test_group_id_changed "${cluster}" "${group_spec}" "${orig_group_id}" && return 0
+        if test_group_id_changed "${cluster}" "${group_spec}" "${orig_group_id}"; then
+            group_resync_marker_removed "${cluster}" "${group_spec}" || return 1
+            return 0
+        fi
     done
     fail "wait for group with name ${group} to change id from ${orig_group_id} failed on ${cluster}"
     return 1

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -165,7 +165,7 @@ void Replayer<I>::schedule_load_group_snapshots() {
   std::lock_guard timer_locker{m_threads->timer_lock};
   std::lock_guard locker{m_lock};
 
-  if (m_state != STATE_REPLAYING) {
+  if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
     return;
   }
 
@@ -186,9 +186,10 @@ void Replayer<I>::handle_schedule_load_group_snapshots(int r) {
 
   {
     std::unique_lock locker{m_lock};
-    if (m_state != STATE_REPLAYING) {
+    if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
       return;
     }
+    m_state = STATE_REPLAYING;
 
     ceph_assert(m_load_snapshots_task != nullptr);
     m_load_snapshots_task = nullptr;
@@ -863,7 +864,10 @@ void Replayer<I>::try_create_group_snapshot(
           continue;
         }
       } else {
-        dout(10) << "all remote snaps synced" << dendl;
+        dout(10) << "all remote snaps synced: idling waiting for new snapshot"
+                 << dendl;
+        ceph_assert(m_state == STATE_REPLAYING);
+        m_state = STATE_IDLE;
         return;
       }
     }
@@ -2240,7 +2244,7 @@ bool Replayer<I>::get_replay_status(std::string* description) {
   dout(10) << dendl;
 
   std::unique_lock locker{m_lock};
-  if (m_state != STATE_REPLAYING) {
+  if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
     derr << "replay not running" << dendl;
     return false;
   }

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -594,28 +594,47 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
     return;
   }
 
+  m_prune_group_snap = nullptr;
   auto prune_creating_group_snaps =
     std::make_shared<std::vector<cls::rbd::GroupSnapshot>>();
   m_last_local_snap = nullptr;
+  const cls::rbd::GroupSnapshot* last_complete_local_snap = nullptr;
   for (const auto& local_snap : m_local_group_snaps) {
-    // latest mirror snapshot (keep updating)
-    if (cls::rbd::get_group_snap_namespace_type(
-          local_snap.snapshot_namespace) ==
-        cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-      m_last_local_snap = &local_snap;
-    }
+    auto mirror_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+      &local_snap.snapshot_namespace);
 
-    // collect creating snapshots
-    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
-      auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-          &local_snap.snapshot_namespace);
-
-      if (local_snap_ns && local_snap_ns->is_primary()) {
-        continue;
+    // user snaps
+    if (!mirror_ns) {
+      if (m_check_creating_snaps &&
+         local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
+        prune_creating_group_snaps->push_back(local_snap);
       }
-
-      prune_creating_group_snaps->push_back(local_snap);
+      continue;
     }
+    // last mirror snap
+    m_last_local_snap = &local_snap;
+
+    // only non-primary snapshots are prune candidates
+    if (mirror_ns->is_non_primary()) {
+      if (is_mirror_group_snapshot_complete(local_snap.state,
+                                            mirror_ns->complete)) {
+        // complete non-primary snapshot
+        last_complete_local_snap = &local_snap;
+
+        // oldest complete non-primary snapshot
+        if (!m_prune_group_snap) {
+          m_prune_group_snap = &local_snap;
+        }
+      } else if (m_check_creating_snaps &&
+        local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
+        prune_creating_group_snaps->push_back(local_snap);
+      }
+    }
+  }
+
+  // retain newest complete non-primary snapshot
+  if (m_prune_group_snap == last_complete_local_snap) {
+    m_prune_group_snap = nullptr;
   }
 
   // We must determine whether the local group is already primary here.
@@ -631,8 +650,10 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
       // happen here, because before we can go to any scanning of unsynced snaps
       // it is efficient to be ready, so that, the replay logic sees a clean
       // local snapshot state and recreates any missing snapshots.
-      if (m_check_creating_snaps) {
-        prune_creating_group_snapshots(&locker, prune_creating_group_snaps);
+      if (!prune_creating_group_snaps->empty()) {
+        m_in_flight_op_tracker.start_op();
+        locker.unlock();
+        prune_creating_group_snapshots(prune_creating_group_snaps);
         return;
       }
       if (ns.is_orphan()) {
@@ -650,6 +671,7 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
     }
   }
 
+  m_check_creating_snaps = false;
   if (m_resync_requested) {
     m_resync_requested = false;
     check_local_group_snapshots(&locker);
@@ -706,7 +728,26 @@ void Replayer<I>::check_local_group_snapshots(
     schedule_load_group_snapshots();
     return;
   }
-  prune_group_snapshots(locker);
+
+  int r = prune_group_snapshots(locker);
+  if (r == -EAGAIN) { // retry later
+    m_refresh_snaps = false;
+    locker->unlock();
+    // Allow some time for the ImageReplayer to complete pending prune operations before retrying.
+    schedule_load_group_snapshots();
+    return;
+  }
+
+  if (r < 0) {
+    derr << "failed to prune group snapshots" << cpp_strerror(r) << dendl;
+    // ignore
+  }
+
+  if (m_refresh_snaps) {
+    m_refresh_snaps = false;
+    load_replayer(locker); // immediately reload
+    return;
+  }
 
   is_rename_requested();
 }
@@ -1220,28 +1261,38 @@ void Replayer<I>::post_mirror_snapshot_created(
   }
 
   // Old synced user snap is removed and not yet reflecting locally, wait for it.
-  bool user_snap_found;
-  for (auto local_snap = m_local_group_snaps.begin();
-      local_snap != m_local_group_snaps.end(); ++local_snap) {
+  bool prune_user_snap = false ;
+  std::unordered_set<std::string> remote_snap_ids;
+  remote_snap_ids.reserve(m_remote_group_snaps.size());
+  for (const auto& remote_snap : m_remote_group_snaps) {
+    remote_snap_ids.insert(remote_snap.id);
+  }
+
+  for (auto& local_snap : m_local_group_snaps) {
     auto snap_type = cls::rbd::get_group_snap_namespace_type(
-        local_snap->snapshot_namespace);
-    if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-      user_snap_found = false;
-      for (auto remote_snap = m_remote_group_snaps.begin();
-          remote_snap != m_remote_group_snaps.end(); ++remote_snap) {
-        if (local_snap->id == remote_snap->id) {
-          user_snap_found = true;
-          break;
-        }
-      }
-      if (!user_snap_found) {
-        prune_user_group_snapshots(&locker);
-        locker.unlock();
-        // there is a user group snap removed on remote, so lets wait for it to removed locally
-        on_finish->complete(-EAGAIN);
-        return;
-      }
+        local_snap.snapshot_namespace);
+    if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
+      continue;
     }
+
+    if (remote_snap_ids.contains(local_snap.id)) {
+      continue;
+    }
+
+    // there is a user group snap removed on remote, so lets wait for it to removed locally
+    prune_user_snap = true;
+    int r = prune_group_snapshot(&local_snap, &locker);
+    if (r != 0) {
+      derr << "failed to remove user group snapshot: " << local_snap.id
+           << ", error: " << cpp_strerror(r) << dendl;
+      // ignore
+    }
+  }
+
+  if (prune_user_snap) {
+    locker.unlock();
+    on_finish->complete(-EAGAIN);
+    return;
   }
 
   // User snap is added and not yet turned created, wait for it.
@@ -1741,9 +1792,18 @@ void Replayer<I>::prune_image_snapshot(ImageReplayer<I>* image_replayer,
   locker.lock();
 }
 
+/*
+ * prune_all_image_snapshots() semantics:
+ *
+ * true:
+ *   all image snapshots already removed
+ *
+ * false:
+ *   async pruning initiated, retry required later
+ */
 template <typename I>
 bool Replayer<I>::prune_all_image_snapshots(
-    cls::rbd::GroupSnapshot *local_snap,
+    const cls::rbd::GroupSnapshot *local_snap,
     std::unique_lock<ceph::mutex>* locker) {
   bool prune_done = true;
   if (!local_snap) {
@@ -1859,17 +1919,8 @@ bool Replayer<I>::prune_all_image_snapshots_by_gsid(
 // and prune them on daemon restart.
 template <typename I>
 void Replayer<I>::prune_creating_group_snapshots(
-    std::unique_lock<ceph::mutex>* locker,
     std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps) {
-
-  if (prune_creating_group_snaps->empty()) {
-    // not found creating snapshots
-    m_check_creating_snaps = false;
-    locker->unlock();
-    schedule_load_group_snapshots();
-    return;
-  }
-  locker->unlock();
+  dout(10) << dendl;
 
   m_out_bl.clear();
   auto local_images =
@@ -1880,7 +1931,9 @@ void Replayer<I>::prune_creating_group_snapshots(
         derr << "failed to list group images: "
              << cpp_strerror(r) << dendl;
         // reload will retry if needed
-        schedule_load_group_snapshots();
+        std::unique_lock locker{m_lock};
+        m_in_flight_op_tracker.finish_op();
+        load_replayer(&locker);
         return;
       }
 
@@ -1897,12 +1950,14 @@ void Replayer<I>::handle_prune_creating_group_snapshots(
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps) {
   std::unique_lock locker{m_lock};
+  bool all_pruned = true;
   for (const auto& local_snap : prune_creating_group_snaps) {
     if (!prune_all_image_snapshots_by_gsid(
           local_snap.id, local_images, &locker)) {
       // still pending image snapshots; retry later
       dout(20) << "image snapshots still pending for: "
                << local_snap.id << dendl;
+      all_pruned = false;
       continue;
     }
 
@@ -1915,164 +1970,138 @@ void Replayer<I>::handle_prune_creating_group_snapshots(
       local_snap.id);
 
     if (r < 0) {
+      all_pruned = false;
       derr << "failed to remove group snapshot "
            << local_snap.id << ": "
            << cpp_strerror(r) << dendl;
     }
   }
 
-  m_check_creating_snaps = false;
-  locker.unlock();
-  schedule_load_group_snapshots();
+  if (all_pruned) {
+    m_check_creating_snaps = false;
+  }
+
+  m_in_flight_op_tracker.finish_op();
+
+  load_replayer(&locker);
 }
 
+/* prune_group_snapshots() semantics:
+ *
+ * r == 0 && m_refresh_snaps == true
+ *   One or more group snapshots were successfully removed.
+ *   Reload local and remote snapshots.
+ *
+ * r == 0 && m_refresh_snaps == false
+ *   No snapshot state changes occurred.
+ *   Continue syncing the next snapshots.
+ *
+ * r == -EAGAIN
+ *   Snapshot pruning is still in progress
+ *   (typically waiting for image snapshot pruning).
+ *   Reload local and remote snapshots and retry.
+ *
+ * r < 0 && r != -EAGAIN
+ *   Return the errno to caller.
+ */
+
 template <typename I>
-void Replayer<I>::prune_user_group_snapshots(
+int Replayer<I>::prune_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
-  for (auto local_snap = m_local_group_snaps.begin();
-      local_snap != m_local_group_snaps.end(); ++local_snap) {
-    auto snap_type = cls::rbd::get_group_snap_namespace_type(
-        local_snap->snapshot_namespace);
-    if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-      bool prune_user_snap = true;
-      for (auto &remote_snap : m_remote_group_snaps) {
-        if (remote_snap.id == local_snap->id) {
-          prune_user_snap = false;
-          break;
-        }
-      }
-      if (!prune_user_snap) {
-        continue;
-      }
-      dout(10) << "pruning user group snap in-progress: "
-               << local_snap->name << ", with id: " << local_snap->id << dendl;
-      // prune all the image snaps of the group snap locally
-      if (!prune_all_image_snapshots(&(*local_snap), locker)) {
-        continue;
-      }
-      dout(10) << "all image snaps are pruned, finally pruning user group snap: "
-               << local_snap->id << dendl;
-      r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-             librbd::util::group_header_name(m_local_group_id), local_snap->id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot : "
-             << local_snap->id << " : " << cpp_strerror(r) << dendl;
-      }
-    }
+  dout(10) << dendl;
+
+  m_refresh_snaps = false;
+  int r = prune_user_group_snapshots(locker);
+  if (r != 0) {
+    return r;
   }
+
+  return prune_mirror_group_snapshot(locker);
 }
 
 template <typename I>
-void Replayer<I>::prune_mirror_group_snapshots(
+int Replayer<I>::prune_user_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
-  bool is_prior_snap_user = false;
-  bool skip_next_snap_check = false;
-  cls::rbd::GroupSnapshot *prune_snap = nullptr;
-  auto last_local_snap_id = m_local_group_snaps.rbegin()->id;
-  for (auto local_snap = m_local_group_snaps.begin();
-      local_snap != m_local_group_snaps.end(); ++local_snap) {
-    auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &local_snap->snapshot_namespace);
-    if (local_snap_ns == nullptr) {
-      if (local_snap->state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
-        break;
-      }
-    } else if (!is_mirror_group_snapshot_complete(local_snap->state,
-                                                  local_snap_ns->complete)) {
-        break;
-    }
+  dout(20) << dendl;
+
+  std::unordered_set<std::string> remote_snap_ids;
+  for (const auto& remote_snap : m_remote_group_snaps) {
+    remote_snap_ids.insert(remote_snap.id);
+  }
+
+  // prune all eligible user snapshots in a single replayer cycle
+  for (auto& local_snap : m_local_group_snaps) {
     auto snap_type = cls::rbd::get_group_snap_namespace_type(
-        local_snap->snapshot_namespace);
-    if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-      is_prior_snap_user = true;
-      if (prune_snap) { // snapshot before user snap exists ?
-        // delete snap before user snap, only if the user snap has next complete mirror snap
-        auto next_local_snap = std::next(local_snap);
-        if (next_local_snap == m_local_group_snaps.end()) {
-          break; // no next snap.
-        }
-        auto next_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &next_local_snap->snapshot_namespace);
-        if (next_local_snap_ns == nullptr) {
-          continue; // next snap is user snap again.
-        } else if (
-          !is_mirror_group_snapshot_complete(next_local_snap->state,
-                                             next_local_snap_ns->complete)) {
-          break; // next snap is not complete yet.
-        }
-      }
-      continue;
-    }
-    if (!prune_snap) {
-      prune_snap = &(*local_snap);
-    }
-
-    if (is_prior_snap_user) {
-      is_prior_snap_user = false; // free to continue prune on next iteratation
-      skip_next_snap_check = true; // as we are pruning mirror snap before user snap
+        local_snap.snapshot_namespace);
+    if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
       continue;
     }
 
-    if (!skip_next_snap_check) {
-      auto next_local_snap = std::next(local_snap);
-      // If next local snap is end, or if it is the syncing in-progress snap,
-      // then we still need this group snapshot.
-      if (next_local_snap == m_local_group_snaps.end()) {
-        break;
-      } else if (next_local_snap->id == last_local_snap_id) {
-        auto next_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &next_local_snap->snapshot_namespace);
-        if (next_local_snap_ns == nullptr) {
-          if (next_local_snap->state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
-            break;
-          }
-        } else if (!is_mirror_group_snapshot_complete(next_local_snap->state,
-                                                      next_local_snap_ns->complete)) {
-          break;
-        }
-      } else {
-        auto next_snap_type = cls::rbd::get_group_snap_namespace_type(
-            next_local_snap->snapshot_namespace);
-        if (next_snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-          continue;
-        }
-      }
-    }
-    mirror_group_snapshot_unlink_peer(prune_snap->id);
-    const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-        prune_snap->snapshot_namespace);
-    if (ns.is_primary() ||
-        !prune_all_image_snapshots(prune_snap, locker)) {
-      prune_snap = nullptr;
-      skip_next_snap_check = false;
+    if (remote_snap_ids.contains(local_snap.id)) {
       continue;
     }
-    dout(10) << "all image snaps are pruned, finally pruning mirror group snap: "
-             << prune_snap->id << dendl;
-    r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-        librbd::util::group_header_name(m_local_group_id), prune_snap->id);
-    if (r < 0) {
-      derr << "failed to remove group snapshot : "
-           << prune_snap->id << " : " << cpp_strerror(r) << dendl;
+
+    dout(10) << "pruning user group snap in-progress: " << local_snap.name
+             << ", with id: " << local_snap.id << dendl;
+    int r = prune_group_snapshot(&local_snap, locker);
+    if (r != 0) {
+      return r;
     }
-    prune_snap = nullptr;
-    skip_next_snap_check = false;
   }
+
+  return 0;
 }
 
 template <typename I>
-void Replayer<I>::prune_group_snapshots(std::unique_lock<ceph::mutex>* locker) {
-  if (m_local_group_snaps.empty()) {
-    return;
+int Replayer<I>::prune_mirror_group_snapshot(
+    std::unique_lock<ceph::mutex>* locker) {
+  dout(20) << dendl;
+
+  // prune only a single mirror snapshot per replayer cycle
+  if (!m_prune_group_snap) {
+    return 0;
   }
-  prune_user_group_snapshots(locker);
-  prune_mirror_group_snapshots(locker);
+
+  mirror_group_snapshot_unlink_peer(m_prune_group_snap->id);
+
+  dout(10) << "pruning mirror group snap in-progress: "
+           << m_prune_group_snap->name << ", with id: "
+           << m_prune_group_snap->id << dendl;
+
+  return prune_group_snapshot(m_prune_group_snap, locker);
 }
 
 template <typename I>
-std::string Replayer<I>::get_global_image_id( ImageReplayer<I>* image_replayer,
+int Replayer<I>::prune_group_snapshot(
+    const cls::rbd::GroupSnapshot* snap,
+    std::unique_lock<ceph::mutex>* locker) {
+  dout(20) << "snap=" << snap->id << dendl;
+
+  // prune image snapshots first
+  if (!prune_all_image_snapshots(snap, locker)) {
+    dout(20) << "image snapshot pruning still in progress for "
+             << snap->id << dendl;
+    return -EAGAIN;
+  }
+
+  dout(10) << "all image snapshots pruned, removing group snapshot: "
+           << snap->id << dendl;
+  int r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
+      librbd::util::group_header_name(m_local_group_id), snap->id);
+  if (r < 0 && r != -ENOENT) {
+    derr << "failed to remove group snapshot " << snap->id << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // local snapshot state changed
+  m_refresh_snaps = true;
+
+  return 0;
+}
+
+template <typename I>
+std::string Replayer<I>::get_global_image_id(ImageReplayer<I>* image_replayer,
     std::unique_lock<ceph::mutex>& locker) {
 
   if (!image_replayer) {

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -200,12 +200,19 @@ void Replayer<I>::handle_schedule_load_group_snapshots(int r) {
     if (m_state != STATE_REPLAYING) {
       return;
     }
+
+    ceph_assert(m_load_snapshots_task != nullptr);
+    m_load_snapshots_task = nullptr;
+
+    if (m_retry_validate_snap) {
+      m_retry_validate_snap = false;
+      if (!m_local_group_snaps.empty() && !m_check_creating_snaps) {
+        validate_local_group_snapshots(&locker);
+        return;
+      }
+    }
+    load_replayer(&locker);
   }
-
-  ceph_assert(m_load_snapshots_task != nullptr);
-  m_load_snapshots_task = nullptr;
-
-  is_resync_requested();
 }
 
 template <typename I>
@@ -381,17 +388,81 @@ void Replayer<I>::init(Context* on_finish) {
   on_finish->complete(0);
 
   m_update_group_state = true;
-  is_resync_requested();
+  {
+    std::unique_lock locker{m_lock};
+    load_replayer(&locker);
+  }
 }
 
 template <typename I>
-void Replayer<I>::is_resync_requested() {
+void Replayer<I>::validate_local_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker) {
   dout(10) << "m_local_group_id=" << m_local_group_id << dendl;
+
+  m_in_flight_op_tracker.start_op();
+  locker->unlock();
+
+  // prepare gather context for async operations
+  auto ctx = new LambdaContext([this](int) {
+    std::unique_lock locker{m_lock};
+    m_in_flight_op_tracker.finish_op();
+    load_replayer(&locker);
+  });
+
+  C_Gather *gather_ctx = new C_Gather(g_ceph_context, ctx);
+
+  // process snapshots requiring validation
+  for (auto &local_snap : m_local_group_snaps) {
+    // skip validation for already complete snapshots
+    auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+        &local_snap.snapshot_namespace);
+    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
+      if (ns == nullptr) {
+        // user group snapshot
+        continue;
+      }
+      if (is_mirror_group_snapshot_complete(local_snap.state, ns->complete)) {
+        continue;
+      }
+    }
+
+    // skip validation for primary snapshots
+    if (ns != nullptr && ns->is_primary()) {
+      continue;
+    }
+
+    // setup validation callback
+    Context *sub_ctx = gather_ctx->new_sub();
+    auto ctx = new LambdaContext([sub_ctx](int r) {
+      sub_ctx->complete(r);
+    });
+
+    // validate incomplete non-primary mirror or regular snapshots
+    validate_image_snaps_sync_complete(local_snap, ctx);
+  }
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::load_replayer(
+    std::unique_lock<ceph::mutex>* locker) {
+  dout(10) << "m_global_group_id=" << m_global_group_id << dendl;
+  if (is_replay_interrupted(locker)) {
+    return;
+  }
+
+  is_resync_requested(locker);
+}
+
+template <typename I>
+void Replayer<I>::is_resync_requested(
+    std::unique_lock<ceph::mutex>* locker) {
 
   librados::ObjectReadOperation op;
   librbd::cls_client::metadata_get_start(&op, RBD_GROUP_RESYNC);
 
   m_out_bl.clear();
+  m_resync_requested = false;
 
   std::string group_header_oid = librbd::util::group_header_name(
       m_local_group_id);
@@ -426,9 +497,206 @@ void Replayer<I>::handle_is_resync_requested(int r) {
   } else if (r == 0) {
     dout(10) << "local group resync requested" << dendl;
     m_resync_requested = true;
-    load_remote_group_snapshots();
+  }
+
+  if (m_resync_requested) {
+    load_remote_group_snapshots(&locker);
     return;
   }
+  load_local_group_snapshots(&locker);
+}
+
+template <typename I>
+void Replayer<I>::load_remote_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker) {
+
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  m_in_flight_op_tracker.start_op();
+  m_remote_group_snaps.clear();
+
+  auto ctx = new LambdaContext(
+    [this] (int r) {
+      handle_load_remote_group_snapshots(r);
+      m_in_flight_op_tracker.finish_op();
+  });
+
+  auto req = librbd::group::ListSnapshotsRequest<I>::create(m_remote_io_ctx,
+      m_remote_group_id, true, true, &m_remote_group_snaps, ctx);
+  req->send();
+}
+
+template <typename I>
+void Replayer<I>::handle_load_remote_group_snapshots(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  std::unique_lock locker{m_lock};
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
+
+  if (r < 0) {  // may be remote group is deleted?
+    derr << "error listing remote mirror group snapshots: " << cpp_strerror(r)
+         << dendl;
+    handle_replay_complete(&locker, r, "failed to list remote group snapshots");
+    return;
+  }
+
+  for (auto remote_snap = m_remote_group_snaps.begin();
+       remote_snap != m_remote_group_snaps.end(); ) {
+    auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+        &remote_snap->snapshot_namespace);
+    if (remote_snap_ns == nullptr) {
+      ++remote_snap;
+      continue;
+    }
+    if (remote_snap_ns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) == 0) {
+      dout(10) << "filtering out snapshot " << remote_snap->id
+               << " with no matching mirror_peer_uuid in: "
+               << remote_snap_ns->mirror_peer_uuids << " (expected: "
+               << m_remote_mirror_peer_uuid << ")" << dendl;
+      remote_snap = m_remote_group_snaps.erase(remote_snap);
+    } else {
+      ++remote_snap;
+    }
+  }
+
+  if (m_resync_requested) {
+    if (is_group_primary(m_remote_group_snaps)) { // remote group primary
+      handle_replay_complete(&locker, 0, "resync requested");
+      return;
+    }
+    load_local_group_snapshots(&locker);
+    return;
+  }
+  check_local_group_snapshots(&locker);
+}
+
+template <typename I>
+void Replayer<I>::load_local_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker) {
+
+  m_in_flight_op_tracker.start_op();
+  m_local_group_snaps.clear();
+
+  auto ctx = new LambdaContext(
+    [this] (int r) {
+      handle_load_local_group_snapshots(r);
+      m_in_flight_op_tracker.finish_op();
+  });
+
+  auto req = librbd::group::ListSnapshotsRequest<I>::create(m_local_io_ctx,
+      m_local_group_id, true, true, &m_local_group_snaps, ctx);
+  req->send();
+}
+
+template <typename I>
+void Replayer<I>::handle_load_local_group_snapshots(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  std::unique_lock locker{m_lock};
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
+
+  if (r < 0) {
+    derr << "error listing local mirror group snapshots: " << cpp_strerror(r)
+         << dendl;
+    handle_replay_complete(&locker, r, "failed to list local group snapshots");
+    return;
+  }
+
+  // We must determine whether the local group is already primary here.
+  // Otherwise, if the remote group snapshots are unavailable for any reason,
+  // replayer will incorrectly report an error status for the local group.
+  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
+  if (last_local_snap) {
+    const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+        last_local_snap->snapshot_namespace);
+    if (ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
+      // Remove any stale 'creating' mirror group snapshots that may have been
+      // left behind if the daemon restarted before replay completed. This must
+      // happen here, because before we can go to any scanning of unsynced snaps
+      // it is efficient to be ready, so that, the replay logic sees a clean
+      // local snapshot state and recreates any missing snapshots.
+      if (m_check_creating_snaps) {
+        prune_creating_group_snapshots_if_any(&locker);
+        return;
+      }
+      if (ns.is_orphan()) {
+        dout(5) << "local group being force promoted" << dendl;
+        handle_replay_complete(&locker, 0, "orphan (force promoting)");
+        return;
+      }
+      if (!is_mirror_group_snapshot_complete(last_local_snap->state,
+                                             ns.complete)) {
+        m_retry_validate_snap = true;
+      }
+    } else { // local is primary
+      handle_replay_complete(&locker, 0, "local group is primary");
+      return;
+    }
+  }
+
+  if (m_resync_requested) {
+    m_resync_requested = false;
+    check_local_group_snapshots(&locker);
+    return;
+  }
+  load_remote_group_snapshots(&locker);
+}
+
+template <typename I>
+void Replayer<I>::check_local_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker) {
+  if (m_local_group_snaps.empty()) {
+    m_check_creating_snaps = false;
+    is_rename_requested();
+    return;
+  }
+
+  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
+  ceph_assert(last_local_snap != nullptr);
+
+  dout(10) << "local mirror snapshot=" << last_local_snap->id << dendl;
+
+  const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      last_local_snap->snapshot_namespace);
+  if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
+    bool split_brain = true;
+    for (const auto& remote_snap : m_remote_group_snaps) {
+      if (remote_snap.id != last_local_snap->id) {
+        continue;
+      }
+      const auto* remote_ns =
+          std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+              &remote_snap.snapshot_namespace);
+      if (remote_ns != nullptr && remote_ns->state ==
+          cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
+        split_brain = false;
+        break;
+      }
+    }
+    if (split_brain) {
+      handle_replay_complete(locker, -EEXIST, "split-brain");
+      return;
+    }
+    m_check_creating_snaps = false;
+  } else if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
+    auto last_remote_snap =
+      get_latest_mirror_group_snapshot(m_remote_group_snaps);
+    if (last_remote_snap != nullptr &&
+        last_local_snap->id == last_remote_snap->id && !m_retry_validate_snap) {
+      handle_replay_complete(locker, -EREMOTEIO, "remote group demoted");
+      return;
+    }
+  }
+
+  if (m_retry_validate_snap) {
+    locker->unlock();
+    schedule_load_group_snapshots();
+    return;
+  }
+  prune_group_snapshots(locker);
 
   is_rename_requested();
 }
@@ -441,8 +709,7 @@ void Replayer<I>::is_rename_requested() {
   librbd::cls_client::dir_get_name_start(&op, m_remote_group_id);
   m_out_bl.clear();
   m_in_flight_op_tracker.start_op();
-  auto comp = create_rados_callback(
-    new LambdaContext([this](int r) {
+  auto comp = create_rados_callback(new LambdaContext([this](int r) {
       handle_is_rename_requested(r);
       m_in_flight_op_tracker.finish_op();
     }));
@@ -476,263 +743,7 @@ void Replayer<I>::handle_is_rename_requested(int r) {
     return;
   }
 
-  auto ctx = new LambdaContext(
-    [this](int r) {
-      validate_local_group_snapshots();
-      m_in_flight_op_tracker.finish_op();
-    });
-  m_in_flight_op_tracker.start_op();
-  m_threads->work_queue->queue(ctx, 0);
-}
-
-template <typename I>
-void Replayer<I>::validate_local_group_snapshots() {
-  dout(10) << "m_local_group_id=" << m_local_group_id << dendl;
-
-  std::unique_lock locker{m_lock};
-  if (is_replay_interrupted(&locker)) {
-    return;
-  }
-
-  if (m_local_group_snaps.empty() || m_check_creating_snaps) {
-    load_local_group_snapshots(&locker);
-    return;
-  }
-
-  m_in_flight_op_tracker.start_op();
-  locker.unlock();
-
-  // prepare gather context for async operations
-  auto ctx = new LambdaContext([this](int) {
-    std::unique_lock locker{m_lock};
-    m_in_flight_op_tracker.finish_op();
-    load_local_group_snapshots(&locker);
-  });
-
-  C_Gather *gather_ctx = new C_Gather(g_ceph_context, ctx);
-
-  // process snapshots requiring validation
-  for (auto &local_snap : m_local_group_snaps) {
-    // skip validation for already complete snapshots
-    auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &local_snap.snapshot_namespace);
-    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
-      if (ns == nullptr) {
-        // user group snapshot
-        continue;
-      }
-      if (is_mirror_group_snapshot_complete(local_snap.state, ns->complete)) {
-        continue;
-      }
-    }
-
-    // skip validation for primary snapshots
-    if (ns != nullptr && ns->is_primary()) {
-      continue;
-    }
-
-    // setup validation callback
-    Context *sub_ctx = gather_ctx->new_sub();
-    auto ctx = new LambdaContext([this, sub_ctx](int r) {
-      if (r < 0) {
-        std::unique_lock locker{m_lock};
-        m_retry_validate_snap = true;
-      }
-      sub_ctx->complete(r);
-    });
-
-    // validate incomplete non-primary mirror or regular snapshots
-    validate_image_snaps_sync_complete(local_snap, ctx);
-  }
-  gather_ctx->activate();
-}
-
-template <typename I>
-void Replayer<I>::load_local_group_snapshots(
-    std::unique_lock<ceph::mutex>* locker) {
-  if (is_replay_interrupted(locker)) {
-    return;
-  }
-
-  m_in_flight_op_tracker.start_op();
-  m_local_group_snaps.clear();
-
-  auto ctx = new LambdaContext(
-    [this] (int r) {
-      handle_load_local_group_snapshots(r);
-      m_in_flight_op_tracker.finish_op();
-  });
-
-  auto req = librbd::group::ListSnapshotsRequest<I>::create(m_local_io_ctx,
-      m_local_group_id, true, true, &m_local_group_snaps, ctx);
-  req->send();
-}
-
-template <typename I>
-void Replayer<I>::handle_load_local_group_snapshots(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  std::unique_lock locker{m_lock};
-  if (is_replay_interrupted(&locker)) {
-    return;
-  }
-
-  if (r < 0) {
-    derr << "error listing local mirror group snapshots: " << cpp_strerror(r)
-         << dendl;
-    handle_replay_complete(&locker, r, "failed to list local group snapshots");
-    return;
-  }
-
-  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
-  if (!last_local_snap) { // no snaps synced yet
-    m_check_creating_snaps = false;
-    load_remote_group_snapshots();
-    return;
-  }
-
-  const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-      last_local_snap->snapshot_namespace);
-  // handle mirror snapshot states
-  if (ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
-    if (ns.is_orphan()) {
-      dout(5) << "local group being force promoted" << dendl;
-      handle_replay_complete(&locker, 0, "orphan (force promoting)");
-      return;
-    }
-    if (m_check_creating_snaps) {
-      prune_creating_group_snapshots_if_any(&locker);
-      return;
-    }
-    if (!is_mirror_group_snapshot_complete(last_local_snap->state, ns.complete)) {
-      m_retry_validate_snap = true;
-    }
-  } else {  // primary snapshot
-    if (is_mirror_group_snapshot_complete(last_local_snap->state, ns.complete)) {
-      handle_replay_complete(&locker, 0, "local group is primary");
-      return;
-    }
-    dout(10) << "found incomplete primary group snapshot: "
-             << last_local_snap->id << dendl;
-    m_retry_validate_snap = true;
-  }
-
-  load_remote_group_snapshots();
-}
-
-template <typename I>
-void Replayer<I>::load_remote_group_snapshots() {
-  dout(10) << "m_remote_group_id=" << m_remote_group_id << dendl;
-
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
-  m_in_flight_op_tracker.start_op();
-  m_remote_group_snaps.clear();
-
-  auto ctx = new LambdaContext(
-    [this] (int r) {
-      handle_load_remote_group_snapshots(r);
-      m_in_flight_op_tracker.finish_op();
-  });
-
-  auto req = librbd::group::ListSnapshotsRequest<I>::create(m_remote_io_ctx,
-      m_remote_group_id, true, true, &m_remote_group_snaps, ctx);
-  req->send();
-}
-
-template <typename I>
-void Replayer<I>::handle_load_remote_group_snapshots(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  std::unique_lock locker{m_lock};
-  if (is_replay_interrupted(&locker)) {
-    return;
-  }
-
-  if (r < 0) {  // may be remote group is deleted?
-    derr << "error listing remote mirror group snapshots: " << cpp_strerror(r)
-         << dendl;
-    handle_replay_complete(&locker, r, "failed to list remote group snapshots");
-    return;
-  }
-
-  if (m_resync_requested) {
-    if (is_group_primary(m_remote_group_snaps)) {
-      handle_replay_complete(&locker, 0, "resync requested");
-      return;
-    }
-    dout(10) << "cannot resync as remote is not primary" << dendl;
-    m_resync_requested = false;
-    is_rename_requested();
-    return;
-  }
-
-  if (m_retry_validate_snap) {
-    m_retry_validate_snap = false;
-    locker.unlock();
-    schedule_load_group_snapshots();
-    return;
-  }
-
-  for (auto remote_snap = m_remote_group_snaps.begin();
-       remote_snap != m_remote_group_snaps.end(); ) {
-    auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &remote_snap->snapshot_namespace);
-    if (remote_snap_ns == nullptr) {
-      ++remote_snap;
-      continue;
-    }
-    if (remote_snap_ns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) == 0) {
-      dout(10) << "filtering out snapshot " << remote_snap->id
-               << " with no matching mirror_peer_uuid in: "
-               << remote_snap_ns->mirror_peer_uuids << " (expected: "
-               << m_remote_mirror_peer_uuid << ")" << dendl;
-      remote_snap = m_remote_group_snaps.erase(remote_snap);
-    } else {
-      ++remote_snap;
-    }
-  }
-  check_local_group_snapshots(&locker);
-}
-
-template <typename I>
-void Replayer<I>::check_local_group_snapshots(
-    std::unique_lock<ceph::mutex>* locker) {
-  if (!m_local_group_snaps.empty()) {
-    prune_group_snapshots(locker);
-    auto last_local_snap = get_latest_group_snapshot(m_local_group_snaps);
-    auto last_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &last_local_snap->snapshot_namespace);
-    if (last_local_snap_ns &&
-        last_local_snap_ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED &&
-        !m_remote_group_snaps.empty()) {
-      if (last_local_snap->id == m_remote_group_snaps.rbegin()->id) {
-        handle_replay_complete(locker, -EREMOTEIO, "remote group demoted");
-        return;
-      }
-    } else if (last_local_snap_ns &&
-     last_local_snap_ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
-      bool split_brain = true;
-      for (auto it = m_remote_group_snaps.begin();
-           it != m_remote_group_snaps.end(); it++) {
-        auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-             &it->snapshot_namespace);
-        if (ns == nullptr ||
-            it->id != last_local_snap->id) {
-          continue;
-        }
-        if (ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
-          split_brain = false;
-          break;
-        }
-      }
-      if (split_brain) {
-        handle_replay_complete(locker, -EEXIST, "split-brain");
-        return;
-      }
-    }
-  }
-
-  scan_for_unsynced_group_snapshots(locker);
+  scan_for_unsynced_group_snapshots(&locker);
 }
 
 template <typename I>
@@ -1040,6 +1051,8 @@ void Replayer<I>::handle_create_mirror_snapshot(
     derr << "failed to create mirror snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
+
+  m_retry_validate_snap = true;
 
   on_finish->complete(r);
 }
@@ -1448,6 +1461,8 @@ void Replayer<I>::handle_create_user_snapshot(
     derr << "failed to create user snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
+
+  m_retry_validate_snap = true;
 
   on_finish->complete(r);
 }

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -47,17 +47,6 @@ const cls::rbd::GroupSnapshot* get_latest_group_snapshot(
   return nullptr;
 }
 
-const cls::rbd::GroupSnapshot* get_latest_mirror_group_snapshot(
-    const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
-  for (auto it = gp_snaps.rbegin(); it != gp_snaps.rend(); ++it) {
-    if (cls::rbd::get_group_snap_namespace_type(it->snapshot_namespace) ==
-         cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-      return &*it;
-    }
-  }
-  return nullptr;
-}
-
 const cls::rbd::GroupSnapshot* get_latest_complete_mirror_group_snapshot(
     const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
   for (auto it = gp_snaps.rbegin(); it != gp_snaps.rend(); ++it) {
@@ -605,13 +594,37 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
     return;
   }
 
+  auto prune_creating_group_snaps =
+    std::make_shared<std::vector<cls::rbd::GroupSnapshot>>();
+  m_last_local_snap = nullptr;
+  for (const auto& local_snap : m_local_group_snaps) {
+    // latest mirror snapshot (keep updating)
+    if (cls::rbd::get_group_snap_namespace_type(
+          local_snap.snapshot_namespace) ==
+        cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
+      m_last_local_snap = &local_snap;
+    }
+
+    // collect creating snapshots
+    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
+      auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+          &local_snap.snapshot_namespace);
+
+      if (local_snap_ns && local_snap_ns->is_primary()) {
+        continue;
+      }
+
+      prune_creating_group_snaps->push_back(local_snap);
+    }
+  }
+
   // We must determine whether the local group is already primary here.
   // Otherwise, if the remote group snapshots are unavailable for any reason,
   // replayer will incorrectly report an error status for the local group.
-  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
-  if (last_local_snap) {
+  m_retry_validate_snap = false;
+  if (m_last_local_snap) {
     const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-        last_local_snap->snapshot_namespace);
+        m_last_local_snap->snapshot_namespace);
     if (ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
       // Remove any stale 'creating' mirror group snapshots that may have been
       // left behind if the daemon restarted before replay completed. This must
@@ -619,7 +632,7 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
       // it is efficient to be ready, so that, the replay logic sees a clean
       // local snapshot state and recreates any missing snapshots.
       if (m_check_creating_snaps) {
-        prune_creating_group_snapshots_if_any(&locker);
+        prune_creating_group_snapshots(&locker, prune_creating_group_snaps);
         return;
       }
       if (ns.is_orphan()) {
@@ -627,7 +640,7 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
         handle_replay_complete(&locker, 0, "orphan (force promoting)");
         return;
       }
-      if (!is_mirror_group_snapshot_complete(last_local_snap->state,
+      if (!is_mirror_group_snapshot_complete(m_last_local_snap->state,
                                              ns.complete)) {
         m_retry_validate_snap = true;
       }
@@ -654,17 +667,16 @@ void Replayer<I>::check_local_group_snapshots(
     return;
   }
 
-  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
-  ceph_assert(last_local_snap != nullptr);
+  ceph_assert(m_last_local_snap != nullptr);
 
-  dout(10) << "local mirror snapshot=" << last_local_snap->id << dendl;
+  dout(10) << "local mirror snapshot=" << m_last_local_snap->id << dendl;
 
   const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-      last_local_snap->snapshot_namespace);
+      m_last_local_snap->snapshot_namespace);
   if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
     bool split_brain = true;
     for (const auto& remote_snap : m_remote_group_snaps) {
-      if (remote_snap.id != last_local_snap->id) {
+      if (remote_snap.id != m_last_local_snap->id) {
         continue;
       }
       const auto* remote_ns =
@@ -681,11 +693,9 @@ void Replayer<I>::check_local_group_snapshots(
       return;
     }
     m_check_creating_snaps = false;
-  } else if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
-    auto last_remote_snap =
-      get_latest_mirror_group_snapshot(m_remote_group_snaps);
-    if (last_remote_snap != nullptr &&
-        last_local_snap->id == last_remote_snap->id && !m_retry_validate_snap) {
+  } else if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED &&
+             !m_retry_validate_snap && !m_remote_group_snaps.empty()) {
+    if (m_last_local_snap->id == m_remote_group_snaps.rbegin()->id) {
       handle_replay_complete(locker, -EREMOTEIO, "remote group demoted");
       return;
     }
@@ -1848,25 +1858,11 @@ bool Replayer<I>::prune_all_image_snapshots_by_gsid(
 // Check for non-primary mirror and user group snapshots in CREATING state,
 // and prune them on daemon restart.
 template <typename I>
-void Replayer<I>::prune_creating_group_snapshots_if_any(
-    std::unique_lock<ceph::mutex>* locker) {
-  auto prune_group_snaps =
-    std::make_shared<std::vector<cls::rbd::GroupSnapshot>>();
-  for (const auto& local_snap : m_local_group_snaps) {
-    if (local_snap.state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
-      continue;
-    }
-    auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &local_snap.snapshot_namespace);
-    // skip primary snapshots;
-    // only prune non-primary mirror and user snapshots in CREATING state
-    if (local_snap_ns && local_snap_ns->is_primary()) {
-      continue;
-    }
-    prune_group_snaps->push_back(local_snap);
-  }
+void Replayer<I>::prune_creating_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker,
+    std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps) {
 
-  if (prune_group_snaps->empty()) {
+  if (prune_creating_group_snaps->empty()) {
     // not found creating snapshots
     m_check_creating_snaps = false;
     locker->unlock();
@@ -1879,7 +1875,7 @@ void Replayer<I>::prune_creating_group_snapshots_if_any(
   auto local_images =
     std::make_shared<std::vector<cls::rbd::GroupImageStatus>>();
   auto* ctx = new LambdaContext(
-    [this, local_images, prune_group_snaps](int r) {
+    [this, local_images, prune_creating_group_snaps](int r) {
       if (r < 0) {
         derr << "failed to list group images: "
              << cpp_strerror(r) << dendl;
@@ -1888,8 +1884,8 @@ void Replayer<I>::prune_creating_group_snapshots_if_any(
         return;
       }
 
-      handle_prune_creating_group_snapshots_if_any(
-        *local_images, *prune_group_snaps);
+      handle_prune_creating_group_snapshots(
+        *local_images, *prune_creating_group_snaps);
     });
 
   // initiate image listing
@@ -1897,31 +1893,36 @@ void Replayer<I>::prune_creating_group_snapshots_if_any(
 }
 
 template <typename I>
-void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
+void Replayer<I>::handle_prune_creating_group_snapshots(
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
-    const std::vector<cls::rbd::GroupSnapshot>& prune_group_snaps) {
-  int r = 0;
-  {
-    std::unique_lock locker{m_lock};
-    for (const auto& local_snap : prune_group_snaps) {
-      if (!prune_all_image_snapshots_by_gsid(
-            local_snap.id, local_images, &locker)) {
-        // still pending image snapshots; retry later
-        continue;
-      }
-      dout(10) << "all image snapshots pruned; removing creating group snapshot: "
+    const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps) {
+  std::unique_lock locker{m_lock};
+  for (const auto& local_snap : prune_creating_group_snaps) {
+    if (!prune_all_image_snapshots_by_gsid(
+          local_snap.id, local_images, &locker)) {
+      // still pending image snapshots; retry later
+      dout(20) << "image snapshots still pending for: "
                << local_snap.id << dendl;
-      r = librbd::cls_client::group_snap_remove(
-          &m_local_io_ctx,
-          librbd::util::group_header_name(m_local_group_id),
-          local_snap.id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot "
-             << local_snap.id << ": "
-             << cpp_strerror(r) << dendl;
-      }
+      continue;
+    }
+
+    dout(10) << "all image snapshots pruned; removing creating group snapshot: "
+             << local_snap.id << dendl;
+
+    int r = librbd::cls_client::group_snap_remove(
+      &m_local_io_ctx,
+      librbd::util::group_header_name(m_local_group_id),
+      local_snap.id);
+
+    if (r < 0) {
+      derr << "failed to remove group snapshot "
+           << local_snap.id << ": "
+           << cpp_strerror(r) << dendl;
     }
   }
+
+  m_check_creating_snaps = false;
+  locker.unlock();
   schedule_load_group_snapshots();
 }
 

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -110,7 +110,7 @@ private:
   std::vector<cls::rbd::GroupSnapshot> m_remote_group_snaps;
   std::vector<std::pair<std::string, ImageReplayer<ImageCtxT> *>> m_replayers_by_image_id;
   const cls::rbd::GroupSnapshot* m_last_local_snap = nullptr;
-
+  const cls::rbd::GroupSnapshot* m_prune_group_snap = nullptr;
   bool m_update_group_state = true;
 
   Context* m_load_snapshots_task = nullptr;
@@ -131,6 +131,7 @@ private:
 
   bool m_check_creating_snaps = true; // check and identify creating snaps just after restart
   bool m_resync_requested = false;
+  bool m_refresh_snaps = false;
 
   bool is_replay_interrupted(std::unique_lock<ceph::mutex>* locker);
 
@@ -249,17 +250,20 @@ private:
       const std::vector<cls::rbd::GroupImageStatus>& local_images,
       std::unique_lock<ceph::mutex>* locker);
   bool prune_all_image_snapshots(
-      cls::rbd::GroupSnapshot *local_snap,
+      const cls::rbd::GroupSnapshot *local_snap,
       std::unique_lock<ceph::mutex>* locker);
-  void prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
-  void prune_mirror_group_snapshots(std::unique_lock<ceph::mutex>* locker);
-  void prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+
   void prune_creating_group_snapshots(
-      std::unique_lock<ceph::mutex>* locker,
-      std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps);
+      std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_snaps);
   void handle_prune_creating_group_snapshots(
       const std::vector<cls::rbd::GroupImageStatus>& local_images,
-      const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps);
+      const std::vector<cls::rbd::GroupSnapshot>& prune_creating_snaps);
+
+  int prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  int prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  int prune_mirror_group_snapshot(std::unique_lock<ceph::mutex>* locker);
+  int prune_group_snapshot(const cls::rbd::GroupSnapshot* snap,
+                           std::unique_lock<ceph::mutex>* locker);
 
   void get_replayers_by_image_id(std::unique_lock<ceph::mutex>* locker);
   std::string get_global_image_id(ImageReplayer<ImageCtxT>* image_replayer,

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -82,6 +82,229 @@ public:
 
 
 private:
+/**
+ * GROUP REPLAYER:
+ * ==============
+ *
+ * At a high level, the Replayer keeps the local mirror group on the secondary
+ * cluster synchronized with the remote primary group. It loads local and
+ * remote group snapshots, validates snapshot synchronization, creates new
+ * group snapshots, waits for image replay and marks group snaps to complete,
+ * updates group state, and prunes snapshots that are no longer needed.
+ *
+ * STATES:
+ * ======
+ *
+ * STATE_INIT: Initial state after construction. No work has been started.
+ * STATE_REPLAYING: Actively loading snapshots, creating new snapshots and wait
+ *             for replays to complete. And prune snapshots no longer needed.
+ * STATE_IDLE: Up to date with the snapshots sync. No work pending. Waiting for
+ *             the scheduler to trigger the next scan.
+ * STATE_COMPLETE: Shutdown has completed. No further work will be scheduled.
+ *
+ *
+ * STATE MACHINE:
+ * =============
+ *
+ * @verbatim
+ *                                             CONSTRUCTOR
+ *                                                 | m_state = STATE_INIT
+ *                                                 v
+ *                                               INIT
+ *                                                 | m_state = STATE_REPLAYING
+ *                                                 v
+ *                                           LOAD_REPLAYER <---------------------------------------------------------------------- +
+ *                                                 |                                                                               ^
+ *                                                 v                                                                               |
+ *                                         IS_RESYNC_REQUESTED                                                                     |
+ *                                                 |  m_resync_requested ?                                                         |
+ *                                   true          v         false                                                                 |
+ *                         + <-------------------- + ------------------------> +                                                   |
+ *                         |                                                   |                                                   |
+ *                         v                                                   v                                                   |
+ *                         + <--------------------------------- +     + -----> +                                                   |
+ *                         |                                    ^     ^        |                                                   |
+ *                         v                                    |     |        v                                                   |
+ *             LOAD_REMOTE_GROUP_SNAPSHOTS                      |     | LOAD_LOCAL_GROUP_SNAPSHOTS                                 |
+ *                         |                                    |     |        |                                                   |
+ *                         | m_resync_requested ?               |     |        v role: primary? true                               |
+ *              false      v       true                         |     |        + ----------------------------------------> +     ^ |
+ *           + ----------- + ---------------- +                 |     |  false |     daemon restart one-time check:        |     | |
+ *           |                                |  remote         |     |        v               snaps in creating phase    ╭─╮  --+ |
+ *           + <------------------ +          v  primary? false╭─╮    |        + -----> PRUNE_CREATING_GROUP_SNAPSHOTS ->-╯|╰----> +
+ *           |                     ^          + ------------->-╯|╰--> +        |                                           |       |
+ *           v                     |          | true            |              v  is last group snap orphan ? true         v       |
+ *  CHECK_LOCAL_GROUP_SNAPSHOTS    |          |                 |              + ----------------------------------------> +       |
+ *           |                     |          |                 |        false |  if incomplete mirror snapshot is found,  |       |
+ *  no snaps v                     |          |                 |              v   set m_retry_validate_snap = true        |       |
+ *    + <--- + ----> +             |          |                 + <----------- +                                           |       |
+ *    |              |             |         ╭─╮                      false    | m_resync_requested?                       |       |
+ *    |              |             + <-------╯|╰-<---------------------------- +                                           |       |
+ *    |              |                        |                       true                                                 |       |
+ *    |              |                        |                                                                            |       |
+ *    |              v  demoted/split-brain   v                                                                            v       |
+ *    |              + ---------------------> + -------------------------------------------------------------------------> +       |
+ *    |              |                                                                                                     |       |
+ *    |              v   m_retry_validate_snap == true                                                                     |       |
+ *    |              + ------------------------------------------------------------------> +                               |       |
+ *    |              |                                                                     |                               |       |
+ *    |              v                 r == -EAGAIN? m_refresh_snaps = false               v                               |       |
+ *    |      PRUNE_GROUP_SNAPSHOTS ------------------------------------------------------> +                               |     ^ |
+ *    |              |                                                                     |                               |     | |
+ *    |              v   m_refresh_snaps == true? m_refresh_snaps = false                 ╭─╮                             ╭─╮  --+ |
+ *    |              + ----------------------------------------------------------------->-╯|╰->------------------------->-╯|╰----> +
+ *    |              |                                                                     v                               |       |
+ *    v              v                 true                                               ╭─╮                              v       |
+ *    + -----> IS_RENAME_REQUESTED ----------------------------------------------------->-╯|╰->--------------------------> +       |
+ *                   |                                                                     |                               |       |
+ *                   v                                                                     |                               v       |
+ *    SCAN_FOR_UNSYNCED_GROUP_SNAPSHOTS                                                    |                HANDLE_REPLAY_COMPLETE |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *        TRY_CREATE_GROUP_SNAPSHOT                                                        |                                       |
+ *                   |    if all snaps synced                                              |                                       |
+ *                   + --------> m_state = STATE_IDLE                                      |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *       CREATE_GROUP_SNAPSHOT                                                             |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *             + --- + --------------- +                                                   |                                       |
+ *             |                       |                                                   |                                       |
+ *             v                       v                                                   |                                       |
+ *    CREATE_MIRROR_SNAPSHOT     CREATE_USER_SNAPSHOT                                      |                                       |
+ *             | m_retry_validate_snap | m_retry_validate_snap                             |                                       |
+ *             v               = true  |               = true                              |                                       |
+ *    UPDATE_LOCAL_GROUP_STATE         |                                                   |                                       |
+ *             |                       |                                                   |                                       |
+ *             v                       v                                                   |                                       |
+ *             + --------- + --------- +                                                   |                                       |
+ *                         |                                                               v                                       |
+ *                         + ------------------------> + <-------------------------------- +                                     ^ |
+ *                                                     |                                                                         | |
+ *                                                     v                             m_retry_validate_snap == false            --+ |
+ *                                         SCHEDULE_LOAD_GROUP_SNAPSHOTS --------------------------------------------------------> +
+ *                                                     |  m_retry_validate_snap == true : m_retry_validate_snap = false            ^
+ *                                                     v  m_state = STATE_REPLAYING                                                |
+ *                                       VALIDATE_LOCAL_GROUP_SNAPSHOTS                                                            |
+ *                                                     |                                                                           |
+ *                                                     v iterate m_local_group_snaps                                               |
+ *                                 + ----------------- + ---------------- +                                                        |
+ *                snapshot already |                                      | snapshot requires                                      |
+ *                   complete      |                                      v     validation                                         |
+ *                                 |                       VALIDATE_IMAGE_SNAPS_SYNC_COMPLETE                                      |
+ *                                 |                                      |                                                        |
+ *                                 |                                      v                                                        |
+ *                                 |                         + ---------- + ---------- +                                           |
+ *                                 |     is mirror snapshot  |                         | is user snapshot                          |
+ *                                 |                         v                         v                                           |
+ *                                 |             MIRROR_SNAPSHOT_COMPLETE      USER_SNAPSHOT_COMPLETE                              |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         v                                           |
+ *                                 |         LOCAL_GROUP_IMAGE_LIST_BY_ID      LOCAL_GROUP_IMAGE_LIST_BY_ID                        |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         v                                           |
+ *                                 |    HANDLE_MIRROR_SNAPSHOT_IMAGE_LIST      HANDLE_USER_SNAPSHOT_IMAGE_LIST                     |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         v                                           |
+ *                                 |         POST_MIRROR_SNAPSHOT_CREATED      POST_USER_SNAPSHOT_CREATED                          |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |      CHECK_MIRROR_SNAPSHOT_SYNC_COMPLETE          |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |            + ---------- + ---------- +            |                                           |
+ *                                 |  images    |                         | all image  |                                           |
+ *                                 |  syncing   |                         | snapshots  |                                           |
+ *                                 |  ( retry   |                         |  sycned    |                                           |
+ *                                 |   next     |                         v            |                                           |
+ *                                 |   cycle)   |         SET_MIRROR_SNAPSHOT_COMPLETE |                                           |
+ *                                 |            |                         |            |                                           |
+ *                                 v            v                         v            v                                           |
+ *                                 + ---------- + ---------- + ---------- + ---------- +                                         ^ |
+ *                                                           |                                                                   | |
+ *                                                           v c_gather waits for all callbacks                                --+ |
+ *                                                           + ------------------------------------------------------------------> +
+ *
+ *
+ *
+ * PRUNE_CREATING_GROUP_SNAPSHOTS PATH
+ * ===================================
+ *
+ *      PRUNE_CREATING_GROUP_SNAPSHOTS
+ *                 |
+ *                 v                      error
+ *      LOCAL_GROUP_IMAGE_LIST_BY_ID --------------> +
+ *                 |                                 |
+ *                 v                                 |
+ *      PRUNE_ALL_IMAGE_SNAPSHOTS_BY_GSID            |
+ *                 |                                 |
+ *                 v                                 v
+ *        PRUNE_IMAGE_SNAPSHOT                 LOAD_REPLAYER
+ *                 |                                 ^
+ *                 v                                 |
+ *         GROUP_SNAP_REMOVE                         |
+ *                 | if all_pruned == true,          |
+ *                 v m_check_creating_snaps = false  |
+ *                 + ------------------------------> +
+ *
+ *
+ *  PRUNE_GROUP_SNAPSHOTS PATH
+ *  ==========================
+ *
+ *        PRUNE_GROUP_SNAPSHOTS
+ *                 |
+ *                 v
+ *      PRUNE_USER_GROUP_SNAPSHOTS
+ *                 |
+ *                 v
+ *     PRUNE_MIRROR_GROUP_SNAPSHOT
+ *                 |
+ *                 v
+ *    MIRROR_GROUP_SNAPSHOT_UNLINK_PEER
+ *                 |
+ *                 v
+ *        PRUNE_GROUP_SNAPSHOT
+ *                 |
+ *                 v
+ *      PRUNE_ALL_IMAGE_SNAPSHOTS
+ *                 |
+ *                 v             -EAGAIN
+ *        PRUNE_IMAGE_SNAPSHOT -------------> SCHEDULE_LOAD_GROUP_SNAPSHOTS
+ *                 |
+ *                 v              error
+ *        GROUP_SNAP_REMOVE ----------------> IS_RENAME_REQUESTED
+ *                 |
+ *                 v  m_refresh_snaps = true
+ *          LOAD_REPLAYER
+ *
+ *
+ *  SHUTDOWN PATH
+ *  =============
+ *
+ *   SHUT_DOWN
+ *      |
+ *      + -> CANCEL_LOAD_GROUP_SNAPSHOTS
+ *      |
+ *      + -> WAIT_FOR_IN_FLIGHT_OPS
+ *                |
+ *                v
+ *           STATE_COMPLETE
+ *
+ * @endverbatim
+ *
+ * HELPER OPERATIONS (NOT REPRESENTED ABOVE)
+ * =================
+ * GET_REPLAYERS_BY_IMAGE_ID
+ * GET_GLOBAL_IMAGE_ID
+ * SET_IMAGE_REPLAYER_LIMITS
+ * SET_IMAGE_REPLAYER_END_LIMITS
+ * NOTIFY_GROUP_LISTENER
+ * IS_REPLAY_INTERRUPTED
+ * GET_REPLAY_STATUS
+ *
+ */
+
   enum State {
     STATE_INIT,
     STATE_REPLAYING,

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -109,6 +109,7 @@ private:
   std::vector<cls::rbd::GroupSnapshot> m_local_group_snaps;
   std::vector<cls::rbd::GroupSnapshot> m_remote_group_snaps;
   std::vector<std::pair<std::string, ImageReplayer<ImageCtxT> *>> m_replayers_by_image_id;
+  const cls::rbd::GroupSnapshot* m_last_local_snap = nullptr;
 
   bool m_update_group_state = true;
 
@@ -253,11 +254,12 @@ private:
   void prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_mirror_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
-  void prune_creating_group_snapshots_if_any(
-      std::unique_lock<ceph::mutex>* locker);
-  void handle_prune_creating_group_snapshots_if_any(
+  void prune_creating_group_snapshots(
+      std::unique_lock<ceph::mutex>* locker,
+      std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps);
+  void handle_prune_creating_group_snapshots(
       const std::vector<cls::rbd::GroupImageStatus>& local_images,
-      const std::vector<cls::rbd::GroupSnapshot>& prune_group_snaps);
+      const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps);
 
   void get_replayers_by_image_id(std::unique_lock<ceph::mutex>* locker);
   std::string get_global_image_id(ImageReplayer<ImageCtxT>* image_replayer,

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -153,15 +153,16 @@ private:
   void validate_image_snaps_sync_complete(
     const cls::rbd::GroupSnapshot &local_snap, Context *on_finish);
 
-  void is_resync_requested();
+  void load_replayer(std::unique_lock<ceph::mutex>* locker);
+  void is_resync_requested(std::unique_lock<ceph::mutex>* locker);
   void handle_is_resync_requested(int r);
   void is_rename_requested();
   void handle_is_rename_requested(int r);
-  void validate_local_group_snapshots();
+  void validate_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void load_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void handle_load_local_group_snapshots(int r);
 
-  void load_remote_group_snapshots();
+  void load_remote_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void handle_load_remote_group_snapshots(int r);
   void check_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
 


### PR DESCRIPTION
Summary

Enhance snapshot validation, reduce redundant processing, and make pruning non-blocking to improve reliability and responsiveness.

Changes
* Defer resync/rename checks until after local and remote snapshots are loaded.
* Avoid indefinite blocking on incomplete snapshots by reloading and re-evaluating remote state.
* Optimize local snapshot loading by identifying latest and creating snapshots in a single pass.
* Convert prune_group_snapshots to async and refresh local state after successful pruning.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
