### PR TITLE
squid: debian: remove stale distutils override from py3dist-overrides

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,4 +1,3 @@
 cephfs python3-cephfs; PEP386
 ceph_argparse python3-ceph-argparse
 ceph_common python3-ceph-common
-distutils python3-distutils


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75919

---

backport of https://github.com/ceph/ceph/pull/68255
parent tracker: https://tracker.ceph.com/issues/75901

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh