### PR TITLE
rgw: align period/zone commands in radosgw-admin help

### DIFF
--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -207,7 +207,7 @@ void usage()
   cout << "  objects expire                   run expired objects cleanup\n";
   cout << "  objects expire-stale list        list stale expired objects (caused by reshard)\n";
   cout << "  objects expire-stale rm          remove stale expired objects\n";
-  cout << "  period rm                        remove a period\n";
+  cout << "  period delete                    remove a period\n";
   cout << "  period get                       get period info\n";
   cout << "  period get-current               get current period info\n";
   cout << "  period pull                      pull a period\n";
@@ -258,7 +258,7 @@ void usage()
   cout << "  zonegroup placement rm           remove a placement target from a zonegroup\n";
   cout << "  zonegroup placement default      set a zonegroup's default placement target\n";
   cout << "  zone create                      create a new zone\n";
-  cout << "  zone rm                          remove a zone\n";
+  cout << "  zone delete                      remove a zone\n";
   cout << "  zone get                         show zone cluster params\n";
   cout << "  zone modify                      modify an existing zone\n";
   cout << "  zone set                         set zone cluster params (requires infile)\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -67,7 +67,7 @@
     objects expire                   run expired objects cleanup
     objects expire-stale list        list stale expired objects (caused by reshard)
     objects expire-stale rm          remove stale expired objects
-    period rm                        remove a period
+    period delete                    remove a period
     period get                       get period info
     period get-current               get current period info
     period pull                      pull a period
@@ -118,7 +118,7 @@
     zonegroup placement rm           remove a placement target from a zonegroup
     zonegroup placement default      set a zonegroup's default placement target
     zone create                      create a new zone
-    zone rm                          remove a zone
+    zone delete                      remove a zone
     zone get                         show zone cluster params
     zone modify                      modify an existing zone
     zone set                         set zone cluster params (requires infile)


### PR DESCRIPTION
 Follow-up to #68228.

  This PR applies the same `rm`/`delete` consistency fix to `radosgw-admin` inline help (`--help`) that was already applied to the man page in #68228.

  The inline help text had command names that did not match the actual command table in `src/rgw/radosgw-admin/radosgw-admin.cc`:

  - `period rm` -> `period delete`
  - `zone rm` -> `zone delete`

  Scope is intentionally narrow and limited to these targeted help-string corrections.

  ## Contribution Guidelines
  - To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

  - If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-
  backports.rst) for the proper workflow.

  - When filling out the below checklist, you may click boxes directly in the GitHub web UI. When entering or editing the entire PR message in the GitHub web UI editor, you may also select
  a checklist item by adding an [x] between the brackets: [x]. Spaces and capitalization matter when checking off items this way.

  ## Checklist
  - Tracker (select at least one)
    - [ ] References tracker ticket
    - [ ] Very recent bug; references commit where it was introduced
    - [ ] New feature (ticket optional)
    - [ ] Doc update (no ticket needed)
    - [x] Code cleanup (no ticket needed)
  - Component impact
    - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
    - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
    - [x] No impact that needs to be tracked
  - Documentation (select at least one)
    - [ ] Updates relevant documentation
    - [x] No doc update is appropriate
  - Tests (select at least one)
    - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
    - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
    - [ ] Includes bug reproducer
    - [x] No tests