### PR TITLE
tentacle: ceph-volume: skip mkfs discard for LVM NVMe OSDs

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/lvm.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvm.py
@@ -6,6 +6,7 @@ from ceph_volume.api import lvm as api
 from ceph_volume.util import prepare as prepare_utils
 from ceph_volume.util import encryption as encryption_utils
 from ceph_volume.util import system, disk
+from ceph_volume.util import nvme as nvme_utils
 from ceph_volume.systemd import systemctl
 from ceph_volume.devices.lvm.common import rollback_osd
 from ceph_volume.devices.lvm.listing import direct_report
@@ -82,6 +83,10 @@ class Lvm(BaseObjectStore):
 
         device = self.args.data
         if disk.is_partition(device) or disk.is_device(device):
+            if device_type == 'block' and self.objectstore == 'bluestore':
+                # NVMe preformat already discards, skip mkfs discard.
+                if nvme_utils.preformat(device):
+                    self.skip_mkfs_discard = True
             # we must create a vg, and then a single lv
             lv_name_prefix = "osd-{}".format(device_type)
             kwargs = {

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
@@ -149,6 +149,25 @@ class TestLvm:
         assert self.lvm.prepare_data_device('block', 'abcd') == m_create_lv.return_value
         assert self.lvm.args.data_size == 102400
 
+    @patch('ceph_volume.objectstore.lvm.nvme_utils.preformat', Mock(return_value=True))
+    @patch('ceph_volume.util.disk.is_device', Mock(return_value=True))
+    @patch('ceph_volume.api.lvm.create_lv')
+    def test_prepare_data_device_preformats_nvme_and_skips_mkfs_discard(self,
+                                                                       m_create_lv: MagicMock,
+                                                                       factory: Callable[..., Namespace]) -> None:
+        args = factory(data='/dev/nvme0n1',
+                       data_slots=1,
+                       data_size=0)
+        self.lvm.args = args
+        self.lvm.objectstore = 'bluestore'
+        m_create_lv.return_value = Volume(lv_name='lv_foo',
+                                          lv_path='/fake-path',
+                                          vg_name='vg_foo',
+                                          lv_tags='',
+                                          lv_uuid='abcd')
+        self.lvm.prepare_data_device('block', 'abcd')
+        assert self.lvm.skip_mkfs_discard is True
+
     @patch('ceph_volume.util.disk.is_device', Mock(return_value=False))
     @patch('ceph_volume.util.disk.is_partition', Mock(return_value=False))
     def test_prepare_data_device_fails(self, factory):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75946

---

backport of https://github.com/ceph/ceph/pull/68220
parent tracker: https://tracker.ceph.com/issues/75873

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh