### PR TITLE
qa/valgrind: generalize suppressions for gcc-14 MismatchedFree

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -953,25 +953,9 @@
    ...
 }
 {
-   rocky10_gcc14_mismatch_delete_map_erase
+   rocky10_gcc14_mismatch_delete
    Memcheck:Free
    fun:_Zda*align_val_t*
-   ...
-   fun:*global_init_prefork*
-}
-{
-   rocky10_gcc14_mismatch_delete_map_erase
-   Memcheck:Free
-   fun:_Zda*align_val_t*
-   ...
-   fun:*ceph6common11CephContext*
-}
-{
-   rocky10_gcc14_mismatch_delete_map_erase
-   Memcheck:Free
-   fun:_Zda*align_val_t*
-   ...
-   fun:exit
 }
 {
    rocky10 still reachable rocksdb leak

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -1,16 +1,12 @@
-
 {
    <allthefrees, so we can behave with tcmalloc>
    Memcheck:Free
    fun:free
-   ...
 }
 {
-   operator delete[] in Rados::shutdown
+   <allthefrees, so we can behave with tcmalloc>
    Memcheck:Free
-   fun:_ZdaPvm
-   ...
-   fun:_ZN8librados7v14_2_05Rados8shutdownEv
+   fun:_Zda*
 }
 {
    older boost mersenne twister uses uninitialized memory for randomness
@@ -582,14 +578,6 @@
         fun:(below main)
 }
 {
-        rocksdb mismatched free bluestore close
-        Memcheck:Free
-        fun:_ZdaPvmSt11align_val_t
-        fun:_ZN12RocksDBStore5closeEv
-        fun:_ZN12RocksDBStoreD*Ev
-        ...
-}
-{
 	libstdc++ leak on xenial
 	Memcheck:Leak
 	fun:malloc
@@ -857,12 +845,6 @@
    ...
 }
 {
-   co_compose bug manifesting under Ubuntu only
-   Memcheck:Free
-   fun:_ZdaPvm
-   ...
-}
-{
    OpenSSL leak still reachable
    Memcheck:Leak
    match-leak-kinds: reachable
@@ -951,11 +933,6 @@
    ...
    fun:*ProtocolV2*
    ...
-}
-{
-   rocky10_gcc14_mismatch_delete
-   Memcheck:Free
-   fun:_Zda*align_val_t*
 }
 {
    rocky10 still reachable rocksdb leak


### PR DESCRIPTION
the rgw suite is showing a handful of these false positives, and i really don't want to micromanage suppressions for every little thing that shows up here

so i chose to generalize the existing suppressions from https://tracker.ceph.com/issues/74604 so that a single suppression would cover this entire class of MismatchedFree warnings

Fixes: https://tracker.ceph.com/issues/75945

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
