### PR TITLE
mgr/cephadm: fix nvmeof reconfig loop by preserving daemon deps

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -173,7 +173,7 @@ class NvmeofService(CephService):
             daemon_spec.extra_files['encryption_key'] = spec.encryption_key
 
         daemon_spec.final_config, _ = self.generate_config(daemon_spec)
-        daemon_spec.deps = []
+        daemon_spec.deps = self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
         return daemon_spec
 
     def daemon_check_post(self, daemon_descrs: List[DaemonDescription]) -> None:


### PR DESCRIPTION
mgr/cephadm: fix nvmeof reconfig loop by preserving daemon deps

**Summary:**

This PR depends on changes from https://github.com/ceph/ceph/pull/67308

When `enable_auth` is enabled for NVMeoF, the service goes through the TLS/mTLS path. Generic ServiceSpec handling then defaults `certificate_source` to `cephadm-signed` when TLS is enabled and no explicit certificate source is provided. During reconcile, cephadm correctly detects this as a daemon dependency change and computes deps including:

`certificate_source: cephadm-signed`

However, `NvmeofService.prepare_create() `was resetting `daemon_spec.deps` to an empty list before returning the deploy spec. As a result, after reconfiguring the daemon, cephadm stored` [] `as the daemon’s last known deps.

On the next reconcile cycle, cephadm again computed the current deps as including `certificate_source: cephadm-signed`, compared them against cached `[],` and concluded that the daemon needed reconfiguration again. This caused the NVMeoF gateway to be repeatedly stopped and restarted every few seconds.

The issue was not caused by cert contents changing repeatedly.

During debugging:
- the rendered ceph-nvmeof.conf remained unchanged across restarts
- the generated TLS/mTLS cert/key files also remained unchanged across restarts

The real problem was that NVMeoF dropped the computed daemon dependencies, so cephadm’s reconcile loop could never converge.

Fix:
Instead of clearing `daemon_spec.deps`, preserve the correct NVMeoF dependencies so that:

- `_check_daemons()` computes the same deps on the next reconcile cycle
- `_create_daemon()` stores the same deps back into cache
- cephadm sees no dependency drift once the daemon is reconfigured

This allows the NVMeoF daemon to converge normally and prevents the repeated reconfig/restart loop when auth/TLS is enabled.


Testing logs:

Before the fix:
```
[root@ds90z2-aviv-cluster-node1 ~]# ceph nvmeof gw info
Error EINVAL: failed to connect to all addresses
```

```
The job identifier is 1190.
Apr 07 10:22:56 ds91-aviv-cluster-node1 bash[1855]: [07-Apr-2026 07:22:56] INFO server.py:43 (7): GatewayServer: SIGTERM...
Apr 07 10:22:56 ds91-aviv-cluster-node1 bash[1855]: [07-Apr-2026 07:22:56] INFO server.py:200 (7): GatewayServer is term...
```

After:
```
[ceph: root@ceph-node-0 ~]# ceph orch ps
NAME                                       HOST         PORTS                   STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  

nvmeof.nvmeof.mygroup1.ceph-node-0.uftimg  ceph-node-0  *:5500,4420,8009,10008  running (32m)    10s ago  32m     147M        -  1.7.3                  31ae061944a9  e908dfaa7527  
osd.0                                      ceph-node-0                          running (39m)    10s ago  39m    35.5M    4096M  20.3.0-5253-

```

```
[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                                  3/3  3m ago     43m  *            
mgr                                                    2/2  3m ago     43m  count:2      
mon                                                    3/5  3m ago     43m  count:5      
nvmeof.nvmeof.mygroup1     ?:4420,5500,8009,10008      1/1  50s ago    35m  ceph-node-0  
osd.all-available-devices                                3  3m ago     42m  * 
```

```
[ceph: root@ceph-node-0 ~]# ceph nvmeof gw info
+-----------+-------+------------------------------------------------+--------+---------------+----+--------+-------------------------------------------------------------+
|Hostname   |Version|Name                                            |Group   |Addr           |Port|Lb Group|Spdk Version                                                 |
+-----------+-------+------------------------------------------------+--------+---------------+----+--------+-------------------------------------------------------------+
|ceph-node-0|1.7.3  |client.nvmeof.nvmeof.mygroup1.ceph-node-0.uftimg|mygroup1|192.168.100.100|5500|1       |SPDK v25.09 git sha1 77d121fa4e83eb534daaccf3e377c2dfc1b8b1d2|
+-----------+-------+------------------------------------------------+--------+---------------+----+--------+-------------------------------------------------------------+

```
Spec:

```
service_type: nvmeof
service_id: nvmeof.mygroup1
service_name: nvmeof.nvmeof.mygroup1
placement:
  hosts:
  - ceph-node-0
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  certificate_source: cephadm-signed
  cluster_connections: 32
  conn_retries: 10
  discovery_bind_retries_limit: 10
  discovery_bind_sleep_interval: 0.5
  discovery_port: 8009
  enable_auth: true
  enable_monitor_client: true
  enable_prometheus_exporter: true
  group: mygroup1
  io_stats_enabled: true
  kmip_cert_dir: ./certs/kmip/{server_name}
  log_directory: /var/log/ceph/
  log_files_enabled: true
  log_files_rotation_enabled: true
  log_level: INFO
  max_gws_in_grp: 16
  max_hosts: 2048
  max_hosts_per_namespace: 16
  max_hosts_per_subsystem: 128
  max_log_directory_backups: 10
  max_log_file_size_in_mb: 10
  max_log_files_count: 20
  max_message_length_in_mb: 4
  max_namespaces: 4096
  max_namespaces_per_subsystem: 512
  max_namespaces_with_netmask: 1000
  max_ns_to_change_lb_grp: 8
  max_subsystems: 128
  monitor_timeout: 1.0
  notifications_interval: 60
  omap_file_lock_duration: 40
  omap_file_lock_on_read: true
  omap_file_lock_retries: 30
  omap_file_lock_retry_sleep_interval: 1.0
  omap_file_update_attempts: 500
  omap_file_update_reloads: 10
  pool: nvmeof
  port: 5500
  prometheus_connection_list_cache_expiration: 60
  prometheus_cycles_to_adjust_speed: 3
  prometheus_frequency_slow_down_factor: 3.0
  prometheus_port: 10008
  prometheus_startup_delay: 240
  prometheus_stats_interval: 10
  rbd_with_crc32c: true
  rebalance_period_sec: 7
  rpc_socket_dir: /var/tmp/
  rpc_socket_name: spdk.sock
  spdk_path: /usr/local/bin/nvmf_tgt
  spdk_ping_interval_in_seconds: 2.0
  spdk_protocol_log_level: WARNING
  spdk_timeout: 60.0
  ssl: true
  state_update_interval_sec: 5
  state_update_notify: true
  subsystem_cache_expiration: 30
  tgt_path: /usr/local/bin/nvmf_tgt
  transport_tcp_options:
    in_capsule_data_size: 8192
    max_io_qpairs_per_ctrlr: 7
  transports: tcp
  verbose_log_messages: true
  verify_keys: true
  verify_listener_ip: true
  verify_nqns: true


``````

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
