### PR TITLE
mgr/dashboard: sanitize toast and notification html

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -40,6 +40,9 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { CoreModule } from '~/app/core/core.module';
 
 describe('RbdSnapshotListComponent', () => {
+  const mockSanitizer = {
+    sanitize: (_context: unknown, value: string | null | undefined) => value ?? null
+  };
   let component: RbdSnapshotListComponent;
   let fixture: ComponentFixture<RbdSnapshotListComponent>;
   let summaryService: SummaryService;
@@ -118,7 +121,7 @@ describe('RbdSnapshotListComponent', () => {
       const actionLabelsI18n = TestBed.inject(ActionLabelsI18n);
       called = false;
       rbdService = new RbdService(null, null);
-      notificationService = new NotificationService(null, null, null);
+      notificationService = new NotificationService(null, null, null, mockSanitizer as any);
       authStorageService = new AuthStorageService();
       authStorageService.set(USER, { 'rbd-image': ['create', 'read', 'update', 'delete'] });
       component = new RbdSnapshotListComponent(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.spec.ts
@@ -6,6 +6,7 @@ import {
   TestBed,
   tick
 } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -32,6 +33,16 @@ import { NotificationsSidebarComponent } from './notifications-sidebar.component
 describe('NotificationsSidebarComponent', () => {
   let component: NotificationsSidebarComponent;
   let fixture: ComponentFixture<NotificationsSidebarComponent>;
+  const mockSanitizer = {
+    sanitize: (_context: unknown, value: string | null | undefined) => {
+      if (typeof value !== 'string') {
+        return value ?? null;
+      }
+      return value
+        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+        .replace(/\son\w+=(["']).*?\1/gi, '');
+    }
+  };
   let prometheusUpdatePermission: string;
   let prometheusReadPermission: string;
   let prometheusCreatePermission: string;
@@ -49,7 +60,14 @@ describe('NotificationsSidebarComponent', () => {
       ClickOutsideModule
     ],
     declarations: [NotificationsSidebarComponent],
-    providers: [PrometheusService, SettingsService, SummaryService, NotificationService, RbdService]
+    providers: [
+      PrometheusService,
+      SettingsService,
+      SummaryService,
+      NotificationService,
+      RbdService,
+      { provide: DomSanitizer, useValue: mockSanitizer }
+    ]
   });
 
   beforeEach(() => {
@@ -165,6 +183,24 @@ describe('NotificationsSidebarComponent', () => {
       tick(6000);
       expect(component.notifications.length).toBe(1);
       expect(component.notifications[0].title).toBe('Sample title');
+      discardPeriodicTasks();
+    }));
+
+    it('should sanitize HTML content before rendering notification messages', fakeAsync(() => {
+      const notificationService: NotificationService = TestBed.inject(NotificationService);
+      fixture.detectChanges();
+
+      notificationService.show(
+        NotificationType.success,
+        'Sample title',
+        '<script>alert(1)</script><b>Safe</b>'
+      );
+      tick(6000);
+      fixture.detectChanges();
+
+      const message = fixture.nativeElement.querySelector('.card-text');
+      expect(message.innerHTML).toContain('<b>Safe</b>');
+      expect(message.innerHTML).not.toContain('<script');
       discardPeriodicTasks();
     }));
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick, flush } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
 import _ from 'lodash';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
@@ -13,12 +14,23 @@ import { TaskMessageService } from './task-message.service';
 
 describe('NotificationService', () => {
   let service: NotificationService;
+  const mockSanitizer = {
+    sanitize: (_context: unknown, value: string | null | undefined) => {
+      if (typeof value !== 'string') {
+        return value ?? null;
+      }
+      return value
+        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+        .replace(/\son\w+=(["']).*?\1/gi, '');
+    }
+  };
 
   configureTestBed({
     providers: [
       NotificationService,
       TaskMessageService,
       { provide: CdDatePipe, useValue: { transform: (d: any) => d } },
+      { provide: DomSanitizer, useValue: mockSanitizer },
       RbdService
     ],
     imports: [HttpClientTestingModule]
@@ -47,8 +59,17 @@ describe('NotificationService', () => {
       'cdNotifications',
       '[{"type":2,"message":"foobar","timestamp":"2018-05-24T09:41:32.726Z"}]'
     );
-    service = new NotificationService(null, null, null);
+    service = new NotificationService(null, null, null, mockSanitizer as any);
     expect(service['dataSource'].getValue().length).toBe(1);
+  }));
+
+  it('should sanitize stored notifications loaded from local storage', fakeAsync(() => {
+    localStorage.setItem(
+      'cdNotifications',
+      '[{"type":2,"message":"<script>alert(1)</script><b>safe</b>","timestamp":"2018-05-24T09:41:32.726Z"}]'
+    );
+    service = new NotificationService(null, null, null, mockSanitizer as any);
+    expect(service['dataSource'].getValue()[0].message).toBe('<b>safe</b>');
   }));
 
   it('should cancel a notification', fakeAsync(() => {
@@ -283,6 +304,23 @@ describe('NotificationService', () => {
       expect(toasts[0].title).toBe('Alert resolved');
       expect(toasts[0].subtitle).toBe('Some alert resolved');
       expect(toasts[0].caption).not.toContain('Prometheus');
+      flush();
+    }));
+
+    it('should sanitize toast message html before passing it to Carbon', fakeAsync(() => {
+      service.show(
+        () =>
+          new CdNotificationConfig(
+            NotificationType.error,
+            'Some error',
+            '<script>alert(1)</script><b>safe</b>'
+          )
+      );
+      tick(510);
+      const toasts = service['activeToastsSource'].getValue();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0].subtitle).toBe('<b>safe</b>');
+      expect(toasts[0].subtitle).not.toContain('<script');
       flush();
     }));
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable, NgZone, SecurityContext } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import _ from 'lodash';
 import { BehaviorSubject } from 'rxjs';
@@ -49,10 +50,50 @@ export class NotificationService {
   constructor(
     private taskMessageService: TaskMessageService,
     private cdDatePipe: CdDatePipe,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private domSanitizer: DomSanitizer
   ) {
     this._loadStoredNotifications();
     this._loadMutedState();
+  }
+
+  private sanitizeHtml(value?: string): string | undefined {
+    if (!_.isString(value)) {
+      return value;
+    }
+    return this.domSanitizer.sanitize(SecurityContext.HTML, value) ?? '';
+  }
+
+  private sanitizeConfig(config: CdNotificationConfig): CdNotificationConfig {
+    config.title = this.sanitizeHtml(config.title);
+    config.message = this.sanitizeHtml(config.message);
+
+    if (config.options) {
+      config.options = {
+        ...config.options,
+        title: this.sanitizeHtml(config.options.title),
+        subtitle: this.sanitizeHtml(config.options.subtitle),
+        caption: this.sanitizeHtml(config.options.caption)
+      };
+    }
+
+    return config;
+  }
+
+  private sanitizeNotification(notification: CdNotification): CdNotification {
+    notification.title = this.sanitizeHtml(notification.title);
+    notification.message = this.sanitizeHtml(notification.message);
+
+    if (notification.options) {
+      notification.options = {
+        ...notification.options,
+        title: this.sanitizeHtml(notification.options.title),
+        subtitle: this.sanitizeHtml(notification.options.subtitle),
+        caption: this.sanitizeHtml(notification.options.caption)
+      };
+    }
+
+    return notification;
   }
 
   private _loadStoredNotifications() {
@@ -71,6 +112,7 @@ export class NotificationService {
         notifications = [];
       }
     }
+    notifications = notifications.map((notification) => this.sanitizeNotification(notification));
     this.dataSource.next(notifications);
     this.hasUnreadSource.next(notifications?.length > 0);
   }
@@ -108,7 +150,7 @@ export class NotificationService {
    * Saving a shown notification in local storage
    */
   save(notification: CdNotification) {
-    const notifications = [notification, ...this.dataSource.getValue()];
+    const notifications = [this.sanitizeNotification(notification), ...this.dataSource.getValue()];
 
     const limited = notifications
       .sort((a, b) => (a.timestamp > b.timestamp ? -1 : 1))
@@ -180,7 +222,7 @@ export class NotificationService {
           application
         );
       }
-      this._queueToShow(config);
+      this._queueToShow(this.sanitizeConfig(config));
     }, this.SHOW_DELAY);
   }
 
@@ -196,7 +238,7 @@ export class NotificationService {
 
   private _showQueued() {
     this._getUnifiedTitleQueue().forEach((config) => {
-      const notification = new CdNotification(config);
+      const notification = this.sanitizeNotification(new CdNotification(config));
 
       if (!notification.isFinishedTask) {
         this.save(notification);
@@ -212,7 +254,7 @@ export class NotificationService {
       if (configs.length > 1) {
         config.message = '<ul>' + configs.map((c) => `<li>${c.message}</li>`).join('') + '</ul>';
       }
-      return config;
+      return this.sanitizeConfig(config);
     });
   }
 
@@ -241,7 +283,7 @@ export class NotificationService {
     const toast: ToastContent = {
       title: notification.title,
       subtitle: notification.message || '',
-      caption: this._renderTimeAndApplicationHtml(notification),
+      caption: this.sanitizeHtml(this._renderTimeAndApplicationHtml(notification)) || '',
       type: carbonType,
       lowContrast: lowContrast,
       showClose: true,


### PR DESCRIPTION
## Summary

Carbon toast rendering uses `innerHTML`, and the dashboard notification sidebar also renders
notification messages as HTML. The shared notification service was passing titles, messages,
and generated caption markup through to those surfaces without sanitizing the content first.

This change sanitizes notification HTML centrally in `NotificationService` before notifications
are stored, rendered in the sidebar, or passed to Carbon toasts. That keeps the existing rich
HTML formatting used for grouped notifications and toast captions, while stripping unsafe markup
from notification content.

Fixes: https://tracker.ceph.com/issues/74770

## Validation

Focused frontend tests rerun locally:

```bash
cd src/pybind/mgr/dashboard/frontend
npm run env_build
npx jest --runInBand src/app/shared/services/notification.service.spec.ts
npx jest --runInBand src/app/shared/components/notifications-sidebar/notifications-sidebar.component.spec.ts
npx jest --runInBand src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
```

Results:

- `notification.service.spec.ts`: 23 tests passed
- `notifications-sidebar.component.spec.ts`: 7 tests passed
- `rbd-snapshot-list.component.spec.ts`: 10 tests passed, 3 skipped

## Manual UI / Screenshot Note

This patch updates shared notification sanitization and regression coverage. A screenshot is not
especially useful here, because the functional change is that unsafe HTML is sanitized while safe
formatted notification content continues to render normally.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

  ## Checklist
  - Tracker (select at least one)
    - [x] References tracker ticket
    - [ ] Very recent bug; references commit where it was introduced
    - [ ] New feature (ticket optional)
    - [ ] Doc update (no ticket needed)
    - [ ] Code cleanup (no ticket needed)
  - Component impact
    - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
    - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
    - [ ] No impact that needs to be tracked
  - Documentation (select at least one)
    - [x] No doc update is appropriate
    - [ ] Updates relevant documentation
  - Tests (select at least one)
    - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
    - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
    - [ ] Includes bug reproducer
    - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
