### PR TITLE
mgr/feedback: fix flaky test_issue_tracker_create_with_invalid_key

### DIFF
--- a/qa/tasks/mgr/dashboard/test_feedback.py
+++ b/qa/tasks/mgr/dashboard/test_feedback.py
@@ -7,6 +7,14 @@ class FeedbackTest(MgrModuleTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls._ceph_cmd(['mgr', 'module', 'enable', 'feedback'], wait=3)
+        # Point the feedback module at an unreachable host so the test
+        # does not depend on tracker.ceph.com being available. Any
+        # create_issue call will fail fast with a ConnectionError
+        # (a RequestException subclass) which the dashboard controller
+        # is expected to surface as HTTP 400.
+        cls._ceph_cmd(['config', 'set', 'mgr',
+                       'mgr/feedback/tracker_url',
+                       'invalid.example.invalid'])
         cls._get(
             '/api/mgr/module',
             retries=5,

--- a/src/pybind/mgr/dashboard/controllers/feedback.py
+++ b/src/pybind/mgr/dashboard/controllers/feedback.py
@@ -38,14 +38,11 @@ class FeedbackController(RESTController):
             response = mgr.remote('feedback', 'validate_and_create_issue',
                                   project, tracker, subject, description, api_key)
         except RuntimeError as error:
-            if "Invalid issue tracker API key" in str(error):
-                raise DashboardException(msg='Error in creating tracker issue: Invalid API key',
-                                         component='feedback')
-            if "KeyError" in str(error):
-                raise DashboardException(msg=f'Error in creating tracker issue: {error}',
-                                         component='feedback')
-            raise DashboardException(msg=f'{error}',
-                                     http_status_code=500,
+            # Any failure from the tracker API (invalid key, network error,
+            # upstream 5xx, etc.) is a client/upstream error, not an internal
+            # server error. Surface it as 400 via DashboardException's default
+            # status code.
+            raise DashboardException(msg=f'Error in creating tracker issue: {error}',
                                      component='feedback')
 
         return response

--- a/src/pybind/mgr/feedback/module.py
+++ b/src/pybind/mgr/feedback/module.py
@@ -9,7 +9,7 @@ from requests.exceptions import RequestException
 
 from .cli import FeedbackCLICommand
 
-from mgr_module import HandleCommandResult, MgrModule
+from mgr_module import HandleCommandResult, MgrModule, Option
 import errno
 
 from .service import CephTrackerClient
@@ -18,6 +18,15 @@ from .model import Feedback
 
 class FeedbackModule(MgrModule):
     CLICommand = FeedbackCLICommand
+
+    MODULE_OPTIONS = [
+        Option(
+            name='tracker_url',
+            type='str',
+            default='tracker.ceph.com',
+            desc='Hostname of the Ceph issue tracker (Redmine) instance',
+            runtime=True),
+    ]
 
     # there are CLI commands we implement
     @FeedbackCLICommand.Read('feedback set api-key')
@@ -60,7 +69,7 @@ class FeedbackModule(MgrModule):
         """
         Fetch issue list
         """
-        tracker_client = CephTrackerClient()
+        tracker_client = CephTrackerClient(self.get_module_option('tracker_url'))
         try:
             response = tracker_client.list_issues()
         except Exception:
@@ -83,7 +92,7 @@ class FeedbackModule(MgrModule):
                 return HandleCommandResult(stderr='Issue tracker key is not set. Set key with `ceph set issue_key <your_key>`')
         except Exception as error:
             return HandleCommandResult(stderr=f'Error in retreiving issue tracker API key: {error}')
-        tracker_client = CephTrackerClient()
+        tracker_client = CephTrackerClient(self.get_module_option('tracker_url'))
         try:
             response = tracker_client.create_issue(feedback, current_api_key)
         except RequestException as error:
@@ -121,13 +130,13 @@ class FeedbackModule(MgrModule):
         return 'Successfully deleted API key'
 
     def get_issues(self):
-        tracker_client = CephTrackerClient()
+        tracker_client = CephTrackerClient(self.get_module_option('tracker_url'))
         return tracker_client.list_issues()
 
     def validate_and_create_issue(self, project: str, tracker: str, subject: str, description: str, api_key=None):
         feedback = Feedback(Feedback.Project[project].value,
                                 Feedback.TrackerType[tracker].value, subject, description)
-        tracker_client = CephTrackerClient()
+        tracker_client = CephTrackerClient(self.get_module_option('tracker_url'))
         stored_api_key = self.get_store('api_key')
         try:
             if api_key:

--- a/src/pybind/mgr/feedback/service.py
+++ b/src/pybind/mgr/feedback/service.py
@@ -6,11 +6,13 @@ from requests.exceptions import RequestException
 
 from .model import Feedback
 
-class config:
-    url = 'tracker.ceph.com'
-    port = 443
+DEFAULT_TRACKER_URL = 'tracker.ceph.com'
+
 
 class CephTrackerClient():
+
+    def __init__(self, tracker_url: str = DEFAULT_TRACKER_URL):
+        self.tracker_url = tracker_url
 
     def list_issues(self):
         '''
@@ -20,7 +22,7 @@ class CephTrackerClient():
             'Content-Type': 'application/json',
         }
         response = requests.get(
-            f'https://{config.url}/issues.json', headers=headers)
+            f'https://{self.tracker_url}/issues.json', headers=headers)
         if not response.ok:
             if response.status_code == 404:
                 raise FileNotFoundError
@@ -40,7 +42,7 @@ class CephTrackerClient():
             raise Exception("Ceph Tracker API Key not set")
         data = json.dumps(feedback.as_dict())
         response = requests.post(
-            f'https://{config.url}/projects/{feedback.project_id}/issues.json',
+            f'https://{self.tracker_url}/projects/{feedback.project_id}/issues.json',
             headers=headers, data=data)
         if not response.ok:
             if response.status_code == 401:


### PR DESCRIPTION
This series addresses the intermittent failure of `test_issue_tracker_create_with_invalid_key` in the dashboard API test suite. The test currently performs a real HTTPS POST to the production `tracker.ceph.com` host, so any upstream hiccup on the tracker leaks into Ceph CI as a test failure on unrelated PRs.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
