### PR TITLE
mgr/dashboard : Unable to remove gateway node from gateway group

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node-add-modal/nvmeof-gateway-node-add-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node-add-modal/nvmeof-gateway-node-add-modal.component.ts
@@ -169,8 +169,8 @@ export class NvmeofGatewayNodeAddModalComponent extends CdForm implements OnInit
 
     const { status, ...modifiedSpec } = this.serviceSpec;
 
-    if ('events' in modifiedSpec) {
-      delete (modifiedSpec as any).events;
+    if (modifiedSpec.events) {
+      delete modifiedSpec.events;
     }
 
     if (modifiedSpec.placement) {
@@ -180,7 +180,7 @@ export class NvmeofGatewayNodeAddModalComponent extends CdForm implements OnInit
     }
 
     if ('locations' in modifiedSpec.placement) {
-      delete (modifiedSpec.placement as any).locations;
+      delete modifiedSpec.placement.locations;
     }
 
     modifiedSpec.placement.hosts = newHosts;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.ts
@@ -26,7 +26,7 @@ import { OrchestratorStatus } from '~/app/shared/models/orchestrator.interface';
 import { Permission } from '~/app/shared/models/permissions';
 
 import { Host } from '~/app/shared/models/host.interface';
-import { CephServiceSpec } from '~/app/shared/models/service.interface';
+import { CephServiceSpec, CephServiceSpecUpdate } from '~/app/shared/models/service.interface';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
@@ -186,11 +186,9 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
         deletionMessage: $localize`Removing <strong>${hostname}</strong> will detach it from the gateway group and stop handling new I/O requests. Active connections may be disrupted.<br><br>You can re-add this node later if required.`
       },
       submitActionObservable: () => {
-        const updatedSpec = _.cloneDeep(this.serviceSpec);
-        updatedSpec.placement.hosts = updatedSpec.placement.hosts.filter((h) => h !== hostname);
-        delete updatedSpec.status;
-        if (updatedSpec['events']) {
-          delete updatedSpec['events'];
+        const updatedSpec = this.buildRemoveGatewaySpecPayload(hostname);
+        if (!updatedSpec) {
+          return of(null);
         }
         return this.taskWrapper
           .wrapTaskAroundCall({
@@ -214,6 +212,34 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
           );
       }
     });
+  }
+
+  private buildRemoveGatewaySpecPayload(hostname: string): CephServiceSpecUpdate | null {
+    if (!this.serviceSpec) {
+      this.notificationService.show(
+        NotificationType.error,
+        $localize`Service specification is missing.`
+      );
+      return null;
+    }
+
+    const { status, ...updatedSpec } = _.cloneDeep(this.serviceSpec);
+
+    if (updatedSpec['events']) {
+      delete updatedSpec['events'];
+    }
+
+    if (!updatedSpec.placement) {
+      updatedSpec.placement = {};
+    }
+
+    if ('locations' in updatedSpec.placement) {
+      delete updatedSpec.placement.locations;
+    }
+
+    const currentHosts = updatedSpec.placement.hosts || [];
+    updatedSpec.placement.hosts = currentHosts.filter((h: string) => h !== hostname);
+    return updatedSpec;
   }
 
   ngOnDestroy(): void {
@@ -275,7 +301,7 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
 
     const allUsedHostnames = new Set<string>();
     groupList.forEach((group: CephServiceSpec) => {
-      const hosts = group.placement?.hosts || (group.spec as any)?.placement?.hosts || [];
+      const hosts = group.placement?.hosts || group.spec?.placement?.hosts || [];
       hosts.forEach((hostname: string) => allUsedHostnames.add(hostname));
     });
 
@@ -301,7 +327,7 @@ export class NvmeofGatewayNodeComponent implements OnInit, OnDestroy {
       this.hosts = [];
     } else {
       const placementHosts =
-        this.serviceSpec.placement?.hosts || (this.serviceSpec.spec as any)?.placement?.hosts || [];
+        this.serviceSpec.placement?.hosts || this.serviceSpec.spec?.placement?.hosts || [];
       const currentGroupHosts = new Set<string>(placementHosts);
 
       this.hosts = (hostList || []).filter((host: Host) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -49,12 +49,14 @@ export interface CephServiceSpec {
   certificate?: CephServiceCertificate;
   spec: CephServiceAdditionalSpec;
   placement: CephServicePlacement;
+  events?: string[];
 }
 
 // Type for service spec update payload (excludes read-only status field)
 export type CephServiceSpecUpdate = Omit<CephServiceSpec, 'status'>;
 
 export interface CephServiceAdditionalSpec {
+  placement?: CephServicePlacement;
   backend_service: string;
   api_user: string;
   api_password: string;
@@ -107,6 +109,7 @@ export interface CephServicePlacement {
   placement?: string;
   hosts?: string[];
   label?: string | string[];
+  locations?: Record<string, string[]>;
 }
 
 export interface QatSepcs {


### PR DESCRIPTION



https://github.com/user-attachments/assets/83c1710b-7cca-49ec-a547-4f4c494698c9

Fixes: https://tracker.ceph.com/issues/75864
Signed-off-by: pujaoshahu <pshahu@redhat.com>







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
