### PR TITLE
qa: fixing several OSD ops test-cases

### DIFF
--- a/qa/suites/orch/cephadm/osds/2-ops/deploy-raw.yaml
+++ b/qa/suites/orch/cephadm/osds/2-ops/deploy-raw.yaml
@@ -24,7 +24,7 @@ tasks:
           echo "At least one raw OSD deployed is stopped"
           exit 1
         fi
-        if ceph-volume lvm list; then
-          echo "ceph-volume lvm list was expected to give non-zero rc with all raw OSDs"
+        if ceph-volume lvm list 2>/dev/null | grep -q 'osd\.'; then
+          echo "ceph-volume lvm list was expected to find no LVM OSDs with all raw OSDs"
           exit 1
         fi

--- a/qa/suites/orch/cephadm/osds/2-ops/rm-zap-add.yaml
+++ b/qa/suites/orch/cephadm/osds/2-ops/rm-zap-add.yaml
@@ -6,12 +6,12 @@ tasks:
         set -x
         ceph orch ps
         ceph orch device ls
-        DEVID=$(ceph device ls | grep osd.1 | awk '{print $1}')
+        DEVID=$(ceph device ls | grep -w 'osd.1' | awk '{print $1}')
         HOST=$(ceph orch device ls | grep $DEVID | awk '{print $1}')
         DEV=$(ceph orch device ls | grep $DEVID | awk '{print $2}')
         echo "host $HOST, dev $DEV, devid $DEVID"
         ceph orch osd rm 1
-        while ceph orch osd rm status | grep ^1 ; do sleep 5 ; done
+        while ceph orch osd rm status | grep -E '^1[[:space:]]' ; do sleep 5 ; done
         ceph orch device zap $HOST $DEV --force
         ceph orch daemon add osd $HOST:$DEV
-        while ! ceph osd dump | grep osd.1 | grep up ; do sleep 5 ; done
+        while ! ceph osd dump | grep -w 'osd.1' | grep up ; do sleep 5 ; done

--- a/qa/suites/orch/cephadm/osds/2-ops/rm-zap-flag.yaml
+++ b/qa/suites/orch/cephadm/osds/2-ops/rm-zap-flag.yaml
@@ -6,10 +6,10 @@ tasks:
         set -x
         ceph orch ps
         ceph orch device ls
-        DEVID=$(ceph device ls | grep osd.1 | awk '{print $1}')
+        DEVID=$(ceph device ls | grep -w 'osd.1' | awk '{print $1}')
         HOST=$(ceph orch device ls | grep "$DEVID" | awk '{print $1}')
         DEV=$(ceph orch device ls | grep "$DEVID" | awk '{print $2}')
         echo "host $HOST, dev $DEV, devid $DEVID"
         ceph orch osd rm --zap --replace 1
-        while ceph orch osd rm status | grep ^1 ; do sleep 5 ; done
-        while ! ceph osd dump | grep osd.1 | grep "up\s*in" ; do sleep 5 ; done
+        while ceph orch osd rm status | grep -E '^1[[:space:]]' ; do sleep 5 ; done
+        while ! ceph osd dump | grep -w 'osd.1' | grep "up\s*in" ; do sleep 5 ; done

--- a/qa/suites/orch/cephadm/osds/2-ops/rm-zap-wait.yaml
+++ b/qa/suites/orch/cephadm/osds/2-ops/rm-zap-wait.yaml
@@ -6,11 +6,11 @@ tasks:
         set -x
         ceph orch ps
         ceph orch device ls
-        DEVID=$(ceph device ls | grep osd.1 | awk '{print $1}')
+        DEVID=$(ceph device ls | grep -w 'osd.1' | awk '{print $1}')
         HOST=$(ceph orch device ls | grep $DEVID | awk '{print $1}')
         DEV=$(ceph orch device ls | grep $DEVID | awk '{print $2}')
         echo "host $HOST, dev $DEV, devid $DEVID"
         ceph orch osd rm 1
-        while ceph orch osd rm status | grep ^1 ; do sleep 5 ; done
+        while ceph orch osd rm status | grep -E '^1[[:space:]]' ; do sleep 5 ; done
         ceph orch device zap $HOST $DEV --force
-        while ! ceph osd dump | grep osd.1 | grep up ; do sleep 5 ; done
+        while ! ceph osd dump | grep -w 'osd.1' | grep up ; do sleep 5 ; done


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
