### PR TITLE
qa: use unique name for the CephFS created during testing

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -23,7 +23,7 @@ import yaml
 from paramiko import SSHException
 from tasks.ceph_manager import CephManager, write_conf, get_valgrind_args
 from tarfile import ReadError
-from tasks.cephfs.filesystem import MDSCluster, Filesystem
+from tasks.cephfs.filesystem import MDSCluster, Filesystem, gen_fsname
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from teuthology import exceptions
@@ -496,7 +496,7 @@ def cephfs_setup(ctx, config):
     if mdss.remotes:
         log.info('Setting up CephFS filesystem(s)...')
         cephfs_config = config.get('cephfs', {})
-        fs_configs =  cephfs_config.pop('fs', [{'name': 'cephfs'}])
+        fs_configs = cephfs_config.get('fs', [{'name': gen_fsname()}])
 
         # wait for standbys to become available (slow due to valgrind, perhaps)
         mdsc = MDSCluster(ctx)

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -120,6 +120,8 @@ class CephFSTestCase(CephTestCase):
 
     def setUp(self):
         super(CephFSTestCase, self).setUp()
+        log.info('Running CephFSTestCase.setUp() now.')
+        self._log_monmap_and_fsmap()
 
         self.config_set('mon', 'mon_allow_pool_delete', True)
 
@@ -206,7 +208,13 @@ class CephFSTestCase(CephTestCase):
 
         self.configs_set = set()
 
+        log.info('Finished running CephFSTestCase.setUp().')
+        self._log_monmap_and_fsmap()
+
     def tearDown(self):
+        log.info('Running CephFSTestCase.tearDown() now.')
+        self._log_monmap_and_fsmap()
+
         self.mds_cluster.clear_firewall()
         for m in self.mounts:
             m.teardown()
@@ -220,7 +228,13 @@ class CephFSTestCase(CephTestCase):
         for subsys, key in self.configs_set:
             self.mds_cluster.clear_ceph_conf(subsys, key)
 
+        log.info('Finished running CephFSTestCase.tearDown().')
+        self._log_monmap_and_fsmap()
         return super(CephFSTestCase, self).tearDown()
+
+    def _log_monmap_and_fsmap(self):
+        self.run_ceph_cmd('mon dump --format json-pretty')
+        self.run_ceph_cmd('fs dump --format json-pretty')
 
     def set_conf(self, subsys, key, value):
         self.configs_set.add((subsys, key))

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -190,7 +190,7 @@ class CephFSTestCase(CephTestCase):
 
             # Mount the requested number of clients
             for i in range(0, self.CLIENTS_REQUIRED):
-                self.mounts[i].mount_wait()
+                self.mounts[i].mount_wait(cephfs_name=self.fs.name)
 
         if self.REQUIRE_BACKUP_FILESYSTEM:
             if not self.REQUIRE_FILESYSTEM:

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -557,13 +557,16 @@ class FilesystemBase(MDSClusterBase):
     This object is for driving a CephFS filesystem.  The MDS daemons driven by
     MDSCluster may be shared with other Filesystems.
     """
-    def __init__(self, ctx, fs_config={}, fscid=None, name=None, create=False, cluster_name='ceph',
-                 **kwargs):
+    def __init__(self, ctx, fs_config={}, fscid=None, name=None, create=False,
+                 cluster_name='ceph', discover=False, **kwargs):
         """
         kwargs accepts recover: bool, allow_dangerous_metadata_overlay: bool,
         yes_i_really_really_mean_it: bool and fs_ops: list[str]
         """
         super(FilesystemBase, self).__init__(ctx, cluster_name=cluster_name)
+
+        if create is True and discover is True:
+            assert False, 'Both "create" and "discover" can\'t be true'
 
         self.name = name
         # TODO: remove this line if testing goes well with it being commented
@@ -589,12 +592,20 @@ class FilesystemBase(MDSClusterBase):
             if fscid is not None:
                 self.id = fscid
                 self.getinfo(refresh = True)
+            if discover:
+                self.name = self.discover_fs_name()
 
         # Stash a reference to the first created filesystem on ctx, so
         # that if someone drops to the interactive shell they can easily
         # poke our methods.
         if not hasattr(self._ctx, "filesystem"):
             self._ctx.filesystem = self
+
+    def discover(self):
+        fss = json.loads(self.run_ceph_cmd('fs ls --format json'))
+        assert len(fss) == 1
+        self.name = fss[0]['name']
+        self.getinfo(refresh=True)
 
     def dead(self):
         try:

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -309,6 +309,15 @@ class CephClusterBase(RunCephCmd):
         log.warn(f'The address {addr} is not blocklisted')
         return False
 
+def gen_fsname():
+    '''
+    Let's attach date-time string to CephFS name as a suffix and make
+    the CephFS name unique.
+    '''
+    return 'testcephfs_' + \
+           datetime.datetime.now().strftime('%Y%b%d_%H_%M_%S')
+
+
 CephCluster = CephClusterBase
 
 class MDSClusterBase(CephClusterBase):
@@ -410,11 +419,12 @@ class MDSClusterBase(CephClusterBase):
     def mds_is_running(self, mds_id):
         return self.mds_daemons[mds_id].running()
 
-    def newfs(self, name='cephfs', create=True, **kwargs):
+    def newfs(self, name=None, create=True, **kwargs):
         """
         kwargs accepts recover: bool, allow_dangerous_metadata_overlay: bool,
         yes_i_really_really_mean_it: bool and fs_ops: list[str]
         """
+        name = gen_fsname() if name is None else name
         return Filesystem(self._ctx, name=name, create=create, **kwargs)
 
     def status(self, epoch=None):
@@ -556,6 +566,9 @@ class FilesystemBase(MDSClusterBase):
         super(FilesystemBase, self).__init__(ctx, cluster_name=cluster_name)
 
         self.name = name
+        # TODO: remove this line if testing goes well with it being commented
+        # out
+        #self.name = gen_fsname() if name is None else name
         self.id = None
         self.metadata_pool_name = None
         self.data_pool_name = None
@@ -708,8 +721,7 @@ class FilesystemBase(MDSClusterBase):
         kwargs accepts recover: bool, allow_dangerous_metadata_overlay: bool,
         yes_i_really_really_mean_it: bool and fs_ops: list[str]
         """
-        if self.name is None:
-            self.name = "cephfs"
+        self.name = gen_fsname() if self.name is None else self.name
         if self.metadata_pool_name is None:
             self.metadata_pool_name = "{0}_metadata".format(self.name)
         if self.data_pool_name is None:

--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -113,6 +113,10 @@ class FuseMountBase(CephFSMountBase):
         if self.client_keyring_path and self.client_id:
             mount_cmd += ['-k', self.client_keyring_path]
 
+        if not self.cephfs_name:
+            self.fs.discover()
+            self.cephfs_name = self.fs.name
+
         self.validate_subvol_options()
 
         if self.cephfs_mntpt:

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -51,8 +51,6 @@ class KernelMountBase(CephFSMount):
 
         if not self.cephfs_mntpt:
             self.cephfs_mntpt = '/'
-        if not self.cephfs_name:
-            self.cephfs_name = 'cephfs'
 
         self._create_mntpt()
 
@@ -109,6 +107,11 @@ class KernelMountBase(CephFSMount):
             if self.cephfs_name:
                 optd['mds_namespace'] = self.cephfs_name
         elif self.syntax_style == 'v2':
+            if not self.cephfs_name:
+                raise RuntimeError('self.cephfs_name is not set. It is '
+                                   'mandatory to provide it when using '
+                                   'v2 style kernel mount command.')
+
             mnt_stx = f'{self.client_id}@.{self.cephfs_name}={self.cephfs_mntpt}'
         else:
             assert 0, f'invalid syntax style: {self.syntax_style}'

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -51,6 +51,8 @@ class KernelMountBase(CephFSMount):
 
         if not self.cephfs_mntpt:
             self.cephfs_mntpt = '/'
+        if not self.cephfs_name:
+            self.cephfs_name = self._get_default_cephfs_name()
 
         self._create_mntpt()
 
@@ -70,6 +72,14 @@ class KernelMountBase(CephFSMount):
             self.gather_mount_info()
         except:
             log.warn('failed to fetch mount info - tests depending on mount addr/inst may fail!')
+
+    def _get_default_cephfs_name(self):
+        cmd_stdout, cmd_stderr = StringIO(), StringIO()
+        self.client_remote.run(args=['ceph', 'fs', 'ls', '--format', 'json'],
+                               stdout=cmd_stdout, stderr=cmd_stderr)
+        cmd_stdout = cmd_stdout.getvalue()
+        cmd_stdout = json.loads(cmd_stdout)
+        return cmd_stdout[0]['name']
 
     def gather_mount_info(self):
         self.id = self._get_global_id()

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1840,8 +1840,6 @@ class CephFSMountBase(object):
 
         if mount_subvol_num is not None:
             # mount_subvol must be an index into the subvol path array for the fs
-            if not self.cephfs_name:
-                self.cephfs_name = 'cephfs'
             assert(hasattr(self.ctx, "created_subvols"))
             # mount_subvol must be specified under client.[0-9] yaml section
             subvol_paths = self.ctx.created_subvols[self.cephfs_name]

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1080,7 +1080,7 @@ class TestRenameCommand(TestAdminCommands):
         """
         That renaming a file system fails if the new name refers to an existing file system.
         """
-        self.fs2 = self.mds_cluster.newfs(name='cephfs2', create=True)
+        self.fs2 = self.mds_cluster.newfs()
 
         # let's unmount the client before failing the FS
         self.mount_a.umount_wait(require_clean=True)
@@ -1441,7 +1441,7 @@ class TestCompatCommands(CephFSTestCase):
         Like test_standby_incompat_reject but with a second fs.
         """
 
-        fs2 = self.mds_cluster.newfs(name="cephfs2", create=True)
+        fs2 = self.mds_cluster.newfs()
         fs2.fail()
         fs2.add_incompat(63, 'placeholder')
         fs2.set_joinable()
@@ -1968,8 +1968,8 @@ class TestFsAuthorize(CephFSTestCase):
         # let's unmount both client before deleting the FS
         self.mount_b.umount_wait(require_clean=True)
         self.mds_cluster.delete_all_filesystems()
-        fs_name = "cephfs-_."
-        self.fs = self.mds_cluster.newfs(name=fs_name)
+        fsname = "testcephfs-_."
+        self.fs = self.mds_cluster.newfs(name=fsname)
         self.fs.wait_for_daemons()
         self.run_ceph_cmd(f'auth caps client.{self.mount_a.client_id} '
                           f'mon "allow r" '
@@ -2170,7 +2170,7 @@ class TestFsAuthorizeUpdate(CephFSTestCase):
         that already had caps for first FS.
         """
         self.fs1 = self.fs
-        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.fs2 = self.mds_cluster.newfs()
         self.mount_b.remount(cephfs_name=self.fs2.name)
         self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
         self.fs1.authorize(self.client_id, ('/', 'rw'))

--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -113,7 +113,7 @@ class TestClusterAffinity(CephFSTestCase):
         """
         That a vanilla standby is preferred over others with mds_join_fs set to another fs.
         """
-        fs2 = self.mds_cluster.newfs(name="cephfs2")
+        fs2 = self.mds_cluster.newfs()
         status, target = self._verify_init()
         active = self.fs.get_active_names(status=status)[0]
         status2, _ = self._verify_init(fs=fs2)
@@ -146,7 +146,7 @@ class TestClusterAffinity(CephFSTestCase):
         standbys = [info['name'] for info in status.get_standbys()]
         for mds in standbys:
             self.config_set('mds.'+mds, 'mds_join_fs', 'cephfs2')
-        fs2 = self.mds_cluster.newfs(name="cephfs2")
+        fs2 = self.mds_cluster.newfs()
         for mds in standbys:
             self._change_target_state(target, mds, {'join_fscid': fs2.id})
         self.fs.rank_fail()
@@ -171,7 +171,7 @@ class TestClusterAffinity(CephFSTestCase):
         standbys = [info['name'] for info in status.get_standbys()]
         for mds in standbys:
             self.config_set('mds.'+mds, 'mds_join_fs', 'cephfs2')
-        fs2 = self.mds_cluster.newfs(name="cephfs2")
+        fs2 = self.mds_cluster.newfs()
         for mds in standbys:
             self._change_target_state(target, mds, {'join_fscid': fs2.id})
         self.fs.set_refuse_standby_for_another_fs(True)
@@ -847,8 +847,8 @@ class TestMultiFilesystems(CephFSTestCase):
                           "true", "--yes-i-really-mean-it")
 
     def _setup_two(self):
-        fs_a = self.mds_cluster.newfs(name="alpha")
-        fs_b = self.mds_cluster.newfs(name="bravo")
+        fs_a = self.mds_cluster.newfs()
+        fs_b = self.mds_cluster.newfs()
 
         self.mds_cluster.mds_restart()
 

--- a/qa/tasks/cephfs/test_multifs_auth.py
+++ b/qa/tasks/cephfs/test_multifs_auth.py
@@ -29,7 +29,7 @@ class TestMultiFS(CephFSTestCase):
         self.run_ceph_cmd(f'auth rm {self.client_name}')
 
         self.fs1 = self.fs
-        self.fs2 = self.mds_cluster.newfs(name='cephfs2', create=True)
+        self.fs2 = self.mds_cluster.newfs()
 
         # we'll reassign caps to client.1 so that it can operate with cephfs2
         self.run_ceph_cmd(f'auth caps client.{self.mount_b.client_id}'

--- a/qa/tasks/mds_pre_upgrade.py
+++ b/qa/tasks/mds_pre_upgrade.py
@@ -20,8 +20,7 @@ def task(ctx, config):
     assert isinstance(config, dict), \
         'snap-upgrade task only accepts a dict for configuration'
 
-    fs = Filesystem(ctx)
-    fs.getinfo() # load name
+    fs = Filesystem(ctx, discover=True)
     fs.set_allow_standby_replay(False)
     fs.set_max_mds(1)
     fs.reach_max_mds()

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -929,6 +929,7 @@ class LocalCephCluster(tasks.cephfs.filesystem.CephClusterBase):
         self._write_conf()
 
 tasks.cephfs.filesystem.CephCluster = LocalCephCluster
+gen_fsname = tasks.cephfs.filesystem.gen_fsname
 
 class LocalMDSCluster(LocalCephCluster, tasks.cephfs.filesystem.MDSClusterBase):
     def __init__(self, ctx, cluster_name='ceph'):
@@ -950,7 +951,8 @@ class LocalMDSCluster(LocalCephCluster, tasks.cephfs.filesystem.MDSClusterBase):
         # FIXME: unimplemented
         pass
 
-    def newfs(self, name='cephfs', create=True, **kwargs):
+    def newfs(self, name=None, create=True, **kwargs):
+        name = gen_fsname() if name is None else name
         return LocalFilesystem(self._ctx, name=name, create=create, **kwargs)
 
     def delete_all_filesystems(self):

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -918,7 +918,7 @@ function test_tell_output_file()
 
 function test_mds_tell()
 {
-  local FS_NAME=cephfs
+  local FS_NAME=testcephfs1
   if ! mds_exists ; then
       echo "Skipping test, no MDS found"
       return
@@ -966,7 +966,7 @@ function test_mds_tell()
 
 function test_mon_mds()
 {
-  local FS_NAME=cephfs
+  local FS_NAME=testcephfs1
   remove_all_fs
 
   ceph osd pool create fs_data 16
@@ -1008,48 +1008,48 @@ function test_mon_mds()
   ceph osd pool create data3 16
   data2_pool=$(ceph osd dump | grep "pool.*'data2'" | awk '{print $2;}')
   data3_pool=$(ceph osd dump | grep "pool.*'data3'" | awk '{print $2;}')
-  ceph fs add_data_pool cephfs $data2_pool
-  ceph fs add_data_pool cephfs $data3_pool
-  ceph fs add_data_pool cephfs 100 >& $TMPFILE || true
+  ceph fs add_data_pool testcephfs1 $data2_pool
+  ceph fs add_data_pool testcephfs1 $data3_pool
+  ceph fs add_data_pool testcephfs1 100 >& $TMPFILE || true
   check_response "Error ENOENT"
-  ceph fs add_data_pool cephfs foobarbaz >& $TMPFILE || true
+  ceph fs add_data_pool testcephfs1 foobarbaz >& $TMPFILE || true
   check_response "Error ENOENT"
-  ceph fs rm_data_pool cephfs $data2_pool
-  ceph fs rm_data_pool cephfs $data3_pool
+  ceph fs rm_data_pool testcephfs1 $data2_pool
+  ceph fs rm_data_pool testcephfs1 $data3_pool
   ceph osd pool delete data2 data2 --yes-i-really-really-mean-it
   ceph osd pool delete data3 data3 --yes-i-really-really-mean-it
-  ceph fs set cephfs max_mds 4
-  ceph fs set cephfs max_mds 3
-  ceph fs set cephfs max_mds 256
-  expect_false ceph fs set cephfs max_mds 257
-  ceph fs set cephfs max_mds 4
-  ceph fs set cephfs max_mds 256
-  expect_false ceph fs set cephfs max_mds 257
-  expect_false ceph fs set cephfs max_mds asdf
-  expect_false ceph fs set cephfs inline_data true
-  ceph fs set cephfs inline_data true --yes-i-really-really-mean-it
-  ceph fs set cephfs inline_data yes --yes-i-really-really-mean-it
-  ceph fs set cephfs inline_data 1 --yes-i-really-really-mean-it
-  expect_false ceph fs set cephfs inline_data --yes-i-really-really-mean-it
-  ceph fs set cephfs inline_data false
-  ceph fs set cephfs inline_data no
-  ceph fs set cephfs inline_data 0
-  expect_false ceph fs set cephfs inline_data asdf
-  ceph fs set cephfs max_file_size 1048576
-  expect_false ceph fs set cephfs max_file_size 123asdf
+  ceph fs set testcephfs1 max_mds 4
+  ceph fs set testcephfs1 max_mds 3
+  ceph fs set testcephfs1 max_mds 256
+  expect_false ceph fs set testcephfs1 max_mds 257
+  ceph fs set testcephfs1 max_mds 4
+  ceph fs set testcephfs1 max_mds 256
+  expect_false ceph fs set testcephfs1 max_mds 257
+  expect_false ceph fs set testcephfs1 max_mds asdf
+  expect_false ceph fs set testcephfs1 inline_data true
+  ceph fs set testcephfs1 inline_data true --yes-i-really-really-mean-it
+  ceph fs set testcephfs1 inline_data yes --yes-i-really-really-mean-it
+  ceph fs set testcephfs1 inline_data 1 --yes-i-really-really-mean-it
+  expect_false ceph fs set testcephfs1 inline_data --yes-i-really-really-mean-it
+  ceph fs set testcephfs1 inline_data false
+  ceph fs set testcephfs1 inline_data no
+  ceph fs set testcephfs1 inline_data 0
+  expect_false ceph fs set testcephfs1 inline_data asdf
+  ceph fs set testcephfs1 max_file_size 1048576
+  expect_false ceph fs set testcephfs1 max_file_size 123asdf
 
-  expect_false ceph fs set cephfs allow_new_snaps
-  ceph fs set cephfs allow_new_snaps true
-  ceph fs set cephfs allow_new_snaps 0
-  ceph fs set cephfs allow_new_snaps false
-  ceph fs set cephfs allow_new_snaps no
-  expect_false ceph fs set cephfs allow_new_snaps taco
+  expect_false ceph fs set testcephfs1 allow_new_snaps
+  ceph fs set testcephfs1 allow_new_snaps true
+  ceph fs set testcephfs1 allow_new_snaps 0
+  ceph fs set testcephfs1 allow_new_snaps false
+  ceph fs set testcephfs1 allow_new_snaps no
+  expect_false ceph fs set testcephfs1 allow_new_snaps taco
 
   # we should never be able to add EC pools as data or metadata pools
   # create an ec-pool...
   ceph osd pool create mds-ec-pool 16 16 erasure
   set +e
-  ceph fs add_data_pool cephfs mds-ec-pool 2>$TMPFILE
+  ceph fs add_data_pool testcephfs1 mds-ec-pool 2>$TMPFILE
   check_response 'erasure-code' $? 22
   set -e
   ec_poolnum=$(ceph osd dump | grep "pool.* 'mds-ec-pool" | awk '{print $2;}')
@@ -1065,7 +1065,7 @@ function test_mon_mds()
   set -e
 
   # Check that `fs new` is no longer permitted
-  expect_false ceph fs new cephfs $metadata_poolnum $data_poolnum --yes-i-really-mean-it 2>$TMPFILE
+  expect_false ceph fs new testcephfs1 $metadata_poolnum $data_poolnum --yes-i-really-mean-it 2>$TMPFILE
 
   # Check that 'fs reset' runs
   ceph fs reset $FS_NAME --yes-i-really-mean-it
@@ -1074,16 +1074,16 @@ function test_mon_mds()
   ceph osd pool create fs_metadata2 16
   ceph osd pool create fs_data2 16
   set +e
-  expect_false ceph fs new cephfs2 fs_metadata2 fs_data2
+  expect_false ceph fs new testcephfs2 fs_metadata2 fs_data2
   set -e
 
   # Check that setting enable_multiple enables creation of second fs
   ceph fs flag set enable_multiple true --yes-i-really-mean-it
-  ceph fs new cephfs2 fs_metadata2 fs_data2
+  ceph fs new testcephfs2 fs_metadata2 fs_data2
 
   # Clean up multi-fs stuff
-  fail_all_mds cephfs2
-  ceph fs rm cephfs2 --yes-i-really-mean-it
+  fail_all_mds testcephfs2
+  ceph fs rm testcephfs2 --yes-i-really-mean-it
   ceph osd pool delete fs_metadata2 fs_metadata2 --yes-i-really-really-mean-it
   ceph osd pool delete fs_data2 fs_data2 --yes-i-really-really-mean-it
 
@@ -2826,7 +2826,7 @@ function test_osd_compact()
 
 function test_mds_tell_help_command()
 {
-  local FS_NAME=cephfs
+  local FS_NAME=testcephfs1
   if ! mds_exists ; then
       echo "Skipping test, no MDS found"
       return


### PR DESCRIPTION
Just 'cephfs' is not easy to track through logs because we have -

*    a CephFS named "cephfs"
*    a python module named "cephfs" (that contains functional tests for CephFS),
 *   a config file section named "cephfs"
 *   package names starting with or ending with "cephfs"
 *   CephFS related tools start with string "cephfs" (example: cepfs-shell, ceph-top, cephfs-data-scan, etc.)
*    daemon names start with "cephfs" (example: cephfs-mirror)
*    OSD pool application tag named "cephfs"

So a unique/distinct name for CephFS make it easy to go through logs.

Fixes: https://tracker.ceph.com/issues/62876






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>