### PR TITLE
tentacle: qa: allow multiple mgr sessions during eviction test

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -8923,22 +8923,40 @@ class TestMisc(TestVolumesHelper):
         self.wait_until_evicted(sessions[0]['id'], timeout=90)
 
     def test_mgr_eviction(self):
-        # unmount any cephfs mounts
+        # unmount any cephfs mounts to start from a clean state
         for i in range(0, self.CLIENTS_REQUIRED):
             self.mounts[i].umount_wait()
-        sessions = self._session_list()
-        self.assertLessEqual(len(sessions), 1) # maybe mgr is already mounted
 
-        # Get the mgr to definitely mount cephfs
+        # Helper to get mgr-specific sessions (type 16)
+        def get_mgr_sessions():
+            all_sessions = self._session_list()
+            mgr_sessions = [s for s in all_sessions if s.get('auth_name', {}).get('type') == 16]
+            return all_sessions, mgr_sessions
+
+        # Ensure we start with only mgr sessions (if any)
+        all_s, mgr_s = get_mgr_sessions()
+        self.assertEqual(len(all_s), len(mgr_s), f"Non-mgr sessions found: {all_s}")
+
+        # Trigger mgr activity to ensure sessions are active
         subvolume = self._gen_subvol_name()
         self._fs_cmd("subvolume", "create", self.volname, subvolume)
-        sessions = self._session_list()
-        self.assertEqual(len(sessions), 1)
 
-        # Now fail the mgr, check the session was evicted
-        mgr = self.mgr_cluster.get_active_id()
-        self.mgr_cluster.mgr_fail(mgr)
-        self.wait_until_evicted(sessions[0]['id'])
+        # Get updated session list and verify they are all mgr types
+        all_sessions, mgr_sessions = get_mgr_sessions()
+        self.assertGreaterEqual(len(mgr_sessions), 1)
+        self.assertEqual(len(all_sessions), len(mgr_sessions),
+                         f"Unexpected session types found: {all_sessions}")
+
+        # Store IDs for eviction check
+        mgr_session_ids = [s['id'] for s in mgr_sessions]
+
+        # Fail the mgr
+        mgr_id = self.mgr_cluster.get_active_id()
+        self.mgr_cluster.mgr_fail(mgr_id)
+
+        # Assert all identified mgr session IDs are evicted
+        for s_id in mgr_session_ids:
+            self.wait_until_evicted(s_id)
 
     def test_names_can_only_be_goodchars(self):
         """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75550

---

backport of https://github.com/ceph/ceph/pull/67556
parent tracker: https://tracker.ceph.com/issues/70580

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh