### PR TITLE
squid: mon/AuthMonitor: add osd w cap for superuser client

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -2444,8 +2444,7 @@ class TestPermErrMsg(CephFSTestCase):
         for wrong_perm in ('w', 'wr'):
             self.negtest_ceph_cmd(
                 args=(f'fs authorize {self.fs.name} {self.CLIENT_NAME} / '
-                      f'{wrong_perm}'), retval=self.EXPECTED_ERRNO,
-                errmsgs=self.EXPECTED_ERRMSG)
+                      f'{wrong_perm}'), retval=self.EXPECTED_ERRNO)
 
 
 class TestFSFail(TestAdminCommands):

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -42,6 +42,8 @@
 #define dout_prefix _prefix(_dout, mon, get_last_committed())
 using namespace TOPNSPC::common;
 
+using namespace std::string_view_literals;
+
 using std::list;
 using std::map;
 using std::make_pair;
@@ -1694,6 +1696,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     string mon_cap_string = "allow r";
     string mds_cap_string, osd_cap_string;
     string osd_cap_wanted = "r";
+    bool osd_cap_needs_w = false;
 
     const Filesystem* fs = nullptr;
     if (filesystem != "*" && filesystem != "all") {
@@ -1719,18 +1722,34 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 	++it;
       }
 
-      if (cap.compare(0, 2, "rw") == 0)
-	osd_cap_wanted = "rw";
-
-      char last='\0';
-      for (size_t i = 2; i < cap.size(); ++i) {
-	char c = cap.at(i);
+      char last = '\0';
+      for (char c : cap) {
+        dout(25) << "permission flag: " << c << dendl;
 	if (last >= c) {
 	  ss << "Permission flags (except 'rw') must be specified in alphabetical order.";
 	  err = -EINVAL;
 	  goto done;
 	}
+        if (last == 'r' && c == 'w') {
+          /* treat 'rw' as a unit permitted at beginning: */
+          last = '\0';
+        } else {
+          last = c;
+        }
 	switch (c) {
+        case 'r':
+          break;
+        case '*':
+          if (cap != "*"sv) {
+	    ss << "Permission '*' implies all, remove other caps.";
+	    err = -EINVAL;
+	    goto done;
+          }
+          osd_cap_needs_w = true;
+          break;
+        case 'w':
+          osd_cap_needs_w = true;
+          break;
 	case 'p':
 	  break;
 	case 's':
@@ -1758,6 +1777,9 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       }
     }
 
+    if (osd_cap_needs_w) {
+      osd_cap_wanted += 'w';
+    }
     osd_cap_string += osd_cap_string.empty() ? "" : ", ";
     osd_cap_string += "allow " + osd_cap_wanted
       + " tag " + pg_pool_t::APPLICATION_NAME_CEPHFS


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75629

---

backport of https://github.com/ceph/ceph/pull/67406
parent tracker: https://tracker.ceph.com/issues/75013

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh