### PR TITLE
squid: qa: resolve py3.12 regression for random.sample

### DIFF
--- a/qa/tasks/cephfs/test_dump_tree.py
+++ b/qa/tasks/cephfs/test_dump_tree.py
@@ -39,7 +39,7 @@ class TestDumpTree(CephFSTestCase):
 
         self.populate()
         inos = self.get_paths_to_ino()
-        target = random.sample(inos.keys(), 1)[0]
+        target = random.sample(list(inos.keys()), 1)[0]
 
         if target != "./":
             target = os.path.dirname(target)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75647

---

backport of https://github.com/ceph/ceph/pull/67557
parent tracker: https://tracker.ceph.com/issues/75089

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh