### PR TITLE
squid: mds: use SimpleLock::WAIT_ALL for wait mask

### DIFF
--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -240,7 +240,7 @@ public:
     return parent->is_waiter_for(getmask(mask));
   }
   bool has_any_waiter() const {
-    return is_waiter_for(std::numeric_limits<uint64_t>::max());
+    return is_waiter_for(WAIT_ALL);
   }
 
   bool is_cached() const {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75558

---

backport of https://github.com/ceph/ceph/pull/67496
parent tracker: https://tracker.ceph.com/issues/75143

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh