### PR TITLE
tentacle: qa/cephadm: derive container image from cephadm release

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -12,7 +12,6 @@ FSID='00000000-0000-0000-0000-0000deadbeef'
 IMAGE_MAIN=${IMAGE_MAIN:-'quay.ceph.io/ceph-ci/ceph:main'}
 IMAGE_REEF=${IMAGE_REEF:-'quay.io/ceph/ceph:v18.2.8'}
 IMAGE_SQUID=${IMAGE_SQUID:-'quay.ceph.io/ceph-ci/ceph:squid'}
-IMAGE_DEFAULT=${IMAGE_MAIN}
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"
 OSD_IMAGE_SIZE='6G'
@@ -45,6 +44,20 @@ fi
 if ! [ -x "$CEPHADM" ]; then
     echo "cephadm not found. Please set \$CEPHADM"
     exit 1
+fi
+
+# Derive IMAGE_DEFAULT from cephadm's own release so that stable branches
+# pull a matching container instead of always using ceph:main.
+# See https://tracker.ceph.com/issues/75821
+if [ -z "$IMAGE_DEFAULT" ]; then
+    _ver=$("$CEPHADM" version 2>/dev/null || true)
+    _release=$(echo "$_ver" | awk '{print $5}')
+    _type=$(echo "$_ver" | awk '{gsub(/[()]/, "", $6); print $6}')
+    if [ -n "$_release" ] && [ "$_type" != "dev" ]; then
+        IMAGE_DEFAULT="quay.ceph.io/ceph-ci/ceph:${_release}"
+    else
+        IMAGE_DEFAULT=${IMAGE_MAIN}
+    fi
 fi
 
 # add image to args


### PR DESCRIPTION
Backport of #68288

Cherry-pick of db3ba638e9fe04d8718c33668eeffd98d705944e to tentacle.

`test_cephadm.sh` hardcodes `IMAGE_DEFAULT` to `ceph:main`, which breaks
every stable branch whenever main is renamed to a new release. The mismatch
check in cephadm correctly rejects the container because its release name
doesn't match cephadm's own release.

Instead of always pulling `ceph:main`, derive `IMAGE_DEFAULT` from the
installed cephadm's version output. On stable builds, use `ceph:<release>`
so the container matches cephadm. On dev builds, fall back to `ceph:main`.

Tracker: https://tracker.ceph.com/issues/75961

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests