### PR TITLE
crimson/os/seastore: handle enoent in SeaStore::Shard::stat

### DIFF
--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1435,6 +1435,9 @@ seastar::future<struct stat> SeaStore::Shard::stat(
     [this, oid](auto &t, auto &onode) {
     return _stat(t, onode, oid);
   }).handle_error(
+    crimson::ct_error::enoent::handle([] {
+      return seastar::make_ready_future<struct stat>();
+    }),
     crimson::ct_error::assert_all{
       "Invalid error in SeaStoreS::stat"
     }

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -926,6 +926,16 @@ TEST_P(seastore_test_t, touch_stat_list_remove)
   });
 }
 
+TEST_P(seastore_test_t, stat_nonexistent)
+{
+  run_async([this] {
+    auto st = sharded_seastore->stat(
+      coll,
+      make_oid(99)).get();
+    EXPECT_EQ(st.st_size, 0);
+  });
+}
+
 using bound_t = seastore_test_t::bound_t;
 constexpr unsigned MAX_LIMIT = std::numeric_limits<unsigned>::max();
 static const seastore_test_t::list_test_cases_t temp_list_cases{


### PR DESCRIPTION
`SeaStore::Shard::stat()` uses `assert_all` as its sole error handler,
which aborts on ENOENT. But `get_onode()` explicitly declares `enoent`
as a valid error type (`onode_manager.h:36-40`), and
`replicated_recovery_backend` calls `stat()` during push-based recovery
on objects that haven't been pulled yet — ENOENT is legitimate there.

`exists()` in the same file already handles this correctly (line 1207).
`stat()` just never got the same treatment.

The fix adds an `enoent` handler before `assert_all`, returning an empty
`struct stat` — same as the existing `!store_active` early return. The
recovery code at `replicated_recovery_backend.cc:831-840` handles
`st_size=0` correctly (clears `copy_subset`).

Includes a unit test that stats a non-existent object to verify it
returns an empty struct instead of aborting.

Tried to reproduce the crash in a 3-OSD vstart cluster with seastore +
CephFS snapshots + OSD bouncing, but the race needs many PGs and
concurrent IO to hit — the original report was from a large
`crimson-rados:cephfs` teuthology run.

Fixes: https://tracker.ceph.com/issues/75814

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests