### PR TITLE
librbd/mirror: remove undo code path in GroupEnableRequest

### DIFF
--- a/src/librbd/mirror/GroupEnableRequest.cc
+++ b/src/librbd/mirror/GroupEnableRequest.cc
@@ -141,11 +141,7 @@ void GroupEnableRequest<I>::handle_prepare_group_images(int r) {
     return;
   }
 
-  if (m_images.empty()) {
-    set_mirror_group_enabling();
-  } else {
-    validate_images();
-  }
+  validate_images();
 }
 
 template <typename I>
@@ -276,15 +272,18 @@ void GroupEnableRequest<I>::handle_create_primary_group_snapshot(int r) {
     return;
   }
 
-  if (m_image_ctxs.empty()) {
-    update_primary_group_snapshot();
-  } else {
-    create_primary_image_snapshots();
-  }
+  create_primary_image_snapshots();
 }
 
 template <typename I>
 void GroupEnableRequest<I>::create_primary_image_snapshots() {
+  // GroupImageCreatePrimaryRequest asserts if there are no member images.
+  // Skip this step and update the primary group snapshot directly.
+  if (m_image_ctxs.empty()) {
+    update_primary_group_snapshot();
+    return;
+  }
+
   ldout(m_cct, 10) << dendl;
 
   auto num_images = m_image_ctxs.size();
@@ -368,11 +367,7 @@ void GroupEnableRequest<I>::handle_update_primary_group_snapshot(int r) {
     return;
   }
 
-  if (m_image_ctxs.empty()) {
-    set_mirror_group_enabled();
-  } else {
-    set_mirror_images_enabled();
-  }
+  set_mirror_images_enabled();
 }
 
 template <typename I>
@@ -479,10 +474,6 @@ void GroupEnableRequest<I>::handle_notify_mirroring_watcher(int r) {
 
 template <typename I>
 void GroupEnableRequest<I>::close_images() {
-  if (m_image_ctxs.empty()) {
-    finish(m_ret_val);
-    return;
-  }
   ldout(m_cct, 10) << dendl;
 
   auto ctx = create_context_callback<

--- a/src/librbd/mirror/GroupEnableRequest.cc
+++ b/src/librbd/mirror/GroupEnableRequest.cc
@@ -10,11 +10,11 @@
 #include "librbd/ImageState.h"
 #include "librbd/MirroringWatcher.h"
 #include "librbd/Utils.h"
+#include "librbd/group/ListSnapshotsRequest.h"
 #include "librbd/mirror/ImageStateUpdateRequest.h"
-#include "librbd/mirror/ImageRemoveRequest.h"
 #include "librbd/mirror/snapshot/GroupImageCreatePrimaryRequest.h"
-#include "librbd/mirror/snapshot/RemoveGroupSnapshotRequest.h"
 #include "librbd/mirror/snapshot/GroupPrepareImagesRequest.h"
+#include "librbd/mirror/snapshot/GroupUnlinkPeerRequest.h"
 
 #include <shared_mutex>
 
@@ -76,41 +76,41 @@ void GroupEnableRequest<I>::handle_get_mirror_group(int r) {
   if (r == 0) {
     if (m_mirror_group.mirror_image_mode != m_mode) {
       lderr(m_cct) << "invalid group mirroring mode" << dendl;
-      r = -EINVAL;
-    } else if (m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_ENABLING) {
-      lderr(m_cct) << "mirroring on group is currently enabling"
-                   << dendl;
-      r = -EINVAL;
-    } else if (m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_ENABLED) {
-      ldout(m_cct, 10) << "mirroring on group is already enabled" << dendl;
-    } else if (
-        m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_DISABLING) {
-      lderr(m_cct) << "mirroring on group is currently disabling" << dendl;
-      r = -EINVAL;
-    } else {
-      lderr(m_cct) << "mirroring on group is in unexpected state: "
-                   << m_mirror_group.state << dendl;
-      r = -EINVAL;
+      finish(-EINVAL);
+      return;
     }
-    finish(r);
-    return;
-  } else if (r < 0) {
-    if (r == -EOPNOTSUPP) {
-      lderr(m_cct) << "mirroring on group is not supported by OSD" << dendl;
+
+    if (m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_ENABLING) {
+      ldout(m_cct, 10) << "resuming group enable" << dendl;
+    } else {
+      if (m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_ENABLED) {
+        ldout(m_cct, 10) << "mirroring on group is already enabled" << dendl;
+      } else if (
+          m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_DISABLING) {
+        lderr(m_cct) << "mirroring on group is currently disabling" << dendl;
+        r = -EINVAL;
+      } else {
+        lderr(m_cct) << "mirroring on group is in unexpected state: "
+                     << m_mirror_group.state << dendl;
+        r = -EINVAL;
+      }
       finish(r);
       return;
-    } else if (r != -ENOENT) {
-      lderr(m_cct) << "failed to retrieve mirror group metadata: "
-                   << cpp_strerror(r) << dendl;
+    }
+  } else if (r < 0) {
+    if (r == -ENOENT) {
+      m_mirror_group.state = cls::rbd::MIRROR_GROUP_STATE_DISABLED;
+    } else {
+      if (r == -EOPNOTSUPP) {
+        lderr(m_cct) << "mirroring on group is not supported by OSD" << dendl;
+      } else {
+        lderr(m_cct) << "failed to retrieve mirror group metadata: "
+                     << cpp_strerror(r) << dendl;
+      }
       finish(r);
       return;
     }
   }
-
-  uuid_d uuid_gen;
-  uuid_gen.generate_random();
-  m_mirror_group.global_group_id = uuid_gen.to_string();
-  m_mirror_group.mirror_image_mode = m_mode;
 
   prepare_group_images();
 }
@@ -182,8 +182,17 @@ void GroupEnableRequest<I>::validate_images() {
 
 template <typename I>
 void GroupEnableRequest<I>::set_mirror_group_enabling() {
+  if (m_mirror_group.state == cls::rbd::MIRROR_GROUP_STATE_ENABLING) {
+    check_primary_group_snap_complete();
+    return;
+  }
+
   ldout(m_cct, 10) << dendl;
 
+  uuid_d uuid_gen;
+  uuid_gen.generate_random();
+  m_mirror_group.global_group_id = uuid_gen.to_string();
+  m_mirror_group.mirror_image_mode = m_mode;
   m_mirror_group.state = cls::rbd::MIRROR_GROUP_STATE_ENABLING;
 
   librados::ObjectWriteOperation op;
@@ -209,7 +218,159 @@ void GroupEnableRequest<I>::handle_set_mirror_group_enabling(int r) {
     return;
   }
 
+  check_primary_group_snap_complete();
+}
+
+template <typename I>
+void GroupEnableRequest<I>::check_primary_group_snap_complete() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = util::create_context_callback<
+    GroupEnableRequest<I>,
+    &GroupEnableRequest<I>::handle_check_primary_group_snap_complete>(
+      this);
+
+  auto req = group::ListSnapshotsRequest<I>::create(
+    m_group_ioctx, m_group_id, true, true, &m_group_snaps, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupEnableRequest<I>::handle_check_primary_group_snap_complete(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to list group snapshots: " << cpp_strerror(r)
+                 << dendl;
+    m_ret_val = r;
+    close_images();
+    return;
+  }
+
+  // Inspect the latest mirror group snapshot. If it is primary and complete,
+  // resume group enable from that snapshot. Otherwise, create a new primary
+  // group snapshot.
+  for (auto it = m_group_snaps.rbegin(); it != m_group_snaps.rend(); ++it) {
+    auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+      &it->snapshot_namespace);
+    if (ns == nullptr) {
+      continue;
+    }
+
+    if (ns->state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
+      lderr(m_cct) << "group snapshot '" << it->name
+                   << "' namespace state is not primary (state="
+                   << ns->state << ")" << dendl;
+      m_ret_val = -EINVAL;
+      close_images();
+      return;
+    }
+
+    if (is_mirror_group_snapshot_complete(it->state, ns->complete)) {
+      // Resume group enable using the inspected snapshot.
+      m_group_snap = *it;
+      // Fetch the global image IDs embedded in the member image snapshot
+      // names. These IDs are required to enable mirroring for the images.
+      fetch_global_image_ids();
+      return;
+    }
+
+    // Latest mirror snapshot exists but is incomplete.
+    break;
+  }
+
+  // No usable mirror group snapshot found. Create a new primary group snapshot.
   create_primary_group_snapshot();
+}
+
+/**
+ * Extract global_image_id from a primary member image snapshot name.
+ *
+ * primary snapshot name format:
+ *  .mirror.primary.<global_image_id>.<pool_id>_<group_id>_<group_snap_id>
+ *
+ */
+std::string_view extract_global_image_id(std::string_view snap_name) {
+  constexpr std::string_view prefix = ".mirror.primary.";
+
+  if (!snap_name.starts_with(prefix)) {
+    return {};
+  }
+
+  auto start = prefix.size();
+  auto end = snap_name.find('.', start);
+  if (end == std::string_view::npos) {
+    return {};
+  }
+
+  return snap_name.substr(start, end - start);
+}
+
+template <typename I>
+void GroupEnableRequest<I>::fetch_global_image_ids() {
+  ldout(m_cct, 10) << "group snapshot '" << m_group_snap.name << "'" << dendl;
+
+  auto num_images = m_image_ctxs.size();
+  if (num_images != m_group_snap.snaps.size()) {
+    lderr(m_cct) << "group snapshot '" << m_group_snap.name
+                 << "' member snap count mismatch: snaps.size()="
+                 << m_group_snap.snaps.size()
+                 << ", expected=" << num_images << dendl;
+    m_ret_val = -EINVAL;
+    close_images();
+    return;
+  }
+
+  // Extract each member image's global_image_id from its snapshot name.
+  m_global_image_ids.resize(num_images);
+  for (size_t i = 0; i < num_images; ++i) {
+    auto ictx = m_image_ctxs[i];
+    auto snap_spec = m_group_snap.snaps[i];
+
+    // Validate that the image still contains the snapshot referenced by
+    // the group snapshot membership.
+    if (snap_spec.pool != ictx->md_ctx.get_id() ||
+        snap_spec.image_id != ictx->id) {
+      lderr(m_cct) << "couldn't locate image '" << snap_spec.image_id
+                   << "' for group snapshot '" << m_group_snap.name
+                   << "'" << dendl;
+      m_ret_val = -EINVAL;
+      close_images();
+      return;
+    }
+
+    std::shared_lock image_locker{ictx->image_lock};
+    auto snap_it = ictx->snap_info.find(snap_spec.snap_id);
+    if (snap_it == ictx->snap_info.end()) {
+      lderr(m_cct) << "image '" << ictx->id
+                   << "' missing snap_id=" << snap_spec.snap_id
+                   << " for group snapshot '" << m_group_snap.name
+                   << "'" << dendl;
+      m_ret_val = -EINVAL;
+      close_images();
+      return;
+    }
+
+    // Extract the global_image_id used for enabling a mirror image.
+    auto global_image_id = std::string(
+      extract_global_image_id(snap_it->second.name));
+    uuid_d uuid;
+    if (!uuid.parse(global_image_id.c_str())) {
+      lderr(m_cct) << "image '" << ictx->id
+                   << "' snapshot '" << snap_it->second.name
+                   << "' does not contain a valid global_image_id" << dendl;
+      m_ret_val = -EINVAL;
+      close_images();
+      return;
+    }
+    m_global_image_ids[i] = global_image_id;
+    ldout(m_cct, 10) << "image '" << ictx->id
+                     << "' global_image_id=" << m_global_image_ids[i]
+                     << dendl;
+  }
+
+  set_mirror_images_enabled();
 }
 
 template <typename I>
@@ -221,6 +382,7 @@ void GroupEnableRequest<I>::create_primary_group_snapshot() {
 
   m_group_snap.name = ".mirror.primary." + m_mirror_group.global_group_id
                 + "." + m_group_snap.id;
+  m_group_snap.state = cls::rbd::GROUP_SNAPSHOT_STATE_CREATING;
 
   ldout(m_cct, 10) << "creating group snapshot " << m_group_snap.name << dendl;
 
@@ -231,7 +393,7 @@ void GroupEnableRequest<I>::create_primary_group_snapshot() {
     lderr(m_cct) << "failed to retrieve min OSD release: " << cpp_strerror(r)
                  << dendl;
     m_ret_val = r;
-    disable_mirror_group();
+    close_images();
     return;
   }
 
@@ -261,14 +423,12 @@ template <typename I>
 void GroupEnableRequest<I>::handle_create_primary_group_snapshot(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
-  m_need_to_cleanup_group_snapshot = true;
-
   if (r < 0) {
     lderr(m_cct) << "failed to create group snapshot: "
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    disable_mirror_group();
+    close_images();
     return;
   }
 
@@ -288,13 +448,11 @@ void GroupEnableRequest<I>::create_primary_image_snapshots() {
 
   auto num_images = m_image_ctxs.size();
   m_global_image_ids.resize(num_images);
-  m_mirror_images.resize(num_images);
 
   uuid_d uuid_gen;
   for (size_t i = 0; i < num_images; i++) {
     uuid_gen.generate_random();
     m_global_image_ids[i] = uuid_gen.to_string();
-    m_mirror_images[i].global_image_id = m_global_image_ids[i];
   }
 
   auto ctx = librbd::util::create_context_callback<
@@ -320,11 +478,7 @@ void GroupEnableRequest<I>::handle_create_primary_image_snapshots(int r) {
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    for (size_t i = 0; i < m_image_ctxs.size(); i++) {
-      m_group_snap.snaps[i].snap_id = m_snap_ids[i];
-    }
-
-    disable_mirror_group();
+    close_images();
     return;
   }
 
@@ -363,7 +517,7 @@ void GroupEnableRequest<I>::handle_update_primary_group_snapshot(int r) {
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    disable_mirror_group();
+    close_images();
     return;
   }
 
@@ -380,7 +534,9 @@ void GroupEnableRequest<I>::set_mirror_images_enabled() {
 
   auto gather_ctx = new C_Gather(m_cct, ctx);
 
-  for (size_t i = 0; i < m_image_ctxs.size(); i++) {
+  auto num_images = m_image_ctxs.size();
+  m_mirror_images.resize(num_images);
+  for (size_t i = 0; i < num_images; i++) {
     auto ictx = m_image_ctxs[i];
 
     m_mirror_images[i].type = cls::rbd::MIRROR_IMAGE_TYPE_GROUP;
@@ -401,14 +557,12 @@ template <typename I>
 void GroupEnableRequest<I>::handle_set_mirror_images_enabled(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
-  m_need_to_cleanup_mirror_images = true;
-
   if (r < 0) {
     lderr(m_cct) << "failed to enabled mirror images: " << cpp_strerror(r)
                  << dendl;
     m_ret_val = r;
 
-    disable_mirror_group();
+    close_images();
     return;
   }
 
@@ -440,8 +594,34 @@ void GroupEnableRequest<I>::handle_set_mirror_group_enabled(int r) {
                  << cpp_strerror(r) << dendl;
     m_ret_val = r;
 
-    disable_mirror_group();
+    close_images();
     return;
+  }
+
+  group_unlink_peer();
+}
+
+template <typename I>
+void GroupEnableRequest<I>::group_unlink_peer() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<
+    GroupEnableRequest<I>,
+    &GroupEnableRequest<I>::handle_group_unlink_peer>(this);
+
+  auto req = mirror::snapshot::GroupUnlinkPeerRequest<I>::create(
+    m_group_ioctx, m_group_id, &m_mirror_peer_uuids, &m_image_ctxs, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void GroupEnableRequest<I>::handle_group_unlink_peer(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to unlink mirror group snapshot: "
+                 << cpp_strerror(r) << dendl;
   }
 
   notify_mirroring_watcher();
@@ -502,230 +682,6 @@ void GroupEnableRequest<I>::handle_close_images(int r) {
   }
 
   finish(m_ret_val);
-}
-
-template <typename I>
-void GroupEnableRequest<I>::disable_mirror_group() {
-  ldout(m_cct, 10) << dendl;
-
-  librados::ObjectWriteOperation op;
-  m_mirror_group.state = cls::rbd::MIRROR_GROUP_STATE_DISABLING;
-
-  cls_client::mirror_group_set(&op, m_group_id, m_mirror_group);
-  auto aio_comp = create_rados_callback<
-    GroupEnableRequest<I>,
-    &GroupEnableRequest<I>::handle_disable_mirror_group>(this);
-  int r = m_group_ioctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
-  ceph_assert(r == 0);
-  aio_comp->release();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::handle_disable_mirror_group(int r) {
-  ldout(m_cct, 10) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(m_cct) << "failed to disable mirror group: " << cpp_strerror(r)
-                 << dendl;
-    close_images();
-    return;
-  }
-
-  if (m_need_to_cleanup_mirror_images) {
-    get_mirror_images_for_cleanup();
-  } else if (m_need_to_cleanup_group_snapshot) {
-    remove_primary_group_snapshot();
-  } else {
-    remove_mirror_group();
-  }
-}
-
-template <typename I>
-void GroupEnableRequest<I>::get_mirror_images_for_cleanup() {
-  ldout(m_cct, 10) << dendl;
-
-  m_mirror_images.clear();
-  m_mirror_images.resize(m_images.size());
-  m_out_bls.resize(m_images.size());
-
-  auto ctx = create_context_callback<
-    GroupEnableRequest<I>,
-    &GroupEnableRequest<I>::handle_get_mirror_images_for_cleanup>(this);
-  auto gather_ctx = new C_Gather(m_cct, ctx);
-
-  for (size_t i = 0; i < m_images.size(); i++) {
-    librados::ObjectReadOperation op;
-    cls_client::mirror_image_get_start(&op, m_images[i].spec.image_id);
-
-    auto on_mirror_image_get = new LambdaContext(
-      [this, i, new_sub_ctx=gather_ctx->new_sub()](int r) {
-        if (r == 0) {
-          auto iter = m_out_bls[i].cbegin();
-          r = cls_client::mirror_image_get_finish(&iter, &m_mirror_images[i]);
-        }
-
-        if (r == -ENOENT) {
-          r = 0;
-          m_mirror_images[i].state = cls::rbd::MIRROR_IMAGE_STATE_DISABLED;
-        } else if (r < 0) {
-          lderr(m_cct) << "failed to get mirror image info for image_id="
-                       << m_images[i].spec.image_id << dendl;
-        }
-
-        new_sub_ctx->complete(r);
-      });
-
-    auto comp = create_rados_callback(on_mirror_image_get);
-
-    int r = m_group_ioctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bls[i]);
-    ceph_assert(r == 0);
-    comp->release();
-  }
-
-  gather_ctx->activate();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::handle_get_mirror_images_for_cleanup(int r) {
-  ldout(m_cct, 10) << "r=" << r <<  dendl;
-
-  m_out_bls.clear();
-
-  if (r < 0) {
-    ldout(m_cct, 10) << "failed to get mirror image info for cleanup" << dendl;
-    close_images();
-    return;
-  }
-
-  disable_mirror_images();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::disable_mirror_images() {
-  ldout(m_cct, 10) << dendl;
-
-  auto ctx = create_context_callback<
-    GroupEnableRequest<I>,
-    &GroupEnableRequest<I>::handle_disable_mirror_images>(this);
-
-  auto gather_ctx = new C_Gather(m_cct, ctx);
-  for (size_t i = 0; i < m_images.size(); i++) {
-    if (m_mirror_images[i].state != cls::rbd::MIRROR_IMAGE_STATE_DISABLING &&
-        m_mirror_images[i].state != cls::rbd::MIRROR_IMAGE_STATE_DISABLED) {
-      auto req = ImageStateUpdateRequest<I>::create(
-        m_image_ctxs[i]->md_ctx, m_image_ctxs[i]->id,
-        cls::rbd::MIRROR_IMAGE_STATE_DISABLING, m_mirror_images[i],
-        gather_ctx->new_sub());
-      req->send();
-    }
-  }
-  gather_ctx->activate();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::handle_disable_mirror_images(int r) {
-  ldout(m_cct, 10) << "r=" << dendl;
-
-  if (r < 0) {
-    lderr(m_cct) << "failed to disable mirror images: " << cpp_strerror(r)
-                 << dendl;
-    close_images();
-    return;
-  }
-
-  remove_primary_group_snapshot();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::remove_primary_group_snapshot() {
-  ldout(m_cct, 10) << dendl;
-
-  auto ctx = create_context_callback<
-    GroupEnableRequest<I>,
-    &GroupEnableRequest<I>::handle_remove_primary_group_snapshot>(this);
-
-  auto req = snapshot::RemoveGroupSnapshotRequest<I>::create(m_group_ioctx,
-     m_group_id, &m_group_snap, &m_image_ctxs, ctx);
-
-  req->send();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::handle_remove_primary_group_snapshot(int r) {
-  ldout(m_cct, 10) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(m_cct) << "failed to remove mirror group snapshot: " << cpp_strerror(r)
-                 << dendl;
-    close_images();
-    return;
-  }
-
-  if (m_need_to_cleanup_mirror_images) {
-    remove_mirror_images();
-  } else {
-    remove_mirror_group();
-  }
-}
-
-template <typename I>
-void GroupEnableRequest<I>::remove_mirror_images() {
-  ldout(m_cct, 10) << dendl;
-
-  auto ctx = create_context_callback<
-    GroupEnableRequest<I>,
-    &GroupEnableRequest<I>::handle_remove_mirror_images>(this);
-
-  auto gather_ctx = new C_Gather(m_cct, ctx);
-  for (size_t i = 0; i < m_images.size(); i++) {
-    auto req = ImageRemoveRequest<I>::create(
-      m_image_ctxs[i]->md_ctx, m_global_image_ids[i], m_image_ctxs[i]->id,
-      gather_ctx->new_sub());
-    req->send();
-  }
-  gather_ctx->activate();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::handle_remove_mirror_images(int r) {
-  ldout(m_cct, 10) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(m_cct) << "failed to remove mirror images: " << cpp_strerror(r)
-                 << dendl;
-    close_images();
-    return;
-  }
-
-  remove_mirror_group();
-}
-
-template <typename I>
-void GroupEnableRequest<I>::remove_mirror_group() {
-  ldout(m_cct, 10) << dendl;
-
-  librados::ObjectWriteOperation op;
-  cls_client::mirror_group_remove(&op, m_group_id);
-
-  auto comp = create_rados_callback<
-    GroupEnableRequest<I>,
-    &GroupEnableRequest<I>::handle_remove_mirror_group>(this);
-  int r = m_group_ioctx.aio_operate(RBD_MIRRORING, comp, &op);
-  ceph_assert(r == 0);
-  comp->release();
-
-}
-
-template <typename I>
-void GroupEnableRequest<I>::handle_remove_mirror_group(int r) {
-  ldout(m_cct, 10) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(m_cct) << "failed to remove mirror group: " << cpp_strerror(r)
-                 << dendl;
-  }
-
-  close_images();
 }
 
 template <typename I>

--- a/src/librbd/mirror/GroupEnableRequest.h
+++ b/src/librbd/mirror/GroupEnableRequest.h
@@ -39,43 +39,50 @@ private:
   /**
    * @verbatim
    *
-   * <start>
-   *    |
-   *    v                         (on error)
-   * GET_MIRROR_GROUP  * * * * * * * * * * *
-   *    |                                  *
-   *    v                                  *
-   * PREPARE_GROUP_IMAGES  * * * * * * * * *
-   *    |                                  *
-   *    v                                  *
-   * VALIDATE_IMAGES   * * * * * * * * * * *
-   *    |                                  *
-   *    v                                  *
-   * SET_MIRROR_GROUP_ENABLING * * * * * * *
-   *    |                                  *
-   *    v (incomplete)                     *
-   * CREATE_PRIMARY_GROUP_SNAP * * * * * * *
-   *    |                                  *
-   *    v (skip if not needed)             *
-   * CREATE_PRIMARY_IMAGE_SNAPS            *
-   *    |                                  *
-   *    v (complete)                       *
-   * UPDATE_PRIMARY_GROUP_SNAP * * * * * * *
-   *    |                                  *
-   *    v                                  *
-   * SET_MIRROR_IMAGES_ENABLED * * * * * * *
-   *    |                                  *
-   *    v                                  *
-   * SET_MIRROR_GROUP_ENABLED  * * * * * * *
-   *    |                                  *
-   *    v                            (if required)
-   * NOTIFY_MIRRORING_WATCHER           cleanup
-   *    |                                  *
-   *    v                                  *
-   * CLOSE_IMAGE < * * * * * * * * * * * * *
-   *    |
-   *    v
-   * <finish>
+   *                            <start>
+   *                               |
+   *                               v                         (on error)
+   *                            GET_MIRROR_GROUP  * * * * * * * * * * * * * * *
+   *                               |                                          *
+   *                               v                         (on error)       *
+   *                            PREPARE_GROUP_IMAGES  * * * * * * * * * * *   *
+   *                               |                                      *   *
+   *                               v                         (on error)   *   *
+   *                            VALIDATE_IMAGES * * * * * * * * * * * * * *   *
+   *                               |                                      *   *
+   *                               V                         (on error)   *   *
+   *                            SET_MIRROR_GROUP_ENABLING * * * * * * * * *   *
+   *                               |                                      *   *
+   *  (complete snapshot present)  v                         (on error)   *   *
+   *        < - - - - - - - - - CHECK_PRIMARY_GROUP_SNAP_COMPLETE * * * * *   *
+   *        |                      | (complete snapshot absent)           *   *
+   *        |                      |                                      *   *
+   *        v                      v (incomplete)            (on error)   *   *
+   *  FETCH_GLOBAL_IMAGE_IDS    CREATE_PRIMARY_GROUP_SNAP * * * * * * * * *   *
+   *        |                      |                                      *   *
+   *        |                      v (skip if not needed)    (on error)   *   *
+   *        |                   CREATE_PRIMARY_IMAGE_SNAPS * * * * * * *  *   *
+   *        |                      |                                      *   *
+   *        |                      v (complete)              (on error)   *   *
+   *        |                   UPDATE_PRIMARY_GROUP_SNAP * * * * * * * * *   *
+   *        |                      |                                      *   *
+   *        |                      v                         (on error)   *   *
+   *        v - - - - - - - - > SET_MIRROR_IMAGES_ENABLED * * * * * * * * *   *
+   *        *                      |                                      *   *
+   *        *                      v                         (on error)   *   *
+   *        *                   SET_MIRROR_GROUP_ENABLED  * * * * * * * * *   *
+   *        *                      |                                      *   *
+   *        *                      v                                      *   *
+   *        *                   GROUP_UNLINK_PEER                         *   *
+   *        *                      |                                      *   *
+   *        *                      v                                      *   *
+   *        *                   NOTIFY_MIRRORING_WATCHER                  *   *
+   *        *                      |                                      *   *
+   *        *  (on error)          v                                      *   *
+   *        * * * * * * * * * * CLOSE_IMAGES < * * * * * * * * * * * * *  *   *
+   *                               |                                          *
+   *                               v * * * * * * * * * * * * * * * * * * * *  *
+   *                            <finish>
    *
    * @endverbatim
    */
@@ -103,11 +110,9 @@ private:
   std::vector<cls::rbd::GroupImageStatus> m_images;
 
   cls::rbd::GroupSnapshot m_group_snap;
+  std::vector<cls::rbd::GroupSnapshot> m_group_snaps;
   std::vector<uint64_t> m_snap_ids;
   std::vector<std::string> m_global_image_ids;
-
-  bool m_need_to_cleanup_group_snapshot = false;
-  bool m_need_to_cleanup_mirror_images = false;
 
   void get_mirror_group();
   void handle_get_mirror_group(int r);
@@ -117,11 +122,16 @@ private:
 
   void validate_images();
 
-  void create_primary_group_snapshot();
-  void handle_create_primary_group_snapshot(int r);
-
   void set_mirror_group_enabling();
   void handle_set_mirror_group_enabling(int r);
+
+  void check_primary_group_snap_complete();
+  void handle_check_primary_group_snap_complete(int r);
+
+  void fetch_global_image_ids();
+
+  void create_primary_group_snapshot();
+  void handle_create_primary_group_snapshot(int r);
 
   void create_primary_image_snapshots();
   void handle_create_primary_image_snapshots(int r);
@@ -135,30 +145,14 @@ private:
   void set_mirror_group_enabled();
   void handle_set_mirror_group_enabled(int r);
 
+  void group_unlink_peer();
+  void handle_group_unlink_peer(int r);
+
   void notify_mirroring_watcher();
   void handle_notify_mirroring_watcher(int r);
 
   void close_images();
   void handle_close_images(int r);
-
-  // Cleanup
-  void disable_mirror_group();
-  void handle_disable_mirror_group(int r);
-
-  void get_mirror_images_for_cleanup();
-  void handle_get_mirror_images_for_cleanup(int r);
-
-  void disable_mirror_images();
-  void handle_disable_mirror_images(int r);
-
-  void remove_primary_group_snapshot();
-  void handle_remove_primary_group_snapshot(int r);
-
-  void remove_mirror_images();
-  void handle_remove_mirror_images(int r);
-
-  void remove_mirror_group();
-  void handle_remove_mirror_group(int r);
 
   void finish(int r);
 };

--- a/src/librbd/mirror/GroupEnableRequest.h
+++ b/src/librbd/mirror/GroupEnableRequest.h
@@ -47,7 +47,7 @@ private:
    *    v                                  *
    * PREPARE_GROUP_IMAGES  * * * * * * * * *
    *    |                                  *
-   *    v  (skip if not needed)            *
+   *    v                                  *
    * VALIDATE_IMAGES   * * * * * * * * * * *
    *    |                                  *
    *    v                                  *
@@ -62,7 +62,7 @@ private:
    *    v (complete)                       *
    * UPDATE_PRIMARY_GROUP_SNAP * * * * * * *
    *    |                                  *
-   *    v (skip if not needed)             *
+   *    v                                  *
    * SET_MIRROR_IMAGES_ENABLED * * * * * * *
    *    |                                  *
    *    v                                  *
@@ -71,7 +71,7 @@ private:
    *    v                            (if required)
    * NOTIFY_MIRRORING_WATCHER           cleanup
    *    |                                  *
-   *    v (skip if not needed)             *
+   *    v                                  *
    * CLOSE_IMAGE < * * * * * * * * * * * * *
    *    |
    *    v

--- a/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupPrepareImagesRequest.cc
@@ -191,8 +191,8 @@ void GroupPrepareImagesRequest<I>::check_mirror_images_disabled() {
 
     auto on_mirror_image_get = new LambdaContext(
       [this, i, new_sub_ctx=gather_ctx->new_sub()](int r) {
+        cls::rbd::MirrorImage mirror_image;
         if (r == 0) {
-          cls::rbd::MirrorImage mirror_image;
           auto iter = m_out_bls[i].cbegin();
           r = cls_client::mirror_image_get_finish(&iter, &mirror_image);
         }
@@ -201,9 +201,15 @@ void GroupPrepareImagesRequest<I>::check_mirror_images_disabled() {
           // image is disabled for mirroring as required
           r = 0;
         } else if (r == 0) {
-          lderr(m_cct) << "image_id=" << m_images[i].spec.image_id
-                       << " is not disabled for mirroring" << dendl;
-          r = -EINVAL;
+          // Allow retrying OP_ENABLE for images that are already enabled.
+          // This handles the case where a previous OP_ENABLE partially
+          // completed.
+          if (!(m_operation == OP_ENABLE &&
+                mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_ENABLED)) {
+            lderr(m_cct) << "image_id=" << m_images[i].spec.image_id
+                         << " is not disabled for mirroring" << dendl;
+            r = -EINVAL;
+          }
         } else {
           lderr(m_cct) << "failed to get mirror image info for image_id="
                        << m_images[i].spec.image_id << ": "


### PR DESCRIPTION
    Currently, the GroupEnableRequest state machine includes an undo path
    that attempts to revert partially completed steps when the request does
    not finish. However, execution of the undo path itself is not
    guaranteed. Recovery instead relies on issuing a `group disable`
    command to undo a partial group enable before retrying `group enable`.
    
    Align GroupEnableRequest with the behavior of other mirror group APIs
    such as promote, demote, and disable, where reissuing the same command
    resumes and completes a partially finished operation. Update the state
    machine accordingly by making steps idempotent where possible and
    skipping steps that are no longer required.
    
    This allows `group enable` to be safely retried after partial completion
    without requiring an explicit `group disable`.
    
    Signed-off-by: Ramana Raja <rraja@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
