### PR TITLE
osd: add missing 'override' specifier

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -213,7 +213,7 @@ public:
     return recovery_state.get_osdmap();
   }
 
-  epoch_t get_osdmap_epoch() const override final {
+  epoch_t get_osdmap_epoch() const final {
     return recovery_state.get_osdmap()->get_epoch();
   }
 
@@ -1407,7 +1407,10 @@ protected:
 
 // ScrubberPasskey getters/misc:
 public:
- const pg_info_t& get_pg_info(ScrubberPasskey) const final { return info; }
+  const pg_info_t& get_pg_info(ScrubberPasskey) const final
+  {
+    return info;
+  }
 
  OSDService* get_pg_osd(ScrubberPasskey) const { return osd; }
 

--- a/src/osd/scheduler/OpScheduler.h
+++ b/src/osd/scheduler/OpScheduler.h
@@ -95,7 +95,7 @@ public:
     queue(std::forward<Args>(args)...)
   {}
 
-  void enqueue(OpSchedulerItem &&item) final {
+  void enqueue(OpSchedulerItem &&item) override {
     unsigned priority = item.get_priority();
     unsigned cost = item.get_cost();
 
@@ -107,7 +107,7 @@ public:
 	item.get_owner(), priority, cost, std::move(item));
   }
 
-  void enqueue_front(OpSchedulerItem &&item) final {
+  void enqueue_front(OpSchedulerItem &&item) override {
     unsigned priority = item.get_priority();
     unsigned cost = item.get_cost();
     if (priority >= cutoff)
@@ -120,29 +120,29 @@ public:
 	priority, cost, std::move(item));
   }
 
-  bool empty() const final {
+  bool empty() const override {
     return queue.empty();
   }
 
-  WorkItem dequeue() final {
+  WorkItem dequeue() override {
     return queue.dequeue();
   }
 
-  void dump(ceph::Formatter &f) const final {
+  void dump(ceph::Formatter &f) const override {
     return queue.dump(&f);
   }
 
-  void print(std::ostream &out) const final {
+  void print(std::ostream &out) const override {
     out << "ClassedOpQueueScheduler(queue=";
     queue.print(out);
     out << ", cutoff=" << cutoff << ")";
   }
 
-  op_queue_type_t get_type() const final {
+  op_queue_type_t get_type() const override {
     return queue.get_type();
   }
 
-  ~ClassedOpQueueScheduler() final {};
+  virtual ~ClassedOpQueueScheduler() {};
 };
 
 }


### PR DESCRIPTION
Note: when using 'final', the compiler does not
check that the function is actually overriding a base class function.

Using only 'override' wherever the class itself is already marked 'final', 'override final' otherwise.
