### PR TITLE
crimson: add missing 'override' specifier

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -336,7 +336,7 @@ class VersionHook final : public AdminSocketHook {
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&&) const final
+				      ceph::bufferlist&&) const override
   {
     LOG_PREFIX(AdminSocket::VersionHook);
     INFO("");
@@ -361,7 +361,7 @@ class GitVersionHook final : public AdminSocketHook {
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&&) const final
+				      ceph::bufferlist&&) const override
   {
     LOG_PREFIX(AdminSocket::AdminSocketHook);
     INFO("");
@@ -384,7 +384,7 @@ class HelpHook final : public AdminSocketHook {
 
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&&) const final
+				      ceph::bufferlist&&) const override
   {
     LOG_PREFIX(AdminSocket::HelpHook);
     INFO("");
@@ -413,7 +413,7 @@ class GetdescsHook final : public AdminSocketHook {
 
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
 				      std::string_view format,
-				      ceph::bufferlist&&) const final
+				      ceph::bufferlist&&) const override
   {
     LOG_PREFIX(AdminSocket::GetdescsHook);
     INFO("");
@@ -441,7 +441,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
 				      std::string_view format,
-				      ceph::bufferlist&&) const final
+				      ceph::bufferlist&&) const override
   {
     LOG_PREFIX(AdminSocket::InjectArgsHook);
     INFO("");
@@ -471,7 +471,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocket::ConfigShowHook);
     INFO("");
@@ -495,7 +495,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocket::ConfigGetHook);
     INFO("");
@@ -532,7 +532,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
                                       std::string_view format,
-                                      ceph::bufferlist&&) const final
+                                      ceph::bufferlist&&) const final override
   {
     LOG_PREFIX(AdminSocket::ConfigSetHook);
     INFO("");
@@ -567,7 +567,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocket::ConfigHelpHook);
     INFO("");

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -57,7 +57,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::OsdStatusHook);
     DEBUG("");
@@ -86,7 +86,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::SendBeaconHook);
     DEBUG("");
@@ -120,7 +120,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
               std::string_view format,
-              ceph::bufferlist&& input) const final
+              ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::RunOSDBenchHook::call);
     DEBUG("");
@@ -209,7 +209,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&&) const final
+				      ceph::bufferlist&&) const final override
   {
     LOG_PREFIX(AdminSocketHook::FlushPgStatsHook);
     DEBUG("");
@@ -236,7 +236,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const override
   {
     LOG_PREFIX(AdminSocketHook::DumpPGStateHistory);
     DEBUG("");
@@ -274,7 +274,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const override
   {
     LOG_PREFIX(AdminSocketHook::DumpPerfCountersHook);
     DEBUG("");
@@ -308,7 +308,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::AssertAlwaysHook);
     DEBUG("");
@@ -334,7 +334,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::DumpMetricsHook);
     DEBUG("");
@@ -432,7 +432,7 @@ public:
 
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::InjectDataErrorHook);
     DEBUG("");
@@ -476,7 +476,7 @@ public:
 
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::InjectMDataErrorHook);
     DEBUG("");
@@ -516,7 +516,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::DumpInFlightOpsHook);
     DEBUG("");
@@ -547,7 +547,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::DumpHistoricOpsHook);
     DEBUG("");
@@ -573,7 +573,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::DumpSlowestHistoricOpsHook);
     DEBUG("");
@@ -598,7 +598,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
 				      std::string_view format,
-				      ceph::bufferlist&& input) const final
+				      ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::DumpRecoveryReservationsHook);
     DEBUG("");
@@ -628,7 +628,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const override
   {
     LOG_PREFIX(AdminSocketHook::DumpReactorBackendHook);
     DEBUG("");
@@ -649,7 +649,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t&,
                                      std::string_view format,
-                                     ceph::bufferlist&& input) const final
+                                     ceph::bufferlist&& input) const final override
   {
     LOG_PREFIX(AdminSocketHook::StoreShardNumsHook);
     DEBUG("");

--- a/src/crimson/admin/pg_commands.cc
+++ b/src/crimson/admin/pg_commands.cc
@@ -36,7 +36,7 @@ public:
   {}
   seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
                                       std::string_view format,
-                                      ceph::bufferlist&& input) const final
+                                      ceph::bufferlist&& input) const final override
   {
     // we have "ceph tell <pgid> <cmd>". and it is the ceph cli's responsibility
     // to add "pgid" to the cmd dict. as rados_pg_command() does not set it for
@@ -102,7 +102,7 @@ private:
   do_command(Ref<PG> pg,
              const cmdmap_t&,
              std::string_view format,
-             ceph::bufferlist&& input) const final
+             ceph::bufferlist&& input) const override
   {
     std::unique_ptr<Formatter> f{Formatter::create(format,
                                                    "json-pretty",
@@ -129,7 +129,7 @@ public:
   do_command(Ref<PG> pg,
              const cmdmap_t& cmdmap,
              std::string_view,
-             ceph::bufferlist&&) const final
+             ceph::bufferlist&&) const override
   {
     // what to do with the unfound object specifically.
     std::string cmd;
@@ -165,7 +165,7 @@ public:
   do_command(Ref<PG> pg,
 	     const cmdmap_t& cmdmap,
 	     std::string_view format,
-	     ceph::bufferlist&&) const final
+	     ceph::bufferlist&&) const final override
   {
     LOG_PREFIX(ScrubCommand::do_command);
     DEBUGDPP("deep: {}", *pg, deep);

--- a/src/crimson/auth/DummyAuth.h
+++ b/src/crimson/auth/DummyAuth.h
@@ -13,19 +13,19 @@ public:
 
   // client
   std::vector<uint32_t>
-  get_supported_auth_methods(int peer_type) final {
+  get_supported_auth_methods(int peer_type) final override {
     return {CEPH_AUTH_NONE};
   }
 
   std::vector<uint32_t>
   get_supported_con_modes(int peer_type,
-			  uint32_t auth_method) final {
+			  uint32_t auth_method) final override {
     return {CEPH_CON_MODE_CRC};
   }
 
   uint32_t pick_con_mode(int peer_type,
 			 uint32_t auth_method,
-			 const std::vector<uint32_t>& preferred_modes) final {
+			 const std::vector<uint32_t>& preferred_modes) final override {
     ceph_assert(auth_method == CEPH_AUTH_NONE);
     ceph_assert(preferred_modes.size() &&
                 preferred_modes[0] == CEPH_CON_MODE_CRC);
@@ -33,7 +33,7 @@ public:
   }
 
   AuthAuthorizeHandler* get_auth_authorize_handler(int peer_type,
-						   int auth_method) final {
+						   int auth_method) final override {
     return nullptr;
   }
 

--- a/src/crimson/common/coroutine.h
+++ b/src/crimson/common/coroutine.h
@@ -60,7 +60,7 @@ struct interrupt_cond_capture {
     template <typename T>
     type_erased_cond_checker(T &&t) : cond(std::forward<T>(t)) {}
 
-    std::optional<Future> may_interrupt() final {
+    std::optional<Future> may_interrupt() override {
       return cond->template may_interrupt<Future>();
     }
   };
@@ -135,7 +135,7 @@ public:
   std::suspend_never initial_suspend() noexcept { return { }; }
   std::suspend_never final_suspend() noexcept { return { }; }
 
-  void run_and_dispose() noexcept final {
+  void run_and_dispose() noexcept final override {
     if constexpr (is_interruptible) {
       cond.restore();
     }

--- a/src/crimson/common/exception.h
+++ b/src/crimson/common/exception.h
@@ -17,7 +17,7 @@ class interruption : public std::exception
 
 class system_shutdown_exception final : public interruption{
 public:
-  const char* what() const noexcept final {
+  const char* what() const noexcept override {
     return "system shutting down";
   }
 };
@@ -25,7 +25,7 @@ public:
 class actingset_changed final : public interruption {
 public:
   actingset_changed(bool sp) : still_primary(sp) {}
-  const char* what() const noexcept final {
+  const char* what() const noexcept override {
     return "acting set changed";
   }
   bool is_primary() const {

--- a/src/crimson/common/logclient.h
+++ b/src/crimson/common/logclient.h
@@ -68,7 +68,7 @@ public:
   OstreamTemp debug() {
     return OstreamTemp(CLOG_DEBUG, this);
   }
-  void debug(std::stringstream &s) final {
+  void debug(std::stringstream &s) final override {
     do_log(CLOG_DEBUG, s);
   }
   /**
@@ -88,28 +88,28 @@ public:
         ceph_abort();
     }
   }
-  OstreamTemp info() final {
+  OstreamTemp info() final override {
     return OstreamTemp(CLOG_INFO, this);
   }
-  void info(std::stringstream &s) final {
+  void info(std::stringstream &s) final override {
     do_log(CLOG_INFO, s);
   }
-  OstreamTemp warn() final {
+  OstreamTemp warn() final override {
     return OstreamTemp(CLOG_WARN, this);
   }
-  void warn(std::stringstream &s) final {
+  void warn(std::stringstream &s) final override {
     do_log(CLOG_WARN, s);
   }
-  OstreamTemp error() final {
+  OstreamTemp error() final override {
     return OstreamTemp(CLOG_ERROR, this);
   }
-  void error(std::stringstream &s) final {
+  void error(std::stringstream &s) final override {
     do_log(CLOG_ERROR, s);
   }
-  OstreamTemp sec() final {
+  OstreamTemp sec() final override {
     return OstreamTemp(CLOG_SEC, this);
   }
-  void sec(std::stringstream &s) final {
+  void sec(std::stringstream &s) final override {
     do_log(CLOG_SEC, s);
   }
 
@@ -163,8 +163,8 @@ public:
 		     uuid_d &fsid,
 		     std::string &host);
 
-  void do_log(clog_type prio, std::stringstream& ss) final;
-  void do_log(clog_type prio, const std::string& s) final;
+  void do_log(clog_type prio, std::stringstream& ss) final override;
+  void do_log(clog_type prio, const std::string& s) final override;
 
 private:
   LogClient *parent;

--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -262,7 +262,7 @@ public:
   }
 
 private:
-  const char *get_type_name() const final {
+  const char *get_type_name() const final override {
     return static_cast<const T*>(this)->type_name;
   }
   using event_list_t = boost::intrusive::list<BlockingEvent>;
@@ -312,7 +312,7 @@ struct AggregateBlockingEvent {
       typename std::list<T>::iterator iter;
       typename T::template Trigger<OpT> trigger;
 
-      typename T::TriggerI &get_trigger() final {
+      typename T::TriggerI &get_trigger() override {
 	return trigger;
       }
 
@@ -322,13 +322,13 @@ struct AggregateBlockingEvent {
 	iter(event.events.emplace(event.events.end())),
 	trigger(*iter, op) {}
 
-      ~TriggerContainer() final {
+      ~TriggerContainer() {
 	event.events.erase(iter);
       }
     };
 
   protected:
-    typename TriggerI::TriggerContainerIRef create_part_trigger() final {
+    typename TriggerI::TriggerContainerIRef create_part_trigger() override {
       return std::make_unique<TriggerContainer>(event, op);
     }
 
@@ -441,13 +441,13 @@ class OperationRegistryT : public OperationRegistryI {
   > registries;
 
 protected:
-  void do_register(Operation *op) final {
+  void do_register(Operation *op) final override {
     const auto op_type = op->get_type();
     registries[op_type].push_back(*op);
     op->set_id(++next_id);
   }
 
-  bool registries_empty() const final {
+  bool registries_empty() const final override {
     return std::all_of(registries.begin(),
 		       registries.end(),
 		       [](auto& opl) {
@@ -656,7 +656,7 @@ public:
  */
 template <class T>
 class OrderedExclusivePhaseT : public PipelineStageIT<T> {
-  void dump_detail(ceph::Formatter *f) const final {
+  void dump_detail(ceph::Formatter *f) const final override {
     f->dump_unsigned("waiting", waiting);
     if (held_by != Operation::NULL_ID) {
       f->dump_unsigned("held_by_operation_id", held_by);
@@ -670,11 +670,11 @@ class OrderedExclusivePhaseT : public PipelineStageIT<T> {
     ExitBarrier(OrderedExclusivePhaseT &phase, Operation::id_t id)
       : phase(&phase), op_id(id) {}
 
-    std::optional<seastar::future<>> wait() final {
+    std::optional<seastar::future<>> wait() override {
       return std::nullopt;
     }
 
-    ~ExitBarrier() final {
+    ~ExitBarrier() {
       assert(phase);
       assert(phase->core == seastar::this_shard_id());
       phase->exit(op_id);
@@ -724,7 +724,7 @@ private:
 template <class T>
 class OrderedConcurrentPhaseT : public PipelineStageIT<T> {
 private:
-  void dump_detail(ceph::Formatter *f) const final {}
+  void dump_detail(ceph::Formatter *f) const final override {}
 
   template <class TriggerT>
   class ExitBarrier final : public PipelineExitBarrierI {
@@ -737,7 +737,7 @@ private:
       seastar::future<> &&barrier,
       TriggerT& trigger) : phase(&phase), barrier(std::move(barrier)), trigger(trigger) {}
 
-    std::optional<seastar::future<>> wait() final {
+    std::optional<seastar::future<>> wait() override {
       assert(phase);
       assert(barrier);
       auto ret = std::move(*barrier);
@@ -745,7 +745,7 @@ private:
       return trigger.maybe_record_exit_barrier(std::move(ret));
     }
 
-    ~ExitBarrier() final {
+    ~ExitBarrier() {
       assert(phase);
       assert(phase->core == seastar::this_shard_id());
       if (barrier) {
@@ -784,17 +784,17 @@ private:
  */
 template <class T>
 class UnorderedStageT : public PipelineStageIT<T> {
-  void dump_detail(ceph::Formatter *f) const final {}
+  void dump_detail(ceph::Formatter *f) const final override {}
 
   class ExitBarrier final : public PipelineExitBarrierI {
   public:
     ExitBarrier() = default;
 
-    std::optional<seastar::future<>> wait() final {
+    std::optional<seastar::future<>> wait() override {
       return std::nullopt;
     }
 
-    ~ExitBarrier() final {}
+    ~ExitBarrier() {}
   };
 
 public:

--- a/src/crimson/common/subop_blocker.h
+++ b/src/crimson/common/subop_blocker.h
@@ -19,7 +19,7 @@ struct SubOpBlocker : crimson::BlockerT<SubOpBlocker<T>> {
 
   using id_done_t = std::pair<crimson::OperationRef, T>;
 
-  void dump_detail(Formatter *f) const final {
+  void dump_detail(Formatter *f) const final override {
     f->open_array_section("dependent_operations");
     {
       for (const auto &kv : subops) {

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -49,8 +49,8 @@ public:
 private:
   std::optional<seastar::future<>> ms_dispatch(
       crimson::net::ConnectionRef conn, Ref<Message> m) override;
-  void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
-  void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id) final;
+  void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final override;
+  void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id) final override;
   seastar::future<> handle_mgr_map(crimson::net::ConnectionRef conn,
 				   Ref<MMgrMap> m);
   seastar::future<> handle_mgr_conf(crimson::net::ConnectionRef conn,

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -119,21 +119,21 @@ public:
   void print(std::ostream&) const;
 private:
   // AuthServer methods
-  std::vector<uint32_t> get_supported_auth_methods(int peer_type) final;
+  std::vector<uint32_t> get_supported_auth_methods(int peer_type) final override;
   std::vector<uint32_t> get_supported_con_modes(int peer_type,
-						uint32_t auth_method) final;
+						uint32_t auth_method) final override;
   uint32_t pick_con_mode(int peer_type,
 			 uint32_t auth_method,
-			 const std::vector<uint32_t>& preferred_modes) final;
+			 const std::vector<uint32_t>& preferred_modes) final override;
   AuthAuthorizeHandler* get_auth_authorize_handler(int peer_type,
-						   int auth_method) final;
+						   int auth_method) final override;
   int handle_auth_request(crimson::net::Connection &conn,
 			  AuthConnectionMeta &auth_meta,
 			  bool more,
 			  uint32_t auth_method,
 			  const ceph::bufferlist& payload,
 			  uint64_t *p_peer_global_id,
-			  ceph::bufferlist *reply) final;
+			  ceph::bufferlist *reply) final override;
 
   crimson::common::CephContext cct; // for auth_registry
   AuthRegistry auth_registry;
@@ -142,19 +142,19 @@ private:
   // AuthClient methods
   crimson::auth::AuthClient::auth_request_t
   get_auth_request(crimson::net::Connection &conn,
-		   AuthConnectionMeta &auth_meta) final;
+		   AuthConnectionMeta &auth_meta) final override;
 
    // Handle server's request to continue the handshake
   ceph::bufferlist handle_auth_reply_more(crimson::net::Connection &conn,
 					  AuthConnectionMeta &auth_meta,
-					  const bufferlist& bl) final;
+					  const bufferlist& bl) final override;
 
    // Handle server's indication that authentication succeeded
   int handle_auth_done(crimson::net::Connection &conn,
 		       AuthConnectionMeta &auth_meta,
 		       uint64_t global_id,
 		       uint32_t con_mode,
-		       const bufferlist& bl) final;
+		       const bufferlist& bl) final override;
 
    // Handle server's indication that the previous auth attempt failed
   int handle_auth_bad_method(crimson::net::Connection &conn,
@@ -162,7 +162,7 @@ private:
 			     uint32_t old_auth_method,
 			     int result,
 			     const std::vector<uint32_t>& allowed_methods,
-			     const std::vector<uint32_t>& allowed_modes) final;
+			     const std::vector<uint32_t>& allowed_modes) final override;
 
 private:
   void tick();

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -29,16 +29,16 @@ public:
  */
 private:
   seastar::future<> notify_out(
-      cc_seq_t cc_seq) final;
+      cc_seq_t cc_seq) override;
 
   seastar::future<> notify_out_fault(
       cc_seq_t cc_seq,
       const char *where,
       std::exception_ptr,
-      io_handler_state) final;
+      io_handler_state) override;
 
   seastar::future<> notify_mark_down(
-      cc_seq_t cc_seq) final;
+      cc_seq_t cc_seq) override;
 
 /*
 * as ProtocolV2 to be called by SocketConnection

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -153,7 +153,7 @@ public:
   Interceptor *interceptor = nullptr;
 #endif
 
-  seastar::future<> mark_down(const entity_addr_t& a) final {
+  seastar::future<> mark_down(const entity_addr_t& a) override {
     auto conn = lookup_conn(a);
     if (conn) {
       return seastar::smp::submit_to(

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -112,7 +112,7 @@ public:
   IOHandler(ChainedDispatchers &,
             SocketConnection &);
 
-  ~IOHandler() final;
+  ~IOHandler();
 
   IOHandler(const IOHandler &) = delete;
   IOHandler(IOHandler &&) = delete;
@@ -123,35 +123,35 @@ public:
  * as ConnectionHandler
  */
 public:
-  seastar::shard_id get_shard_id() const final {
+  seastar::shard_id get_shard_id() const override {
     return shard_states->get_shard_id();
   }
 
-  bool is_connected() const final {
+  bool is_connected() const override {
     ceph_assert_always(seastar::this_shard_id() == get_shard_id());
     return protocol_is_connected;
   }
 
-  seastar::future<> send(MessageURef msg) final;
+  seastar::future<> send(MessageURef msg) override;
 
-  seastar::future<> send_keepalive() final;
+  seastar::future<> send_keepalive() override;
 
-  clock_t::time_point get_last_keepalive() const final {
+  clock_t::time_point get_last_keepalive() const override {
     ceph_assert_always(seastar::this_shard_id() == get_shard_id());
     return last_keepalive;
   }
 
-  clock_t::time_point get_last_keepalive_ack() const final {
+  clock_t::time_point get_last_keepalive_ack() const override {
     ceph_assert_always(seastar::this_shard_id() == get_shard_id());
     return last_keepalive_ack;
   }
 
-  void set_last_keepalive_ack(clock_t::time_point when) final {
+  void set_last_keepalive_ack(clock_t::time_point when) override {
     ceph_assert_always(seastar::this_shard_id() == get_shard_id());
     last_keepalive_ack = when;
   }
 
-  void mark_down() final;
+  void mark_down() override;
 
 /*
  * as IOHandler to be called by ProtocolV2 handshake

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -56,7 +56,7 @@ public:
       alien_done(done) {
   }
 
-  void finish(int) final {
+  void finish(int) override {
     std::ignore = seastar::alien::submit_to(alien, cpuid,
         [&_alien_done=this->alien_done] {
       _alien_done.set_value();

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -106,7 +106,7 @@ public:
     CollectionRef,
     const ghobject_t&,
     uint32_t op_flags = 0) override;
-  seastar::future<std::string> get_default_device_class() final;
+  seastar::future<std::string> get_default_device_class() override;
   get_attr_errorator::future<ceph::bufferlist> omap_get_header(
     CollectionRef,
     const ghobject_t&,

--- a/src/crimson/os/cyanstore/cyan_collection.h
+++ b/src/crimson/os/cyanstore/cyan_collection.h
@@ -39,7 +39,7 @@ struct Collection final : public FuturizedCollection {
   pool_opts_t pool_opts;
 
   Collection(const coll_t& c);
-  ~Collection() final;
+  ~Collection();
 
   ObjectRef create_object() const;
   ObjectRef get_object(ghobject_t oid);

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -43,12 +43,12 @@ struct singleton_ec : std::error_code {
   };
 private:
   struct this_error_category : std::error_category {
-    const char* name() const noexcept final {
+    const char* name() const noexcept final override {
       // XXX: we could concatenate with MsgV at compile-time but the burden
       // isn't worth the benefit.
       return "singleton_ec";
     }
-    std::string message([[maybe_unused]] const int ev) const final {
+    std::string message([[maybe_unused]] const int ev) const final override {
       assert(ev == 42);
       return MsgV;
     }

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -550,30 +550,30 @@ public:
    * JournalTrimmer interfaces
    */
 
-  journal_seq_t get_journal_head() const final {
+  journal_seq_t get_journal_head() const final override {
     return journal_head;
   }
 
-  void set_journal_head(journal_seq_t) final;
+  void set_journal_head(journal_seq_t) final override;
 
-  segment_seq_t get_journal_head_sequence() const final {
+  segment_seq_t get_journal_head_sequence() const final override {
     return journal_head_seq;
   }
 
-  void set_journal_head_sequence(segment_seq_t) final;
+  void set_journal_head_sequence(segment_seq_t) final override;
 
-  journal_seq_t get_dirty_tail() const final {
+  journal_seq_t get_dirty_tail() const final override {
     return journal_dirty_tail;
   }
 
-  journal_seq_t get_alloc_tail() const final {
+  journal_seq_t get_alloc_tail() const final override {
     return journal_alloc_tail;
   }
 
   void update_journal_tails(
-      journal_seq_t dirty_tail, journal_seq_t alloc_tail) final;
+      journal_seq_t dirty_tail, journal_seq_t alloc_tail) final override;
 
-  std::size_t get_trim_size_per_cycle() const final {
+  std::size_t get_trim_size_per_cycle() const final override {
     return config.max_backref_bytes_per_cycle +
       get_dirty_bytes_to_trim();
   }
@@ -607,7 +607,7 @@ public:
         backend_type, reserved_usage, roll_start, roll_size);
   }
 
-  bool try_reserve_inline_usage(std::size_t usage) final {
+  bool try_reserve_inline_usage(std::size_t usage) final override {
     reserved_usage += usage;
     if (should_block_io_on_trim()) {
       reserved_usage -= usage;
@@ -617,7 +617,7 @@ public:
     }
   }
 
-  void release_inline_usage(std::size_t usage) final {
+  void release_inline_usage(std::size_t usage) final override {
     ceph_assert(reserved_usage >= usage);
     reserved_usage -= usage;
   }
@@ -798,35 +798,35 @@ public:
   int64_t allocate(
     segment_id_t segment,
     segment_off_t offset,
-    extent_len_t len) final {
+    extent_len_t len) final override {
     return update_usage(segment, len);
   }
 
   int64_t release(
     segment_id_t segment,
     segment_off_t offset,
-    extent_len_t len) final {
+    extent_len_t len) final override {
     return update_usage(segment, -(int64_t)len);
   }
 
-  int64_t get_usage(segment_id_t segment) const final {
+  int64_t get_usage(segment_id_t segment) const final override {
     return live_bytes_by_segment[segment].live_bytes;
   }
 
-  double calc_utilization(segment_id_t segment) const final {
+  double calc_utilization(segment_id_t segment) const final override {
     auto& seg_bytes = live_bytes_by_segment[segment];
     return (double)seg_bytes.live_bytes / (double)seg_bytes.total_bytes;
   }
 
-  void dump_usage(segment_id_t) const final;
+  void dump_usage(segment_id_t) const final override;
 
-  void reset() final {
+  void reset() final override {
     for (auto &i : live_bytes_by_segment) {
       i.second = {0, 0};
     }
   }
 
-  SpaceTrackerIRef make_empty() const final {
+  SpaceTrackerIRef make_empty() const final override {
     auto ret = SpaceTrackerIRef(new SpaceTrackerSimple(*this));
     ret->reset();
     return ret;
@@ -906,7 +906,7 @@ public:
   int64_t allocate(
     segment_id_t segment,
     segment_off_t offset,
-    extent_len_t len) final {
+    extent_len_t len) final override {
     return segment_usage[segment].allocate(
       segment.device_segment_id(),
       offset,
@@ -917,7 +917,7 @@ public:
   int64_t release(
     segment_id_t segment,
     segment_off_t offset,
-    extent_len_t len) final {
+    extent_len_t len) final override {
     return segment_usage[segment].release(
       segment.device_segment_id(),
       offset,
@@ -925,23 +925,23 @@ public:
       block_size_by_segment_manager[segment.device_id()]);
   }
 
-  int64_t get_usage(segment_id_t segment) const final {
+  int64_t get_usage(segment_id_t segment) const final override {
     return segment_usage[segment].get_usage();
   }
 
-  double calc_utilization(segment_id_t segment) const final {
+  double calc_utilization(segment_id_t segment) const final override {
     return segment_usage[segment].calc_utilization();
   }
 
-  void dump_usage(segment_id_t seg) const final;
+  void dump_usage(segment_id_t seg) const final override;
 
-  void reset() final {
+  void reset() final override {
     for (auto &i: segment_usage) {
       i.second.reset();
     }
   }
 
-  SpaceTrackerIRef make_empty() const final {
+  SpaceTrackerIRef make_empty() const final override {
     auto ret = SpaceTrackerIRef(new SpaceTrackerDetailed(*this));
     ret->reset();
     return ret;
@@ -1338,16 +1338,16 @@ public:
    * SegmentProvider interfaces
    */
 
-  const segment_info_t& get_seg_info(segment_id_t id) const final {
+  const segment_info_t& get_seg_info(segment_id_t id) const final override {
     return segments[id];
   }
 
   segment_id_t allocate_segment(
-      segment_seq_t, segment_type_t, data_category_t, rewrite_gen_t) final;
+      segment_seq_t, segment_type_t, data_category_t, rewrite_gen_t) final override;
 
-  void close_segment(segment_id_t segment) final;
+  void close_segment(segment_id_t segment) final override;
 
-  void update_segment_avail_bytes(segment_type_t type, paddr_t offset) final {
+  void update_segment_avail_bytes(segment_type_t type, paddr_t offset) final override {
     assert(type == segment_type_t::OOL ||
            trimmer != nullptr); // segment_type_t::JOURNAL
     segments.update_written_to(type, offset);
@@ -1355,12 +1355,12 @@ public:
   }
 
   void update_modify_time(
-      segment_id_t id, sea_time_point tp, std::size_t num_extents) final {
+      segment_id_t id, sea_time_point tp, std::size_t num_extents) final override {
     ceph_assert(num_extents == 0 || tp != NULL_TIME);
     segments.update_modify_time(id, tp, num_extents);
   }
 
-  SegmentManagerGroup* get_segment_manager_group() final {
+  SegmentManagerGroup* get_segment_manager_group() final override {
     return sm_group.get();
   }
 
@@ -1368,19 +1368,19 @@ public:
    * AsyncCleaner interfaces
    */
 
-  void set_background_callback(BackgroundListener *cb) final {
+  void set_background_callback(BackgroundListener *cb) final override {
     background_callback = cb;
   }
 
-  void set_extent_callback(ExtentCallbackInterface *cb) final {
+  void set_extent_callback(ExtentCallbackInterface *cb) final override {
     extent_callback = cb;
   }
 
-  const segments_info_t* get_segments_info() const final {
+  const segments_info_t* get_segments_info() const final override {
    return &segments;
   }
 
-  store_statfs_t get_stat() const final {
+  store_statfs_t get_stat() const final override {
     store_statfs_t st;
     st.total = segments.get_total_bytes();
     st.available = segments.get_total_bytes() - stats.used_bytes;
@@ -1392,27 +1392,27 @@ public:
     return st;
   }
 
-  void print(std::ostream &, bool is_detailed) const final;
+  void print(std::ostream &, bool is_detailed) const final override;
 
-  bool check_usage_is_empty() const final {
+  bool check_usage_is_empty() const final override {
     return space_tracker->equals(*space_tracker->make_empty());
   }
 
-  mount_ret mount() final;
+  mount_ret mount() final override;
 
-  void mark_space_used(paddr_t, extent_len_t) final;
+  void mark_space_used(paddr_t, extent_len_t) final override;
 
-  void mark_space_free(paddr_t, extent_len_t) final;
+  void mark_space_free(paddr_t, extent_len_t) final override;
   
-  void commit_space_used(paddr_t addr, extent_len_t len) final {
+  void commit_space_used(paddr_t addr, extent_len_t len) final override {
     mark_space_used(addr, len);
   }
 
-  bool try_reserve_projected_usage(std::size_t) final;
+  bool try_reserve_projected_usage(std::size_t) final override;
 
-  void release_projected_usage(size_t) final;
+  void release_projected_usage(size_t) final override;
 
-  bool should_block_io_on_clean() const final {
+  bool should_block_io_on_clean() const final override {
     assert(background_callback->is_ready());
     if (get_segments_reclaimable() == 0) {
       // No CLOSED segments to reclaim
@@ -1422,12 +1422,12 @@ public:
     return aratio < config.available_ratio_hard_limit;
   }
 
-  bool can_clean_space() const final {
+  bool can_clean_space() const final override {
     assert(background_callback->is_ready());
     return get_segments_reclaimable() > 0;
   }
 
-  bool should_clean_space() const final {
+  bool should_clean_space() const final override {
     assert(background_callback->is_ready());
     if (get_segments_reclaimable() == 0) {
       return false;
@@ -1441,19 +1441,19 @@ public:
     );
   }
 
-  clean_space_ret clean_space() final;
+  clean_space_ret clean_space() final override;
 
-  const std::set<device_id_t>& get_device_ids() const final {
+  const std::set<device_id_t>& get_device_ids() const final override {
     return sm_group->get_device_ids();
   }
 
-  std::size_t get_reclaim_size_per_cycle() const final {
+  std::size_t get_reclaim_size_per_cycle() const final override {
     return config.reclaim_bytes_per_cycle;
   }
 
   // Testing interfaces
 
-  bool check_usage(bool has_cold_tier) final;
+  bool check_usage(bool has_cold_tier) final override;
 
 private:
   /*
@@ -1732,19 +1732,19 @@ public:
    * AsyncCleaner interfaces
    */
 
-  void set_background_callback(BackgroundListener *cb) final {
+  void set_background_callback(BackgroundListener *cb) final override {
     background_callback = cb;
   }
 
-  void set_extent_callback(ExtentCallbackInterface *cb) final {
+  void set_extent_callback(ExtentCallbackInterface *cb) final override {
     extent_callback = cb;
   }
 
-  const segments_info_t* get_segments_info() const final {
+  const segments_info_t* get_segments_info() const final override {
    return nullptr;
   }
 
-  store_statfs_t get_stat() const final {
+  store_statfs_t get_stat() const final override {
     store_statfs_t st;
     st.total = get_total_bytes();
     st.available = get_total_bytes() - get_journal_bytes() - stats.used_bytes;
@@ -1753,44 +1753,44 @@ public:
     return st;
   }
 
-  void print(std::ostream &, bool is_detailed) const final;
+  void print(std::ostream &, bool is_detailed) const final override;
 
-  mount_ret mount() final;
+  mount_ret mount() final override;
 
-  void mark_space_used(paddr_t, extent_len_t) final;
+  void mark_space_used(paddr_t, extent_len_t) final override;
 
-  void mark_space_free(paddr_t, extent_len_t) final;
+  void mark_space_free(paddr_t, extent_len_t) final override;
 
-  void commit_space_used(paddr_t, extent_len_t) final;
+  void commit_space_used(paddr_t, extent_len_t) final override;
 
-  bool try_reserve_projected_usage(std::size_t) final;
+  bool try_reserve_projected_usage(std::size_t) final override;
 
-  void release_projected_usage(size_t) final;
+  void release_projected_usage(size_t) final override;
 
-  bool should_block_io_on_clean() const final {
+  bool should_block_io_on_clean() const final override {
     return false;
   }
 
-  bool can_clean_space() const final {
+  bool can_clean_space() const final override {
     return false;
   }
 
-  bool should_clean_space() const final {
+  bool should_clean_space() const final override {
     return false;
   }
 
-  clean_space_ret clean_space() final;
+  clean_space_ret clean_space() final override;
 
-  const std::set<device_id_t>& get_device_ids() const final {
+  const std::set<device_id_t>& get_device_ids() const final override {
     return rb_group->get_device_ids();
   }
 
-  std::size_t get_reclaim_size_per_cycle() const final {
+  std::size_t get_reclaim_size_per_cycle() const final override {
     return 0;
   }
 
 #ifdef UNIT_TESTS_BUILT
-  void prefill_fragmented_devices() final {
+  void prefill_fragmented_devices() final override {
     LOG_PREFIX(RBMCleaner::prefill_fragmented_devices);
     SUBDEBUG(seastore_cleaner, "");
     auto rbs = rb_group->get_rb_managers();
@@ -1851,9 +1851,9 @@ public:
 
   // Testing interfaces
 
-  bool check_usage(bool has_cold_tier) final;
+  bool check_usage(bool has_cold_tier) final override;
 
-  bool check_usage_is_empty() const final {
+  bool check_usage_is_empty() const final override {
     // TODO
     return true;
   }

--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -62,7 +62,7 @@ public:
 
   static constexpr extent_types_t TYPE = extent_types_t::BACKREF_INTERNAL;
 
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return TYPE;
   }
 };
@@ -87,14 +87,14 @@ public:
 
   static constexpr extent_types_t TYPE = extent_types_t::BACKREF_LEAF;
 
-  extent_types_t get_type() const final  {
+  extent_types_t get_type() const final override  {
     return TYPE;
   }
 
   const_iterator insert(
     const_iterator iter,
     paddr_t key,
-    backref_map_val_t val) final {
+    backref_map_val_t val) final override {
     journal_insert(
       iter,
       key,
@@ -105,33 +105,33 @@ public:
 
   void update(
     const_iterator iter,
-    backref_map_val_t val) final {
+    backref_map_val_t val) final override {
     return journal_update(
       iter,
       val,
       maybe_get_delta_buffer());
   }
 
-  void remove(const_iterator iter) final {
+  void remove(const_iterator iter) final override {
     return journal_remove(
       iter,
       maybe_get_delta_buffer());
   }
 
-  void do_on_rewrite(Transaction &t, CachedExtent &extent) final {}
-  void do_on_replace_prior() final {}
-  void do_prepare_commit() final {}
+  void do_on_rewrite(Transaction &t, CachedExtent &extent) final override {}
+  void do_on_replace_prior() final override {}
+  void do_prepare_commit() final override {}
 
 
   void on_split(
     Transaction &t,
     BackrefLeafNode &left,
-    BackrefLeafNode &right) final {}
+    BackrefLeafNode &right) final override {}
 
   void on_merge(
     Transaction &t,
     BackrefLeafNode &left,
-    BackrefLeafNode &right) final {}
+    BackrefLeafNode &right) final override {}
 
   void on_balance(
     Transaction &t,
@@ -139,17 +139,17 @@ public:
     BackrefLeafNode &right,
     uint32_t pivot_idx,
     BackrefLeafNode &replacement_left,
-    BackrefLeafNode &replacement_right) final {}
+    BackrefLeafNode &replacement_right) final override {}
 
   void adjust_copy_src_dest_on_split(
     Transaction &t,
     BackrefLeafNode &left,
-    BackrefLeafNode &right) final {}
+    BackrefLeafNode &right) final override {}
 
   void adjust_copy_src_dest_on_merge(
     Transaction &t,
     BackrefLeafNode &left,
-    BackrefLeafNode &right) final {}
+    BackrefLeafNode &right) final override {}
 
   void adjust_copy_src_dest_on_balance(
     Transaction &t,
@@ -157,13 +157,13 @@ public:
     BackrefLeafNode &right,
     uint32_t pivot_idx,
     BackrefLeafNode &replacement_left,
-    BackrefLeafNode &replacement_right) final {}
+    BackrefLeafNode &replacement_right) final override {}
   // backref leaf nodes don't have to resolve relative addresses
-  void resolve_relative_addrs(paddr_t base) final {}
+  void resolve_relative_addrs(paddr_t base) final override {}
 
-  void node_resolve_vals(iterator from, iterator to) const final {}
+  void node_resolve_vals(iterator from, iterator to) const final override {}
 
-  void node_unresolve_vals(iterator from, iterator to) const final {}
+  void node_unresolve_vals(iterator from, iterator to) const final override {}
 };
 using BackrefLeafNodeRef = BackrefLeafNode::Ref;
 

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -23,60 +23,60 @@ public:
   {}
 
   mkfs_ret mkfs(
-    Transaction &t) final;
+    Transaction &t) final override;
 
   get_mapping_ret  get_mapping(
     Transaction &t,
-    paddr_t offset) final;
+    paddr_t offset) final override;
 
   get_mappings_ret get_mappings(
     Transaction &t,
     paddr_t offset,
-    paddr_t end) final;
+    paddr_t end) final override;
 
   new_mapping_ret new_mapping(
     Transaction &t,
     paddr_t key,
     extent_len_t len,
     laddr_t val,
-    extent_types_t type) final;
+    extent_types_t type) final override;
 
   merge_cached_backrefs_ret merge_cached_backrefs(
     Transaction &t,
     const journal_seq_t &limit,
-    const uint64_t max) final;
+    const uint64_t max) final override;
 
   remove_mapping_ret remove_mapping(
     Transaction &t,
-    paddr_t offset) final;
+    paddr_t offset) final override;
 
   scan_mapped_space_ret scan_mapped_space(
     Transaction &t,
-    scan_mapped_space_func_t &&f) final;
+    scan_mapped_space_func_t &&f) final override;
 
   init_cached_extent_ret init_cached_extent(
     Transaction &t,
-    CachedExtentRef e) final;
+    CachedExtentRef e) final override;
 
   rewrite_extent_ret rewrite_extent(
     Transaction &t,
-    CachedExtentRef extent) final;
+    CachedExtentRef extent) final override;
 
   Cache::backref_entry_query_mset_t
   get_cached_backref_entries_in_range(
     paddr_t start,
-    paddr_t end) final;
+    paddr_t end) final override;
 
   retrieve_backref_extents_in_range_ret
   retrieve_backref_extents_in_range(
     Transaction &t,
     paddr_t start,
-    paddr_t end) final;
+    paddr_t end) final override;
 
   void cache_new_backref_extent(
     paddr_t paddr,
     paddr_t key,
-    extent_types_t type) final;
+    extent_types_t type) final override;
 
 private:
   Cache &cache;

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -57,7 +57,9 @@ struct FixedKVNode : CachedExtent {
     return get_node_meta().is_in_range(key);
   }
 
-  void on_rewrite(Transaction &t, CachedExtent &extent, extent_len_t off) final {
+  void
+  on_rewrite(Transaction& t, CachedExtent& extent, extent_len_t off) final override
+  {
     assert(get_type() == extent.get_type());
     assert(off == 0);
     range = get_node_meta();
@@ -82,14 +84,14 @@ struct FixedKVNode : CachedExtent {
     }
   }
 
-  void on_delta_write(paddr_t record_block_offset) final {
+  void on_delta_write(paddr_t record_block_offset) final override {
     // All in-memory relative addrs are necessarily record-relative
     assert(get_prior_instance());
     assert(pending_for_transaction);
     resolve_relative_addrs(record_block_offset);
   }
 
-  void on_clean_read() final {
+  void on_clean_read() final override {
     // From initial write of block, relative addrs are necessarily block-relative
     resolve_relative_addrs(get_paddr());
   }
@@ -153,12 +155,12 @@ struct FixedKVInternalNode
   using child_node_t = ChildNode<node_type_t, node_type_t, NODE_KEY>;
   using root_node_t = RootChildNode<RootBlock, node_type_t>;
 
-  bool is_linked() const final {
+  bool is_linked() const final override {
     return this->has_parent_tracker() ||
 	   (this->is_btree_root() && this->has_root_parent());
   }
 
-  void do_on_rewrite(Transaction &t, CachedExtent &extent) final {
+  void do_on_rewrite(Transaction &t, CachedExtent &extent) final override {
     this->parent_node_t::on_rewrite(t, static_cast<node_type_t&>(extent));
   }
 
@@ -177,7 +179,7 @@ struct FixedKVInternalNode
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
-  uint16_t get_node_split_pivot() const final{
+  uint16_t get_node_split_pivot() const final override{
     return this->get_split_pivot().get_offset();
   }
 
@@ -185,7 +187,7 @@ struct FixedKVInternalNode
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
-  void prepare_commit(Transaction &t) final {
+  void prepare_commit(Transaction &t) final override {
     if (!is_rewrite_transaction(t.get_src())) {
       parent_node_t::prepare_commit();
     }
@@ -201,7 +203,7 @@ struct FixedKVInternalNode
     }
   }
 
-  void on_initial_write() final {
+  void on_initial_write() final override {
     // All in-memory relative addrs are necessarily block-relative
     resolve_relative_addrs(this->get_paddr());
     if (this->is_btree_root()) {
@@ -209,11 +211,11 @@ struct FixedKVInternalNode
     }
   }
 
-  void on_data_commit() final {
+  void on_data_commit() final override {
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
-  void on_invalidated(Transaction &t) final {
+  void on_invalidated(Transaction &t) final override {
     this->child_node_t::on_invalidated();
   }
 
@@ -221,11 +223,11 @@ struct FixedKVInternalNode
     return this->get_meta();
   }
 
-  uint32_t calc_crc32c() const final {
+  uint32_t calc_crc32c() const final override {
     return this->calc_phy_checksum();
   }
 
-  void update_in_extent_chksum_field(uint32_t crc) final {
+  void update_in_extent_chksum_field(uint32_t crc) final override {
     this->set_phy_checksum(crc);
   }
 
@@ -244,11 +246,11 @@ struct FixedKVInternalNode
     return CachedExtentRef(new node_type_t(*this));
   };
 
-  void clear_delta() final {
+  void clear_delta() final override {
     delta_buffer.clear();
   }
 
-  void on_replace_prior(Transaction &t) final {
+  void on_replace_prior(Transaction &t) final override {
     if (!is_rewrite_transaction(t.get_src())) {
       this->parent_node_t::on_replace_prior();
       if (this->is_btree_root()) {
@@ -399,7 +401,7 @@ struct FixedKVInternalNode
       pivot);
   }
 
-  void on_fully_loaded() final {
+  void on_fully_loaded() final override {
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
@@ -412,7 +414,7 @@ struct FixedKVInternalNode
    * resolve_relative_addrs fixes up relative internal references
    * based on base.
    */
-  void resolve_relative_addrs(paddr_t base) final {
+  void resolve_relative_addrs(paddr_t base) final override {
     LOG_PREFIX(FixedKVInternalNode::resolve_relative_addrs);
     for (auto i: *this) {
       if (i->get_val().is_relative()) {
@@ -504,7 +506,7 @@ struct FixedKVInternalNode
     return this->get_size() < get_min_capacity();
   }
 
-  void reapply_delta() final {
+  void reapply_delta() final override {
     if (delta_buffer.empty()) {
       return;
     }
@@ -608,7 +610,7 @@ struct FixedKVLeafNode
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
-  bool is_linked() const final {
+  bool is_linked() const final override {
     return this->has_parent_tracker() ||
 	   (this->is_btree_root() && this->has_root_parent());
   }
@@ -629,7 +631,7 @@ struct FixedKVLeafNode
     }
   }
 
-  void on_data_commit() final {
+  void on_data_commit() final override {
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
@@ -637,11 +639,11 @@ struct FixedKVLeafNode
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
-  void on_invalidated(Transaction &t) final {
+  void on_invalidated(Transaction &t) final override {
     this->child_node_t::on_invalidated();
   }
 
-  void on_initial_write() final {
+  void on_initial_write() final override {
     // All in-memory relative addrs are necessarily block-relative
     this->resolve_relative_addrs(this->get_paddr());
     if (this->is_btree_root()) {
@@ -658,7 +660,7 @@ struct FixedKVLeafNode
     return v != modifications;
   }
 
-  uint16_t get_node_split_pivot() const final{
+  uint16_t get_node_split_pivot() const final override{
     return this->get_split_pivot().get_offset();
   }
 
@@ -672,12 +674,12 @@ struct FixedKVLeafNode
     }
   }
 
-  void on_fully_loaded() final {
+  void on_fully_loaded() final override {
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
   virtual void do_prepare_commit() = 0;
-  void prepare_commit(Transaction &t) final {
+  void prepare_commit(Transaction &t) final override {
     if (!is_rewrite_transaction(t.get_src())) {
       do_prepare_commit();
     }
@@ -685,7 +687,7 @@ struct FixedKVLeafNode
   }
 
   virtual void do_on_replace_prior() = 0;
-  void on_replace_prior(Transaction &t) final {
+  void on_replace_prior(Transaction &t) final override {
     ceph_assert(!this->is_rewrite());
     if (!is_rewrite_transaction(t.get_src())) {
       do_on_replace_prior();
@@ -702,11 +704,11 @@ struct FixedKVLeafNode
     return this->get_meta();
   }
 
-  uint32_t calc_crc32c() const final {
+  uint32_t calc_crc32c() const final override {
     return this->calc_phy_checksum();
   }
 
-  void update_in_extent_chksum_field(uint32_t crc) final {
+  void update_in_extent_chksum_field(uint32_t crc) final override {
     this->set_phy_checksum(crc);
   }
 
@@ -724,7 +726,7 @@ struct FixedKVLeafNode
     return CachedExtentRef(new node_type_t(*static_cast<node_type_t*>(this)));
   };
 
-  void clear_delta() final {
+  void clear_delta() final override {
     delta_buffer.clear();
   }
 
@@ -886,7 +888,7 @@ struct FixedKVLeafNode
     return this->get_size() < get_min_capacity();
   }
 
-  void reapply_delta() final {
+  void reapply_delta() final override {
     if (delta_buffer.empty()) {
       return;
     }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -533,7 +533,7 @@ public:
 
   CachedExtentRef peek_extent_viewable_by_trans(
     Transaction &t,
-    CachedExtentRef extent) final
+    CachedExtentRef extent) final override
   {
     assert(extent);
     auto ext = extent->maybe_get_transactional_view(t);
@@ -543,7 +543,7 @@ public:
 
   get_extent_iertr::future<> maybe_wait_accessible(
     Transaction &t,
-    CachedExtent &extent) final {
+    CachedExtent &extent) final override {
     // as of now, only lba tree nodes can go in here,
     // so it must be fully loaded.
     assert(extent.is_valid());
@@ -612,7 +612,7 @@ public:
   get_extent_iertr::future<CachedExtentRef>
   get_extent_viewable_by_trans(
     Transaction &t,
-    CachedExtentRef extent) final
+    CachedExtentRef extent) final override
   {
     assert(extent->is_valid());
 
@@ -945,10 +945,10 @@ private:
     struct callable_wrapper final : callable_i {
       Func func;
       callable_wrapper(Func &&func) : func(std::forward<Func>(func)) {}
-      void operator()(CachedExtent &extent) final {
+      void operator()(CachedExtent &extent) override {
 	return func(extent);
       }
-      ~callable_wrapper() final = default;
+      ~callable_wrapper() = default;
     };
   public:
     std::unique_ptr<callable_i> wrapped;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1478,7 +1478,7 @@ public:
     : CachedExtent(other, s),
      seen_by_users(other.seen_by_users) {}
 
-  void on_rewrite(Transaction &t, CachedExtent &extent, extent_len_t off) final {
+  void on_rewrite(Transaction &t, CachedExtent &extent, extent_len_t off) final override {
     assert(get_type() == extent.get_type());
     auto &lextent = (LogicalCachedExtent&)extent;
     set_laddr((lextent.get_laddr() + off).checked_to_laddr());
@@ -1513,18 +1513,18 @@ public:
   }
 
   void apply_delta_and_adjust_crc(
-    paddr_t base, const ceph::bufferlist &bl) final {
+    paddr_t base, const ceph::bufferlist &bl) final override {
     apply_delta(bl);
     set_last_committed_crc(calc_crc32c());
   }
 
-  bool is_logical() const final {
+  bool is_logical() const final override {
     assert(is_logical_type(get_type()));
     assert(!is_physical_type(get_type()));
     return true;
   }
 
-  std::ostream &print_detail(std::ostream &out) const final;
+  std::ostream &print_detail(std::ostream &out) const final override;
 
   struct modified_region_t {
     extent_len_t offset;
@@ -1551,11 +1551,11 @@ protected:
 
   virtual void logical_on_delta_write() {}
 
-  void on_delta_write(paddr_t record_block_offset) final {
+  void on_delta_write(paddr_t record_block_offset) final override {
     logical_on_delta_write();
   }
 
-  void on_state_commit() final {
+  void on_state_commit() final override {
     auto &prior = static_cast<LogicalCachedExtent&>(*get_prior_instance());
     prior.laddr = laddr;
     do_on_state_commit();

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -107,7 +107,7 @@ struct CollectionNode : LogicalChildNode {
   coll_map_t decoded;
   delta_buffer_t delta_buffer;
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     assert(delta_buffer.empty());
     return CachedExtentRef(new CollectionNode(*this));
   }
@@ -136,7 +136,7 @@ struct CollectionNode : LogicalChildNode {
   using update_ret = CollectionManager::update_ret;
   update_ret update(coll_context_t cc, coll_t coll, unsigned bits);
 
-  void on_clean_read() final {
+  void on_clean_read() final override {
     bufferlist bl;
     bl.append(get_bptr());
     auto iter = bl.cbegin();
@@ -154,7 +154,7 @@ struct CollectionNode : LogicalChildNode {
 
   }
 
-  ceph::bufferlist get_delta() final {
+  ceph::bufferlist get_delta() final override {
     ceph::bufferlist bl;
     // FIXME: CollectionNodes are always first mutated and
     // 	      then checked whether they have enough space,
@@ -171,7 +171,7 @@ struct CollectionNode : LogicalChildNode {
     return bl;
   }
 
-  void apply_delta(const ceph::bufferlist &bl) final {
+  void apply_delta(const ceph::bufferlist &bl) final override {
     assert(bl.length());
     delta_buffer_t buffer;
     auto bptr = bl.begin();
@@ -181,11 +181,11 @@ struct CollectionNode : LogicalChildNode {
   }
 
   static constexpr extent_types_t TYPE = extent_types_t::COLL_BLOCK;
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return TYPE;
   }
 
-  std::ostream &print_detail_l(std::ostream &out) const final;
+  std::ostream &print_detail_l(std::ostream &out) const final override;
 };
 using CollectionNodeRef = CollectionNode::CollectionNodeRef;
 }

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.h
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.h
@@ -26,16 +26,16 @@ class FlatCollectionManager : public CollectionManager {
 public:
   explicit FlatCollectionManager(TransactionManager &tm);
 
-  mkfs_ret mkfs(Transaction &t) final;
+  mkfs_ret mkfs(Transaction &t) final override;
 
   create_ret create(coll_root_t &coll_root, Transaction &t, coll_t cid,
-                    coll_info_t info) final;
+                    coll_info_t info) final override;
 
-  list_ret list(const coll_root_t &coll_root, Transaction &t) final;
+  list_ret list(const coll_root_t &coll_root, Transaction &t) final override;
 
-  remove_ret remove(const coll_root_t &coll_root, Transaction &t, coll_t cid) final;
+  remove_ret remove(const coll_root_t &coll_root, Transaction &t, coll_t cid) final override;
 
-  update_ret update(const coll_root_t &coll_root, Transaction &t, coll_t cid, coll_info_t info) final;
+  update_ret update(const coll_root_t &coll_root, Transaction &t, coll_t cid, coll_info_t info) final override;
 };
 using FlatCollectionManagerRef = std::unique_ptr<FlatCollectionManager>;
 }

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -288,15 +288,15 @@ public:
     return lru.get_capacity_bytes();
   }
 
-  std::size_t get_current_size_bytes() const final {
+  std::size_t get_current_size_bytes() const final override {
     return lru.get_current_size_bytes();
   }
 
-  std::size_t get_current_num_extents() const final {
+  std::size_t get_current_num_extents() const final override {
     return lru.get_current_num_extents();
   }
 
-  void register_metrics(store_index_t store_index) final {
+  void register_metrics(store_index_t store_index) final override {
     namespace sm = seastar::metrics;
     metrics.add_group(
       "cache",
@@ -334,11 +334,11 @@ public:
   void get_stats(
     cache_stats_t &stats,
     bool report_detail,
-    double seconds) const final {
+    double seconds) const final override {
     lru.get_stats("LRU", stats, report_detail, seconds);
   }
 
-  void remove(CachedExtent &extent) final {
+  void remove(CachedExtent &extent) final override {
     if (extent.is_linked_to_list()) {
       lru.remove(extent);
     }
@@ -348,7 +348,7 @@ public:
     CachedExtent &extent,
     const Transaction::src_t* p_src,
     extent_len_t /*load_start*/,
-    extent_len_t /*load_length*/) final {
+    extent_len_t /*load_length*/) final override {
     if (extent.is_linked_to_list()) {
       lru.move_to_top(extent, p_src);
       hit++;
@@ -361,13 +361,13 @@ public:
   void increase_cached_size(
     CachedExtent &extent,
     extent_len_t increased_length,
-    const Transaction::src_t* p_src) final {
+    const Transaction::src_t* p_src) final override {
     if (extent.is_linked_to_list()) {
       lru.increase_cached_size(extent, increased_length, p_src);
     }
   }
 
-  void clear() final {
+  void clear() final override {
     lru.clear();
   }
 
@@ -501,22 +501,22 @@ public:
     return warm_in.get_capacity_bytes() + hot.get_capacity_bytes();
   }
 
-  std::size_t get_current_size_bytes() const final {
+  std::size_t get_current_size_bytes() const final override {
     return warm_in.get_current_size_bytes() + hot.get_current_size_bytes();
   }
 
-  std::size_t get_current_num_extents() const final {
+  std::size_t get_current_num_extents() const final override {
     return warm_in.get_current_num_extents() + hot.get_current_num_extents();
   }
 
-  void register_metrics(store_index_t store_index) final;
+  void register_metrics(store_index_t store_index) final override;
 
   void get_stats(
     cache_stats_t &stats,
     bool report_detail,
-    double seconds) const final;
+    double seconds) const final override;
 
-  void remove(CachedExtent &extent) final {
+  void remove(CachedExtent &extent) final override {
     auto s = extent.get_2q_state();
     if (extent.is_linked_to_list()) {
       if (s == extent_2q_state_t::WarmIn) {
@@ -535,7 +535,7 @@ public:
     CachedExtent &extent,
     const Transaction::src_t* p_src,
     extent_len_t load_start,
-    extent_len_t load_length) final {
+    extent_len_t load_length) final override {
     auto state = extent.get_2q_state();
     auto type = extent.get_type();
     if (extent.is_linked_to_list()) {
@@ -595,7 +595,7 @@ public:
   void increase_cached_size(
     CachedExtent &extent,
     extent_len_t increased_length,
-    const Transaction::src_t* p_src) final {
+    const Transaction::src_t* p_src) final override {
     if (extent.is_linked_to_list()) {
       auto state = extent.get_2q_state();
       if (state == extent_2q_state_t::WarmIn) {
@@ -611,7 +611,7 @@ public:
     }
   }
 
-  void clear() final {
+  void clear() final override {
     LOG_PREFIX(ExtentPinboardTwoQ::clear);
     INFO("close with warm_in: {}({}B), traced by warm_out: {}({}B), hot: {}({}B)",
 	 warm_in.get_current_num_extents(), warm_in.get_current_size_bytes(),

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -75,23 +75,23 @@ public:
                      SegmentProvider &sp,
                      SegmentSeqAllocator &ssa);
 
-  backend_type_t get_type() const final {
+  backend_type_t get_type() const final override {
     return backend_type_t::SEGMENTED;
   }
 
-  writer_stats_t get_stats() const final {
+  writer_stats_t get_stats() const final override {
     return record_submitter.get_stats();
   }
 
-  open_ertr::future<> open() final {
+  open_ertr::future<> open() final override {
     return record_submitter.open(store_index, false).discard_result();
   }
 
   alloc_write_iertr::future<> alloc_write_ool_extents(
     Transaction &t,
-    std::list<CachedExtentRef> &extents) final;
+    std::list<CachedExtentRef> &extents) final override;
 
-  close_ertr::future<> close() final {
+  close_ertr::future<> close() final override {
     return write_guard.close().then([this] {
       return record_submitter.close();
     }).safe_then([this] {
@@ -99,16 +99,16 @@ public:
     });
   }
 
-  paddr_t alloc_paddr(extent_len_t length) final {
+  paddr_t alloc_paddr(extent_len_t length) final override {
     return make_delayed_temp_paddr(0);
   }
 
-  std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) final {
+  std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) final override {
     return {alloc_paddr_result{make_delayed_temp_paddr(0), length}};
   }
 
   bool can_inplace_rewrite(Transaction& t,
-    CachedExtentRef extent) final {
+    CachedExtentRef extent) final override {
     return false;
   }
 
@@ -135,11 +135,11 @@ public:
   RandomBlockOolWriter(RBMCleaner* rb_cleaner) :
     rb_cleaner(rb_cleaner) {}
 
-  backend_type_t get_type() const final {
+  backend_type_t get_type() const final override {
     return backend_type_t::RANDOM_BLOCK;
   }
 
-  writer_stats_t get_stats() const final {
+  writer_stats_t get_stats() const final override {
     writer_stats_t ret = w_stats;
     ret.minus(last_w_stats);
     last_w_stats = w_stats;
@@ -147,7 +147,7 @@ public:
   }
 
   using open_ertr = ExtentOolWriter::open_ertr;
-  open_ertr::future<> open() final {
+  open_ertr::future<> open() final override {
     w_stats = {};
     last_w_stats = {};
     return open_ertr::now();
@@ -155,27 +155,27 @@ public:
 
   alloc_write_iertr::future<> alloc_write_ool_extents(
     Transaction &t,
-    std::list<CachedExtentRef> &extents) final;
+    std::list<CachedExtentRef> &extents) final override;
 
-  close_ertr::future<> close() final {
+  close_ertr::future<> close() final override {
     return write_guard.close().then([this] {
       write_guard = seastar::gate();
       return close_ertr::now();
     });
   }
 
-  paddr_t alloc_paddr(extent_len_t length) final {
+  paddr_t alloc_paddr(extent_len_t length) final override {
     assert(rb_cleaner);
     return rb_cleaner->alloc_paddr(length);
   }
 
-  std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) final {
+  std::list<alloc_paddr_result> alloc_paddrs(extent_len_t length) final override {
     assert(rb_cleaner);
     return rb_cleaner->alloc_paddrs(length);
   }
 
   bool can_inplace_rewrite(Transaction& t,
-    CachedExtentRef extent) final {
+    CachedExtentRef extent) final override {
     if (!extent->is_stable_dirty()) {
       return false;
     }
@@ -186,7 +186,7 @@ public:
   }
 
 #ifdef UNIT_TESTS_BUILT
-  void prefill_fragmented_devices() final {
+  void prefill_fragmented_devices() final override {
     LOG_PREFIX(RandomBlockOolWriter::prefill_fragmented_devices);
     SUBDEBUG(seastore_epm, "");
     return rb_cleaner->prefill_fragmented_devices();
@@ -884,11 +884,11 @@ private:
     }
 
   protected:
-    state_t get_state() const final {
+    state_t get_state() const final override {
       return state;
     }
 
-    void maybe_wake_background() final {
+    void maybe_wake_background() final override {
       if (!is_running()) {
         return;
       }
@@ -897,7 +897,7 @@ private:
       }
     }
 
-    void maybe_wake_blocked_io() final;
+    void maybe_wake_blocked_io() final override;
 
   private:
     // reserve helpers

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -59,21 +59,21 @@ public:
       JournalTrimmer &trimmer, RBMDevice* device, const std::string &path);
   ~CircularBoundedJournal() {}
 
-  JournalTrimmer &get_trimmer() final {
+  JournalTrimmer &get_trimmer() final override {
     return trimmer;
   }
 
-  writer_stats_t get_writer_stats() const final {
+  writer_stats_t get_writer_stats() const final override {
     return record_submitter.get_stats();
   }
 
-  open_for_mkfs_ret open_for_mkfs() final;
+  open_for_mkfs_ret open_for_mkfs() final override;
 
-  open_for_mount_ret open_for_mount() final;
+  open_for_mount_ret open_for_mount() final override;
 
-  close_ertr::future<> close() final;
+  close_ertr::future<> close() final override;
 
-  backend_type_t get_type() final {
+  backend_type_t get_type() final override {
     return backend_type_t::RANDOM_BLOCK;
   }
 
@@ -82,16 +82,16 @@ public:
     OrderingHandle &handle,
     transaction_type_t t_src,
     on_submission_func_t &&on_submission
-  ) final;
+  ) final override;
 
   seastar::future<> flush(
     OrderingHandle &handle
-  ) final {
+  ) final override {
     // TODO
     return seastar::now();
   }
 
-  replay_ret replay(delta_handler_t &&delta_handler) final;
+  replay_ret replay(delta_handler_t &&delta_handler) final override;
 
   rbm_abs_addr get_rbm_addr(journal_seq_t seq) const {
     return convert_paddr_to_abs_addr(seq.offset);
@@ -120,7 +120,7 @@ public:
     return cjs.get_alloc_tail();
   }
 
-  void set_write_pipeline(WritePipeline *_write_pipeline) final {
+  void set_write_pipeline(WritePipeline *_write_pipeline) final override {
     write_pipeline = _write_pipeline;
   }
 
@@ -165,23 +165,23 @@ public:
     cursor.seq.segment_seq += 1;
   }
 
-  void initialize_cursor(scan_valid_records_cursor& cursor) final {
+  void initialize_cursor(scan_valid_records_cursor& cursor) final override {
     cursor.block_size = get_block_size();
   };
 
   Journal::replay_ret replay_segment(
     cbj_delta_handler_t &handler, scan_valid_records_cursor& cursor);
 
-  read_ret read(paddr_t start, size_t len) final;
+  read_ret read(paddr_t start, size_t len) final override;
 
   bool is_record_segment_seq_invalid(scan_valid_records_cursor &cursor,
-    record_group_header_t &h) final;
+    record_group_header_t &h) final override;
 
-  int64_t get_segment_end_offset(paddr_t addr) final {
+  int64_t get_segment_end_offset(paddr_t addr) final override {
     return get_journal_end();
   }
 
-  bool is_checksum_needed() final {
+  bool is_checksum_needed() final override {
     return cjs.is_checksum_needed();
   }
 

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -28,33 +28,33 @@ class CircularBoundedJournal;
 class CircularJournalSpace : public JournalAllocator {
 
  public:
-  const std::string& get_name() const final {
+  const std::string& get_name() const final override {
     return print_name;
   }
 
-  extent_len_t get_block_size() const final;
+  extent_len_t get_block_size() const final override;
 
-  bool can_write() const final {
+  bool can_write() const final override {
     return (device != nullptr);
   }
 
-  segment_nonce_t get_nonce() const final {
+  segment_nonce_t get_nonce() const final override {
     return header.magic;
   }
 
-  bool needs_roll(std::size_t length) const final;
+  bool needs_roll(std::size_t length) const final override;
 
-  roll_ertr::future<> roll() final;
+  roll_ertr::future<> roll() final override;
 
-  journal_seq_t get_written_to() const final {
+  journal_seq_t get_written_to() const final override {
     return written_to;
   }
 
-  write_ertr::future<> write(ceph::bufferlist&& to_write) final;
+  write_ertr::future<> write(ceph::bufferlist&& to_write) final override;
 
-  void update_modify_time(record_t& record) final {}
+  void update_modify_time(record_t& record) final override {}
 
-  close_ertr::future<> close() final {
+  close_ertr::future<> close() final override {
     return write_header(
     ).safe_then([this]() -> close_ertr::future<> {
       initialized = false;
@@ -67,7 +67,7 @@ class CircularJournalSpace : public JournalAllocator {
     );
   }
 
-  open_ret open(bool is_mkfs) final;
+  open_ret open(bool is_mkfs) final override;
 
  public:
   CircularJournalSpace(RBMDevice * device);

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -51,25 +51,25 @@ class SegmentAllocator : public JournalAllocator {
 
  public:
   // overriding methods
-  const std::string& get_name() const final {
+  const std::string& get_name() const final override {
     return print_name;
   }
 
-  extent_len_t get_block_size() const final {
+  extent_len_t get_block_size() const final override {
     return sm_group.get_block_size();
   }
 
-  bool can_write() const final {
+  bool can_write() const final override {
     return !!current_segment;
   }
 
-  segment_nonce_t get_nonce() const final {
+  segment_nonce_t get_nonce() const final override {
     assert(can_write());
     return current_segment_nonce;
   }
 
   // returns true iff the current segment has insufficient space
-  bool needs_roll(std::size_t length) const final {
+  bool needs_roll(std::size_t length) const final override {
     assert(can_write());
     assert(current_segment->get_write_capacity() ==
            sm_group.get_segment_size());
@@ -79,23 +79,23 @@ class SegmentAllocator : public JournalAllocator {
   }
 
   // open for write and generate the correct print name
-  open_ret open(bool is_mkfs) final;
+  open_ret open(bool is_mkfs) final override;
 
   // close the current segment and initialize next one
-  roll_ertr::future<> roll() final;
+  roll_ertr::future<> roll() final override;
 
-  journal_seq_t get_written_to() const final;
+  journal_seq_t get_written_to() const final override;
 
   // write the buffer, return the write result
   //
   // May be called concurrently, but writes may complete in any order.
   // If rolling/opening, no write is allowed.
-  write_ertr::future<> write(ceph::bufferlist&& to_write) final;
+  write_ertr::future<> write(ceph::bufferlist&& to_write) final override;
 
   using close_ertr = base_ertr;
-  close_ertr::future<> close() final;
+  close_ertr::future<> close() final override;
 
-  void update_modify_time(record_t& record) final {
+  void update_modify_time(record_t& record) final override {
     segment_provider.update_modify_time(
       get_segment_id(),
       record.modify_time,

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -31,39 +31,39 @@ public:
       JournalTrimmer &trimmer);
   ~SegmentedJournal() {}
 
-  JournalTrimmer &get_trimmer() final {
+  JournalTrimmer &get_trimmer() final override {
     return trimmer;
   }
 
-  writer_stats_t get_writer_stats() const final {
+  writer_stats_t get_writer_stats() const final override {
     return record_submitter.get_stats();
   }
 
-  open_for_mkfs_ret open_for_mkfs() final;
+  open_for_mkfs_ret open_for_mkfs() final override;
 
-  open_for_mount_ret open_for_mount() final;
+  open_for_mount_ret open_for_mount() final override;
 
-  close_ertr::future<> close() final;
+  close_ertr::future<> close() final override;
 
   submit_record_ertr::future<> submit_record(
     record_t &&record,
     OrderingHandle &handle,
     transaction_type_t t_src,
-    on_submission_func_t &&on_submission) final;
+    on_submission_func_t &&on_submission) final override;
 
-  seastar::future<> flush(OrderingHandle &handle) final;
+  seastar::future<> flush(OrderingHandle &handle) final override;
 
-  replay_ret replay(delta_handler_t &&delta_handler) final;
+  replay_ret replay(delta_handler_t &&delta_handler) final override;
 
-  void set_write_pipeline(WritePipeline *_write_pipeline) final {
+  void set_write_pipeline(WritePipeline *_write_pipeline) final override {
     write_pipeline = _write_pipeline;
   }
 
-  backend_type_t get_type() final {
+  backend_type_t get_type() final override {
     return backend_type_t::SEGMENTED;
   }
 
-  bool is_checksum_needed() final {
+  bool is_checksum_needed() final override {
     // segmented journal always requires checksum
     return true;
   }

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -1107,7 +1107,7 @@ public:
     }
   }
 
-  bool is_retired_placeholder() const final {
+  bool is_retired_placeholder() const final override {
     auto &me = down_cast();
     return me.is_placeholder();
   }
@@ -1180,25 +1180,25 @@ private:
     assert(iter.get_key() == me.get_begin());
     return iter.get_offset();
   }
-  bool _is_valid() const final {
+  bool _is_valid() const final override {
     return down_cast().is_valid();
   }
-  bool _is_stable() const final {
+  bool _is_stable() const final override {
     return down_cast().is_stable();
   }
-  bool _is_mutable() const final {
+  bool _is_mutable() const final override {
     return down_cast().is_mutable();
   }
-  bool _is_exist_clean() const final {
+  bool _is_exist_clean() const final override {
     return down_cast().is_exist_clean();
   }
-  bool _is_exist_mutation_pending() const final {
+  bool _is_exist_mutation_pending() const final override {
     return down_cast().is_exist_mutation_pending();
   }
-  bool _is_pending_io() const final {
+  bool _is_pending_io() const final override {
     return down_cast().is_pending_io();
   }
-  key_t node_begin() const final {
+  key_t node_begin() const final override {
     return down_cast().get_begin();
   }
 };

--- a/src/crimson/os/seastore/logical_child_node.h
+++ b/src/crimson/os/seastore/logical_child_node.h
@@ -37,37 +37,37 @@ public:
     }
   }
 
-  void on_invalidated(Transaction&) final {
+  void on_invalidated(Transaction&) final override {
     this->lba_child_node_t::on_invalidated();
   }
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     ceph_abort_msg("Should never happen for a placeholder");
     return CachedExtentRef();
   }
 
-  ceph::bufferlist get_delta() final {
+  ceph::bufferlist get_delta() final override {
     ceph_abort_msg("Should never happen for a placeholder");
     return ceph::bufferlist();
   }
 
   static constexpr extent_types_t TYPE = extent_types_t::RETIRED_PLACEHOLDER;
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return TYPE;
   }
 
   void apply_delta_and_adjust_crc(
-    paddr_t base, const ceph::bufferlist &bl) final {
+    paddr_t base, const ceph::bufferlist &bl) final override {
     ceph_abort_msg("Should never happen for a placeholder");
   }
 
-  void on_rewrite(Transaction &, CachedExtent&, extent_len_t) final {}
+  void on_rewrite(Transaction &, CachedExtent&, extent_len_t) final override {}
 
-  std::ostream &print_detail(std::ostream &out) const final {
+  std::ostream &print_detail(std::ostream &out) const final override {
     return out << ", RetiredExtentPlaceholder";
   }
 
-  void on_delta_write(paddr_t record_block_offset) final {
+  void on_delta_write(paddr_t record_block_offset) final override {
     ceph_abort_msg("Should never happen for a placeholder");
   }
 
@@ -105,7 +105,7 @@ public:
 
   virtual void lcn_on_invalidated(Transaction &t) {}
 
-  void on_invalidated(Transaction &t) final {
+  void on_invalidated(Transaction &t) final override {
     this->lba_child_node_t::on_invalidated();
     lcn_on_invalidated(t);
   }
@@ -128,7 +128,7 @@ public:
     return (get_laddr() + get_length()).checked_to_laddr();
   }
 protected:
-  void on_replace_prior(Transaction &t) final {
+  void on_replace_prior(Transaction &t) final override {
     assert(is_seen_by_users());
     if (!is_rewrite_transaction(t.get_src())) {
       lba_child_node_t::on_replace_prior();
@@ -136,7 +136,7 @@ protected:
     do_on_replace_prior(t);
   }
   virtual void do_on_replace_prior(Transaction &t) {}
-  void on_data_commit() final {
+  void on_data_commit() final override {
     ceph_abort("impossible");
   }
 };

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -254,19 +254,19 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalChildNode {
   explicit ObjectDataBlock(extent_len_t length)
     : LogicalChildNode(length) {}
 
-  void do_on_state_commit() final {
+  void do_on_state_commit() final override {
     auto &prior = static_cast<ObjectDataBlock&>(*get_prior_instance());
     prior.delta = std::move(delta);
     prior.modified_region = std::move(modified_region);
     prior.cached_overwrites = std::move(cached_overwrites);
   }
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     return CachedExtentRef(new ObjectDataBlock(*this, share_buffer_t{}));
   };
 
   static constexpr extent_types_t TYPE = extent_types_t::OBJECT_DATA_BLOCK;
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return TYPE;
   }
 
@@ -278,11 +278,11 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalChildNode {
     modified_region.union_insert(offset, bl.length());
   }
 
-  ceph::bufferlist get_delta() final;
+  ceph::bufferlist get_delta() final override;
 
-  void apply_delta(const ceph::bufferlist &bl) final;
+  void apply_delta(const ceph::bufferlist &bl) final override;
 
-  std::optional<modified_region_t> get_modified_region() final {
+  std::optional<modified_region_t> get_modified_region() final override {
     if (modified_region.empty()) {
       return std::nullopt;
     }
@@ -290,11 +290,11 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalChildNode {
       modified_region.range_end() - modified_region.range_start()};
   }
 
-  void clear_modified_region() final {
+  void clear_modified_region() final override {
     modified_region.clear();
   }
 
-  void prepare_commit(Transaction &t) final {
+  void prepare_commit(Transaction &t) final override {
     if (is_rewrite_transaction(t.get_src())) {
       return;
     }
@@ -311,7 +311,7 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalChildNode {
     }
   }
 
-  void logical_on_delta_write() final {
+  void logical_on_delta_write() final override {
     delta.clear();
   }
 

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
@@ -67,55 +67,55 @@ public:
   explicit BtreeOMapManager(TransactionManager &tm);
 
   initialize_omap_ret initialize_omap(Transaction &t, laddr_t hint,
-    omap_type_t type) final;
+    omap_type_t type) final override;
 
   omap_get_value_ret omap_get_value(
     const omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key) final;
+    const std::string &key) final override;
 
   omap_set_key_ret omap_set_key(
     omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key, const ceph::bufferlist &value) final;
+    const std::string &key, const ceph::bufferlist &value) final override;
 
   omap_set_keys_ret omap_set_keys(
     omap_root_t &omap_root,
     Transaction &t,
-    std::map<std::string, ceph::bufferlist>&& keys) final;
+    std::map<std::string, ceph::bufferlist>&& keys) final override;
 
   omap_rm_key_ret omap_rm_key(
     omap_root_t &omap_root,
     Transaction &t,
-    const std::string &key) final;
+    const std::string &key) final override;
 
   omap_rm_key_range_ret omap_rm_key_range(
     omap_root_t &omap_root,
     Transaction &t,
     const std::string &first,
-    const std::string &last) final;
+    const std::string &last) final override;
 
   omap_iterate_ret omap_iterate(
     const omap_root_t &omap_root,
     Transaction &t,
     ObjectStore::omap_iter_seek_t &start_from,
-    omap_iterate_cb_t callback) final;
+    omap_iterate_cb_t callback) final override;
 
   omap_list_ret omap_list(
     const omap_root_t &omap_root,
     Transaction &t,
     const std::optional<std::string> &first,
     const std::optional<std::string> &last,
-    omap_list_config_t config = omap_list_config_t()) final;
+    omap_list_config_t config = omap_list_config_t()) final override;
 
   omap_clear_ret omap_clear(
     omap_root_t &omap_root,
-    Transaction &t) final;
+    Transaction &t) final override;
 
   omap_rm_keys_ret omap_rm_keys(
     omap_root_t &omap_root,
     Transaction &t,
-    std::set<std::string>& keys) final;
+    std::set<std::string>& keys) final override;
 };
 using BtreeOMapManagerRef = std::unique_ptr<BtreeOMapManager>;
 

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -67,7 +67,7 @@ struct OMapInnerNode
     return iter_end();
   }
 
-  void do_on_rewrite(Transaction &t, LogicalCachedExtent &extent) final {
+  void do_on_rewrite(Transaction &t, LogicalCachedExtent &extent) final override {
     auto &ext = static_cast<OMapInnerNode&>(extent);
     this->parent_node_t::on_rewrite(t, ext);
     this->sync_children_capacity();
@@ -80,7 +80,7 @@ struct OMapInnerNode
     }
   }
 
-  void prepare_commit(Transaction &t) final {
+  void prepare_commit(Transaction &t) final override {
     if (is_rewrite_transaction(t.get_src())) {
       return;
     }
@@ -114,7 +114,7 @@ struct OMapInnerNode
     }
   }
 
-  void do_on_replace_prior(Transaction &t) final {
+  void do_on_replace_prior(Transaction &t) final override {
     if (is_rewrite_transaction(t.get_src())) {
       return;
     }
@@ -127,11 +127,11 @@ struct OMapInnerNode
     }
   }
 
-  void lcn_on_invalidated(Transaction &t) final {
+  void lcn_on_invalidated(Transaction &t) final override {
     this->child_node_t::on_invalidated();
   }
 
-  void on_initial_write() final {
+  void on_initial_write() final override {
     if (this->is_btree_root()) {
       //TODO: should involve RootChildNode
       this->child_node_t::reset_parent_tracker();
@@ -142,7 +142,7 @@ struct OMapInnerNode
     return this->get_split_pivot().get_offset();
   }
 
-  omap_node_meta_t get_node_meta() const final { return get_meta(); }
+  omap_node_meta_t get_node_meta() const final override { return get_meta(); }
   bool extent_will_overflow(size_t ksize, std::optional<size_t> vsize) const {
     return is_overflow(ksize);
   }
@@ -152,15 +152,15 @@ struct OMapInnerNode
   bool extent_is_below_min() const { return below_min(); }
   uint32_t get_node_size() { return get_size(); }
 
-  void on_fully_loaded() final {
+  void on_fully_loaded() final override {
     this->set_layout_buf(this->get_bptr().c_str());
   }
 
-  void on_clean_read() final {
+  void on_clean_read() final override {
     this->sync_children_capacity();
   }
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     assert(delta_buffer.empty());
     return CachedExtentRef(new OMapInnerNode(*this));
   }
@@ -170,39 +170,39 @@ struct OMapInnerNode
     return is_mutation_pending() ? &delta_buffer : nullptr;
   }
 
-  get_value_ret get_value(omap_context_t oc, const std::string &key) final;
+  get_value_ret get_value(omap_context_t oc, const std::string &key) final override;
 
   insert_ret insert(
     omap_context_t oc,
     const std::string &key,
-    const ceph::bufferlist &value) final;
+    const ceph::bufferlist &value) final override;
 
   bool exceeds_max_kv_limit(
     const std::string &key,
-    const ceph::bufferlist &value) const final {
+    const ceph::bufferlist &value) const final override {
     return (key.length() + sizeof(laddr_le_t)) > (capacity() / 4);
   }
 
   rm_key_ret rm_key(
     omap_context_t oc,
-    const std::string &key) final;
+    const std::string &key) final override;
 
   rm_key_range_ret rm_key_range(
     omap_context_t oc,
-    key_range_t &key_range) final;
+    key_range_t &key_range) final override;
 
   iterate_ret iterate(
     omap_context_t oc,
     ObjectStore::omap_iter_seek_t &start_from,
-    omap_iterate_cb_t callback) final;
+    omap_iterate_cb_t callback) final override;
 
   list_ret list(
     omap_context_t oc,
     const std::optional<std::string> &first,
     const std::optional<std::string> &last,
-    omap_list_config_t config) final;
+    omap_list_config_t config) final override;
 
-  clear_ret clear(omap_context_t oc) final;
+  clear_ret clear(omap_context_t oc) final override;
 
   using split_children_iertr = base_iertr;
   using split_children_ret = split_children_iertr::future
@@ -210,10 +210,10 @@ struct OMapInnerNode
   split_children_ret make_split_children(omap_context_t oc);
 
   full_merge_ret make_full_merge(
-    omap_context_t oc, OMapNodeRef right) final;
+    omap_context_t oc, OMapNodeRef right) final override;
 
   make_balanced_ret make_balanced(
-    omap_context_t oc, OMapNodeRef right, uint32_t pivot_idx) final;
+    omap_context_t oc, OMapNodeRef right, uint32_t pivot_idx) final override;
 
   using make_split_insert_iertr = base_iertr; 
   using make_split_insert_ret = make_split_insert_iertr::future<mutation_result_t>;
@@ -234,14 +234,14 @@ struct OMapInnerNode
     omap_context_t oc, internal_const_iterator_t iter,
     mutation_result_t mresult);
 
-  std::ostream &print_detail_l(std::ostream &out) const final;
+  std::ostream &print_detail_l(std::ostream &out) const final override;
 
   static constexpr extent_types_t TYPE = extent_types_t::OMAP_INNER;
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return TYPE;
   }
 
-  ceph::bufferlist get_delta() final {
+  ceph::bufferlist get_delta() final override {
     ceph::bufferlist bl;
     if (!delta_buffer.empty()) {
       encode(delta_buffer, bl);
@@ -250,7 +250,7 @@ struct OMapInnerNode
     return bl;
   }
 
-  void apply_delta(const ceph::bufferlist &bl) final {
+  void apply_delta(const ceph::bufferlist &bl) final override {
     assert(bl.length());
     delta_inner_buffer_t buffer;
     auto bptr = bl.cbegin();
@@ -329,7 +329,7 @@ struct OMapLeafNode
   using base_child_t = BaseChildNode<OMapInnerNode, std::string>;
   using child_node_t = ChildNode<OMapInnerNode, OMapLeafNode, std::string>;
 
-  void do_on_rewrite(Transaction &t, LogicalCachedExtent &extent) final {
+  void do_on_rewrite(Transaction &t, LogicalCachedExtent &extent) final override {
     // During rewriting, an omap node may not be seen by users yet.
     // If it becomes seen upon commiting, we need to fix the rewritting
     // extent in prepare_commit().
@@ -340,11 +340,11 @@ struct OMapLeafNode
     }
   }
 
-  void lcn_on_invalidated(Transaction &t) final {
+  void lcn_on_invalidated(Transaction &t) final override {
     this->child_node_t::on_invalidated();
   }
 
-  void prepare_commit(Transaction &t) final {
+  void prepare_commit(Transaction &t) final override {
     if (is_rewrite_transaction(t.get_src())) {
       return;
     }
@@ -377,7 +377,7 @@ struct OMapLeafNode
     }
   }
 
-  void do_on_replace_prior(Transaction &t) final {
+  void do_on_replace_prior(Transaction &t) final override {
     ceph_assert(!this->is_rewrite());
     if (!this->is_btree_root() && !is_rewrite_transaction(t.get_src())) {
       [[maybe_unused]] auto &prior =
@@ -408,7 +408,7 @@ struct OMapLeafNode
     this->set_layout_buf(this->get_bptr().c_str(), this->get_bptr().length());
   }
 
-  omap_node_meta_t get_node_meta() const final { return get_meta(); }
+  omap_node_meta_t get_node_meta() const final override { return get_meta(); }
   bool extent_will_overflow(
     size_t ksize, std::optional<size_t> vsize) const {
     return is_overflow(ksize, *vsize);
@@ -419,11 +419,11 @@ struct OMapLeafNode
   bool extent_is_below_min() const { return below_min(); }
   uint32_t get_node_size() { return get_size(); }
 
-  void on_fully_loaded() final {
+  void on_fully_loaded() final override {
     this->set_layout_buf(this->get_bptr().c_str(), this->get_bptr().length());
   }
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     assert(delta_buffer.empty());
     return CachedExtentRef(new OMapLeafNode(*this));
   }
@@ -434,39 +434,39 @@ struct OMapLeafNode
   }
 
   get_value_ret get_value(
-    omap_context_t oc, const std::string &key) final;
+    omap_context_t oc, const std::string &key) final override;
 
   insert_ret insert(
     omap_context_t oc,
     const std::string &key,
-    const ceph::bufferlist &value) final;
+    const ceph::bufferlist &value) final override;
 
   bool exceeds_max_kv_limit(
     const std::string &key,
-    const ceph::bufferlist &value) const final {
+    const ceph::bufferlist &value) const final override {
     return (key.length() + value.length()) > (capacity() / 4);
   }
 
   rm_key_ret rm_key(
-    omap_context_t oc, const std::string &key) final;
+    omap_context_t oc, const std::string &key) final override;
 
   rm_key_range_ret rm_key_range(
     omap_context_t oc,
-    key_range_t &key_range) final;
+    key_range_t &key_range) final override;
 
   iterate_ret iterate(
     omap_context_t oc,
     ObjectStore::omap_iter_seek_t &start_from,
-    omap_iterate_cb_t callback) final;
+    omap_iterate_cb_t callback) final override;
 
   list_ret list(
     omap_context_t oc,
     const std::optional<std::string> &first,
     const std::optional<std::string> &last,
-    omap_list_config_t config) final;
+    omap_list_config_t config) final override;
 
   clear_ret clear(
-    omap_context_t oc) final;
+    omap_context_t oc) final override;
 
   using split_children_iertr = base_iertr;
   using split_children_ret = split_children_iertr::future
@@ -476,19 +476,19 @@ struct OMapLeafNode
 
   full_merge_ret make_full_merge(
     omap_context_t oc,
-    OMapNodeRef right) final;
+    OMapNodeRef right) final override;
 
   make_balanced_ret make_balanced(
     omap_context_t oc,
     OMapNodeRef _right,
-    uint32_t pivot_idx) final;
+    uint32_t pivot_idx) final override;
 
   static constexpr extent_types_t TYPE = extent_types_t::OMAP_LEAF;
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return TYPE;
   }
 
-  ceph::bufferlist get_delta() final {
+  ceph::bufferlist get_delta() final override {
     ceph::bufferlist bl;
     if (!delta_buffer.empty()) {
       encode(delta_buffer, bl);
@@ -497,7 +497,7 @@ struct OMapLeafNode
     return bl;
   }
 
-  void apply_delta(const ceph::bufferlist &_bl) final {
+  void apply_delta(const ceph::bufferlist &_bl) final override {
     assert(_bl.length());
     ceph::bufferlist bl = _bl;
     bl.rebuild();
@@ -511,7 +511,7 @@ struct OMapLeafNode
     return this->get_split_pivot().get_offset();
   }
 
-  std::ostream &print_detail_l(std::ostream &out) const final;
+  std::ostream &print_detail_l(std::ostream &out) const final override;
 
   std::pair<internal_const_iterator_t, internal_const_iterator_t>
   get_leaf_entries(std::string &key);

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.h
@@ -58,7 +58,7 @@ class LogManager : public OMapManager {
 public:
   LogManager(TransactionManager &tm);
   initialize_omap_ret initialize_omap(Transaction &t,
-    laddr_t hint, omap_type_t type) final;
+    laddr_t hint, omap_type_t type) final override;
 
   /**
    * omap_set_keys
@@ -71,14 +71,14 @@ public:
    * @param _kvs   Batch of keys to set
    */
   omap_set_keys_ret omap_set_keys(omap_root_t &log_root,
-    Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) final;
+    Transaction &t, std::map<std::string, ceph::bufferlist>&& _kvs) final override;
 
   // see omap_set_keys
   omap_set_key_ret omap_set_key(
     omap_root_t &log_root,
     Transaction &t,
     const std::string &key,
-    const ceph::bufferlist &value) final;
+    const ceph::bufferlist &value) final override;
 
   /**
    * omap_get_value
@@ -92,7 +92,7 @@ public:
    */
   omap_get_value_ret
   omap_get_value(const omap_root_t &log_root, Transaction &t,
-    const std::string &key) final;
+    const std::string &key) final override;
 
   /**
    * omap_list
@@ -114,7 +114,7 @@ public:
     const std::optional<std::string> &first,
     const std::optional<std::string> &last,
     OMapManager::omap_list_config_t config =
-    OMapManager::omap_list_config_t()) final;
+    OMapManager::omap_list_config_t()) final override;
 
   /**
    * omap_rm_key_range
@@ -132,7 +132,7 @@ public:
     omap_root_t &log_root,
     Transaction &t,
     const std::string &first,
-    const std::string &last) final;
+    const std::string &last) final override;
 
   /**
    * omap_rm_key
@@ -151,13 +151,13 @@ public:
   omap_rm_key_ret omap_rm_key(
     omap_root_t &log_root,
     Transaction &t,
-    const std::string &key) final;
+    const std::string &key) final override;
 
 
   omap_rm_keys_ret omap_rm_keys(
     omap_root_t &omap_root,
     Transaction &t,
-    std::set<std::string>& keys) final;
+    std::set<std::string>& keys) final override;
 
   /**
    * omap_clear
@@ -169,7 +169,7 @@ public:
    *
    */
   omap_clear_ret omap_clear(omap_root_t &log_root,
-    Transaction &t) final;
+    Transaction &t) final override;
 
 
   /**
@@ -196,7 +196,7 @@ public:
     Transaction &t,
     ObjectStore::omap_iter_seek_t &start_from,
     omap_iterate_cb_t callback
-  ) final;
+  ) final override;
 
 
   omap_list_iertr::future<>

--- a/src/crimson/os/seastore/omap_manager/log/log_node.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.h
@@ -781,7 +781,7 @@ struct LogNode
   }
   ~LogNode() {}
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     assert(delta_buffer.empty());
     return CachedExtentRef(new LogNode(*this));
   }
@@ -916,7 +916,7 @@ struct LogNode
     const std::optional<std::string> &last,
     std::map<std::string, bufferlist> &kvs);
 
-  std::ostream &print_detail_l(std::ostream &out) const final;
+  std::ostream &print_detail_l(std::ostream &out) const final override;
 
   laddr_t get_dup_tail_addr() const {
     if (is_mutation_pending() || is_exist_mutation_pending()) {
@@ -988,14 +988,14 @@ struct LogNode
     }
   }
 
-  void logical_on_delta_write() final {
+  void logical_on_delta_write() final override {
     update_delta();
     set_reserved_len(0);
     set_reserved_size(0);
   }
 
   // TODO: consistent view in a transaction
-  void prepare_commit(Transaction &t) final {
+  void prepare_commit(Transaction &t) final override {
     if (is_rewrite_transaction(t.get_src())) {
       return;
     }
@@ -1007,7 +1007,7 @@ struct LogNode
     }
   }
 
-  void on_fully_loaded() final {
+  void on_fully_loaded() final override {
     this->set_layout_buf(this->get_bptr().c_str(), this->get_bptr().length());
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -61,14 +61,14 @@ struct FLTreeOnode final : Onode, Value {
     };
     Recorder(bufferlist &bl) : ValueDeltaRecorder(bl) {}
 
-    value_magic_t get_header_magic() const final {
+    value_magic_t get_header_magic() const final override {
       return TREE_CONF.value_magic;
     }
 
     void apply_value_delta(
       ceph::bufferlist::const_iterator &bliter,
       NodeExtentMutable &value,
-      laddr_offset_t value_addr_offset) final;
+      laddr_offset_t value_addr_offset) final override;
 
     void encode_update(NodeExtentMutable &payload_mut, delta_op_t op);
   };
@@ -76,7 +76,7 @@ struct FLTreeOnode final : Onode, Value {
   bool is_alive() const {
     return status != status_t::DELETED;
   }
-  const onode_layout_t &get_layout() const final {
+  const onode_layout_t &get_layout() const override {
     assert(status != status_t::DELETED);
     return *read_payload<onode_layout_t>();
   }
@@ -92,7 +92,7 @@ struct FLTreeOnode final : Onode, Value {
     layout_func(p.first, p.second);
   }
 
-  void swap_layout(Transaction &t, Onode &onode) final {
+  void swap_layout(Transaction &t, Onode &onode) override {
     _swap_layout(t, static_cast<FLTreeOnode&>(onode));
   }
 
@@ -142,7 +142,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void set_need_cow(Transaction &t) final {
+  void set_need_cow(Transaction &t) override {
     with_mutable_layout(
       t,
       [](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -156,7 +156,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void unset_need_cow(Transaction &t) final {
+  void unset_need_cow(Transaction &t) override {
     with_mutable_layout(
       t,
       [](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -170,7 +170,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void update_onode_size(Transaction &t, uint32_t size) final {
+  void update_onode_size(Transaction &t, uint32_t size) override {
     with_mutable_layout(
       t,
       [size](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -184,7 +184,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void update_omap_root(Transaction &t, omap_root_t &oroot) final {
+  void update_omap_root(Transaction &t, omap_root_t &oroot) override {
     assert(oroot.get_type() == omap_type_t::OMAP ||
 	  oroot.get_type() == omap_type_t::LOG);
     with_mutable_layout(
@@ -200,7 +200,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void update_xattr_root(Transaction &t, omap_root_t &xroot) final {
+  void update_xattr_root(Transaction &t, omap_root_t &xroot) override {
     assert(xroot.get_type() == omap_type_t::XATTR);
     with_mutable_layout(
       t,
@@ -215,7 +215,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void update_object_data(Transaction &t, object_data_t &odata) final {
+  void update_object_data(Transaction &t, object_data_t &odata) override {
     with_mutable_layout(
       t,
       [&odata](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -229,7 +229,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void update_object_info(Transaction &t, ceph::bufferlist &oi_bl) final {
+  void update_object_info(Transaction &t, ceph::bufferlist &oi_bl) override {
     with_mutable_layout(
       t,
       [&oi_bl](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -248,7 +248,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void clear_object_info(Transaction &t) final {
+  void clear_object_info(Transaction &t) override {
     with_mutable_layout(
       t, [](NodeExtentMutable &payload_mut, Recorder *recorder) {
 	auto &mlayout = *reinterpret_cast<onode_layout_t*>(
@@ -262,7 +262,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void update_snapset(Transaction &t, ceph::bufferlist &ss_bl) final {
+  void update_snapset(Transaction &t, ceph::bufferlist &ss_bl) override {
     with_mutable_layout(
       t,
       [&ss_bl](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -281,7 +281,7 @@ struct FLTreeOnode final : Onode, Value {
     });
   }
 
-  void clear_snapset(Transaction &t) final {
+  void clear_snapset(Transaction &t) override {
     with_mutable_layout(
       t,
       [](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -301,10 +301,10 @@ struct FLTreeOnode final : Onode, Value {
     status = status_t::DELETED;
   }
 
-  laddr_t get_hint() const final {
+  laddr_t get_hint() const override {
     return Value::get_hint();
   }
-  ~FLTreeOnode() final {}
+  ~FLTreeOnode() {}
 };
 
 using OnodeTree = Btree<FLTreeOnode>;
@@ -333,29 +333,29 @@ public:
 
   contains_onode_ret contains_onode(
     Transaction &trans,
-    const ghobject_t &hoid) final;
+    const ghobject_t &hoid) final override;
 
   get_onode_ret get_onode(
     Transaction &trans,
-    const ghobject_t &hoid) final;
+    const ghobject_t &hoid) final override;
 
   get_or_create_onode_ret get_or_create_onode(
     Transaction &trans,
-    const ghobject_t &hoid) final;
+    const ghobject_t &hoid) final override;
 
   get_or_create_onodes_ret get_or_create_onodes(
     Transaction &trans,
-    const std::vector<ghobject_t> &hoids) final;
+    const std::vector<ghobject_t> &hoids) final override;
 
   erase_onode_ret erase_onode(
     Transaction &trans,
-    OnodeRef &onode) final;
+    OnodeRef &onode) final override;
 
   list_onodes_ret list_onodes(
     Transaction &trans,
     const ghobject_t& start,
     const ghobject_t& end,
-    uint64_t limit) final;
+    uint64_t limit) final override;
 
   ~FLTreeOnodeManager();
 };

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -46,7 +46,7 @@ class NodeExtent : public LogicalChildNode {
     return NodeExtentMutable(get_bptr().c_str(), get_length());
   }
 
-  std::ostream& print_detail_l(std::ostream& out) const final {
+  std::ostream& print_detail_l(std::ostream& out) const final override {
     return out << ", fltree_header=" << get_header();
   }
 

--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -61,8 +61,8 @@ public:
     return handle;
   }
 private:
-  void dump_detail(ceph::Formatter *f) const final {}
-  void print(std::ostream &) const final {}
+  void dump_detail(ceph::Formatter *f) const final override {}
+  void print(std::ostream &) const final override {}
 };
 
 struct OperationProxy {
@@ -92,26 +92,26 @@ struct OperationProxyT : OperationProxy {
     return static_cast<const OpT*>(op.get());
   }
 
-  seastar::future<> enter(WritePipeline::ReserveProjectedUsage& s) final {
+  seastar::future<> enter(WritePipeline::ReserveProjectedUsage& s) final override {
     return that()->enter_stage(s);
   }
-  seastar::future<> enter(WritePipeline::OolWritesAndLBAUpdates& s) final {
+  seastar::future<> enter(WritePipeline::OolWritesAndLBAUpdates& s) final override {
     return that()->enter_stage(s);
   }
-  seastar::future<> enter(WritePipeline::Prepare& s) final {
+  seastar::future<> enter(WritePipeline::Prepare& s) final override {
     return that()->enter_stage(s);
   }
-  seastar::future<> enter(WritePipeline::DeviceSubmission& s) final {
+  seastar::future<> enter(WritePipeline::DeviceSubmission& s) final override {
     return that()->enter_stage(s);
   }
-  seastar::future<> enter(WritePipeline::Finalize& s) final {
+  seastar::future<> enter(WritePipeline::Finalize& s) final override {
     return that()->enter_stage(s);
   }
 
-  void exit() final {
+  void exit() final override {
     return that()->handle.exit();
   }
-  seastar::future<> complete() final {
+  seastar::future<> complete() final override {
     return that()->handle.complete();
   }
 };

--- a/src/crimson/os/seastore/random_block_manager/avlallocator.h
+++ b/src/crimson/os/seastore/random_block_manager/avlallocator.h
@@ -63,12 +63,12 @@ public:
   AvlAllocator(bool detailed) :
     detailed(detailed) {}
   std::optional<interval_set<rbm_abs_addr>> alloc_extent(
-    size_t size) final;
+    size_t size) final override;
   std::optional<interval_set<rbm_abs_addr>> alloc_extents(
-    size_t size) final;
+    size_t size) final override;
 
-  void free_extent(rbm_abs_addr addr, size_t size) final;
-  void mark_extent_used(rbm_abs_addr addr, size_t size) final;
+  void free_extent(rbm_abs_addr addr, size_t size) final override;
+  void mark_extent_used(rbm_abs_addr addr, size_t size) final override;
   void init(rbm_abs_addr addr, size_t size, size_t b_size);
 
   struct dispose_rs {
@@ -94,17 +94,17 @@ public:
     base_addr = 0;
   }
 
-  uint64_t get_available_size() const final {
+  uint64_t get_available_size() const final override {
     return available_size;
   }
 
-  uint64_t get_max_alloc_size() const final {
+  uint64_t get_max_alloc_size() const final override {
     return max_alloc_size;
   }
 
   bool is_free_extent(rbm_abs_addr start, size_t size);
 
-  void complete_allocation(rbm_abs_addr start, size_t size) final {
+  void complete_allocation(rbm_abs_addr start, size_t size) final override {
     if (detailed) {
       assert(reserved_extent_tracker.contains(start, size));
       reserved_extent_tracker.erase(start, size);
@@ -118,7 +118,7 @@ public:
     return false;
   }
 
-  rbm_extent_state_t get_extent_state(rbm_abs_addr addr, size_t size) final {
+  rbm_extent_state_t get_extent_state(rbm_abs_addr addr, size_t size) final override {
     if (is_reserved_extent(addr, size)) {
       return rbm_extent_state_t::RESERVED;
     } else if (is_free_extent(addr, size)) {

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
@@ -229,10 +229,10 @@ public:
   using RBMDevice::read;
   read_ertr::future<> read(
     uint64_t offset,
-    bufferptr &bptr) final;
+    bufferptr &bptr) final override;
   read_ertr::future<> _readv(
     uint64_t offset,
-    std::vector<bufferptr> ptrs) final;
+    std::vector<bufferptr> ptrs) final override;
 
   read_ertr::future<> nvme_read(
     uint64_t offset, size_t len, void *buffer_ptr);
@@ -245,21 +245,21 @@ public:
     uint64_t offset,
     uint64_t len) override;
 
-  mount_ret mount() final;
+  mount_ret mount() final override;
 
-  nvme_command_ertr::future<> initialize_nvme_features() final;
+  nvme_command_ertr::future<> initialize_nvme_features() final override;
 
-  mkfs_ret mkfs(device_config_t config) final;
+  mkfs_ret mkfs(device_config_t config) final override;
 
   write_ertr::future<> writev(
     uint64_t offset,
     ceph::bufferlist bl,
-    uint16_t stream = 0) final;
+    uint16_t stream = 0) final override;
 
   write_ertr::future<> nvme_write(
     uint64_t offset, size_t len, void *buffer_ptr);
 
-  stat_device_ret stat_device() final {
+  stat_device_ret stat_device() final override {
     auto stat = co_await seastar::file_stat(
       device_path, seastar::follow_symlink::yes
     ).handle_exception([](auto e) -> stat_device_ret {
@@ -285,15 +285,15 @@ public:
     co_return std::move(stat);
   }
 
-  std::string get_device_path() const final {
+  std::string get_device_path() const final override {
     return device_path;
   }
 
-  seastar::future<> start(uint32_t shard_nums) final;
+  seastar::future<> start(uint32_t shard_nums) final override;
 
-  seastar::future<> stop() final;
+  seastar::future<> stop() final override;
 
-  Device& get_sharded_device(store_index_t store_index = 0) final;
+  Device& get_sharded_device(store_index_t store_index = 0) final override;
 
   uint64_t get_preffered_write_granularity() const { return write_granularity; }
   uint64_t get_preffered_write_alignment() const { return write_alignment; }

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -50,21 +50,21 @@ struct RootBlock : CachedExtent {
       backref_root_node(nullptr)
   {}
 
-  void on_rewrite(Transaction&, CachedExtent&, extent_len_t) final {}
+  void on_rewrite(Transaction&, CachedExtent&, extent_len_t) final override {}
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     return CachedExtentRef(new RootBlock(*this));
   };
 
   static constexpr extent_types_t TYPE = extent_types_t::ROOT;
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return extent_types_t::ROOT;
   }
 
-  void on_replace_prior(Transaction &t) final;
+  void on_replace_prior(Transaction &t) final override;
 
   /// dumps root as delta
-  ceph::bufferlist get_delta() final {
+  ceph::bufferlist get_delta() final override {
     ceph::bufferlist bl;
     ceph::buffer::ptr bptr(sizeof(root_t));
     *reinterpret_cast<root_t*>(bptr.c_str()) = root;
@@ -73,7 +73,7 @@ struct RootBlock : CachedExtent {
   }
 
   /// overwrites root
-  void apply_delta_and_adjust_crc(paddr_t base, const ceph::bufferlist &_bl) final {
+  void apply_delta_and_adjust_crc(paddr_t base, const ceph::bufferlist &_bl) final override {
     assert(_bl.length() == sizeof(root_t));
     ceph::bufferlist bl = _bl;
     bl.rebuild();
@@ -82,21 +82,21 @@ struct RootBlock : CachedExtent {
   }
 
   /// Patches relative addrs in memory based on record commit addr
-  void on_delta_write(paddr_t record_block_offset) final {
+  void on_delta_write(paddr_t record_block_offset) final override {
     root.adjust_addrs_from_base(record_block_offset);
   }
 
-  complete_load_ertr::future<> complete_load() final {
+  complete_load_ertr::future<> complete_load() final override {
     ceph_abort_msg("Root is only written via deltas");
   }
 
-  void on_initial_write() final {
+  void on_initial_write() final override {
     ceph_abort_msg("Root is only written via deltas");
   }
 
   root_t &get_root() { return root; }
 
-  std::ostream &print_detail(std::ostream &out) const final {
+  std::ostream &print_detail(std::ostream &out) const final override {
     return out << ", root_block(lba_root_node=" << (void*)lba_root_node
 	       << ", backref_root_node=" << (void*)backref_root_node
 	       << ")";

--- a/src/crimson/os/seastore/root_meta.h
+++ b/src/crimson/os/seastore/root_meta.h
@@ -20,17 +20,17 @@ struct RootMetaBlock : LogicalChildNode {
   RootMetaBlock(const RootMetaBlock &rhs)
     : LogicalChildNode(rhs) {}
 
-  CachedExtentRef duplicate_for_write(Transaction&) final {
+  CachedExtentRef duplicate_for_write(Transaction&) final override {
     return CachedExtentRef(new RootMetaBlock(*this));
   }
 
   static constexpr extent_types_t TYPE = extent_types_t::ROOT_META;
-  extent_types_t get_type() const final {
+  extent_types_t get_type() const final override {
     return extent_types_t::ROOT_META;
   }
 
   /// dumps root meta as delta
-  ceph::bufferlist get_delta() final {
+  ceph::bufferlist get_delta() final override {
     ceph::bufferlist bl;
     ceph::buffer::ptr bptr(get_bptr(), 0, MAX_META_LENGTH);
     bl.append(bptr);
@@ -38,7 +38,7 @@ struct RootMetaBlock : LogicalChildNode {
   }
 
   /// overwrites root
-  void apply_delta(const ceph::bufferlist &_bl) final
+  void apply_delta(const ceph::bufferlist &_bl) final override
   {
     assert(_bl.length() == MAX_META_LENGTH);
     ceph::bufferlist bl = _bl;

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -97,14 +97,14 @@ public:
   FileMDStore(const std::string& root) : root(root) {}
 
   write_meta_ret write_meta(
-    const std::string& key, const std::string& value) final {
+    const std::string& key, const std::string& value) override {
     std::string path = fmt::format("{}/{}", root, key);
     ceph::bufferlist bl;
     bl.append(value + "\n");
     return crimson::write_file(std::move(bl), path);
   }
 
-  read_meta_ret read_meta(const std::string& key) final {
+  read_meta_ret read_meta(const std::string& key) override {
     std::string path = fmt::format("{}/{}", root, key);
     return seastar::file_exists(
       path

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -591,7 +591,7 @@ public:
 
   seastar::future<std::vector<coll_core_t>> list_collections() override;
 
-  seastar::future<std::string> get_default_device_class() final;
+  seastar::future<std::string> get_default_device_class() override;
 
   BackendStore get_backend_store(store_index_t store_index) override {
     assert(!shard_stores.local().mshard_stores.empty());

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -174,7 +174,7 @@ using SegmentManagerRef = std::unique_ptr<SegmentManager>;
 
 class SegmentManager : public Device {
 public:
-  backend_type_t get_backend_type() const final {
+  backend_type_t get_backend_type() const final override {
     return backend_type_t::SEGMENTED;
   }
 

--- a/src/crimson/os/seastore/segment_manager_group.h
+++ b/src/crimson/os/seastore/segment_manager_group.h
@@ -126,16 +126,16 @@ private:
     return device_ids.count(id) >= 1;
   }
 
-  void initialize_cursor(scan_valid_records_cursor &cursor) final;
+  void initialize_cursor(scan_valid_records_cursor &cursor) final override;
 
-  read_ret read(paddr_t start, size_t len) final;
+  read_ret read(paddr_t start, size_t len) final override;
 
   bool is_record_segment_seq_invalid(scan_valid_records_cursor &cursor,
-    record_group_header_t &header) final {
+    record_group_header_t &header) final override {
     return false;
   }
 
-  int64_t get_segment_end_offset(paddr_t addr) final {
+  int64_t get_segment_end_offset(paddr_t addr) final override {
     auto& seg_addr = addr.as_seg_paddr();
     auto& segment_manager = *segment_managers[seg_addr.get_segment_id().device_id()];
     return static_cast<int64_t>(segment_manager.get_segment_size());

--- a/src/crimson/os/seastore/transaction_interruptor.h
+++ b/src/crimson/os/seastore/transaction_interruptor.h
@@ -18,7 +18,7 @@ namespace crimson::os::seastore {
 struct TransactionConflictCondition {
   class transaction_conflict final : public std::exception {
   public:
-    const char* what() const noexcept final {
+    const char* what() const noexcept override {
       return "transaction conflict detected";
     }
   };

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -848,27 +848,27 @@ public:
       Transaction::src_t src,
       const char* name,
       cache_hint_t cache_hint = CACHE_HINT_TOUCH,
-      bool is_weak=false) final {
+      bool is_weak=false) final override {
     return cache->create_transaction(src, name, cache_hint, is_weak);
   }
 
   using ExtentCallbackInterface::submit_transaction_direct_ret;
   submit_transaction_direct_ret submit_transaction_direct(
     Transaction &t,
-    std::optional<journal_seq_t> seq_to_trim = std::nullopt) final;
+    std::optional<journal_seq_t> seq_to_trim = std::nullopt) final override;
 
   using ExtentCallbackInterface::get_next_dirty_extents_ret;
   get_next_dirty_extents_ret get_next_dirty_extents(
     Transaction &t,
     journal_seq_t seq,
-    size_t max_bytes) final;
+    size_t max_bytes) final override;
 
   using ExtentCallbackInterface::rewrite_extent_ret;
   rewrite_extent_ret rewrite_extent(
     Transaction &t,
     CachedExtentRef extent,
     rewrite_gen_t target_generation,
-    sea_time_point modify_time) final;
+    sea_time_point modify_time) final override;
 
   using ExtentCallbackInterface::get_extents_if_live_ret;
   get_extents_if_live_ret get_extents_if_live(
@@ -876,7 +876,7 @@ public:
     extent_types_t type,
     paddr_t paddr,
     laddr_t laddr,
-    extent_len_t len) final;
+    extent_len_t len) final override;
 
   /**
    * read_root_meta

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -248,7 +248,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
       shard_id_map<ceph::os::Transaction> *transactions,
       DoutPrefixProvider *dpp,
       const OSDMapRef &osdmap,
-      bool &first_write_in_interval) final
+      bool &first_write_in_interval) final override
   {
     assert(t);
     ECTransaction::generate_transactions(
@@ -271,7 +271,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
   bool skip_transaction(
       std::set<shard_id_t> &pending_roll_forward,
       shard_id_t shard,
-      ceph::os::Transaction &transaction) final {
+      ceph::os::Transaction &transaction) final override {
     if (transaction.empty()) {
       return true;
     }

--- a/src/crimson/osd/ec_backend.h
+++ b/src/crimson/osd/ec_backend.h
@@ -38,10 +38,10 @@ public:
 	    bool allows_ecoverwrites,
 	    DoutPrefixProvider &dpp,
 	    ECListener &eclistener);
-  seastar::future<> stop() final {
+  seastar::future<> stop() final override {
     return seastar::now();
   }
-  void on_actingset_changed(bool same_primary) final {}
+  void on_actingset_changed(bool same_primary) final override {}
 
   write_iertr::future<> handle_rep_write_op(
     Ref<MOSDECSubOpWrite>,
@@ -54,7 +54,7 @@ public:
 
   PGBackend::get_attr_ierrorator::future<ceph::bufferlist> getxattr(
     const hobject_t& soid,
-    std::string&& key) const final;
+    std::string&& key) const final override;
 
 private:
   friend class ECRecoveryBackend;
@@ -64,7 +64,7 @@ private:
         uint64_t object_size,
         uint64_t off,
         uint64_t len,
-        uint32_t flags) final;
+        uint32_t flags) final override;
   rep_op_fut_t
   submit_transaction(const std::set<pg_shard_t> &pg_shards,
 		     crimson::osd::ObjectContextRef&& obc,
@@ -72,9 +72,9 @@ private:
 		     ceph::os::Transaction&& txn,
 		     osd_op_params_t&& req,
 		     epoch_t min_epoch, epoch_t max_epoch,
-		     std::vector<pg_log_entry_t>&& log_entries) final;
+		     std::vector<pg_log_entry_t>&& log_entries) final override;
   seastar::future<> request_committed(const osd_reqid_t& reqid,
-				       const eversion_t& version) final {
+				       const eversion_t& version) final override {
     return seastar::now();
   }
 

--- a/src/crimson/osd/ec_recovery_backend.h
+++ b/src/crimson/osd/ec_recovery_backend.h
@@ -38,13 +38,13 @@ public:
 
   interruptible_future<> handle_recovery_op(
     Ref<MOSDFastDispatchOp> m,
-    crimson::net::ConnectionXcoreRef conn) final;
+    crimson::net::ConnectionXcoreRef conn) final override;
 
   interruptible_future<> recover_object(
     const hobject_t& soid,
-    eversion_t need) final;
+    eversion_t need) final override;
 
-  seastar::future<> on_stop() final {
+  seastar::future<> on_stop() final override {
     return seastar::now();
   }
 
@@ -58,7 +58,7 @@ private:
 
   void maybe_load_obc(
     const std::map<std::string, ceph::bufferlist, std::less<>>& raw_attrs,
-    RecoveryOp &op) final;
+    RecoveryOp &op) final override;
 
   interruptible_future<> handle_push_reply(
     Ref<MOSDPGPushReply> m);

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -285,9 +285,9 @@ public:
     obc_lru.for_each(std::forward<F>(f));
   }
 
-  std::vector<std::string> get_tracked_keys() const noexcept final;
+  std::vector<std::string> get_tracked_keys() const noexcept final override;
   void handle_conf_change(const crimson::common::ConfigProxy& conf,
-                          const std::set <std::string> &changed) final;
+                          const std::set <std::string> &changed) final override;
 };
 
 std::optional<hobject_t> resolve_oid(const SnapSet &ss,

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -122,31 +122,31 @@ public:
       : pimpl(pimpl), conn(conn) {
     }
 
-    osd_reqid_t get_reqid() const final {
+    osd_reqid_t get_reqid() const override {
       return pimpl->get_reqid();
     }
-    bool has_flag(uint32_t flag) const final {
+    bool has_flag(uint32_t flag) const override {
       return pimpl->has_flag(flag);
     }
-    utime_t get_mtime() const final {
+    utime_t get_mtime() const override {
       return pimpl->get_mtime();
     };
-    epoch_t get_map_epoch() const final {
+    epoch_t get_map_epoch() const override {
       return pimpl->get_map_epoch();
     }
-    entity_inst_t get_orig_source_inst() const final {
+    entity_inst_t get_orig_source_inst() const override {
       // We can't get the origin source address from the message
       // since (In Crimson) the connection is maintained
       // outside of the Message.
       return entity_inst_t(get_source(), conn->get_peer_addr());
     }
-    entity_name_t get_source() const final {
+    entity_name_t get_source() const override {
       return pimpl->get_source();
     }
-    uint64_t get_features() const final {
+    uint64_t get_features() const override {
       return pimpl->get_features();
     }
-    snapid_t get_snapid() const final {
+    snapid_t get_snapid() const override {
       return pimpl->get_snapid();
     }
   };
@@ -499,7 +499,7 @@ auto OpsExecuter::with_effect_on_obc(
          effect_func(std::move(effect_func)),
          obc(std::move(obc)) {
     }
-    seastar::future<> execute(Ref<PG> pg) final {
+    seastar::future<> execute(Ref<PG> pg) override {
       return std::move(effect_func)(std::move(ctx),
                                     std::move(obc),
                                     std::move(pg));

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -98,9 +98,9 @@ class OSD final : public crimson::net::Dispatcher,
   OSDSuperblock superblock;
 
   // Dispatcher methods
-  std::optional<seastar::future<>> ms_dispatch(crimson::net::ConnectionRef, MessageRef) final;
-  void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
-  void ms_handle_remote_reset(crimson::net::ConnectionRef conn) final;
+  std::optional<seastar::future<>> ms_dispatch(crimson::net::ConnectionRef, MessageRef) override;
+  void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
+  void ms_handle_remote_reset(crimson::net::ConnectionRef conn) override;
 
   std::optional<seastar::future<>> do_ms_dispatch(crimson::net::ConnectionRef, MessageRef);
 
@@ -110,11 +110,11 @@ class OSD final : public crimson::net::Dispatcher,
   // which pgs were scanned for min_lec
   std::vector<pg_t> min_last_epoch_clean_pgs;
   void update_stats();
-  seastar::future<MessageURef> get_stats() final;
+  seastar::future<MessageURef> get_stats() override;
 
   // AuthHandler methods
   void handle_authentication(const EntityName& name,
-			     const AuthCapsInfo& caps) final;
+			     const AuthCapsInfo& caps) override;
 
   seastar::sharded<PGShardMapping> pg_to_shard_mappings;
   seastar::sharded<OSDSingletonState> osd_singleton_state;
@@ -131,9 +131,9 @@ class OSD final : public crimson::net::Dispatcher,
   seastar::timer<seastar::lowres_clock> stats_timer;
   std::vector<ShardServices::shard_stats_t> shard_stats;
 
-  std::vector<std::string> get_tracked_keys() const noexcept final;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
-                          const std::set<std::string> &changed) final;
+                          const std::set<std::string> &changed) override;
 
   // admin-socket
   seastar::lw_shared_ptr<crimson::admin::AdminSocket> asok;
@@ -146,7 +146,7 @@ public:
       crimson::net::MessengerRef client_msgr,
       crimson::net::MessengerRef hb_front_msgr,
       crimson::net::MessengerRef hb_back_msgr);
-  ~OSD() final;
+  ~OSD();
 
   auto &get_pg_shard_manager() {
     return pg_shard_manager;

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -156,11 +156,11 @@ struct OperationT : InterruptibleOperation {
   using IRef = boost::intrusive_ptr<T>;
   using ICRef = boost::intrusive_ptr<const T>;
 
-  unsigned get_type() const final {
+  unsigned get_type() const final override {
     return static_cast<unsigned>(T::type);
   }
 
-  const char *get_type_name() const final {
+  const char *get_type_name() const final override {
     return T::type_name;
   }
 
@@ -365,9 +365,9 @@ public:
   void start();
   seastar::future<> stop();
 
-  std::vector<std::string> get_tracked_keys() const noexcept final;
+  std::vector<std::string> get_tracked_keys() const noexcept final override;
   void handle_conf_change(const ConfigProxy& conf,
-			  const std::set<std::string> &changed) final;
+			  const std::set<std::string> &changed) final override;
   void update_from_config(const ConfigProxy &conf);
 
   bool available() const {
@@ -400,7 +400,7 @@ public:
 
   void initialize_scheduler(CephContext* cct, ConfigProxy &conf, bool is_rotational, int whoami);
 private:
-  void dump_detail(Formatter *f) const final;
+  void dump_detail(Formatter *f) const final override;
 
   crimson::osd::scheduler::SchedulerRef scheduler;
 

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -67,14 +67,14 @@ public:
     Ref<PG> pg,
     ShardServices& ss,
     epoch_t epoch_started);
-  void print(std::ostream&) const final;
+  void print(std::ostream&) const override;
 
   std::tuple<
     RecoveryBackend::RecoveryBlockingEvent
   > tracking_events;
 
 private:
-  void dump_detail(Formatter* f) const final;
+  void dump_detail(Formatter* f) const override;
   interruptible_future<seastar::stop_iteration> do_recovery() override;
   const hobject_t soid;
   const eversion_t need;

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -214,8 +214,8 @@ public:
     crimson::net::ConnectionRef, Ref<MOSDOp> &&m);
   ~ClientRequest();
 
-  void print(std::ostream &) const final;
-  void dump_detail(Formatter *f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(Formatter *f) const override;
 
   static constexpr bool can_create() { return false; }
   spg_t get_pgid() const {

--- a/src/crimson/osd/osd_operations/ecrep_request.h
+++ b/src/crimson/osd/osd_operations/ecrep_request.h
@@ -39,8 +39,8 @@ public:
       req{std::forward<MessageRefT>(req)}
   {}
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(ceph::Formatter* f) const override;
 
   static constexpr bool can_create() { return false; }
   spg_t get_pgid() const {

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -34,8 +34,8 @@ private:
   static constexpr OperationTypeCode type =
     OperationTypeCode::internal_client_request;
 
-  void print(std::ostream &) const final;
-  void dump_detail(Formatter *f) const final;
+  void print(std::ostream &) const final override;
+  void dump_detail(Formatter *f) const final override;
 
   CommonPGPipeline& client_pp();
 

--- a/src/crimson/osd/osd_operations/logmissing_request.h
+++ b/src/crimson/osd/osd_operations/logmissing_request.h
@@ -29,8 +29,8 @@ public:
   static constexpr OperationTypeCode type = OperationTypeCode::logmissing_request;
   LogMissingRequest(crimson::net::ConnectionRef&&, Ref<MOSDPGUpdateLogMissing>&&);
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(ceph::Formatter* f) const override;
 
   static constexpr bool can_create() { return false; }
   spg_t get_pgid() const {

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.h
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.h
@@ -29,8 +29,8 @@ public:
   static constexpr OperationTypeCode type = OperationTypeCode::logmissing_request_reply;
   LogMissingRequestReply(crimson::net::ConnectionRef&&, Ref<MOSDPGUpdateLogMissingReply>&&);
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(ceph::Formatter* f) const override;
 
   static constexpr bool can_create() { return false; }
   spg_t get_pgid() const {

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -87,12 +87,12 @@ public:
     evt(std::forward<Args>(args)...)
   {}
 
-  bool requires_pg() const final {
+  bool requires_pg() const final override {
     return evt.requires_pg;
   }
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const final override;
+  void dump_detail(ceph::Formatter* f) const final override;
   seastar::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pg);
 };
@@ -104,7 +104,7 @@ protected:
   // must be after conn due to ConnectionPipeline's life-time
   PipelineHandle handle;
 
-  void on_pg_absent(ShardServices &) final;
+  void on_pg_absent(ShardServices &) final override;
   PeeringEvent::interruptible_future<> complete_rctx(
     ShardServices &shard_services,
     Ref<PG> pg) override;

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -47,8 +47,8 @@ public:
     PeeringCtx &&rctx, bool do_init);
   ~PGAdvanceMap();
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter *f) const final;
+  void print(std::ostream &) const final override;
+  void dump_detail(ceph::Formatter *f) const final override;
   seastar::future<> start();
   PipelineHandle &get_handle() { return handle; }
 

--- a/src/crimson/osd/osd_operations/pgpct_request.h
+++ b/src/crimson/osd/osd_operations/pgpct_request.h
@@ -29,8 +29,8 @@ public:
   static constexpr OperationTypeCode type = OperationTypeCode::pgpct_request;
   PGPCTRequest(crimson::net::ConnectionRef&&, Ref<MOSDPGPCT>&&);
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(ceph::Formatter* f) const override;
 
   static constexpr bool can_create() { return false; }
   spg_t get_pgid() const {

--- a/src/crimson/osd/osd_operations/recovery_subrequest.h
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.h
@@ -26,12 +26,12 @@ public:
     Ref<MOSDFastDispatchOp>&& m)
     : RemoteOperation(std::move(conn)), m(m) {}
 
-  void print(std::ostream& out) const final
+  void print(std::ostream& out) const override
   {
     out << *m;
   }
 
-  void dump_detail(Formatter *f) const final
+  void dump_detail(Formatter *f) const override
   {
   }
 

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -29,8 +29,8 @@ public:
   static constexpr OperationTypeCode type = OperationTypeCode::replicated_request;
   RepRequest(crimson::net::ConnectionRef&&, Ref<MOSDRepOp>&&);
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(ceph::Formatter* f) const override;
 
   static constexpr bool can_create() { return false; }
   spg_t get_pgid() const {

--- a/src/crimson/osd/osd_operations/replicated_request_reply.h
+++ b/src/crimson/osd/osd_operations/replicated_request_reply.h
@@ -28,8 +28,8 @@ public:
     OperationTypeCode::replicated_request_reply;
   ReplicatedRequestReply(crimson::net::ConnectionRef&&, Ref<MOSDRepOpReply>&&);
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(ceph::Formatter* f) const override;
 
   spg_t get_pgid() const {
     return req->get_spg();

--- a/src/crimson/osd/osd_operations/scrub_events.h
+++ b/src/crimson/osd/osd_operations/scrub_events.h
@@ -79,7 +79,7 @@ public:
 class ScrubRequested final : public RemoteScrubEventBaseT<ScrubRequested> {
   bool deep = false;
 protected:
-  ifut<> handle_event(PG &pg) final;
+  ifut<> handle_event(PG &pg) override;
 
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::scrub_requested;
@@ -93,10 +93,10 @@ public:
     return epoch;
   }
 
-  void print(std::ostream &out) const final {
+  void print(std::ostream &out) const override {
     out << "(deep=" << deep << ")";
   }
-  void dump_detail(ceph::Formatter *f) const final {
+  void dump_detail(ceph::Formatter *f) const override {
     f->dump_bool("deep", deep);
   }
 
@@ -105,7 +105,7 @@ public:
 class ScrubMessage final : public RemoteScrubEventBaseT<ScrubMessage> {
   MessageRef m;
 protected:
-  ifut<> handle_event(PG &pg) final;
+  ifut<> handle_event(PG &pg) override;
 
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::scrub_message;
@@ -121,10 +121,10 @@ public:
     return epoch;
   }
 
-  void print(std::ostream &out) const final {
+  void print(std::ostream &out) const override {
     out << "(m=" << *m << ")";
   }
-  void dump_detail(ceph::Formatter *f) const final {
+  void dump_detail(ceph::Formatter *f) const override {
     f->dump_stream("m") << *m;
   }
 
@@ -158,16 +158,16 @@ public:
   ScrubFindRange(const hobject_t &begin, Args&&... args)
     : ScrubAsyncOpT(std::forward<Args>(args)...), begin(begin) {}
 
-  void print(std::ostream &out) const final {
+  void print(std::ostream &out) const final override {
     out << "(begin=" << begin << ")";
   }
-  void dump_detail(ceph::Formatter *f) const final {
+  void dump_detail(ceph::Formatter *f) const final override {
     f->dump_stream("begin") << begin;
   }
 
 
 protected:
-  ifut<> run(PG &pg) final;
+  ifut<> run(PG &pg) final override;
 };
 
 class ScrubReserveRange : public ScrubAsyncOpT<ScrubReserveRange> {
@@ -184,17 +184,17 @@ public:
   ScrubReserveRange(const hobject_t &begin, const hobject_t &end, Args&&... args)
     : ScrubAsyncOpT(std::forward<Args>(args)...), begin(begin), end(end) {}
 
-  void print(std::ostream &out) const final {
+  void print(std::ostream &out) const final override {
     out << "(begin=" << begin << ", end=" << end << ")";
   }
-  void dump_detail(ceph::Formatter *f) const final {
+  void dump_detail(ceph::Formatter *f) const final override {
     f->dump_stream("begin") << begin;
     f->dump_stream("end") << end;
   }
 
 
 protected:
-  ifut<> run(PG &pg) final;
+  ifut<> run(PG &pg) final override;
 };
 
 class ScrubScan : public ScrubAsyncOpT<ScrubScan> {
@@ -217,14 +217,14 @@ class ScrubScan : public ScrubAsyncOpT<ScrubScan> {
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::scrub_scan;
 
-  void print(std::ostream &out) const final {
+  void print(std::ostream &out) const final override {
     out << "(deep=" << deep
 	<< ", local=" << local
 	<< ", begin=" << begin
 	<< ", end=" << end
 	<< ")";
   }
-  void dump_detail(ceph::Formatter *f) const final {
+  void dump_detail(ceph::Formatter *f) const final override {
     f->dump_bool("deep", deep);
     f->dump_bool("local", local);
     f->dump_stream("begin") << begin;
@@ -237,7 +237,7 @@ public:
     : ScrubAsyncOpT(pg), deep(deep), local(local), begin(begin), end(end) {}
 
 protected:
-  ifut<> run(PG &pg) final;
+  ifut<> run(PG &pg) final override;
 };
 
 struct obj_scrub_progress_t {

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -52,8 +52,8 @@ public:
       snapid(snapid),
       needs_pause(needs_pause) {}
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const override;
+  void dump_detail(ceph::Formatter* f) const override;
   snap_trim_event_ret_t start();
 
 private:
@@ -104,8 +104,8 @@ public:
     snap_to_trim(snap_to_trim) {
   }
 
-  void print(std::ostream &) const final;
-  void dump_detail(ceph::Formatter* f) const final;
+  void print(std::ostream &) const final override;
+  void dump_detail(ceph::Formatter* f) const final override;
   snap_trim_obj_subevent_ret_t start();
 
   CommonPGPipeline& client_pp();

--- a/src/crimson/osd/osdmap_gate.h
+++ b/src/crimson/osd/osdmap_gate.h
@@ -43,7 +43,7 @@ public:
 
     seastar::shared_promise<epoch_t> promise;
 
-    void dump_detail(Formatter *f) const final;
+    void dump_detail(Formatter *f) const final override;
   };
   using Blocker = OSDMapBlocker;
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -192,7 +192,7 @@ public:
     ObjectContextRef obc,
     bool is_delete,
     ceph::os::Transaction *t
-    ) final {
+    ) final override {
     std::ignore = get_recovery_handler()->on_local_recover(
       oid, recovery_info, is_delete, *t);
   }
@@ -200,21 +200,21 @@ public:
     const hobject_t &oid,
     const object_stat_sum_t &stat_diff,
     bool is_delete
-    ) final {
+    ) final override {
     get_recovery_handler()->on_global_recover(
       oid, stat_diff, is_delete);
   }
   void on_peer_recover(
     pg_shard_t peer,
     const hobject_t &oid,
-    const ObjectRecoveryInfo &recovery_info) final {
+    const ObjectRecoveryInfo &recovery_info) final override {
     get_recovery_handler()->on_peer_recover(peer, oid, recovery_info);
   }
   void on_failed_pull(
     const std::set<pg_shard_t> &from,
     const hobject_t &soid,
     const eversion_t &v
-    ) final {
+    ) final override {
     get_recovery_handler()->on_failed_recover(from, soid, v);
   }
 
@@ -222,37 +222,37 @@ public:
     return get_peering_state().is_repair();
   }
 
-  bool check_failsafe_full() final {
+  bool check_failsafe_full() final override {
     // not implemented yet
     return false;
   }
 
-  epoch_t get_last_peering_reset_epoch() const final {
+  epoch_t get_last_peering_reset_epoch() const final override {
     return get_last_peering_reset();
   }
 
-  pg_shard_t primary_shard() const final {
+  pg_shard_t primary_shard() const final override {
     return get_primary();
   }
-  bool pgb_is_primary() const final {
+  bool pgb_is_primary() const final override {
     return is_primary();
   }
 
   hobject_t get_temp_recovery_object(
     const hobject_t& target,
-    eversion_t version) final {
+    eversion_t version) final override {
     return get_recovery_handler()->get_temp_recovery_object(target, version);
   }
-  void inc_osd_stat_repaired() final {
+  void inc_osd_stat_repaired() final override {
     std::ignore = shard_services.inc_osd_stat_repaired();
   }
   // ECListener ends
 
-  const pg_shard_t& get_pg_whoami() const final {
+  const pg_shard_t& get_pg_whoami() const final override {
     return pg_whoami;
   }
 
-  const spg_t& get_pgid() const final {
+  const spg_t& get_pgid() const final override {
     return pgid;
   }
 
@@ -266,7 +266,7 @@ public:
     return *backend;
   }
   // EpochSource
-  epoch_t get_osdmap_epoch() const final {
+  epoch_t get_osdmap_epoch() const final override {
     return peering_state.get_osdmap_epoch();
   }
 
@@ -278,18 +278,18 @@ public:
     return peering_state.get_pg_committed_to();
   }
 
-  const pg_info_t& get_info() const final {
+  const pg_info_t& get_info() const final override {
     return peering_state.get_info();
   }
 
   // DoutPrefixProvider
-  std::ostream& gen_prefix(std::ostream& out) const final {
+  std::ostream& gen_prefix(std::ostream& out) const final override {
     return out << *this;
   }
-  crimson::common::CephContext *get_cct() const final {
+  crimson::common::CephContext *get_cct() const final override {
     return shard_services.get_cct();
   }
-  unsigned get_subsys() const final {
+  unsigned get_subsys() const final override {
     return ceph_subsys_osd;
   }
 
@@ -306,9 +306,9 @@ public:
     bool dirty_info,
     bool dirty_big_info,
     bool need_write_epoch,
-    ceph::os::Transaction &t) final;
+    ceph::os::Transaction &t) final override;
 
-  uint64_t get_snap_trimq_size() const final {
+  uint64_t get_snap_trimq_size() const final override {
     return std::size(snap_trimq);
   }
 
@@ -348,7 +348,7 @@ public:
 
   void send_cluster_message(
     int osd, MessageURef m,
-    epoch_t epoch, bool share_map_update=false) final {
+    epoch_t epoch, bool share_map_update=false) final override {
     LOG_PREFIX(PG::send_cluster_message);
     SUBDEBUGDPP(
       osd, "message {} to {} share_map_update {}",
@@ -364,23 +364,23 @@ public:
     std::ignore = shard_services.send_to_osd(osd, std::move(m), epoch);
   }
 
-  void send_pg_created(pg_t pgid) final {
+  void send_pg_created(pg_t pgid) final override {
     LOG_PREFIX(PG::send_pg_created);
     SUBDEBUGDPP(osd, "pgid {}", *this, pgid);
     shard_services.send_pg_created(orderer, pgid);
   }
 
-  bool try_flush_or_schedule_async() final;
+  bool try_flush_or_schedule_async() final override;
 
   void start_flush_on_transaction(
-    ceph::os::Transaction &t) final {
+    ceph::os::Transaction &t) final override {
     t.register_on_commit(
       new LambdaContext([this](int r){
 	peering_state.complete_flush();
     }));
   }
 
-  void on_flushed() final {
+  void on_flushed() final override {
     // will be needed for unblocking IO operations/peering
   }
 
@@ -398,16 +398,16 @@ public:
 
   void schedule_event_after(
     PGPeeringEventRef event,
-    float delay) final {
+    float delay) final override {
     start_peering_event_operation(std::move(*event), delay);
   }
-  std::vector<pg_shard_t> get_replica_recovery_order() const final {
+  std::vector<pg_shard_t> get_replica_recovery_order() const final override {
     return peering_state.get_replica_recovery_order();
   }
   void request_local_background_io_reservation(
     unsigned priority,
     PGPeeringEventURef on_grant,
-    PGPeeringEventURef on_preempt) final {
+    PGPeeringEventURef on_preempt) final override {
     LOG_PREFIX(PG::request_local_background_io_reservation);
     SUBDEBUGDPP(
       osd, "priority {} on_grant {} on_preempt {}",
@@ -427,7 +427,7 @@ public:
   }
 
   void update_local_background_io_priority(
-    unsigned priority) final {
+    unsigned priority) final override {
     LOG_PREFIX(PG::update_local_background_io_priority);
     SUBDEBUGDPP(osd, "priority {}", *this, priority);
     shard_services.local_update_priority(
@@ -436,7 +436,7 @@ public:
       priority);
   }
 
-  void cancel_local_background_io_reservation() final {
+  void cancel_local_background_io_reservation() final override {
     LOG_PREFIX(PG::cancel_local_background_io_reservation);
     SUBDEBUGDPP(osd, "", *this);
     shard_services.local_cancel_reservation(
@@ -447,7 +447,7 @@ public:
   void request_remote_recovery_reservation(
     unsigned priority,
     PGPeeringEventURef on_grant,
-    PGPeeringEventURef on_preempt) final {
+    PGPeeringEventURef on_preempt) final override {
     LOG_PREFIX(PG::request_remote_recovery_reservation);
     SUBDEBUGDPP(
       osd, "priority {} on_grant {} on_preempt {}",
@@ -466,7 +466,7 @@ public:
     );
   }
 
-  void cancel_remote_recovery_reservation() final {
+  void cancel_remote_recovery_reservation() final override {
     LOG_PREFIX(PG::cancel_remote_recovery_reservation);
     SUBDEBUGDPP(osd, "", *this);
     shard_services.remote_cancel_reservation(orderer, pgid);
@@ -474,7 +474,7 @@ public:
 
   void schedule_event_on_commit(
     ceph::os::Transaction &t,
-    PGPeeringEventRef on_commit) final {
+    PGPeeringEventRef on_commit) final override {
     LOG_PREFIX(PG::schedule_event_on_commit);
     SUBDEBUGDPP(osd, "on_commit {}", *this, on_commit->get_desc());
 
@@ -485,26 +485,26 @@ public:
 	}));
   }
 
-  void update_heartbeat_peers(std::set<int> peers) final {
+  void update_heartbeat_peers(std::set<int> peers) final override {
     // Not needed yet
   }
-  void set_probe_targets(const std::set<pg_shard_t> &probe_set) final {
+  void set_probe_targets(const std::set<pg_shard_t> &probe_set) final override {
     // Not needed yet
   }
-  void clear_probe_targets() final {
+  void clear_probe_targets() final override {
     // Not needed yet
   }
-  void queue_want_pg_temp(const std::vector<int> &wanted) final {
+  void queue_want_pg_temp(const std::vector<int> &wanted) final override {
     LOG_PREFIX(PG::queue_want_pg_temp);
     SUBDEBUGDPP(osd, "wanted {}", *this, wanted);
     shard_services.queue_want_pg_temp(orderer, pgid.pgid, wanted);
   }
-  void clear_want_pg_temp() final {
+  void clear_want_pg_temp() final override {
     LOG_PREFIX(PG::clear_want_pg_temp);
     SUBDEBUGDPP(osd, "", *this);
     shard_services.remove_want_pg_temp(orderer, pgid.pgid);
   }
-  void check_recovery_sources(const OSDMapRef& newmap) final {
+  void check_recovery_sources(const OSDMapRef& newmap) final override {
     LOG_PREFIX(PG::check_recovery_sources);
     recovery_backend->for_each_recovery_waiter(
       [newmap, FNAME, this](auto &, auto &waiter) {
@@ -520,83 +520,83 @@ public:
         }
       });
   }
-  void check_blocklisted_watchers() final;
-  void clear_primary_state() final {
+  void check_blocklisted_watchers() final override;
+  void clear_primary_state() final override {
     recovery_finisher = nullptr;
     projected_log = PGLog::IndexedLog();
   }
 
   void queue_check_readable(epoch_t last_peering_reset,
-			    ceph::timespan delay) final;
-  void recheck_readable() final;
+			    ceph::timespan delay) final override;
+  void recheck_readable() final override;
 
-  unsigned get_target_pg_log_entries() const final;
+  unsigned get_target_pg_log_entries() const final override;
 
   void init_collection_pool_opts();
   void on_pool_change();
-  void on_role_change() final {
+  void on_role_change() final override {
     // Not needed yet
   }
-  void on_change(ceph::os::Transaction &t) final;
-  void on_activate(interval_set<snapid_t> to_trim) final;
-  void on_replica_activate() final;
-  void on_activate_complete() final;
-  void on_new_interval() final {
+  void on_change(ceph::os::Transaction &t) final override;
+  void on_activate(interval_set<snapid_t> to_trim) final override;
+  void on_replica_activate() final override;
+  void on_activate_complete() final override;
+  void on_new_interval() final override {
     recovery_finisher = nullptr;
   }
-  Context *on_clean() final;
-  void on_activate_committed() final {
+  Context *on_clean() final override;
+  void on_activate_committed() final override {
     if (!is_primary()) {
       wait_for_active_blocker.unblock();
     }
   }
-  void on_active_exit() final {
+  void on_active_exit() final override {
     // Not needed yet
   }
 
-  void on_removal(ceph::os::Transaction &t) final;
+  void on_removal(ceph::os::Transaction &t) final override;
 
   void clear_log_entry_maps();
 
   std::pair<ghobject_t, bool>
-  do_delete_work(ceph::os::Transaction &t, ghobject_t _next) final;
+  do_delete_work(ceph::os::Transaction &t, ghobject_t _next) final override;
 
   // merge/split not ready
-  void clear_ready_to_merge() final {}
-  void set_not_ready_to_merge_target(pg_t pgid, pg_t src) final {}
-  void set_not_ready_to_merge_source(pg_t pgid) final {}
-  void set_ready_to_merge_target(eversion_t lu, epoch_t les, epoch_t lec) final {}
-  void set_ready_to_merge_source(eversion_t lu) final {}
+  void clear_ready_to_merge() final override {}
+  void set_not_ready_to_merge_target(pg_t pgid, pg_t src) final override {}
+  void set_not_ready_to_merge_source(pg_t pgid) final override {}
+  void set_ready_to_merge_target(eversion_t lu, epoch_t les, epoch_t lec) final override {}
+  void set_ready_to_merge_source(eversion_t lu) final override {}
 
-  void on_active_actmap() final;
-  void on_active_advmap(const OSDMapRef &osdmap) final;
+  void on_active_actmap() final override;
+  void on_active_advmap(const OSDMapRef &osdmap) final override;
 
-  epoch_t cluster_osdmap_trim_lower_bound() final {
+  epoch_t cluster_osdmap_trim_lower_bound() final override {
     return shard_services.get_osdmap_tlb();
   }
 
-  void on_backfill_reserved() final {
+  void on_backfill_reserved() final override {
     recovery_handler->on_backfill_reserved();
   }
-  void on_backfill_suspended() final {
+  void on_backfill_suspended() final override {
     recovery_handler->backfill_suspended();
   }
 
-  void on_recovery_cancelled() final {
+  void on_recovery_cancelled() final override {
     cancel_pglog_based_recovery_op();
   }
 
-  void on_recovery_reserved() final {
+  void on_recovery_reserved() final override {
     recovery_handler->start_pglogbased_recovery();
   }
 
 
   bool try_reserve_recovery_space(
-    int64_t primary_num_bytes, int64_t local_num_bytes) final {
+    int64_t primary_num_bytes, int64_t local_num_bytes) final override {
     // TODO
     return true;
   }
-  void unreserve_recovery_space() final {}
+  void unreserve_recovery_space() final override {}
 
   void remove_maybe_snapmapped_object(
     ceph::os::Transaction &t,
@@ -627,45 +627,45 @@ public:
       ) override;
   };
   PGLog::LogEntryHandlerRef get_log_handler(
-    ceph::os::Transaction &t) final {
+    ceph::os::Transaction &t) final override {
     return std::make_unique<PG::PGLogEntryHandler>(this, &t);
   }
 
-  void rebuild_missing_set_with_deletes(PGLog &pglog) final {
+  void rebuild_missing_set_with_deletes(PGLog &pglog) final override {
     ceph_assert(0 == "Impossible for crimson");
   }
 
-  PerfCounters &get_peering_perf() final {
+  PerfCounters &get_peering_perf() final override {
     return shard_services.get_recoverystate_perf_logger();
   }
-  PerfCounters &get_perf_logger() final {
+  PerfCounters &get_perf_logger() final override {
     return shard_services.get_perf_logger();
   }
 
-  void log_state_enter(const char *state) final;
+  void log_state_enter(const char *state) final override;
   void log_state_exit(
     const char *state_name, utime_t enter_time,
-    uint64_t events, utime_t event_dur) final;
+    uint64_t events, utime_t event_dur) final override;
 
-  void dump_recovery_info(Formatter *f) const final {
+  void dump_recovery_info(Formatter *f) const final override {
   }
 
-  OstreamTemp get_clog_info() final {
+  OstreamTemp get_clog_info() final override {
     // not needed yet: replace with not a stub (needs to be wired up to monc)
     return OstreamTemp(CLOG_INFO, nullptr);
   }
-  OstreamTemp get_clog_debug() final {
+  OstreamTemp get_clog_debug() final override {
     // not needed yet: replace with not a stub (needs to be wired up to monc)
     return OstreamTemp(CLOG_DEBUG, nullptr);
   }
-  OstreamTemp get_clog_error() final {
+  OstreamTemp get_clog_error() final override {
     // not needed yet: replace with not a stub (needs to be wired up to monc)
     return OstreamTemp(CLOG_ERROR, nullptr);
   }
 
-  ceph::signedspan get_mnow() const final;
-  HeartbeatStampsRef get_hb_stamps(int peer) final;
-  void schedule_renew_lease(epoch_t plr, ceph::timespan delay) final;
+  ceph::signedspan get_mnow() const final override;
+  HeartbeatStampsRef get_hb_stamps(int peer) final override;
+  void schedule_renew_lease(epoch_t plr, ceph::timespan delay) final override;
 
 
   // Utility
@@ -675,19 +675,19 @@ public:
   bool is_active_clean() const {
     return peering_state.is_active() && peering_state.is_clean();
   }
-  bool is_primary() const final {
+  bool is_primary() const final override {
     return peering_state.is_primary();
   }
   bool is_nonprimary() const {
     return peering_state.is_nonprimary();
   }
-  bool is_peered() const final {
+  bool is_peered() const final override {
     return peering_state.is_peered();
   }
-  bool is_recovering() const final {
+  bool is_recovering() const final override {
     return peering_state.is_recovering();
   }
-  bool is_backfilling() const final {
+  bool is_backfilling() const final override {
     return peering_state.is_backfilling();
   }
   uint64_t get_last_user_version() const {
@@ -921,10 +921,10 @@ public:
     return eversion_t(get_osdmap_epoch(),
 		      projected_last_update.version + 1);
   }
-  ShardServices& get_shard_services() final {
+  ShardServices& get_shard_services() final override {
     return shard_services;
   }
-  DoutPrefixProvider* get_dpp() final {
+  DoutPrefixProvider* get_dpp() final override {
     return this;
   }
   seastar::future<> stop();
@@ -960,7 +960,7 @@ public:
 
   scrub::PGScrubber scrubber;
 
-  void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) final;
+  void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) final override;
 
   ObjectContextRegistry obc_registry;
   ObjectContextLoader obc_loader;
@@ -970,12 +970,12 @@ private:
   SnapMapper snap_mapper;
 public:
   // PeeringListener
-  void publish_stats_to_osd() final;
-  void clear_publish_stats() final;
+  void publish_stats_to_osd() final override;
+  void clear_publish_stats() final override;
   pg_stat_t get_stats() const;
   void apply_stats(
     const hobject_t &soid,
-    const object_stat_sum_t &delta_stats) final;
+    const object_stat_sum_t &delta_stats) final override;
 
 private:
   std::optional<pg_stat_t> pg_stats;
@@ -998,19 +998,19 @@ public:
   void get_dynamic_perf_stats(DynamicPerfStats *stats) {
     std::swap(dp_stats, *stats);
   }
-  OSDriver &get_osdriver() final {
+  OSDriver &get_osdriver() final override {
     return osdriver;
   }
-  SnapMapper &get_snap_mapper() final {
+  SnapMapper &get_snap_mapper() final override {
     return snap_mapper;
   }
-  RecoveryBackend* get_recovery_backend() final {
+  RecoveryBackend* get_recovery_backend() final override {
     return recovery_backend.get();
   }
-  PGRecovery* get_recovery_handler() final {
+  PGRecovery* get_recovery_handler() final override {
     return recovery_handler.get();
   }
-  PeeringState& get_peering_state() final {
+  PeeringState& get_peering_state() final override {
     return peering_state;
   }
   const PeeringState& get_peering_state() const {
@@ -1025,14 +1025,14 @@ public:
   hobject_t get_last_backfill_started() const {
     return get_backfill_state().get_last_backfill_started();
   }
-  bool has_reset_since(epoch_t epoch) const final {
+  bool has_reset_since(epoch_t epoch) const final override {
     return peering_state.pg_has_reset_since(epoch);
   }
 
   const pg_missing_tracker_t& get_local_missing() const {
     return peering_state.get_pg_log().get_missing();
   }
-  epoch_t get_last_peering_reset() const final {
+  epoch_t get_last_peering_reset() const final override {
     return peering_state.get_last_peering_reset();
   }
   const std::set<pg_shard_t> &get_acting_recovery_backfill() const {
@@ -1045,7 +1045,7 @@ public:
     return peering_state.is_backfill_target(osd);
   }
   // it's also ECListener's method
-  void begin_peer_recover(pg_shard_t peer, const hobject_t oid) final {
+  void begin_peer_recover(pg_shard_t peer, const hobject_t oid) final override {
     peering_state.begin_peer_recover(peer, oid);
   }
   uint64_t min_peer_features() const {
@@ -1122,8 +1122,8 @@ public:
     return can_discard_replica_op(m, m.get_map_epoch());
   }
 
-  void set_pglog_based_recovery_op(PglogBasedRecovery *op) final;
-  void reset_pglog_based_recovery_op() final;
+  void set_pglog_based_recovery_op(PglogBasedRecovery *op) final override;
+  void reset_pglog_based_recovery_op() final override;
   void cancel_pglog_based_recovery_op();
 
 private:
@@ -1166,11 +1166,11 @@ private:
   bool can_discard_replica_op(const Message& m, epoch_t m_map_epoch) const;
   bool can_discard_op(const MOSDOp& m) const;
   void context_registry_on_change();
-  bool is_missing_object(const hobject_t& soid) const final {
+  bool is_missing_object(const hobject_t& soid) const final override {
     return get_local_missing().is_missing(soid);
   }
   bool is_unreadable_object(const hobject_t &oid,
-			    eversion_t* v = 0) const final {
+			    eversion_t* v = 0) const final override {
     return is_missing_object(oid) ||
       !peering_state.get_missing_loc().readable_with_acting(
 	oid, get_actingset(), v);

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -103,7 +103,7 @@ class PGMap {
   struct PGCreationState : BlockerT<PGCreationState> {
     static constexpr const char * type_name = "PGCreation";
 
-    void dump_detail(Formatter *f) const final;
+    void dump_detail(Formatter *f) const final override;
 
     spg_t pgid;
     seastar::shared_promise<Ref<PG>> promise;

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -50,7 +50,7 @@ public:
   void enqueue_push(
     const hobject_t& obj,
     const eversion_t& v,
-    const std::vector<pg_shard_t> &peers) final;
+    const std::vector<pg_shard_t> &peers) final override;
 private:
   PGRecoveryListener* pg;
   size_t start_primary_recovery_ops(
@@ -129,24 +129,24 @@ private:
   void request_replica_scan(
     const pg_shard_t& target,
     const hobject_t& begin,
-    const hobject_t& end) final;
+    const hobject_t& end) final override;
   void request_primary_scan(
-    const hobject_t& begin) final;
+    const hobject_t& begin) final override;
   void enqueue_drop(
     const pg_shard_t& target,
     const hobject_t& obj,
-    const eversion_t& v) final;
+    const eversion_t& v) final override;
   void send_recovery_deletes(
     const hobject_t& obj,
-    const std::vector<pg_shard_t>& peers) final;
-  void maybe_flush() final;
+    const std::vector<pg_shard_t>& peers) final override;
+  void maybe_flush() final override;
   void update_peers_last_backfill(
-    const hobject_t& new_last_backfill) final;
-  bool budget_available() const final;
+    const hobject_t& new_last_backfill) final override;
+  bool budget_available() const final override;
 
   template <typename T>
   void start_peering_event_operation_listener(T &&evt, float delay = 0);
-  void backfilled() final;
+  void backfilled() final override;
   void request_backfill();
   void all_replicas_recovered();
 

--- a/src/crimson/osd/replicated_backend.h
+++ b/src/crimson/osd/replicated_backend.h
@@ -31,13 +31,13 @@ public:
 		    CollectionRef coll,
 		    crimson::osd::ShardServices& shard_services,
 		    DoutPrefixProvider &dpp);
-  void got_rep_op_reply(const MOSDRepOpReply& reply) final;
-  seastar::future<> stop() final;
-  void on_actingset_changed(bool same_primary) final;
+  void got_rep_op_reply(const MOSDRepOpReply& reply) final override;
+  seastar::future<> stop() final override;
+  void on_actingset_changed(bool same_primary) final override;
 
   PGBackend::get_attr_ierrorator::future<ceph::bufferlist> getxattr(
     const hobject_t& soid,
-    std::string&& key) const final;
+    std::string&& key) const final override;
 
 private:
   ll_read_ierrorator::future<ceph::bufferlist>
@@ -45,7 +45,7 @@ private:
         uint64_t object_size,
         uint64_t off,
         uint64_t len,
-        uint32_t flags) final;
+        uint32_t flags) final override;
   rep_op_fut_t submit_transaction(
     const std::set<pg_shard_t> &pg_shards,
     crimson::osd::ObjectContextRef&& obc,
@@ -53,7 +53,7 @@ private:
     ceph::os::Transaction&& txn,
     osd_op_params_t&& osd_op_p,
     epoch_t min_epoch, epoch_t max_epoch,
-    std::vector<pg_log_entry_t>&& log_entries) final;
+    std::vector<pg_log_entry_t>&& log_entries) final override;
   const pg_t pgid;
   class pending_on_t : public seastar::weakly_referencable<pending_on_t> {
   public:
@@ -93,7 +93,7 @@ private:
     ceph_tid_t tid);
 
   seastar::future<> request_committed(
-    const osd_reqid_t& reqid, const eversion_t& at_version) final;
+    const osd_reqid_t& reqid, const eversion_t& at_version) final override;
 
   seastar::timer<seastar::lowres_clock> pct_timer;
 

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -25,11 +25,11 @@ public:
 			    PGBackend* backend);
   interruptible_future<> handle_recovery_op(
     Ref<MOSDFastDispatchOp> m,
-    crimson::net::ConnectionXcoreRef conn) final;
+    crimson::net::ConnectionXcoreRef conn) final override;
 
   interruptible_future<> recover_object(
     const hobject_t& soid,
-    eversion_t need) final;
+    eversion_t need) final override;
 
 protected:
   interruptible_future<> handle_pull(
@@ -96,7 +96,7 @@ protected:
   interruptible_future<std::optional<PushOp>> _handle_push_reply(
     pg_shard_t peer,
     const PushReplyOp &op);
-  seastar::future<> on_stop() final {
+  seastar::future<> on_stop() final override {
     return seastar::now();
   }
 private:

--- a/src/crimson/osd/scheduler/mclock_scheduler.h
+++ b/src/crimson/osd/scheduler/mclock_scheduler.h
@@ -176,31 +176,31 @@ public:
   std::string display_queues() const;
 
   // Enqueue op in the back of the regular queue
-  void enqueue(item_t &&item) final;
+  void enqueue(item_t &&item) final override;
 
   // Enqueue the op in the front of the high priority queue
-  void enqueue_front(item_t &&item) final;
+  void enqueue_front(item_t &&item) final override;
 
   // Return an op to be dispatch
-  WorkItem dequeue() final;
+  WorkItem dequeue() final override;
 
   // Returns if the queue is empty
-  bool empty() const final {
+  bool empty() const final override {
     return scheduler.empty() && high_priority.empty();
   }
 
   // Formatted output of the queue
-  void dump(ceph::Formatter &f) const final;
+  void dump(ceph::Formatter &f) const final override;
 
-  void print(std::ostream &ostream) const final {
+  void print(std::ostream &ostream) const final override {
     ostream << "mClockScheduer ";
     ostream << ", cutoff=" << cutoff_priority;
   }
 
-  std::vector<std::string> get_tracked_keys() const noexcept final;
+  std::vector<std::string> get_tracked_keys() const noexcept final override;
 
   void handle_conf_change(const ConfigProxy& conf,
-			  const std::set<std::string> &changed) final;
+			  const std::set<std::string> &changed) final override;
 
   double get_cost_per_io() const {
     return mclock_conf.get_cost_per_io();

--- a/src/crimson/osd/scheduler/scheduler.cc
+++ b/src/crimson/osd/scheduler/scheduler.cc
@@ -88,7 +88,7 @@ public:
     ] = conf.get_val<uint64_t>("osd_client_op_priority");
   }
 
-  void enqueue(item_t &&item) final {
+  void enqueue(item_t &&item) override {
     if (use_strict(item.params.klass))
       queue.enqueue_strict(
 	item.params.owner, get_priority(item.params.klass), std::move(item));
@@ -98,7 +98,7 @@ public:
 	item.params.cost, std::move(item));
   }
 
-  void enqueue_front(item_t &&item) final {
+  void enqueue_front(item_t &&item) override {
     if (use_strict(item.params.klass))
       queue.enqueue_strict_front(
 	item.params.owner, get_priority(item.params.klass), std::move(item));
@@ -108,19 +108,19 @@ public:
 	item.params.cost, std::move(item));
   }
 
-  bool empty() const final {
+  bool empty() const override {
     return queue.empty();
   }
 
-  WorkItem dequeue() final {
+  WorkItem dequeue() override {
     return queue.dequeue();
   }
 
-  void dump(ceph::Formatter &f) const final {
+  void dump(ceph::Formatter &f) const override {
     return queue.dump(&f);
   }
 
-  void print(std::ostream &out) const final {
+  void print(std::ostream &out) const override {
     out << "ClassedOpQueueScheduler(queue=";
     queue.print(out);
     out << ", cutoff=" << cutoff << ")";

--- a/src/crimson/osd/scrub/pg_scrubber.h
+++ b/src/crimson/osd/scrub/pg_scrubber.h
@@ -103,35 +103,35 @@ public:
     const hobject_t &hoid);
 
 private:
-  DoutPrefixProvider &get_dpp() final { return dpp; }
+  DoutPrefixProvider &get_dpp() final override { return dpp; }
 
-  void notify_scrub_start(bool deep) final;
-  void notify_scrub_end(bool deep) final;
+  void notify_scrub_start(bool deep) final override;
+  void notify_scrub_end(bool deep) final override;
 
-  const std::set<pg_shard_t> &get_ids_to_scrub() const final;
+  const std::set<pg_shard_t> &get_ids_to_scrub() const final override;
 
-  chunk_validation_policy_t get_policy() const final;
+  chunk_validation_policy_t get_policy() const final override;
 
-  void request_range(const hobject_t &start) final;
-  void reserve_range(const hobject_t &start, const hobject_t &end) final;
-  void release_range() final;
+  void request_range(const hobject_t &start) final override;
+  void reserve_range(const hobject_t &start, const hobject_t &end) final override;
+  void release_range() final override;
   void scan_range(
     pg_shard_t target,
     eversion_t version,
     bool deep,
     const hobject_t &start,
-    const hobject_t &end) final;
-  bool await_update(const eversion_t &version) final;
+    const hobject_t &end) final override;
+  bool await_update(const eversion_t &version) final override;
   void generate_and_submit_chunk_result(
     const hobject_t &begin,
     const hobject_t &end,
-    bool deep) final;
+    bool deep) final override;
   void emit_chunk_result(
     const request_range_result_t &range,
-    chunk_result_t &&result) final;
+    chunk_result_t &&result) final override;
   void emit_scrub_result(
     bool deep,
-    object_stat_sum_t scrub_stats) final;
+    object_stat_sum_t scrub_stats) final override;
 };
 
 };

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -353,10 +353,10 @@ private:
   epoch_t up_thru_wanted = 0;
   seastar::future<> send_alive(epoch_t want);
 
-  std::vector<std::string> get_tracked_keys() const noexcept final;
+  std::vector<std::string> get_tracked_keys() const noexcept final override;
   void handle_conf_change(
     const ConfigProxy& conf,
-    const std::set <std::string> &changed) final;
+    const std::set <std::string> &changed) final override;
 
   seastar::future<local_cached_map_t> get_local_map(epoch_t e);
   seastar::future<std::unique_ptr<OSDMap>> load_map(epoch_t e);
@@ -631,9 +631,9 @@ public:
   }
 
   // OSDMapService
-  cached_map_t get_map() const final { return local_state.get_osdmap(); }
-  epoch_t get_up_epoch() const final { return local_state.up_epoch; }
-  seastar::future<cached_map_t> get_map(epoch_t e) final {
+  cached_map_t get_map() const final override { return local_state.get_osdmap(); }
+  epoch_t get_up_epoch() const final override { return local_state.up_epoch; }
+  seastar::future<cached_map_t> get_map(epoch_t e) final override {
     return with_singleton(
       [](auto &sstate, epoch_t e) {
 	return sstate.get_local_map(

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -30,9 +30,9 @@ public:
       watch(std::move(watch)) {
   }
 
-  const hobject_t& get_target_oid() const final;
-  PG::do_osd_ops_params_t get_do_osd_ops_params() const final;
-  std::vector<OSDOp> create_osd_ops() final;
+  const hobject_t& get_target_oid() const override;
+  PG::do_osd_ops_params_t get_do_osd_ops_params() const override;
+  std::vector<OSDOp> create_osd_ops() override;
 
 private:
   WatchRef watch;

--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -127,7 +127,7 @@ class PGLogWorkload final : public StoreBenchWorkload {
   unsigned log_length = 256;
 
 public:
-  po::options_description get_options() final {
+  po::options_description get_options() override {
     po::options_description ret{"PGLogWorkload"};
     ret.add_options()
       ("num-logs", po::value<unsigned>(&num_logs),
@@ -142,8 +142,8 @@ public:
   }
   seastar::future<results_t> run(
     const common_options_t &common,
-    crimson::os::FuturizedStore &global_store) final;
-  ~PGLogWorkload() final {}
+    crimson::os::FuturizedStore &global_store) override;
+  ~PGLogWorkload() {}
 };
 
 class RGWIndexWorkload final : public StoreBenchWorkload {
@@ -157,7 +157,7 @@ class RGWIndexWorkload final : public StoreBenchWorkload {
 public:
   po::options_description options{"RGWIndexWorkload"};
 
-  po::options_description get_options() final {
+  po::options_description get_options() override {
     po::options_description ret{"PGLogWorkload"};
     ret.add_options()
       ("num_indices", po::value<unsigned>(&num_indices),
@@ -180,8 +180,8 @@ public:
   }
   seastar::future<results_t> run(
     const common_options_t &common,
-    crimson::os::FuturizedStore &global_store) final;
-  ~RGWIndexWorkload() final {}
+    crimson::os::FuturizedStore &global_store) override;
+  ~RGWIndexWorkload() {}
 };
 
 /**
@@ -592,7 +592,7 @@ class RandomWriteWorkload final : public StoreBenchWorkload {
     return size_per_shard / size_per_obj;
   }
 public:
-  po::options_description get_options() final {
+  po::options_description get_options() override {
     po::options_description ret{"RandomWriteWorkload"};
     ret.add_options()
       ("prefill-size", po::value<uint64_t>(&prefill_size),
@@ -612,8 +612,8 @@ public:
   }
   seastar::future<results_t> run(
     const common_options_t &common,
-    crimson::os::FuturizedStore &global_store) final;
-  ~RandomWriteWorkload() final {}
+    crimson::os::FuturizedStore &global_store) override;
+  ~RandomWriteWorkload() {}
 };
 
 seastar::future<bufferptr> generate_random_bp(uint64_t size)

--- a/src/crimson/tools/store_nbd/fs_driver.h
+++ b/src/crimson/tools/store_nbd/fs_driver.h
@@ -11,27 +11,27 @@ public:
   FSDriver(config_t config)
   : config(config)
   {}
-  ~FSDriver() final {}
+  ~FSDriver() {}
 
-  bufferptr get_buffer(size_t size) final {
+  bufferptr get_buffer(size_t size) override {
     return ceph::buffer::create_page_aligned(size);
   }
 
   seastar::future<> write(
     off_t offset,
-    bufferptr ptr) final;
+    bufferptr ptr) override;
 
   seastar::future<bufferlist> read(
     off_t offset,
-    size_t size) final;
+    size_t size) override;
 
   size_t get_size() const {
     return size;
   }
 
-  seastar::future<> mount() final;
+  seastar::future<> mount() override;
 
-  seastar::future<> close() final;
+  seastar::future<> close() override;
 
 private:
   size_t size = 0;

--- a/src/crimson/tools/store_nbd/tm_driver.h
+++ b/src/crimson/tools/store_nbd/tm_driver.h
@@ -11,25 +11,25 @@
 class TMDriver final : public BlockDriver {
 public:
   TMDriver(config_t config) : config(config) {}
-  ~TMDriver() final {}
+  ~TMDriver() {}
 
-  bufferptr get_buffer(size_t size) final {
+  bufferptr get_buffer(size_t size) override {
     return ceph::buffer::create_page_aligned(size);
   }
 
   seastar::future<> write(
     off_t offset,
-    bufferptr ptr) final;
+    bufferptr ptr) override;
 
   seastar::future<bufferlist> read(
     off_t offset,
-    size_t size) final;
+    size_t size) override;
 
-  size_t get_size() const final;
+  size_t get_size() const override;
 
-  seastar::future<> mount() final;
+  seastar::future<> mount() override;
 
-  seastar::future<> close() final;
+  seastar::future<> close() override;
 
 private:
   const config_t config;


### PR DESCRIPTION
Note: when using 'final' without 'override', the compiler does not signal an error
if the member function is not actually overriding a base class function.

Here we modify the code: to use only 'override' wherever the class
itself is already marked 'final', and 'override final' otherwise.