### PR TITLE
ceph-volume: add --osd-fsid support to raw mode prepare

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -71,6 +71,11 @@ def create_parser(prog: str, description: str) -> argparse.ArgumentParser:
         type=arg_validators.valid_osd_id,
     )
     parser.add_argument(
+        '--osd-fsid',
+        help='Reuse an existing OSD fsid',
+        default=None,
+    )
+    parser.add_argument(
         '--osd-type',
         dest='osd_type',
         help='The Ceph OSD type to use.',

--- a/src/ceph-volume/ceph_volume/objectstore/raw.py
+++ b/src/ceph-volume/ceph_volume/objectstore/raw.py
@@ -85,7 +85,7 @@ class Raw(BaseObjectStore):
 
     @decorators.needs_root
     def prepare(self) -> None:
-        self.osd_fsid = system.generate_uuid()
+        self.osd_fsid = self.osd_fsid or system.generate_uuid()
         crush_device_class = self.args.crush_device_class
         if self.encrypted and not self.with_tpm:
             self.dmcrypt_key = os.getenv('CEPH_VOLUME_DMCRYPT_SECRET', '')

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
@@ -46,6 +46,7 @@ class TestPrepare(object):
         assert 'Path to bluestore block.db block device' in stdout
         assert 'Path to bluestore block.wal block device' in stdout
         assert 'Enable device encryption via dm-crypt' in stdout
+        assert 'Reuse an existing OSD fsid' in stdout
 
     @patch('ceph_volume.util.arg_validators.set_dmcrypt_no_workqueue', return_value=MagicMock())
     @patch('ceph_volume.util.arg_validators.ValidRawDevice.__call__')

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
@@ -92,6 +92,34 @@ class TestRaw:
         assert self.raw_bs.prepare_osd_req.mock_calls == [call(tmpfs=True)]
         assert self.raw_bs.osd_mkfs.called
         assert self.raw_bs.prepare_dmcrypt.called
+        m_generate_uuid.assert_called_once()
+
+    @patch('ceph_volume.objectstore.raw.nvme_utils.preformat', return_value=False)
+    @patch('ceph_volume.objectstore.raw.prepare_utils.create_id')
+    @patch('ceph_volume.objectstore.raw.system.generate_uuid')
+    def test_prepare_uses_external_osd_fsid(self,
+                                            m_generate_uuid,
+                                            m_create_id,
+                                            m_nvme_preformat,
+                                            is_root,
+                                            factory):
+        external = '824f7edf-371f-4b75-9231-4ab62a32d5c0'
+        m_create_id.return_value = MagicMock()
+        args = factory(crush_device_class=None, no_tmpfs=True, osd_fsid=external)
+        args.data = '/dev/sdx'
+        self.raw_bs.args = args
+        self.raw_bs.osd_fsid = getattr(args, 'osd_fsid', '')
+        self.raw_bs.block_device_path = args.data
+        self.raw_bs.prepare_dmcrypt = MagicMock()
+        self.raw_bs.prepare_osd_req = MagicMock()
+        self.raw_bs.osd_mkfs = MagicMock()
+        self.raw_bs.secrets = {}
+        self.raw_bs.encrypted = False
+        self.raw_bs.prepare()
+        m_generate_uuid.assert_not_called()
+        m_create_id.assert_called_once()
+        assert m_create_id.call_args[0][0] == external
+        assert self.raw_bs.osd_fsid == external
 
     @patch('ceph_volume.objectstore.raw.nvme_utils.preformat', return_value=True)
     @patch('ceph_volume.objectstore.raw.prepare_utils.create_id')


### PR DESCRIPTION
## Summary

The LVM mode already supports `--osd-fsid` to allow external tools (e.g., Kubernetes operators) to pre-register an OSD ID+UUID via `ceph osd new` and then pass both to ceph-volume. This ensures the operator retains full control of the OSD ID lifecycle and can reliably clean up on prepare failure (no orphan OSDs).

The raw mode was missing this support:
- `prepare()` unconditionally called `system.generate_uuid()`, ignoring any `--osd-fsid` value
- When an operator pre-registered `osd.N` with `uuid_A` and then ran `ceph-volume raw prepare --osd-id N --dmcrypt`, ceph-volume generated `uuid_B` internally and called `ceph osd new uuid_B N`, which failed with `EINVAL` because the ID was already registered with a different UUID

## Changes

- **`devices/raw/common.py`**: Add `--osd-fsid` argument to the raw mode argument parser, consistent with the LVM mode
- **`objectstore/raw.py`**: Honor an externally provided `osd_fsid`, falling back to `generate_uuid()` only when none is given, consistent with the LVM mode (`self.osd_fsid = self.osd_fsid or system.generate_uuid()`)

## Testing

Tested with ceph-osd-operator on Ceph 20.2.0 (Tentacle):
- `ceph-volume raw prepare --osd-id <id> --osd-fsid <uuid> --data /dev/vdb` works correctly
- `ceph-volume raw prepare --osd-id <id> --osd-fsid <uuid> --dmcrypt --data /dev/vdb` no longer fails with EINVAL
- Without `--osd-fsid`, behavior is unchanged (UUID auto-generated)

Signed-off-by: Duanming Zhou <zhouduanming@gmail.com>