### PR TITLE
crimson/osd: move to a unified on-device super-block structure

### DIFF
--- a/src/crimson/os/seastore/device.cc
+++ b/src/crimson/os/seastore/device.cc
@@ -3,6 +3,8 @@
 
 #include "device.h"
 
+#include <seastar/core/smp.hh>
+
 #include "segment_manager.h"
 #include "random_block_manager.h"
 #include "random_block_manager/rbm_device.h"
@@ -32,6 +34,83 @@ std::ostream& operator<<(std::ostream& out, const device_config_t& conf)
         << ": " << v << ", ";
   }
   return out << "))";
+}
+
+std::ostream& operator<<(std::ostream& out, const device_shard_info_t& si)
+{
+  fmt::print(out, "{}", si);
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const device_superblock_t& sb)
+{
+  fmt::print(out, "{}", sb);
+  return out;
+}
+
+void device_superblock_t::validate() const
+{
+  // NOTE: magic is validated at the read site, outside this struct.
+  ceph_assert(version == CRIMSON_DEVICE_SUPERBLOCK_VERSION);
+  if (crimson::common::get_conf<bool>(
+          "seastore_require_partition_count_match_reactor_count")) {
+    ceph_assert(shard_num == seastar::smp::count);
+  }
+  ceph_assert(block_size > 0);
+  ceph_assert(config.spec.magic != 0);
+  ceph_assert(config.spec.id <= DEVICE_ID_MAX_VALID);
+  if (!config.major_dev) {
+    ceph_assert(config.secondary_devices.empty());
+  }
+  for (const auto& [k, v] : config.secondary_devices) {
+    ceph_assert(k != config.spec.id);
+    ceph_assert(k <= DEVICE_ID_MAX_VALID);
+    ceph_assert(k == v.id);
+    ceph_assert(v.magic != 0);
+    ceph_assert(v.dtype > device_type_t::NONE);
+    ceph_assert(v.dtype < device_type_t::NUM_TYPES);
+  }
+  if (config.spec.dtype == device_type_t::ZBD) {
+    // ZBD: check zone/segment geometry
+    ceph_assert(segment_capacity > 0);
+    ceph_assert_always(segment_capacity <= SEGMENT_OFF_MAX);
+  }
+  auto backend = get_default_backend_of_device(config.spec.dtype);
+  if (backend == backend_type_t::SEGMENTED) {
+    ceph_assert(segment_size > 0 && segment_size % block_size == 0);
+    ceph_assert_always(segment_size <= SEGMENT_OFF_MAX);
+    ceph_assert(shard_infos.size() >= shard_num);
+    for (unsigned int i = 0; i < shard_num; i++) {
+      ceph_assert(shard_infos[i].size > 0);
+      ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
+      ceph_assert(shard_infos[i].segments > 0);
+      ceph_assert_always(shard_infos[i].segments <= DEVICE_SEGMENT_ID_MAX);
+      if (config.spec.dtype != device_type_t::ZBD) {
+        // HDD: check tracker and first-segment offsets
+        ceph_assert(shard_infos[i].size > segment_size &&
+                    shard_infos[i].size % block_size == 0);
+        ceph_assert(shard_infos[i].tracker_offset > 0 &&
+                    shard_infos[i].tracker_offset % block_size == 0);
+        ceph_assert(shard_infos[i].first_segment_offset >
+                      shard_infos[i].tracker_offset &&
+                    shard_infos[i].first_segment_offset % block_size == 0);
+      }
+    }
+  } else {
+    // RBM
+    ceph_assert(total_size > 0);
+    ceph_assert(get_default_backend_of_device(config.spec.dtype) ==
+                backend_type_t::RANDOM_BLOCK);
+    ceph_assert(shard_infos.size() >= shard_num);
+    for (unsigned int i = 0; i < shard_num; i++) {
+      ceph_assert(shard_infos[i].size > block_size &&
+                  shard_infos[i].size % block_size == 0);
+      ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
+      ceph_assert(journal_size > 0 && journal_size % block_size == 0);
+      ceph_assert(shard_infos[i].start_offset < total_size &&
+                  shard_infos[i].start_offset % block_size == 0);
+    }
+  }
 }
 
 seastar::future<DeviceRef>

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -3,10 +3,15 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "include/buffer_fwd.h"
 
+#include "common/fmt_common.h"
 #include "crimson/common/errorator.h"
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/common/smp_helpers.h"
@@ -77,6 +82,211 @@ struct device_config_t {
 };
 
 std::ostream& operator<<(std::ostream&, const device_config_t&);
+
+/* -----------------------------------------------------------------------
+ * Unified superblock written at offset 0 on every Crimson device type:
+ *   HDD (block-segment), ZBD (zoned-block), RBM (random-block / NVMe)
+ * -----------------------------------------------------------------------
+ */
+
+/// On-disk superblock magic type (23 bytes, matching classic BlueStore prefix size).
+/// Written outside the DENC envelope at device offset 0.
+using superblock_magic_t = std::array<std::byte, 23>;
+
+/// Magic identifying all Crimson device superblocks: "CRIMSON_DEVICE\0..."
+constexpr superblock_magic_t CRIMSON_DEVICE_SUPERBLOCK_MAGIC = {{
+    std::byte{'C'}, std::byte{'R'}, std::byte{'I'}, std::byte{'M'},
+    std::byte{'S'}, std::byte{'O'}, std::byte{'N'}, std::byte{'_'},
+    std::byte{'D'}, std::byte{'E'}, std::byte{'V'}, std::byte{'I'},
+    std::byte{'C'}, std::byte{'E'}, std::byte{0},   std::byte{0},
+    std::byte{0},   std::byte{0},   std::byte{0},   std::byte{0},
+    std::byte{0},   std::byte{0},   std::byte{0}
+}};
+
+/// Size constants for the on-disk prefix (magic + null padding) that
+/// precedes the DENC-encoded superblock, matching the classic BlueStore
+/// 60-byte label prefix layout.
+constexpr size_t SUPERBLOCK_MAGIC_SIZE = sizeof(CRIMSON_DEVICE_SUPERBLOCK_MAGIC); // 23
+constexpr size_t SUPERBLOCK_MAGIC_PAD  = 37; // matching the UID block in BlueStore's
+constexpr size_t SUPERBLOCK_HEADER_PREFIX = SUPERBLOCK_MAGIC_SIZE + SUPERBLOCK_MAGIC_PAD;
+static_assert(SUPERBLOCK_HEADER_PREFIX == 60);
+
+/// Current superblock format version
+constexpr uint8_t CRIMSON_DEVICE_SUPERBLOCK_VERSION = 1;
+
+/// Feature bits stored in device_superblock_t::feature
+enum class device_feature_t : uint64_t {
+  NVME_END_TO_END_PROTECTION = 1,
+};
+
+/// Unified per-shard layout info for all device types.
+/// Fields unused by a given device type are left at their zero default.
+struct device_shard_info_t {
+  size_t size = 0;                    ///< usable shard size in bytes (all)
+  size_t segments = 0;                ///< number of segments (HDD/ZBD; 0 for RBM)
+  uint64_t first_segment_offset = 0;  ///< byte offset of first segment (HDD/ZBD)
+  uint64_t tracker_offset = 0;        ///< byte offset of segment-state tracker (HDD)
+  uint64_t start_offset = 0;          ///< byte offset of shard start (RBM)
+
+  DENC(device_shard_info_t, v, p) {
+    DENC_START(1, 1, p);
+    denc(v.size, p);
+    denc(v.segments, p);
+    denc(v.first_segment_offset, p);
+    denc(v.tracker_offset, p);
+    denc(v.start_offset, p);
+    DENC_FINISH(p);
+  }
+
+  auto fmt_print_ctx(auto& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(),
+      "device_shard_info(size={:#x}, segments={}, "
+      "first_segment_offset={:#x}, tracker_offset={:#x}, start_offset={:#x})",
+      size, segments, first_segment_offset, tracker_offset, start_offset);
+  }
+};
+
+std::ostream& operator<<(std::ostream&, const device_shard_info_t&);
+
+/// Unified on-disk superblock for all Crimson device types.
+/// Fields specific to a device type are zero for other types.
+struct device_superblock_t {
+  // --- Fixed header (all device types) ---
+  // NOTE: the magic string is written/read separately at device offset 0,
+  // outside this DENC-encoded structure (see SUPERBLOCK_HEADER_PREFIX).
+  uint16_t version = CRIMSON_DEVICE_SUPERBLOCK_VERSION;
+  uint16_t shard_num = 0;
+  size_t segment_size = 0;   ///< logical segment size in bytes (HDD/ZBD; 0 for RBM)
+  size_t block_size = 0;
+  device_config_t config;
+
+  // --- Device-type-specific size information (union concept) ---
+  size_t total_size = 0;          ///< total device capacity in bytes (RBM)
+  uint64_t journal_size = 0;      ///< journal area size in bytes (RBM)
+  size_t segment_capacity = 0;    ///< usable bytes/segment = zone_capacity*zones_per_segment (ZBD)
+  size_t zones_per_segment = 0;   ///< zones per segment (ZBD)
+  size_t zone_size = 0;           ///< physical zone size in bytes (ZBD)
+  size_t zone_capacity = 0;       ///< usable zone capacity in bytes (ZBD)
+
+  // --- Per-shard information ---
+  std::vector<device_shard_info_t> shard_infos;
+
+  // --- RBM-specific remaining fields ---
+  checksum_t crc = 0;
+  uint64_t feature = 0;          ///< device_feature_t bits
+  uint32_t nvme_block_size = 0;  ///< NVMe logical block size (E2E protection)
+
+  DENC(device_superblock_t, v, p) {
+    DENC_START(1, 1, p);
+    denc(v.version, p);
+    denc(v.shard_num, p);
+    denc(v.segment_size, p);
+    denc(v.block_size, p);
+    denc(v.config, p);
+    denc(v.total_size, p);
+    denc(v.journal_size, p);
+    denc(v.segment_capacity, p);
+    denc(v.zones_per_segment, p);
+    denc(v.zone_size, p);
+    denc(v.zone_capacity, p);
+    denc(v.shard_infos, p);
+    denc(v.crc, p);
+    denc(v.feature, p);
+    denc(v.nvme_block_size, p);
+    DENC_FINISH(p);
+  }
+
+  void validate() const;
+
+  /// Create a superblock for a segmented (HDD/SSD) device.
+  static device_superblock_t make_segmented(
+    uint16_t shard_num,
+    size_t segment_size,
+    size_t block_size,
+    device_config_t config,
+    std::vector<device_shard_info_t> shard_infos)
+  {
+    device_superblock_t sb;
+    sb.shard_num = shard_num;
+    sb.segment_size = segment_size;
+    sb.block_size = block_size;
+    sb.config = std::move(config);
+    sb.shard_infos = std::move(shard_infos);
+    return sb;
+  }
+
+  /// Create a superblock for a ZBD (zone-based) segmented device.
+  static device_superblock_t make_zbd(
+    uint16_t shard_num,
+    size_t segment_size,
+    size_t block_size,
+    device_config_t config,
+    size_t zone_size,
+    size_t zone_capacity,
+    size_t zones_per_segment,
+    std::vector<device_shard_info_t> shard_infos)
+  {
+    device_superblock_t sb;
+    sb.shard_num = shard_num;
+    sb.segment_size = segment_size;
+    sb.block_size = block_size;
+    sb.config = std::move(config);
+    sb.segment_capacity = zone_capacity * zones_per_segment;
+    sb.zones_per_segment = zones_per_segment;
+    sb.zone_size = zone_size;
+    sb.zone_capacity = zone_capacity;
+    sb.shard_infos = std::move(shard_infos);
+    return sb;
+  }
+
+  /// Create a superblock for an RBM (random-block) device.
+  static device_superblock_t make_rbm(
+    uint16_t shard_num,
+    size_t block_size,
+    size_t total_size,
+    uint64_t journal_size,
+    device_config_t config,
+    std::vector<device_shard_info_t> shard_infos)
+  {
+    device_superblock_t sb;
+    sb.shard_num = shard_num;
+    sb.block_size = block_size;
+    sb.total_size = total_size;
+    sb.journal_size = journal_size;
+    sb.config = std::move(config);
+    sb.shard_infos = std::move(shard_infos);
+    return sb;
+  }
+
+  bool is_end_to_end_data_protection() const {
+    return feature & (uint64_t)device_feature_t::NVME_END_TO_END_PROTECTION;
+  }
+  void set_end_to_end_data_protection() {
+    feature |= (uint64_t)device_feature_t::NVME_END_TO_END_PROTECTION;
+  }
+
+  auto fmt_print_ctx(auto& ctx) const -> decltype(ctx.out()) {
+    fmt::format_to(ctx.out(),
+      "device_superblock(version={}, shard_num={}, "
+      "segment_size={:#x}, block_size={:#x}, config={}, "
+      "total_size={:#x}, journal_size={:#x}, "
+      "segment_capacity={:#x}, zones_per_segment={}, "
+      "zone_size={:#x}, zone_capacity={:#x}, "
+      "crc={}, feature={:#x}, nvme_block_size={}, shards:[",
+      (unsigned)version, shard_num,
+      segment_size, block_size, config,
+      total_size, journal_size,
+      segment_capacity, zones_per_segment,
+      zone_size, zone_capacity,
+      crc, feature, nvme_block_size);
+    for (const auto& si : shard_infos) {
+      fmt::format_to(ctx.out(), "{},", si);
+    }
+    return fmt::format_to(ctx.out(), "])");
+  }
+};
+
+std::ostream& operator<<(std::ostream&, const device_superblock_t&);
 
 class Device;
 using DeviceRef = std::unique_ptr<Device>;
@@ -184,6 +394,8 @@ check_create_device_ret check_create_device(
 
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::device_spec_t)
 WRITE_CLASS_DENC(crimson::os::seastore::device_config_t)
+WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::device_shard_info_t)
+WRITE_CLASS_DENC(crimson::os::seastore::device_superblock_t)
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<crimson::os::seastore::device_config_t> : fmt::ostream_formatter {};

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -27,74 +27,6 @@ struct alloc_paddr_result {
   extent_len_t len;
 };
 
-struct rbm_shard_info_t {
-  std::size_t size = 0;
-  uint64_t start_offset = 0;
-
-  DENC(rbm_shard_info_t, v, p) {
-    DENC_START(1, 1, p);
-    denc(v.size, p);
-    denc(v.start_offset, p);
-    DENC_FINISH(p);
-  }
-};
-
-enum class rbm_feature_t : uint64_t {
-  RBM_NVME_END_TO_END_PROTECTION = 1,
-};
-
-struct rbm_superblock_t {
-  size_t size = 0;
-  size_t block_size = 0;
-  uint64_t feature = 0;
-  uint64_t journal_size = 0;
-  checksum_t crc = 0;
-  device_config_t config;
-  uint32_t shard_num = 0;
-  // Must be assigned if ent-to-end-data-protection features is enabled
-  uint32_t nvme_block_size = 0;
-  std::vector<rbm_shard_info_t> shard_infos;
-
-  DENC(rbm_superblock_t, v, p) {
-    DENC_START(1, 1, p);
-    denc(v.size, p);
-    denc(v.block_size, p);
-    denc(v.feature, p);
-
-    denc(v.journal_size, p);
-    denc(v.crc, p);
-    denc(v.config, p);
-    denc(v.shard_num, p);
-    denc(v.nvme_block_size, p);
-    denc(v.shard_infos, p);
-    DENC_FINISH(p);
-  }
-
-  void validate() const {
-    ceph_assert(block_size > 0);
-    for (unsigned int i = 0; i < seastar::smp::count; i ++) {
-      ceph_assert(shard_infos[i].size > block_size &&
-                  shard_infos[i].size % block_size == 0);
-      ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
-      ceph_assert(journal_size > 0 &&
-                  journal_size % block_size == 0);
-      ceph_assert(shard_infos[i].start_offset < size &&
-		  shard_infos[i].start_offset % block_size == 0);
-    }
-    ceph_assert(config.spec.magic != 0);
-    ceph_assert(get_default_backend_of_device(config.spec.dtype) ==
-		backend_type_t::RANDOM_BLOCK);
-    ceph_assert(config.spec.id <= DEVICE_ID_MAX_VALID);
-  }
-
-  bool is_end_to_end_data_protection() const {
-    return (feature & (uint64_t)rbm_feature_t::RBM_NVME_END_TO_END_PROTECTION);
-  }
-  void set_end_to_end_data_protection() {
-    feature |= (uint64_t)rbm_feature_t::RBM_NVME_END_TO_END_PROTECTION;
-  }
-};
-
 enum class rbm_extent_state_t {
   FREE,		// not allocated
   RESERVED,	// extent is reserved by alloc_new_extent, but is not persistent
@@ -184,18 +116,6 @@ namespace random_block_device {
 seastar::future<std::unique_ptr<random_block_device::RBMDevice>> 
   get_rb_device(const std::string &device);
 
-std::ostream &operator<<(std::ostream &out, const rbm_superblock_t &header);
-std::ostream &operator<<(std::ostream &out, const rbm_shard_info_t &shard);
+std::ostream &operator<<(std::ostream &out, const rbm_extent_state_t &state);
 }
 
-WRITE_CLASS_DENC_BOUNDED(
-  crimson::os::seastore::rbm_shard_info_t
-)
-WRITE_CLASS_DENC_BOUNDED(
-  crimson::os::seastore::rbm_superblock_t
-)
-
-#if FMT_VERSION >= 90000
-template<> struct fmt::formatter<crimson::os::seastore::rbm_superblock_t> : fmt::ostream_formatter {};
-template<> struct fmt::formatter<crimson::os::seastore::rbm_shard_info_t> : fmt::ostream_formatter {};
-#endif

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -205,28 +205,4 @@ void BlockRBManager::prefill_fragmented_device()
 }
 #endif
 
-std::ostream &operator<<(std::ostream &out, const rbm_superblock_t &header)
-{
-  out << " rbm_superblock_t(size=" << header.size
-       << ", block_size=" << header.block_size
-       << ", feature=" << header.feature
-       << ", journal_size=" << header.journal_size
-       << ", crc=" << header.crc
-       << ", config=" << header.config
-       << ", shard_num=" << header.shard_num
-       << ", end_to_end_data_protection=" << header.is_end_to_end_data_protection()
-       << ", device_block_size=" << header.nvme_block_size;
-  for (auto p : header.shard_infos) {
-    out << p;
-  }
-  return out << ")";
-}
-
-std::ostream &operator<<(std::ostream &out, const rbm_shard_info_t &shard)
-{
-  out << " rbm_shard_info_t(size=" << shard.size
-      << ", start_offset=" << shard.start_offset;
-  return out << ")";
-}
-
 }

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -37,9 +37,10 @@ public:
   /*
    * Ondisk layout (TODO)
    *
-   * ---------------------------------------------------------------------------
-   * | rbm_superblock_t | metadatas |        ...      |    data blocks    |
-   * ---------------------------------------------------------------------------
+   * -------------------------------------------------------------------------------
+   * | 23B magic | 37B null padding | DENC-encoded superblock header | data blocks |
+   * |           |                  | header (device_superblock_t)   |             |
+   * -------------------------------------------------------------------------------
    */
 
   read_ertr::future<> read(paddr_t addr, bufferptr &buffer) override;

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -44,26 +44,30 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
     );
   }
 
-  super.block_size = (*st).block_size;
-  super.size = (*st).size;
-  super.config = std::move(config);
-  super.journal_size = journal_size;
-  ceph_assert_always(super.journal_size > 0);
-  ceph_assert_always(super.size >= super.journal_size);
+  const size_t cur_block_size = (*st).block_size;
+  const size_t cur_total_size = (*st).size;
+  ceph_assert_always(journal_size > 0);
+  ceph_assert_always(cur_total_size >= journal_size);
   ceph_assert_always(shard_num > 0);
 
-  std::vector<rbm_shard_info_t> shard_infos(shard_num);
+  const size_t aligned_size =
+    (cur_total_size / shard_num) -
+    ((cur_total_size / shard_num) % cur_block_size);
+
+  std::vector<device_shard_info_t> shard_infos(shard_num);
   for (int i = 0; i < shard_num; i++) {
-    uint64_t aligned_size = 
-      (super.size / shard_num) -
-      ((super.size / shard_num) % super.block_size);
     shard_infos[i].size = aligned_size;
     shard_infos[i].start_offset = i * aligned_size;
-    assert(shard_infos[i].size > super.journal_size);
+    assert(shard_infos[i].size > journal_size);
   }
-  super.shard_infos = shard_infos;
-  super.shard_num = shard_num;
   shard_info = shard_infos[seastar::this_shard_id()];
+  super = device_superblock_t::make_rbm(
+    shard_num,
+    cur_block_size,
+    cur_total_size,
+    journal_size,
+    std::move(config),
+    std::move(shard_infos));
   DEBUG("super {} ", super);
 
   // write super block
@@ -100,24 +104,46 @@ write_ertr::future<> RBMDevice::write_rbm_superblock()
 
   bufferlist bl;
   encode(super, bl);
-  auto iter = bl.begin();
   auto bp = bufferptr(ceph::buffer::create_page_aligned(super.block_size));
-  assert(bl.length() < super.block_size);
-  iter.copy(bl.length(), bp.c_str());
+  bp.zero();
+  // magic at offset 0, followed by 37 bytes of null padding (just zeroed)
+  std::memcpy(bp.c_str(),
+	      CRIMSON_DEVICE_SUPERBLOCK_MAGIC.data(), SUPERBLOCK_MAGIC_SIZE);
+  // DENC-encoded superblock at offset 60
+  assert(SUPERBLOCK_HEADER_PREFIX + bl.length() < super.block_size);
+  auto iter = bl.begin();
+  iter.copy(bl.length(), bp.c_str() + SUPERBLOCK_HEADER_PREFIX);
   co_return co_await write(RBM_START_ADDRESS, bp);
 }
 
-read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
+read_ertr::future<device_superblock_t> RBMDevice::read_rbm_superblock(
   rbm_abs_addr addr)
 {
   LOG_PREFIX(RBMDevice::read_rbm_superblock);
   assert(super.block_size > 0);
   auto bptr = bufferptr(ceph::buffer::create_page_aligned(super.block_size));
   co_await read(addr, bptr);
+
+  // verify magic at offset 0
+  superblock_magic_t disk_magic;
+  std::memcpy(disk_magic.data(), bptr.c_str(), SUPERBLOCK_MAGIC_SIZE);
+  if (disk_magic != CRIMSON_DEVICE_SUPERBLOCK_MAGIC) {
+    ERROR("invalid superblock magic in read_rbm_superblock, got: {:02x}",
+      fmt::join(
+        std::views::transform(disk_magic,
+          [](std::byte b) { return std::to_integer<uint8_t>(b); }),
+        " "));
+    co_return co_await read_ertr::future<device_superblock_t>(
+      crimson::ct_error::input_output_error::make()
+    );
+  }
+
+  // decode DENC superblock from offset 60
   bufferlist bl;
-  bl.append(bptr);
+  bl.append(bptr.c_str() + SUPERBLOCK_HEADER_PREFIX,
+	    bptr.length() - SUPERBLOCK_HEADER_PREFIX);
   auto p = bl.cbegin();
-  rbm_superblock_t super_block;
+  device_superblock_t super_block;
   bool err = false;
   try {
     decode(super_block, p);
@@ -127,7 +153,7 @@ read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
     err = true;
   }
   if (err) {
-    co_return co_await read_ertr::future<rbm_superblock_t>(
+    co_return co_await read_ertr::future<device_superblock_t>(
       crimson::ct_error::input_output_error::make()
     );
   }
@@ -135,15 +161,16 @@ read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
   bufferlist meta_b_header;
   super_block.crc = 0;
   encode(super_block, meta_b_header);
-  assert(ceph::encoded_sizeof<rbm_superblock_t>(super_block) <
-      super_block.block_size);
+  assert(SUPERBLOCK_HEADER_PREFIX +
+	 ceph::encoded_sizeof<device_superblock_t>(super_block) <
+	 super_block.block_size);
 
   // Do CRC verification only if data protection is not supported.
   if (super_block.is_end_to_end_data_protection() == false) {
     if (meta_b_header.crc32c(-1) != crc) {
       DEBUG("bad crc on super block, expected {} != actual {} ",
 	    meta_b_header.crc32c(-1), crc);
-      co_return co_await read_ertr::future<rbm_superblock_t>(
+      co_return co_await read_ertr::future<device_superblock_t>(
 	crimson::ct_error::input_output_error::make()
       );
     }
@@ -153,7 +180,7 @@ read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
   super_block.crc = crc;
   super = super_block;
   DEBUG("got {} ", super);
-  co_return co_await read_ertr::future<rbm_superblock_t>(
+  co_return co_await read_ertr::future<device_superblock_t>(
     read_ertr::ready_future_marker{},
     super_block
   );
@@ -231,7 +258,8 @@ read_ertr::future<uint32_t> RBMDevice::get_shard_nums()
 
 EphemeralRBMDeviceRef create_test_ephemeral(uint64_t journal_size, uint64_t data_size) {
   return EphemeralRBMDeviceRef(
-    new EphemeralRBMDevice(journal_size + data_size + 
+    new EphemeralRBMDevice(
+      (journal_size + data_size) * seastar::smp::count +
 	random_block_device::RBMDevice::get_shard_reserved_size(),
 	EphemeralRBMDevice::TEST_BLOCK_SIZE));
 }
@@ -331,7 +359,7 @@ EphemeralRBMDevice::mount_ret EphemeralRBMDevice::mount() {
 }
 
 EphemeralRBMDevice::mkfs_ret EphemeralRBMDevice::mkfs(device_config_t config) {
-  return do_primary_mkfs(config, 1, DEFAULT_TEST_CBJOURNAL_SIZE);
+  return do_primary_mkfs(config, seastar::smp::count, DEFAULT_TEST_CBJOURNAL_SIZE);
 }
 
 }

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -84,8 +84,8 @@ public:
     return _readv(rbm_addr, std::move(ptrs));
   }
 protected:
-  rbm_superblock_t super;
-  rbm_shard_info_t shard_info;
+  device_superblock_t super;
+  device_shard_info_t shard_info;
   uint32_t device_shard_nums = 0;
   store_index_t store_index = 0;
   bool shard_status = true;
@@ -126,7 +126,7 @@ public:
   secondary_device_set_t& get_secondary_devices() final {
     return super.config.secondary_devices;
   }
-  std::size_t get_available_size() const { return super.size; }
+  std::size_t get_available_size() const { return super.total_size; }
   extent_len_t get_block_size() const { return super.block_size; }
 
   read_ertr::future<uint32_t> get_shard_nums() final;
@@ -179,7 +179,7 @@ public:
 
   write_ertr::future<> write_rbm_superblock();
 
-  read_ertr::future<rbm_superblock_t> read_rbm_superblock(rbm_abs_addr addr);
+  read_ertr::future<device_superblock_t> read_rbm_superblock(rbm_abs_addr addr);
 
   using stat_device_ret =
     read_ertr::future<seastar::stat_data>;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -123,11 +123,6 @@ constexpr device_id_t DEVICE_ID_SEGMENTED_MIN = 0;
 constexpr device_id_t DEVICE_ID_RANDOM_BLOCK_MIN = 
   1 << (std::numeric_limits<device_id_t>::digits - 1);
 
-// TODO this Signature is only applicable for segment devices(SSD/HDD) not
-// for other two devices like ZBD/RANDOM_BLOCK_SSD
-constexpr const char SEASTORE_SUPERBLOCK_SIGN[] = "seastore block device\n";
-constexpr std::size_t SEASTORE_SUPERBLOCK_SIGN_LEN = sizeof(SEASTORE_SUPERBLOCK_SIGN) - 1;
-
 struct device_id_printer_t {
   device_id_t id;
 };

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -13,33 +13,6 @@ SET_SUBSYS(seastore_device);
 
 namespace crimson::os::seastore {
 
-std::ostream& operator<<(std::ostream& out, const block_shard_info_t& sf)
-{
-  out << "("
-      << "size=0x" << std::hex << sf.size << std::dec
-      << ", segments=" << sf.segments
-      << ", tracker_offset=0x" << std::hex << sf.tracker_offset
-      << ", first_segment_offset=0x" << sf.first_segment_offset << std::dec
-      <<")";
-  return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const block_sm_superblock_t& sb)
-{
-  out << "superblock("
-      << "shard_num=" << sb.shard_num
-      << ", segment_size=0x" << std::hex << sb.segment_size
-      << ", block_size=0x" << sb.block_size << std::dec
-      << ", shard_info:";
-  for (auto &sf : sb.shard_infos) {
-    out << sf
-        << ",";
-  }
-  out << "config=" << sb.config
-      << ")";
-  return out;
-}
-
 std::ostream& operator<<(std::ostream &out, Segment::segment_state_t s)
 {
   using state_t = Segment::segment_state_t;

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -34,47 +34,41 @@ SegmentManager::get_segment_manager(
 {
 #ifdef HAVE_ZNS
 LOG_PREFIX(SegmentManager::get_segment_manager);
-  return seastar::do_with(
-    static_cast<size_t>(0),
-    [FNAME,
-     dtype,
-     device](auto &nr_zones) {
-      return seastar::open_file_dma(
-	device + "/block",
-	seastar::open_flags::rw
-      ).then([FNAME,
-	      dtype,
-	      device,
-	      &nr_zones](auto file) {
-	return seastar::do_with(
-	  file,
-	  [&nr_zones](auto &f) -> seastar::future<int> {
-	    ceph_assert(f);
-	    return f.ioctl(BLKGETNRZONES, (void *)&nr_zones);
-	  });
-      }).then([FNAME,
-	       dtype,
-	       device,
-	       &nr_zones](auto ret) -> crimson::os::seastore::SegmentManagerRef {
-	crimson::os::seastore::SegmentManagerRef sm;
-	INFO("Found {} zones.", nr_zones);
-	if (nr_zones != 0) {
-	  return std::make_unique<
-	    segment_manager::zbd::ZBDSegmentManager
+  if (dtype == device_type_t::ZBD) {
+    return seastar::do_with(
+      static_cast<size_t>(0),
+      [FNAME, device](auto &nr_zones) {
+	return seastar::open_file_dma(
+	  device + "/block",
+	  seastar::open_flags::rw
+	).then([&nr_zones](auto file) {
+	  return seastar::do_with(
+	    file,
+	    [&nr_zones](auto &f) -> seastar::future<int> {
+	      ceph_assert(f);
+	      return f.ioctl(BLKGETNRZONES, (void *)&nr_zones);
+	    });
+	}).then([FNAME,
+		 device,
+		 &nr_zones](auto ret) -> crimson::os::seastore::SegmentManagerRef {
+	  INFO("Found {} zones.", nr_zones);
+	  if (nr_zones != 0) {
+	    return std::make_unique<
+	      segment_manager::zbd::ZBDSegmentManager
 	    >(device + "/block");
-	} else {
-	  return std::make_unique<
-	    segment_manager::block::BlockSegmentManager
-	    >(device + "/block", dtype);
-	}
+	  } else {
+	    return std::make_unique<
+	      segment_manager::block::BlockSegmentManager
+	    >(device + "/block", device_type_t::ZBD);
+	  }
+	});
       });
-    });
-#else
+  }
+#endif
   return seastar::make_ready_future<crimson::os::seastore::SegmentManagerRef>(
     std::make_unique<
       segment_manager::block::BlockSegmentManager
     >(device + "/block", dtype));
-#endif
 }
 
 }

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -21,80 +21,6 @@
 namespace crimson::os::seastore {
 
 using std::vector;
-struct block_shard_info_t {
-  std::size_t size;
-  std::size_t segments;
-  uint64_t tracker_offset;
-  uint64_t first_segment_offset;
-
-  DENC(block_shard_info_t, v, p) {
-    DENC_START(1, 1, p);
-    denc(v.size, p);
-    denc(v.segments, p);
-    denc(v.tracker_offset, p);
-    denc(v.first_segment_offset, p);
-    DENC_FINISH(p);
-  }
-};
-
-struct block_sm_superblock_t {
-  uint32_t shard_num = 0;
-  size_t segment_size = 0;
-  size_t block_size = 0;
-
-  std::vector<block_shard_info_t> shard_infos;
-
-  device_config_t config;
-
-  DENC(block_sm_superblock_t, v, p) {
-    DENC_START(1, 1, p);
-    denc(v.shard_num, p);
-    denc(v.segment_size, p);
-    denc(v.block_size, p);
-    denc(v.shard_infos, p);
-    denc(v.config, p);
-    DENC_FINISH(p);
-  }
-
-  void validate() const {
-    if(crimson::common::get_conf<bool>("seastore_require_partition_count_match_reactor_count")) {
-      ceph_assert(shard_num == seastar::smp::count);
-    }
-    ceph_assert(block_size > 0);
-    ceph_assert(segment_size > 0 &&
-                segment_size % block_size == 0);
-    ceph_assert_always(segment_size <= SEGMENT_OFF_MAX);
-    for (unsigned int i = 0; i < shard_num; i ++) {
-      ceph_assert(shard_infos[i].size > segment_size &&
-                  shard_infos[i].size % block_size == 0);
-      ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
-      ceph_assert(shard_infos[i].segments > 0);
-      ceph_assert_always(shard_infos[i].segments <= DEVICE_SEGMENT_ID_MAX);
-      ceph_assert(shard_infos[i].tracker_offset > 0 &&
-                  shard_infos[i].tracker_offset % block_size == 0);
-      ceph_assert(shard_infos[i].first_segment_offset > shard_infos[i].tracker_offset &&
-                  shard_infos[i].first_segment_offset % block_size == 0);
-    }
-    ceph_assert(config.spec.magic != 0);
-    ceph_assert(get_default_backend_of_device(config.spec.dtype) ==
-		backend_type_t::SEGMENTED);
-    ceph_assert(config.spec.id <= DEVICE_ID_MAX_VALID);
-    if (!config.major_dev) {
-      ceph_assert(config.secondary_devices.size() == 0);
-    }
-    for (const auto& [k, v] : config.secondary_devices) {
-      ceph_assert(k != config.spec.id);
-      ceph_assert(k <= DEVICE_ID_MAX_VALID);
-      ceph_assert(k == v.id);
-      ceph_assert(v.magic != 0);
-      ceph_assert(v.dtype > device_type_t::NONE);
-      ceph_assert(v.dtype < device_type_t::NUM_TYPES);
-    }
-  }
-};
-
-std::ostream& operator<<(std::ostream&, const block_shard_info_t&);
-std::ostream& operator<<(std::ostream&, const block_sm_superblock_t&);
 
 class Segment : public boost::intrusive_ref_counter<
   Segment,
@@ -204,15 +130,3 @@ public:
 };
 
 }
-
-WRITE_CLASS_DENC(
-  crimson::os::seastore::block_shard_info_t
-)
-WRITE_CLASS_DENC(
-  crimson::os::seastore::block_sm_superblock_t
-)
-
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<crimson::os::seastore::block_shard_info_t> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<crimson::os::seastore::block_sm_superblock_t> : fmt::ostream_formatter {};
-#endif

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -238,7 +238,7 @@ SegmentStateTracker::read_in(
 }
 using std::vector;
 static
-block_sm_superblock_t make_superblock(
+device_superblock_t make_superblock(
   device_id_t device_id,
   device_config_t sm_config,
   const seastar::stat_data &data)
@@ -262,7 +262,7 @@ block_sm_superblock_t make_superblock(
   size_t segments = (size - tracker_off - total_tracker_size) / config_segment_size;
   size_t segments_per_shard = segments / seastar::smp::count;
 
-  vector<block_shard_info_t> shard_infos(seastar::smp::count);
+  vector<device_shard_info_t> shard_infos(seastar::smp::count);
   for (unsigned int i = 0; i < seastar::smp::count; i++) {
     shard_infos[i].size = segments_per_shard * config_segment_size;
     shard_infos[i].segments = segments_per_shard;
@@ -280,13 +280,12 @@ block_sm_superblock_t make_superblock(
     INFO("shard {} infos: {}", i, shard_infos[i]);
   }
 
-  return block_sm_superblock_t{
+  return device_superblock_t::make_segmented(
     seastar::smp::count,
     config_segment_size,
     data.block_size,
-    shard_infos,
-    std::move(sm_config)
-  };
+    std::move(sm_config),
+    std::move(shard_infos));
 }
 
 using open_device_ret = 
@@ -326,31 +325,33 @@ BlockSegmentManager::access_ertr::future<>
 write_superblock(
     device_id_t device_id,
     seastar::file &device,
-    block_sm_superblock_t sb)
+    device_superblock_t sb)
 {
   LOG_PREFIX(block_write_superblock);
   DEBUG("{} write {}", device_id_printer_t{device_id}, sb);
   sb.validate();
-  assert(ceph::encoded_sizeof<block_sm_superblock_t>(sb) <
-	 sb.block_size);
+  assert(SUPERBLOCK_HEADER_PREFIX +
+	 ceph::encoded_sizeof<device_superblock_t>(sb) < sb.block_size);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sb.block_size)),
     [=, &device](auto &bp)
   {
-    //  Encode SEASTORE_SUPERBLOCK_SIGN at offset 0 before
-    //  encoding anything else
+    bp.zero();
+    // magic at offset 0, followed by 37 bytes of null padding (already zero)
+    std::memcpy(bp.c_str(),
+		CRIMSON_DEVICE_SUPERBLOCK_MAGIC.data(), SUPERBLOCK_MAGIC_SIZE);
+    // DENC-encoded superblock at offset 60
     bufferlist bl;
-    bl.append(SEASTORE_SUPERBLOCK_SIGN);
     encode(sb, bl);
     auto iter = bl.begin();
-    assert(bl.length() < sb.block_size);
-    iter.copy(bl.length(), bp.c_str());
+    assert(SUPERBLOCK_HEADER_PREFIX + bl.length() < sb.block_size);
+    iter.copy(bl.length(), bp.c_str() + SUPERBLOCK_HEADER_PREFIX);
     return do_write(device_id, device, 0, bp);
   });
 }
 
 static
-BlockSegmentManager::access_ertr::future<block_sm_superblock_t>
+BlockSegmentManager::access_ertr::future<device_superblock_t>
 read_superblock(seastar::file &device, seastar::stat_data sd)
 {
   LOG_PREFIX(block_read_superblock);
@@ -366,28 +367,32 @@ read_superblock(seastar::file &device, seastar::stat_data sd)
       bp.length(),
       bp
     ).safe_then([=, &bp] {
-      bufferlist bl;
-      bl.push_back(bp);
-      block_sm_superblock_t ret;
-      auto bliter = bl.cbegin();
-      // Validate the magic prefix
-      std::string sb_magic;
-      bliter.copy(SEASTORE_SUPERBLOCK_SIGN_LEN, sb_magic);
-      if (sb_magic != SEASTORE_SUPERBLOCK_SIGN) {
-        ERROR("invalid superblock signature: got '{}' expected '{}'",
-	      sb_magic, SEASTORE_SUPERBLOCK_SIGN);
-        ceph_abort_msg("invalid superblock signature");
+      // verify magic at offset 0
+      superblock_magic_t disk_magic;
+      std::memcpy(disk_magic.data(), bp.c_str(), SUPERBLOCK_MAGIC_SIZE);
+      if (disk_magic != CRIMSON_DEVICE_SUPERBLOCK_MAGIC) {
+        ERROR("invalid superblock magic, got: {:02x}",
+          fmt::join(
+            std::views::transform(disk_magic,
+              [](std::byte b) { return std::to_integer<uint8_t>(b); }),
+            " "));
+        ceph_abort_msg("invalid superblock magic");
       }
-
+      // decode DENC superblock from offset 60
+      bufferlist bl;
+      bl.append(bp.c_str() + SUPERBLOCK_HEADER_PREFIX,
+		bp.length() - SUPERBLOCK_HEADER_PREFIX);
+      device_superblock_t ret;
+      auto bliter = bl.cbegin();
       try {
         decode(ret, bliter);
       } catch (...) {
         ERROR("got decode error!");
         ceph_assert(0 == "invalid superblock");
       }
-      assert(ceph::encoded_sizeof<block_sm_superblock_t>(ret) +
-	     SEASTORE_SUPERBLOCK_SIGN_LEN <= sd.block_size);
-      return BlockSegmentManager::access_ertr::future<block_sm_superblock_t>(
+      assert(SUPERBLOCK_HEADER_PREFIX +
+	     ceph::encoded_sizeof<device_superblock_t>(ret) <= sd.block_size);
+      return BlockSegmentManager::access_ertr::future<device_superblock_t>(
         BlockSegmentManager::access_ertr::ready_future_marker{},
         ret);
     });
@@ -548,7 +553,7 @@ BlockSegmentManager::mount_ret BlockSegmentManager::shard_mount()
       device_id_printer_t{get_device_id()},
         seastar::this_shard_id() + seastar::smp::count * store_index,
         sb.shard_num);
-      store_active = false;
+      shard_status = false;
       return mount_ertr::now();
     }
     shard_info = sb.shard_infos[seastar::this_shard_id() + seastar::smp::count * store_index];
@@ -556,7 +561,7 @@ BlockSegmentManager::mount_ret BlockSegmentManager::shard_mount()
     sb.validate();
     superblock = sb;
     stats.data_read.increment(
-        ceph::encoded_sizeof<block_sm_superblock_t>(superblock));
+        ceph::encoded_sizeof<device_superblock_t>(superblock));
     tracker = std::make_unique<SegmentStateTracker>(
       shard_info.segments,
       superblock.block_size);
@@ -610,7 +615,7 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::primary_mkfs(
 
   seastar::file device;
   seastar::stat_data stat;
-  block_sm_superblock_t sb;
+  device_superblock_t sb;
   std::unique_ptr<SegmentStateTracker> tracker;
 
   using crimson::common::get_conf;
@@ -625,7 +630,7 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::primary_mkfs(
     std::ignore = device.close();
   });
   sb = make_superblock(get_device_id(), sm_config, stat);
-  stats.metadata_write.increment(ceph::encoded_sizeof<block_sm_superblock_t>(sb));
+  stats.metadata_write.increment(ceph::encoded_sizeof<device_superblock_t>(sb));
   co_await write_superblock(get_device_id(), device, sb);
   INFO("{} complete", device_id_printer_t{get_device_id()});
 }
@@ -831,7 +836,7 @@ SegmentManager::read_ertr::future<> BlockSegmentManager::read(
 void BlockSegmentManager::register_metrics(store_index_t store_index)
 {
   LOG_PREFIX(BlockSegmentManager::register_metrics);
-  if (!store_active) {
+  if (!shard_status) {
     INFO("{} shard {} is not active, skip registering metrics",
          device_id_printer_t{get_device_id()}, store_index);
     return;

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -220,8 +220,8 @@ private:
 
   std::string device_path;
   std::unique_ptr<SegmentStateTracker> tracker;
-  block_shard_info_t shard_info;
-  block_sm_superblock_t superblock;
+  device_shard_info_t shard_info;
+  device_superblock_t superblock;
   seastar::file device;
 
   void set_device_id(device_id_t id) {
@@ -260,7 +260,8 @@ private:
 
   uint32_t device_shard_nums = 0;
   store_index_t store_index = 0;
-  bool store_active = true;
+  bool shard_status = true;
+
   class MultiShardDevices {
     public:
       std::vector<std::unique_ptr<BlockSegmentManager>> mshard_devices;

--- a/src/crimson/os/seastore/segment_manager/zbd.cc
+++ b/src/crimson/os/seastore/segment_manager/zbd.cc
@@ -91,9 +91,9 @@ static open_device_ret open_device(
   );
 }
 
-static zbd_sm_metadata_t make_metadata(
+static device_superblock_t make_metadata(
   uint64_t total_size,
-  seastore_meta_t meta,
+  device_config_t config,
   const seastar::stat_data &data,
   size_t zone_size_sectors,
   size_t zone_capacity_sectors,
@@ -142,7 +142,7 @@ static zbd_sm_metadata_t make_metadata(
     per_shard_segments,
     per_shard_available_size);
 
-  std::vector<zbd_shard_info_t> shard_infos(seastar::smp::count);
+  std::vector<device_shard_info_t> shard_infos(seastar::smp::count);
   for (unsigned int i = 0; i < seastar::smp::count; i++) {
     shard_infos[i].size = per_shard_available_size;
     shard_infos[i].segments = per_shard_segments;
@@ -152,16 +152,15 @@ static zbd_sm_metadata_t make_metadata(
          i, shard_infos[i].first_segment_offset);
   }
 
-  zbd_sm_metadata_t ret = zbd_sm_metadata_t{
+  auto ret = device_superblock_t::make_zbd(
     seastar::smp::count,
     segment_size,
-    zone_capacity * zones_per_segment,
-    zones_per_segment,
-    zone_capacity,
     data.block_size,
+    std::move(config),
     zone_size,
-    shard_infos,
-    meta};
+    zone_capacity,
+    zones_per_segment,
+    std::move(shard_infos));
   ret.validate();
   return ret;
 }
@@ -343,21 +342,26 @@ static write_ertr::future<> do_writev(
 }
 
 static ZBDSegmentManager::access_ertr::future<>
-write_metadata(seastar::file &device, zbd_sm_metadata_t sb)
+write_metadata(seastar::file &device, device_superblock_t sb)
 {
-  assert(ceph::encoded_sizeof_bounded<zbd_sm_metadata_t>() <
-	 sb.block_size);
+  assert(SUPERBLOCK_HEADER_PREFIX +
+	 ceph::encoded_sizeof<device_superblock_t>(sb) < sb.block_size);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sb.block_size)),
     [=, &device](auto &bp) {
       LOG_PREFIX(ZBDSegmentManager::write_metadata);
       DEBUG("block_size 0x{:x}", sb.block_size);
+      bp.zero();
+      // magic at offset 0, followed by 37 bytes of null padding (just zero'ed)
+      std::memcpy(bp.c_str(),
+		  CRIMSON_DEVICE_SUPERBLOCK_MAGIC.data(), SUPERBLOCK_MAGIC_SIZE);
+      // DENC-encoded superblock at offset 60
       bufferlist bl;
       encode(sb, bl);
       auto iter = bl.begin();
-      assert(bl.length() < sb.block_size);
+      assert(SUPERBLOCK_HEADER_PREFIX + bl.length() < sb.block_size);
       DEBUG("buffer length 0x{:x}", bl.length());
-      iter.copy(bl.length(), bp.c_str());
+      iter.copy(bl.length(), bp.c_str() + SUPERBLOCK_HEADER_PREFIX);
       DEBUG("doing writeout");
       return do_write(device, 0, bp);
     });
@@ -430,11 +434,9 @@ static read_ertr::future<> do_readv(
 }
 
 static
-ZBDSegmentManager::access_ertr::future<zbd_sm_metadata_t>
+ZBDSegmentManager::access_ertr::future<device_superblock_t>
 read_metadata(seastar::file &device, seastar::stat_data sd)
 {
-  assert(ceph::encoded_sizeof_bounded<zbd_sm_metadata_t>() <
-	 sd.block_size);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sd.block_size)),
     [=, &device](auto &bp) {
@@ -444,13 +446,32 @@ read_metadata(seastar::file &device, seastar::stat_data sd)
 	bp.length(),
 	bp
       ).safe_then([=, &bp] {
+        LOG_PREFIX(ZBDSegmentManager::read_metadata);
+	// verify magic at offset 0
+	superblock_magic_t disk_magic;
+	std::memcpy(disk_magic.data(), bp.c_str(), SUPERBLOCK_MAGIC_SIZE);
+	if (disk_magic != CRIMSON_DEVICE_SUPERBLOCK_MAGIC) {
+          ERROR("invalid superblock magic, got: {:02x}",
+            fmt::join(
+              std::views::transform(disk_magic,
+                [](std::byte b) { return std::to_integer<uint8_t>(b); }),
+              " "));
+	  ceph_abort_msg("invalid superblock magic");
+	}
+	// decode DENC superblock from offset 60
 	bufferlist bl;
-	bl.push_back(bp);
-	zbd_sm_metadata_t ret;
+	bl.append(bp.c_str() + SUPERBLOCK_HEADER_PREFIX,
+		  bp.length() - SUPERBLOCK_HEADER_PREFIX);
+	device_superblock_t ret;
 	auto bliter = bl.cbegin();
-	decode(ret, bliter);
+        try {
+	  decode(ret, bliter);
+        } catch (...) {
+          ERROR("got decode error!");
+          ceph_abort_msg("failed to decode superblock");
+        }
         ret.validate();
-	return ZBDSegmentManager::access_ertr::future<zbd_sm_metadata_t>(
+	return ZBDSegmentManager::access_ertr::future<device_superblock_t>(
 	  ZBDSegmentManager::access_ertr::ready_future_marker{},
 	  ret);
       });
@@ -535,7 +556,7 @@ ZBDSegmentManager::mkfs_ret ZBDSegmentManager::primary_mkfs(
   return seastar::do_with(
     seastar::file{},
     seastar::stat_data{},
-    zbd_sm_metadata_t{},
+    device_superblock_t{},
     size_t(),
     size_t(),
     size_t(),
@@ -581,7 +602,7 @@ ZBDSegmentManager::mkfs_ret ZBDSegmentManager::primary_mkfs(
                 zone_size_sects, zone_capacity_sects);
 	  sb = make_metadata(
             size,
-	    config.meta,
+	    config,
 	    stat,
 	    zone_size_sects,
 	    zone_capacity_sects,
@@ -589,7 +610,7 @@ ZBDSegmentManager::mkfs_ret ZBDSegmentManager::primary_mkfs(
 	    nr_zones);
 	  metadata = sb;
 	  stats.metadata_write.increment(
-	    ceph::encoded_sizeof_bounded<zbd_sm_metadata_t>());
+	    ceph::encoded_sizeof<device_superblock_t>(sb));
 	  DEBUG("Wrote to stats.");
 	  return write_metadata(device, sb);
 	}).finally([&, FNAME] {
@@ -836,17 +857,17 @@ Segment::write_ertr::future<> ZBDSegmentManager::segment_write(
 
 device_id_t ZBDSegmentManager::get_device_id() const
 {
-  return metadata.device_id;
+  return metadata.config.spec.id;
 };
 
 secondary_device_set_t& ZBDSegmentManager::get_secondary_devices()
 {
-  return metadata.secondary_devices;
+  return metadata.config.secondary_devices;
 };
 
 magic_t ZBDSegmentManager::get_magic() const
 {
-  return metadata.magic;
+  return metadata.config.spec.magic;
 };
 
 segment_off_t ZBDSegment::get_write_capacity() const

--- a/src/crimson/os/seastore/segment_manager/zbd.h
+++ b/src/crimson/os/seastore/segment_manager/zbd.h
@@ -20,71 +20,6 @@
 
 namespace crimson::os::seastore::segment_manager::zbd {
 
-  struct zbd_shard_info_t {
-    size_t size = 0;
-    size_t segments = 0;
-    size_t first_segment_offset = 0;
-
-    DENC(zbd_shard_info_t, v, p) {
-      DENC_START(1, 1, p);
-      denc(v.size, p);
-      denc(v.segments, p);
-      denc(v.first_segment_offset, p);
-      DENC_FINISH(p);
-    }
-  };
-
-  struct zbd_sm_metadata_t {
-    uint32_t shard_num = 0;
-    size_t segment_size = 0;
-    size_t segment_capacity = 0;
-    size_t zones_per_segment = 0;
-    size_t zone_capacity = 0;
-    size_t block_size = 0;
-    size_t zone_size = 0;
-
-    std::vector<zbd_shard_info_t> shard_infos;
-
-    seastore_meta_t meta;
-    
-    bool major_dev = false;
-    magic_t magic = 0;
-    device_type_t dtype = device_type_t::NONE;
-    device_id_t device_id = 0;
-    secondary_device_set_t secondary_devices;
-
-    DENC(zbd_sm_metadata_t, v, p) {
-      DENC_START(1, 1, p);
-      denc(v.shard_num, p);
-      denc(v.segment_size, p);
-      denc(v.segment_capacity, p);
-      denc(v.zones_per_segment, p);
-      denc(v.zone_capacity, p);
-      denc(v.block_size, p);
-      denc(v.zone_size, p);
-      denc(v.shard_infos, p);
-      denc(v.meta, p);
-      denc(v.magic, p);
-      denc(v.dtype, p);
-      denc(v.device_id, p);
-      if (v.major_dev) {
-	denc(v.secondary_devices, p);
-      }
-      DENC_FINISH(p);
-    }
-
-    void validate() const {
-      for (unsigned int i = 0; i < seastar::smp::count; i++) {
-        ceph_assert_always(shard_infos[i].size > 0);
-        ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
-        ceph_assert_always(shard_infos[i].segments > 0);
-        ceph_assert_always(shard_infos[i].segments <= DEVICE_SEGMENT_ID_MAX);
-      }
-      ceph_assert_always(segment_capacity > 0);
-      ceph_assert_always(segment_capacity <= SEGMENT_OFF_MAX);
-    }
-  };
-
   using write_ertr = crimson::errorator<crimson::ct_error::input_output_error>;
   using read_ertr = crimson::errorator<crimson::ct_error::input_output_error>;
 
@@ -117,7 +52,7 @@ namespace crimson::os::seastore::segment_manager::zbd {
     write_ertr::future<> write_padding_bytes(size_t padding_bytes);
   };
 
-  class ZBDSegmentManager final : public SegmentManager{
+  class ZBDSegmentManager final : public SegmentManager {
   // interfaces used by Device
   public:
     seastar::future<> start(uint32_t shard_nums) override;
@@ -145,7 +80,8 @@ namespace crimson::os::seastore::segment_manager::zbd {
     read_ertr::future<> read(
       paddr_t addr, 
       size_t len, 
-      ceph::bufferptr &out) final;
+      ceph::bufferptr &out) override;
+
     read_ertr::future<> readv(
       paddr_t addr,
       std::vector<bufferptr> ptrs) override;
@@ -154,7 +90,7 @@ namespace crimson::os::seastore::segment_manager::zbd {
 
     device_type_t get_device_type() const override {
       return device_type_t::ZBD;
-    }
+    };
 
     size_t get_available_size() const override {
       return shard_info.size;
@@ -169,7 +105,7 @@ namespace crimson::os::seastore::segment_manager::zbd {
     };
 
     const seastore_meta_t &get_meta() const {
-      return metadata.meta;
+      return metadata.config.meta;
     };
 
     device_id_t get_device_id() const override;
@@ -186,10 +122,11 @@ namespace crimson::os::seastore::segment_manager::zbd {
   private:
     friend class ZBDSegment;
     std::string device_path;
-    zbd_shard_info_t shard_info;
-    zbd_sm_metadata_t metadata;
+    device_shard_info_t shard_info;
+    device_superblock_t metadata;
     seastar::file device;
     uint32_t nr_zones;
+
     struct effort_t {
       uint64_t num = 0;
       uint64_t bytes = 0;
@@ -237,6 +174,7 @@ namespace crimson::os::seastore::segment_manager::zbd {
     uint32_t device_shard_nums = 0;
     store_index_t store_index = 0;
     bool shard_status = true;
+
     class MultiShardDevices {
     public:
       std::vector<std::unique_ptr<ZBDSegmentManager>> mshard_devices;
@@ -260,9 +198,3 @@ namespace crimson::os::seastore::segment_manager::zbd {
 
 }
 
-WRITE_CLASS_DENC_BOUNDED(
-  crimson::os::seastore::segment_manager::zbd::zbd_shard_info_t
-)
-WRITE_CLASS_DENC_BOUNDED(
-  crimson::os::seastore::segment_manager::zbd::zbd_sm_metadata_t
-)

--- a/src/crimson/tools/objectstore/crimson_objectstore_tool.cc
+++ b/src/crimson/tools/objectstore/crimson_objectstore_tool.cc
@@ -456,7 +456,7 @@ public:
   explicit SeastoreMetaReader(const std::string& path, const std::string& device_type) :
     m_data_path(path), m_device_type(device_type) {}
 
-  tl::expected<crimson::os::seastore::block_sm_superblock_t, std::string> load_seastore_superblock() {
+  tl::expected<crimson::os::seastore::device_superblock_t, std::string> load_seastore_superblock() {
     try {
       std::string block_path = m_data_path + "/block";
 
@@ -479,26 +479,22 @@ public:
 
       auto bliter = bl.cbegin();
 
-      // fmt::println(std::cout, "Device type: {}", m_device_type);
-
-      if (m_device_type != "RANDOM_BLOCK_SSD") {
-        // TODO this Signature is only applicable for segment devices(SSD/HDD) not
-        // for other two devices like ZBD/RANDOM_BLOCK_SSD
-        constexpr const char SEASTORE_SUPERBLOCK_SIGN[] = "seastore block device\n";
-        constexpr std::size_t SEASTORE_SUPERBLOCK_SIGN_LEN = sizeof(SEASTORE_SUPERBLOCK_SIGN) - 1;
-
-        // Validate the magic prefix
-        std::string sb_magic;
-        bliter.copy(SEASTORE_SUPERBLOCK_SIGN_LEN, sb_magic);
-        if (sb_magic != SEASTORE_SUPERBLOCK_SIGN) {
-          return tl::unexpected("invalid superblock signature " + block_path);
-        }
+      // Check magic string before attempting full decode, so that a
+      // non-crimson device produces a clear error instead of a decode
+      // exception.
+      std::string magic;
+      try {
+        denc(magic, bliter);
+      } catch (...) {}
+      if (magic != crimson::os::seastore::CRIMSON_DEVICE_SUPERBLOCK_MAGIC) {
+        return tl::unexpected("invalid superblock signature in " + block_path);
       }
 
-      crimson::os::seastore::block_sm_superblock_t superblock;
+      bliter = bl.cbegin();
+      crimson::os::seastore::device_superblock_t superblock;
       decode(superblock, bliter);
 
-      ceph_assert(ceph::encoded_sizeof<crimson::os::seastore::block_sm_superblock_t>(superblock) <
+      ceph_assert(ceph::encoded_sizeof<crimson::os::seastore::device_superblock_t>(superblock) <
                   block_size);
 
       return superblock;

--- a/src/crimson/tools/objectstore/crimson_objectstore_tool.cc
+++ b/src/crimson/tools/objectstore/crimson_objectstore_tool.cc
@@ -89,6 +89,9 @@ enum class operation_type_t {
   DUMP,
   SET_SIZE,
   CLEAR_DATA_DIGEST,
+
+  // Device-inspection operations (--op)
+  DUMP_SUPERBLOCK,
 };
 
 std::string to_string(operation_type_t op) {
@@ -111,6 +114,7 @@ std::string to_string(operation_type_t op) {
     case operation_type_t::DUMP: return "dump";
     case operation_type_t::SET_SIZE: return "set-size";
     case operation_type_t::CLEAR_DATA_DIGEST: return "clear-data-digest";
+    case operation_type_t::DUMP_SUPERBLOCK: return "dump-superblock";
     default: return "unknown";
   }
 }
@@ -119,6 +123,7 @@ tl::expected<operation_type_t, std::string> parse_pg_operation(const std::string
   if (op_str == "list-pgs") return operation_type_t::LIST_PGS;
   if (op_str == "list") return operation_type_t::LIST_OBJECTS;
   if (op_str == "info") return operation_type_t::INFO;
+  if (op_str == "dump-superblock") return operation_type_t::DUMP_SUPERBLOCK;
   return tl::unexpected("Unsupported PG operation: " + op_str);
 }
 
@@ -155,6 +160,7 @@ struct operation_params_t {
 struct objectstore_config_t {
   // Basic parameters
   std::string data_path;
+  std::string dev_path;
   std::string device_type;
   std::string type;
   std::string format;
@@ -187,12 +193,14 @@ struct objectstore_config_t {
        "store type, default: seastore")
       ("data-path", bpo::value<std::string>(&data_path),
        "path to object store, mandatory")
+      ("dev-path", bpo::value<std::string>(&dev_path),
+       "path to device file (alternative to --data-path for dump-superblock)")
       ("device-type", bpo::value<std::string>(&device_type)->default_value("SSD"),
        "path to object store, defualt: SSD")
       ("pgid", bpo::value<std::string>(&pgid_str),
        "PG id, mandatory for info operation")
       ("op", bpo::value<std::string>(&op),
-       "Arg is one of [info, list, list-pgs]")
+       "Arg is one of [info, list, list-pgs, dump-superblock]")
       ("file", bpo::value<std::string>(&file),
        "path of file to read from or write to")
       ("format", bpo::value<std::string>(&format)->default_value("json-pretty"),
@@ -439,63 +447,173 @@ void print_usage(const bpo::options_description& desc) {
   std::cout << "if not specified or if '-' specified." << std::endl;
 }
 
+static void dump_superblock(
+  Formatter& formatter,
+  const crimson::os::seastore::device_superblock_t& sb)
+{
+  formatter.open_object_section("superblock");
+
+  {
+    // Display the magic as a printable string (from the on-disk constant)
+    const auto& magic = crimson::os::seastore::CRIMSON_DEVICE_SUPERBLOCK_MAGIC;
+    std::string magic_str(reinterpret_cast<const char*>(magic.data()),
+			  crimson::os::seastore::SUPERBLOCK_MAGIC_SIZE);
+    auto pos = magic_str.find('\0');
+    if (pos != std::string::npos)
+      magic_str.resize(pos);
+    formatter.dump_string("magic", magic_str);
+  }
+  formatter.dump_unsigned("version", sb.version);
+  formatter.dump_unsigned("shard_num", sb.shard_num);
+  formatter.dump_unsigned("segment_size", sb.segment_size);
+  formatter.dump_unsigned("block_size", sb.block_size);
+
+  // config
+  {
+    Formatter::ObjectSection config_section(formatter, "config");
+    formatter.dump_bool("major_dev", sb.config.major_dev);
+    formatter.dump_format(
+        "spec_magic", "0x%lx", static_cast<uint64_t>(sb.config.spec.magic));
+    formatter.dump_stream("spec_dtype") << sb.config.spec.dtype;
+    formatter.dump_unsigned("spec_id", sb.config.spec.id);
+    formatter.dump_stream("meta") << sb.config.meta;
+
+    // secondary devices (in the config)
+    {
+      Formatter::ArraySection secondary_devices_section(
+          formatter, "secondary_devices");
+      for (const auto& [dev_id, spec] : sb.config.secondary_devices) {
+        Formatter::ObjectSection device_section(formatter, "device");
+        formatter.dump_unsigned("device_id", dev_id);
+        formatter.dump_format(
+            "magic", "0x%lx", static_cast<uint64_t>(spec.magic));
+        formatter.dump_stream("dtype") << spec.dtype;
+      }
+    }
+  }
+
+  // rbm
+  {
+    Formatter::ObjectSection rbm_section(formatter, "rbm");
+    formatter.dump_unsigned("total_size", sb.total_size);
+    formatter.dump_unsigned("journal_size", sb.journal_size);
+    formatter.dump_unsigned("crc", sb.crc);
+    formatter.dump_unsigned("feature", sb.feature);
+    formatter.dump_unsigned("nvme_block_size", sb.nvme_block_size);
+  }
+
+  // zbd
+  {
+    Formatter::ObjectSection zbd_section(formatter, "zbd");
+    formatter.dump_unsigned("segment_capacity", sb.segment_capacity);
+    formatter.dump_unsigned("zones_per_segment", sb.zones_per_segment);
+    formatter.dump_unsigned("zone_size", sb.zone_size);
+    formatter.dump_unsigned("zone_capacity", sb.zone_capacity);
+  }
+
+  // shards
+  {
+    Formatter::ArraySection shards_section(formatter, "shards");
+    for (auto i = 0u; i < sb.shard_infos.size(); ++i) {
+      const auto& si = sb.shard_infos[i];
+      Formatter::ObjectSection shard_section(formatter, "shard");
+      formatter.dump_unsigned("shard", i);
+      formatter.dump_unsigned("size", si.size);
+      formatter.dump_unsigned("segments", si.segments);
+      formatter.dump_unsigned("first_segment_offset", si.first_segment_offset);
+      formatter.dump_unsigned("tracker_offset", si.tracker_offset);
+      formatter.dump_unsigned("start_offset", si.start_offset);
+    }
+  }
+
+  formatter.close_section();
+  formatter.flush(std::cout);
+}
+
 class SeastoreMetaReader {
 private:
   std::string m_data_path;
+  std::string m_dev_path;
   std::string m_device_type;
 
-  size_t get_filesystem_block_size(const std::string& path) {
-    struct stat st;
-    if (stat(path.c_str(), &st) == 0) {
-      return st.st_blksize;
+  std::string get_block_path() const {
+    if (!m_dev_path.empty()) {
+      return m_dev_path;
     }
-    return 4096;
+    return m_data_path + "/block";
   }
 
 public:
-  explicit SeastoreMetaReader(const std::string& path, const std::string& device_type) :
-    m_data_path(path), m_device_type(device_type) {}
+  explicit SeastoreMetaReader(
+    const std::string& data_path,
+    const std::string& device_type,
+    const std::string& dev_path = {})
+    : m_data_path(data_path)
+    , m_dev_path(dev_path)
+    , m_device_type(device_type) {}
 
   tl::expected<crimson::os::seastore::device_superblock_t, std::string> load_seastore_superblock() {
     try {
-      std::string block_path = m_data_path + "/block";
+      std::string block_path = get_block_path();
 
-      size_t block_size = get_filesystem_block_size(block_path);
+      // Read enough to cover the superblock — 64KiB should be plenty
+      // for any device type.
+      constexpr size_t read_size = 64 * 1024;
 
       std::ifstream file(block_path, std::ios::binary);
       if (!file.is_open()) {
         return tl::unexpected("Could not open block file: " + block_path);
       }
 
-      std::vector<char> buf(block_size);
-      file.read(buf.data(), block_size);
-
-      if (!file.good() && !file.eof()) {
+      std::vector<char> buf(read_size);
+      file.read(buf.data(), read_size);
+      const auto nread = file.gcount();
+      if (nread == 0) {
         return tl::unexpected("Could not read superblock from " + block_path);
       }
 
-      bufferlist bl;
-      bl.append(buf.data(), block_size);
+      using crimson::os::seastore::superblock_magic_t;
+      using crimson::os::seastore::CRIMSON_DEVICE_SUPERBLOCK_MAGIC;
+      using crimson::os::seastore::SUPERBLOCK_MAGIC_SIZE;
+      using crimson::os::seastore::SUPERBLOCK_HEADER_PREFIX;
 
-      auto bliter = bl.cbegin();
-
-      // Check magic string before attempting full decode, so that a
-      // non-crimson device produces a clear error instead of a decode
-      // exception.
-      std::string magic;
-      try {
-        denc(magic, bliter);
-      } catch (...) {}
-      if (magic != crimson::os::seastore::CRIMSON_DEVICE_SUPERBLOCK_MAGIC) {
-        return tl::unexpected("invalid superblock signature in " + block_path);
+      // Both Crimson and BlueStore devices share the same on-disk prefix
+      // layout: a 23-byte magic at offset 0, 37 bytes of type-specific
+      // data, and DENC-encoded content starting at offset 60.
+      if (static_cast<size_t>(nread) < SUPERBLOCK_HEADER_PREFIX) {
+        return tl::unexpected("file too small for superblock header: " + block_path);
       }
 
-      bliter = bl.cbegin();
-      crimson::os::seastore::device_superblock_t superblock;
-      decode(superblock, bliter);
+      // Extract the 23-byte magic at offset 0
+      superblock_magic_t disk_magic;
+      std::memcpy(disk_magic.data(), buf.data(), SUPERBLOCK_MAGIC_SIZE);
 
-      ceph_assert(ceph::encoded_sizeof<crimson::os::seastore::device_superblock_t>(superblock) <
-                  block_size);
+      // BlueStore uses "bluestore block device\n" — same 23-byte size
+      static constexpr char bluestore_magic[] = "bluestore block device\n";
+      static_assert(sizeof(bluestore_magic) - 1 == SUPERBLOCK_MAGIC_SIZE);
+
+      if (disk_magic != CRIMSON_DEVICE_SUPERBLOCK_MAGIC) {
+        if (std::memcmp(disk_magic.data(), bluestore_magic,
+                        SUPERBLOCK_MAGIC_SIZE) == 0) {
+          return tl::unexpected(
+            block_path + " is a BlueStore device, not a Crimson device");
+        }
+        return tl::unexpected("unrecognized device magic in " + block_path);
+      }
+
+      // Decode DENC superblock from offset 60
+      bufferlist bl;
+      bl.append(buf.data() + SUPERBLOCK_HEADER_PREFIX,
+		nread - SUPERBLOCK_HEADER_PREFIX);
+      auto bliter = bl.cbegin();
+
+      crimson::os::seastore::device_superblock_t superblock;
+      try {
+        decode(superblock, bliter);
+      } catch (const std::exception& e) {
+        return tl::unexpected(
+          "failed to decode superblock from " + block_path + ": " + e.what());
+      }
 
       return superblock;
 
@@ -604,7 +722,8 @@ seastar::future<int> run_tool(StoreTool& st, objectstore_config_t& config) {
   }
 
   // Resolve object and pgid before executing operations
-  if (config.operation->op != operation_type_t::LIST_PGS) {
+  if (config.operation->op != operation_type_t::LIST_PGS &&
+      config.operation->op != operation_type_t::DUMP_SUPERBLOCK) {
     bool resolved = co_await resolve_operation_parameters(st, config);
     if (!resolved) {
       co_return EXIT_FAILURE;
@@ -623,6 +742,18 @@ seastar::future<int> run_tool(StoreTool& st, objectstore_config_t& config) {
       for (const auto& pgid_str : pgid_strs) {
         fmt::println(std::cout, "{}", pgid_str);
       }
+      break;
+    }
+
+    case operation_type_t::DUMP_SUPERBLOCK: {
+      SeastoreMetaReader reader(
+          config.data_path, config.device_type, config.dev_path);
+      auto sb_result = reader.load_seastore_superblock();
+      if (!sb_result) {
+        fmt::println(std::cerr, "{}", sb_result.error());
+        co_return EXIT_FAILURE;
+      }
+      dump_superblock(*formatter.get(), *sb_result);
       break;
     }
 
@@ -1044,7 +1175,33 @@ int main(int argc, const char* argv[])
     return EXIT_FAILURE;
   }
 
-  // Validate required parameters
+  // Validate path parameters
+  if (vm.count("dev-path") && vm.count("data-path")) {
+    fmt::println(std::cerr, "Cannot specify both --data-path and --dev-path");
+    return EXIT_FAILURE;
+  }
+
+  if (vm.count("dev-path") &&
+      config.operation->op != operation_type_t::DUMP_SUPERBLOCK) {
+    fmt::println(
+        std::cerr, "--dev-path is only supported with --op dump-superblock");
+    return EXIT_FAILURE;
+  }
+
+  // dump-superblock with --dev-path: no store mount needed
+  if (config.operation->op == operation_type_t::DUMP_SUPERBLOCK &&
+      vm.count("dev-path")) {
+    std::unique_ptr<Formatter> formatter(Formatter::create(config.format));
+    SeastoreMetaReader reader({}, config.device_type, config.dev_path);
+    auto sb_result = reader.load_seastore_superblock();
+    if (!sb_result) {
+      fmt::println(std::cerr, "{}", sb_result.error());
+      return EXIT_FAILURE;
+    }
+    dump_superblock(*formatter.get(), *sb_result);
+    return EXIT_SUCCESS;
+  }
+
   if (!vm.count("data-path")) {
     fmt::println(std::cerr, "Must provide --data-path");
     print_usage(desc);

--- a/src/test/crimson/seastore/test_randomblock_manager.cc
+++ b/src/test/crimson/seastore/test_randomblock_manager.cc
@@ -127,14 +127,14 @@ TEST_F(rbm_test_t, mkfs_test)
    auto super = read_rbm_superblock();
    ASSERT_TRUE(
        super.block_size == block_size &&
-       super.size == size
+       super.total_size == size
    );
    config.spec.id = DEVICE_ID_NULL;
    mkfs();
    super = read_rbm_superblock();
    ASSERT_TRUE(
        super.config.spec.id == DEVICE_ID_NULL &&
-       super.size == size 
+       super.total_size == size
    );
  });
 }


### PR DESCRIPTION
This commit refactors the on-/off- device super-block structure
used by Seastore to a unified format that
can accommodate all three relevant device types -
HDD/SSD ( (device_type_t::HDD & device_type_t::SSD),
Zoned block devices (ZNS & SMR; device_type_t::ZBD), and
Random Block devices (NVMe; device_type_t::RANDOM_BLOCK_SSD).

**This is a breaking change for existing Seastore devices!**

The on-disk format starts with:
23B magic: same size as Bluestore devices, but the magic string is CRIMSON_DEVICE, then
37B of nulls (the corresponding field in Classic devices is the UUID).

A unified device_config_t is now used for all device types.

The per-shard data structure is also unified, now including a union
of all relevant fields for each device type.

table 1: the common header (device_superblock_t):

| Field             | Type                        | HDD/SSD                      | ZNS/SMR                          | RBM (NVMe)                             |
| ----------------- | --------------------------- | ---------------------------- | ---------------------------- | ---------------------------------------- |
| version           | uint8_t                     | 1                            | 1                            | 1                                        |
| shard_num         | uint                        | number of shards             | number of shards             | number of shards                         |
| segment_size      | size_t                      | logical segment size (bytes) | logical segment size (bytes) | 0 (unused)                               |
| block_size        | size_t                      | filesystem block size        | filesystem block size        | filesystem block size                    |
| config            | device_config_t             | device identity/meta         | device identity/meta         | device identity/meta                     |
| total_size        | size_t                      | 0 (unused)                   | 0 (unused)                   | total device capacity (bytes)            |
| journal_size      | uint64_t                    | 0 (unused)                   | 0 (unused)                   | journal area size (bytes)                |
| segment_capacity  | size_t                      | 0 (unused)                   | usable bytes/segment         | 0 (unused)                               |
| zones_per_segment | size_t                      | 0 (unused)                   | zones per logical segment    | 0 (unused)                               |
| zone_size         | size_t                      | 0 (unused)                   | physical zone size (bytes)   | 0 (unused)                               |
| zone_capacity     | size_t                      | 0 (unused)                   | usable bytes per zone        | 0 (unused)                               |
| shard_infos       | vector<device_shard_info_t> | one entry per shard          | one entry per shard          | one entry per shard                      |
| crc               | checksum_t                  | 0 (unused)                   | 0 (unused)                   | CRC of serialized superblock             |
| feature           | uint64_t                    | 0 (unused)                   | 0 (unused)                   | NVME_END_TO_END_PROTECTION bit           |
| nvme_block_size   | uint32_t                    | 0 (unused)                   | 0 (unused)                   | NVMe logical block size (E2E protection) |




