### PR TITLE
tentacle: mgr/dashboard: Add location to gateway info command in NVMeoF CLI

### DIFF
--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -41,6 +41,9 @@ class GatewayInfo(NamedTuple):
     max_namespaces: Annotated[int, CliFlags.DROP]
     max_namespaces_per_subsystem: Annotated[int, CliFlags.DROP]
     max_subsystems: Annotated[int, CliFlags.DROP]
+    gateway_initialization_over: Annotated[bool, CliFlags.DROP]
+    io_stats_enabled: Annotated[bool, CliFlags.DROP]
+    location: Annotated[str, CliFlags.DROP]
     spdk_version: Optional[str] = ""
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75974

---

backport of https://github.com/ceph/ceph/pull/68343
parent tracker: https://tracker.ceph.com/issues/75968

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh