### PR TITLE
mgr/dashboard : NVMe-oF – Design cards for the gateway group page when the table has no data

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -102,6 +102,8 @@ import { NvmeSubsystemViewBreadcrumbResolver } from './nvme-subsystem-view/nvme-
 import { NvmeSubsystemViewComponent } from './nvme-subsystem-view/nvme-subsystem-view.component';
 import { NvmeofSubsystemPerformanceComponent } from './nvmeof-subsystem-performance/nvmeof-subsystem-performance.component';
 import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
+import { NvmeofSetupCardsComponent } from './nvmeof-setup-cards/nvmeof-setup-cards.component';
+import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 
 @NgModule({
   imports: [
@@ -135,7 +137,9 @@ import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
     ContainedListModule,
     SideNavModule,
     LayoutModule,
-    ThemeModule
+    ThemeModule,
+    NvmeofSetupCardsComponent,
+    NvmeofGatewayGroupFilterComponent
   ],
   declarations: [
     RbdListComponent,
@@ -329,6 +333,7 @@ const routes: Routes = [
   {
     path: 'nvmeof',
     canActivate: [ModuleStatusGuardService],
+    component: NvmeofTabsComponent,
     data: {
       breadcrumbs: true,
       text: 'NVMe/TCP',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.html
@@ -1,0 +1,13 @@
+<div class="nvmeof-gateway-group-filter">
+  <span class="nvmeof-gateway-group-filter__label cds--type-body-compact-01"
+        i18n>Gateway group:</span>
+  <cds-combo-box type="single"
+                 class="nvmeof-gateway-group-filter__combo"
+                 [placeholder]="placeholder"
+                 [items]="items"
+                 [disabled]="disabled"
+                 (selected)="onSelected($event)"
+                 (clear)="onClear()">
+    <cds-dropdown-list></cds-dropdown-list>
+  </cds-combo-box>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.scss
@@ -1,0 +1,20 @@
+:host {
+  display: contents;
+}
+
+.nvmeof-gateway-group-filter {
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  margin-left: var(--cds-spacing-05);
+
+  &__label {
+    white-space: nowrap;
+    color: var(--cds-text-secondary);
+  }
+
+  &__combo {
+    min-inline-size: 14rem;
+    max-inline-size: 20rem;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter.component';
+
+describe('NvmeofGatewayGroupFilterComponent', () => {
+  let fixture: ComponentFixture<NvmeofGatewayGroupFilterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NvmeofGatewayGroupFilterComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NvmeofGatewayGroupFilterComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should render combo box with filter class', () => {
+    const combo = fixture.nativeElement.querySelector('cds-combo-box');
+    expect(combo).toBeTruthy();
+    expect(combo.classList.contains('nvmeof-gateway-group-filter__combo')).toBe(true);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.ts
@@ -1,0 +1,27 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ComboBoxModule } from 'carbon-components-angular';
+import { GroupsComboboxItem } from '~/app/shared/api/nvmeof.service';
+
+@Component({
+  selector: 'cd-nvmeof-gateway-group-filter',
+  templateUrl: './nvmeof-gateway-group-filter.component.html',
+  styleUrls: ['./nvmeof-gateway-group-filter.component.scss'],
+  standalone: true,
+  imports: [ComboBoxModule]
+})
+export class NvmeofGatewayGroupFilterComponent {
+  @Input() items: GroupsComboboxItem[] = [];
+  @Input() disabled = false;
+  @Input() placeholder = $localize`Enter group name`;
+
+  @Output() selected = new EventEmitter<GroupsComboboxItem>();
+  @Output() cleared = new EventEmitter<void>();
+
+  onSelected(item: GroupsComboboxItem): void {
+    this.selected.emit(item);
+  }
+
+  onClear(): void {
+    this.cleared.emit();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.html
@@ -1,26 +1,28 @@
-<cd-nvmeof-tabs></cd-nvmeof-tabs>
-
-<ng-container *ngIf="gatewayGroup$ | async as gateways">
-  <cd-table
-    #table
-    [data]="gateways"
-    [columns]="columns"
-    columnMode="flex"
-    selectionType="single"
-    identifier="name"
-    (updateSelection)="updateSelection($event)"
-    (fetchData)="fetchData()"
-    emptyStateTitle="No gateway group created"
-    i18n-emptyStateTitle
-    emptyStateMessage="Set up your first gateway group to start using NVMe over Fabrics. This will allow you to create high-performance block storage with NVMe/TCP protocol."
-    i18n-emptyStateMessage>
-  <cd-table-actions class="table-actions"
-                    [permission]="permission"
-                    [selection]="selection"
-                    [tableActions]="tableActions">
-  </cd-table-actions>
-  </cd-table>
-</ng-container>
+<div class="nvmeof-content-layout">
+  <div class="nvmeof-content-main">
+    <ng-container *ngIf="gatewayGroup$ | async as gateways">
+      <cd-table
+        #table
+        [data]="gateways"
+        [columns]="columns"
+        columnMode="flex"
+        selectionType="single"
+        identifier="name"
+        (updateSelection)="updateSelection($event)"
+        (fetchData)="fetchData()"
+        emptyStateTitle="No gateway group created"
+        i18n-emptyStateTitle
+        emptyStateMessage="Set up your first gateway group to start using NVMe over Fabrics. This will allow you to create high-performance block storage with NVMe/TCP protocol."
+        i18n-emptyStateMessage>
+      <cd-table-actions class="table-actions"
+                        [permission]="permission"
+                        [selection]="selection"
+                        [tableActions]="tableActions">
+      </cd-table-actions>
+      </cd-table>
+    </ng-container>
+  </div>
+</div>
 
 <ng-template #dateTpl
              let-created="data.value">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { NvmeofGatewayGroupComponent } from './nvmeof-gateway-group.component';
 import { GridModule, TabsModule } from 'carbon-components-angular';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { NvmeofStateService } from '../nvmeof-state.service';
 import { of } from 'rxjs';
 import { HttpClientModule } from '@angular/common/http';
 import { SharedModule } from '~/app/shared/shared.module';
@@ -16,11 +18,16 @@ describe('NvmeofGatewayGroupComponent', () => {
       listGatewayGroups: jest.fn().mockReturnValue(of([])),
       listSubsystems: jest.fn().mockReturnValue(of([]))
     };
+    const nvmeofStateServiceSpy = { requestRefresh: jest.fn() };
 
     await TestBed.configureTestingModule({
       imports: [HttpClientModule, SharedModule, TabsModule, GridModule],
       declarations: [NvmeofGatewayGroupComponent],
-      providers: [{ provide: NvmeofService, useValue: nvmeofServiceSpy }]
+      providers: [
+        { provide: NvmeofService, useValue: nvmeofServiceSpy },
+        { provide: NvmeofStateService, useValue: nvmeofStateServiceSpy }
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofGatewayGroupComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject, forkJoin, Observable, of } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { catchError, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { GatewayGroup, NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { HostService } from '~/app/shared/api/host.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
@@ -24,6 +24,7 @@ import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impa
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
+import { NvmeofStateService } from '../nvmeof-state.service';
 
 const BASE_URL = 'block/nvmeof/gateways';
 
@@ -65,7 +66,6 @@ export class NvmeofGatewayGroupComponent implements OnInit {
 
   viewUrl = `/${BASE_URL}/view`;
   icons = Icons;
-
   iconSize = IconSize;
 
   constructor(
@@ -78,7 +78,8 @@ export class NvmeofGatewayGroupComponent implements OnInit {
     public taskWrapper: TaskWrapperService,
     private notificationService: NotificationService,
     private urlBuilder: URLBuilderService,
-    private router: Router
+    private router: Router,
+    private nvmeofStateService: NvmeofStateService
   ) {}
 
   ngOnInit(): void {
@@ -171,7 +172,9 @@ export class NvmeofGatewayGroupComponent implements OnInit {
             return of([]);
           })
         )
-      )
+      ),
+      tap(() => this.nvmeofStateService.requestRefresh()),
+      shareReplay({ bufferSize: 1, refCount: true })
     );
     this.checkNodesAvailability();
   }
@@ -209,7 +212,9 @@ export class NvmeofGatewayGroupComponent implements OnInit {
       submitActionObservable: () => {
         return this.taskWrapper
           .wrapTaskAroundCall({
-            task: new FinishedTask('nvmeof/gateway/delete', { group: selectedGroup.spec.group }),
+            task: new FinishedTask('service/delete', {
+              service_name: serviceName
+            }),
             call: this.cephServiceService.delete(serviceName)
           })
           .pipe(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
@@ -44,8 +44,6 @@ export class NvmeofGatewayComponent implements OnInit, OnDestroy {
     this.route.queryParams.subscribe((params) => {
       if (params['tab'] && Object.values(TABS).includes(params['tab'])) {
         this.activeTab = params['tab'] as TABS;
-      } else {
-        this.activeTab = TABS.gateways;
       }
       this.breadcrumbService.setTabCrumb(TAB_LABELS[this.activeTab]);
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.html
@@ -1,30 +1,8 @@
-<cd-nvmeof-tabs></cd-nvmeof-tabs>
-
-<div cdsGrid
-     [useCssGrid]="true"
-     [narrow]="true"
-     [fullWidth]="true">
-<div cdsCol
-     [columnNumbers]="{sm: 4, md: 8}">
-  <div class="cds-mt-3 form-item"
-       cdsRow>
-    <cds-combo-box
-        type="single"
-        label="Selected Gateway Group"
-        i18n-label
-        [placeholder]="gwGroupPlaceholder"
-        [items]="gwGroups"
-        (selected)="onGroupSelection($event)"
-        (clear)="onGroupClear()"
-        [disabled]="gwGroupsEmpty">
-      <cds-dropdown-list></cds-dropdown-list>
-    </cds-combo-box>
-  </div>
-</div>
-</div>
-
+<div class="nvmeof-content-layout">
+  <div class="nvmeof-content-main">
 <ng-container *ngIf="namespaces$ | async as namespaces">
   <cd-table [data]="namespaces"
+            [compactSearchField]="true"
             columnMode="flex"
             (fetchData)="fetchData()"
             [columns]="namespacesColumns"
@@ -37,6 +15,15 @@
             emptyStateMessage="Namespaces are storage volumes mapped to subsystems for host access. Create a namespace to start provisioning storage within a subsystem."
             i18n-emptyStateMessage>
 
+    <div class="table-filter">
+      <cd-nvmeof-gateway-group-filter [items]="gwGroups"
+                                      [placeholder]="gwGroupPlaceholder"
+                                      [disabled]="gwGroupsEmpty"
+                                      (selected)="onGroupSelection($event)"
+                                      (cleared)="onGroupClear()">
+      </cd-nvmeof-gateway-group-filter>
+    </div>
+
   <div class="table-actions">
     <cd-table-actions [permission]="permission"
                       [selection]="selection"
@@ -46,5 +33,7 @@
   </div>
 </cd-table>
 </ng-container>
+  </div>
+</div>
 
 <router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
@@ -12,6 +12,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
 import { NvmeofNamespacesListComponent } from './nvmeof-namespaces-list.component';
+import { NvmeofGatewayGroupFilterComponent } from '../nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 
 const mockNamespaces = [
   {
@@ -65,7 +66,12 @@ describe('NvmeofNamespacesListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NvmeofNamespacesListComponent, NvmeofSubsystemsDetailsComponent],
-      imports: [HttpClientModule, RouterTestingModule, SharedModule],
+      imports: [
+        HttpClientModule,
+        RouterTestingModule,
+        SharedModule,
+        NvmeofGatewayGroupFilterComponent
+      ],
       providers: [
         { provide: NvmeofService, useClass: MockNvmeOfService },
         { provide: AuthStorageService, useClass: MockAuthStorageService },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.ts
@@ -17,8 +17,9 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
-import { catchError, map, switchMap, takeUntil } from 'rxjs/operators';
+import { NvmeofStateService } from '../nvmeof-state.service';
+import { BehaviorSubject, Observable, forkJoin, of, Subject } from 'rxjs';
+import { catchError, map, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 const DEFAULT_PLACEHOLDER = $localize`Enter group name`;
 
@@ -41,9 +42,9 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
   permission: Permission;
   namespaces$: Observable<NvmeofSubsystemNamespace[]>;
   private namespaceSubject = new BehaviorSubject<void>(undefined);
-
   // Gateway group dropdown properties
   gwGroups: GroupsComboboxItem[] = [];
+  groupSelectionCleared = false;
   gwGroupsEmpty: boolean = false;
   gwGroupPlaceholder: string = DEFAULT_PLACEHOLDER;
 
@@ -58,14 +59,26 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
     private authStorageService: AuthStorageService,
     private taskWrapper: TaskWrapperService,
     private nvmeofService: NvmeofService,
-    private dimlessBinaryPipe: DimlessBinaryPipe
+    private dimlessBinaryPipe: DimlessBinaryPipe,
+    private nvmeofStateService: NvmeofStateService
   ) {
     this.permission = this.authStorageService.getPermissions().nvmeof;
   }
 
   ngOnInit() {
     this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
-      if (params?.['group']) this.onGroupSelection({ content: params?.['group'] });
+      const hasGroupParam = Object.prototype.hasOwnProperty.call(params ?? {}, 'group');
+      if (params?.['group']) {
+        this.groupSelectionCleared = false;
+        this.onGroupSelection({ content: params?.['group'] }, false);
+      } else if (hasGroupParam) {
+        this.groupSelectionCleared = true;
+        if (this.group) {
+          this.onGroupClear(false);
+        }
+      } else {
+        this.groupSelectionCleared = false;
+      }
     });
     this.setGatewayGroups();
     this.namespacesColumns = [
@@ -142,29 +155,63 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
     this.namespaces$ = this.namespaceSubject.pipe(
       switchMap(() => {
         if (!this.group) {
-          return of([]);
+          if (this.groupSelectionCleared) {
+            return of([]);
+          }
+          return this.fetchAllGroupsNamespaces();
         }
         return this.nvmeofService.listNamespaces(this.group).pipe(
-          map((res: NvmeofSubsystemNamespace[] | { namespaces: NvmeofSubsystemNamespace[] }) => {
-            const namespaces = Array.isArray(res) ? res : res.namespaces || [];
-            // Deduplicate by nsid + subsystem NQN (API with wildcard can return duplicates per gateway)
-            const seen = new Set<string>();
-            return namespaces
-              .filter((ns) => {
-                const key = `${ns.nsid}_${ns['ns_subsystem_nqn']}`;
-                if (seen.has(key)) return false;
-                seen.add(key);
-                return true;
-              })
-              .map((ns) => ({
-                ...ns,
-                unique_id: `${ns.nsid}_${ns['ns_subsystem_nqn']}`
-              }));
-          }),
+          map((res: any) => this.normalizeAndDedup(res)),
           catchError(() => of([]))
         );
       }),
+      shareReplay({ bufferSize: 1, refCount: true }),
       takeUntil(this.destroy$)
+    );
+  }
+
+  private normalizeAndDedup(
+    res: NvmeofSubsystemNamespace[] | { namespaces: NvmeofSubsystemNamespace[] }
+  ): (NvmeofSubsystemNamespace & { unique_id: string })[] {
+    const namespaces = Array.isArray(res) ? res : res.namespaces || [];
+    const seen = new Set<string>();
+    return namespaces
+      .filter((ns) => {
+        const key = `${ns.nsid}_${ns['ns_subsystem_nqn']}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .map((ns) => ({ ...ns, unique_id: `${ns.nsid}_${ns['ns_subsystem_nqn']}` }));
+  }
+
+  private fetchAllGroupsNamespaces() {
+    return this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const groups: CephServiceSpec[] = Array.isArray(firstItem) ? firstItem : [];
+        const validGroups = groups.filter((g) => g?.spec?.group);
+        if (validGroups.length === 0) return of([]);
+        return forkJoin(
+          validGroups.map((g) =>
+            this.nvmeofService.listNamespaces(g.spec.group).pipe(
+              map((res: any) => this.normalizeAndDedup(res)),
+              catchError(() => of([]))
+            )
+          )
+        ).pipe(
+          map((results) => {
+            // Deduplicate again across groups
+            const seen = new Set<string>();
+            return (results as any[]).flat().filter((ns: any) => {
+              if (seen.has(ns.unique_id)) return false;
+              seen.add(ns.unique_id);
+              return true;
+            });
+          })
+        );
+      }),
+      catchError(() => of([]))
     );
   }
 
@@ -181,14 +228,22 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
   }
 
   // Gateway groups methods
-  onGroupSelection(selected: GroupsComboboxItem) {
+  onGroupSelection(selected: GroupsComboboxItem, syncQueryParam = true) {
     selected.selected = true;
     this.group = selected.content;
+    this.groupSelectionCleared = false;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(this.group);
+    }
     this.listNamespaces();
   }
 
-  onGroupClear() {
+  onGroupClear(syncQueryParam = true) {
     this.group = null;
+    this.groupSelectionCleared = true;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(null);
+    }
     this.listNamespaces();
   }
 
@@ -213,12 +268,17 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
 
   updateGroupSelectionState() {
     if (this.gwGroups.length) {
-      if (!this.group) {
+      if (this.group) {
+        this.gwGroups = this.gwGroups.map((g) => ({
+          ...g,
+          selected: g.content === this.group
+        }));
+      } else if (!this.groupSelectionCleared) {
         this.onGroupSelection(this.gwGroups[0]);
       } else {
         this.gwGroups = this.gwGroups.map((g) => ({
           ...g,
-          selected: g.content === this.group
+          selected: false
         }));
       }
       this.gwGroupsEmpty = false;
@@ -227,6 +287,14 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
       this.gwGroupsEmpty = true;
       this.gwGroupPlaceholder = $localize`No groups available`;
     }
+  }
+
+  private syncGroupQueryParam(group: string | null) {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { group: group ?? '' },
+      queryParamsHandling: 'merge'
+    });
   }
 
   handleGatewayGroupsError(error: any) {
@@ -251,13 +319,15 @@ export class NvmeofNamespacesListComponent implements OnInit, OnDestroy {
         deletionMessage: $localize`Deleting the namespace <strong>${namespace.nsid}</strong> will permanently remove all resources, services, and configurations within it. This action cannot be undone.`
       },
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask('nvmeof/namespace/delete', {
-            nqn: subsystemNqn,
-            nsid: namespace.nsid
-          }),
-          call: this.nvmeofService.deleteNamespace(subsystemNqn, namespace.nsid, this.group)
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask('nvmeof/namespace/delete', {
+              nqn: subsystemNqn,
+              nsid: namespace.nsid
+            }),
+            call: this.nvmeofService.deleteNamespace(subsystemNqn, namespace.nsid, this.group)
+          })
+          .pipe(tap({ complete: () => this.nvmeofStateService.requestRefresh() }))
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.html
@@ -1,0 +1,103 @@
+<cd-productive-card class="nvmeof-setup-cards">
+  <ng-template #header>
+    <div cdsStack="vertical"
+         gap="3">
+      <h2 class="cds--type-heading-compact-03"
+          i18n>Recommended first-time setup</h2>
+      <p class="cds--type-body-01"
+         i18n>
+        Start your NVMe over Fabrics configuration by creating the essential resources in sequence.
+      </p>
+    </div>
+  </ng-template>
+
+  <div class="nvmeof-setup-cards__columns">
+
+    <div class="nvmeof-setup-cards__column">
+      <div class="nvmeof-setup-cards__column-content">
+        <div class="nvmeof-setup-cards__step-row">
+          <span class="cds--type-label-01"
+                i18n>1.</span>
+          <span class="cds--type-heading-compact-01"
+                i18n>Create Gateway groups</span>
+        </div>
+        <p class="cds--type-label-01"
+           i18n>
+          Group NVMe gateway nodes to enable high availability and<br>load balancing for storage targets.
+        </p>
+        <div class="nvmeof-setup-cards__info">
+          @if (hasGatewayGroups) {
+          <cd-icon type="success"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>Gateway group configured successfully.</span>
+          } @else {
+          <cd-icon type="info"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>No gateway groups configured for this cluster yet.</span>
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="nvmeof-setup-cards__column">
+      <div class="nvmeof-setup-cards__column-content">
+        <div class="nvmeof-setup-cards__step-row">
+          <span class="cds--type-label-01"
+                i18n>2.</span>
+          <span class="cds--type-heading-compact-01"
+                i18n>Create Subsystems</span>
+        </div>
+        <p class="cds--type-label-01"
+           i18n>
+         Define storage targets by creating NVMe subsystems and <br> configuring security, listeners, and host access.
+        </p>
+        <div class="nvmeof-setup-cards__info">
+          @if (hasSubsystems) {
+          <cd-icon type="success"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>Subsystem configured successfully.</span>
+          } @else {
+          <cd-icon type="info"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>No subsystem configured for this cluster yet.</span>
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="nvmeof-setup-cards__column">
+      <div class="nvmeof-setup-cards__column-content">
+        <div class="nvmeof-setup-cards__step-row">
+          <span class="cds--type-label-01"
+                i18n>3.</span>
+          <span class="cds--type-heading-compact-01"
+                i18n>Create Namespaces</span>
+        </div>
+        <p class="cds--type-label-01"
+           i18n>
+          Create storage namespaces backed by Ceph block images. This <br>completes your NVMe over Fabrics setup.
+        </p>
+        <div class="nvmeof-setup-cards__info">
+          @if (hasNamespaces) {
+          <cd-icon type="success"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>Namespaces mapped successfully.</span>
+          } @else {
+          <cd-icon type="info"></cd-icon>
+          <span class="cds--type-label-01"
+                i18n>No namespace allocated or mapped yet.</span>
+          }
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  @if (isAllConfigured) {
+  <div class="nvmeof-setup-cards__completion">
+    <a cdsLink
+       (click)="viewStatus.emit()"
+       i18n>Configuration complete. View status →</a>
+  </div>
+  }
+</cd-productive-card>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.scss
@@ -1,0 +1,59 @@
+.nvmeof-setup-cards__columns {
+  display: flex;
+  align-items: stretch;
+  padding-bottom: var(--cds-spacing-05);
+}
+
+.nvmeof-setup-cards__column {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: var(--cds-spacing-03) var(--cds-spacing-05) var(--cds-spacing-05);
+  display: flex;
+  flex-direction: column;
+}
+
+.nvmeof-setup-cards__column-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: var(--cds-spacing-03);
+}
+
+.nvmeof-setup-cards__step-row {
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+}
+
+.nvmeof-setup-cards__step-icon {
+  flex-shrink: 0;
+}
+
+.nvmeof-setup-cards__info {
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  gap: var(--cds-spacing-03);
+}
+
+.nvmeof-setup-cards__completion {
+  padding: var(--cds-spacing-04) var(--cds-spacing-05);
+
+  a {
+    cursor: pointer;
+  }
+}
+
+:host ::ng-deep .nvmeof-setup-cards {
+  &.productive-card .productive-card-header {
+    padding: var(--cds-spacing-03) var(--cds-spacing-05);
+  }
+
+  &.productive-card .productive-card-section {
+    padding: 0;
+  }
+
+  .productive-card-section {
+    padding: var(--cds-spacing-02);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { LayoutModule, LayerModule, LinkModule, TilesModule } from 'carbon-components-angular';
+import { ProductiveCardComponent } from '~/app/shared/components/productive-card/productive-card.component';
+import { ComponentsModule } from '~/app/shared/components/components.module';
+
+@Component({
+  selector: 'cd-nvmeof-setup-cards',
+  templateUrl: './nvmeof-setup-cards.component.html',
+  styleUrl: './nvmeof-setup-cards.component.scss',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    LayoutModule,
+    LayerModule,
+    TilesModule,
+    LinkModule,
+    ProductiveCardComponent,
+    ComponentsModule
+  ]
+})
+export class NvmeofSetupCardsComponent {
+  @Input() hasGatewayGroups = false;
+  @Input() hasSubsystems = false;
+  @Input() hasNamespaces = false;
+  @Input() isAllConfigured = false;
+  @Output() viewStatus = new EventEmitter<void>();
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.spec.ts
@@ -1,0 +1,187 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Subject } from 'rxjs';
+
+import { NvmeofStateService } from './nvmeof-state.service';
+import { SummaryService } from '~/app/shared/services/summary.service';
+
+describe('NvmeofStateService', () => {
+  let service: NvmeofStateService;
+  let summaryData$: Subject<any>;
+  let summaryServiceSpy: any;
+
+  const emitSummary = (tasks: any[]) => summaryData$.next({ finished_tasks: tasks });
+
+  beforeEach(() => {
+    summaryData$ = new Subject<any>();
+    summaryServiceSpy = {
+      subscribe: jest.fn().mockImplementation((callback: (s: any) => void) => {
+        return summaryData$.subscribe(callback);
+      })
+    };
+
+    TestBed.configureTestingModule({
+      providers: [NvmeofStateService, { provide: SummaryService, useValue: summaryServiceSpy }]
+    });
+
+    service = TestBed.inject(NvmeofStateService);
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should emit refresh$ when requestRefresh is called', (done) => {
+    service.refresh$.subscribe(() => done());
+    service.requestRefresh();
+  });
+
+  it('should not emit refresh$ on the first summary update (initialization baseline)', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([
+      {
+        name: 'service/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'nvmeof.rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('should emit refresh$ when a new NVMe service/delete task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'service/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'nvmeof.rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a new NVMe service/create task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'service/create',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'nvmeof.rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a nvmeof/subsystem/delete task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'nvmeof/subsystem/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { nqn: 'sub1' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a nvmeof/namespace/create task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'nvmeof/namespace/create',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { nqn: 'sub1' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit refresh$ when a nvmeof/namespace/delete task appears', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'nvmeof/namespace/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { nsid: 1, nqn: 'sub1' }
+      }
+    ]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit refresh$ for non-NVMe tasks', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([{ name: 'rbd/create', end_time: '2026-01-01T00:00:00Z', metadata: {} }]);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not emit refresh$ for service/delete of a non-NVMe service', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    emitSummary([]); // init
+    emitSummary([
+      {
+        name: 'service/delete',
+        end_time: '2026-01-01T00:00:00Z',
+        metadata: { service_name: 'rbd.default' }
+      }
+    ]);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not emit refresh$ for the same task appearing again', () => {
+    const refreshSpy = jest.fn();
+    service.refresh$.subscribe(refreshSpy);
+
+    const task = {
+      name: 'service/delete',
+      end_time: '2026-01-01T00:00:00Z',
+      metadata: { service_name: 'nvmeof.rbd.default' }
+    };
+
+    emitSummary([]); // init
+    emitSummary([task]); // new task — emits once
+    emitSummary([task]); // same task — no second emit
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should unsubscribe from SummaryService on destroy', () => {
+    const unsubscribeSpy = jest.fn();
+    const mockSubscription = { unsubscribe: unsubscribeSpy };
+    summaryServiceSpy.subscribe.mockReturnValueOnce(mockSubscription);
+
+    const freshService = new NvmeofStateService(summaryServiceSpy as any);
+    freshService.ngOnDestroy();
+
+    expect(unsubscribeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, OnDestroy } from '@angular/core';
+
+import { merge, Subject, Subscription } from 'rxjs';
+
+import { FinishedTask } from '~/app/shared/models/finished-task';
+import { Summary } from '~/app/shared/models/summary.model';
+import { SummaryService } from '~/app/shared/services/summary.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NvmeofStateService implements OnDestroy {
+  private readonly explicitRefreshSource = new Subject<void>();
+  private readonly taskRefreshSource = new Subject<void>();
+  private summarySubscription: Subscription;
+  private seenTaskSignatures = new Set<string>();
+  private summaryInitialized = false;
+
+  readonly refresh$ = merge(
+    this.explicitRefreshSource.asObservable(),
+    this.taskRefreshSource.asObservable()
+  );
+
+  constructor(private summaryService: SummaryService) {
+    this.summarySubscription = this.summaryService.subscribe((summary: Summary) => {
+      const nvmeTasks = (summary?.finished_tasks ?? []).filter((t: FinishedTask) =>
+        this.isNvmeTask(t)
+      );
+      const currentSignatures = new Set(
+        nvmeTasks.map((t: FinishedTask) => this.getTaskSignature(t))
+      );
+
+      if (!this.summaryInitialized) {
+        this.summaryInitialized = true;
+        this.seenTaskSignatures = currentSignatures;
+        return;
+      }
+
+      const hasNewTask = [...currentSignatures].some((sig) => !this.seenTaskSignatures.has(sig));
+      this.seenTaskSignatures = currentSignatures;
+
+      if (hasNewTask) {
+        this.taskRefreshSource.next();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.summarySubscription?.unsubscribe();
+  }
+
+  requestRefresh(): void {
+    this.explicitRefreshSource.next();
+  }
+
+  private isNvmeTask(task: FinishedTask): boolean {
+    if (task?.name === 'service/create' || task?.name === 'service/delete') {
+      return (
+        typeof task?.metadata?.['service_name'] === 'string' &&
+        (task.metadata['service_name'] as string).startsWith('nvmeof.')
+      );
+    }
+    return [
+      'nvmeof/subsystem/delete',
+      'nvmeof/namespace/create',
+      'nvmeof/namespace/delete'
+    ].includes(task?.name);
+  }
+
+  private getTaskSignature(task: FinishedTask): string {
+    return JSON.stringify({
+      name: task.name,
+      end_time: task.end_time,
+      metadata: task.metadata
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
@@ -1,31 +1,10 @@
-<cd-nvmeof-tabs></cd-nvmeof-tabs>
-
-<div cdsGrid
-     [useCssGrid]="true"
-     [narrow]="true"
-     [fullWidth]="true">
-<div cdsCol
-     [columnNumbers]="{sm: 4, md: 8}">
-  <div class="cds-mt-3 form-item"
-       cdsRow>
-    <cds-combo-box
-        type="single"
-        label="Selected Gateway Group"
-        i18n-label
-        [placeholder]="gwGroupPlaceholder"
-        [items]="gwGroups"
-        (selected)="onGroupSelection($event)"
-        (clear)="onGroupClear()"
-        [disabled]="gwGroupsEmpty">
-      <cds-dropdown-list></cds-dropdown-list>
-    </cds-combo-box>
-  </div>
-</div>
-</div>
+<div class="nvmeof-content-layout">
+  <div class="nvmeof-content-main">
 <ng-container *ngIf="subsystems$ | async as subsystems">
   <cd-table #table
             [data]="subsystems"
             [columns]="subsystemsColumns"
+            [compactSearchField]="true"
             columnMode="flex"
             selectionType="single"
             (updateSelection)="updateSelection($event)"
@@ -34,6 +13,15 @@
             i18n-emptyStateTitle
             emptyStateMessage="Subsystems group NVMe namespaces and manage host access. Create a subsystem to start mapping NVMe volumes to hosts."
             i18n-emptyStateMessage>
+
+    <div class="table-filter">
+      <cd-nvmeof-gateway-group-filter [items]="gwGroups"
+                                      [placeholder]="gwGroupPlaceholder"
+                                      [disabled]="gwGroupsEmpty"
+                                      (selected)="onGroupSelection($event)"
+                                      (cleared)="onGroupClear()">
+      </cd-nvmeof-gateway-group-filter>
+    </div>
 
     <div class="table-actions">
       <cd-table-actions [permission]="permissions.nvmeof"
@@ -50,6 +38,8 @@
     </cd-nvmeof-subsystems-details>
   </cd-table>
 </ng-container>
+  </div>
+</div>
 
 <ng-template #customTableItemTemplate
              let-value="data.value"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SharedModule } from '~/app/shared/shared.module';
 
@@ -10,7 +12,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofSubsystemsComponent } from './nvmeof-subsystems.component';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
-import { ComboBoxModule, GridModule } from 'carbon-components-angular';
+import { NvmeofGatewayGroupFilterComponent } from '../nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 
 const mockSubsystems = [
@@ -93,13 +95,19 @@ describe('NvmeofSubsystemsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NvmeofSubsystemsComponent, NvmeofSubsystemsDetailsComponent],
-      imports: [HttpClientModule, RouterTestingModule, SharedModule, ComboBoxModule, GridModule],
+      imports: [
+        HttpClientModule,
+        RouterTestingModule,
+        SharedModule,
+        NvmeofGatewayGroupFilterComponent
+      ],
       providers: [
         { provide: NvmeofService, useClass: MockNvmeOfService },
         { provide: AuthStorageService, useClass: MockAuthStorageService },
         { provide: ModalCdsService, useClass: MockModalService },
         { provide: TaskWrapperService, useClass: MockTaskWrapperService }
-      ]
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofSubsystemsComponent);
@@ -132,5 +140,14 @@ describe('NvmeofSubsystemsComponent', () => {
 
   it('should set first group as default initially', () => {
     expect(component.group).toBe(mockGroups[0][0].spec.group);
+  });
+
+  it('should not show existing subsystem records when dropdown selection is empty', (done) => {
+    component.onGroupClear();
+    component.subsystems$.pipe(take(1)).subscribe((subsystems) => {
+      expect(subsystems).toEqual([]);
+      done();
+    });
+    component.getSubsystems();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
@@ -22,8 +22,9 @@ import { NvmeofService, GroupsComboboxItem } from '~/app/shared/api/nvmeof.servi
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { BehaviorSubject, forkJoin, Observable, of, Subject } from 'rxjs';
-import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { catchError, map, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import { NvmeofStateService } from '../nvmeof-state.service';
 
 const BASE_URL = 'block/nvmeof/subsystems';
 const DEFAULT_PLACEHOLDER = $localize`Enter group name`;
@@ -57,10 +58,12 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
   context: CdTableFetchDataContext;
   gwGroups: GroupsComboboxItem[] = [];
   group: string = null;
+  groupSelectionCleared = false;
   gwGroupsEmpty: boolean = false;
   gwGroupPlaceholder: string = DEFAULT_PLACEHOLDER;
   authType = NvmeofSubsystemAuthType;
   subsystems$: Observable<(NvmeofSubsystem & { gw_group?: string; initiator_count?: number })[]>;
+
   private subsystemSubject = new BehaviorSubject<void>(undefined);
 
   private destroy$ = new Subject<void>();
@@ -72,7 +75,8 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     private router: Router,
     private route: ActivatedRoute,
     private modalService: ModalCdsService,
-    private taskWrapper: TaskWrapperService
+    private taskWrapper: TaskWrapperService,
+    private nvmeofStateService: NvmeofStateService
   ) {
     super();
     this.permissions = this.authStorageService.getPermissions();
@@ -80,7 +84,18 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
 
   ngOnInit() {
     this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
-      if (params?.['group']) this.onGroupSelection({ content: params?.['group'] });
+      const hasGroupParam = Object.prototype.hasOwnProperty.call(params ?? {}, 'group');
+      if (params?.['group']) {
+        this.groupSelectionCleared = false;
+        this.onGroupSelection({ content: params?.['group'] }, false);
+      } else if (hasGroupParam) {
+        this.groupSelectionCleared = true;
+        if (this.group) {
+          this.onGroupClear(false);
+        }
+      } else {
+        this.groupSelectionCleared = false;
+      }
     });
     this.setGatewayGroups();
     this.subsystemsColumns = [
@@ -133,13 +148,16 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     this.subsystems$ = this.subsystemSubject.pipe(
       switchMap(() => {
         if (!this.group) {
-          return of([]);
+          if (this.groupSelectionCleared) {
+            return of([]);
+          }
+          return this.fetchAllGroupsSubsystems();
         }
         return this.nvmeofService.listSubsystems(this.group).pipe(
-          switchMap((subsystems: NvmeofSubsystem[] | NvmeofSubsystem) => {
-            const subs = Array.isArray(subsystems) ? subsystems : [subsystems];
+          switchMap((subsystems: any) => {
+            const subs: NvmeofSubsystem[] = Array.isArray(subsystems) ? subsystems : [subsystems];
             if (subs.length === 0) return of([]);
-            return forkJoin(subs.map((sub) => this.enrichSubsystemWithInitiators(sub)));
+            return forkJoin(subs.map((sub) => this.enrichSubsystemForGroup(sub, this.group)));
           }),
           catchError((error) => {
             this.handleError(error);
@@ -150,6 +168,7 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
       tap((subs) => {
         this.subsystems = subs;
       }),
+      shareReplay({ bufferSize: 1, refCount: true }),
       takeUntil(this.destroy$)
     );
   }
@@ -179,21 +198,31 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
         forceDeleteAcknowledgementMessage: $localize`I understand this may remove resources still attached to this subsystem.`
       },
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask('nvmeof/subsystem/delete', { nqn: subsystem.nqn }),
-          call: this.nvmeofService.deleteSubsystem(subsystem.nqn, this.group)
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask('nvmeof/subsystem/delete', { nqn: subsystem.nqn }),
+            call: this.nvmeofService.deleteSubsystem(subsystem.nqn, this.group)
+          })
+          .pipe(tap({ complete: () => this.nvmeofStateService.requestRefresh() }))
     });
   }
 
-  onGroupSelection(selected: GroupsComboboxItem) {
+  onGroupSelection(selected: GroupsComboboxItem, syncQueryParam = true) {
     selected.selected = true;
     this.group = selected.content;
+    this.groupSelectionCleared = false;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(this.group);
+    }
     this.getSubsystems();
   }
 
-  onGroupClear() {
+  onGroupClear(syncQueryParam = true) {
     this.group = null;
+    this.groupSelectionCleared = true;
+    if (syncQueryParam) {
+      this.syncGroupQueryParam(null);
+    }
     this.getSubsystems();
   }
 
@@ -220,18 +249,31 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     if (this.gwGroups.length) {
       this.gwGroupsEmpty = false;
       this.gwGroupPlaceholder = DEFAULT_PLACEHOLDER;
-      if (!this.group) {
+      if (this.group) {
+        this.gwGroups = this.gwGroups.map((g) => ({
+          ...g,
+          selected: g.content === this.group
+        }));
+      } else if (!this.groupSelectionCleared) {
         this.onGroupSelection(this.gwGroups[0]);
       } else {
         this.gwGroups = this.gwGroups.map((g) => ({
           ...g,
-          selected: g.content === this.group
+          selected: false
         }));
       }
     } else {
       this.gwGroupsEmpty = true;
       this.gwGroupPlaceholder = $localize`No groups available`;
     }
+  }
+
+  private syncGroupQueryParam(group: string | null) {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { group: group ?? '' },
+      queryParamsHandling: 'merge'
+    });
   }
 
   handleGatewayGroupsError(error: any) {
@@ -248,8 +290,8 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     this.context?.error?.(error);
   }
 
-  private enrichSubsystemWithInitiators(sub: NvmeofSubsystem) {
-    return this.nvmeofService.getInitiators(sub.nqn, this.group).pipe(
+  private enrichSubsystemForGroup(sub: NvmeofSubsystem, group: string) {
+    return this.nvmeofService.getInitiators(sub.nqn, group).pipe(
       catchError(() => of([])),
       map((initiators: NvmeofSubsystemInitiator[] | { hosts?: NvmeofSubsystemInitiator[] }) => {
         let count = 0;
@@ -257,14 +299,39 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
         else if (initiators?.hosts && Array.isArray(initiators.hosts)) {
           count = initiators.hosts.length;
         }
-
         return {
           ...sub,
-          gw_group: this.group,
+          gw_group: group,
           initiator_count: count,
           auth: getSubsystemAuthStatus(sub, initiators)
         } as NvmeofSubsystem & { initiator_count?: number; auth?: string };
       })
+    );
+  }
+
+  private fetchAllGroupsSubsystems() {
+    return this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const groups: CephServiceSpec[] = Array.isArray(firstItem) ? firstItem : [];
+        const validGroups = groups.filter((g) => g?.spec?.group);
+        if (validGroups.length === 0) return of([]);
+        return forkJoin(
+          validGroups.map((g) =>
+            this.nvmeofService.listSubsystems(g.spec.group).pipe(
+              switchMap((subsystems: any) => {
+                const subs: NvmeofSubsystem[] = Array.isArray(subsystems)
+                  ? subsystems
+                  : [subsystems];
+                if (subs.length === 0) return of([]);
+                return forkJoin(subs.map((sub) => this.enrichSubsystemForGroup(sub, g.spec.group)));
+              }),
+              catchError(() => of([]))
+            )
+          )
+        ).pipe(map((results) => (results as any[][]).flat()));
+      }),
+      catchError(() => of([]))
     );
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.html
@@ -1,31 +1,46 @@
-<fieldset>
-  <legend>
-    <h1 class="cds--type-heading-03">NVMe over Fabrics (TCP)</h1>
-  <cd-help-text>Monitor and manage NVMe-over-TCP resources for high-performance block storage.</cd-help-text>
-  </legend>
-</fieldset>
-<section>
-  <cds-tabs type="contained"
-            followFocus="true"
-            isNavigation="true"
-            [cacheActive]="false">
-  <cds-tab
-    heading="Gateways"
-    i18n-heading
-    [active]="activeTab === Tabs.gateways"
-    (selected)="onSelected(Tabs.gateways)">
-  </cds-tab>
-  <cds-tab
-    heading="Subsystems"
-    i18n-heading
-    [active]="activeTab === Tabs.subsystems"
-    (selected)="onSelected(Tabs.subsystems)">
-  </cds-tab>
-  <cds-tab
-    heading="Namespaces"
-    i18n-heading
-    [active]="activeTab === Tabs.namespaces"
-    (selected)="onSelected(Tabs.namespaces)">
-  </cds-tab>
-</cds-tabs>
-</section>
+@if (showTabsShell) {
+  <fieldset>
+    <legend class="cds-mb-5">
+      <h1 class="cds--type-heading-03">NVMe over Fabrics (TCP)</h1>
+      <cd-help-text>Monitor and manage NVMe-over-TCP resources for high-<br>performance block storage.</cd-help-text>
+    </legend>
+  </fieldset>
+
+  @if (showSetupCards) {
+  <cd-nvmeof-setup-cards class="cds-mt-5"
+                         [hasGatewayGroups]="hasGatewayGroups"
+                         [hasSubsystems]="hasSubsystems"
+                         [hasNamespaces]="hasNamespaces"
+                         [isAllConfigured]="isAllConfigured"
+                         (viewStatus)="dismissOnboarding()">
+  </cd-nvmeof-setup-cards>
+  }
+
+  <section class="cds-mt-5">
+    <cds-tabs type="contained"
+              followFocus="true"
+              isNavigation="true"
+              [cacheActive]="false">
+    <cds-tab
+      heading="Gateways"
+      i18n-heading
+      [active]="activeTab === Tabs.gateways"
+      (selected)="onSelected(Tabs.gateways)">
+    </cds-tab>
+    <cds-tab
+      heading="Subsystems"
+      i18n-heading
+      [active]="activeTab === Tabs.subsystems"
+      (selected)="onSelected(Tabs.subsystems)">
+    </cds-tab>
+    <cds-tab
+      heading="Namespaces"
+      i18n-heading
+      [active]="activeTab === Tabs.namespaces"
+      (selected)="onSelected(Tabs.namespaces)">
+    </cds-tab>
+  </cds-tabs>
+  </section>
+}
+
+<router-outlet></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
@@ -1,26 +1,58 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Event as RouterEvent, NavigationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 
 import { TabsModule } from 'carbon-components-angular';
 
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { NvmeofStateService } from '../nvmeof-state.service';
 import { NvmeofTabsComponent } from './nvmeof-tabs.component';
 import { SharedModule } from '~/app/shared/shared.module';
+import { NvmeofSetupCardsComponent } from '../nvmeof-setup-cards/nvmeof-setup-cards.component';
 
 describe('NvmeofTabsComponent', () => {
   let component: NvmeofTabsComponent;
   let fixture: ComponentFixture<NvmeofTabsComponent>;
   let router: Router;
+  let nvmeofServiceSpy: any;
+  let queryParams$: BehaviorSubject<any>;
+  let refresh$: Subject<void>;
+  let routerEvents$: Subject<RouterEvent>;
+
+  const mockGroups = [
+    [{ spec: { group: 'grp1' }, placement: { hosts: ['h1'] }, status: { running: 1, size: 1 } }]
+  ];
+  const mockSubsystems = [{ nqn: 'sub1', namespace_count: 2, initiator_count: 0 }];
+  const mockNamespaces = [{ nsid: 1, rbd_image_name: 'img1', rbd_pool_name: 'rbd' }];
+
+  const setQueryParams = (params: any) => queryParams$.next(params);
+  const emitRefresh = () => refresh$.next();
 
   beforeEach(async () => {
+    queryParams$ = new BehaviorSubject<any>({ group: 'grp1' });
+    refresh$ = new Subject<void>();
+    nvmeofServiceSpy = {
+      listGatewayGroups: jest.fn().mockReturnValue(of(mockGroups)),
+      listSubsystems: jest.fn().mockReturnValue(of(mockSubsystems)),
+      listNamespaces: jest.fn().mockReturnValue(of(mockNamespaces))
+    };
+
     await TestBed.configureTestingModule({
       declarations: [NvmeofTabsComponent],
-      imports: [RouterTestingModule, SharedModule, TabsModule]
+      imports: [RouterTestingModule, SharedModule, TabsModule, NvmeofSetupCardsComponent],
+      providers: [
+        { provide: NvmeofService, useValue: nvmeofServiceSpy },
+        { provide: ActivatedRoute, useValue: { queryParams: queryParams$.asObservable() } },
+        { provide: NvmeofStateService, useValue: { refresh$: refresh$.asObservable() } }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(NvmeofTabsComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
+    routerEvents$ = new Subject<RouterEvent>();
+    jest.spyOn(router, 'events', 'get').mockReturnValue(routerEvents$.asObservable());
   });
 
   it('should create', () => {
@@ -51,25 +83,59 @@ describe('NvmeofTabsComponent', () => {
     expect(component.activeTab).toBe(component.Tabs.gateways);
   });
 
+  it('should hide the shell on namespace create routes', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/namespaces/create');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(false);
+  });
+
+  it('should keep the shell visible on namespace list routes', () => {
+    jest.spyOn(router, 'url', 'get').mockReturnValue('/block/nvmeof/namespaces');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(true);
+  });
+
+  it('should keep the shell visible on list routes with a secondary outlet', () => {
+    jest
+      .spyOn(router, 'url', 'get')
+      .mockReturnValue('/block/nvmeof/subsystems(modal:create)?group=default');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(true);
+  });
+
+  it('should hide the shell when primary route is a create page with secondary outlet', () => {
+    jest
+      .spyOn(router, 'url', 'get')
+      .mockReturnValue('/block/nvmeof/subsystems/create(modal:create)?group=default');
+    component.ngOnInit();
+    expect(component.showTabsShell).toBe(false);
+  });
+
   it('should navigate to correct path on tab selection', () => {
     spyOn(router, 'navigate');
     component.onSelected(component.Tabs.subsystems);
-    expect(component.selectedTab).toBe(component.Tabs.subsystems);
-    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/subsystems']);
+    expect(component.activeTab).toBe(component.Tabs.subsystems);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/subsystems'], {
+      queryParamsHandling: 'preserve'
+    });
   });
 
   it('should navigate to gateways on selecting gateways tab', () => {
     spyOn(router, 'navigate');
     component.onSelected(component.Tabs.gateways);
-    expect(component.selectedTab).toBe(component.Tabs.gateways);
-    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/gateways']);
+    expect(component.activeTab).toBe(component.Tabs.gateways);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/gateways'], {
+      queryParamsHandling: 'preserve'
+    });
   });
 
   it('should navigate to namespaces on selecting namespaces tab', () => {
     spyOn(router, 'navigate');
     component.onSelected(component.Tabs.namespaces);
-    expect(component.selectedTab).toBe(component.Tabs.namespaces);
-    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/namespaces']);
+    expect(component.activeTab).toBe(component.Tabs.namespaces);
+    expect(router.navigate).toHaveBeenCalledWith(['block/nvmeof/namespaces'], {
+      queryParamsHandling: 'preserve'
+    });
   });
 
   it('should expose TABS enum via Tabs getter', () => {
@@ -77,5 +143,231 @@ describe('NvmeofTabsComponent', () => {
     expect(tabs.gateways).toBe('gateways');
     expect(tabs.subsystems).toBe('subsystems');
     expect(tabs.namespaces).toBe('namespaces');
+  });
+
+  describe('setup cards scenarios', () => {
+    it('should show setup cards', () => {
+      component.ngOnInit();
+      expect(component.showSetupCards).toBe(true);
+    });
+
+    it('should show setup cards when no group is selected in dropdown', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of(mockSubsystems));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of(mockNamespaces));
+      setQueryParams({});
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+      expect(component.showSetupCards).toBe(true);
+    });
+
+    it('scenario: no gateway groups — all steps pending', () => {
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of([[]]));
+      component.ngOnInit();
+      expect(component.hasGatewayGroups).toBe(false);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+      expect(component.showSetupCards).toBe(true);
+    });
+
+    it('scenario: selected gateway group exists, no subsystems — step 1 complete', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of([]));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway group does not exist — step 1 complete only', () => {
+      component.ngOnInit();
+      setQueryParams({ group: 'grp-other' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway groups exists, no subsystems in object response — step 1 complete', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of({ subsystems: [] }));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway group + subsystems, no namespaces — steps 1 & 2 complete', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(
+        of([{ nqn: 'sub1', namespace_count: 0, initiator_count: 0 }])
+      );
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(true);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('scenario: selected gateway group all configured — isAllConfigured is true', () => {
+      component.ngOnInit();
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(true);
+      expect(component.hasNamespaces).toBe(true);
+      expect(component.isAllConfigured).toBe(true);
+    });
+
+    it('scenario: selected gateway group all configured in object response — isAllConfigured is true', () => {
+      component.ngOnInit();
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(
+        of({ subsystems: [{ nqn: 'sub1', namespace_count: 2, initiator_count: 0 }] })
+      );
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(
+        of({ namespaces: [{ nsid: 1, rbd_image_name: 'img1', rbd_pool_name: 'rbd' }] })
+      );
+      setQueryParams({ group: 'grp1' });
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(true);
+      expect(component.hasNamespaces).toBe(true);
+      expect(component.isAllConfigured).toBe(true);
+    });
+
+    it('should hide setup cards on dismissOnboarding', () => {
+      component.ngOnInit();
+      component.loadSetupState();
+      component.showSetupCards = true;
+      component.dismissOnboarding();
+      expect(component.showSetupCards).toBe(false);
+    });
+
+    it('should keep setup cards hidden after refresh when onboarding was dismissed', () => {
+      component.ngOnInit();
+      component.dismissOnboarding();
+
+      emitRefresh();
+
+      expect(component.showSetupCards).toBe(false);
+    });
+
+    it('should refresh setup cards when a relevant delete task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh setup cards when an NVMeoF gateway service delete task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh setup cards when an NVMeoF gateway service create task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh setup cards when a namespace create task finishes', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      emitRefresh();
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call loadSetupState on NavigationEnd (e.g. navigating back from a form)', () => {
+      const loadSetupStateSpy = jest.spyOn(component, 'loadSetupState');
+
+      component.ngOnInit();
+      loadSetupStateSpy.mockClear();
+
+      routerEvents$.next(
+        new NavigationEnd(1, '/block/nvmeof/namespaces', '/block/nvmeof/namespaces')
+      );
+
+      expect(loadSetupStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show the initial gateway-only state after the last subsystem and namespace are removed', () => {
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of([]));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('should show the initial empty state after the last gateway is removed', () => {
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of([[]]));
+
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(false);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('should refresh setup cards when the gateway list refreshes to empty', () => {
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of([[]]));
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(false);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
+
+    it('should show gateway step complete after a gateway is created', () => {
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValueOnce(of([[]]));
+      component.ngOnInit();
+
+      nvmeofServiceSpy.listGatewayGroups.mockReturnValue(of(mockGroups));
+      nvmeofServiceSpy.listSubsystems.mockReturnValue(of([]));
+      nvmeofServiceSpy.listNamespaces.mockReturnValue(of([]));
+
+      emitRefresh();
+
+      expect(component.hasGatewayGroups).toBe(true);
+      expect(component.hasSubsystems).toBe(false);
+      expect(component.hasNamespaces).toBe(false);
+      expect(component.isAllConfigured).toBe(false);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.ts
@@ -1,5 +1,12 @@
-import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Observable, Subject, forkJoin, of } from 'rxjs';
+import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
+
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { CephServiceSpec } from '~/app/shared/models/service.interface';
+import { NvmeofSubsystem, NvmeofSubsystemNamespace } from '~/app/shared/models/nvmeof';
+import { NvmeofStateService } from '../nvmeof-state.service';
 
 const NVMEOF_PATH = 'block/nvmeof';
 
@@ -9,26 +16,191 @@ enum TABS {
   namespaces = 'namespaces'
 }
 
+type SetupState = {
+  hasGatewayGroups: boolean;
+  hasSubsystems: boolean;
+  hasNamespaces: boolean;
+};
+
 @Component({
   selector: 'cd-nvmeof-tabs',
   templateUrl: './nvmeof-tabs.component.html',
   styleUrls: ['./nvmeof-tabs.component.scss'],
   standalone: false
 })
-export class NvmeofTabsComponent implements OnInit {
-  selectedTab: TABS;
+export class NvmeofTabsComponent implements OnInit, OnDestroy {
   activeTab: TABS = TABS.gateways;
+  showTabsShell = true;
+  showSetupCards = false;
+  hasGatewayGroups = false;
+  hasSubsystems = false;
+  hasNamespaces = false;
+  isAllConfigured = false;
+  selectedGatewayGroup: string | null = null;
+  private onboardingDismissed = false;
 
-  constructor(private router: Router) {}
+  private destroy$ = new Subject<void>();
+  private setupStateRefresh$ = new Subject<void>();
 
-  ngOnInit(): void {
-    const currentPath = this.router.url;
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+    private nvmeofService: NvmeofService,
+    private nvmeofStateService: NvmeofStateService
+  ) {}
+
+  private updateActiveTab(currentPath: string): void {
     this.activeTab = Object.values(TABS).find((tab) => currentPath.includes(tab)) || TABS.gateways;
   }
 
+  private updateShellVisibility(currentPath: string): void {
+    const urlTree = this.router.parseUrl(currentPath);
+    const primarySegments =
+      urlTree.root.children['primary']?.segments.map((segment) => segment.path) ?? [];
+    const primaryPath = `/${primarySegments.join('/')}`;
+
+    this.showTabsShell = /^\/block\/nvmeof\/(gateways|subsystems|namespaces)$/.test(primaryPath);
+  }
+
+  private normalizeSubsystemsResponse(response: unknown): NvmeofSubsystem[] {
+    if (Array.isArray(response)) {
+      return response as NvmeofSubsystem[];
+    }
+
+    const subsystems = (response as { subsystems?: NvmeofSubsystem[] } | null)?.subsystems;
+    return Array.isArray(subsystems) ? subsystems : [];
+  }
+
+  private normalizeNamespacesResponse(response: unknown): NvmeofSubsystemNamespace[] {
+    if (Array.isArray(response)) {
+      return response as NvmeofSubsystemNamespace[];
+    }
+
+    const namespaces = (response as { namespaces?: NvmeofSubsystemNamespace[] } | null)?.namespaces;
+    return Array.isArray(namespaces) ? namespaces : [];
+  }
+
+  ngOnInit(): void {
+    this.updateActiveTab(this.router.url);
+    this.updateShellVisibility(this.router.url);
+
+    this.setupStateRefresh$
+      .pipe(
+        switchMap(() => this.fetchSetupState()),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(({ hasGatewayGroups, hasSubsystems, hasNamespaces }) => {
+        this.hasGatewayGroups = hasGatewayGroups;
+        this.hasSubsystems = hasSubsystems;
+        this.hasNamespaces = hasNamespaces;
+        this.isAllConfigured = hasGatewayGroups && hasSubsystems && hasNamespaces;
+        this.showSetupCards = !this.onboardingDismissed;
+      });
+
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((event) => {
+        this.updateActiveTab(event.urlAfterRedirects);
+        this.updateShellVisibility(event.urlAfterRedirects);
+        this.loadSetupState();
+      });
+
+    this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      this.selectedGatewayGroup = params?.['group']?.trim() || null;
+      this.loadSetupState();
+    });
+
+    this.nvmeofStateService.refresh$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.loadSetupState());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private fetchSetupState(): Observable<SetupState> {
+    return this.nvmeofService.listGatewayGroups().pipe(
+      switchMap((gatewayGroups: CephServiceSpec[][]) => {
+        const firstItem = (gatewayGroups as any)?.[0];
+        const rawGroups: CephServiceSpec[] = Array.isArray(firstItem)
+          ? (firstItem as CephServiceSpec[])
+          : Array.isArray(gatewayGroups)
+            ? (gatewayGroups as unknown as CephServiceSpec[])
+            : [];
+        const groups = rawGroups.filter((g: CephServiceSpec) => g?.spec?.group);
+        const hasGatewayGroups = groups.length > 0;
+
+        if (!hasGatewayGroups) {
+          return of({ hasGatewayGroups: false, hasSubsystems: false, hasNamespaces: false });
+        }
+
+        // Empty dropdown selection: keep setup in initial state for steps 2 and 3.
+        if (!this.selectedGatewayGroup) {
+          return of({ hasGatewayGroups, hasSubsystems: false, hasNamespaces: false });
+        }
+
+        const selectedGroupExists = groups.some(
+          (group: CephServiceSpec) => group.spec.group === this.selectedGatewayGroup
+        );
+        if (!selectedGroupExists) {
+          return of({ hasGatewayGroups, hasSubsystems: false, hasNamespaces: false });
+        }
+
+        return forkJoin({
+          subsystemsResponse: this.nvmeofService
+            .listSubsystems(this.selectedGatewayGroup)
+            .pipe(catchError(() => of([]))),
+          namespacesResponse: this.nvmeofService
+            .listNamespaces(this.selectedGatewayGroup)
+            .pipe(catchError(() => of([])))
+        }).pipe(
+          map(
+            ({
+              subsystemsResponse,
+              namespacesResponse
+            }: {
+              subsystemsResponse: unknown;
+              namespacesResponse: unknown;
+            }) => {
+              const subsystems = this.normalizeSubsystemsResponse(subsystemsResponse);
+              const namespaces = this.normalizeNamespacesResponse(namespacesResponse);
+              const totalNamespaces = subsystems.reduce(
+                (sum, s) => sum + (s.namespace_count || 0),
+                0
+              );
+              return {
+                hasGatewayGroups,
+                hasSubsystems: subsystems.length > 0,
+                hasNamespaces: namespaces.length > 0 || totalNamespaces > 0
+              };
+            }
+          ),
+          catchError(() => of({ hasGatewayGroups, hasSubsystems: false, hasNamespaces: false }))
+        );
+      }),
+      catchError(() => of({ hasGatewayGroups: false, hasSubsystems: false, hasNamespaces: false }))
+    );
+  }
+
+  loadSetupState(): void {
+    this.setupStateRefresh$.next();
+  }
+
+  dismissOnboarding(): void {
+    this.onboardingDismissed = true;
+    this.showSetupCards = false;
+  }
+
   onSelected(tab: TABS) {
-    this.selectedTab = tab;
-    this.router.navigate([`${NVMEOF_PATH}/${tab}`]);
+    this.activeTab = tab;
+    this.router.navigate([`${NVMEOF_PATH}/${tab}`], {
+      queryParamsHandling: 'preserve'
+    });
   }
 
   public get Tabs(): typeof TABS {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -41,6 +41,9 @@
     </cds-table-toolbar-actions>
     <!-- end batch actions -->
     <cds-table-toolbar-content>
+      <!-- gateway group / custom filter slot -->
+      <ng-content select=".table-filter"></ng-content>
+      <!-- end custom filter slot -->
       <!-- search -->
       <cds-table-toolbar-search *ngIf="searchField"
                                 [expandable]="false"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -130,6 +130,9 @@ export class TableComponent implements AfterViewInit, OnInit, OnChanges, OnDestr
   // Display search field inside tool header?
   @Input()
   searchField? = true;
+  // Limit toolbar search width (e.g. when a prefix filter is shown).
+  @Input()
+  compactSearchField? = false;
   // Display the table header?
   @Input()
   header? = true;


### PR DESCRIPTION




https://github.com/user-attachments/assets/fe70c385-26f0-4ec1-a146-86a7d3c7d94b






---
Fixes: https://tracker.ceph.com/issues/75684

Signed-off-by: pujaoshahu <pshahu@redhat.com>

---

Summery:

This PR improves the NVMe/TCP dashboard onboarding flow so the setup cards and tab experience stay in sync with gateway group, subsystem, and namespace operations. It also cleans up the shared NVMe/TCP tab shell so list pages keep the onboarding context while create/detail routes render without being incorrectly wrapped by the tab layout.

 Key changes:

-  Added a new NVMe/TCP setup cards component to show first-time setup progress for gateway groups, subsystems, and namespaces.

-  Moved the shared NVMe/TCP tabs/onboarding shell into a common parent flow so the cards persist correctly across Gateways, Subsystems, and Namespaces list pages.
- Hid the shared shell on create/detail routes so forms like Create Namespace no longer render inside the list-page tab container.
- Updated gateway group, subsystem, and namespace list views to work with shared group selection and the new onboarding state model.
- Added refresh handling so the setup cards update after gateway group create/delete, namespace create/delete, and subsystem delete operations.
- Added a gateway-list-driven refresh path so the setup cards also follow the actual rendered gateway list state when the last gateway group is removed.
- Expanded Jest coverage around the shared NVMe/TCP tab shell and related list views to cover onboarding state transitions and refresh behavior.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
