### PR TITLE
src/common/version: Improve logic for handling the vendor version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,15 @@ endif()
 
 set(CEPH_MAN_DIR "share/man" CACHE STRING "Install location for man pages (relative to prefix).")
 
+set(CEPH_VENDOR_VERSION "" CACHE STRING
+  "Vendor-supplied version string written to <datadir>/ceph/vendor_version at install time.  \
+Leave empty (the default) to omit the file entirely.")
+if(CEPH_VENDOR_VERSION)
+  file(WRITE ${CMAKE_BINARY_DIR}/vendor_version "${CEPH_VENDOR_VERSION}\n")
+  install(FILES ${CMAKE_BINARY_DIR}/vendor_version
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/ceph)
+endif()
+
 option(ENABLE_SHARED "build shared libraries" ON)
 if(ENABLE_SHARED)
   set(CEPH_SHARED SHARED)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1477,6 +1477,7 @@ cmake .. \
     -DWITH_BABELTRACE:BOOL=OFF \
 %endif
     $CEPH_EXTRA_CMAKE_ARGS \
+%{?ceph_vendor_version: -DCEPH_VENDOR_VERSION="%{ceph_vendor_version}" \}
 %if 0%{with ocf}
     -DWITH_OCF:BOOL=ON \
 %endif
@@ -1829,6 +1830,7 @@ exit 0
 %{_mandir}/man8/rgw-gap-list.8*
 %{_mandir}/man8/rgw-restore-bucket-index.8*
 %dir %{_datadir}/ceph/
+%{?ceph_vendor_version:%{_datadir}/ceph/vendor_version}
 %{_datadir}/ceph/known_hosts_drop.ceph.com
 %{_datadir}/ceph/id_rsa_drop.ceph.com
 %{_datadir}/ceph/id_rsa_drop.ceph.com.pub

--- a/debian/rules
+++ b/debian/rules
@@ -50,6 +50,9 @@ endif
 ifeq ($(SCCACHE), true)
 extraopts += -DWITH_SCCACHE=ON
 endif
+ifneq ($(CEPH_VENDOR_VERSION),)
+  extraopts += -DCEPH_VENDOR_VERSION=$(CEPH_VENDOR_VERSION)
+endif
 
 ifeq ($(DWZ), false)
 override_dh_dwz:
@@ -82,6 +85,10 @@ override_dh_auto_install:
 	install -D -m 440 sudoers.d/ceph-smartctl $(DESTDIR)/etc/sudoers.d/ceph-smartctl
 	install -D -m 755 src/tools/rbd_nbd/rbd-nbd_quiesce $(DESTDIR)/usr/libexec/rbd-nbd/rbd-nbd_quiesce
 
+	if [ -f $(CURDIR)/obj-$(DEB_HOST_GNU_TYPE)/vendor_version ]; then \
+		install -m 644 -D $(CURDIR)/obj-$(DEB_HOST_GNU_TYPE)/vendor_version \
+			$(DESTDIR)/usr/share/ceph/vendor_version; \
+	fi
 	install -m 644 -D monitoring/ceph-mixin/prometheus_alerts.yml $(DESTDIR)/etc/prometheus/ceph/ceph_default_alerts.yml
 	install -m 644 -D monitoring/ceph-mixin/dashboards_out/* ${DESTDIR}/etc/grafana/dashboards/ceph-dashboard
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,9 @@ include(CheckCXXCompilerFlag)
 # for erasure and compressor plugins
 set(CEPH_INSTALL_PKGLIBDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
 set(CEPH_INSTALL_FULL_PKGLIBDIR ${CMAKE_INSTALL_FULL_LIBDIR}/${PROJECT_NAME})
-# for mgr plugins
+# for mgr plugins and data files (e.g. vendor_version)
 set(CEPH_INSTALL_DATADIR ${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME})
+set(CEPH_INSTALL_FULL_DATADIR ${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME})
 # so libceph-common can be found
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 if(NOT CMAKE_INSTALL_RPATH)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2576,7 +2576,7 @@ void Client::populate_metadata(const std::string &mount_root)
   }
 
   // Ceph version
-  metadata["ceph_version"] = pretty_version_to_str();
+  metadata["ceph_version"] = pretty_version_to_str(cct);
   metadata["ceph_sha1"] = git_version_to_str();
 
   // Apply any metadata from the user's configured overrides

--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -8,12 +8,13 @@
 #include "BackTrace.h"
 #include "common/version.h"
 #include "common/Formatter.h"
+#include "global/global_context.h"  
 
 namespace ceph {
 
 void ClibBackTrace::print(std::ostream& out) const
 {
-  out << " " << pretty_version_to_str() << std::endl;
+  out << " " << pretty_version_to_str(g_ceph_context) << std::endl;
   for (size_t i = skip; i < size; i++) {
     out << " " << (i-skip+1) << ": " << demangle(strings[i]) << std::endl;
   }

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -20,6 +20,7 @@
 #include "common/config.h"
 #include "common/strtol.h" // for strict_strtof()
 #include "common/version.h"
+#include "global/global_context.h" 
 #include "include/str_list.h"
 
 #include <sstream>
@@ -508,7 +509,7 @@ CephInitParameters ceph_argparse_early_args
       break;
     }
     else if (ceph_argparse_flag(args, i, "--version", "-v", (char*)NULL)) {
-      std::cout << pretty_version_to_str() << std::endl;
+      std::cout << pretty_version_to_str(g_ceph_context) << std::endl;
       _exit(0);
     }
     else if (ceph_argparse_witharg(args, i, &val, "--conf", "-c", (char*)NULL)) {

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -16,6 +16,8 @@
 
 #include "common/ceph_context.h"
 
+#include <fstream>
+#include <iterator>
 #include <mutex>
 #include <iostream>
 #include <sstream>
@@ -815,6 +817,50 @@ CephContext::CephContext(uint32_t module_type_,
   _crypto_random.reset(new CryptoRandom());
 
   lookup_or_create_singleton_object<MempoolObs>("mempool_obs", false, this);
+}
+
+void CephContext::set_vendor_version_file(const std::string& path)
+{
+  static constexpr size_t MAX_VENDOR_VERSION_SIZE = 256;
+
+  // Clear the version initially so all failure paths safely default to empty
+  _vendor_version.clear();
+
+  std::ifstream file(path);
+  if (!file) {
+    return;
+  }
+
+  try {
+    // Allocate buffer to read up to MAX + 1 bytes to easily check for overflow
+    std::string content(MAX_VENDOR_VERSION_SIZE + 1, '\0');
+    
+    // Perform a single block read instead of iterating character-by-character
+    file.read(&content[0], content.size());
+    std::streamsize bytes_read = file.gcount();
+
+    // If we read more than the maximum allowed size, reject the file entirely
+    if (bytes_read > MAX_VENDOR_VERSION_SIZE) {
+      return;
+    }
+
+    // Shrink the string down to the actual number of bytes read
+    content.resize(bytes_read);
+
+    // Efficiently find and trim trailing newlines and carriage returns
+    size_t last_valid_char = content.find_last_not_of("\r\n");
+    if (last_valid_char == std::string::npos) {
+      return; // File was empty or contained only linebreaks
+    }
+
+    content.erase(last_valid_char + 1);
+    _vendor_version = " vendor " + content;
+
+  } catch (const std::exception& e) {
+    // If an exception (like std::bad_alloc) occurs, safely exit. 
+    // _vendor_version is already empty.
+    return;
+  }
 }
 
 void CephContext::modify_msgr_hook(

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -99,10 +99,15 @@ public:
   crimson::common::PerfCountersCollection& _perf_counters_collection;
   CephContext* get();
   void put();
+  void set_vendor_version_file(const std::string& path);
+  const std::string& get_vendor_version() const {
+    return _vendor_version;
+  }
 private:
   std::unique_ptr<CryptoRandom> _crypto_random;
   unsigned nref = 1;
   ceph::PluginRegistry* _plugin_registry;
+  std::string _vendor_version;
 };
 }
 #else
@@ -250,6 +255,11 @@ public:
     return _plugin_registry;
   }
 
+  void set_vendor_version_file(const std::string& path);
+  const std::string& get_vendor_version() const {
+    return _vendor_version;
+  }
+
   void set_uid_gid(uid_t u, gid_t g) {
     _set_uid = u;
     _set_gid = g;
@@ -320,6 +330,8 @@ private:
   uint32_t _module_type;
 
   int _init_flags;
+
+  std::string _vendor_version;
 
   uid_t _set_uid; ///< uid to drop privs to
   gid_t _set_gid; ///< gid to drop privs to

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6971,3 +6971,12 @@ options:
   flags:
   - no_mon_update
   - startup
+- name: ceph_vendor_version_file
+  type: str
+  level: advanced
+  desc: File where the vendor version information is fetched from
+  default: /usr/lib/ceph/ceph_vendor_version
+  services:
+  - common
+  flags:
+  - startup

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6980,3 +6980,4 @@ options:
   - common
   flags:
   - startup
+  - no_mon_update

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6975,7 +6975,7 @@ options:
   type: str
   level: advanced
   desc: File where the vendor version information is fetched from
-  default: /usr/lib/ceph/ceph_vendor_version
+  default: @CEPH_INSTALL_FULL_DATADIR@/vendor_version
   services:
   - common
   flags:

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -233,7 +233,7 @@ int get_windows_version(POSVERSIONINFOEXW ver) {
 void collect_sys_info(map<string, string> *m, CephContext *cct)
 {
   // version
-  (*m)["ceph_version"] = pretty_version_to_str();
+  (*m)["ceph_version"] = pretty_version_to_str(cct);
   (*m)["ceph_version_short"] = ceph_version_to_str();
   (*m)["ceph_release"] = ceph_release_to_str();
 

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -28,6 +28,8 @@
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
 
+static std::string g_vendor_version;
+
 const char *ceph_version_to_str()
 {
   char* debug_version_for_testing = getenv("ceph_debug_version_for_testing");
@@ -48,30 +50,33 @@ const char *git_version_to_str(void)
   return STRINGIFY(CEPH_GIT_VER);
 }
 
-static std::string read_vendor_release_file()
+void ceph_set_vendor_version_file(const std::string& path)
 {
-  auto filename = "/etc/ceph_version";
-  std::ifstream file(filename);
-
-  if(!file.is_open()){
-    return "";
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    g_vendor_version.clear();
+    return;
   }
 
   std::string content;
   try {
-    content.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+    content.assign(std::istreambuf_iterator<char>(file),
+                   std::istreambuf_iterator<char>());
   } catch (const std::exception &e) {
-    return "";
+    g_vendor_version.clear();
+    return;
   }
+
+  while (!content.empty() &&
+         (content.back() == '\n' || content.back() == '\r')) {
+    content.pop_back();
+  }
+
   if (!content.empty()) {
-    while (!content.empty() && (content.back() == '\n' || content.back() == '\r')) {
-      content.pop_back();
-    }
-    return std::string(" release ") + content;
+    g_vendor_version = " release " + content;
+  } else {
+    g_vendor_version.clear();
   }
-
-  return "";
-
 }
 
 std::string const pretty_version_to_str(void)
@@ -85,7 +90,7 @@ std::string const pretty_version_to_str(void)
 #ifdef WITH_CRIMSON
       << " (crimson)"
 #endif
-      << read_vendor_release_file()
+      << g_vendor_version
       ;
   return oss.str();
 }

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -29,6 +29,7 @@
 #define STRINGIFY(x) _STR(x)
 
 static std::string g_vendor_version;
+static constexpr size_t MAX_VENDOR_VERSION_SIZE = 256;
 
 const char *ceph_version_to_str()
 {
@@ -60,8 +61,14 @@ void ceph_set_vendor_version_file(const std::string& path)
 
   std::string content;
   try {
-    content.assign(std::istreambuf_iterator<char>(file),
-                   std::istreambuf_iterator<char>());
+    content.reserve(MAX_VENDOR_VERSION_SIZE);
+    for (std::istreambuf_iterator<char> it(file), end; it != end; ++it) {
+      if (content.size() == MAX_VENDOR_VERSION_SIZE) {
+        g_vendor_version.clear();
+        return;
+      }
+      content.push_back(*it);
+    }
   } catch (const std::exception &e) {
     g_vendor_version.clear();
     return;

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -17,19 +17,14 @@
 
 #include <stdlib.h>
 #include <sstream>
-#include <fstream>
 #include <string>
-#include <iterator>
-
 
 #include "ceph_ver.h"
+#include "common/ceph_context.h"
 #include "common/ceph_strings.h"
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
-
-static std::string g_vendor_version;
-static constexpr size_t MAX_VENDOR_VERSION_SIZE = 256;
 
 const char *ceph_version_to_str()
 {
@@ -51,42 +46,7 @@ const char *git_version_to_str(void)
   return STRINGIFY(CEPH_GIT_VER);
 }
 
-void ceph_set_vendor_version_file(const std::string& path)
-{
-  std::ifstream file(path);
-  if (!file.is_open()) {
-    g_vendor_version.clear();
-    return;
-  }
-
-  std::string content;
-  try {
-    content.reserve(MAX_VENDOR_VERSION_SIZE);
-    for (std::istreambuf_iterator<char> it(file), end; it != end; ++it) {
-      if (content.size() == MAX_VENDOR_VERSION_SIZE) {
-        g_vendor_version.clear();
-        return;
-      }
-      content.push_back(*it);
-    }
-  } catch (const std::exception &e) {
-    g_vendor_version.clear();
-    return;
-  }
-
-  while (!content.empty() &&
-         (content.back() == '\n' || content.back() == '\r')) {
-    content.pop_back();
-  }
-
-  if (!content.empty()) {
-    g_vendor_version = " release " + content;
-  } else {
-    g_vendor_version.clear();
-  }
-}
-
-std::string const pretty_version_to_str(void)
+std::string const pretty_version_to_str(CephContext* cct)
 {
   std::ostringstream oss;
   oss << "ceph version " << CEPH_GIT_NICE_VER
@@ -97,7 +57,7 @@ std::string const pretty_version_to_str(void)
 #ifdef WITH_CRIMSON
       << " (crimson)"
 #endif
-      << g_vendor_version
+      << (cct ? cct->get_vendor_version() : "")
       ;
   return oss.str();
 }

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -33,4 +33,8 @@ std::string const pretty_version_to_str(void);
 // Release type ("dev", "rc", or "stable")
 const char *ceph_release_type(void);
 
+// Cache the vendor version string read from the configured file path.
+// Must be called once during CephContext initialization.
+void ceph_set_vendor_version_file(const std::string& path);
+
 #endif

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -17,6 +17,7 @@
 #define CEPH_COMMON_VERSION_H
 
 #include <string>
+#include "include/common_fwd.h"
 
 // Return a string describing the Ceph version
 const char *ceph_version_to_str();
@@ -27,14 +28,11 @@ const char *ceph_release_to_str(void);
 // Return a string describing the git version
 const char *git_version_to_str(void);
 
-// Return a formatted string describing the ceph and git versions
-std::string const pretty_version_to_str(void);
+// Return a formatted string describing the ceph and git versions.
+// If cct is non-null, the vendor version string is appended.
+std::string const pretty_version_to_str(CephContext* cct = nullptr);
 
 // Release type ("dev", "rc", or "stable")
 const char *ceph_release_type(void);
-
-// Cache the vendor version string read from the configured file path.
-// Must be called once during CephContext initialization.
-void ceph_set_vendor_version_file(const std::string& path);
 
 #endif

--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -1089,7 +1089,7 @@ int main(int argc, const char** argv)
 
   switch (cmd) {
     case Command::Version:
-      std::cout << pretty_version_to_str() << std::endl;
+      std::cout << pretty_version_to_str(g_ceph_context) << std::endl;
       return 0;
     case Command::Help:
       print_usage();

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -471,6 +471,9 @@ global_init(const std::map<std::string,std::string> *defaults,
     // cppcheck-suppress memleak
   }
 
+  ceph_set_vendor_version_file(
+    g_conf().get_val<std::string>("ceph_vendor_version_file"));
+
   if (code_env == CODE_ENVIRONMENT_DAEMON && !(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     output_ceph_version();
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -69,7 +69,7 @@ static void output_ceph_version()
 {
   char buf[1024];
   snprintf(buf, sizeof(buf), "%s, process %s, pid %d",
-	   pretty_version_to_str().c_str(),
+	   pretty_version_to_str(g_ceph_context).c_str(),
 	   get_process_name_cpp().c_str(), getpid());
   generic_dout(0) << buf << dendl;
 }
@@ -471,7 +471,7 @@ global_init(const std::map<std::string,std::string> *defaults,
     // cppcheck-suppress memleak
   }
 
-  ceph_set_vendor_version_file(
+  g_ceph_context->set_vendor_version_file(
     g_conf().get_val<std::string>("ceph_vendor_version_file"));
 
   if (code_env == CODE_ENVIRONMENT_DAEMON && !(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -611,7 +611,7 @@ ceph_cluster_log(BaseMgrModule *self, PyObject *args)
 static PyObject *
 ceph_get_version(BaseMgrModule *self, PyObject *args)
 {
-  return PyUnicode_FromString(pretty_version_to_str().c_str());
+  return PyUnicode_FromString(pretty_version_to_str(g_ceph_context).c_str());
 }
 
 static PyObject *

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4093,11 +4093,11 @@ void Monitor::handle_command(MonOpRequestRef op)
   } else if (prefix == "version") {
     if (f) {
       f->open_object_section("version");
-      f->dump_string("version", pretty_version_to_str());
+      f->dump_string("version", pretty_version_to_str(cct));
       f->close_section();
       f->flush(ds);
     } else {
-      ds << pretty_version_to_str();
+      ds << pretty_version_to_str(cct);
     }
     rdata.append(ds);
     rs = "";

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -705,7 +705,7 @@ class MonitorDBStore
   }
 
   int create_and_open(std::ostream &out) {
-    int r = write_meta("ceph_version_when_created", pretty_version_to_str());
+    int r = write_meta("ceph_version_when_created", pretty_version_to_str(g_ceph_context));
     if (r < 0)
       return r;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2326,7 +2326,7 @@ int OSD::write_meta(CephContext *cct, ObjectStore *store, uuid_d& cluster_fsid, 
       return r;
   }
 
-  r = store->write_meta("ceph_version_when_created", pretty_version_to_str());
+  r = store->write_meta("ceph_version_when_created", pretty_version_to_str(cct));
   if (r < 0)
     return r;
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -2363,7 +2363,7 @@ static int rbd_nbd(int argc, const char *argv[])
     usage();
     return 0;
   } else if (r == VERSION_INFO) {
-    std::cout << pretty_version_to_str() << std::endl;
+    std::cout << pretty_version_to_str(g_ceph_context) << std::endl;
     return 0;
   } else if (r < 0) {
     cerr << err_msg.str() << std::endl;

--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -1331,7 +1331,7 @@ static int rbd_wnbd(int argc, const char *argv[])
     usage();
     return 0;
   } else if (r == VERSION_INFO) {
-    std::cout << pretty_version_to_str() << std::endl;
+    std::cout << pretty_version_to_str(g_ceph_context) << std::endl;
     return 0;
   } else if (r < 0) {
     std::cout << err_msg.str() << std::endl;


### PR DESCRIPTION
The PR https://github.com/ceph/ceph/pull/67299 added a feature will allowed vendors to their release version information to the output of the `ceph version(s)` command. As discussed here https://github.com/ceph/ceph/pull/67693, there are some issues with the approach taken in the PR. 

This PR aims at solving them, in this we do the following:
1. `ceph_vendor_version_file` config options has been added, to allow users to decide where to fetch the vendor release information from
2. Instead of open/close-ing the file - the value of the file is now cache during the startup of the cluster. This avoid unnecessary file read calls
3. A sane character limit (256 bytes) is set for reading the file - to avoid any issues.

For reference, the output of the commands looks like the follows:

The version output becomes

```
> ceph version

ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) vendor 8.1.0
```

The same suffix is reflected consistently for `ceph versions`

```
> ceph versions
{
    "mon": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) vendor 8.1.0": 3
    },
    "mgr": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) vendor 8.1.0": 1
    },
    "osd": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) vendor 8.1.0": 3
    },
    "mds": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) vendor 8.1.0": 3
    },
    "overall": {
        "ceph version 8d7daada90 (98d7daada90c6585c6724f69793e804a5e23cb24) tentacle (dev - Debug) vendor 8.1.0": 10
    }
}
```

Fixes: https://tracker.ceph.com/issues/75954

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
