### PR TITLE
crimson/os/seastore: do not treat non-ZNS devices as errors

### DIFF
--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -61,47 +61,41 @@ SegmentManager::get_segment_manager(
 {
 #ifdef HAVE_ZNS
 LOG_PREFIX(SegmentManager::get_segment_manager);
-  return seastar::do_with(
-    static_cast<size_t>(0),
-    [FNAME,
-     dtype,
-     device](auto &nr_zones) {
-      return seastar::open_file_dma(
-	device + "/block",
-	seastar::open_flags::rw
-      ).then([FNAME,
-	      dtype,
-	      device,
-	      &nr_zones](auto file) {
-	return seastar::do_with(
-	  file,
-	  [&nr_zones](auto &f) -> seastar::future<int> {
-	    ceph_assert(f);
-	    return f.ioctl(BLKGETNRZONES, (void *)&nr_zones);
-	  });
-      }).then([FNAME,
-	       dtype,
-	       device,
-	       &nr_zones](auto ret) -> crimson::os::seastore::SegmentManagerRef {
-	crimson::os::seastore::SegmentManagerRef sm;
-	INFO("Found {} zones.", nr_zones);
-	if (nr_zones != 0) {
-	  return std::make_unique<
-	    segment_manager::zbd::ZBDSegmentManager
+  if (dtype == device_type_t::ZBD) {
+    return seastar::do_with(
+      static_cast<size_t>(0),
+      [FNAME, device](auto &nr_zones) {
+	return seastar::open_file_dma(
+	  device + "/block",
+	  seastar::open_flags::rw
+	).then([&nr_zones](auto file) {
+	  return seastar::do_with(
+	    file,
+	    [&nr_zones](auto &f) -> seastar::future<int> {
+	      ceph_assert(f);
+	      return f.ioctl(BLKGETNRZONES, (void *)&nr_zones);
+	    });
+	}).then([FNAME,
+		 device,
+		 &nr_zones](auto ret) -> crimson::os::seastore::SegmentManagerRef {
+	  INFO("Found {} zones.", nr_zones);
+	  if (nr_zones != 0) {
+	    return std::make_unique<
+	      segment_manager::zbd::ZBDSegmentManager
 	    >(device + "/block");
-	} else {
-	  return std::make_unique<
-	    segment_manager::block::BlockSegmentManager
-	    >(device + "/block", dtype);
-	}
+	  } else {
+	    return std::make_unique<
+	      segment_manager::block::BlockSegmentManager
+	    >(device + "/block", device_type_t::ZBD);
+	  }
+	});
       });
-    });
-#else
+  }
+#endif
   return seastar::make_ready_future<crimson::os::seastore::SegmentManagerRef>(
     std::make_unique<
       segment_manager::block::BlockSegmentManager
     >(device + "/block", dtype));
-#endif
 }
 
 }

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -30,23 +30,18 @@ std::ostream& operator<<(std::ostream &out, Segment::segment_state_t s)
 
 seastar::future<crimson::os::seastore::SegmentManagerRef>
 SegmentManager::get_segment_manager(
-  const std::string &device, device_type_t dtype)
+    const std::string& device,
+    device_type_t dtype)
 {
+  const std::string device_block = device + "/block";
 #ifdef HAVE_ZNS
   LOG_PREFIX(SegmentManager::get_segment_manager);
-  auto file = co_await seastar::open_file_dma(
-	device + "/block",
-	seastar::open_flags::rw);
-  ceph_assert(file);
-  uint32_t nr_zones = 0;
-  auto ret = co_await file.ioctl(BLKGETNRZONES, &nr_zones);
-  ceph_assert(ret == 0);
-  INFO("Found {} zones.", nr_zones);
-  if (nr_zones != 0) {
-    co_return std::make_unique<segment_manager::zbd::ZBDSegmentManager>(device + "/block");
+  if (dtype == device_type_t::ZBD) {
+    co_return std::make_unique<segment_manager::zbd::ZBDSegmentManager>(
+        device_block);
   }
 #endif
-  co_return std::make_unique<segment_manager::block::BlockSegmentManager>(device + "/block", dtype);
+  co_return std::make_unique<segment_manager::block::BlockSegmentManager>(
+      device_block, dtype);
 }
-
 } // namespace crimson::os::seastore


### PR DESCRIPTION
in SegmentManager::get_segment_manager(). 

And do not try to parse the ZNS segments out of non-ZNSes.

Note - without this change, OSD built with WITH_ZNS fail to start.
