### PR TITLE
cls: return EIO instead of ceph::from_error_code()

### DIFF
--- a/src/cls/sem_set/module.cc
+++ b/src/cls/sem_set/module.cc
@@ -259,7 +259,7 @@ int list(cls_method_context_t hctx, buffer::list *in, buffer::list *out)
     } catch (const sys::system_error& e) {
       CLS_ERR("CAN'T HAPPEN: %s: failed to decode seamaphore: %s",
 	      __PRETTY_FUNCTION__, e.what());
-      return ceph::from_error_code(e.code());;
+      return -EIO;
     }
     if (!more) {
       res.cursor.clear();


### PR DESCRIPTION
In `cls/sem_set/module.cc`, the list() function's catch block
called `ceph::from_error_code(e.code())`, but
the symbol was unresolved in some build configurations.
