### PR TITLE
ceph.spec: declare PyYAML and Jinja2 Requires for cephadm RPM

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -558,13 +558,39 @@ Requires:       which
 %if 0%{?weak_deps}
 Recommends:     podman >= 2.0.2
 %endif
+# Cephadm zipapp: CMake sets CEPHADM_BUNDLED_DEPENDENCIES to pip, rpm, or none
+# (see build / cmake block below):
+#  - with cephadm_bundling, with cephadm_pip_deps: pip at build, no stanzas here
+#  - with cephadm_bundling, without cephadm_pip_deps: build-time RPM deps only
+#  - without cephadm_bundling: unbundled cephadm, runtime Requires for yaml/jinja2
+# CentOS Storage SIG #75389 needs the unbundled branch (--without cephadm_bundling)
+# after dropping downstream patch 0036; pip-mode SIG builds are a separate SIG fix.
 %if 0%{with cephadm_bundling}
 %if 0%{without cephadm_pip_deps}
-BuildRequires: python3-jinja2 >= 2.10
-%endif
+# Zipapp built from system RPMs at build time; bundled zipapp is self-contained at runtime.
+# SUSE and RHEL/Fedora use different PyPI RPM names (Jinja2/PyYAML vs jinja2/pyyaml).
+%if 0%{?suse_version}
+BuildRequires: python%{python3_pkgversion}-Jinja2 >= 2.10
+BuildRequires: python%{python3_pkgversion}-PyYAML
 %else
-Requires: python3-jinja2 >= 2.10
+BuildRequires: python%{python3_pkgversion}-jinja2 >= 2.10
+BuildRequires: python%{python3_pkgversion}-pyyaml
 %endif
+%dnl suse/else: rpm bundle, distinct RPM names only (not duplicate stanzas)
+%endif
+%dnl end without cephadm_pip_deps (CEPHADM_BUNDLED_DEPENDENCIES=rpm)
+%else
+# Unbundled cephadm: host must provide yaml and jinja2 at runtime.
+%if 0%{?suse_version}
+Requires: python%{python3_pkgversion}-Jinja2 >= 2.10
+Requires: python%{python3_pkgversion}-PyYAML
+%else
+Requires: python%{python3_pkgversion}-jinja2 >= 2.10
+Requires: python%{python3_pkgversion}-pyyaml
+%endif
+%dnl suse/else: unbundled cephadm (CEPHADM_BUNDLED_DEPENDENCIES=none)
+%endif
+%dnl end with cephadm_bundling
 %description -n cephadm
 Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed
 with systemd and podman.


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75389
Signed-off-by: Kobi Ginon <kginon@redhat.com>
**Jenkins Job Link**
https://shaman.ceph.com/builds/ceph/issue-75389-yaml-and-jinja2-deps-on-centos-distro/
https://jenkins.ceph.com/job/ceph-dev-pipeline/4827/


cephadm's zipapp imports yaml and jinja2. When the package is built with cephadm_bundling and RPM-sourced deps (--without cephadm_pip_deps), only BuildRequires were listed for jinja2 and no runtime Requires were declared for PyYAML or Jinja2, so minimal "dnf install cephadm" could fail with ModuleNotFoundError. The unbundled cephadm case also lacked PyYAML.

Add matching BuildRequires/Requires in the rpm-bundle branch and Requires (plus SUSE naming for Jinja2/PyYAML) in the no-bundle branch.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
