### PR TITLE
tentacle: mgr/dashboard: Add port and secure-listeners to subsystem add NVMeoF CLI command

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -235,6 +235,9 @@ else:
                 "dhchap_key": Param(str, "Subsystem DH-HMAC-CHAP key", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "network_mask": Param([str],
+                                      "Network mask to automatically create listeners",
+                                      True, None),
             },
         )
         @convert_to_model(model.SubsystemStatus)
@@ -242,13 +245,14 @@ else:
         def create(self, nqn: str, enable_ha: Optional[bool] = True,
                    max_namespaces: Optional[int] = None, no_group_append: Optional[bool] = False,
                    serial_number: Optional[str] = None, dhchap_key: Optional[str] = None,
-                   gw_group: Optional[str] = None, traddr: Optional[str] = None):
+                   gw_group: Optional[str] = None, traddr: Optional[str] = None,
+                   network_mask: Optional[List[str]] = None):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
                     subsystem_nqn=nqn, serial_number=serial_number,
                     max_namespaces=max_namespaces, enable_ha=enable_ha,
                     no_group_append=no_group_append,
-                    dhchap_key=dhchap_key
+                    dhchap_key=dhchap_key, network_mask=network_mask,
                 )
             )
 
@@ -310,6 +314,62 @@ else:
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.change_subsystem_key(
                 NVMeoFClient.pb2.change_subsystem_key_req(
                     subsystem_nqn=nqn, dhchap_key=None
+                )
+            )
+
+        @empty_response
+        @NvmeofCLICommand(
+            "nvmeof subsystem add_network", model.RequestStatus,
+            success_message_template=("Adding network mask {network_mask} for subsystem "
+                                      "{nqn}: Successful")
+        )
+        @EndpointDoc(
+            "Add subsystem network mask",
+            parameters={
+                "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "network_mask": Param(str, "Network mask to add"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "traddr": Param(str, "NVMeoF gateway address", True, None),
+            },
+        )
+        @convert_to_model(model.RequestStatus)
+        @handle_nvmeof_error
+        def add_network(self, nqn: str, network_mask: str, gw_group: Optional[str] = None,
+                        traddr: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                traddr=traddr
+            ).stub.add_subsystem_network(
+                NVMeoFClient.pb2.add_subsystem_network_req(
+                    subsystem_nqn=nqn, network_mask=network_mask
+                )
+            )
+
+        @empty_response
+        @NvmeofCLICommand(
+            "nvmeof subsystem del_network", model.RequestStatus,
+            success_message_template=("Deleting network mask {network_mask} for subsystem "
+                                      "{nqn}: Successful")
+        )
+        @EndpointDoc(
+            "Delete subsystem network mask",
+            parameters={
+                "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "network_mask": Param(str, "Network mask to remove"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "traddr": Param(str, "NVMeoF gateway address", True, None),
+            },
+        )
+        @convert_to_model(model.RequestStatus)
+        @handle_nvmeof_error
+        def del_network(self, nqn: str, network_mask: str, gw_group: Optional[str] = None,
+                        traddr: Optional[str] = None):
+            return NVMeoFClient(
+                gw_group=gw_group,
+                traddr=traddr
+            ).stub.del_subsystem_network(
+                NVMeoFClient.pb2.del_subsystem_network_req(
+                    subsystem_nqn=nqn, network_mask=network_mask
                 )
             )
 

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -326,8 +326,6 @@ else:
         @empty_response
         @NvmeofCLICommand(
             "nvmeof subsystem add_network", model.RequestStatus,
-            success_message_template=("Adding network mask {network_mask} for subsystem "
-                                      "{nqn}: Successful")
         )
         @EndpointDoc(
             "Add subsystem network mask",
@@ -354,8 +352,6 @@ else:
         @empty_response
         @NvmeofCLICommand(
             "nvmeof subsystem del_network", model.RequestStatus,
-            success_message_template=("Deleting network mask {network_mask} for subsystem "
-                                      "{nqn}: Successful")
         )
         @EndpointDoc(
             "Delete subsystem network mask",

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -238,6 +238,10 @@ else:
                 "network_mask": Param([str],
                                       "Network mask to automatically create listeners",
                                       True, None),
+                "port": Param(int, "Port to use for the created listeners", True, None),
+                "secure_listeners": Param(bool,
+                                          "Make all the auto-listeners for this subsystem secure",
+                                          True, False),
             },
         )
         @convert_to_model(model.SubsystemStatus)
@@ -246,13 +250,15 @@ else:
                    max_namespaces: Optional[int] = None, no_group_append: Optional[bool] = False,
                    serial_number: Optional[str] = None, dhchap_key: Optional[str] = None,
                    gw_group: Optional[str] = None, traddr: Optional[str] = None,
-                   network_mask: Optional[List[str]] = None):
+                   network_mask: Optional[List[str]] = None,
+                   port: Optional[int] = None, secure_listeners: Optional[bool] = False):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
                     subsystem_nqn=nqn, serial_number=serial_number,
                     max_namespaces=max_namespaces, enable_ha=enable_ha,
                     no_group_append=no_group_append,
                     dhchap_key=dhchap_key, network_mask=network_mask,
+                    port=port, secure_listeners=secure_listeners
                 )
             )
 

--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -85,6 +85,7 @@ class Subsystem(NamedTuple):
     has_dhchap_key: bool
     allow_any_host: bool
     created_without_key: bool = False
+    network_mask: Annotated[List[str], CliFieldTransformer(lambda v: "\n".join(v))] = []
 
 
 class SubsystemList(NamedTuple):

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9748,6 +9748,11 @@ paths:
                 max_namespaces:
                   description: Maximum number of namespaces
                   type: integer
+                network_mask:
+                  description: Network mask to automatically create listeners
+                  items:
+                    type: string
+                  type: array
                 no_group_append:
                   default: false
                   description: Do not append gateway group name to the NQN

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9760,6 +9760,13 @@ paths:
                 nqn:
                   description: NVMeoF subsystem NQN
                   type: string
+                port:
+                  description: Port to use for the created listeners
+                  type: integer
+                secure_listeners:
+                  default: false
+                  description: Make all the auto-listeners for this subsystem secure
+                  type: boolean
                 serial_number:
                   description: Subsystem serial number
                   type: string


### PR DESCRIPTION
This PR is backport of these two main PRs (in order):
1. https://github.com/ceph/ceph/pull/67766
2. https://github.com/ceph/ceph/pull/68363

(68363 is dependent on 67766 - so it makes sense to take them together.)

backport tracker: https://tracker.ceph.com/issues/76005

---

backport of https://github.com/ceph/ceph/pull/68363
parent tracker: https://tracker.ceph.com/issues/75998

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh