### PR TITLE
squid: mgr/volumes: fix bugs related missing UUID dir from a subvol

### DIFF
--- a/qa/suites/fs/volumes/tasks/volumes/test/basic.yaml
+++ b/qa/suites/fs/volumes/tasks/volumes/test/basic.yaml
@@ -5,4 +5,5 @@ tasks:
         - tasks.cephfs.test_volumes.TestVolumes
         - tasks.cephfs.test_volumes.TestSubvolumeGroups
         - tasks.cephfs.test_volumes.TestSubvolumes
+        - tasks.cephfs.test_volumes.TestCorruptedSubvolumes
         - tasks.cephfs.test_subvolume

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -8810,3 +8810,23 @@ class TestCorruptedSubvolumes(TestVolumesHelper):
                               retval=errno.ENOENT,
                               errmsgs='mount path missing for subvolume')
         self.run_ceph_cmd(f'fs subvolume rm {self.volname} {sv1} --force')
+
+    def test_rm_subvol_that_has_snap_and_missing__UUID_dir(self):
+        sv1 = 'sv1'
+        ss1 = 'ss1'
+
+        self.run_ceph_cmd(f'fs subvolume create {self.volname} {sv1}')
+        self.run_ceph_cmd(f'fs subvolume snapshot create {self.volname} {sv1} {ss1}')
+
+        sv_path = self.get_ceph_cmd_stdout('fs subvolume getpath '
+                                           f'{self.volname} {sv1}').strip()[1:]
+        self.mount_a.run_shell(f'sudo rmdir {sv_path}', omit_sudo=False)
+
+        self.negtest_ceph_cmd(f'fs subvolume snapshot rm {self.volname} {sv1} {ss1}',
+                              retval=errno.ENOENT,
+                              errmsgs='mount path missing for subvolume')
+        self.run_ceph_cmd(f'fs subvolume snapshot rm {self.volname} {sv1} {ss1} '
+                           '--force')
+
+        # cleanup
+        self.run_ceph_cmd(f'fs subvolume rm {self.volname} {sv1} --force')

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -8830,3 +8830,26 @@ class TestCorruptedSubvolumes(TestVolumesHelper):
 
         # cleanup
         self.run_ceph_cmd(f'fs subvolume rm {self.volname} {sv1} --force')
+
+    def test_clone_when_src_subvol_has_missing_UUID_dir(self):
+        sv1 = 'sv1'
+        ss1 = 'ss1'
+        c1 = 'c1'
+
+        self.run_ceph_cmd(f'fs subvolume create {self.volname} {sv1}')
+        sv_path = self.get_ceph_cmd_stdout('fs subvolume getpath '
+                                           f'{self.volname} {sv1}').strip()
+        sv_path = sv_path[1:]
+        self.run_ceph_cmd(f'fs subvolume snapshot create {self.volname} {sv1} {ss1}')
+        self.run_ceph_cmd('config set mgr mgr/volumes/snapshot_clone_delay 2')
+        self.run_ceph_cmd(f'fs subvolume snapshot clone {self.volname} {sv1} {ss1} {c1}')
+
+        self.mount_a.run_shell(f'sudo rmdir {sv_path}', omit_sudo=False)
+
+        time.sleep(2)
+        self._wait_for_clone_to_fail(c1, timo=20)
+
+        # cleanup
+        self.run_ceph_cmd(f'fs subvolume snapshot rm {self.volname} {sv1} {ss1} '
+                           '--force')
+        self.run_ceph_cmd(f'fs subvolume rm {self.volname} {sv1} --force')

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -8789,3 +8789,24 @@ class TestPerModuleFinsherThread(TestVolumesHelper):
 
         # verify trash dir is clean
         self._wait_for_trash_empty()
+
+class TestCorruptedSubvolumes(TestVolumesHelper):
+    '''
+    Test that certain cases like subvolume deletion and clone cancellations and
+    deletions are handled well on a corrupted subvolume as well.
+    '''
+
+    def test_rm_subvol_with_missing_UUID_dir(self):
+        sv1 = 'sv1'
+
+        self.run_ceph_cmd(f'fs subvolume create {self.volname} {sv1}')
+
+        sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {self.volname} '
+                                           f'{sv1}').strip()[1:]
+        sv_path = os.path.join(self.mount_a.hostfs_mntpt, sv_path)
+        self.mount_a.run_shell(f'sudo rmdir {sv_path}', omit_sudo=False)
+
+        self.negtest_ceph_cmd(f'fs subvolume rm {self.volname} {sv1}',
+                              retval=errno.ENOENT,
+                              errmsgs='mount path missing for subvolume')
+        self.run_ceph_cmd(f'fs subvolume rm {self.volname} {sv1} --force')

--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -213,12 +213,12 @@ def do_clone(fs_client, volspec, volname, groupname, subvolname, should_cancel):
             set_quota_on_clone(fs_handle, (subvol0, subvol1, subvol2))
 
 def update_clone_failure_status(fs_client, volspec, volname, groupname, subvolname, ve):
-    with open_clone_subvol_pair_in_vol(fs_client, volspec, volname, groupname,
-            subvolname, lockless=False) as (subvol0, subvol1, subvol2):
+    with open_at_volume(fs_client, volspec, volname, groupname, subvolname,
+                        SubvolumeOpType.CLONE_INTERNAL) as clone:
         if ve.errno == -errno.EINTR:
-            subvol0.add_clone_failure(-ve.errno, "user interrupted clone operation")
+            clone.add_clone_failure(-ve.errno, "user interrupted clone operation")
         else:
-            subvol0.add_clone_failure(-ve.errno, ve.error_str)
+            clone.add_clone_failure(-ve.errno, ve.error_str)
 
 def log_clone_failure(volname, groupname, subvolname, ve):
     if ve.errno == -errno.EINTR:
@@ -246,7 +246,7 @@ def handle_clone_failed(fs_client, volspec, volname, index, groupname, subvolnam
     try:
         # detach source but leave the clone section intact for later inspection
         with open_clone_subvol_pair_in_vol(fs_client, volspec, volname, groupname,
-                subvolname) as (subvol0, subvol1, subvol2):
+                subvolname, failed=True) as (subvol0, subvol1, subvol2):
             subvol1.detach_snapshot(subvol2, index)
     except (MetadataMgrException, VolumeException) as e:
         log.error("failed to detach clone from snapshot: {0}".format(e))

--- a/src/pybind/mgr/volumes/fs/operations/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/operations/subvolume.py
@@ -99,7 +99,8 @@ def open_subvol_in_group(mgr, vol_handle, vol_spec, group_name, subvol_name,
 
 @contextmanager
 def open_clone_subvol_pair_in_vol(vc, vol_spec, vol_name, group_name,
-                                  subvol_name, lockless=False):
+                                  subvol_name, lockless=False, failed=False):
+
     with open_subvol_in_vol(vc, vol_spec, vol_name, group_name, subvol_name,
                             SubvolumeOpType.CLONE_INTERNAL, lockless) \
                             as (vol_handle, _, dst_subvol):
@@ -110,9 +111,14 @@ def open_clone_subvol_pair_in_vol(vc, vol_spec, vol_name, group_name,
             # use the same subvolume to avoid metadata overwrites
             yield (dst_subvol, dst_subvol, src_snap_name)
         else:
+            if failed:
+                op_type = SubvolumeOpType.CLONE_FAILED
+            else:
+                op_type = SubvolumeOpType.CLONE_SOURCE
+
             with open_subvol_in_group(vc.mgr, vol_handle, vol_spec,
                                       src_group_name, src_subvol_name,
-                                      SubvolumeOpType.CLONE_SOURCE) \
+                                      op_type) \
                                       as src_subvol:
                 yield (dst_subvol, src_subvol, src_snap_name)
 

--- a/src/pybind/mgr/volumes/fs/operations/template.py
+++ b/src/pybind/mgr/volumes/fs/operations/template.py
@@ -48,6 +48,7 @@ class SubvolumeOpType(Enum):
     RESIZE                = 'resize'
     SNAP_CREATE           = 'snap-create'
     SNAP_REMOVE           = 'snap-rm'
+    SNAP_REMOVE_FORCE     = 'snap-rm-force'
     SNAP_LIST             = 'snap-ls'
     SNAP_GETPATH          = 'snap-getpath'
     SNAP_INFO             = 'snap-info'

--- a/src/pybind/mgr/volumes/fs/operations/template.py
+++ b/src/pybind/mgr/volumes/fs/operations/template.py
@@ -58,6 +58,7 @@ class SubvolumeOpType(Enum):
     CLONE_CREATE          = 'clone-create'
     CLONE_STATUS          = 'clone-status'
     CLONE_CANCEL          = 'clone-cancel'
+    CLONE_FAILED          = 'clone-failed'
     CLONE_INTERNAL        = 'clone_internal'
     ALLOW_ACCESS          = 'allow-access'
     DENY_ACCESS           = 'deny-access'

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -279,6 +279,7 @@ class SubvolumeV2(SubvolumeV1):
                 SubvolumeOpType.LIST,
                 SubvolumeOpType.INFO,
                 SubvolumeOpType.SNAP_REMOVE,
+                SubvolumeOpType.SNAP_REMOVE_FORCE,
                 SubvolumeOpType.SNAP_LIST,
                 SubvolumeOpType.SNAP_GETPATH,
                 SubvolumeOpType.SNAP_INFO,
@@ -334,7 +335,7 @@ class SubvolumeV2(SubvolumeV1):
                 raise VolumeException(-errno.ENOENT, "subvolume '{0}' does not exist".format(self.subvolname))
             raise VolumeException(me.args[0], me.args[1])
         except cephfs.ObjectNotFound:
-            if op_type == SubvolumeOpType.REMOVE_FORCE:
+            if op_type in (SubvolumeOpType.REMOVE_FORCE, SubvolumeOpType.SNAP_REMOVE_FORCE):
                 log.debug("since --force is passed, ignoring missing subvolume '"
                           f"path '{subvol_path}' for subvolume "
                           f"{self.subvolname}'")

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -285,7 +285,8 @@ class SubvolumeV2(SubvolumeV1):
                 SubvolumeOpType.SNAP_INFO,
                 SubvolumeOpType.SNAP_PROTECT,
                 SubvolumeOpType.SNAP_UNPROTECT,
-                SubvolumeOpType.CLONE_SOURCE
+                SubvolumeOpType.CLONE_SOURCE,
+                SubvolumeOpType.CLONE_FAILED
             }
 
         return {SubvolumeOpType.REMOVE_FORCE,
@@ -293,7 +294,8 @@ class SubvolumeV2(SubvolumeV1):
                 SubvolumeOpType.CLONE_STATUS,
                 SubvolumeOpType.CLONE_CANCEL,
                 SubvolumeOpType.CLONE_INTERNAL,
-                SubvolumeOpType.CLONE_SOURCE}
+                SubvolumeOpType.CLONE_SOURCE,
+                SubvolumeOpType.CLONE_FAILED}
 
     def open(self, op_type):
         if not isinstance(op_type, SubvolumeOpType):
@@ -339,6 +341,11 @@ class SubvolumeV2(SubvolumeV1):
                 log.debug("since --force is passed, ignoring missing subvolume '"
                           f"path '{subvol_path}' for subvolume "
                           f"{self.subvolname}'")
+                return
+            elif op_type == SubvolumeOpType.CLONE_FAILED:
+                log.debug('since clone failed, letting that register in .meta '
+                          'file and ignoring missing subvolume path '
+                          f'{subvol_path} for subvolume {self.subvolname}')
                 return
             log.debug("missing subvolume path '{0}' for subvolume '{1}'".format(subvol_path, self.subvolname))
             raise VolumeException(-errno.ENOENT, "mount path missing for subvolume '{0}'".format(self.subvolname))

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -334,6 +334,11 @@ class SubvolumeV2(SubvolumeV1):
                 raise VolumeException(-errno.ENOENT, "subvolume '{0}' does not exist".format(self.subvolname))
             raise VolumeException(me.args[0], me.args[1])
         except cephfs.ObjectNotFound:
+            if op_type == SubvolumeOpType.REMOVE_FORCE:
+                log.debug("since --force is passed, ignoring missing subvolume '"
+                          f"path '{subvol_path}' for subvolume "
+                          f"{self.subvolname}'")
+                return
             log.debug("missing subvolume path '{0}' for subvolume '{1}'".format(subvol_path, self.subvolname))
             raise VolumeException(-errno.ENOENT, "mount path missing for subvolume '{0}'".format(self.subvolname))
         except cephfs.Error as e:

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -749,7 +749,8 @@ class VolumeClient(CephfsClient["Module"]):
         try:
             with open_volume(self, volname) as fs_handle:
                 with open_group(fs_handle, self.volspec, groupname) as group:
-                    with open_subvol(self.mgr, fs_handle, self.volspec, group, subvolname, SubvolumeOpType.SNAP_REMOVE) as subvolume:
+                    op = SubvolumeOpType.SNAP_REMOVE_FORCE if force else SubvolumeOpType.SNAP_REMOVE
+                    with open_subvol(self.mgr, fs_handle, self.volspec, group, subvolname, op) as subvolume:
                         subvolume.remove_snapshot(snapname, force)
         except VolumeException as ve:
             # ESTALE serves as an error to state that subvolume is currently stale due to internal removal and,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76035
backport tracker: https://tracker.ceph.com/issues/77034

---

backport of https://github.com/ceph/ceph/pull/65467
backport of https://github.com/ceph/ceph/pull/68351
parent tracker: https://tracker.ceph.com/issues/72955
parent tracker: https://tracker.ceph.com/issues/72956

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh