### PR TITLE
rgw: hide storage class from s3 clients

### DIFF
--- a/doc/releases/tentacle.rst
+++ b/doc/releases/tentacle.rst
@@ -70,6 +70,8 @@ Configuration Changes
 
 * ``nvmeof_mon_client_tick_period``: The default beacon tick interval has been lowered from 2 seconds to 1 second.
 
+* ``rgw_override_return_storage_class``: New advanced RGW option that overrides the storage class value reported in read responses (HEAD/GET object headers and ListObjects output). When set, all storage class values returned to clients are replaced with the configured string, regardless of the actual storage class stored in object metadata. Useful for hiding internal or automatic storage class names from S3 clients.
+
 
 Changelog
 ---------

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -396,6 +396,14 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_override_return_storage_class
+  type: str
+  level: advanced
+  desc: Override the storage class reported on read responses (HEAD/GET headers and ListObjects responses)
+  default:
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_relaxed_region_enforcement
   type: bool
   level: advanced

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -371,6 +371,19 @@ inline bool str_has_cntrl(const char* s) {
   return str_has_cntrl(_s);
 }
 
+static std::string get_override_return_storage_class(
+    req_state* s,
+    const std::string& storage_class)
+{
+  const auto& configured_storage_class = s->cct->_conf->rgw_override_return_storage_class;
+  if (!configured_storage_class.empty()) {
+    ldpp_dout(s, 20) << "overriding storage class: " << storage_class
+                     << " -> " << configured_storage_class << dendl;
+    return configured_storage_class;
+  }
+  return storage_class;
+}
+
 // remove any aws-chunked entries from the comma-separated list
 static std::string content_encoding_without_aws_chunked(std::string_view value)
 {
@@ -745,6 +758,12 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
   }
 
 done:
+  {
+    const auto storage_class_iter = response_attrs.find("X-Amz-Storage-Class");
+    if (storage_class_iter != response_attrs.end()) {
+      storage_class_iter->second = get_override_return_storage_class(s, storage_class_iter->second);
+    }
+  }
   for (riter = response_attrs.begin(); riter != response_attrs.end();
        ++riter) {
     dump_header(s, riter->first, riter->second);
@@ -1998,7 +2017,8 @@ void RGWListBucket_ObjStore_S3::send_versioned_response()
         s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
         s->formatter->dump_int("Size", iter->meta.accounted_size);
         auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
-        s->formatter->dump_string("StorageClass", storage_class.c_str());
+        auto effective_storage_class = get_override_return_storage_class(s, storage_class);
+        s->formatter->dump_string("StorageClass", effective_storage_class.c_str());
       }
       dump_owner(s, iter->meta.owner, iter->meta.owner_display_name);
       if (iter->meta.appendable) {
@@ -2090,7 +2110,8 @@ void RGWListBucket_ObjStore_S3::send_response()
       s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
       s->formatter->dump_int("Size", iter->meta.accounted_size);
       auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
-      s->formatter->dump_string("StorageClass", storage_class.c_str());
+      auto effective_storage_class = get_override_return_storage_class(s, storage_class);
+      s->formatter->dump_string("StorageClass", effective_storage_class.c_str());
       dump_owner(s, iter->meta.owner, iter->meta.owner_display_name);
       if (s->system_request) {
 	s->formatter->dump_string("RgwxTag", iter->tag);
@@ -2165,7 +2186,8 @@ void RGWListBucket_ObjStore_S3v2::send_versioned_response()
         s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
         s->formatter->dump_int("Size", iter->meta.accounted_size);
         auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
-        s->formatter->dump_string("StorageClass", storage_class.c_str());
+        auto effective_storage_class = get_override_return_storage_class(s, storage_class);
+        s->formatter->dump_string("StorageClass", effective_storage_class.c_str());
       }
       if (fetchOwner == true) {
         dump_owner(s, iter->meta.owner, iter->meta.owner_display_name);
@@ -2234,7 +2256,8 @@ void RGWListBucket_ObjStore_S3v2::send_response()
       s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
       s->formatter->dump_int("Size", iter->meta.accounted_size);
       auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
-      s->formatter->dump_string("StorageClass", storage_class.c_str());
+      auto effective_storage_class = get_override_return_storage_class(s, storage_class);
+      s->formatter->dump_string("StorageClass", effective_storage_class.c_str());
       if (fetchOwner == true) {
         dump_owner(s, iter->meta.owner, iter->meta.owner_display_name);
       }
@@ -4181,11 +4204,8 @@ void RGWGetObjAttrs_ObjStore_S3::send_response()
 
     if (requested_attributes & as_flag(ReqAttributes::StorageClass)) {
       auto iter = attrs.find(RGW_ATTR_STORAGE_CLASS);
-      if (iter != attrs.end()) {
-	s->formatter->dump_string("StorageClass", iter->second.to_str());
-      } else {
-	s->formatter->dump_string("StorageClass", "STANDARD");
-      }
+      std::string storage_class = (iter != attrs.end()) ? iter->second.to_str() : "STANDARD";
+      s->formatter->dump_string("StorageClass", get_override_return_storage_class(s, storage_class).c_str());
     }
     s->formatter->close_section();
   } /* op_ret == 0 */
@@ -4803,7 +4823,7 @@ void RGWListMultipart_ObjStore_S3::send_response()
     s->formatter->dump_string("Bucket", s->bucket_name);
     s->formatter->dump_string("Key", s->object->get_name());
     s->formatter->dump_string("UploadId", upload_id);
-    s->formatter->dump_string("StorageClass", placement->get_storage_class());
+    s->formatter->dump_string("StorageClass", get_override_return_storage_class(s, placement->get_storage_class()).c_str());
     s->formatter->dump_int("PartNumberMarker", marker);
     s->formatter->dump_int("NextPartNumberMarker", cur_max);
     s->formatter->dump_int("MaxParts", max_parts);
@@ -4882,7 +4902,7 @@ void RGWListBucketMultiparts_ObjStore_S3::send_response()
       const ACLOwner& owner = upload->get_owner();
       dump_owner(s, owner.id, owner.display_name, "Initiator");
       dump_owner(s, owner.id, owner.display_name); // Owner
-      s->formatter->dump_string("StorageClass", "STANDARD");
+      s->formatter->dump_string("StorageClass", get_override_return_storage_class(s, "STANDARD").c_str());
       dump_time(s, "Initiated", upload->get_mtime());
       s->formatter->close_section();
     }


### PR DESCRIPTION
This adds an optional storage class parameter to RGWRados::rewrite_obj(), allowing radosgw-admin to rewrite objects into a specific storage class rather than always using the bucket's default placement.

The implementation reads the object's current storage class and preserves it if --storage-class is not specified. If --storage-class is provided, the object is rewritten to that storage class.

The destination placement rule is built by inheriting from the bucket's placement rule and then applying the storage class override if specified. It also validates the resulting placement before performing the rewrite.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
