### PR TITLE
rgw: fix an issue with bi get not honoring plain BI instance id

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -364,6 +364,23 @@ static std::string cls_rgw_after_versions(const std::string& key)
   return key + '\1'; // suffix "\1" sorts after suffixes like "\0v123\0iabc"
 }
 
+static void encode_obj_index_plain_key(const cls_rgw_obj_key& key, uint64_t ver_epoch, string *index_key)
+{
+  *index_key = key.name;
+  if (key.instance.empty()) {
+    return;
+  }
+
+  string ver_delim("\0v", 2);
+  string inst_delim("\0i", 2);
+  index_key->append(ver_delim);
+  string str_epoch;
+  decreasing_str(ver_epoch, &str_epoch);
+  index_key->append(str_epoch);
+  index_key->append(inst_delim);
+  index_key->append(key.instance);
+}
+
 static void encode_obj_versioned_data_key(const cls_rgw_obj_key& key,
 					  std::string* index_key,
 					  bool append_delete_marker_suffix = false)
@@ -1652,7 +1669,7 @@ public:
     return true;
   }
 
-  uint64_t get_epoch() {
+  uint64_t get_epoch() const {
     return olh_data_entry.epoch;
   }
 
@@ -1660,7 +1677,7 @@ public:
     return olh_data_entry;
   }
 
-  void update(cls_rgw_obj_key& key, bool delete_marker) {
+  void update(const cls_rgw_obj_key& key, bool delete_marker) {
     olh_data_entry.delete_marker = delete_marker;
     olh_data_entry.key = key;
   }
@@ -1683,19 +1700,19 @@ public:
     update_olh_log(olh_data_entry, op, op_tag, key, delete_marker, epoch);
   }
 
-  bool exists() { return olh_data_entry.exists; }
+  bool exists() const { return olh_data_entry.exists; }
 
   void set_exists(bool exists) {
     olh_data_entry.exists = exists;
   }
 
-  bool pending_removal() { return olh_data_entry.pending_removal; }
+  bool pending_removal() const { return olh_data_entry.pending_removal; }
 
   void set_pending_removal(bool pending_removal) {
     olh_data_entry.pending_removal = pending_removal;
   }
 
-  const string& get_tag() { return olh_data_entry.tag; }
+  const string& get_tag() const { return olh_data_entry.tag; }
   void set_tag(const string& tag) {
     olh_data_entry.tag = tag;
   }
@@ -2825,7 +2842,23 @@ static int rgw_bi_get_op(cls_method_context_t hctx, bufferlist *in, bufferlist *
 
   switch (op.type) {
     case BIIndexType::Plain:
-      idx = op.key.name;
+      if (!op.key.instance.empty()) {
+        // we need to obtain the instance BI entry for the key first - so we can
+        // get a hold of the versioned_epoch which is necessary to build the idx
+        // string for the plain entry with non-empty instance string;
+        string obj_index_key;
+        encode_obj_versioned_data_key(op.key, &obj_index_key);
+        rgw_bucket_dir_entry entry;
+        int ret = read_index_entry(hctx, obj_index_key, &entry);
+        if (ret < 0) {
+          CLS_LOG(1, "ERROR: read_index_entry(): cls_cxx_map_get_val returned %d", ret);
+          return ret;
+        }
+        encode_obj_index_plain_key(op.key, entry.versioned_epoch, &idx);
+      }
+      else {
+        idx = op.key.name;
+      }
       break;
     case BIIndexType::Instance:
       encode_obj_index_key(op.key, &idx);


### PR DESCRIPTION
rgw: fix an issue with bi get not honoring plain BI instance id
    
Fixes: https://tracker.ceph.com/issues/75993
Signed-off-by: Igor Gomon <igomon@bloomberg.net>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
