### PR TITLE
Add experimental support for LRC to Optimised EC and Direct Reads

### DIFF
--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -677,7 +677,7 @@ namespace ceph {
        */
       FLAG_EC_PLUGIN_REQUIRE_SUB_CHUNKS = 1<<5,
       /* Optimized EC is supported only if this flag is set. All other flags
-       * are irrelevant if this flag is false.
+       * are irrelevant if this flag or the experimental flag are false.
        */
       FLAG_EC_PLUGIN_OPTIMIZED_SUPPORTED = 1<<6,
       /* This plugin supports the ability to encode CRCs of data shards to get
@@ -690,6 +690,12 @@ namespace ceph {
        * shard and that the data shards are simply striped.
        */
       FLAG_EC_PLUGIN_DIRECT_READS = 1<<8,
+      /* Optimized EC is allowed to be used expermimentally if this flag is set.
+         All other flags are irrelevant if this flag or the supported flag are
+         false. Experimental plugins are not supported and are purely for
+         development and testing.
+       */
+      FLAG_EC_PLUGIN_OPTIMIZED_EXPERIMENTAL = 1<<9
     };
     static const char *get_optimization_flag_name(const plugin_flags flag) {
       switch (flag) {
@@ -702,8 +708,9 @@ namespace ceph {
       case FLAG_EC_PLUGIN_OPTIMIZED_SUPPORTED: return "optimizedsupport";
       case FLAG_EC_PLUGIN_CRC_ENCODE_DECODE_SUPPORT:
         return "crcencodedecode";
-      case FLAG_EC_PLUGIN_DIRECT_READS:
-        return "directreads";
+      case FLAG_EC_PLUGIN_DIRECT_READS: return "directreads";
+      case FLAG_EC_PLUGIN_OPTIMIZED_EXPERIMENTAL:
+        return "experimentaloptimizedsupport";
       default: return "???";
       }
     }

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -106,9 +106,11 @@ public:
 			     std::ostream *ss) const override;
 
   uint64_t get_supported_optimizations() const override {
-    return FLAG_EC_PLUGIN_PARTIAL_READ_OPTIMIZATION |
+    return FLAG_EC_PLUGIN_OPTIMIZED_EXPERIMENTAL |
+      FLAG_EC_PLUGIN_PARTIAL_READ_OPTIMIZATION |
       FLAG_EC_PLUGIN_PARTIAL_WRITE_OPTIMIZATION |
-      FLAG_EC_PLUGIN_ZERO_INPUT_ZERO_OUTPUT_OPTIMIZATION;
+      FLAG_EC_PLUGIN_ZERO_INPUT_ZERO_OUTPUT_OPTIMIZATION |
+      FLAG_EC_PLUGIN_DIRECT_READS;
   }
 
   unsigned int get_chunk_count() const override {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8549,7 +8549,7 @@ int OSDMonitor::prepare_new_pool(string& name,
   // For Crimson - only EC-optimized pools are supported.
   if (pi->is_erasure()) {
     if (crimson) {
-      if (auto r = enable_pool_ec_optimizations(*pi, true); !r) {
+      if (auto r = enable_pool_ec_optimizations(*pi, true, false); !r) {
         // for Crimson - failure is not an option
         *ss << r.error().message;
         return r.error().error;
@@ -8557,7 +8557,7 @@ int OSDMonitor::prepare_new_pool(string& name,
     } else {
       if (cct->_conf.get_val<bool>("osd_pool_default_flag_ec_optimizations")) {
         // Silently fail if the pool cannot support ec optimizations.
-        std::ignore = enable_pool_ec_optimizations(*pi, true);
+        std::ignore = enable_pool_ec_optimizations(*pi, true, false);
       }
     }
   }
@@ -8603,7 +8603,8 @@ bool OSDMonitor::prepare_unset_flag(MonOpRequestRef op, int flag)
 }
 
 tl::expected<void, ErrorNMessage>
-OSDMonitor::enable_pool_ec_optimizations(pg_pool_t &p, bool enable)
+OSDMonitor::enable_pool_ec_optimizations(pg_pool_t &p, bool enable,
+                                         bool yes_i_really_mean_it)
 {
   if (!p.is_erasure()) {
     return tl::unexpected(ErrorNMessage{
@@ -8634,6 +8635,12 @@ OSDMonitor::enable_pool_ec_optimizations(pg_pool_t &p, bool enable)
       return tl::unexpected(ErrorNMessage{
 	  -EINVAL,
 	  "ec optimizations not currently supported for pool profile."});
+    } else if (!yes_i_really_mean_it && (erasure_code->get_supported_optimizations() &
+        ErasureCodeInterface::FLAG_EC_PLUGIN_OPTIMIZED_EXPERIMENTAL) != 0) {
+        return tl::unexpected(ErrorNMessage{
+	  -EINVAL,
+	  "This is experimental for use in test and development and is not a "
+                  "supported configuration."});
     }
 
     if ((chunk_size % 4096) != 0) {
@@ -9243,7 +9250,9 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       return -EINVAL;
     }
     bool was_enabled = p.allows_ecoptimizations();
-    if (auto r = enable_pool_ec_optimizations(p, enable); !r) {
+    bool force = false;
+    cmd_getval(cmdmap, "yes_i_really_mean_it", force);
+    if (auto r = enable_pool_ec_optimizations(p, enable, force); !r) {
       ss << r.error().message;
       return r.error().error;
     }
@@ -15925,7 +15934,7 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
     ss << "the 2 " << dividing_bucket
        << "instances in the cluster have differing weights "
        << weight1 << " and " << weight2
-       << " but stretch mode currently" 
+       << " but stretch mode currently"
        <<" requires the difference to be no greater than "
        << stretch_max_weight_delta * 100 << "%";
     *errcode = -EINVAL;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -758,7 +758,8 @@ public:
       ceph::Formatter *f);
 
   tl::expected<void, ErrorNMessage>
-  enable_pool_ec_optimizations(pg_pool_t &pool, bool enable);
+   enable_pool_ec_optimizations(pg_pool_t &pool, bool enable,
+                                bool yes_i_really_mean_it);
   void maybe_enable_pool_split_ops(pg_pool_t &p);
   int prepare_command_pool_set(const cmdmap_t& cmdmap,
                                std::stringstream& ss);


### PR DESCRIPTION
Add experimental support for LRC to be used for testing of Optimised EC and DirectReads. This is behind an experimental flag and will give warnings if you try to enable it on a system. It is only intended for usage in testing.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
