### PR TITLE
mgr/dashboard: introduce traddr for backward compatibility

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -12,7 +12,8 @@ from ..exceptions import DashboardException
 from ..model import nvmeof as model
 from ..security import Scope
 from ..services.nvmeof_cli import NvmeofCLICommand, convert_to_bytes, \
-    escape_address_if_ipv6, format_host_updates
+    escape_address_if_ipv6, format_host_updates, \
+    resolve_nvmeof_server_address
 from ..services.nvmeof_client import get_gateway_locations
 from ..services.orchestrator import OrchClient
 from ..tools import str_to_bool
@@ -39,10 +40,22 @@ else:
         @NvmeofCLICommand(
             "nvmeof gateway info", model.GatewayInfo, alias="nvmeof gw info"
         )
-        @EndpointDoc("Get information about the NVMeoF gateway")
+        @EndpointDoc(
+            "Get information about the NVMeoF gateway",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayInfo)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -109,10 +122,22 @@ else:
         @NvmeofCLICommand(
             "nvmeof gateway version", model.GatewayVersion, alias="nvmeof gw version"
         )
-        @EndpointDoc("Get the version of the NVMeoF gateway")
+        @EndpointDoc(
+            "Get the version of the NVMeoF gateway",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayVersion)
         @handle_nvmeof_error
-        def version(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+        def version(self, gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                    traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_info = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -129,11 +154,23 @@ else:
             "nvmeof gateway get_log_level", model.GatewayLogLevelInfo,
             alias="nvmeof gw get_log_level"
         )
-        @EndpointDoc("Get NVMeoF gateway log level information")
+        @EndpointDoc(
+            "Get NVMeoF gateway log level information",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayLogLevelInfo)
         @handle_nvmeof_error
         def get_log_level(self, gw_group: Optional[str] = None,
-                          server_address: Optional[str] = None):
+                          server_address: Optional[str] = None,
+                          traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_log_level = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -147,11 +184,24 @@ else:
         @NvmeofCLICommand(
             "nvmeof gateway set_log_level", model.RequestStatus, alias="nvmeof gw set_log_level",
             success_message_template="Set gateway log level to {log_level}: Successful")
-        @EndpointDoc("Set NVMeoF gateway log levels")
+        @EndpointDoc(
+            "Set NVMeoF gateway log levels",
+            parameters={
+                "log_level": Param(str, "Log level"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_log_level(self, log_level: str, gw_group: Optional[str] = None,
-                          server_address: Optional[str] = None):
+                          server_address: Optional[str] = None,
+                          traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             log_level = log_level.strip().lower()
             gw_log_level = NVMeoFClient(gw_group=gw_group,
                                         server_address=server_address).stub.set_gateway_log_level(
@@ -163,11 +213,23 @@ else:
         @Endpoint('GET', '/stats')
         @NvmeofCLICommand(
             "nvmeof gateway get_stats", model.GatewayStatsInfo, alias="nvmeof gw get_stats")
-        @EndpointDoc("Get NVMeoF statistics for the gateway")
+        @EndpointDoc(
+            "Get NVMeoF statistics for the gateway",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayStatsInfo)
         @handle_nvmeof_error
         def get_gw_stats(self, gw_group: Optional[str] = None,
-                         server_address: Optional[str] = None):
+                         server_address: Optional[str] = None,
+                         traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_stats = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -181,11 +243,24 @@ else:
         @NvmeofCLICommand(
             "nvmeof gateway listener_info", model.GatewayListenersInfo,
             alias="nvmeof gw listener_info")
-        @EndpointDoc("Get NVMeoF gateway's listeners info")
+        @EndpointDoc(
+            "Get NVMeoF gateway's listeners info",
+            parameters={
+                "nqn": Param(str, "NVMeoF subsystem NQN"),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GatewayListenersInfo)
         @handle_nvmeof_error
         def listener_info(self, nqn: str, gw_group: Optional[str] = None,
-                          server_address: Optional[str] = None):
+                          server_address: Optional[str] = None,
+                          traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             gw_listener_info = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -206,12 +281,18 @@ else:
                 "enabled": Param(bool, "Enable IO statistics collection"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_io_stats_mode(self, enabled: bool, gw_group: Optional[str] = None,
-                              server_address: Optional[str] = None):
+                              server_address: Optional[str] = None,
+                              traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             io_stats = NVMeoFClient(gw_group=gw_group,
                                     server_address=server_address).stub.set_gateway_io_stats_mode(
                 NVMeoFClient.pb2.set_gateway_io_stats_mode_req(enabled=enabled)
@@ -224,13 +305,26 @@ else:
         @ReadPermission
         @Endpoint('GET', '/log_level')
         @NvmeofCLICommand("nvmeof spdk_log_level get", model.SpdkNvmfLogFlagsAndLevelInfo)
-        @EndpointDoc("Get NVMeoF gateway spdk log levels")
+        @EndpointDoc(
+            "Get NVMeoF gateway spdk log levels",
+            parameters={
+                "all_log_flags": Param(bool, "Get all log flags", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.SpdkNvmfLogFlagsAndLevelInfo)
         @handle_nvmeof_error
         def get_spdk_log_level(
             self, all_log_flags: Optional[bool] = None,
-            gw_group: Optional[str] = None, server_address: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             spdk_log_level = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -246,14 +340,29 @@ else:
             model.RequestStatus,
             success_message_template="Set SPDK log levels and nvmf log flags: Successful"
         )
-        @EndpointDoc("Set NVMeoF gateway spdk log levels")
+        @EndpointDoc(
+            "Set NVMeoF gateway spdk log levels",
+            parameters={
+                "log_level": Param(str, "SPDK log level", True, None),
+                "print_level": Param(str, "SPDK print level", True, None),
+                "extra_log_flags": Param([str], "Extra log flags", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_spdk_log_level(self, log_level: Optional[str] = None,
                                print_level: Optional[str] = None,
                                extra_log_flags: Optional[List[str]] = None,
                                gw_group: Optional[str] = None,
-                               server_address: Optional[str] = None):
+                               server_address: Optional[str] = None,
+                               traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             log_level = log_level.strip().upper() if log_level else None
             print_level = print_level.strip().upper() if print_level else None
             spdk_log_level = NVMeoFClient(
@@ -270,14 +379,27 @@ else:
         @Endpoint('PUT', '/log_level/disable')
         @NvmeofCLICommand("nvmeof spdk_log_level disable", model.RequestStatus,
                           success_message_template="Disable SPDK log flags: Successful")
-        @EndpointDoc("Disable NVMeoF gateway spdk log")
+        @EndpointDoc(
+            "Disable NVMeoF gateway spdk log",
+            parameters={
+                "extra_log_flags": Param([str], "Extra log flags", True, None),
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def disable_spdk_log_level(
             self, extra_log_flags: Optional[List[str]] = None,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             spdk_log_level = NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -291,10 +413,22 @@ else:
     class NVMeoFSubsystem(RESTController):
         @pick(field="subsystems")
         @NvmeofCLICommand("nvmeof subsystem list", model.SubsystemList)
-        @EndpointDoc("List all NVMeoF subsystems")
+        @EndpointDoc(
+            "List all NVMeoF subsystems",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None):
+        def list(self, gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -310,12 +444,18 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
         def get(self, nqn: str, gw_group: Optional[str] = None,
-                server_address: Optional[str] = None):
+                server_address: Optional[str] = None,
+                traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -344,6 +484,7 @@ else:
                 "secure_listeners": Param(bool,
                                           "Make all the auto-listeners for this subsystem secure",
                                           True, False),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.SubsystemStatus)
@@ -353,7 +494,12 @@ else:
                    serial_number: Optional[str] = None, dhchap_key: Optional[str] = None,
                    gw_group: Optional[str] = None, server_address: Optional[str] = None,
                    network_mask: Optional[List[str]] = None,
-                   port: Optional[int] = None, secure_listeners: Optional[bool] = False):
+                   port: Optional[int] = None, secure_listeners: Optional[bool] = False,
+                   traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -377,12 +523,18 @@ else:
                 "force": Param(bool, "Force delete", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, force: Optional[str] = "false", gw_group: Optional[str] = None,
-                   server_address: Optional[str] = None):
+                   server_address: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -399,6 +551,7 @@ else:
                 "dhchap_key": Param(str, "Subsystem DH-HMAC-CHAP key"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @empty_response
@@ -407,7 +560,12 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(self, nqn: str, dhchap_key: str, gw_group: Optional[str] = None,
-                       server_address: Optional[str] = None):
+                       server_address: Optional[str] = None,
+                       traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -424,6 +582,7 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @empty_response
@@ -432,7 +591,12 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_key(self, nqn: str, gw_group: Optional[str] = None,
-                    server_address: Optional[str] = None):
+                    server_address: Optional[str] = None,
+                    traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -455,12 +619,18 @@ else:
                 "network_mask": Param(str, "Network mask to add"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def add_network(self, nqn: str, network_mask: str, gw_group: Optional[str] = None,
-                        server_address: Optional[str] = None):
+                        server_address: Optional[str] = None,
+                        traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -483,12 +653,18 @@ else:
                 "network_mask": Param(str, "Network mask to remove"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_network(self, nqn: str, network_mask: str, gw_group: Optional[str] = None,
-                        server_address: Optional[str] = None):
+                        server_address: Optional[str] = None,
+                        traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -514,6 +690,7 @@ else:
                 "port": Param(int, "KMIP server endpoint port", True, 5696),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -521,7 +698,12 @@ else:
         def add_kmip_server_endpoint(self, nqn: str, server_name: str,
                                      address: Optional[str] = None,
                                      port: Optional[int] = 5696, gw_group: Optional[str] = None,
-                                     server_address: Optional[str] = None):
+                                     server_address: Optional[str] = None,
+                                     traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             ep = NVMeoFClient.pb2.kmip_server_endpoint(address=address, port=port)
             return NVMeoFClient(
                 gw_group=gw_group,
@@ -548,6 +730,7 @@ else:
                 "port": Param(int, "KMIP server endpoint port", True, 5696),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -555,7 +738,12 @@ else:
         def del_kmip_server_endpoint(self, nqn: str, server_name: str,
                                      address: Optional[str] = None,
                                      port: Optional[int] = 5696, gw_group: Optional[str] = None,
-                                     server_address: Optional[str] = None):
+                                     server_address: Optional[str] = None,
+                                     traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             ep = NVMeoFClient.pb2.kmip_server_endpoint(address=address, port=port)
             return NVMeoFClient(
                 gw_group=gw_group,
@@ -577,12 +765,18 @@ else:
                                      True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.SubsystemListKMIPEndpoints)
         @handle_nvmeof_error
         def list_eps(self, nqn: Optional[str] = None, server_name: Optional[str] = None,
-                     gw_group: Optional[str] = None, server_address: Optional[str] = None):
+                     gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                     traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -592,13 +786,26 @@ else:
             )
 
         @NvmeofCLICommand("nvmeof get_subsystems", model.GetSubsystems)
+        @EndpointDoc(
+            "Get NVMeoF subsystems",
+            parameters={
+                "gw_group": Param(str, "NVMeoF gateway group", True, None),
+                "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
+            }
+        )
         @convert_to_model(model.GetSubsystems)
         @handle_nvmeof_error
         def get_subsystems(
             self,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -617,12 +824,18 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.ListenerList)
         @handle_nvmeof_error
         def list(self, nqn: str, gw_group: Optional[str] = None,
-                 server_address: Optional[str] = None):
+                 server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -752,12 +965,18 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID to filter by", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None, nsid: Optional[str] = None,
-                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -776,12 +995,18 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
         def get(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                server_address: Optional[str] = None):
+                server_address: Optional[str] = None,
+                traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -802,12 +1027,18 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceIOStats)
         @handle_nvmeof_error
         def io_stats(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
-                     server_address: Optional[str] = None):
+                     server_address: Optional[str] = None,
+                     traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -854,6 +1085,7 @@ else:
                                 True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceCreation)
@@ -877,11 +1109,16 @@ else:
             location: Optional[str] = None,
             gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
             rados_namespace: Optional[str] = None,
             encryption_format: Optional[List[str]] = None,
             encryption_algorithm: Optional[str] = None,
             key_id: Optional[List[str]] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             encryption_format = encryption_format or []
             key_id = key_id or []
             if len(encryption_format) != len(key_id):
@@ -965,6 +1202,7 @@ else:
                                 True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "Target gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceCreation)
@@ -988,11 +1226,16 @@ else:
             location: Optional[str] = None,
             gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
             rados_namespace: Optional[str] = None,
             encryption_format: Optional[List[str]] = None,
             encryption_algorithm: Optional[str] = None,
             key_id: Optional[List[str]] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             if size and rbd_image_size:
                 raise DashboardException(
                     msg="Can use size or rbd_image_size but not both",
@@ -1068,6 +1311,7 @@ else:
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1082,8 +1326,13 @@ else:
             w_mbytes_per_second: Optional[int] = None,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1116,6 +1365,7 @@ else:
                 "load_balancing_group": Param(int, "Load balancing group", True, None),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1126,8 +1376,13 @@ else:
             nsid: str,
             load_balancing_group: Optional[int] = None,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1147,6 +1402,7 @@ else:
                 "rbd_image_size": Param(int, "RBD image size"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1157,8 +1413,13 @@ else:
             nsid: str,
             rbd_image_size: int,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             mib = 1024 * 1024
             new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
@@ -1186,6 +1447,7 @@ else:
                 "rbd_image_size": Param(str, "RBD image size"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1196,8 +1458,13 @@ else:
             nsid: str,
             rbd_image_size: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             if rbd_image_size:
                 rbd_image_size_b = convert_to_bytes(rbd_image_size, default_unit='MB')
             mib = 1024 * 1024
@@ -1234,6 +1501,7 @@ else:
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1245,8 +1513,13 @@ else:
             host_nqn: str,
             force: Optional[bool] = None,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1274,6 +1547,7 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1284,8 +1558,13 @@ else:
             nsid: str,
             host_nqn: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1322,6 +1601,7 @@ else:
                 "force": Param(bool, 'True if visible to all hosts', True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1333,8 +1613,13 @@ else:
             auto_visible: str,
             force: Optional[bool] = False,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1376,6 +1661,7 @@ else:
                 ),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1386,8 +1672,13 @@ else:
             nsid: str,
             auto_resize_enabled: bool,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1425,6 +1716,7 @@ else:
                 "rbd_trash_image_on_delete": Param(bool, 'True if active'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1435,8 +1727,13 @@ else:
             nsid: str,
             rbd_trash_image_on_delete: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address,
@@ -1462,6 +1759,7 @@ else:
                 "nsid": Param(str, "NVMeoF Namespace ID"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1471,8 +1769,13 @@ else:
             nqn: str,
             nsid: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1503,6 +1806,7 @@ else:
                 "location": Param(str, "Namespace location"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.NamespaceList)
@@ -1521,7 +1825,12 @@ else:
             location: Optional[str] = None,
             gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             contains_failure = False
 
             if rbd_image_size:
@@ -1613,6 +1922,7 @@ else:
                 "force": Param(str, "Force remove the RBD image", True, False),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1624,7 +1934,12 @@ else:
             force: Optional[str] = "false",
             gw_group: Optional[str] = None,
             server_address: Optional[str] = None,
+            traddr: Optional[str] = None,
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1663,14 +1978,20 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.HostsInfo, finalize=_update_hosts)
         @handle_nvmeof_error
         def list(
             self, nqn: str,
-            gw_group: Optional[str] = None, server_address: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1695,6 +2016,7 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to allow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -1703,8 +2025,13 @@ else:
             self, nqn: str, host_nqn: str, dhchap_key: Optional[str] = None,
             dhchap_controller_key: Optional[str] = None,
             psk: Optional[str] = None, gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1733,12 +2060,18 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN. Use "*" to disallow any host.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def delete(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-                   server_address: Optional[str] = None):
+                   server_address: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1763,14 +2096,20 @@ else:
                 "dhchap_key": Param(str, 'Host DH-HMAC-CHAP key'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(
             self, nqn: str, host_nqn: str, dhchap_key: str,
-            gw_group: Optional[str] = None, server_address: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1799,14 +2138,20 @@ else:
                 "dhchap_controller_key": Param(str, 'Host DH-HMAC-CHAP controller key'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_controller_key(
             self, nqn: str, host_nqn: str, dhchap_controller_key: str,
-            gw_group: Optional[str] = None, server_address: Optional[str] = None
+            gw_group: Optional[str] = None, server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1833,14 +2178,20 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_key(
             self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1867,14 +2218,20 @@ else:
                 "host_nqn": Param(str, 'NVMeoF host NQN.'),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_controller_key(
             self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1907,12 +2264,18 @@ else:
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.ConnectionList, finalize=_update_connections)
         @handle_nvmeof_error
         def list(self, nqn: Optional[str] = None,
-                 gw_group: Optional[str] = None, server_address: Optional[str] = None):
+                 gw_group: Optional[str] = None, server_address: Optional[str] = None,
+                 traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             if not nqn:
                 nqn = '*'
             return NVMeoFClient(
@@ -1934,6 +2297,7 @@ else:
                 "host_nqn": Param(str, "NVMeoF host NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.ConnectionIOStatistics)
@@ -1943,8 +2307,13 @@ else:
             nqn: str,
             host_nqn: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -1968,6 +2337,7 @@ else:
                 "host_nqn": Param(str, "NVMeoF host NQN"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
+                "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
         @convert_to_model(model.ConnectionIOStatistics)
@@ -1977,8 +2347,13 @@ else:
             nqn: str,
             host_nqn: str,
             gw_group: Optional[str] = None,
-            server_address: Optional[str] = None
+            server_address: Optional[str] = None,
+            traddr: Optional[str] = None
         ):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             return NVMeoFClient(
                 gw_group=gw_group,
                 server_address=server_address
@@ -2012,7 +2387,9 @@ else:
                          'subsystem_nqn': (str, 'Subsystem NQN'),
                          "allow_all": Param(bool, 'Allow all hosts. Default is True.'),
                          "hosts": Param(List, 'List containg host nqn and dhchap key'),
-                         "gw_group": Param(str, "NVMeoF gateway group")
+                         "gw_group": Param(str, "NVMeoF gateway group"),
+                         "server_address": Param(str, "NVMeoF gateway address", True, None),
+                         "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
                      })
         @empty_response
         @handle_nvmeof_error
@@ -2021,7 +2398,12 @@ else:
                 gw_group: str,
                 hosts: Optional[list[dict]] = None,
                 allow_all: bool = True,
-                server_address: Optional[str] = None):
+                server_address: Optional[str] = None,
+                traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             response = None
 
             if allow_all:
@@ -2056,7 +2438,9 @@ else:
                      parameters={
                          "subsystem_nqn": Param(str, "NVMeoF subsystem NQN"),
                          "host_nqn": Param(str, 'Comma separated list of NVMeoF host NQN.'),
-                         "gw_group": Param(str, "NVMeoF gateway group")
+                         "gw_group": Param(str, "NVMeoF gateway group"),
+                         "server_address": Param(str, "NVMeoF gateway address", True, None),
+                         "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
                      })
         @empty_response
         @handle_nvmeof_error
@@ -2064,7 +2448,12 @@ else:
         def remove(self, subsystem_nqn: str,
                    host_nqn: str,
                    gw_group: str,
-                   server_address: Optional[str] = None):
+                   server_address: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             response = None
             to_delete_nqns = host_nqn.split(',')
 
@@ -2093,6 +2482,7 @@ else:
                          ),
                          "gw_group": Param(str, "NVMeoF gateway group", True, None),
                          "server_address": Param(str, "NVMeoF gateway address", True, None),
+                         "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
                      })
         @empty_response
         @handle_nvmeof_error
@@ -2102,7 +2492,12 @@ else:
                                     gw_group: str,
                                     host_nqn: str = "",
                                     force: Optional[bool] = None,
-                                    server_address: Optional[str] = None):
+                                    server_address: Optional[str] = None,
+                                    traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             response = None
             all_host_nqns = host_nqn.split(',')
             force = str_to_bool(force) if force else None
@@ -2128,6 +2523,7 @@ else:
                          "host_nqn": Param(str, 'Comma separated list of NVMeoF host NQN.'),
                          "gw_group": Param(str, "NVMeoF gateway group", True, None),
                          "server_address": Param(str, "NVMeoF gateway address", True, None),
+                         "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
                      })
         @empty_response
         @handle_nvmeof_error
@@ -2137,7 +2533,12 @@ else:
                                        subsystem_nqn: str,
                                        host_nqn: str,
                                        gw_group: str,
-                                       server_address: Optional[str] = None):
+                                       server_address: Optional[str] = None,
+                                       traddr: Optional[str] = None):
+            server_address = resolve_nvmeof_server_address(
+                server_address=server_address,
+                traddr=traddr
+            )
             response = None
             to_delete_nqns = host_nqn.split(',')
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -12558,13 +12558,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -12634,6 +12642,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - enabled
               type: object
@@ -12673,19 +12684,28 @@ paths:
   /api/nvmeof/gateway/listener_info/{nqn}:
     get:
       parameters:
-      - in: path
+      - description: NVMeoF subsystem NQN
+        in: path
         name: nqn
         required: true
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -12716,13 +12736,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -12757,10 +12785,16 @@ paths:
             schema:
               properties:
                 gw_group:
+                  description: NVMeoF gateway group
                   type: string
                 log_level:
+                  description: Log level
                   type: string
                 server_address:
+                  description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - log_level
@@ -12802,13 +12836,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -12839,13 +12881,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -12876,18 +12926,27 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: Get all log flags
         in: query
         name: all_log_flags
         schema:
-          type: string
+          type: boolean
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -12922,14 +12981,24 @@ paths:
             schema:
               properties:
                 extra_log_flags:
-                  type: string
+                  description: Extra log flags
+                  items:
+                    type: string
+                  type: array
                 gw_group:
+                  description: NVMeoF gateway group
                   type: string
                 log_level:
+                  description: SPDK log level
                   type: string
                 print_level:
+                  description: SPDK print level
                   type: string
                 server_address:
+                  description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -12974,10 +13043,18 @@ paths:
             schema:
               properties:
                 extra_log_flags:
-                  type: string
+                  description: Extra log flags
+                  items:
+                    type: string
+                  type: array
                 gw_group:
+                  description: NVMeoF gateway group
                   type: string
                 server_address:
+                  description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -13017,13 +13094,21 @@ paths:
     get:
       parameters:
       - allowEmptyValue: true
+        description: NVMeoF gateway group
         in: query
         name: gw_group
         schema:
           type: string
       - allowEmptyValue: true
+        description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -13091,6 +13176,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - nqn
               type: object
@@ -13154,6 +13242,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -13207,6 +13301,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -13252,6 +13352,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -13295,6 +13401,12 @@ paths:
         description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -13348,6 +13460,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - host_nqn
@@ -13412,6 +13527,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -13473,6 +13594,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - dhchap_controller_key
@@ -13539,6 +13663,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - dhchap_key
               type: object
@@ -13601,6 +13728,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               type: object
       responses:
         '200':
@@ -13661,6 +13791,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               type: object
       responses:
         '200':
@@ -13714,6 +13847,12 @@ paths:
         description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -13929,6 +14068,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -14037,6 +14182,9 @@ paths:
                 size:
                   description: Deprecated. Use `rbd_image_size` instead
                   type: integer
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
                 trash_image:
                   default: false
                   description: Trash the RBD image when namespace is removed
@@ -14110,6 +14258,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -14167,6 +14321,12 @@ paths:
         description: NVMeoF gateway address
         in: query
         name: server_address
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -14236,6 +14396,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
                 trash_image:
                   description: Trash RBD image after removing namespace
                   type: boolean
@@ -14299,6 +14462,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - host_nqn
@@ -14364,6 +14530,9 @@ paths:
                   type: integer
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -14432,6 +14601,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - auto_visible
               type: object
@@ -14498,6 +14670,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
               required:
               - host_nqn
               type: object
@@ -14561,6 +14736,12 @@ paths:
         name: server_address
         schema:
           type: string
+      - allowEmptyValue: true
+        description: NVMeoF gateway address (deprecated)
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -14610,6 +14791,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               type: object
       responses:
@@ -14673,6 +14857,9 @@ paths:
                   type: integer
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - rbd_image_size
@@ -14739,6 +14926,9 @@ paths:
                   type: string
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - auto_resize_enabled
@@ -14815,6 +15005,9 @@ paths:
                 server_address:
                   description: NVMeoF gateway address
                   type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
+                  type: string
                 w_mbytes_per_second:
                   description: Write MB/s
                   type: integer
@@ -14880,6 +15073,9 @@ paths:
                   type: boolean
                 server_address:
                   description: NVMeoF gateway address
+                  type: string
+                traddr:
+                  description: NVMeoF gateway address (deprecated)
                   type: string
               required:
               - rbd_trash_image_on_delete

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -14,6 +14,7 @@ from mgr_module import CLICheckNonemptyFileInput, HandleCommandResult
 from prettytable import PrettyTable
 
 from ..cli import DBCLICommand
+from ..exceptions import DashboardException
 from ..model.nvmeof import CliFieldTransformer, CliFlags, CliHeader
 from ..rest_client import RequestException
 from .nvmeof_conf import ManagedByOrchestratorException, \
@@ -136,6 +137,36 @@ def convert_from_bytes(num_in_bytes):
         size_str = f"{size:.1f}"
 
     return f"{size_str}{units[unit_index]}"
+
+
+def resolve_nvmeof_server_address(
+    *,
+    server_address: Optional[str] = None,
+    traddr: Optional[str] = None,
+    require: bool = False,
+) -> Optional[str]:
+    sa = (server_address or "").strip() or None
+    ta = (traddr or "").strip() or None
+
+    if sa and ta:
+        raise DashboardException(
+            msg="Pass either 'server_address' or deprecated 'traddr', not both.",
+            code="server_address_and_traddr_mutually_exclusive",
+            http_status_code=400,
+            component="nvmeof",
+        )
+
+    resolved = sa or ta
+
+    if require and not resolved:
+        raise DashboardException(
+            msg="Missing required gateway address: 'server_address' (or deprecated 'traddr').",
+            code="missing_server_address",
+            http_status_code=400,
+            component="nvmeof",
+        )
+
+    return resolved
 
 
 class OutputFormatter(ABC):

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
@@ -10,10 +10,11 @@ from mgr_module import HandleCommandResult
 
 from ..cli import DBCLICommand
 from ..controllers import EndpointDoc
+from ..exceptions import DashboardException
 from ..model.nvmeof import CliFieldTransformer, CliFlags, CliHeader
 from ..services.nvmeof_cli import AnnotatedDataTextOutputFormatter, \
     NvmeofCLICommand, convert_from_bytes, convert_to_bytes, \
-    format_host_updates
+    format_host_updates, resolve_nvmeof_server_address
 from ..tests import CLICommandTestMixin
 
 
@@ -1295,3 +1296,57 @@ class TestFormatHostUpdates:
             template_item="H {host_nqn} {nqn}",
         )
         assert out == "H h1 nqn.test\nW nqn.test"
+
+
+class TestResolveNvmeofServerAddress:
+    def test_resolve_returns_server_address_when_set(self):
+        assert resolve_nvmeof_server_address(
+            server_address="10.0.0.1",
+            traddr=None,
+            require=False,
+        ) == "10.0.0.1"
+
+    def test_resolve_uses_traddr_fallback_when_server_address_missing(self):
+        assert resolve_nvmeof_server_address(
+            server_address=None,
+            traddr="10.0.0.2",
+            require=False,
+        ) == "10.0.0.2"
+
+    def test_resolve_strips_whitespace_and_treats_empty_as_none(self):
+        assert resolve_nvmeof_server_address(
+            server_address="  ",
+            traddr=" 10.0.0.2 ",
+            require=False,
+        ) == "10.0.0.2"
+
+    def test_resolve_rejects_both_server_address_and_traddr(self):
+        with pytest.raises(DashboardException) as excinfo:
+            resolve_nvmeof_server_address(
+                server_address="10.0.0.1",
+                traddr="10.0.0.2",
+                require=False,
+            )
+
+        err = excinfo.value
+        assert err.status == 400
+        assert err.code == "server_address_and_traddr_mutually_exclusive"
+
+    def test_resolve_require_true_rejects_missing(self):
+        with pytest.raises(DashboardException) as excinfo:
+            resolve_nvmeof_server_address(
+                server_address=None,
+                traddr=None,
+                require=True,
+            )
+
+        err = excinfo.value
+        assert err.status == 400
+        assert err.code == "missing_server_address"
+
+    def test_resolve_require_false_allows_missing(self):
+        assert resolve_nvmeof_server_address(
+            server_address=None,
+            traddr=None,
+            require=False,
+        ) is None


### PR DESCRIPTION
a while ago we renamed `traddr` to `server_address`(https://github.com/ceph/ceph/pull/66822). We had some difficulties and decided to keep `traddr` as a fallback until we will deprecate it later on. 

fixes:  https://tracker.ceph.com/issues/75978



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
