### PR TITLE
mgr: Bucket scoped OSD upgrades using ok-to-upgrade

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -100,42 +100,45 @@ For example, to upgrade to v16.2.6, run the following command:
        ceph orch upgrade start --image quay.io/ceph/ceph:v16.2.6
 
 
-CRUSH bucket scoped OSD upgrades (``osd ok-to-upgrade``)
+CRUSH bucket-scoped OSD upgrades (``osd ok-to-upgrade``)
 ========================================================
 
-For **OSD-only** upgrades you can limit which failure domain cephadm works
-through and ask the monitor which OSDs under a given CRUSH bucket may safely
-move to the target **Ceph short version** (the same string as
-``ceph_version_short`` in OSD metadata, e.g. ``20.3.0-3803-g63ca1ffb5a2`` or
-``20.1.0-144.el9cp``).
+When performing OSD upgrades as part of a staggered Ceph upgrade,
+one may constrain the set of OSDs on which cephadm will operate.
+This ability is available in the Ceph Umbrella and later releases.
+As cephadm progresses through the specified CRUSH bucket, it asks
+the Monitors which OSDs may safely move to the target release.
+This process uses the ceph osd ok-to-upgrade command.
 
 Requirements:
 
 * For OSD-only upgrades, pass both ``--crush_bucket_type`` and ``--crush_bucket_name``.
   Supported types today are ``host``, ``rack``, and ``chassis``.
 * The monitor's ``osd ok-to-upgrade`` expects the target **short** Ceph version
-  (same shape as ``ceph_version_short`` in ``ceph osd metadata``). Cephadm does
-  **not** fall back to ``osd ok-to-stop`` for bucket-scoped OSD runs. If the mon
-  returns no OSDs (e.g. unknown bucket name), cephadm logs details and retries.
-* If bucket parameters are not provided, cephadm will fall back to ``osd ok-to-stop`` 
+  (same shape as ``ceph_version_short`` in ``ceph osd metadata``).
+* If the Monitors indicate to cephadm that no OSDs in the selected CRUSH bucket
+  are okay to upgrade, cephadm will log details then retry the operation.
+  If the bucket parameters for a ceph osd ok-to-upgrade upgrade are not provided,
+  cephadm will fall back to the default ceph osd ok-to-stop gate for OSD upgrades.
+* If bucket parameters are not provided, cephadm will fall back to ``osd ok-to-stop``
   for OSD upgrades.
-* Bucket scope applies only to OSDs. Other daemon types (mon, mgr, mds) are 
-  upgraded cluster-wide without bucket constraints.
+* Bucket-scope upgrades apply only to OSDs. CRUSH buckets do not influence upgrades
+  of other daemon types, for example Monitors, Managers, and MDSes.
 
 Example:
 
 .. prompt:: bash #
 
-  ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:recent-git-branch-name
+  ceph orch upgrade start --image quay.io/ceph/ceph:v21.2.1
     --daemon-types osd \\
     --crush_bucket_type rack --crush_bucket_name rack-a
 
-For each failure domain batch, cephadm calls ``ceph osd ok-to-upgrade`` with the 
-specified failure domain name, the target short version, and ``max`` set to
+When performing OSD upgrades withiin this failure domain, cephadm calls
+ceph osd ok-to-upgrade with the specified bucket name and type, and max set to
 :confval:`mgr/cephadm/max_parallel_osd_upgrades`
 
-Note that it is not recommended to change the CRUSH bucket type or name after
-the upgrade has started as it may cause the upgrade to fail.
+Note: do not change the cluster's topology during an OSD upgrade phase.
+This includes the name or type of any CRUSH bucket.
 
 
 Monitoring the Upgrade

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -112,16 +112,15 @@ This process uses the ceph ``osd ok-to-upgrade`` command.
 
 Requirements:
 
-* For OSD-only upgrades, pass both ``--crush_bucket_type`` and ``--crush_bucket_name``.
-  Supported types today are ``host``, ``rack``, and ``chassis``.
+* For OSD-only upgrades, pass both ``--crush_bucket_type`` and ``--crush_bucket_name``
+  and ``--daemon-types osd`` only. Supported types today are ``host``, ``rack``,
+  and ``chassis``.
 * The Monitor's ``osd ok-to-upgrade`` expects the target **short** Ceph version
   (same shape as ``ceph_version_short`` in ``ceph osd metadata``).
 * If the Monitors indicate to cephadm that no OSDs in the selected CRUSH bucket
   are okay to upgrade, cephadm will log details and then retry the operation.
-  If the bucket parameters for a ceph ``osd ok-to-upgrade`` upgrade are not provided,
+*  If the bucket parameters for a ceph ``osd ok-to-upgrade`` upgrade are not provided,
   cephadm will fall back to the default ceph osd ok-to-stop gate for OSD upgrades.
-* If bucket parameters are not provided, cephadm will fall back to ``osd ok-to-stop``
-  for OSD upgrades.
 * Bucket-scope upgrades apply only to OSDs. CRUSH buckets do not influence upgrades
   of other daemon types, for example Monitors, Managers, and MDSes.
 

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -108,17 +108,17 @@ one may constrain the set of OSDs on which cephadm will operate.
 This ability is available in the Ceph Umbrella and later releases.
 As cephadm progresses through the specified CRUSH bucket, it asks
 the Monitors which OSDs may safely move to the target release.
-This process uses the ceph osd ok-to-upgrade command.
+This process uses the ceph ``osd ok-to-upgrade`` command.
 
 Requirements:
 
 * For OSD-only upgrades, pass both ``--crush_bucket_type`` and ``--crush_bucket_name``.
   Supported types today are ``host``, ``rack``, and ``chassis``.
-* The monitor's ``osd ok-to-upgrade`` expects the target **short** Ceph version
+* The Monitor's ``osd ok-to-upgrade`` expects the target **short** Ceph version
   (same shape as ``ceph_version_short`` in ``ceph osd metadata``).
 * If the Monitors indicate to cephadm that no OSDs in the selected CRUSH bucket
-  are okay to upgrade, cephadm will log details then retry the operation.
-  If the bucket parameters for a ceph osd ok-to-upgrade upgrade are not provided,
+  are okay to upgrade, cephadm will log details and then retry the operation.
+  If the bucket parameters for a ceph ``osd ok-to-upgrade`` upgrade are not provided,
   cephadm will fall back to the default ceph osd ok-to-stop gate for OSD upgrades.
 * If bucket parameters are not provided, cephadm will fall back to ``osd ok-to-stop``
   for OSD upgrades.
@@ -129,16 +129,16 @@ Example:
 
 .. prompt:: bash #
 
-  ceph orch upgrade start --image quay.io/ceph/ceph:v21.2.1
-    --daemon-types osd \\
+  ceph orch upgrade start --image quay.io/ceph/ceph:v21.2.1 \
+    --daemon-types osd \
     --crush_bucket_type rack --crush_bucket_name rack-a
 
-When performing OSD upgrades withiin this failure domain, cephadm calls
-ceph osd ok-to-upgrade with the specified bucket name and type, and max set to
+When performing OSD upgrades within this failure domain, cephadm calls
+ceph ``osd ok-to-upgrade`` with the specified bucket name and type, and max set to
 :confval:`mgr/cephadm/max_parallel_osd_upgrades`
 
-Note: do not change the cluster's topology during an OSD upgrade phase.
-This includes the name or type of any CRUSH bucket.
+.. warning:: Do not change the cluster's topology during an OSD upgrade phase.
+   This includes the name or type of any CRUSH bucket.
 
 
 Monitoring the Upgrade

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -100,6 +100,44 @@ For example, to upgrade to v16.2.6, run the following command:
        ceph orch upgrade start --image quay.io/ceph/ceph:v16.2.6
 
 
+CRUSH bucket scoped OSD upgrades (``osd ok-to-upgrade``)
+========================================================
+
+For **OSD-only** upgrades you can limit which failure domain cephadm works
+through and ask the monitor which OSDs under a given CRUSH bucket may safely
+move to the target **Ceph short version** (the same string as
+``ceph_version_short`` in OSD metadata, e.g. ``20.3.0-3803-g63ca1ffb5a2`` or
+``20.1.0-144.el9cp``).
+
+Requirements:
+
+* For OSD-only upgrades, pass both ``--crush_bucket_type`` and ``--crush_bucket_name``.
+  Supported types today are ``host``, ``rack``, and ``chassis``.
+* The monitor's ``osd ok-to-upgrade`` expects the target **short** Ceph version
+  (same shape as ``ceph_version_short`` in ``ceph osd metadata``). Cephadm does
+  **not** fall back to ``osd ok-to-stop`` for bucket-scoped OSD runs. If the mon
+  returns no OSDs (e.g. unknown bucket name), cephadm logs details and retries.
+* If bucket parameters are not provided, cephadm will fall back to ``osd ok-to-stop`` 
+  for OSD upgrades.
+* Bucket scope applies only to OSDs. Other daemon types (mon, mgr, mds) are 
+  upgraded cluster-wide without bucket constraints.
+
+Example:
+
+.. prompt:: bash #
+
+  ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:recent-git-branch-name
+    --daemon-types osd \\
+    --crush_bucket_type rack --crush_bucket_name rack-a
+
+For each failure domain batch, cephadm calls ``ceph osd ok-to-upgrade`` with the 
+specified failure domain name, the target short version, and ``max`` set to
+:confval:`mgr/cephadm/max_parallel_osd_upgrades`
+
+Note that it is not recommended to change the CRUSH bucket type or name after
+the upgrade has started as it may cause the upgrade to fail.
+
+
 Monitoring the Upgrade
 ======================
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4197,6 +4197,10 @@ Then run the following:
             raise OrchestratorError(
                 '--hosts cannot be combined with --crush_bucket_type or --crush_bucket_name')
 
+        if services is not None and (bucket_type is not None or bucket_name is not None):
+            raise OrchestratorError(
+                '--services cannot be combined with --crush_bucket_type or --crush_bucket_name')
+
         if limit is not None:
             if limit < 1:
                 raise OrchestratorError(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4162,7 +4162,8 @@ Then run the following:
 
     @handle_orch_error
     def upgrade_start(self, image: str, version: str, daemon_types: Optional[List[str]] = None, host_placement: Optional[str] = None,
-                      services: Optional[List[str]] = None, limit: Optional[int] = None) -> str:
+                      services: Optional[List[str]] = None, limit: Optional[int] = None,
+                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> str:
         if self.inventory.get_host_with_state("maintenance"):
             raise OrchestratorError("Upgrade aborted - you have host(s) in maintenance state")
         if self.offline_hosts:
@@ -4192,12 +4193,17 @@ Then run the following:
                 raise OrchestratorError(
                     f'Upgrade aborted - hosts parameter "{host_placement}" provided did not match any hosts')
 
+        if hosts and (bucket_type is not None or bucket_name is not None):
+            raise OrchestratorError(
+                '--hosts cannot be combined with --crush_bucket_type or --crush_bucket_name')
+
         if limit is not None:
             if limit < 1:
                 raise OrchestratorError(
                     f'Upgrade aborted - --limit arg must be a positive integer, not {limit}')
 
-        return self.upgrade.upgrade_start(image, version, daemon_types, hosts, services, limit)
+        return self.upgrade.upgrade_start(
+            image, version, daemon_types, hosts, services, limit, bucket_type, bucket_name)
 
     @handle_orch_error
     def upgrade_pause(self) -> str:

--- a/src/pybind/mgr/cephadm/tests/test_remote_executables.py
+++ b/src/pybind/mgr/cephadm/tests/test_remote_executables.py
@@ -104,6 +104,8 @@ def _names(node):
         return [f"<Subscript: {node.value}{node.slice}>"]
     if isinstance(node, ast.BinOp):
         return [f"<BinaryOp: {_names(node.left)} {_names(node.op)} {_names(node.right)}"]
+    if isinstance(node, ast.BoolOp):
+        return [f"<BoolOp: {node.op} {[_names(v) for v in node.values]}>"]
     if (
         isinstance(node, ast.Add)
         or isinstance(node, ast.Sub)

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -60,6 +60,23 @@ def test_upgrade_start_hosts_mutually_exclusive_with_bucket(cephadm_module: Ceph
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_start_services_mutually_exclusive_with_bucket(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'test'):
+        with with_host(cephadm_module, 'test2'):
+            with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                with pytest.raises(OrchestratorError) as err:
+                    cephadm_module.upgrade_start(
+                        'image_id', None,
+                        services=['mgr'],
+                        bucket_type='rack',
+                        bucket_name='rack-a',
+                    )
+                assert str(err.value) == (
+                    '--services cannot be combined with --crush_bucket_type or '
+                    '--crush_bucket_name')
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
 def test_upgrade_start_offline_hosts(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'test'):
         with with_host(cephadm_module, 'test2'):
@@ -283,8 +300,7 @@ def test_upgrade_status_which_full_cluster_with_crush_bucket(cephadm_module: Cep
     )
     with mock.patch.object(cephadm_module.upgrade, '_get_upgrade_info', return_value=('0/0', [])):
         status = wait(cephadm_module, cephadm_module.upgrade_status())
-    assert status.which == (
-        'Upgrading all daemon types on all hosts (OSDs only in bucket scope)')
+    assert status.which == 'Upgrading all daemon types on all hosts'
 
 
 def test_parse_ok_to_upgrade_mon_json_nested_and_flat():
@@ -522,13 +538,16 @@ def test_validate_failure_domain_upgrade_options_multi_token_name(cephadm_module
 
 
 def test_validate_failure_domain_upgrade_options_daemon_types(cephadm_module: CephadmOrchestrator):
-    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
-        'rack', 'rack-a', None)
-    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
-        'rack', 'rack-a', ['osd', 'mds'])
-    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
-        'rack', 'rack-a', ['mgr', 'mon', 'osd'])
-    osd_msg = 'Bucket parameters for OSD upgrade require --daemon-types to include "osd"'
+    osd_msg = 'Bucket parameters for OSD upgrade require --daemon-types to be "osd"'
+    with pytest.raises(OrchestratorError):
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'rack', 'rack-a', None)
+    with pytest.raises(OrchestratorError):
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'rack', 'rack-a', ['osd', 'mds'])
+    with pytest.raises(OrchestratorError):
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'rack', 'rack-a', ['mgr', 'mon', 'osd'])
     with pytest.raises(OrchestratorError) as err:
         cephadm_module.upgrade._validate_failure_domain_upgrade_options(
             'rack', 'rack-a', ['mgr', 'mon'])

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest import mock
 
 import pytest
@@ -7,6 +8,7 @@ from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 from cephadm import CephadmOrchestrator
 from cephadm.upgrade import (
     CephadmUpgrade,
+    OkToUpgradeMonReport,
     UpgradeState,
     parse_ok_to_upgrade_mon_json,
     request_osd_ok_to_upgrade_report,
@@ -294,18 +296,173 @@ def test_parse_ok_to_upgrade_mon_json_nested_and_flat():
     assert d['ok_to_upgrade'] is True
 
 
+def test_ok_to_upgrade_mon_report_from_parsed_body():
+    rep = OkToUpgradeMonReport.from_parsed_body({
+        'ok_to_upgrade': True,
+        'all_osds_upgraded': False,
+        'osds_ok_to_upgrade': [0, 1],
+        'osds_in_crush_bucket': [2, 3],
+        'osds_upgraded': [4],
+        'bad_no_version': [5],
+    })
+    assert rep.ok_to_upgrade is True
+    assert rep.all_osds_upgraded is False
+    assert rep.osds_ok_to_upgrade == [0, 1]
+    assert rep.osds_in_crush_bucket == [2, 3]
+    assert rep.osds_upgraded == [4]
+    assert rep.bad_no_version == [5]
+    assert rep.mon_resp_as_dict()['bad_no_version'] == [5]
+
+
+def test_ok_to_upgrade_mon_report_non_list_osd_array_becomes_empty():
+    rep = OkToUpgradeMonReport.from_parsed_body({
+        'ok_to_upgrade': True,
+        'all_osds_upgraded': False,
+        'osds_ok_to_upgrade': 'not-a-list',
+    })
+    assert rep.osds_ok_to_upgrade == []
+
+
+def test_ok_to_upgrade_mon_report_matches_mgr_json_formatter_shape():
+    """
+    Shape produced by upgrade_osd_report::dump + JSONFormatter (DaemonServer):
+    array sections are bare int lists, not objects per element.
+    """
+    mon_stdout = (
+        '{"ok_to_upgrade":{'
+        '"ok_to_upgrade":true,'
+        '"all_osds_upgraded":false,'
+        '"osds_in_crush_bucket":[10,11],'
+        '"osds_ok_to_upgrade":[10],'
+        '"osds_upgraded":[],'
+        '"bad_no_version":[]'
+        '}}'
+    )
+    body = parse_ok_to_upgrade_mon_json(mon_stdout)
+    rep = OkToUpgradeMonReport.from_parsed_body(body)
+    assert rep.ok_to_upgrade is True
+    assert rep.all_osds_upgraded is False
+    assert rep.osds_in_crush_bucket == [10, 11]
+    assert rep.osds_ok_to_upgrade == [10]
+    assert rep.osds_upgraded == []
+    assert rep.bad_no_version == []
+
+
+def test_ok_to_upgrade_mon_report_from_parsed_body_rejects_non_mapping():
+    with pytest.raises(ValueError, match='expected JSON object'):
+        OkToUpgradeMonReport.from_parsed_body([])
+
+
+def test_ok_to_upgrade_mon_report_warns_on_non_boolean_flags(caplog):
+    caplog.set_level(logging.WARNING)
+    rep = OkToUpgradeMonReport.from_parsed_body({
+        'ok_to_upgrade': 'unexpected-string',
+        'all_osds_upgraded': False,
+    })
+    assert rep.ok_to_upgrade is None
+    assert rep.all_osds_upgraded is False
+    assert any('expected boolean' in r.message for r in caplog.records)
+
+
 def test_request_osd_ok_to_upgrade_report(cephadm_module: CephadmOrchestrator):
     cephadm_module.check_mon_command = mock.MagicMock(
         return_value=(0, '{"ok_to_upgrade": {"ok_to_upgrade": true}}', ''))
     rep = request_osd_ok_to_upgrade_report(
         cephadm_module, 'mybucket', '20.1.0-144.el9cp', max_osds=3)
-    assert rep['ok_to_upgrade'] is True
+    assert rep.ok_to_upgrade is True
     cephadm_module.check_mon_command.assert_called_once()
     cmd = cephadm_module.check_mon_command.call_args[0][0]
     assert cmd['prefix'] == 'osd ok-to-upgrade'
     assert cmd['crush_bucket'] == 'mybucket'
     assert cmd['ceph_version'] == '20.1.0-144.el9cp'
     assert cmd['max'] == 3
+
+
+def test_parse_ok_to_upgrade_mon_json_invalid_raises():
+    with pytest.raises(json.JSONDecodeError):
+        parse_ok_to_upgrade_mon_json('not-json{')
+
+
+def test_request_osd_ok_to_upgrade_report_invalid_json(cephadm_module: CephadmOrchestrator):
+    cephadm_module.check_mon_command = mock.MagicMock(
+        return_value=(0, 'not-json{', ''))
+    with pytest.raises(json.JSONDecodeError):
+        request_osd_ok_to_upgrade_report(
+            cephadm_module, 'mybucket', '20.1.0', max_osds=3)
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_wait_for_ok_to_upgrade_osd_batch_json_decode_pauses(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'img',
+        'pid',
+        target_version='20.1.0',
+        crush_bucket_type='host',
+        crush_bucket_name='host1',
+    )
+    with mock.patch(
+        'cephadm.upgrade.request_osd_ok_to_upgrade_report',
+        side_effect=json.JSONDecodeError('msg', 'doc', 0),
+    ):
+        ok = cephadm_module.upgrade._wait_for_ok_to_upgrade_osd_batch([])
+    assert ok is False
+    assert cephadm_module.upgrade.upgrade_state.paused is True
+    assert 'UPGRADE_EXCEPTION' in cephadm_module.health_checks
+    assert 'invalid JSON' in cephadm_module.health_checks['UPGRADE_EXCEPTION']['summary']
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_wait_for_ok_to_upgrade_osd_batch_value_error_pauses(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'img',
+        'pid',
+        target_version='20.1.0',
+        crush_bucket_type='host',
+        crush_bucket_name='host1',
+    )
+    with mock.patch(
+        'cephadm.upgrade.request_osd_ok_to_upgrade_report',
+        side_effect=ValueError(
+            "osd ok-to-upgrade: expected JSON object after unwrap, got <class 'list'>"),
+    ):
+        ok = cephadm_module.upgrade._wait_for_ok_to_upgrade_osd_batch([])
+    assert ok is False
+    assert cephadm_module.upgrade.upgrade_state.paused is True
+    assert 'UPGRADE_EXCEPTION' in cephadm_module.health_checks
+    assert (
+        'unexpected JSON shape'
+        in cephadm_module.health_checks['UPGRADE_EXCEPTION']['summary']
+    )
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_wait_for_ok_to_upgrade_osd_batch_bad_no_version_pauses(
+        cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'img',
+        'pid',
+        target_version='20.1.0',
+        crush_bucket_type='host',
+        crush_bucket_name='host1',
+    )
+    bad_rep = OkToUpgradeMonReport(
+        ok_to_upgrade=True,
+        all_osds_upgraded=False,
+        osds_ok_to_upgrade=[],
+        osds_in_crush_bucket=[0, 1],
+        osds_upgraded=[],
+        bad_no_version=[99],
+    )
+    with mock.patch(
+        'cephadm.upgrade.request_osd_ok_to_upgrade_report',
+        return_value=bad_rep,
+    ):
+        ok = cephadm_module.upgrade._wait_for_ok_to_upgrade_osd_batch([])
+    assert ok is False
+    assert cephadm_module.upgrade.upgrade_state.paused is True
+    assert 'UPGRADE_OSD_NO_VERSION' in cephadm_module.health_checks
+    detail = cephadm_module.health_checks['UPGRADE_OSD_NO_VERSION']['detail'][0]
+    assert 'osd.99' in detail
 
 
 def test_validate_failure_domain_upgrade_options_ok(cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -314,13 +314,18 @@ def test_ok_to_upgrade_mon_report_from_parsed_body():
     assert rep.mon_resp_as_dict()['bad_no_version'] == [5]
 
 
-def test_ok_to_upgrade_mon_report_non_list_osd_array_becomes_empty():
+def test_ok_to_upgrade_mon_report_non_list_osd_array_becomes_empty(caplog):
+    caplog.set_level(logging.WARNING, logger='cephadm.upgrade')
     rep = OkToUpgradeMonReport.from_parsed_body({
         'ok_to_upgrade': True,
         'all_osds_upgraded': False,
         'osds_ok_to_upgrade': 'not-a-list',
     })
     assert rep.osds_ok_to_upgrade == []
+    assert any(
+        'expected list of osd ids' in r.getMessage()
+        for r in caplog.records
+    )
 
 
 def test_ok_to_upgrade_mon_report_matches_mgr_json_formatter_shape():

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -5,7 +5,12 @@ import pytest
 
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 from cephadm import CephadmOrchestrator
-from cephadm.upgrade import CephadmUpgrade, UpgradeState
+from cephadm.upgrade import (
+    CephadmUpgrade,
+    UpgradeState,
+    parse_ok_to_upgrade_mon_json,
+    request_osd_ok_to_upgrade_report,
+)
 from cephadm.ssh import HostConnectionError
 from cephadm.utils import ContainerInspectInfo
 from orchestrator import OrchestratorError, DaemonDescription
@@ -34,6 +39,22 @@ def test_upgrade_start(cephadm_module: CephadmOrchestrator):
 
                 assert wait(cephadm_module, cephadm_module.upgrade_stop()
                             ) == 'Stopped upgrade to image_id'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_start_hosts_mutually_exclusive_with_bucket(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'test'):
+        with with_host(cephadm_module, 'test2'):
+            with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                with pytest.raises(OrchestratorError) as err:
+                    cephadm_module.upgrade_start(
+                        'image_id', None,
+                        daemon_types=['osd'],
+                        host_placement='test',
+                        bucket_type='rack',
+                        bucket_name='rack-a',
+                    )
+                assert str(err.value) == '--hosts cannot be combined with --crush_bucket_type or --crush_bucket_name'
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -198,7 +219,168 @@ def test_upgrade_state_null(cephadm_module: CephadmOrchestrator):
     assert CephadmUpgrade(cephadm_module).upgrade_state is None
 
 
+def test_upgrade_state_crush_roundtrip():
+    u = UpgradeState(
+        'target', 'pid', crush_bucket_type='rack', crush_bucket_name='rack1')
+    restored = UpgradeState.from_json(u.to_json())
+    assert restored
+    assert restored.crush_bucket_type == 'rack'
+    assert restored.crush_bucket_name == 'rack1'
+
+
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_status_which_crush_osd_only(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target', 'pid',
+        target_digests=['digest1'],
+        daemon_types=['osd'],
+        crush_bucket_type='rack',
+        crush_bucket_name='rack1',
+    )
+    with mock.patch.object(cephadm_module.upgrade, '_get_upgrade_info', return_value=('0/0', [])):
+        status = wait(cephadm_module, cephadm_module.upgrade_status())
+    assert status.which == 'Upgrading daemons of type(s) osd (OSDs in bucket scope)'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_status_which_crush_osd_only_uppercase(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target', 'pid',
+        target_digests=['digest1'],
+        daemon_types=['OSD'],
+        crush_bucket_type='rack',
+        crush_bucket_name='rack1',
+    )
+    with mock.patch.object(cephadm_module.upgrade, '_get_upgrade_info', return_value=('0/0', [])):
+        status = wait(cephadm_module, cephadm_module.upgrade_status())
+    assert status.which == 'Upgrading daemons of type(s) OSD (OSDs in bucket scope)'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_status_which_crush_mixed_daemon_types(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target', 'pid',
+        target_digests=['digest1'],
+        daemon_types=['mon', 'osd'],
+        crush_bucket_type='rack',
+        crush_bucket_name='rack1',
+    )
+    with mock.patch.object(cephadm_module.upgrade, '_get_upgrade_info', return_value=('0/0', [])):
+        status = wait(cephadm_module, cephadm_module.upgrade_status())
+    assert status.which == (
+        'Upgrading daemons of type(s) mon,osd (OSDs in bucket scope)')
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_status_which_full_cluster_with_crush_bucket(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target', 'pid',
+        target_digests=['digest1'],
+        crush_bucket_type='rack',
+        crush_bucket_name='rack1',
+    )
+    with mock.patch.object(cephadm_module.upgrade, '_get_upgrade_info', return_value=('0/0', [])):
+        status = wait(cephadm_module, cephadm_module.upgrade_status())
+    assert status.which == (
+        'Upgrading all daemon types on all hosts (OSDs only in bucket scope)')
+
+
+def test_parse_ok_to_upgrade_mon_json_nested_and_flat():
+    nested = '{"ok_to_upgrade": {"ok_to_upgrade": true, "all_osds_upgraded": false}}'
+    inner = parse_ok_to_upgrade_mon_json(nested)
+    assert inner['ok_to_upgrade'] is True
+    flat = '{"ok_to_upgrade": true}'
+    d = parse_ok_to_upgrade_mon_json(flat)
+    assert d['ok_to_upgrade'] is True
+
+
+def test_request_osd_ok_to_upgrade_report(cephadm_module: CephadmOrchestrator):
+    cephadm_module.check_mon_command = mock.MagicMock(
+        return_value=(0, '{"ok_to_upgrade": {"ok_to_upgrade": true}}', ''))
+    rep = request_osd_ok_to_upgrade_report(
+        cephadm_module, 'mybucket', '20.1.0-144.el9cp', max_osds=3)
+    assert rep['ok_to_upgrade'] is True
+    cephadm_module.check_mon_command.assert_called_once()
+    cmd = cephadm_module.check_mon_command.call_args[0][0]
+    assert cmd['prefix'] == 'osd ok-to-upgrade'
+    assert cmd['crush_bucket'] == 'mybucket'
+    assert cmd['ceph_version'] == '20.1.0-144.el9cp'
+    assert cmd['max'] == 3
+
+
+def test_validate_failure_domain_upgrade_options_ok(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+        'rack', 'rack-a', ['osd'])
+
+
+def test_validate_failure_domain_upgrade_options_chassis_ok(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+        'chassis', 'c1', ['osd'])
+
+
+def test_validate_failure_domain_upgrade_options_host_ok(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+        'host', 'host1', ['osd'])
+
+
+def test_validate_failure_domain_upgrade_options_invalid_type(cephadm_module: CephadmOrchestrator):
+    with pytest.raises(OrchestratorError) as err:
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'root', 'default', ['osd'])
+    assert str(err.value) == (
+        "Supported bucket types for OSD upgrade are: chassis, host, rack (specified: 'root')")
+
+
+def test_validate_failure_domain_upgrade_options_pairing(cephadm_module: CephadmOrchestrator):
+    both_msg = 'Both --crush_bucket_type and --crush_bucket_name must be specified together'
+    with pytest.raises(OrchestratorError) as err:
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'rack', None, ['osd'])
+    assert str(err.value) == both_msg
+    with pytest.raises(OrchestratorError) as err:
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            None, 'rack-a', ['osd'])
+    assert str(err.value) == both_msg
+
+
+def test_validate_failure_domain_upgrade_options_comma_in_name(cephadm_module: CephadmOrchestrator):
+    with pytest.raises(OrchestratorError) as err:
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'rack', 'a,b', ['osd'])
+    assert str(err.value) == (
+        'Invalid --crush_bucket_name: use a single name token without commas')
+
+
+def test_validate_failure_domain_upgrade_options_multi_token_name(cephadm_module: CephadmOrchestrator):
+    with pytest.raises(OrchestratorError) as err:
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'rack', 'rack-a rack-b', ['osd'])
+    assert str(err.value) == (
+        'Invalid --crush_bucket_name: use a single name token without commas')
+
+
+def test_validate_failure_domain_upgrade_options_daemon_types(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+        'rack', 'rack-a', None)
+    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+        'rack', 'rack-a', ['osd', 'mds'])
+    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+        'rack', 'rack-a', ['mgr', 'mon', 'osd'])
+    osd_msg = 'Bucket parameters for OSD upgrade require --daemon-types to include "osd"'
+    with pytest.raises(OrchestratorError) as err:
+        cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+            'rack', 'rack-a', ['mgr', 'mon'])
+    assert str(err.value) == osd_msg
+
+
+def test_validate_failure_domain_upgrade_options_name_not_consulting_crush_map(
+        cephadm_module: CephadmOrchestrator):
+    """Name existence in the CRUSH map is not validated here."""
+    cephadm_module.upgrade._validate_failure_domain_upgrade_options(
+        'rack', 'not-in-map', ['osd'])
+
+
+@mock.patch('cephadm.serve.CephadmServe._run_cephadm', _run_cephadm('{}'))
 def test_not_enough_mgrs(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1'):
         with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=1)), CephadmOrchestrator.apply_mgr, ''):

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -4,7 +4,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass, field, asdict
-from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, Mapping, cast, Set
+from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
 from cephadm.services.service_registry import service_registry
 
 import orchestrator
@@ -60,7 +60,7 @@ def normalize_image_digest(digest: str, default_registry: str) -> str:
     return digest
 
 
-def _get_boolean_values_from_mon_json(value: Any) -> Optional[bool]:
+def _get_bool_value_from_mon_json(value: Any) -> Optional[bool]:
     """Handle only JSON booleans for ``ok_to_upgrade`` / ``all_osds_upgraded``."""
     if isinstance(value, bool):
         return value
@@ -79,6 +79,12 @@ def _get_osd_ids_from_mon_json(value: Any) -> List[int]:
     """
     if isinstance(value, list):
         return list(value)
+    if value is not None:
+        logger.warning(
+            'osd ok-to-upgrade: expected list of osd ids, got %s: %r',
+            type(value),
+            value,
+        )
     return []
 
 
@@ -89,8 +95,12 @@ class OkToUpgradeMonReport:
     parse_ok_to_upgrade_mon_json unwraps the top-level ok_to_upgrade object.
 
     Field names match the keys in the inner report object from the mon JSON.
-    (ok_to_upgrade, all_osds_upgraded, osds_in_crush_bucket,
-     osds_ok_to_upgrade, osds_upgraded, bad_no_version).
+    ok_to_upgrade: : JSON bool; True if mon found a safe batch of OSDs to upgrade.
+    all_osds_upgraded: : JSON bool; True if every bucket OSD already on target ceph_version.
+    osds_ok_to_upgrade: List[int] : OSD ids safe to upgrade this step
+    osds_in_crush_bucket: List[int] : OSD ids under the named CRUSH bucket
+    osds_upgraded: List[int] : OSD ids already matching target ceph_version_short in metadata.
+    bad_no_version: List[int] : OSD ids with missing ceph_version_short in mgr metadata.
     """
 
     ok_to_upgrade: Optional[bool]
@@ -102,13 +112,13 @@ class OkToUpgradeMonReport:
 
     @classmethod
     def from_parsed_body(cls, body: Any) -> 'OkToUpgradeMonReport':
-        if not isinstance(body, Mapping):
+        if not isinstance(body, dict):
             raise ValueError(
                 f'osd ok-to-upgrade: expected JSON object after unwrap, got {type(body)!r}')
         b = dict(body)
         return cls(
-            ok_to_upgrade=_get_boolean_values_from_mon_json(b.get('ok_to_upgrade')),
-            all_osds_upgraded=_get_boolean_values_from_mon_json(b.get('all_osds_upgraded')),
+            ok_to_upgrade=_get_bool_value_from_mon_json(b.get('ok_to_upgrade')),
+            all_osds_upgraded=_get_bool_value_from_mon_json(b.get('all_osds_upgraded')),
             osds_ok_to_upgrade=_get_osd_ids_from_mon_json(b.get('osds_ok_to_upgrade')),
             osds_in_crush_bucket=_get_osd_ids_from_mon_json(b.get('osds_in_crush_bucket')),
             osds_upgraded=_get_osd_ids_from_mon_json(b.get('osds_upgraded')),
@@ -266,8 +276,10 @@ class CephadmUpgrade:
         else:
             self.upgrade_state = None
         self.upgrade_info_str: str = ''
-        # Set during _to_upgrade when last osd ok-to-upgrade call reported all bucket OSDs
-        # on target version (no batch ids); used for logging and to skip repeat mon RPCs.
+        # Set during _to_upgrade when last osd ok-to-upgrade reported all bucket OSDs
+        # on target version (all_osds_upgraded=True). For OSDs still in need_upgrade for an
+        # image/digest mismatch, this helps the code fall back to ok-to-stop for
+        # per-daemon PG safety.
         self._ok_to_upgrade_all_osds_upgraded: bool = False
         # osd.<id> names under the upgrade CRUSH bucket from the last osd ok-to-upgrade
         # report (``osds_in_crush_bucket``). Used so ok-to-stop ``known`` (cluster-wide)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -300,7 +300,7 @@ class CephadmUpgrade:
     def _upgrade_status_osd_bucket_scope_active(self) -> bool:
         """True when upgrade state selects OSD bucket scope"""
         st = self.upgrade_state
-        return bool(st and st.crush_bucket_name)
+        return bool(st and st.crush_bucket_name and st.crush_bucket_type)
 
     def upgrade_status(self) -> orchestrator.UpgradeStatusSpec:
         r = orchestrator.UpgradeStatusSpec()
@@ -325,8 +325,6 @@ class CephadmUpgrade:
                     which_str += f' on host(s) {",".join(self.upgrade_state.hosts)}'
             elif self.upgrade_state.hosts is not None:
                 which_str = f'Upgrading all daemons on host(s) {",".join(self.upgrade_state.hosts)}'
-            elif osd_bucket_scope:
-                which_str = 'Upgrading all daemon types on all hosts (OSDs only in bucket scope)'
             else:
                 which_str = 'Upgrading all daemon types on all hosts'
             if self.upgrade_state.total_count is not None and self.upgrade_state.remaining_count is not None:
@@ -489,17 +487,6 @@ class CephadmUpgrade:
             raise OrchestratorError(
                 f'Supported bucket types for OSD upgrade are: {allowed} (specified: {crush_bucket_type!r})')
 
-        osd_in_upgrade_scope = (
-            daemon_types is None
-            or any(
-                (dt or '').strip().lower() == 'osd'
-                for dt in daemon_types
-            )
-        )
-        if not osd_in_upgrade_scope:
-            raise OrchestratorError(
-                'Bucket parameters for OSD upgrade require --daemon-types to include "osd"')
-
         single_bucket_name = (
             ',' not in bucket_name
             and len(bucket_name.split()) == 1
@@ -508,6 +495,15 @@ class CephadmUpgrade:
         if not single_bucket_name:
             raise OrchestratorError(
                 'Invalid --crush_bucket_name: use a single name token without commas')
+
+        osd_only = (
+            daemon_types is not None
+            and len(daemon_types) == 1
+            and (daemon_types[0] or '').strip().lower() == 'osd'
+        )
+        if not osd_only:
+            raise OrchestratorError(
+                'Bucket parameters for OSD upgrade require --daemon-types to be "osd"')
 
     @staticmethod
     def is_mon_error_for_invalid_bucket(err: MonCommandFailed) -> bool:

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1,8 +1,9 @@
+import errno
 import json
 import logging
 import time
 import uuid
-from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast
+from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
 from cephadm.services.service_registry import service_registry
 
 import orchestrator
@@ -21,6 +22,10 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# Underlying mon ok-to-upgrade command supports the following
+# OSD upgrade failure domain types relevant for parallelization.
+CEPH_ORCH_VALID_OSD_UPGRADE_CRUSH_BUCKETS = frozenset({'rack', 'chassis', 'host'})
 
 # from ceph_fs.h
 CEPH_MDSMAP_ALLOW_STANDBY_REPLAY = (1 << 5)
@@ -54,6 +59,58 @@ def normalize_image_digest(digest: str, default_registry: str) -> str:
     return digest
 
 
+def parse_ok_to_upgrade_mon_json(out: str) -> dict:
+    """
+    Parse mon JSON from ``osd ok-to-upgrade``. The monitor nests the
+    report under a top-level ``ok_to_upgrade`` object.
+    If the report is not nested, return the entire JSON object.
+    """
+    parsed = json.loads(out)
+    nested_ok_report = parsed.get('ok_to_upgrade')
+    if isinstance(nested_ok_report, dict):
+        return nested_ok_report
+    return parsed
+
+
+def request_osd_ok_to_upgrade_report(
+    mgr: "CephadmOrchestrator",
+    crush_bucket: str,
+    ceph_version_short: str,
+    max_osds: int,
+) -> dict:
+    """
+    Send ``osd ok-to-upgrade`` to the monitor.
+
+    *ceph_version_short* must be the **inspected** short token from the target
+    image's ``ceph version …`` line (same as ``upgrade_state.target_version``
+    after the first pull in ``_do_upgrade``). It is not necessarily the same
+    string as CLI ``--ceph-version`` (e.g. tag ``18.2.1`` vs build suffix).
+    """
+    cmd: Dict[str, Any] = {
+        'prefix': 'osd ok-to-upgrade',
+        'crush_bucket': crush_bucket,
+        'ceph_version': ceph_version_short,
+        'max': max_osds,
+    }
+    _return_code, mon_out, _stderr = mgr.check_mon_command(cmd)
+    report = parse_ok_to_upgrade_mon_json(mon_out)
+    logger.debug(
+        'Upgrade: osd ok-to-upgrade mon response: requested max=%s crush_bucket=%r '
+        'ceph_version=%r ok_to_upgrade=%s all_osds_upgraded=%s osds_ok_to_upgrade=%s '
+        'osds_in_crush_bucket=%s osds_upgraded=%s bad_no_version=%s',
+        max_osds,
+        crush_bucket,
+        ceph_version_short,
+        report.get('ok_to_upgrade'),
+        report.get('all_osds_upgraded'),
+        report.get('osds_ok_to_upgrade'),
+        report.get('osds_in_crush_bucket'),
+        report.get('osds_upgraded'),
+        report.get('bad_no_version'),
+    )
+    return report
+
+
 class UpgradeState:
     def __init__(self,
                  target_name: str,
@@ -71,6 +128,8 @@ class UpgradeState:
                  services: Optional[List[str]] = None,
                  total_count: Optional[int] = None,
                  remaining_count: Optional[int] = None,
+                 crush_bucket_type: Optional[str] = None,
+                 crush_bucket_name: Optional[str] = None,
                  ):
         self._target_name: str = target_name  # Use CephadmUpgrade.target_image instead.
         self.progress_id: str = progress_id
@@ -88,6 +147,8 @@ class UpgradeState:
         self.services = services
         self.total_count = total_count
         self.remaining_count = remaining_count
+        self.crush_bucket_type = crush_bucket_type
+        self.crush_bucket_name = crush_bucket_name
 
     def to_json(self) -> dict:
         return {
@@ -106,6 +167,8 @@ class UpgradeState:
             'services': self.services,
             'total_count': self.total_count,
             'remaining_count': self.remaining_count,
+            'crush_bucket_type': self.crush_bucket_type,
+            'crush_bucket_name': self.crush_bucket_name,
         }
 
     @classmethod
@@ -127,7 +190,8 @@ class CephadmUpgrade:
         'UPGRADE_REDEPLOY_DAEMON',
         'UPGRADE_BAD_TARGET_VERSION',
         'UPGRADE_EXCEPTION',
-        'UPGRADE_OFFLINE_HOST'
+        'UPGRADE_OFFLINE_HOST',
+        'UPGRADE_INVALID_CRUSH_BUCKET',
     ]
 
     def __init__(self, mgr: "CephadmOrchestrator"):
@@ -139,6 +203,13 @@ class CephadmUpgrade:
         else:
             self.upgrade_state = None
         self.upgrade_info_str: str = ''
+        # Set during _to_upgrade when last osd ok-to-upgrade call reported all bucket OSDs
+        # on target version (no batch ids); used for logging and to skip repeat mon RPCs.
+        self._ok_to_upgrade_all_osds_upgraded: bool = False
+        # osd.<id> names under the upgrade CRUSH bucket from the last osd ok-to-upgrade
+        # report (``osds_in_crush_bucket``). Used so ok-to-stop ``known`` (cluster-wide)
+        # cannot schedule OSDs outside the bucket.
+        self._ok_to_upgrade_osds_in_crush_bucket: Optional[Set[str]] = None
 
     @property
     def target_image(self) -> str:
@@ -151,6 +222,11 @@ class CephadmUpgrade:
         # FIXME: we assume the first digest is the best one to use
         return self.upgrade_state.target_digests[0]
 
+    def _upgrade_status_osd_bucket_scope_active(self) -> bool:
+        """True when upgrade state selects OSD bucket scope"""
+        st = self.upgrade_state
+        return bool(st and st.crush_bucket_name)
+
     def upgrade_status(self) -> orchestrator.UpgradeStatusSpec:
         r = orchestrator.UpgradeStatusSpec()
         if self.upgrade_state:
@@ -159,8 +235,13 @@ class CephadmUpgrade:
             r.progress, r.services_complete = self._get_upgrade_info()
             r.is_paused = self.upgrade_state.paused
 
+            osd_bucket_scope = self._upgrade_status_osd_bucket_scope_active()
             if self.upgrade_state.daemon_types is not None:
-                which_str = f'Upgrading daemons of type(s) {",".join(self.upgrade_state.daemon_types)}'
+                daemon_types = self.upgrade_state.daemon_types
+                which_str = f'Upgrading daemons of type(s) {",".join(daemon_types)}'
+                types_norm = [(dt or '').strip().lower() for dt in daemon_types]
+                if osd_bucket_scope and 'osd' in types_norm:
+                    which_str += ' (OSDs in bucket scope)'
                 if self.upgrade_state.hosts is not None:
                     which_str += f' on host(s) {",".join(self.upgrade_state.hosts)}'
             elif self.upgrade_state.services is not None:
@@ -169,6 +250,8 @@ class CephadmUpgrade:
                     which_str += f' on host(s) {",".join(self.upgrade_state.hosts)}'
             elif self.upgrade_state.hosts is not None:
                 which_str = f'Upgrading all daemons on host(s) {",".join(self.upgrade_state.hosts)}'
+            elif osd_bucket_scope:
+                which_str = 'Upgrading all daemon types on all hosts (OSDs only in bucket scope)'
             else:
                 which_str = 'Upgrading all daemon types on all hosts'
             if self.upgrade_state.total_count is not None and self.upgrade_state.remaining_count is not None:
@@ -310,8 +393,58 @@ class CephadmUpgrade:
             r["tags"] = sorted(ls)
         return r
 
+    def _validate_failure_domain_upgrade_options(
+        self,
+        crush_bucket_type: Optional[str],
+        crush_bucket_name: Optional[str],
+        daemon_types: Optional[List[str]],
+    ) -> None:
+        # Validates syntax only. Bucket existence validated by monitor's
+        # osd ok-to-upgrade to avoid duplicate validation across layers.
+        bucket_type = (crush_bucket_type or '').strip().lower()
+        bucket_name = (crush_bucket_name or '').strip()
+
+        both_crush_args = bool(bucket_type) and bool(bucket_name)
+        if not both_crush_args:
+            raise OrchestratorError(
+                'Both --crush_bucket_type and --crush_bucket_name must be specified together')
+
+        if bucket_type not in CEPH_ORCH_VALID_OSD_UPGRADE_CRUSH_BUCKETS:
+            allowed = ', '.join(sorted(CEPH_ORCH_VALID_OSD_UPGRADE_CRUSH_BUCKETS))
+            raise OrchestratorError(
+                f'Supported bucket types for OSD upgrade are: {allowed} (specified: {crush_bucket_type!r})')
+
+        osd_in_upgrade_scope = (
+            daemon_types is None
+            or any(
+                (dt or '').strip().lower() == 'osd'
+                for dt in daemon_types
+            )
+        )
+        if not osd_in_upgrade_scope:
+            raise OrchestratorError(
+                'Bucket parameters for OSD upgrade require --daemon-types to include "osd"')
+
+        single_bucket_name = (
+            ',' not in bucket_name
+            and len(bucket_name.split()) == 1
+            and bool(bucket_name)
+        )
+        if not single_bucket_name:
+            raise OrchestratorError(
+                'Invalid --crush_bucket_name: use a single name token without commas')
+
+    @staticmethod
+    def is_mon_error_for_invalid_bucket(err: MonCommandFailed) -> bool:
+        """
+        CRUSH bucket errors from ``osd ok-to-upgrade`` mon command.
+        Typically ENOENT: unknown bucket name or no OSDs under that bucket.
+        """
+        return f'retval: {-errno.ENOENT}' in str(err)
+
     def upgrade_start(self, image: str, version: str, daemon_types: Optional[List[str]] = None,
-                      hosts: Optional[List[str]] = None, services: Optional[List[str]] = None, limit: Optional[int] = None) -> str:
+                      hosts: Optional[List[str]] = None, services: Optional[List[str]] = None, limit: Optional[int] = None,
+                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> str:
         fail_fs_value = cast(bool, self.mgr.get_module_option_ex(
             'orchestrator', 'fail_fs', False))
         if self.mgr.mode != 'root':
@@ -326,6 +459,13 @@ class CephadmUpgrade:
             target_name = normalize_image_digest(image, self.mgr.default_registry)
         else:
             raise OrchestratorError('must specify either image or version')
+
+        # Validate the failure domain upgrade options
+        # if the user has provided either or both of the
+        # --crush_bucket_type and --crush_bucket_name arguments.
+        if bucket_type is not None or bucket_name is not None:
+            self._validate_failure_domain_upgrade_options(
+                bucket_type, bucket_name, daemon_types)
 
         if daemon_types is not None or services is not None or hosts is not None:
             self._validate_upgrade_filters(target_name, daemon_types, hosts, services)
@@ -357,6 +497,8 @@ class CephadmUpgrade:
             services=services,
             total_count=limit,
             remaining_count=limit,
+            crush_bucket_type=bucket_type,
+            crush_bucket_name=bucket_name,
         )
         self._update_upgrade_progress(0.0)
         self._save_upgrade_state()
@@ -490,6 +632,7 @@ class CephadmUpgrade:
         target_image = self.target_image
         self.mgr.log.info('Upgrade: Stopped')
         self.upgrade_state = None
+        self._ok_to_upgrade_osds_in_crush_bucket = None
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()
         self.mgr.event.set()
@@ -561,6 +704,154 @@ class CephadmUpgrade:
 
             time.sleep(15)
             tries -= 1
+        return False
+
+    def _upgrade_uses_ok_to_upgrade_for_osds(self) -> bool:
+        """
+        When ``upgrade_start`` persisted CRUSH bucket scope (bucket type/name
+        and upgrade includes OSDs, validated there), OSDs that still need the target
+        image are batched via ``osd ok-to-upgrade``. If the mon reports
+        ``all_osds_upgraded`` but mgr still has ``(daemon, redeploy_only=False)``
+        rows (same Ceph version string, different container digest/name),
+        ``_to_upgrade`` falls back to ``_wait_for_ok_to_stop`` per daemon like the
+        non-bucket path. Redeploy-only rows are also handled with ok-to-stop.
+        """
+        if not self.upgrade_state:
+            return False
+        state = self.upgrade_state
+        if not state.crush_bucket_name or not state.crush_bucket_type:
+            return False
+
+        return True
+
+    def _cache_osds_in_crush_bucket_from_ok_to_upgrade_report(self, report: dict) -> None:
+        raw = report.get('osds_in_crush_bucket')
+        if isinstance(raw, list):
+            self._ok_to_upgrade_osds_in_crush_bucket = {
+                f'osd.{osd_id}' for osd_id in raw
+            }
+
+    def is_osd_upgrade_valid_for_failure_domain(self, d: DaemonDescription) -> bool:
+        # If not using ok-to-upgrade for OSDs, any OSD is valid.
+        if not self._upgrade_uses_ok_to_upgrade_for_osds():
+            return True
+
+        if d.daemon_type != 'osd':
+            return True
+        # If not in the CRUSH bucket, it is not valid.
+        bset = self._ok_to_upgrade_osds_in_crush_bucket
+        if not bset:
+            return False
+        return d.name() in bset
+
+    def _wait_for_ok_to_upgrade_osd_batch(
+            self,
+            known_ok_to_upgrade: List[str],
+    ) -> bool:
+        """
+        Query ``osd ok-to-upgrade`` once and append approved daemon names
+        (``osd.<id>``) to *known_ok_to_upgrade*.
+
+        *max* is ``mgr.max_parallel_osd_upgrades``, matching ``osd ok-to-stop``.
+
+        The monitor's ``ceph_version`` argument is *upgrade_state.target_version*:
+        the short token taken from the target image after inspect in ``_do_upgrade``
+        (not the raw CLI ``--ceph-version`` string).
+        """
+        assert self.upgrade_state is not None
+        bucket_name = self.upgrade_state.crush_bucket_name
+        ceph_version_short = self.upgrade_state.target_version
+        if not bucket_name or not ceph_version_short:
+            logger.error(
+                'Upgrade: CRUSH bucket OSD upgrade missing bucket name or '
+                'target_version (inspected short from image); cannot call '
+                'osd ok-to-upgrade (no ok-to-stop fallback for this mode)')
+            return False
+
+        max_parallel = self.mgr.max_parallel_osd_upgrades
+        remaining_tries = 4
+        while remaining_tries > 0:
+            if not self.upgrade_state or self.upgrade_state.paused:
+                return False
+
+            try:
+                report = request_osd_ok_to_upgrade_report(
+                    self.mgr,
+                    bucket_name,
+                    ceph_version_short,
+                    max_osds=max_parallel,
+                )
+            except MonCommandFailed as err:
+                if self.is_mon_error_for_invalid_bucket(err):
+                    st = self.upgrade_state
+                    btype = st.crush_bucket_type if st else None
+                    logger.error('Upgrade: osd ok-to-upgrade failed (CRUSH bucket): %s', err)
+                    self._fail_upgrade('UPGRADE_INVALID_CRUSH_BUCKET', {
+                        'severity': 'error',
+                        'summary': 'Upgrade: invalid failure domain for OSD upgrade',
+                        'count': 1,
+                        'detail': [
+                            str(err),
+                            f'Invalid failure domain for OSD upgrade: --crush_bucket_type={btype!r} '
+                            f'--crush_bucket_name={bucket_name!r}',
+                        ],
+                    })
+                    return False
+                logger.info('Upgrade: osd ok-to-upgrade not ready: %s', err)
+                time.sleep(15)
+                remaining_tries -= 1
+                continue
+
+            self._cache_osds_in_crush_bucket_from_ok_to_upgrade_report(report)
+
+            # Detailed mon fields logged in ``request_osd_ok_to_upgrade_report``.
+            # Same JSON shape as ``osd ok-to-stop`` → ``osds``: array of OSD ids.
+            raw_osds = report.get('osds_ok_to_upgrade')
+            if isinstance(raw_osds, list):
+                approved_names = [f'osd.{osd_id}' for osd_id in raw_osds]
+            else:
+                approved_names = []
+            bad_no_version = report.get('bad_no_version') or []
+            if (
+                not approved_names
+                and report.get('all_osds_upgraded') is True
+                and not bad_no_version
+            ):
+                self._ok_to_upgrade_all_osds_upgraded = True
+                logger.info(
+                    'Upgrade: osd ok-to-upgrade reports all OSDs under crush_bucket=%r '
+                    'on ceph_version=%r',
+                    bucket_name,
+                    ceph_version_short,
+                )
+                return True
+
+            if not approved_names:
+                logger.info(
+                    'Upgrade: osd ok-to-upgrade returned no OSDs for '
+                    'crush_bucket=%r ceph_version=%r (wrong or missing CRUSH '
+                    'bucket name is a common cause; also check bucket has OSDs '
+                    'not yet on the target version). Report: %s',
+                    bucket_name,
+                    ceph_version_short,
+                    report,
+                )
+                time.sleep(15)
+                remaining_tries -= 1
+                continue
+
+            # gets reset for each batch of OSDs
+            self._ok_to_upgrade_all_osds_upgraded = False
+
+            known_ok_to_upgrade.extend(approved_names)
+            logger.info(
+                'Upgrade: osd ok-to-upgrade bucket=%r max=%s approved %s',
+                bucket_name,
+                max_parallel,
+                approved_names,
+            )
+            return True
+
         return False
 
     def _clear_upgrade_health_checks(self) -> None:
@@ -806,10 +1097,13 @@ class CephadmUpgrade:
                 continue
 
             if correct_image:
+                # Matches target (digests or image name per use_repo_digest) but not
+                # deployed_by target digests; redeploy only.
                 logger.debug('daemon %s.%s not deployed by correct version' % (
                     d.daemon_type, d.daemon_id))
                 need_upgrade_deployer.append((d, True))
             else:
+                # Does not match target digests or target image name
                 logger.debug('daemon %s.%s not correct (%s, %s, %s)' % (
                     d.daemon_type, d.daemon_id,
                     d.container_image_name, d.container_image_digests, d.version))
@@ -817,9 +1111,13 @@ class CephadmUpgrade:
 
         return (need_upgrade_self, need_upgrade, need_upgrade_deployer, done)
 
+    # return True if the upgrade is safe to proceed, False otherwise
+    # to_upgrade is a list of daemons that need to be upgraded
     def _to_upgrade(self, need_upgrade: List[Tuple[DaemonDescription, bool]], target_image: str) -> Tuple[bool, List[Tuple[DaemonDescription, bool]]]:
         to_upgrade: List[Tuple[DaemonDescription, bool]] = []
         known_ok_to_stop: List[str] = []
+        known_ok_to_upgrade: List[str] = []
+        self._ok_to_upgrade_all_osds_upgraded = False
         for d_entry in need_upgrade:
             d = d_entry[0]
             assert d.daemon_type is not None
@@ -832,17 +1130,65 @@ class CephadmUpgrade:
                         'daemon %s has unknown container_image_id but has correct image name' % (d.name()))
                     continue
 
-            if known_ok_to_stop:
-                if d.name() in known_ok_to_stop:
-                    logger.info(f'Upgrade: {d.name()} is also safe to restart')
+            # d_entry[1] True means that the daemon is already on the target image and
+            # just needs redeployment. Use ok-to-stop for PG safety.
+            # Without this branch, redeploy-only bucket OSDs never appear in the osd
+            # ok-to-upgrade batch and are skipped (continue), so they never reach
+            # to_upgrade and the upgrade can stall while they remain in need_upgrade.
+            if (
+                d.daemon_type == 'osd'
+                and self._upgrade_uses_ok_to_upgrade_for_osds()
+                and d_entry[1]
+            ):
+                if not self.is_osd_upgrade_valid_for_failure_domain(d):
+                    continue
+                if not self._wait_for_ok_to_stop(d, known_ok_to_stop):
+                    return False, to_upgrade
+                logger.info(f'Upgrade: {d.name()} is safe to redeploy')
+                to_upgrade.append(d_entry)
+                if not known_ok_to_stop:
+                    break
+                continue
+
+            if known_ok_to_stop or known_ok_to_upgrade:
+                if (
+                    (d.name() in known_ok_to_stop or d.name() in known_ok_to_upgrade)
+                    and self.is_osd_upgrade_valid_for_failure_domain(d)
+                ):
+                    logger.info(f'Upgrade: {d.name()} is safe to restart')
                     to_upgrade.append(d_entry)
                 continue
 
             if d.daemon_type == 'osd':
-                # NOTE: known_ok_to_stop is an output argument for
-                # _wait_for_ok_to_stop
-                if not self._wait_for_ok_to_stop(d, known_ok_to_stop):
-                    return False, to_upgrade
+                if self._upgrade_uses_ok_to_upgrade_for_osds():
+                    # Refresh ok-to-upgrade batch when we do not have one yet.
+                    if not known_ok_to_upgrade and not self._ok_to_upgrade_all_osds_upgraded:
+                        if not self._wait_for_ok_to_upgrade_osd_batch(known_ok_to_upgrade):
+                            return False, to_upgrade
+
+                    if d.name() not in known_ok_to_upgrade:
+                        # Mon ok-to-upgrade state (all upgraded) can disagree with cephadm's
+                        # view of this OSD (still wrong image in need_upgrade);
+                        # Handle with ok-to-stop for PG safety.
+                        if (
+                            self._ok_to_upgrade_all_osds_upgraded
+                            and not known_ok_to_upgrade
+                            and not d_entry[1]
+                        ):
+                            if not self.is_osd_upgrade_valid_for_failure_domain(d):
+                                continue
+                            if not self._wait_for_ok_to_stop(d, known_ok_to_stop):
+                                return False, to_upgrade
+                            # Add to to_upgrade list for redeployment.
+                            to_upgrade.append(d_entry)
+                            if not known_ok_to_stop:
+                                break
+                        continue
+                else:
+                    # NOTE: known_ok_to_stop is an output argument for
+                    # _wait_for_ok_to_stop
+                    if not self._wait_for_ok_to_stop(d, known_ok_to_stop):
+                        return False, to_upgrade
 
             if d.daemon_type == 'mon' and self._enough_mons_for_ok_to_stop():
                 if not self._wait_for_ok_to_stop(d, known_ok_to_stop):
@@ -860,11 +1206,28 @@ class CephadmUpgrade:
                         and not self._wait_for_ok_to_stop(d, known_ok_to_stop):
                     return False, to_upgrade
 
+            if (
+                d.daemon_type == 'osd'
+                and self._upgrade_uses_ok_to_upgrade_for_osds()
+                and not self.is_osd_upgrade_valid_for_failure_domain(d)
+            ):
+                continue
+
             to_upgrade.append(d_entry)
 
-            # if we don't have a list of others to consider, stop now
+            # ok-to-stop did not add peer names to known_ok_to_stop.
+            # For osd/mds/mon we then stop scanning need_upgrade this pass.
+            # This helps:
+            # 1. Limit how many core daemons get queued in a single pass without
+            #    a mon-supplied peer batch in known_ok_to_stop.
+            # 2. Yield between batches of core daemons to allow the mon to catch up.
             if d.daemon_type in ['osd', 'mds', 'mon'] and not known_ok_to_stop:
+                # osd ok-to-upgrade batch is not empty, so keep looping to
+                # add more OSDs to the batch
+                if d.daemon_type == 'osd' and self._upgrade_uses_ok_to_upgrade_for_osds() and (len(known_ok_to_upgrade) > 0):
+                    continue  # do not break
                 break
+
         return True, to_upgrade
 
     def _upgrade_daemons(self, to_upgrade: List[Tuple[DaemonDescription, bool]], target_image: str, target_digests: Optional[List[str]] = None) -> None:
@@ -1091,6 +1454,7 @@ class CephadmUpgrade:
             self.mgr.remote('progress', 'complete',
                             self.upgrade_state.progress_id)
         self.upgrade_state = None
+        self._ok_to_upgrade_osds_in_crush_bucket = None
         self._save_upgrade_state()
 
     def _do_upgrade(self):
@@ -1142,7 +1506,9 @@ class CephadmUpgrade:
                 })
                 return
             self.upgrade_state.target_id = target_id
-            # extract the version portion of 'ceph version {version} ({sha1})'
+            # Short token from ``ceph version …`` inside the target image; this
+            # is what the monitor expects for ``osd ok-to-upgrade`` ceph_version
+            # (may differ from CLI --ceph-version, e.g. full build id vs tag).
             self.upgrade_state.target_version = target_version.split(' ')[2]
             self.upgrade_state.target_digests = target_digests
             self._save_upgrade_state()
@@ -1210,6 +1576,10 @@ class CephadmUpgrade:
             logger.debug('Upgrade: Checking %s daemons' % daemon_type)
             daemons_of_type = [d for d in daemons if d.daemon_type == daemon_type]
 
+            # need_upgrade_self: True if the daemon is active mgr itself and needs to be upgraded
+            # need_upgrade: List of daemons that need to be upgraded
+            # need_upgrade_deployer: List of daemons that need to be redeployed
+            # done: Number of daemons that have been upgraded
             need_upgrade_self, need_upgrade, need_upgrade_deployer, done = self._detect_need_upgrade(
                 daemons_of_type, target_digests, target_image)
             upgraded_daemon_count += done

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -3,7 +3,8 @@ import json
 import logging
 import time
 import uuid
-from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
+from dataclasses import dataclass, field, asdict
+from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, Mapping, cast, Set
 from cephadm.services.service_registry import service_registry
 
 import orchestrator
@@ -59,11 +60,71 @@ def normalize_image_digest(digest: str, default_registry: str) -> str:
     return digest
 
 
+def _get_boolean_values_from_mon_json(value: Any) -> Optional[bool]:
+    """Handle only JSON booleans for ``ok_to_upgrade`` / ``all_osds_upgraded``."""
+    if isinstance(value, bool):
+        return value
+    if value is not None:
+        logger.warning('osd ok-to-upgrade: expected boolean, got %s: %r', type(value), value)
+    return None
+
+
+def _get_osd_ids_from_mon_json(value: Any) -> List[int]:
+    """
+    OSD id list fields from ``osd ok-to-upgrade`` inner JSON.
+
+    Per-element types are not checked: the monitor's ``upgrade_osd_report::dump``
+    path emits bare integer arrays for these keys, and the mgr treats that as the
+    contract for this command.
+    """
+    if isinstance(value, list):
+        return list(value)
+    return []
+
+
+@dataclass(frozen=True)
+class OkToUpgradeMonReport:
+    """
+    Normalized view of the inner mon JSON for osd ok-to-upgrade after
+    parse_ok_to_upgrade_mon_json unwraps the top-level ok_to_upgrade object.
+
+    Field names match the keys in the inner report object from the mon JSON.
+    (ok_to_upgrade, all_osds_upgraded, osds_in_crush_bucket,
+     osds_ok_to_upgrade, osds_upgraded, bad_no_version).
+    """
+
+    ok_to_upgrade: Optional[bool]
+    all_osds_upgraded: Optional[bool]
+    osds_ok_to_upgrade: List[int] = field(default_factory=list)
+    osds_in_crush_bucket: List[int] = field(default_factory=list)
+    osds_upgraded: List[int] = field(default_factory=list)
+    bad_no_version: List[int] = field(default_factory=list)
+
+    @classmethod
+    def from_parsed_body(cls, body: Any) -> 'OkToUpgradeMonReport':
+        if not isinstance(body, Mapping):
+            raise ValueError(
+                f'osd ok-to-upgrade: expected JSON object after unwrap, got {type(body)!r}')
+        b = dict(body)
+        return cls(
+            ok_to_upgrade=_get_boolean_values_from_mon_json(b.get('ok_to_upgrade')),
+            all_osds_upgraded=_get_boolean_values_from_mon_json(b.get('all_osds_upgraded')),
+            osds_ok_to_upgrade=_get_osd_ids_from_mon_json(b.get('osds_ok_to_upgrade')),
+            osds_in_crush_bucket=_get_osd_ids_from_mon_json(b.get('osds_in_crush_bucket')),
+            osds_upgraded=_get_osd_ids_from_mon_json(b.get('osds_upgraded')),
+            bad_no_version=_get_osd_ids_from_mon_json(b.get('bad_no_version')),
+        )
+
+    def mon_resp_as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
 def parse_ok_to_upgrade_mon_json(out: str) -> dict:
     """
-    Parse mon JSON from ``osd ok-to-upgrade``. The monitor nests the
-    report under a top-level ``ok_to_upgrade`` object.
-    If the report is not nested, return the entire JSON object.
+    Parse mon JSON from ``osd ok-to-upgrade``.
+    osd ok-to-upgrade implementation in DaemonServer.cc dumps the response
+    as a top-level boolean object with the inner report object as the key-values
+
     """
     parsed = json.loads(out)
     nested_ok_report = parsed.get('ok_to_upgrade')
@@ -77,7 +138,7 @@ def request_osd_ok_to_upgrade_report(
     crush_bucket: str,
     ceph_version_short: str,
     max_osds: int,
-) -> dict:
+) -> OkToUpgradeMonReport:
     """
     Send ``osd ok-to-upgrade`` to the monitor.
 
@@ -93,7 +154,8 @@ def request_osd_ok_to_upgrade_report(
         'max': max_osds,
     }
     _return_code, mon_out, _stderr = mgr.check_mon_command(cmd)
-    report = parse_ok_to_upgrade_mon_json(mon_out)
+    body = parse_ok_to_upgrade_mon_json(mon_out)
+    report = OkToUpgradeMonReport.from_parsed_body(body)
     logger.debug(
         'Upgrade: osd ok-to-upgrade mon response: requested max=%s crush_bucket=%r '
         'ceph_version=%r ok_to_upgrade=%s all_osds_upgraded=%s osds_ok_to_upgrade=%s '
@@ -101,12 +163,12 @@ def request_osd_ok_to_upgrade_report(
         max_osds,
         crush_bucket,
         ceph_version_short,
-        report.get('ok_to_upgrade'),
-        report.get('all_osds_upgraded'),
-        report.get('osds_ok_to_upgrade'),
-        report.get('osds_in_crush_bucket'),
-        report.get('osds_upgraded'),
-        report.get('bad_no_version'),
+        report.ok_to_upgrade,
+        report.all_osds_upgraded,
+        report.osds_ok_to_upgrade,
+        report.osds_in_crush_bucket,
+        report.osds_upgraded,
+        report.bad_no_version,
     )
     return report
 
@@ -192,6 +254,7 @@ class CephadmUpgrade:
         'UPGRADE_EXCEPTION',
         'UPGRADE_OFFLINE_HOST',
         'UPGRADE_INVALID_CRUSH_BUCKET',
+        'UPGRADE_OSD_NO_VERSION',
     ]
 
     def __init__(self, mgr: "CephadmOrchestrator"):
@@ -724,12 +787,12 @@ class CephadmUpgrade:
 
         return True
 
-    def _cache_osds_in_crush_bucket_from_ok_to_upgrade_report(self, report: dict) -> None:
-        raw = report.get('osds_in_crush_bucket')
-        if isinstance(raw, list):
-            self._ok_to_upgrade_osds_in_crush_bucket = {
-                f'osd.{osd_id}' for osd_id in raw
-            }
+    def _cache_osds_in_crush_bucket_from_ok_to_upgrade_report(
+            self, report: OkToUpgradeMonReport) -> None:
+        ids = report.osds_in_crush_bucket
+        self._ok_to_upgrade_osds_in_crush_bucket = {
+            f'osd.{osd_id}' for osd_id in ids
+        }
 
     def is_osd_upgrade_valid_for_failure_domain(self, d: DaemonDescription) -> bool:
         # If not using ok-to-upgrade for OSDs, any OSD is valid.
@@ -781,6 +844,25 @@ class CephadmUpgrade:
                     ceph_version_short,
                     max_osds=max_parallel,
                 )
+            except json.JSONDecodeError as err:
+                logger.error('Upgrade: osd ok-to-upgrade JSON parse failed: %s', err)
+                self._fail_upgrade('UPGRADE_EXCEPTION', {
+                    'severity': 'error',
+                    'summary': 'Upgrade: osd ok-to-upgrade returned invalid JSON',
+                    'count': 1,
+                    'detail': [str(err)],
+                })
+                return False
+            except ValueError as err:
+                logger.error(
+                    'Upgrade: osd ok-to-upgrade unexpected response shape: %s', err)
+                self._fail_upgrade('UPGRADE_EXCEPTION', {
+                    'severity': 'error',
+                    'summary': 'Upgrade: osd ok-to-upgrade returned unexpected JSON shape',
+                    'count': 1,
+                    'detail': [str(err)],
+                })
+                return False
             except MonCommandFailed as err:
                 if self.is_mon_error_for_invalid_bucket(err):
                     st = self.upgrade_state
@@ -804,18 +886,30 @@ class CephadmUpgrade:
 
             self._cache_osds_in_crush_bucket_from_ok_to_upgrade_report(report)
 
+            if report.bad_no_version:
+                osd_names = ', '.join(f'osd.{i}' for i in report.bad_no_version)
+                self._fail_upgrade('UPGRADE_OSD_NO_VERSION', {
+                    'severity': 'error',
+                    'summary': (
+                        'Upgrade: osd ok-to-upgrade reported OSDs without a detectable '
+                        'Ceph version'
+                    ),
+                    'count': len(report.bad_no_version),
+                    'detail': [
+                        f'The monitor cannot compare these OSDs to the target version '
+                        f'({ceph_version_short!r}): {osd_names}. '
+                        'Resolve daemon or version reporting on those OSDs before '
+                        'continuing the upgrade.',
+                    ],
+                })
+                return False
+
             # Detailed mon fields logged in ``request_osd_ok_to_upgrade_report``.
-            # Same JSON shape as ``osd ok-to-stop`` → ``osds``: array of OSD ids.
-            raw_osds = report.get('osds_ok_to_upgrade')
-            if isinstance(raw_osds, list):
-                approved_names = [f'osd.{osd_id}' for osd_id in raw_osds]
-            else:
-                approved_names = []
-            bad_no_version = report.get('bad_no_version') or []
+            approved_names = [f'osd.{osd_id}' for osd_id in report.osds_ok_to_upgrade]
             if (
                 not approved_names
-                and report.get('all_osds_upgraded') is True
-                and not bad_no_version
+                and report.all_osds_upgraded is True
+                and not report.bad_no_version
             ):
                 self._ok_to_upgrade_all_osds_upgraded = True
                 logger.info(
@@ -834,7 +928,7 @@ class CephadmUpgrade:
                     'not yet on the target version). Report: %s',
                     bucket_name,
                     ceph_version_short,
-                    report,
+                    report.mon_resp_as_dict(),
                 )
                 time.sleep(15)
                 remaining_tries -= 1

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -182,9 +182,11 @@ class UpgradeManager(ResourceManager):
     @wait_api_result
     def start(self, image: str, version: str, daemon_types: Optional[List[str]] = None,
               host_placement: Optional[str] = None, services: Optional[List[str]] = None,
-              limit: Optional[int] = None) -> str:
-        return self.api.upgrade_start(image, version, daemon_types, host_placement, services,
-                                      limit)
+              limit: Optional[int] = None, bucket_type: Optional[str] = None,
+              bucket_name: Optional[str] = None) -> str:
+        return self.api.upgrade_start(
+            image, version, daemon_types, host_placement, services, limit,
+            bucket_type, bucket_name)
 
     @wait_api_result
     def pause(self) -> str:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -949,7 +949,8 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def upgrade_start(self, image: Optional[str], version: Optional[str], daemon_types: Optional[List[str]],
-                      hosts: Optional[str], services: Optional[List[str]], limit: Optional[int]) -> OrchResult[str]:
+                      hosts: Optional[str], services: Optional[List[str]], limit: Optional[int],
+                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> OrchResult[str]:
         raise NotImplementedError()
 
     def upgrade_pause(self) -> OrchResult[str]:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2586,13 +2586,17 @@ Usage:
                        hosts: Optional[str] = None,
                        services: Optional[str] = None,
                        limit: Optional[int] = None,
-                       ceph_version: Optional[str] = None) -> HandleCommandResult:
+                       ceph_version: Optional[str] = None,
+                       crush_bucket_type: Optional[str] = None,
+                       crush_bucket_name: Optional[str] = None) -> HandleCommandResult:
         """Initiate upgrade"""
         self._upgrade_check_image_name(image, ceph_version)
+
         # Split comma-separated lists and trim whitespace so "mon, crash" and "mon,crash" are equivalent.
         dtypes = [d.strip() for d in daemon_types.split(',')] if daemon_types is not None else None
         service_names = [s.strip() for s in services.split(',')] if services is not None else None
-        completion = self.upgrade_start(image, ceph_version, dtypes, hosts, service_names, limit)
+        completion = self.upgrade_start(image, ceph_version, dtypes, hosts, service_names, limit,
+                                        crush_bucket_type, crush_bucket_name)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 


### PR DESCRIPTION
This change introduces new bucket params to support failure domain specific OSD upgrades. 

ceph orch upgrade start --image=<quay.io/...> --daemon-types=osd --crush_bucket_type=<chassis/rack/host> --crush_bucket_name=<crushname>

1. Introduce new options  --crush_bucket_type, --crush_bucket_name, so that customers with well defined hierarchies can selectively upgrade racks/chassis as a primary requirement for 9.1. 
2  Bucket scope applies only to OSDs and needs --daemon_types to be osd only. 
3. If the new options are not provided, the existing code flow with ok-to-stop works as is.
4. The command shall only accept CRUSH names as in "ceph osd tree" output.
5. The --hosts option is exclusive with bucket params as there could be failure domain differences. 
6. The [staggered]( https://docs.ceph.com/en/latest/cephadm/upgrade/#staggered-upgrade) upgrade sequence needs to be maintained while upgrading OSDs.

Tests performed: (Read bucket params as --crush_bucket_type/name)
1. Invalid bucket params:
```
Invalid bucket type -- 
[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --daemon_types=osd --bucket-type=root --bucket_name=xyz
Error EINVAL: Supported bucket types for OSD upgrade are: chassis, rack (specified: 'root')

--hosts exclusive with bucket params --
[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --daemon_types=osd --bucket-type=rack --bucket_name=localrack --hosts=ceph-node-0
Error EINVAL: --hosts cannot be combined with --bucket-type or --bucket-name
[ceph: root@ceph-node-0 /]#

``` 

2. max parallel OSDs upgraded within the rack scope

```
[ceph: root@ceph-node-0 /]# ceph osd tree
ID  CLASS  WEIGHT   TYPE NAME             STATUS  REWEIGHT  PRI-AFF
-9         0.03918  rack localrack                                 
-3         0.01959      host ceph-node-1                           
 1    hdd  0.00980          osd.1             up   1.00000  1.00000
 2    hdd  0.00980          osd.2             up   1.00000  1.00000
-7         0.01959      host ceph-node-2                           
 4    hdd  0.00980          osd.4             up   1.00000  1.00000
 5    hdd  0.00980          osd.5             up   1.00000  1.00000
-1         0.01959  root default                                   
-5         0.01959      host ceph-node-0                           
 0    hdd  0.00980          osd.0             up   1.00000  1.00000
 3    hdd  0.00980          osd.3             up   1.00000  1.00000
[ceph: root@ceph-node-0 /]#

[ceph: root@ceph-node-0 /]# ceph config get mgr mgr/cephadm/max_parallel_osd_upgrades
2

...
2026-04-15T18:21:10.022+0000 7f54c6ce56c0  0 log_channel(cephadm) log [INF] : Upgrade: osd ok-to-upgrade bucket='localrack' max=2 approved ['osd.1', 'osd.2']   
2026-04-15T18:21:54.531+0000 7f54c6ce56c0  0 [cephadm INFO cephadm.upgrade] Upgrade: osd ok-to-upgrade bucket='localrack' max=2 approved ['osd.4', 'osd.5']   
...

2026-04-15T18:22:38.546+0000 7f54c6ce56c0  0 log_channel(cephadm) log [INF] : Upgrade: osd ok-to-upgrade reports all OSDs under crush_bucket='localrack' on ceph_version='21.0.0-567-g460da8cf' 
...

Only rack OSDs are upgraded. osd.0 and osd.3 are still on 19.2.3 since outside the rack.

[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                    HOST         PORTS                                 STATUS          REFRESHED  AGE  MEM USE  MEM LIM  VERSION               IMAGE ID      CONTAINER ID  
crash.ceph-node-0       ceph-node-0                                        running (10m)     10m ago   2h    7432k        -  21.0.0-567-g460da8cf  0131061c8ba6  18d8486872a9  
crash.ceph-node-1       ceph-node-1                                        running (10m)     92s ago   2h    7436k        -  21.0.0-567-g460da8cf  0131061c8ba6  27040c06a66d  
crash.ceph-node-2       ceph-node-2                                        running (10m)     76s ago   2h    7428k        -  21.0.0-567-g460da8cf  0131061c8ba6  c5f5707c7e62  
mgr.ceph-node-0.fwolbq  ceph-node-0  *:9283,8765,8765,8765,8765            running (15m)     10m ago   2h     180M        -  21.0.0-567-g460da8cf  0131061c8ba6  d23e777ee925  
mgr.ceph-node-1.ghcjyr  ceph-node-1  *:8765,8765,8765,8765,8765,8765,8765  running (14m)     92s ago   2h     147M        -  21.0.0-567-g460da8cf  0131061c8ba6  9410bc46a248  
mon.ceph-node-0         ceph-node-0                                        running (12m)     10m ago   2h    36.6M    2048M  21.0.0-567-g460da8cf  0131061c8ba6  83979a907b12  
mon.ceph-node-1         ceph-node-1                                        running (11m)     92s ago   2h    42.9M    2048M  21.0.0-567-g460da8cf  0131061c8ba6  d61599b6092b  
mon.ceph-node-2         ceph-node-2                                        running (11m)     76s ago   2h    42.4M    2048M  21.0.0-567-g460da8cf  0131061c8ba6  82b9642a98ac  
osd.0                   ceph-node-0                                        running (2h)      10m ago   2h    60.1M    4096M  19.2.3                aade1b12b8e6  a8f1c3d1a1bc  
osd.1                   ceph-node-1                                        running (2m)      92s ago   2h    48.4M    4096M  21.0.0-567-g460da8cf  0131061c8ba6  74f8e63fdf36  
osd.2                   ceph-node-1                                        running (2m)      92s ago   2h    48.2M    4096M  21.0.0-567-g460da8cf  0131061c8ba6  12e3d208f70e  
osd.3                   ceph-node-0                                        running (2h)      10m ago   2h    62.7M    4096M  19.2.3                aade1b12b8e6  ab4e3d7f2131  
osd.4                   ceph-node-2                                        running (113s)    76s ago   2h    47.4M    1492M  21.0.0-567-g460da8cf  0131061c8ba6  0d4b061a7a41  
osd.5                   ceph-node-2                                        running (97s)     76s ago   2h    49.3M    1492M  21.0.0-567-g460da8cf  0131061c8ba6  9eb3403e5948  


```


3. When no bucket params are used, ok-to-stop covers all the OSDs and upgrades the remaining to OSDs outside the rack
```

# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --daemon_types=osd 
[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                    HOST         PORTS                                           STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION               IMAGE ID      CONTAINER ID  
crash.ceph-node-0       ceph-node-0                                                  running (31m)    10m ago   2h    7428k        -  21.0.0-567-g460da8cf  5eddafb5498e  c41525a28853  
crash.ceph-node-1       ceph-node-1                                                  running (31m)     2m ago   2h    7432k        -  21.0.0-567-g460da8cf  5eddafb5498e  4b7ab211ee72  
crash.ceph-node-2       ceph-node-2                                                  running (31m)     2m ago   2h    7419k        -  21.0.0-567-g460da8cf  5eddafb5498e  bfd99c13a089  
mgr.ceph-node-0.fwolbq  ceph-node-0  *:9283,8765,8765,8765,8765,8765                 running (34m)    10m ago   2h     190M        -  21.0.0-567-g460da8cf  5eddafb5498e  0055c1488013  
mgr.ceph-node-1.ghcjyr  ceph-node-1  *:8765,8765,8765,8765,8765,8765,8765,8765,8765  running (33m)     2m ago   2h     150M        -  21.0.0-567-g460da8cf  5eddafb5498e  6e7da669747d  
mon.ceph-node-0         ceph-node-0                                                  running (33m)    10m ago   2h    55.1M    2048M  21.0.0-567-g460da8cf  5eddafb5498e  a424d9817cc7  
mon.ceph-node-1         ceph-node-1                                                  running (32m)     2m ago   2h    52.2M    2048M  21.0.0-567-g460da8cf  5eddafb5498e  e557ceec7766  
mon.ceph-node-2         ceph-node-2                                                  running (32m)     2m ago   2h    47.8M    2048M  21.0.0-567-g460da8cf  5eddafb5498e  67f1c8bdf3f6  
osd.0                   ceph-node-0                                                  running (21m)    10m ago   2h    53.7M    4096M  21.0.0-567-g460da8cf  5eddafb5498e  678ec9faaf45  
osd.1                   ceph-node-1                                                  running (25m)     2m ago   2h    58.6M    4096M  21.0.0-567-g460da8cf  5eddafb5498e  255551d8085e  
osd.2                   ceph-node-1                                                  running (25m)     2m ago   2h    59.4M    4096M  21.0.0-567-g460da8cf  5eddafb5498e  cde4b53080be  
osd.3                   ceph-node-0                                                  running (21m)    10m ago   2h    54.9M    4096M  21.0.0-567-g460da8cf  5eddafb5498e  8b74fce29203  
osd.4                   ceph-node-2                                                  running (24m)     2m ago   2h    58.1M    1492M  21.0.0-567-g460da8cf  5eddafb5498e  29bcb4cdcf34  
osd.5                   ceph-node-2                                                  running (24m)     2m ago   2h    58.7M    1492M  21.0.0-567-g460da8cf  5eddafb5498e  729613d7490b  
[ceph: root@ceph-node-0 /]#
```


4.  Upgraded rack level which contains  ceph-node-0  and  ceph-node-1

```

[ceph: root@ceph-node-0 /]# ceph osd tree
ID  CLASS  WEIGHT   TYPE NAME             STATUS  REWEIGHT  PRI-AFF
-9         0.03918  rack localrack                                 
-5         0.01959      host ceph-node-0                           
 1    hdd  0.00980          osd.1             up   1.00000  1.00000
 3    hdd  0.00980          osd.3             up   1.00000  1.00000
-3         0.01959      host ceph-node-1                           
 0    hdd  0.00980          osd.0             up   1.00000  1.00000
 2    hdd  0.00980          osd.2             up   1.00000  1.00000
-1         0.01959  root default                                   
-7         0.01959      host ceph-node-2                           
 4    hdd  0.00980          osd.4             up   1.00000  1.00000
 5    hdd  0.00980          osd.5             up   1.00000  1.00000
[ceph: root@ceph-node-0 /]#

[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                    HOST         PORTS                            STATUS          REFRESHED   AGE  MEM USE  MEM LIM  VERSION               IMAGE ID      CONTAINER ID  
crash.ceph-node-0       ceph-node-0                                   running (2m)      97s ago   99m    7432k        -  21.0.0-567-g460da8cf  230c1b0945c7  3cbba3ba4f0b  
crash.ceph-node-1       ceph-node-1                                   running (2m)      15s ago   98m    7432k        -  21.0.0-567-g460da8cf  230c1b0945c7  74e7b0652898  
crash.ceph-node-2       ceph-node-2                                   running (2m)       2m ago   95m    7428k        -  21.0.0-567-g460da8cf  230c1b0945c7  6925b8277006  
mgr.ceph-node-0.pkrnno  ceph-node-0  *:9283,8765,8765,8765            running (54m)     97s ago  101m     193M        -  21.0.0-567-g460da8cf  230c1b0945c7  c78f6b22e7c0  
mgr.ceph-node-1.ovhgok  ceph-node-1  *:8765,8765,8765,8765,8765,8765  running (53m)     15s ago   97m     153M        -  21.0.0-567-g460da8cf  230c1b0945c7  572195086f50  
mon.ceph-node-0         ceph-node-0                                   running (52m)     97s ago  101m    68.7M    2048M  21.0.0-567-g460da8cf  230c1b0945c7  12b2cc3a370d  
mon.ceph-node-1         ceph-node-1                                   running (52m)     15s ago   97m    60.4M    2048M  21.0.0-567-g460da8cf  230c1b0945c7  f20a07ed0f6d  
mon.ceph-node-2         ceph-node-2                                   running (3m)       2m ago   94m    22.6M    2048M  21.0.0-567-g460da8cf  230c1b0945c7  0aa81349e36f  
osd.0                   ceph-node-1                                   running (55s)     15s ago   97m    47.8M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  6ca064f7044d  
osd.1                   ceph-node-0                                   running (2m)      97s ago   97m    48.5M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  531eb2cd783f  
osd.2                   ceph-node-1                                   running (19s)     15s ago   97m    41.9M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  82cb6cc7fe1e  
osd.3                   ceph-node-0                                   running (100s)    97s ago   97m    31.6M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  5fcbdee52cdb  
osd.4                   ceph-node-2                                   running (94m)      2m ago   94m    61.5M    1492M  19.2.3                aade1b12b8e6  a60e4672256d  
osd.5                   ceph-node-2                                   running (94m)      2m ago   94m    62.5M    1492M  19.2.3                aade1b12b8e6  550095003de8  
```

5. Host bucket support, upgrading OSDs specific to ceph-node-2.
```
[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --daemon_types=osd --bucket-type=host --bucket_name=ceph-node-2
Initiating upgrade to quay.io/ashjoshi/ceph:upgradetesting
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
{
    "in_progress": true,
    "target_image": "quay.io/ashjoshi/ceph@sha256:28a118772e26024ad87efdf7bfa11e19bb8ab0bf07e7bec8ea0cd2592df5d034",
    "services_complete": [
        "mon",
        "crash",
        "mgr"
    ],
    "which": "Upgrading daemons of type(s) osd (OSDs in bucket scope)",
    "progress": "12/14 daemons upgraded",
    "message": "Currently upgrading osd daemons",
    "is_paused": false
}
[ceph: root@ceph-node-0 /]#

[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                    HOST         PORTS                            STATUS         REFRESHED   AGE  MEM USE  MEM LIM  VERSION               IMAGE ID      CONTAINER ID  
crash.ceph-node-0       ceph-node-0                                   running (5m)      4m ago  102m    7432k        -  21.0.0-567-g460da8cf  230c1b0945c7  3cbba3ba4f0b  
crash.ceph-node-1       ceph-node-1                                   running (5m)      2m ago  100m    7432k        -  21.0.0-567-g460da8cf  230c1b0945c7  74e7b0652898  
crash.ceph-node-2       ceph-node-2                                   running (5m)     23s ago   97m    7428k        -  21.0.0-567-g460da8cf  230c1b0945c7  6925b8277006  
mgr.ceph-node-0.pkrnno  ceph-node-0  *:9283,8765,8765,8765            running (56m)     4m ago  103m     193M        -  21.0.0-567-g460da8cf  230c1b0945c7  c78f6b22e7c0  
mgr.ceph-node-1.ovhgok  ceph-node-1  *:8765,8765,8765,8765,8765,8765  running (56m)     2m ago   99m     153M        -  21.0.0-567-g460da8cf  230c1b0945c7  572195086f50  
mon.ceph-node-0         ceph-node-0                                   running (55m)     4m ago  103m    68.7M    2048M  21.0.0-567-g460da8cf  230c1b0945c7  12b2cc3a370d  
mon.ceph-node-1         ceph-node-1                                   running (54m)     2m ago   99m    60.4M    2048M  21.0.0-567-g460da8cf  230c1b0945c7  f20a07ed0f6d  
mon.ceph-node-2         ceph-node-2                                   running (5m)     23s ago   96m    31.6M    2048M  21.0.0-567-g460da8cf  230c1b0945c7  0aa81349e36f  
osd.0                   ceph-node-1                                   running (3m)      2m ago  100m    47.8M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  6ca064f7044d  
osd.1                   ceph-node-0                                   running (4m)      4m ago  100m    48.5M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  531eb2cd783f  
osd.2                   ceph-node-1                                   running (2m)      2m ago  100m    41.9M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  82cb6cc7fe1e  
osd.3                   ceph-node-0                                   running (4m)      4m ago  100m    31.6M    4096M  21.0.0-567-g460da8cf  230c1b0945c7  5fcbdee52cdb  
osd.4                   ceph-node-2                                   running (57s)    23s ago   97m    46.2M    1492M  21.0.0-567-g460da8cf  230c1b0945c7  639a3ac3827f  
osd.5                   ceph-node-2                                   running (27s)    23s ago   97m    31.2M    1492M  21.0.0-567-g460da8cf  230c1b0945c7  cc94a6114755  
```

7. Validations to check exclusivity of bucket scoped OSD upgrades with daemon_types, services 

```
[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --daemon_types=osd,mds --crush_bucket_type=host --crush_bucket_name=ceph-node-0 
Error EINVAL: Bucket parameters for OSD upgrade require --daemon-types to be "osd"
[ceph: root@ceph-node-0 /]#

[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --crush_bucket_type=host --crush_bucket_name=ceph-node-1 --services osd.all-available-devices
Error EINVAL: --services cannot be combined with --crush_bucket_type or --crush_bucket_name
[ceph: root@ceph-node-0 /]#

[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image=quay.io/ashjoshi/ceph:upgradetesting --crush_bucket_type=host --crush_bucket_name=ceph-node-1 
Error EINVAL: Bucket parameters for OSD upgrade require --daemon-types to be "osd"
[ceph: root@ceph-node-0 /]# 

```


Fixes: https://tracker.ceph.com/issues/75603
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
