### PR TITLE
tentacle: ceph_mon: Fix shutdown order to destroy Monitor before closing mon store

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -899,14 +899,15 @@ int main(int argc, const char **argv)
   msgr->wait();
   mgr_msgr->wait();
 
-  store.close();
-
   unregister_async_signal_handler(SIGHUP, handle_mon_signal);
   unregister_async_signal_handler(SIGINT, handle_mon_signal);
   unregister_async_signal_handler(SIGTERM, handle_mon_signal);
   shutdown_async_signal_handler();
 
+  // Destroy the Monitor (and its iterators) before closing the store.
   delete mon;
+  store.close();
+
   delete msgr;
   delete mgr_msgr;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76050

---

backport of https://github.com/ceph/ceph/pull/68166
parent tracker: https://tracker.ceph.com/issues/75834

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh