### PR TITLE
mon: include cleanup

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1380,6 +1380,57 @@ void MonClient::handle_command_reply(MCommandReply *reply)
   reply->put();
 }
 
+class MonClient::ContextVerter {
+  std::string* outs;
+  ceph::bufferlist* outbl;
+  Context* onfinish;
+
+public:
+  ContextVerter(std::string* outs, ceph::bufferlist* outbl, Context* onfinish)
+    : outs(outs), outbl(outbl), onfinish(onfinish) {}
+  ~ContextVerter() = default;
+  ContextVerter(const ContextVerter&) = default;
+  ContextVerter& operator =(const ContextVerter&) = default;
+  ContextVerter(ContextVerter&&) = default;
+  ContextVerter& operator =(ContextVerter&&) = default;
+
+  void operator()(boost::system::error_code e,
+		  std::string s,
+		  ceph::bufferlist bl) {
+    if (outs)
+      *outs = std::move(s);
+    if (outbl)
+      *outbl = std::move(bl);
+    if (onfinish)
+      onfinish->complete(ceph::from_error_code(e));
+  }
+};
+
+void MonClient::start_mon_command(std::vector<std::string>&& cmd, bufferlist&& inbl,
+				  bufferlist *outbl, std::string *outs,
+				  Context *onfinish)
+{
+  start_mon_command(std::move(cmd), std::move(inbl),
+		    ContextVerter(outs, outbl, onfinish));
+}
+
+void MonClient::start_mon_command(int mon_rank, std::vector<std::string>&& cmd,
+				  bufferlist&& inbl, bufferlist *outbl, std::string *outs,
+				  Context *onfinish)
+{
+  start_mon_command(mon_rank, std::move(cmd), std::move(inbl),
+		    ContextVerter(outs, outbl, onfinish));
+}
+
+void MonClient::start_mon_command(std::string&& mon_name,  ///< mon name, with mon. prefix
+				  std::vector<std::string>&& cmd, bufferlist&& inbl,
+				  bufferlist *outbl, std::string *outs,
+				  Context *onfinish)
+{
+  start_mon_command(std::move(mon_name), std::move(cmd), std::move(inbl),
+		    ContextVerter(outs, outbl, onfinish));
+}
+
 int MonClient::_cancel_mon_command(uint64_t tid)
 {
   ceph_assert(ceph_mutex_is_locked(monc_lock));

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1174,6 +1174,24 @@ int MonClient::wait_auth_rotating(double timeout)
 
 // ---------
 
+MonClient::MonCommand::MonCommand(MonClient& monc, uint64_t t, CommandCompletion&& onfinish)
+  : tid(t), onfinish(std::move(onfinish)) {
+  auto timeout =
+      monc.cct->_conf.get_val<std::chrono::seconds>("rados_mon_op_timeout");
+  if (timeout.count() > 0) {
+    cancel_timer.emplace(monc.service, timeout);
+    cancel_timer->async_wait(
+      [this, &monc](boost::system::error_code ec) {
+        if (ec)
+          return;
+        std::scoped_lock l(monc.monc_lock);
+        monc._cancel_mon_command(tid);
+      });
+  }
+}
+
+MonClient::MonCommand::~MonCommand() = default;
+
 void MonClient::_send_command(MonCommand *r)
 {
   if (r->is_tell()) {

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -721,52 +721,18 @@ public:
       }, consigned);
   }
 
-  class ContextVerter {
-    std::string* outs;
-    ceph::bufferlist* outbl;
-    Context* onfinish;
+  class ContextVerter;
 
-  public:
-    ContextVerter(std::string* outs, ceph::bufferlist* outbl, Context* onfinish)
-      : outs(outs), outbl(outbl), onfinish(onfinish) {}
-    ~ContextVerter() = default;
-    ContextVerter(const ContextVerter&) = default;
-    ContextVerter& operator =(const ContextVerter&) = default;
-    ContextVerter(ContextVerter&&) = default;
-    ContextVerter& operator =(ContextVerter&&) = default;
-
-    void operator()(boost::system::error_code e,
-		    std::string&& s,
-		    ceph::bufferlist&& bl) {
-      if (outs)
-	*outs = std::move(s);
-      if (outbl)
-	*outbl = std::move(bl);
-      if (onfinish)
-	onfinish->complete(ceph::from_error_code(e));
-    }
-  };
-
-  void start_mon_command(std::vector<std::string> cmd, bufferlist&& inbl,
+  void start_mon_command(std::vector<std::string>&& cmd, bufferlist&& inbl,
 			 bufferlist *outbl, std::string *outs,
-			 Context *onfinish) {
-    start_mon_command(std::move(cmd), std::move(inbl),
-		      ContextVerter(outs, outbl, onfinish));
-  }
+			 Context *onfinish);
   void start_mon_command(int mon_rank, std::vector<std::string>&& cmd,
 			 bufferlist&& inbl, bufferlist *outbl, std::string *outs,
-			 Context *onfinish) {
-    start_mon_command(mon_rank, std::move(cmd), std::move(inbl),
-		      ContextVerter(outs, outbl, onfinish));
-  }
+			 Context *onfinish);
   void start_mon_command(std::string&& mon_name,  ///< mon name, with mon. prefix
 			 std::vector<std::string>&& cmd, bufferlist&& inbl,
 			 bufferlist *outbl, std::string *outs,
-			 Context *onfinish) {
-    start_mon_command(std::move(mon_name), std::move(cmd), std::move(inbl),
-		      ContextVerter(outs, outbl, onfinish));
-  }
-
+			 Context *onfinish);
 
   // version requests
 public:

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -581,21 +581,8 @@ private:
     CommandCompletion onfinish;
     std::optional<boost::asio::steady_timer> cancel_timer;
 
-    MonCommand(MonClient& monc, uint64_t t, CommandCompletion&& onfinish)
-      : tid(t), onfinish(std::move(onfinish)) {
-      auto timeout =
-          monc.cct->_conf.get_val<std::chrono::seconds>("rados_mon_op_timeout");
-      if (timeout.count() > 0) {
-	cancel_timer.emplace(monc.service, timeout);
-	cancel_timer->async_wait(
-          [this, &monc](boost::system::error_code ec) {
-	    if (ec)
-	      return;
-	    std::scoped_lock l(monc.monc_lock);
-	    monc._cancel_mon_command(tid);
-	  });
-      }
-    }
+    MonCommand(MonClient& monc, uint64_t t, CommandCompletion&& onfinish);
+    ~MonCommand();
 
     bool is_tell() const {
       return target_name.size() || target_rank >= 0;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -60,11 +60,14 @@
 #include "messages/MMonGetPurgedSnaps.h"
 #include "messages/MMonGetPurgedSnapsReply.h"
 
+#include "msg/Messenger.h"
+
 #include "common/JSONFormatter.h"
 #include "common/TextTable.h"
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
 #include "common/perf_counters.h"
+#include "common/prime.h"
 #include "common/PriorityCache.h"
 #include "common/strtol.h"
 #include "common/numa.h"

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -31,8 +31,6 @@
 #include "include/encoding.h"
 #include "common/simple_cache.hpp"
 #include "common/PriorityCache.h"
-#include "msg/Messenger.h"
-#include "common/prime.h"
 
 #include "osd/OSDMap.h"
 #include "osd/OSDMapMapping.h"


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
