### PR TITLE
build: Update python packaging for src/python-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -144,6 +144,7 @@
 %global _find_debuginfo_dwz_opts %{nil}
 %endif
 %bcond_with sccache
+%bcond_with pypkg
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}
@@ -1540,6 +1541,9 @@ cmake .. \
 %if %{with sccache}
     -DWITH_SCCACHE=ON \
 %endif
+%if 0%{with pypkg}
+    -DWITH_PYPKG:BOOL=ON \
+%endif
 %if 0%{with cephadm_bundling}
 %if 0%{with cephadm_pip_deps}
     -DCEPHADM_BUNDLED_DEPENDENCIES=pip
@@ -2587,7 +2591,7 @@ fi
 
 %files -n python%{python3_pkgversion}-ceph-common
 %{python3_sitelib}/ceph
-%{python3_sitelib}/ceph-*.egg-info
+%{python3_sitelib}/ceph-*.%{?with_pypkg:dist}%{!?with_pypkg:egg}-info
 
 %if 0%{with cephfs_shell}
 %files -n cephfs-shell

--- a/cmake/modules/PythonPackage.cmake
+++ b/cmake/modules/PythonPackage.cmake
@@ -1,0 +1,84 @@
+find_package(Python3 ${WITH_PYTHON3} EXACT
+  QUIET
+  REQUIRED
+  COMPONENTS Interpreter)
+
+function(create_python_package pkgname)
+  set(options BUILD_ISOLATION)
+  set(oneValueArgs WHEELDIR)
+  cmake_parse_arguments(PARSE_ARGV 0 pypkg
+    "${options}" "${oneValueArgs}" "")
+  if(NOT "${pypkg_WHEELDIR}")
+    set(pypkg_WHEELDIR "${CMAKE_CURRENT_BINARY_DIR}/wheels/${pkgname}")
+  endif()
+
+  python_package_build_pip_wheel(
+    "${pkgname}" "${pypkg_WHEELDIR}" "${pypkg_BUILD_ISOLATION}"
+  )
+  python_package_install_pip_wheel("${pkgname}" "${pypkg_WHEELDIR}")
+endfunction(create_python_package)
+
+
+function(
+  python_package_build_pip_wheel
+  pkgname
+  wheeldir
+  build_isolation
+)
+  list(APPEND build_args
+    --wheel-dir "${wheeldir}"
+    --no-deps
+    --use-pep517
+    --disable-pip-version-check
+    --no-clean
+    --progress-bar=off
+    --verbose
+  )
+  if(NOT "${build_isolation}")
+    list(APPEND build_args --no-build-isolation)
+  endif()
+  list(APPEND build_args "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  add_custom_command(
+    OUTPUT ${wheeldir}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml
+    COMMAND ${Python3_EXECUTABLE} -m pip wheel ${build_args}
+  )
+  if(NOT TARGET build-wheel-${pkgname})
+    add_custom_target(build-wheel-${pkgname} ALL
+      DEPENDS ${wheeldir})
+  endif()
+endfunction(python_package_build_pip_wheel)
+
+function(
+  python_package_install_pip_wheel
+  pkgname
+  wheeldir
+)
+  list(APPEND install_args
+    "--prefix=${CMAKE_INSTALL_PREFIX}"
+    --no-deps
+    --disable-pip-version-check
+    --progress-bar=off
+    --root-user-action=ignore
+    --verbose
+    --ignore-installed
+    --no-warn-script-location
+    --no-index
+    --no-cache-dir
+    --find-links "${wheeldir}"
+    "${pkgname}"
+  )
+
+  install(CODE "
+    set(args \"${install_args}\")
+    if(DEFINED ENV{DESTDIR})
+      list(INSERT args 1 --root=\$ENV{DESTDIR})
+    endif()
+    message(DEBUG PythonPackage.install_cmd=
+      \"${Python3_EXECUTABLE} -m pip install\" \"\${args}\")
+    execute_process(
+      COMMAND ${Python3_EXECUTABLE} -m pip install \${args}
+      WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\"
+      COMMAND_ERROR_IS_FATAL ANY)")
+endfunction(python_package_install_pip_wheel)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -789,6 +789,7 @@ if(NOT CEPH_BUILD_VIRTUALENV)
 endif()
 
 option(WITH_CEPHADM "Flag to determine if cephadm should be built" ON)
+option(WITH_PYPKG "Build using PEP517 & PEP518 packaging when possible" OFF)
 
 if(NOT WIN32)
 add_subdirectory(pybind)

--- a/src/python-common/CMakeLists.txt
+++ b/src/python-common/CMakeLists.txt
@@ -1,5 +1,10 @@
-include(Distutils)
-distutils_install_module(ceph)
+if(WITH_PYPKG)
+  include(PythonPackage)
+  create_python_package(ceph)
+else()
+  include(Distutils)
+  distutils_install_module(ceph)
+endif()
 
 if(WITH_TESTS)
   include(AddCephTest)

--- a/src/python-common/pyproject.toml
+++ b/src/python-common/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "ceph"
+description = "Core pure-Python libraries for the Ceph Project"
+version = "1.0.0"  # TODO: Make dynamic
+readme = "README.rst"
+keywords = ["ceph"]
+
+# SETUPTOOLS complains about these values because it still finds
+# setup.py. Can probably be dropped if backend is switched.
+# For example, I briefly experimented with flit as a backend and
+# it did not need these.
+dynamic = ["license", "classifiers", "dependencies"]
+
+[[project.authors]]
+name = "Ceph Project"
+email = "dev@ceph.io"
+
+[project.urls]
+Homepage = "https://ceph.io"
+Repository = "https://github.com/ceph/ceph"
+
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Time is marching on and the state of the art with python packaging has
not stood still. In Python 3.12, distutils has been removed after being
deprecated for a couple of versions. According to the Python Packaging
User Guide [1]: "However, `python setup.py` and the use of `setup.py` as a
command line tool are deprecated."

Currently, ceph provides a decent sized and growing library of python
code in `src/python-common/ceph`. It currently relies on `setup.py` and
the deprecated `python setup.py install` command. This change aims to be
the first step in moving toward a more contemporary approach so that we
don't get caught late when the older approaches really stop working.

Because ceph's primary diver of "build stuff" is CMake, there was an
existing `cmake/modules/Distutils.cmake` that invokes a `python setup.py
install` command. Rather than risk breaking older distros we add a new
`cmake/modules/PythonPackage.cmake` file that uses the PEP 517/518
[2][3] style

of packaging. I could not find some existing CMake support for this
so unfortunately I had to write this.

The approach taken is loosely based on what the rpm build process does.
It invokes pip's wheel subcommand to build a wheel (during the build
phase) and then uses pip to install the wheel to install the content
to the system.

[1] https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
[2] https://peps.python.org/pep-0517/
[3] https://peps.python.org/pep-0518/

Additional commits add support for the new packaging based cmake file in src/python-common for the ceph package and provides a pyproject.toml file. Each commit contains some commentary on the change.



TODO:
* [x] Add support for rpm spec.in
* [x] CI build tests with 
  * [x] Option disabled (default)
  * [x] Option enabled on el10



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
