### PR TITLE
rgw/admin: 75617 add radosgw admin object rm --all

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -147,8 +147,12 @@ as follows:
   Purge bucket index entries.
 
 :command:`object rm`
-  Remove an S3/Swift object. Include "--yes-i-really-mean-it" to remove object's
-  entry from bucket index, for example if it's damaged.
+  Remove an S3/Swift object. Include ``--yes-i-really-mean-it`` to remove
+  object's entry from bucket index, for example if it's damaged.
+  Use ``--all`` with ``--bucket`` to remove all objects from a bucket while
+  leaving the bucket itself and its policies (ACL, lifecycle, etc.) intact.
+  Objects are queued to garbage collection as normal; combine with
+  ``--bypass-gc`` to remove via async AIO instead.
 
 :command:`object stat`
   Stat an S3/Swift object for its metadata.
@@ -881,9 +885,15 @@ Options
    When specified with bucket limit check,
    list only buckets nearing or over the current max objects per shard value.
 
+.. option:: --all
+
+   When specified with ``object rm`` and ``--bucket``, removes all objects
+   from the bucket while leaving the bucket itself intact.
+   Requires ``--yes-i-really-mean-it``.
+
 .. option:: --bypass-gc
 
-   When specified with bucket deletion,
+   When specified with bucket deletion or ``object rm --all``,
    triggers object deletion without involving GC.
 
 .. option:: --inconsistent-index

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -622,6 +622,37 @@ commands, as in the following examples:
    be restarted for the changes to take effect.
 
 
+.. _radosgw-bucket-management:
+
+Bucket Management
+=================
+
+.. _radosgw-remove-all-objects:
+
+Removing All Objects from a Bucket
+-----------------------------------
+
+The ``object rm --all`` command removes all objects from a bucket while leaving
+the bucket itself and its policies (ACL, lifecycle configuration, etc.) intact.
+This differs from ``bucket rm``, which deletes the bucket entirely.
+
+``--yes-i-really-mean-it`` is required as a guardrail. Objects are deleted and
+queued to garbage collection as normal:
+
+.. prompt:: bash #
+
+   radosgw-admin object rm --all --bucket=<bucket-name> --yes-i-really-mean-it
+
+To remove objects via async AIO instead, bypassing garbage collection, use
+``--bypass-gc``:
+
+.. prompt:: bash #
+
+   radosgw-admin object rm --all --bucket=<bucket-name> --bypass-gc --yes-i-really-mean-it
+
+.. note:: This command may not be supported by all drivers. In that case
+   it will return ``ENOTSUP``.
+
 .. _radosgw-rate-limit-management:
 
 Rate Limit Management

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -810,6 +810,152 @@ def task(ctx, config):
         ['bucket', 'rm', '--bucket', bucket_name, '--purge-objects'],
         check_status=True)
 
+    # TESTCASE 'object-rm-all-no-confirm', 'object', 'rm', 'all objects without --yes-i-really-mean-it', 'fails'
+    bucket_name_all = bucket_name + 'all'
+    connection.create_bucket(Bucket=bucket_name_all)
+    for key_name in ['a', 'b', 'c']:
+        connection.put_object(Bucket=bucket_name_all, Key=key_name, Body=key_name)
+
+    (err, out) = rgwadmin(ctx, client,
+        ['object', 'rm', '--all', '--bucket', bucket_name_all])
+    assert err
+
+    # TESTCASE 'object-rm-all', 'object', 'rm', 'all objects from bucket', 'succeeds, objects deleted, bucket preserved'
+    (err, out) = rgwadmin(ctx, client,
+        ['object', 'rm', '--all', '--bucket', bucket_name_all,
+         '--yes-i-really-mean-it'],
+        check_status=True)
+
+    # bucket should still exist and be empty
+    (err, out) = rgwadmin(ctx, client,
+        ['bucket', 'stats', '--bucket', bucket_name_all], check_status=True)
+    assert out['usage']['rgw.main']['num_objects'] == 0
+
+    connection.delete_bucket(Bucket=bucket_name_all)
+
+    # TESTCASE 'object-rm-all-versioned', 'object', 'rm', 'all objects from versioned bucket', 'succeeds, all versions and delete markers deleted, versioning state preserved'
+    bucket_name_ver = bucket_name + 'ver'
+    connection.create_bucket(Bucket=bucket_name_ver)
+    connection.put_bucket_versioning(
+        Bucket=bucket_name_ver,
+        VersioningConfiguration={'Status': 'Enabled'}
+    )
+    # put two versions of each key
+    for key_name in ['x', 'y']:
+        connection.put_object(Bucket=bucket_name_ver, Key=key_name, Body='v1')
+        connection.put_object(Bucket=bucket_name_ver, Key=key_name, Body='v2')
+    # delete 'x' via S3 to produce a delete marker
+    connection.delete_object(Bucket=bucket_name_ver, Key='x')
+
+    # confirm there are now versions and a delete marker before the rm
+    versions_before = connection.list_object_versions(Bucket=bucket_name_ver)
+    assert 'Versions' in versions_before
+    assert 'DeleteMarkers' in versions_before
+
+    (err, out) = rgwadmin(ctx, client,
+        ['object', 'rm', '--all', '--bucket', bucket_name_ver,
+         '--yes-i-really-mean-it'],
+        check_status=True)
+
+    # versioning state must be preserved
+    versioning = connection.get_bucket_versioning(Bucket=bucket_name_ver)
+    assert versioning['Status'] == 'Enabled'
+
+    # all versions and delete markers must be gone
+    versions = connection.list_object_versions(Bucket=bucket_name_ver)
+    assert 'Versions' not in versions
+    assert 'DeleteMarkers' not in versions
+
+    connection.delete_bucket(Bucket=bucket_name_ver)
+
+    # TESTCASE 'object-rm-all-bypass-gc', 'object', 'rm', 'all objects with --bypass-gc', 'succeeds, tail data deleted immediately without queuing into GC'
+    bucket_name_bgc = bucket_name + 'bgc'
+    connection.create_bucket(Bucket=bucket_name_bgc)
+    # use a large object so it has tail data that would normally be queued for GC
+    connection.put_object(Bucket=bucket_name_bgc, Key='big', Body='foo' * 10000000)
+
+    # drain any GC entries from earlier in the test before we check
+    rgwadmin(ctx, client, ['gc', 'process'], check_status=True)
+
+    (err, out) = rgwadmin(ctx, client,
+        ['object', 'rm', '--all', '--bucket', bucket_name_bgc,
+         '--yes-i-really-mean-it', '--bypass-gc'],
+        check_status=True)
+
+    # tail data should have been deleted in-line, not queued for GC
+    (err, out) = rgwadmin(ctx, client, ['gc', 'list', '--include-all'])
+    omit_tdir = hasattr(ctx.rgw, 'omit_tdir') and ctx.rgw.omit_tdir == True
+    if not omit_tdir:
+        assert len(out) == 0
+
+    connection.delete_bucket(Bucket=bucket_name_bgc)
+
+    # TESTCASE 'object-rm-all-preserves-config', 'object', 'rm', 'all objects from bucket with lifecycle and CORS', 'succeeds, lifecycle and CORS config preserved'
+    bucket_name_cfg = bucket_name + 'cfg'
+    connection.create_bucket(Bucket=bucket_name_cfg)
+
+    connection.put_bucket_lifecycle_configuration(
+        Bucket=bucket_name_cfg,
+        LifecycleConfiguration={
+            'Rules': [{
+                'ID': 'test-rule',
+                'Status': 'Enabled',
+                'Filter': {'Prefix': ''},
+                'Expiration': {'Days': 30},
+            }]
+        }
+    )
+    connection.put_bucket_cors(
+        Bucket=bucket_name_cfg,
+        CORSConfiguration={
+            'CORSRules': [{
+                'AllowedMethods': ['GET'],
+                'AllowedOrigins': ['*'],
+            }]
+        }
+    )
+    for key_name in ['u', 'v', 'w']:
+        connection.put_object(Bucket=bucket_name_cfg, Key=key_name, Body=key_name)
+
+    (err, out) = rgwadmin(ctx, client,
+        ['object', 'rm', '--all', '--bucket', bucket_name_cfg,
+         '--yes-i-really-mean-it'],
+        check_status=True)
+
+    # lifecycle and CORS must survive the object removal
+    lc = connection.get_bucket_lifecycle_configuration(Bucket=bucket_name_cfg)
+    assert lc['Rules'][0]['ID'] == 'test-rule'
+
+    cors = connection.get_bucket_cors(Bucket=bucket_name_cfg)
+    assert cors['CORSRules'][0]['AllowedOrigins'] == ['*']
+
+    (err, out) = rgwadmin(ctx, client,
+        ['bucket', 'stats', '--bucket', bucket_name_cfg], check_status=True)
+    assert out['usage']['rgw.main']['num_objects'] == 0
+
+    connection.delete_bucket(Bucket=bucket_name_cfg)
+
+    # TESTCASE 'object-rm-all-locked', 'object', 'rm', 'all objects including object-locked objects', 'succeeds, locked objects deleted'
+    bucket_name_lock = bucket_name + 'lock'
+    connection.create_bucket(
+        Bucket=bucket_name_lock,
+        ObjectLockEnabledForBucket=True)
+    connection.put_object(Bucket=bucket_name_lock, Key='locked', Body='locked')
+    connection.put_object_legal_hold(
+        Bucket=bucket_name_lock, Key='locked',
+        LegalHold={'Status': 'ON'})
+
+    (err, out) = rgwadmin(ctx, client,
+        ['object', 'rm', '--all', '--bucket', bucket_name_lock,
+         '--yes-i-really-mean-it'],
+        check_status=True)
+
+    (err, out) = rgwadmin(ctx, client,
+        ['bucket', 'stats', '--bucket', bucket_name_lock], check_status=True)
+    assert out['usage'].get('rgw.main', {}).get('num_objects', 0) == 0
+
+    connection.delete_bucket(Bucket=bucket_name_lock)
+
     # TESTCASE 'caps-add', 'caps', 'add', 'add user cap', 'succeeds'
     caps='user=read'
     (err, out) = rgwadmin(ctx, client, ['caps', 'add', '--uid', user1, '--caps', caps])

--- a/src/bash_completion/radosgw-admin
+++ b/src/bash_completion/radosgw-admin
@@ -44,12 +44,16 @@ _radosgw_admin()
                 COMPREPLY=( $(compgen -W "create rm" -- ${cur}) )
                 return 0
                 ;;
+            bucket)
+                COMPREPLY=( $(compgen -W "list limit check link unlink chown stats rm rewrite radoslist reshard sync check" -- ${cur}) )
+                return 0
+                ;;
             buckets)
                 COMPREPLY=( $(compgen -W "list unlink" -- ${cur}) )
                 return 0
                 ;;
             *)
-                COMPREPLY=( $(compgen -W "user subuser key buckets policy log" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "user subuser key bucket buckets policy log" -- ${cur}) )
                 return 0
             ;;
         esac

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -293,6 +293,14 @@ class DaosBucket : public StoreBucket {
                                bool keep_index_consistent,
                                optional_yield y,
                                const DoutPrefixProvider* dpp) override;
+  virtual int remove_all_objects(const DoutPrefixProvider* dpp,
+			   bool delete_children, optional_yield y) override
+    { return -ENOTSUP; }
+  virtual int remove_all_objects_bypass_gc(int concurrent_max,
+				     bool keep_index_consistent,
+				     optional_yield y,
+				     const DoutPrefixProvider* dpp) override
+    { return -ENOTSUP; }
   virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
   virtual int set_acl(const DoutPrefixProvider* dpp,
                       RGWAccessControlPolicy& acl, optional_yield y) override;

--- a/src/rgw/driver/motr/rgw_sal_motr.h
+++ b/src/rgw/driver/motr/rgw_sal_motr.h
@@ -356,6 +356,14 @@ class MotrBucket : public StoreBucket {
         keep_index_consistent,
         optional_yield y, const
         DoutPrefixProvider *dpp) override;
+    virtual int remove_all_objects(const DoutPrefixProvider* dpp,
+			     bool delete_children, optional_yield y) override
+      { return -ENOTSUP; }
+    virtual int remove_all_objects_bypass_gc(int concurrent_max,
+				       bool keep_index_consistent,
+				       optional_yield y,
+				       const DoutPrefixProvider* dpp) override
+      { return -ENOTSUP; }
     virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
     virtual int set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy& acl, optional_yield y) override;
     virtual int load_bucket(const DoutPrefixProvider *dpp, optional_yield y) override;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -887,6 +887,14 @@ public:
 			       bool keep_index_consistent,
 			       optional_yield y,
 			       const DoutPrefixProvider *dpp) override;
+  virtual int remove_all_objects(const DoutPrefixProvider* dpp,
+		    bool delete_children, optional_yield y) override
+    { return -ENOTSUP; }
+  virtual int remove_all_objects_bypass_gc(int concurrent_max,
+			      bool keep_index_consistent,
+			      optional_yield y,
+			      const DoutPrefixProvider* dpp) override
+    { return -ENOTSUP; }
   virtual int create(const DoutPrefixProvider* dpp,
 		     const CreateParams& params,
 		     optional_yield y) override;

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1491,6 +1491,24 @@ int RGWBucketAdminOp::remove_bucket(rgw::sal::Driver* driver, const rgw::SiteCon
   return ret;
 }
 
+int RGWBucketAdminOp::remove_all_objects(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state,
+				   optional_yield y, const DoutPrefixProvider *dpp,
+				   bool bypass_gc, bool keep_index_consistent)
+{
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+
+  int ret = driver->load_bucket(dpp, rgw_bucket(op_state.get_tenant(),
+                                                op_state.get_bucket_name()),
+                                &bucket, y);
+  if (ret < 0)
+    return ret;
+
+  if (bypass_gc)
+    return bucket->remove_all_objects_bypass_gc(op_state.get_max_aio(), keep_index_consistent, y, dpp);
+
+  return bucket->remove_all_objects(dpp, op_state.will_delete_children(), y);
+}
+
 int RGWBucketAdminOp::remove_object(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWBucket bucket;

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -398,6 +398,8 @@ public:
 
   static int remove_bucket(rgw::sal::Driver* driver, const rgw::SiteConfig& site, RGWBucketAdminOpState& op_state, optional_yield y,
 			   const DoutPrefixProvider *dpp, bool bypass_gc = false, bool keep_index_consistent = true, bool forwarded_request = false);
+  static int remove_all_objects(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, optional_yield y,
+			  const DoutPrefixProvider *dpp, bool bypass_gc = false, bool keep_index_consistent = true);
   static int remove_object(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, optional_yield y);
   static int info(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
   static int limit_check(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -364,18 +364,11 @@ int RadosUser::list_groups(const DoutPrefixProvider* dpp, optional_yield y,
 
 RadosBucket::~RadosBucket() {}
 
-int RadosBucket::remove(const DoutPrefixProvider* dpp,
-			bool delete_children,
-			optional_yield y)
+int RadosBucket::delete_objects_sync(const DoutPrefixProvider* dpp,
+					 bool delete_children,
+					 optional_yield y)
 {
   int ret;
-
-  // Refresh info
-  ret = load_bucket(dpp, y);
-  if (ret < 0) {
-    return ret;
-  }
-
   ListParams params;
   params.list_versions = true;
   params.allow_unordered = true;
@@ -416,7 +409,24 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
     }
   }
 
-  // remove lifecycle config, if any (XXX note could be made generic)
+  return 0;
+}
+
+
+int RadosBucket::remove(const DoutPrefixProvider* dpp,
+			bool delete_children,
+			optional_yield y)
+{
+  int ret;
+
+  // Refresh info
+  ret = load_bucket(dpp, y);
+  if (ret < 0) {
+    return ret;
+  }
+
+  ret = delete_objects_sync(dpp, delete_children, y);
+
   if (get_attrs().count(RGW_ATTR_LC)) {
     constexpr bool update_attrs = false; // don't update xattrs, we're deleting
     (void) store->getRados()->get_lc()->remove_bucket_config(
@@ -448,6 +458,7 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
   }
 
   librados::Rados& rados = *store->getRados()->get_rados_handle();
+  const bool own_bucket = store->get_zone()->get_zonegroup().get_id() == info.zonegroup;
   if (own_bucket) {
     ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, nullptr);
     if (ret < 0) {
@@ -488,14 +499,13 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
   return ret;
 }
 
-int RadosBucket::remove_bypass_gc(int concurrent_max, bool
-				  keep_index_consistent,
-				  optional_yield y, const
-				  DoutPrefixProvider *dpp)
+int RadosBucket::delete_objects_aio(const DoutPrefixProvider* dpp,
+					optional_yield y,
+					int concurrent_max,
+					bool keep_index_consistent)
 {
   int ret;
   map<RGWObjCategory, RGWStorageStats> stats;
-  map<string, bool> common_prefixes;
   RGWObjectCtx obj_ctx(store);
   CephContext *cct = store->ctx();
 
@@ -610,11 +620,20 @@ int RadosBucket::remove_bypass_gc(int concurrent_max, bool
   }
 
   sync_owner_stats(dpp, y, nullptr);
-  if (ret < 0) {
-     ldpp_dout(dpp, 1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
-  }
 
-  RGWObjVersionTracker objv_tracker;
+  return 0;
+}
+
+int RadosBucket::remove_bypass_gc(int concurrent_max, bool
+				   keep_index_consistent,
+				   optional_yield y, const
+				   DoutPrefixProvider *dpp)
+{
+  int ret = delete_objects_aio(dpp, y, concurrent_max, keep_index_consistent);
+  if (ret < 0) {
+    ldpp_dout(dpp, -1) << "ERROR: delete_objects_aio returned " << ret << dendl;
+    return ret;
+  }
 
   // this function can only be run if caller wanted children to be
   // deleted, so we can ignore the check for children as any that
@@ -622,10 +641,42 @@ int RadosBucket::remove_bypass_gc(int concurrent_max, bool
   ret = remove(dpp, true, y);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: could not remove bucket " << this << dendl;
-    return ret;
   }
 
   return ret;
+}
+
+int RadosBucket::remove_all_objects(const DoutPrefixProvider* dpp, bool delete_children, optional_yield y)
+{
+  int ret = load_bucket(dpp, y);
+  if (ret < 0)
+    return ret;
+
+  // Use standard per-object deletion so objects are queued to garbage
+  // collection as normal.
+  ret = delete_objects_sync(dpp, delete_children, y);
+  if (ret < 0) {
+    return ret;
+  }
+
+  const bool own_bucket = store->get_zone()->get_zonegroup().get_id() == info.zonegroup;
+  if (own_bucket) {
+    librados::Rados& rados = *store->getRados()->get_rados_handle();
+    ret = store->ctl()->bucket->sync_owner_stats(dpp, rados, info.owner, info, y, nullptr);
+    if (ret < 0) {
+      ldout(store->ctx(), 1) << "WARNING: failed sync user stats. ret=" << ret << dendl;
+    }
+  }
+
+  return 0;
+}
+
+int RadosBucket::remove_all_objects_bypass_gc(int concurrent_max,
+					bool keep_index_consistent,
+					optional_yield y,
+					const DoutPrefixProvider* dpp)
+{
+  return delete_objects_aio(dpp, y, concurrent_max, keep_index_consistent);
 }
 
 int RadosBucket::load_bucket(const DoutPrefixProvider* dpp, optional_yield y)

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -702,6 +702,9 @@ class RadosBucket : public StoreBucket {
     RadosStore* store;
     RGWAccessControlPolicy acls;
     std::string topics_oid() const;
+    int delete_objects_sync(const DoutPrefixProvider* dpp, bool delete_children, optional_yield y);
+    int delete_objects_aio(const DoutPrefixProvider* dpp, optional_yield y,
+			       int concurrent_max, bool keep_index_consistent);
 
   public:
     RadosBucket(RadosStore *_st)
@@ -729,6 +732,12 @@ class RadosBucket : public StoreBucket {
 				 keep_index_consistent,
 				 optional_yield y, const
 				 DoutPrefixProvider *dpp) override;
+    virtual int remove_all_objects(const DoutPrefixProvider* dpp,
+			     bool delete_children, optional_yield y) override;
+    virtual int remove_all_objects_bypass_gc(int concurrent_max,
+				       bool keep_index_consistent,
+				       optional_yield y,
+				       const DoutPrefixProvider* dpp) override;
     virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
     virtual int set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy& acl, optional_yield y) override;
     int create(const DoutPrefixProvider* dpp, const CreateParams& params,

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -199,6 +199,8 @@ void usage()
   cout << "  bi list                          list raw bucket index entries\n";
   cout << "  bi purge                         purge bucket index entries\n";
   cout << "  object rm                        remove object; include --yes-i-really-mean-it to force removal from bucket index\n";
+  cout << "                                   use --all to remove all objects from a bucket while keeping the bucket itself;\n";
+  cout << "                                   combine with --bypass-gc to remove via async AIO instead of garbage collection\n";
   cout << "  object put                       put object\n";
   cout << "  object stat                      stat an object for its metadata\n";
   cout << "  object unlink                    unlink object from bucket index\n";
@@ -3747,6 +3749,7 @@ int main(int argc, const char **argv)
   int sync_stats = false;
   int reset_stats = false;
   int bypass_gc = false;
+  int all_objects = false;
   int warnings_only = false;
   int inconsistent_index = false;
 
@@ -4194,6 +4197,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_binary_flag(args, i, &extra_info, NULL, "--extra-info", (char*)NULL)) {
      // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &bypass_gc, NULL, "--bypass-gc", (char*)NULL)) {
+     // do nothing
+    } else if (ceph_argparse_binary_flag(args, i, &all_objects, NULL, "--all", (char*)NULL)) {
      // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &warnings_only, NULL, "--warnings-only", (char*)NULL)) {
      // do nothing
@@ -8523,12 +8528,41 @@ next:
       return -ret;
     }
 
-    rgw_obj_key key(object, object_version);
-
-    ret = rgw_remove_object(dpp(), driver, bucket.get(), key, null_yield, yes_i_really_mean_it);
-    if (ret < 0) {
-      cerr << "ERROR: object remove returned: " << cpp_strerror(-ret) << std::endl;
-      return -ret;
+    if (all_objects) {
+      if (bucket_name.empty()) {
+        cerr << "ERROR: bucket name required" << std::endl;
+        return EINVAL;
+      }
+      if (!object.empty()) {
+        cerr << "ERROR: --object is not compatible with --all" << std::endl;
+        return EINVAL;
+      }
+      if (!object_version.empty()) {
+        cerr << "ERROR: --object-version is not compatible with --all" << std::endl;
+        return EINVAL;
+      }
+      if (!yes_i_really_mean_it) {
+        cerr << "ERROR: this command removes all objects in the bucket. "
+             << "Add --yes-i-really-mean-it to confirm." << std::endl;
+        return EINVAL;
+      }
+      bucket_op.set_delete_children(true);
+      ret = RGWBucketAdminOp::remove_all_objects(driver, bucket_op, null_yield, dpp(), bypass_gc, true);
+      if (ret < 0) {
+        cerr << "ERROR: remove_all_objects returned: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
+    } else {
+      if (object.empty()) {
+        cerr << "ERROR: object not specified" << std::endl;
+        return EINVAL;
+      }
+      rgw_obj_key key(object, object_version);
+      ret = rgw_remove_object(dpp(), driver, bucket.get(), key, null_yield, yes_i_really_mean_it);
+      if (ret < 0) {
+        cerr << "ERROR: object remove returned: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
     }
   }
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -911,6 +911,17 @@ class Bucket {
 				 keep_index_consistent,
 				 optional_yield y, const
 				 DoutPrefixProvider *dpp) = 0;
+    /** Remove all objects from the bucket but keep the bucket itself and its
+     *  policies (lifecycle, ACL, etc.).  Objects are queued to garbage
+     *  collection as normal. */
+    virtual int remove_all_objects(const DoutPrefixProvider* dpp, bool delete_children, optional_yield y) = 0;
+    /** Remove all objects from the bucket but keep the bucket itself and its
+     *  policies (lifecycle, ACL, etc.), bypassing garbage collection via
+     *  async AIO deletion. */
+    virtual int remove_all_objects_bypass_gc(int concurrent_max,
+				       bool keep_index_consistent,
+				       optional_yield y,
+				       const DoutPrefixProvider* dpp) = 0;
     /** Get then ACL for this bucket */
     virtual RGWAccessControlPolicy& get_acl(void) = 0;
     /** Set the ACL for this bucket */

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -146,6 +146,14 @@ protected:
 				   keep_index_consistent,
 				   optional_yield y, const
 				   DoutPrefixProvider *dpp) override;
+      virtual int remove_all_objects(const DoutPrefixProvider* dpp,
+			       bool delete_children, optional_yield y) override
+        { return -ENOTSUP; }
+      virtual int remove_all_objects_bypass_gc(int concurrent_max,
+					 bool keep_index_consistent,
+					 optional_yield y,
+					 const DoutPrefixProvider* dpp) override
+        { return -ENOTSUP; }
       virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
       virtual int set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy& acl, optional_yield y) override;
       int create(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -837,6 +837,19 @@ int FilterBucket::remove_bypass_gc(int concurrent_max,
   return next->remove_bypass_gc(concurrent_max, keep_index_consistent, y, dpp);
 }
 
+int FilterBucket::remove_all_objects(const DoutPrefixProvider* dpp, bool delete_children, optional_yield y)
+{
+  return next->remove_all_objects(dpp, delete_children, y);
+}
+
+int FilterBucket::remove_all_objects_bypass_gc(int concurrent_max,
+					 bool keep_index_consistent,
+					 optional_yield y,
+					 const DoutPrefixProvider* dpp)
+{
+  return next->remove_all_objects_bypass_gc(concurrent_max, keep_index_consistent, y, dpp);
+}
+
 int FilterBucket::set_acl(const DoutPrefixProvider* dpp,
 			  RGWAccessControlPolicy &acl, optional_yield y)
 {

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -578,6 +578,11 @@ public:
 			       keep_index_consistent,
 			       optional_yield y, const
 			       DoutPrefixProvider *dpp) override;
+  virtual int remove_all_objects(const DoutPrefixProvider* dpp, bool delete_children, optional_yield y) override;
+  virtual int remove_all_objects_bypass_gc(int concurrent_max,
+				     bool keep_index_consistent,
+				     optional_yield y,
+				     const DoutPrefixProvider* dpp) override;
   virtual RGWAccessControlPolicy& get_acl(void) override { return next->get_acl(); }
   virtual int set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy& acl,
 		      optional_yield y) override;

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -59,6 +59,8 @@
     bi list                          list raw bucket index entries
     bi purge                         purge bucket index entries
     object rm                        remove object; include --yes-i-really-mean-it to force removal from bucket index
+                                     use --all to remove all objects from a bucket while keeping the bucket itself;
+                                     combine with --bypass-gc to remove via async AIO instead of garbage collection
     object put                       put object
     object stat                      stat an object for its metadata
     object unlink                    unlink object from bucket index


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75617

This PR adds an `--all `flag to the existing `radosgw-admin object rm` command that inherits the object deletion behavior including **versioned objects, legal hold bypass, and GC handling**. It does not delete the bucket or wipe lifecycle rules, CORS, ACLs, versioning state, or object lock configuration of the bucket.

`object rm --all` lets admins empty a source bucket after multisite migration without destroying the bucket's identity and configuration - keeping the bucket ready for immediate reuse.
Usage:

`radosgw-admin object rm --all --bucket=<bucket> --yes-i-really-mean-it [--bypass-gc]`

Testing:

Added test coverage in qa/tasks/radosgw_admin.py covering:

- [x]     Missing --yes-i-really-mean-it guard rejects the command
- [x]     Basic bucket emptying - objects deleted, bucket preserved and empty
- [x]     Versioned bucket - all versions and delete markers removed, versioning state preserved
- [x]     --bypass-gc - tail data deleted inline, nothing queued in GC
- [x]     Lifecycle rules and CORS configuration survive the operation
- [x]     Remove locked object while preserving the bucket


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
