### PR TITLE
mon: make tiebreaker mon optional in stretch-mode

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -632,7 +632,11 @@ rules and failure handling on all pools. For a given PG to successfully peer
 and be marked active, ``min_size`` replicas will now need to be active under all
 (currently two) CRUSH buckets of type <dividing_bucket>.
 
-<tiebreaker_mon> is the tiebreaker Monitor to use if a network split happens.
+<tiebreaker_mon> is the tiebreaker mon to use if a network split happens.
+This parameter is optional. If not supplied, the system will automatically
+select a monitor that is not in either data zone. If there are multiple
+monitors outside the data zones, automatic selection will fail and you must
+explicitly specify the tiebreaker monitor.
 
 <dividing_bucket> is the bucket type across which to stretch.
 This will typically be ``datacenter`` or other CRUSH hierarchy bucket type that
@@ -642,7 +646,7 @@ denotes physically or logically distant subdivisions.
 
 Usage::
 
-    ceph mon enable_stretch_mode <tiebreaker_mon> <new_crush_rule> <dividing_bucket>
+	ceph mon enable_stretch_mode {<tiebreaker_mon>} <new_crush_rule> <dividing_bucket>
 
 Subcommand ``remove`` removes Monitor named <name>.
 

--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -30,13 +30,13 @@ We will here consider two standard configurations: a configuration with two
 data centers (or, in clouds, two availability zones), and a configuration with
 three data centers.
 
-In the two-site configuration, Ceph arranges for each site to hold a copy of
-the data. A third site houses a tiebreaker (arbiter, witness)
+In the two-zone configuration, Ceph arranges for each zone to hold a copy of
+the data. A third zone houses a tiebreaker (arbiter, witness)
 Monitor. This tiebreaker Monitor picks a winner when a network connection
-between sites fails and both data centers remain alive.
+between zones fails and both data centers remain alive.
 
 The tiebreaker monitor can be a VM. It can also have higher network latency
-to the OSD site(s) than OSD site(s) can have to each other.
+to the OSD zone(s) than OSD zone(s) can have to each other.
 
 The standard Ceph configuration is able to survive many network failures or
 data-center failures without compromising data availability. When enough
@@ -133,19 +133,23 @@ converge according to configured replication policy and return to normal operati
 
 Connectivity Monitor Election Strategy
 ---------------------------------------
-When using stretch mode, the Monitor election strategy must be set to ``connectivity``.
+Stretch mode requires the Monitor election strategy to be set to ``connectivity``.
 This strategy tracks network connectivity between Monitors and is
 used to determine which data center should be favored when the cluster
 experiences netsplit.
 
-See `Changing Monitor Elections`_
+**Note:** When you enable stretch mode with ``ceph mon enable_stretch_mode``,
+the cluster will automatically switch the election strategy to ``connectivity``
+if it is not already set. Manual configuration is not required.
+
+See `Changing Monitor Elections`_ for more details on election strategies.
 
 Stretch Peering Rule
 --------------------
 One critical behavior of stretch mode is its ability to prevent a PG from going ``active`` if the acting set
 contains only replicas from a single data center. This safeguard is crucial for mitigating the risk of data
-loss during site failures because if a PG were allowed to go ``active`` with replicas only at a single site,
-writes could be acknowledged despite a lack of redundancy. In the event of a site failure, all data in the
+loss during zone failures because if a PG were allowed to go ``active`` with replicas only at a single zone,
+writes could be acknowledged despite a lack of redundancy. In the event of a zone failure, all data in the
 affected PG would be lost.
 
 Entering Stretch Mode
@@ -158,7 +162,7 @@ with the CRUSH topology.
 
    .. prompt:: bash $
 
-      ceph mon set_location a datacenter=site1
+      ceph mon set_location a datacenter=zone1
 
 #. Generate a CRUSH rule that places two copies in each data center.
    This requires editing the CRUSH map directly:
@@ -170,17 +174,15 @@ with the CRUSH topology.
 
 #. Edit the ``crush.map.txt`` file to add a new rule. Here there is only one
    other rule (``id 1``), but you will likely need to use a different, unique rule ID. We
-   have two ``datacenter`` buckets named ``site1`` and ``site2``:
+   have two ``datacenter`` buckets named ``zone1`` and ``zone2``:
 
    ::
 
-      rule stretch_rule {
+      rule stretch_replicated_rule {
              id 1
              type replicated
-             step take site1
-             step chooseleaf firstn 2 type host
-             step emit
-             step take site2
+             step take default
+             step choose firstn 0 type datacenter
              step chooseleaf firstn 2 type host
              step emit
      }
@@ -191,47 +193,39 @@ with the CRUSH topology.
       of the available space from the datacenter, not the available space for
       the pools associated with the CRUSH rule.
    
-      For example, consider a cluster with two CRUSH rules, ``stretch_rule`` and
-      ``stretch_replicated_rule``::
+      For example, consider a cluster with two CRUSH rules, ``stretch_replicated_rule`` and
+      ``stretch_replicated_rule_alt``::
 
-         rule stretch_rule {
+         rule stretch_replicated_rule {
               id 1
               type replicated
-              step take DC1
-              step chooseleaf firstn 2 type host
-              step emit
-              step take DC2
+              step take default
+              step choose firstn 0 type datacenter
               step chooseleaf firstn 2 type host
               step emit
          }
          
-         rule stretch_replicated_rule {
+         rule stretch_replicated_rule_alt {
                  id 2
                  type replicated
-                 step take default
-                 step choose firstn 0 type datacenter
+                 step take zone1
+                 step chooseleaf firstn 2 type host
+                 step emit
+                 step take zone2
                  step chooseleaf firstn 2 type host
                  step emit
          }
 
-      In the above example, ``stretch_rule`` will report an incorrect value for
+      In the above example, ``stretch_replicated_rule_alt`` will report an incorrect value for
       ``MAX AVAIL``. ``stretch_replicated_rule`` will report the correct value.
-      This is because ``stretch_rule`` is defined in such a way that
+      This is because ``stretch_replicated_rule_alt`` is defined in such a way that
       ``PGMap::get_rule_avail`` considers only the available capacity of a single
       ``datacenter``, and not (as would be correct) the total available capacity from
       both ``datacenters``.
       
-      Here is a workaround. Instead of defining the stretch rule as defined in
-      the ``stretch_rule`` above, define it as follows::
-
-         rule stretch_rule {
-           id 2
-           type replicated
-           step take default
-           step choose firstn 0 type datacenter
-           step chooseleaf firstn 2 type host
-           step emit
-         }
+      The recommended approach is to use the ``stretch_replicated_rule`` definition shown
+      above (with ``take default`` and ``choose firstn 0 type datacenter``), which correctly
+      reports ``MAX AVAIL``.
 
       See https://tracker.ceph.com/issues/56650 for more detail on this workaround.
 
@@ -244,27 +238,39 @@ with the CRUSH topology.
       crushtool -c crush.map.txt -o crush2.map.bin
       ceph osd setcrushmap -i crush2.map.bin
 
-#. Run the Monitors in ``connectivity`` mode. See `Changing Monitor Elections`_.
+#. Direct the cluster to enter stretch mode. The cluster will automatically
+   switch to the `connectivity` election strategy if not already configured.
+   
+   When a tiebreaker Monitor is provisioned, it must be assigned to a CRUSH 
+   `datacenter` location that is neither `zone1` nor `zone2`. This data center 
+   should not be predefined in your CRUSH map.
+   
+   An explicit tiebreaker Monitor is optional. If not specified, the cluster will
+   automatically select a Monitor that has been assigned to a `datacenter` (or the
+   specified bucket type) that differs from the main data zones.
+   
+   **Option 1: Automatic tiebreaker selection** (recommended):
+   
+   Let the cluster automatically select the tiebreaker:
 
    .. prompt:: bash $
 
-      ceph mon set election_strategy connectivity
+      ceph mon set_location e datacenter=zone3
+      ceph mon enable_stretch_mode stretch_replicated_rule datacenter
 
-#. Direct the cluster to enter stretch mode. In this example, ``mon.e`` is the
-   tiebreaker Monitor and we are splitting across CRUSH ``datacenters``. The tiebreaker
-   monitor must be assigned a CRUSH ``datacenter`` that is neither ``site1`` nor
-   ``site2``. This data center **should not** be predefined in your CRUSH map. Here 
-   we are placing ``mon.e`` in a virtual data center named ``site3``:
+   **Option 2: Explicit tiebreaker monitor**:
+   
+   Alternatively, you can explicitly specify ``mon.e`` as the tiebreaker Monitor:
 
    .. prompt:: bash $
 
-      ceph mon set_location e datacenter=site3
-      ceph mon enable_stretch_mode e stretch_rule datacenter
+      ceph mon set_location e datacenter=zone3
+      ceph mon enable_stretch_mode e stretch_replicated_rule datacenter
 
 When stretch mode is enabled, PGs will become active only when they peer
 across CRUSH ``datacenter`` (or across whichever CRUSH bucket type was specified),
 assuming both are available. Pools will increase in size from the default ``3`` to
-``4``, and two replicas will be placed at each site. OSDs will be allowed to
+``4``, and two replicas will be placed at each zone. OSDs will be allowed to
 connect to Monitors only if they are in the same data center as the Monitors.
 New Monitors will not be allowed to join the cluster if they do not specify a
 CRUSH location.
@@ -273,7 +279,7 @@ If all OSDs and Monitors in one of the ``datacenter`` become inaccessible at onc
 the cluster in the surviving ``datacenter`` enters  *degraded stretch mode*.
 A health state warning will be
 raised, pools' ``min_size`` will be reduced to ``1``, and the cluster will be
-allowed to go active with the components and data at the single remaining site. Pool ``size``
+allowed to go active with the components and data at the single remaining zone. Pool ``size``
 does not change, so warnings will be raised that the PGs are undersized,
 but a special stretch mode flag will prevent the OSDs from
 creating extra copies in the remaining data center. This means that the data
@@ -285,8 +291,8 @@ only from the ``datacenter`` that was ``up`` throughout the duration of the
 downtime. When all PGs are in a known state, and are neither degraded nor
 undersized / incomplete, the cluster transitions back to regular stretch mode, ends the
 warning, restores pools' ``min_size`` to its original value of ``2``, requires
-PGs at both sites to peer, and no longer requires the site that was up throughout the
-duration of the downtime when peering. This makes failover to the other site
+PGs at both zones to peer, and no longer requires the zone that was up throughout the
+duration of the downtime when peering. This makes failover to the other zone
 possible, if needed.
 
 .. _Changing Monitor elections: ../change-mon-elections
@@ -324,7 +330,7 @@ is in degraded stretch mode or healthy stretch mode.
 
 Limitations of Stretch Mode 
 ===========================
-When using stretch mode, OSDs must be located at exactly two sites. 
+When using stretch mode, OSDs must be located at exactly two zones. 
 
 Two Monitors must be run in each data center, plus a tiebreaker in a third
 (possibly in the cloud) for a total of five Monitors. While in stretch mode, OSDs
@@ -351,7 +357,7 @@ data centers has been restored. This reduces the potential for data loss.
    For example, the following rule specifying the ``ssd`` device class will not work::
 
       rule stretch_replicated_rule {
-                 id 2
+                 id 1
                  type replicated class ssd
                  step take default
                  step choose firstn 0 type datacenter

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1729,12 +1729,12 @@ int CrushWrapper::get_parent_of_type(int item, int type, int rule) const
   return 0; // not found
 }
 
-void CrushWrapper::get_subtree_of_type(int type, vector<int> *subtrees)
+void CrushWrapper::get_subtree_of_type(int type, vector<int> *subtrees) const
 {
   set<int> roots;
   find_roots(&roots);
   for (auto r: roots) {
-    crush_bucket *b = get_bucket(r);
+    const crush_bucket *b = get_bucket(r);
     if (IS_ERR(b))
       continue;
     get_children_of_type(b->id, type, subtrees);

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -787,7 +787,7 @@ public:
   /**
    * enumerate all subtrees by type
    */
-  void get_subtree_of_type(int type, std::vector<int> *subtrees);
+  void get_subtree_of_type(int type, std::vector<int> *subtrees) const;
 
 
   /**

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -551,7 +551,7 @@ COMMAND("mon set_location " \
 	"specify location <args> for the monitor <name>, using CRUSH bucket names", \
 	"mon", "rw")
 COMMAND("mon enable_stretch_mode " \
-	"name=tiebreaker_mon,type=CephString, "
+	"name=tiebreaker_mon,type=CephString,req=false, "
 	"name=new_crush_rule,type=CephString, "
 	"name=dividing_bucket,type=CephString, ",
 	"enable stretch mode, changing the peering rules and "

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -1141,76 +1141,80 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
       mon.osdmon()->wait_for_writeable(op, new Monitor::C_RetryMessage(&mon, op));
       return false;  /* do not propose, yet */
     }
-    {
-      if (monmap.stretch_mode_enabled) {
-	ss << "stretch mode is already engaged";
-	err = -EINVAL;
-        goto reply_no_propose;
-      }
-      if (pending_map.stretch_mode_enabled) {
-	ss << "stretch mode currently committing";
-	err = 0;
-        goto reply_no_propose;
-      }
-      string tiebreaker_mon;
-      if (!cmd_getval(cmdmap, "tiebreaker_mon", tiebreaker_mon)) {
-	ss << "must specify a tiebreaker monitor";
-	err = -EINVAL;
-        goto reply_no_propose;
-      }
-      string new_crush_rule;
-      if (!cmd_getval(cmdmap, "new_crush_rule", new_crush_rule)) {
-	ss << "must specify a new crush rule that spreads out copies over multiple sites";
-	err = -EINVAL;
-        goto reply_no_propose;
-      }
-      string dividing_bucket;
-      if (!cmd_getval(cmdmap, "dividing_bucket", dividing_bucket)) {
-	ss << "must specify a dividing bucket";
-	err = -EINVAL;
-        goto reply_no_propose;
-      }
-      //okay, initial arguments make sense, check pools and cluster state
-      err = mon.osdmon()->check_cluster_features(CEPH_FEATUREMASK_STRETCH_MODE, ss);
-      if (err)
-        goto reply_no_propose;
-      struct Plugger {
-	Paxos &p;
-	Plugger(Paxos &p) : p(p) { p.plug(); }
-	~Plugger() { p.unplug(); }
-      } plugger(paxos);
-
-      set<pg_pool_t*> pools;
-      bool okay = false;
-      int errcode = 0;
-
-      mon.osdmon()->try_enable_stretch_mode_pools(ss, &okay, &errcode,
-						   &pools, new_crush_rule);
-      if (!okay) {
-	err = errcode;
-        goto reply_no_propose;
-      }
-      try_enable_stretch_mode(ss, &okay, &errcode, false,
-			      tiebreaker_mon, dividing_bucket);
-      if (!okay) {
-	err = errcode;
-        goto reply_no_propose;
-      }
-      mon.osdmon()->try_enable_stretch_mode(ss, &okay, &errcode, false,
-					     dividing_bucket, 2, pools, new_crush_rule);
-      if (!okay) {
-	err = errcode;
-        goto reply_no_propose;
-      }
-      // everything looks good, actually commit the changes!
-      try_enable_stretch_mode(ss, &okay, &errcode, true,
-			      tiebreaker_mon, dividing_bucket);
-      mon.osdmon()->try_enable_stretch_mode(ss, &okay, &errcode, true,
-					     dividing_bucket,
-					     2, // right now we only support 2 sites
-					     pools, new_crush_rule);
-      ceph_assert(okay == true);
+    if (monmap.stretch_mode_enabled) {
+      ss << "stretch mode is already engaged";
+      err = -EINVAL;
+      goto reply_no_propose;
     }
+    if (pending_map.stretch_mode_enabled) {
+      ss << "stretch mode currently committing";
+      err = 0;
+      goto reply_no_propose;
+    }
+    string new_crush_rule;
+    if (!cmd_getval(cmdmap, "new_crush_rule", new_crush_rule)) {
+      ss << "must specify a new crush rule that spreads out copies over multiple sites";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    string dividing_bucket;
+    if (!cmd_getval(cmdmap, "dividing_bucket", dividing_bucket)) {
+      ss << "must specify a dividing bucket";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    string tiebreaker_mon;
+    if (!cmd_getval(cmdmap, "tiebreaker_mon", tiebreaker_mon)) {
+      tiebreaker_mon = "";
+    }
+    //okay, initial arguments make sense, check pools and cluster state
+    err = mon.osdmon()->check_cluster_features(CEPH_FEATUREMASK_STRETCH_MODE, ss);
+    if (err) goto reply_no_propose;
+    
+    // Get pending CRUSH once for validation
+    CrushWrapper crush = mon.osdmon()->_get_pending_crush();
+    
+    set<pg_pool_t*> pools;
+    bool okay = false;
+    int errcode = 0;
+    struct Plugger {
+      // RAII helper to make sure no paxos commits during critical section.
+      // Auto unplug upon destruction.
+      public:
+        explicit Plugger(Paxos &p) : paxos(p) { paxos.plug(); }
+        ~Plugger() { paxos.unplug(); }
+        Plugger(const Plugger&) = delete; // prevent copying
+        Plugger& operator=(const Plugger&) = delete; // prevent object assignment
+      private:
+        Paxos &paxos;
+    };
+    Plugger plugger(paxos);
+    mon.osdmon()->try_enable_stretch_mode_pools(ss, &okay, &errcode,
+              &pools, new_crush_rule);
+    if (!okay) {
+      err = errcode;
+      goto reply_no_propose;
+    }
+    try_enable_stretch_mode(ss, &okay, &errcode, false,
+          tiebreaker_mon, dividing_bucket, crush);
+    if (!okay) {
+      err = errcode;
+      goto reply_no_propose;
+    }
+    mon.osdmon()->try_enable_stretch_mode(ss, &okay, &errcode, false,
+              dividing_bucket, 2, pools, new_crush_rule, crush);
+    if (!okay) {
+      err = errcode;
+      goto reply_no_propose;
+    }
+    // everything looks good, actually commit the changes!
+    try_enable_stretch_mode(ss, &okay, &errcode, true,
+          tiebreaker_mon, dividing_bucket, crush);
+    mon.osdmon()->try_enable_stretch_mode(ss, &okay, &errcode, true,
+              dividing_bucket,
+              2, // right now we only support 2 sites
+              pools, new_crush_rule, crush);
+    ceph_assert(okay == true);
     request_proposal(mon.osdmon());
   } else if (prefix == "mon disable_stretch_mode") {
     if (!mon.osdmon()->is_writeable()) {
@@ -1276,83 +1280,207 @@ reply_propose:
   }
 }
 
-void MonmapMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
-					    int *errcode, bool commit,
-					    const string& tiebreaker_mon,
-					    const string& dividing_bucket)
+void MonmapMonitor::validate_and_enable_stretch_mode(
+    const MonMap& monmap, // passed as arg for unittest
+    MonMap& pending_map, // passed as arg for unittest
+    stringstream& ss, bool *okay,
+    int *errcode, bool commit,
+    string tiebreaker_mon,
+    const string& dividing_bucket,
+    const CrushWrapper& crush)
 {
-  dout(20) << __func__ << dendl;
+  /* A helper function so that we can unittest
+  *  the logic of going into stretch mode.
+  *  Validates against the current committed monmap state,
+  *  but modifies pending_map only when commit=true.
+  */
   *okay = false;
-  if (pending_map.strategy != MonMap::CONNECTIVITY) {
-    ss << "Monitors must use the connectivity strategy to enable stretch mode";
-    *errcode = -EINVAL;
-    ceph_assert(!commit);
-    return;
+  MonMap::election_strategy strategy = pending_map.strategy;
+  if (strategy != MonMap::CONNECTIVITY) {
+    strategy = MonMap::CONNECTIVITY;
   }
-  if (!pending_map.contains(tiebreaker_mon)) {
-    ss << "mon " << tiebreaker_mon << "does not seem to exist";
+  // Validate tiebreaker_mon only if explicitly specified
+  if (!tiebreaker_mon.empty() && !monmap.contains(tiebreaker_mon)) {
+    ss << "mon " << tiebreaker_mon << " does not seem to exist";
     *errcode = -ENOENT;
-    ceph_assert(!commit);
     return;
   }
-  map<string,string> buckets;
-  for (const auto&mii : mon.monmap->mon_info) {
-    const auto& mi = mii.second;
-    const auto& bi = mi.crush_loc.find(dividing_bucket);
-    if (bi == mi.crush_loc.end()) {
+  
+  // Get CRUSH subtrees and dividing_id
+  int dividing_id = *crush.get_validated_type_id(dividing_bucket);
+  vector<int> subtrees;
+  crush.get_subtree_of_type(dividing_id, &subtrees);
+  if (subtrees.size() != 2) {
+    ss << "there are " << subtrees.size() << " " << dividing_bucket
+       << "'s in the cluster but stretch mode currently only works with 2!";
+    *errcode = -EINVAL;
+    return;
+  }
+
+  // Get subtree names from CRUSH
+  set<string> subtree_names;
+  for (int subtree_id : subtrees) {
+    const char *subtree_name = crush.get_item_name(subtree_id);
+    if (subtree_name) {
+      subtree_names.insert(subtree_name);
+    }
+  }
+  
+  if (subtree_names.size() != 2) {
+    ss << "Could not get names for both CRUSH subtrees";
+    *errcode = -EINVAL;
+    return;
+  }
+  
+  // Build map of monitor names to their location at dividing_bucket level
+  map<string,string> mon_name_to_crush_loc;
+  for (const auto& [mon_name, mon_info] : monmap.mon_info) {
+    auto loc_it = mon_info.crush_loc.find(dividing_bucket);
+    if (loc_it == mon_info.crush_loc.end()) {
       ss << "Could not find location entry for " << dividing_bucket
-	 << " on monitor " << mi.name;
+	       << " on monitor " << mon_name;
       *errcode = -EINVAL;
-      ceph_assert(!commit);
       return;
     }
-    buckets[mii.first] = bi->second;
+    mon_name_to_crush_loc.emplace(mon_name, loc_it->second);
   }
-  string bucket1, bucket2, tiebreaker_bucket;
-  for (auto& i : buckets) {
-    if (i.first == tiebreaker_mon) {
-      tiebreaker_bucket = i.second;
-      continue;
+
+  // Identify the two data zones - they must match the CRUSH subtree names
+  map<string, set<string>> location_to_mons;
+  for (const auto& [mon_name, loc_name] : mon_name_to_crush_loc) {
+    location_to_mons[loc_name].insert(mon_name);
+  }
+
+  vector<string> data_zones;
+  for (const string& subtree_name : subtree_names) {
+    if (location_to_mons.count(subtree_name)) {
+      data_zones.push_back(subtree_name);
     }
-    if (bucket1.empty()) {
-      bucket1 = i.second;
+  }
+
+  if (data_zones.size() != 2) {
+    ss << "Could not find monitors in both CRUSH subtrees (";
+    for (auto it = subtree_names.begin(); it != subtree_names.end(); ++it) {
+      if (it != subtree_names.begin()) ss << ", ";
+      ss << *it;
     }
-    if (bucket1 != i.second &&
-	bucket2.empty()) {
-      bucket2 = i.second;
+    ss << "); found monitors only in: ";
+    for (size_t i = 0; i < data_zones.size(); ++i) {
+      if (i > 0) ss << ", ";
+      ss << data_zones[i];
     }
-    if (bucket1 != i.second &&
-	bucket2 != i.second) {
-      ss << "There are too many monitor buckets for stretch mode, found "
-	 << bucket1 << "," << bucket2 << "," << i.second;
+    *errcode = -EINVAL;
+    return;
+  }
+
+  string data_zone1 = data_zones[0];
+  string data_zone2 = data_zones[1];
+
+  // Verify each data zone has at least 1 monitor
+  size_t zone1_mon_count = location_to_mons[data_zone1].size();
+  size_t zone2_mon_count = location_to_mons[data_zone2].size();
+
+  if (zone1_mon_count == 0 || zone2_mon_count == 0) {
+    ss << "Each data zone must have at least 1 monitor; "
+       << data_zone1 << " has " << zone1_mon_count << ", "
+       << data_zone2 << " has " << zone2_mon_count;
+    *errcode = -EINVAL;
+    return;
+  }
+
+  // Auto-select tiebreaker monitor if not specified
+  if (tiebreaker_mon.empty()) {
+    // Find tiebreaker monitor(s) - must be exactly one monitor not in data zones
+    vector<string> tiebreaker_mons;
+    for (const auto& [mon_name, loc_name] : mon_name_to_crush_loc) {
+      if (loc_name != data_zone1 && loc_name != data_zone2) {
+        tiebreaker_mons.push_back(mon_name);
+      }
+    }
+
+    if (tiebreaker_mons.empty()) {
+      ss << "Could not auto-select a tiebreaker monitor; "
+         << "must have a monitor in a third " << dividing_bucket
+         << " location (found only " << data_zone1 << " and " << data_zone2 << ")";
       *errcode = -EINVAL;
-      ceph_assert(!commit);
+      return;
+    }
+
+    if (tiebreaker_mons.size() > 1) {
+      ss << "Could not auto-select a tiebreaker monitor; "
+         << "found " << tiebreaker_mons.size() << " monitors (" << tiebreaker_mons
+         << ") not in the 2 data zones "
+         << data_zone1 << " and " << data_zone2 << ", need exactly 1";
+      *errcode = -EINVAL;
+      return;
+    }
+
+    // Exactly one tiebreaker monitor found
+    tiebreaker_mon = tiebreaker_mons[0];
+  } else {
+    // Validate explicitly specified tiebreaker monitor
+    auto tiebreaker_loc_it = mon_name_to_crush_loc.find(tiebreaker_mon);
+    if (tiebreaker_loc_it == mon_name_to_crush_loc.end()) {
+      // tiebreaker doesn't belong to any of the dividing_bucket locations
+      ss << "tiebreaker monitor " << tiebreaker_mon
+         << " does not have a location specified for " << dividing_bucket;
+      *errcode = -EINVAL;
+      return;
+    }
+
+    const string& tiebreaker_location = tiebreaker_loc_it->second;
+    if (tiebreaker_location == data_zone1 || tiebreaker_location == data_zone2) {
+      ss << "tiebreaker monitor " << tiebreaker_mon
+         << " is in " << tiebreaker_location
+         << ", which is one of the two data zones ("
+         << data_zone1 << ", " << data_zone2
+         << "); tiebreaker must be in a third location";
+      *errcode = -EINVAL;
       return;
     }
   }
-  if (bucket1.empty() || bucket2.empty()) {
-    ss << "There are not enough monitor buckets for stretch mode;"
-       << " must have at least 2 plus the tiebreaker but only found "
-       << (bucket1.empty() ? bucket1 : bucket2);
-    *errcode = -EINVAL;
-    ceph_assert(!commit);
-    return;
-  }
-  if (tiebreaker_bucket == bucket1 ||
-      tiebreaker_bucket == bucket2) {
-    ss << "The named tiebreaker monitor " << tiebreaker_mon
-       << " is in the same CRUSH bucket " << tiebreaker_bucket
-       << " as other monitors";
-    *errcode = -EINVAL;
-    ceph_assert(!commit);
-    return;
-  }
+
   if (commit) {
+    pending_map.strategy = strategy;
     pending_map.disallowed_leaders.insert(tiebreaker_mon);
     pending_map.tiebreaker_mon = tiebreaker_mon;
     pending_map.stretch_mode_enabled = true;
   }
   *okay = true;
+}
+
+void MonmapMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
+					    int *errcode, bool commit,
+					    string tiebreaker_mon,
+					    const string& dividing_bucket,
+					    const CrushWrapper& crush)
+{
+  dout(20) << __func__ << dendl;
+  
+  // Check if monitors support connectivity election strategy if not already using it
+  if (pending_map.strategy != MonMap::CONNECTIVITY) {
+    if (!mon.get_quorum_mon_features().contains_all(
+        ceph::features::mon::FEATURE_PINGING)) {
+      *okay = false;
+      *errcode = -ENOTSUP;
+      ss << "Not all monitors support changing election strategies; please upgrade first!";
+      return;
+    }
+  }
+  
+  validate_and_enable_stretch_mode(*mon.monmap, pending_map, ss, okay, errcode, commit,
+                                     tiebreaker_mon, dividing_bucket, crush);
+
+  // Add debug logging if successful
+  if (*okay && !tiebreaker_mon.empty()) {
+    // Note: tiebreaker_mon may have been auto-selected, but we can't easily retrieve it here
+    // The validate_and_enable_stretch_mode function modifies it internally
+    dout(20) << __func__ << " stretch mode validation succeeded" << dendl;
+  }
+
+  if (!*okay) {
+    ceph_assert(!commit);
+  }
 }
 
 void MonmapMonitor::trigger_degraded_stretch_mode(const set<string>& dead_mons)

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -89,13 +89,35 @@ private:
    * @param okay: Filled to true if okay, false if validation fails
    * @param errcode: filled with -errno if there's a problem
    * @param commit: true if we should commit the change, false if just testing
-   * @param tiebreaker_mon: the name of the monitor to declare tiebreaker
+   * @param tiebreaker_mon: the name of the monitor to declare tiebreaker (empty for auto-select)
    * @param dividing_bucket: the bucket type (eg 'dc') that divides the cluster
+   * @param crush: the pending CrushWrapper for validating monitor locations against subtrees
+   *
+   * Note: CRUSH bucket type and subtree count validation is performed by
+   * OSDMonitor::try_enable_stretch_mode() to avoid redundancy.
    */
   void try_enable_stretch_mode(std::stringstream& ss, bool *okay,
 			       int *errcode, bool commit,
-			       const std::string& tiebreaker_mon,
-			       const std::string& dividing_bucket);
+			       std::string tiebreaker_mon,
+			       const std::string& dividing_bucket,
+			       const CrushWrapper& crush);
+
+public:
+  /**
+   * Static helper for validating and enabling stretch mode on a MonMap.
+   * Extracted for testability - can be called from unit tests.
+   * Parameters same as try_enable_stretch_mode above.
+   * @param monmap: current committed monmap to validate against
+   * @param pending_map: pending monmap to modify when commit=true
+   */
+  static void validate_and_enable_stretch_mode(
+			       const MonMap& monmap,
+			       MonMap& pending_map,
+			       std::stringstream& ss, bool *okay,
+			       int *errcode, bool commit,
+			       std::string tiebreaker_mon,
+			       const std::string& dividing_bucket,
+			       const CrushWrapper& crush);
 
 public:
   /**

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -15582,6 +15582,10 @@ void OSDMonitor::try_enable_stretch_mode_pools(stringstream& ss, bool *okay,
 					       set<pg_pool_t*>* pools,
 					       const string& new_crush_rule)
 {
+  /* Validate pool configurations for stretch mode enablement.
+   * This checks that the specified crush rule exists and that all pools
+   * are replicated pools with default size/min_size.
+   */
   dout(20) << __func__ << dendl;
   *okay = false;
   int new_crush_rule_result = osdmap.crush->get_rule_id(new_crush_rule);
@@ -15623,11 +15627,11 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
 					 const string& dividing_bucket,
 					 uint32_t bucket_count,
 					 const set<pg_pool_t*>& pools,
-					 const string& new_crush_rule)
+					 const string& new_crush_rule,
+					 CrushWrapper& crush)
 {
   dout(20) << __func__ << dendl;
   *okay = false;
-  CrushWrapper crush = _get_pending_crush();
   int dividing_id = -1;
   if (auto type_id = crush.get_validated_type_id(dividing_bucket);
       !type_id.has_value()) {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -851,7 +851,8 @@ public:
 			       const std::string& dividing_bucket,
 			       uint32_t bucket_count,
 			       const std::set<pg_pool_t*>& pools,
-			       const std::string& new_crush_rule);
+			       const std::string& new_crush_rule,
+			       CrushWrapper& crush);
   /**
   *
   * Set all stretch mode values of all pools back to pre-stretch mode values.

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -88,3 +88,10 @@ add_executable(unittest_mon_election
   )
 add_ceph_unittest(unittest_mon_election)
 target_link_libraries(unittest_mon_election mon global)
+
+# unittest_monmap_monitor
+add_executable(unittest_monmap_monitor
+  test_monmap_monitor.cc
+  )
+add_ceph_unittest(unittest_monmap_monitor)
+target_link_libraries(unittest_monmap_monitor mon global)

--- a/src/test/mon/test_monmap_monitor.cc
+++ b/src/test/mon/test_monmap_monitor.cc
@@ -1,0 +1,524 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Test stretch mode logic in MonmapMonitor
+ * 
+ * Tests tiebreaker validation, auto-selection, and stretch mode enablement
+ * for monitor-side stretch cluster configuration.
+ */
+
+#include "gtest/gtest.h"
+#include "mon/MonMap.h"
+#include "mon/MonmapMonitor.h"
+#include "mon/Monitor.h"
+#include "mon/Paxos.h"
+#include "crush/CrushWrapper.h"
+#include "common/ceph_context.h"
+#include "global/global_init.h"
+#include "common/common_init.h"
+#include "common/ceph_argparse.h"
+
+#include <memory>
+#include <sstream>
+
+using namespace std;
+
+class MonmapMonitorStretchTest : public ::testing::Test {
+protected:
+  unique_ptr<CephContext> cct;
+  MonMap monmap;
+  CrushWrapper crush;
+  
+  void SetUp() override {
+    vector<const char*> args;
+    cct.reset(new CephContext(CEPH_ENTITY_TYPE_MON));
+    cct->_conf.set_val("mon_election_default_strategy", "3"); // connectivity
+  }
+
+  void setup_basic_monmap_5mons() {
+    // Create 5 monitors: a, b (zone1), c, d (zone2), e (zone3)
+    monmap.strategy = MonMap::CONNECTIVITY;
+    
+    entity_addrvec_t addrs_a;
+    entity_addr_t addr_a;
+    addr_a.parse("127.0.0.1:6789");
+    addrs_a.v.push_back(addr_a);
+    monmap.add("a", addrs_a);
+    monmap.mon_info["a"].crush_loc["zone"] = "zone1";
+
+    entity_addrvec_t addrs_b;
+    entity_addr_t addr_b;
+    addr_b.parse("127.0.0.2:6789");
+    addrs_b.v.push_back(addr_b);
+    monmap.add("b", addrs_b);
+    monmap.mon_info["b"].crush_loc["zone"] = "zone1";
+
+    entity_addrvec_t addrs_c;
+    entity_addr_t addr_c;
+    addr_c.parse("127.0.0.3:6789");
+    addrs_c.v.push_back(addr_c);
+    monmap.add("c", addrs_c);
+    monmap.mon_info["c"].crush_loc["zone"] = "zone2";
+
+    entity_addrvec_t addrs_d;
+    entity_addr_t addr_d;
+    addr_d.parse("127.0.0.4:6789");
+    addrs_d.v.push_back(addr_d);
+    monmap.add("d", addrs_d);
+    monmap.mon_info["d"].crush_loc["zone"] = "zone2";
+
+    entity_addrvec_t addrs_e;
+    entity_addr_t addr_e;
+    addr_e.parse("127.0.0.5:6789");
+    addrs_e.v.push_back(addr_e);
+    monmap.add("e", addrs_e);
+    monmap.mon_info["e"].crush_loc["zone"] = "zone3";
+  }
+
+  void setup_crush_two_zones() {
+    // Create a CRUSH map with two zones (zone1, zone2)
+    crush.create();
+    crush.set_max_devices(10);
+    
+    // Set up type hierarchy: root (type 10) > zone (type 8) > host (type 1) > osd (type 0)
+    crush.set_type_name(10, "root");
+    crush.set_type_name(8, "zone");
+    crush.set_type_name(1, "host");
+    crush.set_type_name(0, "osd");
+    
+    // Insert OSDs into zone1 and zone2
+    // This will automatically create the zone buckets and make them valid subtrees
+    map<string,string> loc_zone1;
+    loc_zone1["root"] = "default";
+    loc_zone1["zone"] = "zone1";
+    loc_zone1["host"] = "host1";
+    
+    map<string,string> loc_zone2;
+    loc_zone2["root"] = "default";
+    loc_zone2["zone"] = "zone2";
+    loc_zone2["host"] = "host2";
+    
+    // Insert a few OSDs in each zone to make them valid subtrees
+    crush.insert_item(cct.get(), 0, 1.0, "osd.0", loc_zone1);
+    crush.insert_item(cct.get(), 1, 1.0, "osd.1", loc_zone1);
+    crush.insert_item(cct.get(), 2, 1.0, "osd.2", loc_zone2);
+    crush.insert_item(cct.get(), 3, 1.0, "osd.3", loc_zone2);
+  }
+
+  void setup_monmap_bad_tiebreaker_in_zone1() {
+    // Create 5 monitors where 'e' is in zone1 (same as a, b)
+    monmap.strategy = MonMap::CONNECTIVITY;
+    
+    entity_addrvec_t addrs_a;
+    entity_addr_t addr_a;
+    addr_a.parse("127.0.0.1:6789");
+    addrs_a.v.push_back(addr_a);
+    monmap.add("a", addrs_a);
+    monmap.mon_info["a"].crush_loc["zone"] = "zone1";
+    
+    entity_addrvec_t addrs_b;
+    entity_addr_t addr_b;
+    addr_b.parse("127.0.0.2:6789");
+    addrs_b.v.push_back(addr_b);
+    monmap.add("b", addrs_b);
+    monmap.mon_info["b"].crush_loc["zone"] = "zone1";
+    
+    entity_addrvec_t addrs_c;
+    entity_addr_t addr_c;
+    addr_c.parse("127.0.0.3:6789");
+    addrs_c.v.push_back(addr_c);
+    monmap.add("c", addrs_c);
+    monmap.mon_info["c"].crush_loc["zone"] = "zone2";
+    
+    entity_addrvec_t addrs_d;
+    entity_addr_t addr_d;
+    addr_d.parse("127.0.0.4:6789");
+    addrs_d.v.push_back(addr_d);
+    monmap.add("d", addrs_d);
+    monmap.mon_info["d"].crush_loc["zone"] = "zone2";
+    
+    entity_addrvec_t addrs_e;
+    entity_addr_t addr_e;
+    addr_e.parse("127.0.0.5:6789");
+    addrs_e.v.push_back(addr_e);
+    monmap.add("e", addrs_e);
+    monmap.mon_info["e"].crush_loc["zone"] = "zone1"; // BAD: in data zone
+  }
+
+  void setup_monmap_multiple_tiebreakers() {
+    // Create 6 monitors with 2 in zone3 (e and f)
+    monmap.strategy = MonMap::CONNECTIVITY;
+    
+    entity_addrvec_t addrs_a;
+    entity_addr_t addr_a;
+    addr_a.parse("127.0.0.1:6789");
+    addrs_a.v.push_back(addr_a);
+    monmap.add("a", addrs_a);
+    monmap.mon_info["a"].crush_loc["zone"] = "zone1";
+    
+    entity_addrvec_t addrs_b;
+    entity_addr_t addr_b;
+    addr_b.parse("127.0.0.2:6789");
+    addrs_b.v.push_back(addr_b);
+    monmap.add("b", addrs_b);
+    monmap.mon_info["b"].crush_loc["zone"] = "zone1";
+    
+    entity_addrvec_t addrs_c;
+    entity_addr_t addr_c;
+    addr_c.parse("127.0.0.3:6789");
+    addrs_c.v.push_back(addr_c);
+    monmap.add("c", addrs_c);
+    monmap.mon_info["c"].crush_loc["zone"] = "zone2";
+    
+    entity_addrvec_t addrs_d;
+    entity_addr_t addr_d;
+    addr_d.parse("127.0.0.4:6789");
+    addrs_d.v.push_back(addr_d);
+    monmap.add("d", addrs_d);
+    monmap.mon_info["d"].crush_loc["zone"] = "zone2";
+    
+    entity_addrvec_t addrs_e;
+    entity_addr_t addr_e;
+    addr_e.parse("127.0.0.5:6789");
+    addrs_e.v.push_back(addr_e);
+    monmap.add("e", addrs_e);
+    monmap.mon_info["e"].crush_loc["zone"] = "zone3";
+    
+    entity_addrvec_t addrs_f;
+    entity_addr_t addr_f;
+    addr_f.parse("127.0.0.6:6789");
+    addrs_f.v.push_back(addr_f);
+    monmap.add("f", addrs_f);
+    monmap.mon_info["f"].crush_loc["zone"] = "zone3"; // Multiple in zone3
+  }
+
+  void setup_monmap_zero_monitors_in_zone2() {
+    // Create 3 monitors: a, b (zone1), e (zone3)
+    // No monitors in zone2 - should fail validation
+    monmap.strategy = MonMap::CONNECTIVITY;
+
+    entity_addrvec_t addrs_a;
+    entity_addr_t addr_a;
+    addr_a.parse("127.0.0.1:6789");
+    addrs_a.v.push_back(addr_a);
+    monmap.add("a", addrs_a);
+    monmap.mon_info["a"].crush_loc["zone"] = "zone1";
+
+    entity_addrvec_t addrs_b;
+    entity_addr_t addr_b;
+    addr_b.parse("127.0.0.2:6789");
+    addrs_b.v.push_back(addr_b);
+    monmap.add("b", addrs_b);
+    monmap.mon_info["b"].crush_loc["zone"] = "zone1";
+
+    entity_addrvec_t addrs_e;
+    entity_addr_t addr_e;
+    addr_e.parse("127.0.0.5:6789");
+    addrs_e.v.push_back(addr_e);
+    monmap.add("e", addrs_e);
+    monmap.mon_info["e"].crush_loc["zone"] = "zone3";
+  }
+
+  void setup_monmap_one_monitor_per_zone() {
+    // Create 3 monitors: a (zone1), c (zone2), e (zone3)
+    // Minimal valid configuration - 1 monitor per zone
+    monmap.strategy = MonMap::CONNECTIVITY;
+
+    entity_addrvec_t addrs_a;
+    entity_addr_t addr_a;
+    addr_a.parse("127.0.0.1:6789");
+    addrs_a.v.push_back(addr_a);
+    monmap.add("a", addrs_a);
+    monmap.mon_info["a"].crush_loc["zone"] = "zone1";
+
+    entity_addrvec_t addrs_c;
+    entity_addr_t addr_c;
+    addr_c.parse("127.0.0.3:6789");
+    addrs_c.v.push_back(addr_c);
+    monmap.add("c", addrs_c);
+    monmap.mon_info["c"].crush_loc["zone"] = "zone2";
+
+    entity_addrvec_t addrs_e;
+    entity_addr_t addr_e;
+    addr_e.parse("127.0.0.5:6789");
+    addrs_e.v.push_back(addr_e);
+    monmap.add("e", addrs_e);
+    monmap.mon_info["e"].crush_loc["zone"] = "zone3";
+  }
+};
+
+// Test success when explicitly supplied tiebreaker
+TEST_F(MonmapMonitorStretchTest, ExplicitTiebreakerSuccess) {
+  setup_basic_monmap_5mons();
+  setup_crush_two_zones();
+  
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+  
+  // Test validation phase (commit=false)
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "e", "zone", crush);
+  
+  EXPECT_TRUE(okay) << "Validation failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  EXPECT_FALSE(monmap.stretch_mode_enabled) 
+    << "Should not be enabled in validation phase";
+  
+  // Test commit phase (commit=true)
+  ss.str("");
+  okay = false;
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, true, "e", "zone", crush);
+  
+  EXPECT_TRUE(okay) << "Commit failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  EXPECT_TRUE(monmap.stretch_mode_enabled);
+  EXPECT_EQ(monmap.tiebreaker_mon, "e");
+  EXPECT_TRUE(monmap.disallowed_leaders.count("e"));
+}
+
+// Test success when auto-selecting of tiebreaker monitor
+TEST_F(MonmapMonitorStretchTest, AutoSelectTiebreakerSuccess) {
+  setup_basic_monmap_5mons();
+  setup_crush_two_zones();
+  
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+  
+  // Test with empty tiebreaker_mon string (triggers auto-selection)
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "", "zone", crush);
+  
+  EXPECT_TRUE(okay) << "Auto-selection validation failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  
+  // Commit with auto-selection
+  ss.str("");
+  okay = false;
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, true, "", "zone", crush);
+  
+  EXPECT_TRUE(okay) << "Auto-selection commit failed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  EXPECT_TRUE(monmap.stretch_mode_enabled);
+  EXPECT_EQ(monmap.tiebreaker_mon, "e") 
+    << "Should auto-select 'e' as tiebreaker";
+  EXPECT_TRUE(monmap.disallowed_leaders.count("e"));
+}
+
+// Test success when strategy is automatically changed to CONNECTIVITY
+TEST_F(MonmapMonitorStretchTest, StrategyAutoChangedToConnectivity) {
+  setup_basic_monmap_5mons();
+  setup_crush_two_zones();
+  
+  // Start with classic strategy
+  monmap.strategy = MonMap::CLASSIC;
+  
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+  
+  // Validation phase should succeed and prepare strategy change
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "e", "zone", crush);
+  
+  EXPECT_TRUE(okay) << "Validation should succeed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  EXPECT_FALSE(monmap.stretch_mode_enabled) 
+    << "Should not be enabled in validation phase";
+  
+  // Commit phase should enable stretch mode and change strategy
+  ss.str("");
+  okay = false;
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, true, "e", "zone", crush);
+  
+  EXPECT_TRUE(okay) << "Commit should succeed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  EXPECT_TRUE(monmap.stretch_mode_enabled);
+  EXPECT_EQ(monmap.strategy, MonMap::CONNECTIVITY) 
+    << "Strategy should be changed to CONNECTIVITY";
+  EXPECT_EQ(monmap.tiebreaker_mon, "e");
+  EXPECT_TRUE(monmap.disallowed_leaders.count("e"));
+}
+
+// Test failure when auto-selecting and tiebreaker is in a data zone
+TEST_F(MonmapMonitorStretchTest, AutoSelectFailTiebreakerInDataZone) {
+  setup_monmap_bad_tiebreaker_in_zone1(); // 'e' is in zone1, not zone3
+  setup_crush_two_zones();
+  
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+  
+  // Try auto-selection - should fail because 'e' is in zone1
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "", "zone", crush);
+  
+  EXPECT_FALSE(okay) << "Should fail when no tiebreaker in third zone";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_FALSE(monmap.stretch_mode_enabled);
+  
+  string error_msg = ss.str();
+  EXPECT_TRUE(error_msg.find("Could not auto-select a tiebreaker monitor") != string::npos)
+    << "Error message: " << error_msg;
+  EXPECT_TRUE(error_msg.find("third") != string::npos)
+    << "Should mention need for third location. Error: " << error_msg;
+}
+
+// Test failure when explicitly specifying tiebreaker in a data zone
+TEST_F(MonmapMonitorStretchTest, ExplicitTiebreakerInDataZoneFails) {
+  setup_monmap_bad_tiebreaker_in_zone1();
+  setup_crush_two_zones();
+  
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+  
+  // Explicitly specify 'e' which is in zone1 (a data zone)
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "e", "zone", crush);
+  
+  EXPECT_FALSE(okay) << "Should fail when tiebreaker is in data zone";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_FALSE(monmap.stretch_mode_enabled);
+
+  string error_msg = ss.str();
+  EXPECT_TRUE(error_msg.find("one of the two data zones") != string::npos)
+    << "Error message: " << error_msg;
+}
+
+// Test failure when multiple potential tiebreakers exist
+TEST_F(MonmapMonitorStretchTest, AutoSelectFailMultipleTiebreakers) {
+  setup_monmap_multiple_tiebreakers(); // Both 'e' and 'f' are in zone3
+  setup_crush_two_zones();
+  
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+  
+  // Try auto-selection - should fail with multiple candidates
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "", "zone", crush);
+  
+  EXPECT_FALSE(okay) << "Should fail with multiple tiebreaker candidates";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_FALSE(monmap.stretch_mode_enabled);
+  
+  string error_msg = ss.str();
+  EXPECT_TRUE(error_msg.find("Could not auto-select") != string::npos)
+    << "Error message: " << error_msg;
+  EXPECT_TRUE(error_msg.find("found 2 monitors") != string::npos ||
+              error_msg.find("but need exactly 1") != string::npos)
+    << "Should mention multiple monitors found. Error: " << error_msg;
+}
+
+// Test failure when tiebreaker monitor doesn't exist
+TEST_F(MonmapMonitorStretchTest, NonExistentTiebreakerFails) {
+  setup_basic_monmap_5mons();
+  setup_crush_two_zones();
+  
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+  
+  // Specify a monitor that doesn't exist
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "nonexistent", "zone", crush);
+  
+  EXPECT_FALSE(okay) << "Should fail with non-existent monitor";
+  EXPECT_EQ(errcode, -ENOENT);
+  
+  string error_msg = ss.str();
+  EXPECT_TRUE(error_msg.find("does not seem to exist") != string::npos)
+    << "Error message: " << error_msg;
+}
+
+// Test failure when one data zone has 0 monitors
+TEST_F(MonmapMonitorStretchTest, ZeroMonitorsInDataZoneFails) {
+  setup_monmap_zero_monitors_in_zone2(); // No monitors in zone2
+  setup_crush_two_zones();
+
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+
+  // Try to enable stretch mode - should fail due to no monitors in zone2
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "e", "zone", crush);
+
+  EXPECT_FALSE(okay) << "Should fail when a data zone has 0 monitors";
+  EXPECT_EQ(errcode, -EINVAL);
+  EXPECT_FALSE(monmap.stretch_mode_enabled);
+
+  string error_msg = ss.str();
+  // Validation fails early when detecting monitors aren't in both CRUSH subtrees
+  EXPECT_TRUE(error_msg.find("Could not find monitors in both CRUSH subtrees") != string::npos)
+    << "Error message: " << error_msg;
+  EXPECT_TRUE(error_msg.find("found monitors only in") != string::npos)
+    << "Should mention which zones have monitors. Error: " << error_msg;
+}
+
+// Test success with minimal valid configuration (1 monitor per zone)
+TEST_F(MonmapMonitorStretchTest, OneMonitorPerZoneSucceeds) {
+  setup_monmap_one_monitor_per_zone(); // a (zone1), c (zone2), e (zone3)
+  setup_crush_two_zones();
+
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+
+  // Validation phase with explicit tiebreaker
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "e", "zone", crush);
+
+  EXPECT_TRUE(okay) << "Validation should succeed with 1 monitor per zone: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+
+  // Commit phase
+  ss.str("");
+  okay = false;
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, true, "e", "zone", crush);
+
+  EXPECT_TRUE(okay) << "Commit should succeed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  EXPECT_TRUE(monmap.stretch_mode_enabled);
+  EXPECT_EQ(monmap.tiebreaker_mon, "e");
+}
+
+// Test success with auto-selection and 1 monitor per zone
+TEST_F(MonmapMonitorStretchTest, OneMonitorPerZoneAutoSelectSucceeds) {
+  setup_monmap_one_monitor_per_zone(); // a (zone1), c (zone2), e (zone3)
+  setup_crush_two_zones();
+
+  stringstream ss;
+  bool okay = false;
+  int errcode = 0;
+
+  // Auto-selection with minimal valid configuration
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, false, "", "zone", crush);
+
+  EXPECT_TRUE(okay) << "Auto-selection should succeed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+
+  // Commit with auto-selection
+  ss.str("");
+  okay = false;
+  MonmapMonitor::validate_and_enable_stretch_mode(
+      monmap, monmap, ss, &okay, &errcode, true, "", "zone", crush);
+
+  EXPECT_TRUE(okay) << "Commit should succeed: " << ss.str();
+  EXPECT_EQ(errcode, 0);
+  EXPECT_TRUE(monmap.stretch_mode_enabled);
+  EXPECT_EQ(monmap.tiebreaker_mon, "e") << "Should auto-select 'e' as tiebreaker";
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Motivation:
To future support EC stretch feature, we need to
simplify how we enable stretch-mode

Solution:
Make tiebreaker argument optional.

old:
```
ceph mon enable_stretch_mode <tiebreaker_mon> <new_crush_rule> <dividing_bucket>
```
new:
```
ceph mon enable_stretch_mode <tiebreaker_mon (optional)> <new_crush_rule> <dividing_bucket>
```

Ceph will try to auto-select a tiebreaker mon that resides in the crush <dividing_bucket> type but doesn't belong to any of the data sites which the OSDs resides in.

Moreover, `ceph mon enable_stretch_mode` will automatically set monitor election strategy to Connectivity.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
