### PR TITLE
bluestore, extblkdev: Now plugins can raise health warnings

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -151,7 +151,7 @@ class BlockDevice {
 public:
   CephContext* cct;
   typedef void (*aio_callback_t)(void *handle, void *aio);
-  void collect_alerts(osd_alert_list_t& alerts, const std::string& device_name);
+  virtual void collect_alerts(osd_alert_list_t& alerts, const std::string& device_name);
 
 private:
   ceph::mutex ioc_reap_lock = ceph::make_mutex("BlockDevice::ioc_reap_lock");

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -925,6 +925,9 @@ bool KernelDevice::try_discard(interval_set<uint64_t> &to_release,
 void KernelDevice::collect_alerts(osd_alert_list_t& alerts, const std::string& device_name)
 {
   BlockDevice::collect_alerts(alerts, device_name);
+  if (ebd_impl) {
+    ebd_impl->collect_alerts(alerts);
+  }
 }
 
 void KernelDevice::_aio_log_start(

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -922,6 +922,11 @@ bool KernelDevice::try_discard(interval_set<uint64_t> &to_release,
   return false;
 }
 
+void KernelDevice::collect_alerts(osd_alert_list_t& alerts, const std::string& device_name)
+{
+  BlockDevice::collect_alerts(alerts, device_name);
+}
+
 void KernelDevice::_aio_log_start(
   IOContext *ioc,
   uint64_t offset,

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -101,6 +101,8 @@ private:
                    bool async = true,
                    bool force = false) override;
 
+  void collect_alerts(osd_alert_list_t& alerts, const std::string& device_name) override;
+
   int _aio_start();
   void _aio_stop();
 

--- a/src/extblkdev/ExtBlkDevInterface.h
+++ b/src/extblkdev/ExtBlkDevInterface.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <ostream>
 #include <memory>
+#include "osd/osd_types.h"
 #ifdef __linux__
 #include <sys/capability.h>
 #else
@@ -112,6 +113,14 @@ namespace ceph {
      * @return 0 on success or a negative errno on error.
      */
     virtual int get_plugin_id(std::string& id_str) = 0;
+
+    /**
+     * Retrieve alerts from the plugin, if any.
+     * This function is used to give plugin a way to signal health warnings.
+     *
+     * @param [out] alerts append warnings here.
+     */
+    virtual void collect_alerts(osd_alert_list_t& alerts) {}
   };
 
   typedef std::shared_ptr<ExtBlkDevInterface> ExtBlkDevInterfaceRef;

--- a/src/extblkdev/ExtBlkDevPlugin.cc
+++ b/src/extblkdev/ExtBlkDevPlugin.cc
@@ -224,7 +224,8 @@ namespace ceph {
         preload_result = 0;
 	return 0;
       }
-      return limit_caps(cct);
+      preload_result = limit_caps(cct);
+      return preload_result;
 #else
       preload_result = 0;
       return 0;

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -126,6 +126,9 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
   struct timespec last_access = {0};
   PerfCounters *perfc = nullptr;
 
+  bool error_accessing_log = false;
+  bool error_multivolume = false;
+
   uint64_t get_partition_physical_size() const {return psize;}
   uint64_t get_partition_logical_size() const {return lsize;}
   uint64_t get_partition_physical_avail() const {return pavail;}
@@ -199,7 +202,7 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
   }
 
 
-  int get_fcm_utilization()
+  int get_fcm_utilization_core()
   {
     struct timespec tnow;
     clock_gettime(CLOCK_MONOTONIC_COARSE, &tnow);
@@ -253,6 +256,23 @@ class ExtBlkDevFcm : public ceph::ExtBlkDevInterface
     last_access = tnow;
 
     return 0;
+  }
+
+  int get_fcm_utilization() {
+    int result = get_fcm_utilization_core();
+    if (result < 0) {
+      // raise alert status
+      error_accessing_log = true;
+    }
+    if (result == 0) {
+      // clear alert
+      error_accessing_log = false;
+    }
+    if (result > 0) {
+      // We only retrieve log every 15s.
+      // We did not retrieve it in this run, so no change on error_accessing_log.
+    }
+    return result;
   }
 
   static int fcm_get_int_property(const std::string& devpath, const std::string& attr)
@@ -317,22 +337,22 @@ public:
                  << " vendor=" << vendor << " at " << devpath << dendl;
         // get vendor and device id of underlying hardware, compare with FCM ids
         if (vendor == 0x1014 && device == 0x0634) {
-          if (raw_devices.size() > 1) {
-            derr << __func__
-                 << "Device " << logdevname_a << " consist of " << raw_devices.size()
-                 << " devices: " << raw_devices
-                 << dendl;
-            ceph_abort("Multi-device volumes are unsupported for FCM plugin");
-          }
           fcm_devices.push_back(fcm_dev(d));
           dout(1) << __func__ << " Found FCM vendor/device id on " << d << dendl;
         }
       }
     }
+
     if(fcm_devices.empty()){
       return -1000;
+    } else {
+      if (raw_devices.size() > 1) {
+        error_multivolume = true;
+        derr << __func__ << "Device " << logdevname_a << " consist of "
+             << raw_devices.size() << " devices: " << raw_devices << dendl;
+        derr << "Multi-device volumes are unsupported for FCM plugin" << dendl;
+      }
     }
-
     // get size of logical volume/partition
     int rc=get_lsize();
     if(rc<0)
@@ -345,12 +365,8 @@ public:
 	return rc;
     }
 
-    // do initial query for utilization to ensure query mechanism works
-    rc=get_fcm_utilization();
-    if(rc<0){
-      derr << __func__ << " Device detected, but FCM utilization log cannot be accessed (check capabilites!)" << dendl;
-      return rc;
-    }
+    // do initial query for utilization to maybe raise health warning
+    get_fcm_utilization();
     return 0;
   }
   enum perf_counters: uint32_t
@@ -474,6 +490,31 @@ public:
     id_str = "fcm";
     return 0;
   };
+
+  void collect_alerts(osd_alert_list_t& alerts) override
+  {
+    if (error_accessing_log) {
+      std::string& v = alerts["EXTBLKDEV"];
+      if (!v.empty()) {
+        v += "; ";
+      }
+      v.append("failed accessing FCM utilization log");
+    }
+    if (!cct->_conf->bdev_enable_discard) {
+      std::string& v = alerts["EXTBLKDEV"];
+      if (!v.empty()) {
+        v += "; ";
+      }
+      v.append("bdev_enable_discard not enabled - free space will leak");
+    }
+    if (error_multivolume) {
+      std::string& v = alerts["EXTBLKDEV"];
+      if (!v.empty()) {
+        v += "; ";
+      }
+      v.append("multivolume fcm will not work properly");
+    }
+  }
 };
 
 class ExtBlkDevPluginFcm : public ceph::ExtBlkDevPlugin {
@@ -494,10 +535,6 @@ public:
     if (r != 0) {
       delete fcm;
       return r;
-    } else {
-      if (!cct->_conf->bdev_enable_discard) {
-        derr << "FCM device in use, but bdev_enable_discard not enabled. Free space will leak." << dendl;
-      }
     }
     ext_blk_dev.reset(fcm);
     return 0;

--- a/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
+++ b/src/extblkdev/fcm/ExtBlkDevPluginFcm.cc
@@ -301,7 +301,8 @@ public:
   ~ExtBlkDevFcm(){
     unregister_perf_counters();
   }
-  int init(const std::string& logdevname_a){
+  int init(const std::string& logdevname_a) override
+  {
     logdevname=logdevname_a;
 
     // determine device name for underlying hardware
@@ -430,8 +431,8 @@ public:
     return result;
   }
 
-  virtual const std::string& get_devname() const {return logdevname;}
-  int get_state(ExtBlkDevState& state)
+  const std::string& get_devname() const override {return logdevname;}
+  int get_state(ExtBlkDevState& state) override
   {
     int rc=get_fcm_utilization();
     if(rc<0)
@@ -456,7 +457,7 @@ public:
 
     return 0;
   }
-  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
+  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) override
   {
     int rc=get_fcm_utilization();
     if(rc<0)

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3332,6 +3332,8 @@ void PGMap::get_health_checks(
         summary += " experiencing slow discard operations";
       } else if (asum.first == "BLUESTORE_FREE_FRAGMENTATION") {
         summary += " experiencing high free space fragmentation of BlueStore";
+      } else if (asum.first == "EXTBLKDEV") {
+        summary += " reporting problems with ExtBlkDev plugin";
       }
 
       auto& d = checks->add(asum.first, HEALTH_WARN, summary, asum.second.first);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -4798,10 +4798,11 @@ bool BlueFS::debug_get_is_dev_dirty(FileWriter *h, uint8_t dev)
 }
 
 void BlueFS::collect_alerts(osd_alert_list_t& alerts) {
-  if (bdev[BDEV_DB]) {
+  if (bdev[BDEV_DB] &&
+    (!is_shared_alloc(BDEV_DB) /*BlueStore is collecting alerts for its bdev*/) ) {
     bdev[BDEV_DB]->collect_alerts(alerts, "DB");
   }
-  if (bdev[BDEV_WAL]) {
+  if (bdev[BDEV_WAL] /*WAL is never shared*/) {
     bdev[BDEV_WAL]->collect_alerts(alerts, "WAL");
   }
   _update_logger_stats(); // just to have it updated more frequently

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7186,6 +7186,7 @@ int BlueStore::_open_bdev(bool create)
 
   if (!create && cct->_conf->bluestore_use_ebd) {
     // for regular bdev opens check if it was deployed with plugin
+    ebd_health_alert.clear();
     string meta_plugin_id;
     r = read_meta("extblkdev", &meta_plugin_id);
     if (r == 0) {
@@ -7197,19 +7198,15 @@ int BlueStore::_open_bdev(bool create)
       }
       string bdev_plugin_id;
       r = bdev->detect_ebd(bdev_plugin_id);
-      bool is_osd = cct->get_module_type() & CEPH_ENTITY_TYPE_OSD;
       if (r != 0) {
+        ebd_health_alert = "plugin '" + meta_plugin_id + "' not loaded";
         derr << __func__ << " plugin " << meta_plugin_id << " not loaded" << dendl;
-        if (is_osd) {
-          goto fail_close;
-        }
       } else {
         if (meta_plugin_id != bdev_plugin_id) {
+          ebd_health_alert = " plugin '" + meta_plugin_id + "' used on mkfs, "
+            "but now uses plugin '" + bdev_plugin_id + "'";
           derr << __func__ << " plugin '" << meta_plugin_id << "' used on mkfs, "
             << "but now uses plugin '" << bdev_plugin_id << "'" << dendl;
-          if (is_osd) {
-            goto fail_close;
-          }
         }
       }
     }
@@ -19571,6 +19568,13 @@ void BlueStore::_log_alerts(osd_alert_list_t& alerts)
     cct->_conf.get_val<double>("bluestore_warn_on_free_fragmentation") * 1e6) {
     alerts.emplace("BLUESTORE_FREE_FRAGMENTATION",
       fmt::format("{0:.6f}", logger->get(l_bluestore_fragmentation) * 1e-6));
+  }
+  if (!ebd_health_alert.empty()) {
+    std::string& v = alerts["EXTBLKDEV"];
+    if (!v.empty()) {
+      v += "; ";
+    }
+    v.append(ebd_health_alert);
   }
 }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2355,6 +2355,8 @@ private:
   std::string freelist_type;
   FreelistManager *fm = nullptr;
 
+  std::string ebd_health_alert; ///< used to report ExtBlkDev plugin problem up the health chain
+
   Allocator *alloc = nullptr;   ///< allocator consumed by BlueStore
   bluefs_shared_alloc_context_t shared_alloc; ///< consumed by BlueFS (may be == alloc)
 


### PR DESCRIPTION
Instead of throwing errors extblkdev plugins can now raise health warnings.
Created new health warnings:
EXTBLKDEV: plugin xxx not loaded
EXTBLKDEV: plugin xxx used on mkfs, but now uses plugin yyy
EXTBLKDEV: multivolume fcm will not work properly
EXTBLKDEV: failed accessing FCM utilization log
EXTBLKDEV: bdev_enable_discard not enabled - free space will leak

Fixes, by completely changing logic: https://tracker.ceph.com/issues/75819

See also:
#68173
#68391

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
