### PR TITLE
squid: mgr/crash, mgr/status: return negative errno to fix CLI exit code

### DIFF
--- a/qa/tasks/mgr/test_crash.py
+++ b/qa/tasks/mgr/test_crash.py
@@ -106,3 +106,22 @@ class TestCrash(MgrTestCase):
             'crash', 'ls',
         )
         self.assertNotIn(self.oldest_crashid, retstr)
+
+    def test_info_nonexistent(self):
+        rc = self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+            'crash', 'info', 'does-not-exist',
+        )
+        self.assertNotEqual(0, rc)
+
+    def test_post_malformed(self):
+        rc = self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+            'crash', 'post', '-i', '-',
+            stdin='{"not_a_valid_crash": true}',
+        )
+        self.assertNotEqual(0, rc)
+
+    def test_archive_nonexistent(self):
+        rc = self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+            'crash', 'archive', 'does-not-exist',
+        )
+        self.assertNotEqual(0, rc)

--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -225,7 +225,7 @@ class Module(MgrModule):
         assert self.crashes is not None
         crash = self.crashes.get(crashid)
         if not crash:
-            return errno.EINVAL, '', 'crash info: %s not found' % crashid
+            return -errno.EINVAL, '', 'crash info: %s not found' % crashid
         val = json.dumps(crash, indent=4, sort_keys=True)
         return 0, val, ''
 
@@ -237,7 +237,7 @@ class Module(MgrModule):
         try:
             metadata = self.validate_crash_metadata(inbuf)
         except Exception as e:
-            return errno.EINVAL, '', 'malformed crash metadata: %s' % e
+            return -errno.EINVAL, '', 'malformed crash metadata: %s' % e
         if 'backtrace' in metadata:
             backtrace = cast(List[str], metadata.get('backtrace'))
             assert_msg = cast(Optional[str], metadata.get('assert_msg'))
@@ -342,7 +342,7 @@ class Module(MgrModule):
         assert self.crashes is not None
         crash = self.crashes.get(crashid)
         if not crash:
-            return errno.EINVAL, '', 'crash info: %s not found' % crashid
+            return -errno.EINVAL, '', 'crash info: %s not found' % crashid
         if not crash.get('archived'):
             crash['archived'] = str(datetime.datetime.utcnow())
             self.crashes[crashid] = crash

--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -223,7 +223,7 @@ class Module(MgrModule):
                 output += "\n" + pools_table.get_string() + "\n"
 
         if not output and not json_output and fs_filter is not None:
-            return errno.EINVAL, "", "Invalid filesystem: " + fs_filter
+            return -errno.EINVAL, "", "Invalid filesystem: " + fs_filter
 
         standby_table = PrettyTable(["STANDBY MDS"], border=False)
         standby_table.left_padding_width = 0
@@ -317,7 +317,7 @@ class Module(MgrModule):
 
             if not found:
                 msg = "Bucket '{0}' not found".format(bucket_filter)
-                return errno.ENOENT, msg, ""
+                return -errno.ENOENT, msg, ""
 
         # Build dict of OSD ID to stats
         osd_stats = dict([(o['osd'], o) for o in self.get("osd_stats")['osd_stats']])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76055

---

backport of https://github.com/ceph/ceph/pull/68282
parent tracker: https://tracker.ceph.com/issues/75937

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh