### PR TITLE
squid: ceph.spec.in: replace golang github prometheus with promtool binary path

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -418,7 +418,7 @@ BuildRequires:	lz4-devel >= 1.7
 %if 0%{with make_check}
 BuildRequires:	golang
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
-BuildRequires:	golang-github-prometheus
+BuildRequires:	/usr/bin/promtool
 BuildRequires:	libtool-ltdl-devel
 BuildRequires:	xmlsec1
 BuildRequires:	xmlsec1-devel


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76037

---

backport of https://github.com/ceph/ceph/pull/68336
parent tracker: https://tracker.ceph.com/issues/76036

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh