### PR TITLE
tool/ceph-kvstore-tool: add --pretty-binary-key option

### DIFF
--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -1,6 +1,8 @@
   $ ceph-kvstore-tool --help
   Usage: ceph-kvstore-tool <rocksdb|bluestore-kv> <store path> command [args...]
   
+  Options:
+    --pretty-binary-key    Use/dump binary keys in a print pretty format
   Commands:
     list [prefix]
     list-crc [prefix]

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -26,6 +26,7 @@
 #include "global/global_context.h"
 #include "global/global_init.h"
 
+#include "common/pretty_binary.h"
 #include "kvstore_tool.h"
 
 using namespace std;
@@ -34,6 +35,8 @@ void usage(const char *pname)
 {
   std::cout << "Usage: " << pname << " <rocksdb|bluestore-kv> <store path> command [args...]\n"
     << "\n"
+    << "Options:\n"
+    << "  --pretty-binary-key    Use/dump binary keys in a print pretty format\n"
     << "Commands:\n"
     << "  list [prefix]\n"
     << "  list-crc [prefix]\n"
@@ -56,6 +59,33 @@ void usage(const char *pname)
     << std::endl;
 }
 
+std::string format_key(const std::string &key, bool pretty_binary_key = false)
+{
+  if (pretty_binary_key) {
+    return pretty_binary_string(key);
+  }
+  return url_escape(key);
+}
+
+std::string parse_key(const std::string &key, bool pretty_binary_key, std::string &err)
+{
+  err.clear();
+  try {
+    if (pretty_binary_key)
+      return pretty_binary_string_reverse(key);
+    return url_unescape(key);
+  } catch (const std::invalid_argument &e) {
+    std::ostringstream oss;
+    oss << "invalid pretty binary string: " << e.what();
+    err = oss.str();
+  } catch (const std::runtime_error &e)
+  {
+    err = e.what();
+  }
+
+  return "";
+}
+
 int main(int argc, const char *argv[])
 {
   auto args = argv_to_vec(argc, argv);
@@ -63,6 +93,17 @@ int main(int argc, const char *argv[])
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
   }
+
+  bool pretty_binary_key = [&args] { //pick --pretty-binary-key from args
+    auto arg_it = std::find_if(args.begin(), args.end(),
+        [](const char* val) {return strcmp(val, "--pretty-binary-key") == 0;});
+    if (arg_it != args.end()) {
+      args.erase(arg_it);
+      return true;
+    }
+    return false;
+  }();
+  
   if (ceph_argparse_need_usage(args)) {
     usage(argv[0]);
     exit(0);
@@ -131,13 +172,13 @@ int main(int argc, const char *argv[])
       prefix = url_unescape(argv[4]);
 
     bool do_crc = (cmd == "list-crc");
-    st.list(prefix, do_crc, false);
+    st.list(prefix, do_crc, pretty_binary_key, false);
 
   } else if (cmd == "dump") {
     string prefix;
     if (argc > 4)
       prefix = url_unescape(argv[4]);
-    st.list(prefix, false, true);
+    st.list(prefix, false, pretty_binary_key, true);
 
   } else if (cmd == "exists") {
     string key;
@@ -146,11 +187,17 @@ int main(int argc, const char *argv[])
       return 1;
     }
     string prefix(url_unescape(argv[4]));
-    if (argc > 5)
-      key = url_unescape(argv[5]);
+    if (argc > 5) {
+      std::string err;
+      key = parse_key(argv[5], pretty_binary_key, err);
+      if (!err.empty()) {
+        std::cerr << err << std::endl;
+        return 1;
+      }
+    }
 
     bool ret = st.exists(prefix, key);
-    std::cout << "(" << url_escape(prefix) << ", " << url_escape(key) << ") "
+    std::cout << "(" << url_escape(prefix) << ", " << format_key(key, pretty_binary_key) << ") "
       << (ret ? "exists" : "does not exist")
       << std::endl;
     return (ret ? 0 : 1);
@@ -161,11 +208,16 @@ int main(int argc, const char *argv[])
       return 1;
     }
     string prefix(url_unescape(argv[4]));
-    string key(url_unescape(argv[5]));
+    std::string err;
+    std::string key = parse_key(argv[5], pretty_binary_key, err);
+    if (!err.empty()) {
+      std::cerr << err << std::endl;
+      return 1;
+    }
 
     bool exists = false;
     bufferlist bl = st.get(prefix, key, exists);
-    std::cout << "(" << url_escape(prefix) << ", " << url_escape(key) << ")";
+    std::cout << "(" << url_escape(prefix) << ", " << format_key(key, pretty_binary_key) << ")";
     if (!exists) {
       std::cout << " does not exist" << std::endl;
       return 1;
@@ -208,11 +260,16 @@ int main(int argc, const char *argv[])
       return 1;
     }
     string prefix(url_unescape(argv[4]));
-    string key(url_unescape(argv[5]));
+    std::string err;
+    string key = parse_key(argv[5], pretty_binary_key, err);
+    if (!err.empty()) {
+      std::cerr << err << std::endl;
+      return 1;
+    }
 
     bool exists = false;
     bufferlist bl = st.get(prefix, key, exists);
-    std::cout << "(" << url_escape(prefix) << ", " << url_escape(key) << ") ";
+    std::cout << "(" << url_escape(prefix) << ", " << format_key(key, pretty_binary_key) << ") ";
     if (!exists) {
       std::cout << " does not exist" << std::endl;
       return 1;
@@ -230,16 +287,21 @@ int main(int argc, const char *argv[])
       return 1;
     }
     string prefix(url_unescape(argv[4]));
-    string key(url_unescape(argv[5]));
+    std::string err;
+    string key = parse_key(argv[5], pretty_binary_key, err);
+    if (!err.empty()) {
+      std::cerr << err << std::endl;
+      return 1;
+    }
 
     bool exists = false;
     bufferlist bl = st.get(prefix, key, exists);
     if (!exists) {
-      std::cerr << "(" << url_escape(prefix) << "," << url_escape(key)
+      std::cerr << "(" << url_escape(prefix) << "," << format_key(key, pretty_binary_key)
                 << ") does not exist" << std::endl;
       return 1;
     }
-    std::cout << "(" << url_escape(prefix) << "," << url_escape(key)
+    std::cout << "(" << url_escape(prefix) << "," << format_key(key, pretty_binary_key)
               << ") size " << byte_u_t(bl.length()) << std::endl;
 
   } else if (cmd == "set") {
@@ -248,7 +310,12 @@ int main(int argc, const char *argv[])
       return 1;
     }
     string prefix(url_unescape(argv[4]));
-    string key(url_unescape(argv[5]));
+    std::string err;
+    string key = parse_key(argv[5], pretty_binary_key, err);
+    if (!err.empty()) {
+      std::cerr << err << std::endl;
+      return 1;
+    }
     string subcmd(argv[6]);
 
     bufferlist val;
@@ -275,7 +342,7 @@ int main(int argc, const char *argv[])
     bool ret = st.set(prefix, key, val);
     if (!ret) {
       std::cerr << "error setting ("
-                << url_escape(prefix) << "," << url_escape(key) << ")" << std::endl;
+                << url_escape(prefix) << "," << format_key(key, pretty_binary_key) << ")" << std::endl;
       return 1;
     }
   } else if (cmd == "rm") {
@@ -284,12 +351,17 @@ int main(int argc, const char *argv[])
       return 1;
     }
     string prefix(url_unescape(argv[4]));
-    string key(url_unescape(argv[5]));
+    std::string err;
+    string key = parse_key(argv[5], pretty_binary_key, err);
+    if (!err.empty()) {
+      std::cerr << err << std::endl;
+      return 1;
+    }
 
     bool ret = st.rm(prefix, key);
     if (!ret) {
       std::cerr << "error removing ("
-                << url_escape(prefix) << "," << url_escape(key) << ")"
+                << url_escape(prefix) << "," << format_key(key, pretty_binary_key) << ")"
 		<< std::endl;
       return 1;
     }
@@ -338,7 +410,7 @@ int main(int argc, const char *argv[])
       return 1;
     }
     std::ofstream fs(argv[4]);
-    uint32_t crc = st.traverse(string(), true, false, &fs);
+    uint32_t crc = st.traverse(string(), true, pretty_binary_key, false, &fs);
     std::cout << "store at '" << argv[4] << "' crc " << crc << std::endl;
 
   } else if (cmd == "compact") {
@@ -356,8 +428,19 @@ int main(int argc, const char *argv[])
       return 1;
     }
     string prefix(url_unescape(argv[4]));
-    string start(url_unescape(argv[5]));
-    string end(url_unescape(argv[6]));
+    std::string err;
+    string start = parse_key(argv[5], pretty_binary_key, err);
+    if (!err.empty()) {
+      std::cerr << err << std::endl;
+      return 1;
+    }
+    string end = parse_key(argv[6], pretty_binary_key, err);
+    if (!err.empty()) {
+      std::cerr << err << std::endl;
+      return 1;
+    }
+    std::cout << "(" << url_escape(prefix) << "," << format_key(start, pretty_binary_key)
+              << " ~ " << format_key(end, pretty_binary_key) << ")" << std::endl;
     st.compact_range(prefix, start, end);
   } else if (cmd == "stats") {
     st.print_stats();

--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -83,6 +83,7 @@ int StoreTool::load_bluestore(const string& path, bool read_only, bool to_repair
 
 uint32_t StoreTool::traverse(const string& prefix,
                              const bool do_crc,
+                             const bool pretty_binary_key,
                              const bool do_value_dump,
                              ostream *out)
 {
@@ -100,8 +101,13 @@ uint32_t StoreTool::traverse(const string& prefix,
     if (!prefix.empty() && (rk.first != prefix))
       break;
 
-    if (out)
-      *out << url_escape(rk.first) << "\t" << url_escape(rk.second);
+    if (out) {
+      if (pretty_binary_key) {
+        *out << url_escape(rk.first) << "\t" << pretty_binary_string(rk.second);
+      } else {
+        *out << url_escape(rk.first) << "\t" << url_escape(rk.second);
+      }
+    }
     if (do_crc) {
       bufferlist bl;
       bl.append(rk.first);
@@ -130,9 +136,9 @@ uint32_t StoreTool::traverse(const string& prefix,
 }
 
 void StoreTool::list(const string& prefix, const bool do_crc,
-                     const bool do_value_dump)
+                     const bool pretty_binary_key, const bool do_value_dump)
 {
-  traverse(prefix, do_crc, do_value_dump,& std::cout);
+  traverse(prefix, do_crc, pretty_binary_key, do_value_dump,& std::cout);
 }
 
 bool StoreTool::exists(const string& prefix)

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -42,10 +42,12 @@ public:
 	    bool need_stats = false);
   uint32_t traverse(const std::string& prefix,
                     const bool do_crc,
+                    const bool pretty_binary_key,
                     const bool do_value_dump,
                     std::ostream *out);
   void list(const std::string& prefix,
 	    const bool do_crc,
+	    const bool pretty_binary_key,
 	    const bool do_value_dump);
   bool exists(const std::string& prefix);
   bool exists(const std::string& prefix, const std::string& key);


### PR DESCRIPTION
Background
The output of keys in ceph-kvstore-tool can be difficult to read in some cases.
For example:
For BlueStore's Onode, its metadata shards (extent_map_shards) are stored in rocksdb as KV pairs.
Shard information:
```bash
ceph-objectstore-tool --data-path dev/osd0 --no-mon-config '["1.0",{"oid":"demo","key":"","snapid":-2,"hash":820372161,"max":0,"pool":1,"namespace":"","max":0}]' dump | jq ".onode.extent_map_shards"
[
  {
    "offset": 0,
    "bytes": 453
  },
  {
    "offset": 393216,
    "bytes": 455
  },
  {
    "offset": 786432,
    "bytes": 455
  },
  {
    "offset": 1179648,
    "bytes": 455
  },
  {
    "offset": 1572864,
    "bytes": 455
  },
  {
    "offset": 1966080,
    "bytes": 455
  },
  {
    "offset": 2359296,
    "bytes": 455
  },
  {
    "offset": 2752512,
    "bytes": 455
  },
  {
    "offset": 3145728,
    "bytes": 455
  },
  {
    "offset": 3538944,
    "bytes": 455
  },
  {
    "offset": 3932160,
    "bytes": 305
  }
]
```
KV form:
```bash
ceph-kvstore-tool bluestore-kv dev/osd0 list O  2>/dev/null | grep demo 
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%00%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%06%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%0c%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%12%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%18%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%1e%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%24%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%2a%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%000%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%006%00%00x
O	%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%3c%00%00x
```

Comparison reveals:
Relatively high readability:
offset: 0(0x000000)       -> key: '%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%00%00%00x'
offset: 393216(0x060000)  -> key: '%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%06%00%00x'
...
offset: 2359296(0x240000)  -> key: '%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%24%00%00x'
offset: 2752512(0x2a0000)  -> key: '%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%00%2a%00%00x'

Relatively poor readability:
offset: 3145728(0x300000) -> key: '%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%000%00%00x'
offset: 3538944(0x360000) -> key: '%7f%80%00%00%00%00%00%00%01%83G%a7%0c%21demo%21%3d%ff%ff%ff%ff%ff%ff%ff%fe%ff%ff%ff%ff%ff%ff%ff%ffo%006%00%00x'

The output format here is not a bug; it is just relatively difficult to read.
tchaikov [[#68195 (comment)](https://github.com/ceph/ceph/pull/68195#discussion_r3032912532)] pointed out that the key output uses url_escape, sticking to the RFC 3986 standard. Many thanks to tchaikov for the help.
```text
unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
```


Based on the above background, I want to add a new option to improve the readability of binary_strings as much as possible, while supporting encoding/decoding for input/output, since ceph-kvstore-tool supports both key output and input.

After adding --pretty-binary-key
- newly usage
```bash
ceph-kvstore-tool --help
Usage: ./bin/ceph-kvstore-tool <rocksdb|bluestore-kv> <store path> command [args...]

Options:
  --pretty-binary-key	binary keys in a print pretty format.
Commands:
  list [prefix]
  list-crc [prefix]
  dump [prefix]
  exists <prefix> [key]
  get <prefix> <key> [out <file>]
  crc <prefix> <key>
  get-size [<prefix> <key>]
  set <prefix> <key> [ver <N>|in <file>]
  rm <prefix> <key>
  rm-prefix <prefix>
  store-copy <path> [num-keys-per-tx] [rocksdb|...] 
  store-crc <path>
  compact
  compact-prefix <prefix>
  compact-range <prefix> <start> <end>
  destructive-repair  (use only as last resort! may corrupt healthy data)
  stats
  histogram [prefix]

```
- `list`method
```bash
ceph-kvstore-tool bluestore-kv dev/osd0 list O --pretty-binary-key 2>/dev/null | grep demo 
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0000000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0006000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F000C000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0012000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0018000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F001E000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0024000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F002A000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0030000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0036000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F003C000078
```
- `get`method
```bash
ceph-kvstore-tool bluestore-kv dev/osd0 get O '0x7F80000000000000018347A70C'\''!demo!='\''0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0030000078' --pretty-binary-key 2>/dev/null
(O, 0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0030000078)
00000000  02 06 02 83 18 43 01 12  0a 00 00 43 04 04 0c 40  |.....C.....C...@|
00000010  48 5e 19 72 7d d3 6c 56  21 b3 6a a3 eb ce 0a 1c  |H^.r}.lV!.j.....|
00000020  fa 4c e3 ba e5 a9 1c 97  0d d6 97 8d 50 49 22 a1  |.L..........PI".|
00000030  e5 bb 4c 5d ad 89 21 e6  89 03 eb c4 cb 85 2b 69  |..L]..!.......+i|
00000040  22 f9 e6 74 98 26 c8 6f  0c 28 c9 46 92 50 5a a8  |"..t.&.o.(.F.PZ.|
...
000001c0  1c e4 19 19 ac 13 33                              |......3|
```
- `set`method
```bash
ceph-kvstore-tool bluestore-kv dev/osd0 set O '0x7F80000000000000018347A70C'\''!demo!='\''0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0030000078' --pretty-binary-key in /tmp/a
```
- `rm`method
```bash
ceph-kvstore-tool bluestore-kv dev/osd0 rm O '0x7F80000000000000018347A70C'\''!demo!='\''0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0036000078' --pretty-binary-key 2>/dev/null
ceph-kvstore-tool bluestore-kv dev/osd0 list O --pretty-binary-key 2>/dev/null | grep demo 
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0000000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0006000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F000C000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0012000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0018000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F001E000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0024000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F002A000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F0030000078
O	0x7F80000000000000018347A70C'!demo!='0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF6F003C000078
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
