### PR TITLE
tentacle: qa: suppress false positive delete map mismatch errors

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -933,25 +933,9 @@
    ...
 }
 {
-   rocky10_gcc14_mismatch_delete_map_erase
+   rocky10_gcc14_mismatch_delete
    Memcheck:Free
    fun:_Zda*align_val_t*
-   ...
-   fun:*global_init_prefork*
-}
-{
-   rocky10_gcc14_mismatch_delete_map_erase
-   Memcheck:Free
-   fun:_Zda*align_val_t*
-   ...
-   fun:*ceph6common11CephContext*
-}
-{
-   rocky10_gcc14_mismatch_delete_map_erase
-   Memcheck:Free
-   fun:_Zda*align_val_t*
-   ...
-   fun:exit
 }
 {
    rocky10 still reachable rocksdb leak

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -932,4 +932,24 @@
    fun:*ProtocolV2*
    ...
 }
-
+{
+   rocky10_gcc14_mismatch_delete_map_erase
+   Memcheck:Free
+   fun:_Zda*align_val_t*
+   ...
+   fun:*global_init_prefork*
+}
+{
+   rocky10_gcc14_mismatch_delete_map_erase
+   Memcheck:Free
+   fun:_Zda*align_val_t*
+   ...
+   fun:*ceph6common11CephContext*
+}
+{
+   rocky10_gcc14_mismatch_delete_map_erase
+   Memcheck:Free
+   fun:_Zda*align_val_t*
+   ...
+   fun:exit
+}

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -953,3 +953,14 @@
    ...
    fun:exit
 }
+{
+   rocky10 still reachable rocksdb leak
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znam
+   fun:UnknownInlinedFun
+   fun:_GLOBAL__sub_I_error_handler.cc.lto_priv.0
+   fun:_sub_I_65535_0.0
+   fun:__libc_start_main@@GLIBC_2.34
+   fun:(below main)
+}

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -1,16 +1,12 @@
-
 {
    <allthefrees, so we can behave with tcmalloc>
    Memcheck:Free
    fun:free
-   ...
 }
 {
-   operator delete[] in Rados::shutdown
+   <allthefrees, so we can behave with tcmalloc>
    Memcheck:Free
-   fun:_ZdaPvm
-   ...
-   fun:_ZN8librados7v14_2_05Rados8shutdownEv
+   fun:_Zda*
 }
 {
    older boost mersenne twister uses uninitialized memory for randomness
@@ -837,12 +833,6 @@
    ...
 }
 {
-   co_compose bug manifesting under Ubuntu only
-   Memcheck:Free
-   fun:_ZdaPvm
-   ...
-}
-{
    OpenSSL leak still reachable
    Memcheck:Leak
    match-leak-kinds: reachable
@@ -931,11 +921,6 @@
    ...
    fun:*ProtocolV2*
    ...
-}
-{
-   rocky10_gcc14_mismatch_delete
-   Memcheck:Free
-   fun:_Zda*align_val_t*
 }
 {
    rocky10 still reachable rocksdb leak


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/75642

---

backports of:
https://github.com/ceph/ceph/pull/67230
https://github.com/ceph/ceph/pull/68289
https://github.com/ceph/ceph/pull/67733
parent trackers:
https://tracker.ceph.com/issues/74604
https://tracker.ceph.com/issues/75893
https://tracker.ceph.com/issues/75945

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh