### PR TITLE
mgr/dashboard: tearsheet-layout-fix

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.html
@@ -6,7 +6,7 @@
        [narrow]="true"
        [fullWidth]="true">
     <div cdsCol
-         [columnNumbers]="{lg: 10}"
+         [columnNumbers]="{sm: 4, md: 8, lg: 16}"
          class="cd-nvmeof-subsystem-step-two">
       <div cdsRow
            class="form-item cds-mb-0">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.scss
@@ -1,4 +1,9 @@
 .cd-nvmeof-subsystem-step-two {
+  // Full width of the tearsheet content column; min-inline-size allows nested
+  // Carbon grid rows to shrink instead of bleeding into the right influencer.
+  min-inline-size: 0;
+  inline-size: 100%;
+
   &-manual-hosts {
     display: flex;
     align-items: flex-start;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.scss
@@ -18,6 +18,12 @@
   max-inline-size: none;
   display: flex;
   flex-direction: column;
+
+  // Keep header from shrinking; body row must be allowed to shrink below content height
+  // so inner .tearsheet-content can scroll (default min-height: auto prevents this).
+  > .tearsheet-header {
+    flex-shrink: 0;
+  }
 }
 
 // Global Carbon override sets .cds--modal-scroll-content to max-height: 70vh.
@@ -75,11 +81,18 @@
 
 // BODY
 .tearsheet-body {
-  padding-block: 0;
-  padding-inline: 0;
-  padding: 0;
   margin: 0;
+  padding: 0;
   height: 100%;
+}
+
+// Wide tearsheet: body is a flex child of .cds--modal-container--lg; must shrink so
+// .tearsheet-content scrolls and the footer stays in view on tall steps (e.g. Review).
+.cds--modal-container.cds--modal-container--lg > .tearsheet-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-block-size: 0;
+  height: auto;
 }
 
 .tearsheet-left-influencer {
@@ -88,16 +101,42 @@
   overflow-block: auto;
   overflow-y: auto;
   margin: 0;
+  min-height: 0;
+  min-block-size: 0;
 }
 
 .tearsheet-right-influencer {
   background-color: var(--cds-background);
   padding: var(--cds-spacing-05) var(--cds-spacing-05);
+  border-inline-start: 1px solid var(--cds-border-subtle-01);
+  min-inline-size: 0;
+  min-block-size: 0;
+}
+
+// Two-column body (main content + right influencer): bound the inner grid so
+// nested form rows and dividers stay in the left column (host access step).
+.tearsheet-main > .cds--css-grid {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-block-size: 0;
+  inline-size: 100%;
+}
+
+.tearsheet-main > .cds--css-grid > .tearsheet-content {
+  min-width: 0;
+  min-inline-size: 0;
+  min-height: 0;
+  min-block-size: 0;
+  max-block-size: none;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .tearsheet-main {
   margin: 0;
   height: 100%;
+  min-height: 0;
+  min-block-size: 0;
   display: flex;
   flex-direction: column;
 
@@ -129,6 +168,7 @@
 //FOOTER
 .tearsheet-footer {
   background-color: var(--cds-layer-01);
+  flex-shrink: 0;
 
   &-submit {
     display: flex;


### PR DESCRIPTION
mgr/dashboard: tearsheet-layout-fix

Fixes: https://tracker.ceph.com/issues/76084

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

## Summary

Fixes dashboard **tearsheet** layout on **narrow viewports** (including **macOS Chrome/Safari at 100% zoom**): the **Review** step could hide the modal action bar, and **Host access** with **Restrict to specific hosts** could misalign dividers and let the main column visually bleed into the right **Added hosts** panel.


## What was wrong

1. **Create Subsystem → Review**  
   The wide tearsheet uses a **fixed-height flex column** on `.cds--modal-container--lg`. The body section (`.tearsheet-body`) behaved like a flex item with the default **`min-height: auto`**, so it would not shrink shorter than the Review summary. Taller Review content **grew past the viewport**, so **Cancel / Previous / Create** sat **below the visible area** even though earlier wizard steps looked fine.
<img width="1913" height="955" alt="image (2)" src="https://github.com/user-attachments/assets/5eec1e95-291f-49f1-9de7-0c0d97292ef7" />



2. **Host access → Restrict to specific hosts**  
   With the **right influencer** (two-column layout), the step form still spanned **`lg: 10`** inside a **16-column** Carbon grid, so the left column did not use the full width. Combined with the inner content grid, **rows / separators** could **extend visually into the right column** instead of staying in the main pane.

<img width="1300" height="744" alt="Screenshot From 2026-04-17 14-09-01" src="https://github.com/user-attachments/assets/a973dc59-7afc-4171-96ca-fc1ab58305a4" />


## How this fixes it

- **Modal column:** Keep the header from shrinking; make **`.tearsheet-body`** a proper flex child (`flex: 1 1 auto`, **`min-height: 0`**, `height: auto`) so height is bounded and **`.tearsheet-content` scrolls** while the **footer stays visible**.
- **Chain:** `min-height: 0` / `min-inline-size: 0` on the left column / main area where needed; **`flex-shrink: 0`** on the footer.
- **Host step:** Span the full inner grid (**`sm: 4, md: 8, lg: 16`**) and constrain the **inner `cds--css-grid`** split (e.g. **`overflow-x: hidden`** on the left content column, stable right column) so layout stays aligned when the right panel is shown.

## How to verify

- **Review:** Shorten the window height (or DevTools responsive height ~600–700px), open **Review** — footer actions remain at the bottom of the modal; summary scrolls inside the modal body.
- **Host access:** Choose **Restrict to specific hosts** — form and dividers stay in the left column; **Added hosts** panel stays clean on the right.
- **Cross-browser:** Additionally verified via **Browserling** (tunneled local dashboard) in remote desktop browsers (e.g. Safari / Chrome) for the same flows.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
