### PR TITLE
mgr/dashboard: mgr/dashboard: Carbonize Realm Name and Token block in Multi-site Replication Wizard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-wizard/rgw-multisite-wizard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-wizard/rgw-multisite-wizard.component.html
@@ -73,10 +73,10 @@
                   <select class="form-select"
                           id="selectedRealm"
                           formControlName="selectedRealm">
-                  <option *ngFor="let realm of realmList"
-                          [value]="realm">
+                    <option *ngFor="let realm of realmList"
+                            [value]="realm">
                         {{ realm }}
-                  </option>
+                    </option>
                   </select>
                 </div>
               </div>
@@ -360,43 +360,54 @@
 </ng-template>
 
 <ng-template #exportTokenTemplate>
-  <div *ngFor="let realminfo of realms">
-    <div class="form-group row">
-      <label class="cd-col-form-label"
-             for="realmName"
-             i18n>Realm Name</label>
-      <div class="cd-col-form-input">
-        <input id="realmName"
-               name="realmName"
-               type="text"
-               [value]="realminfo.realm"
-               readonly>
-        <cd-help-text>
-          <span i18n>Name of the realm that will be involved in replication.</span>
-        </cd-help-text>
-      </div>
-    </div>
-    <div class="form-group row">
-      <label class="cd-col-form-label"
-             for="token"
-             i18n>Token</label>
-      <div class="cd-col-form-input">
-        <input id="realmToken"
-               name="realmToken"
-               type="text"
-               [value]="realminfo.token"
-               class="me-2 mb-4"
-               readonly>
-        <cd-copy-2-clipboard-button [source]="realminfo.token"
-                                    [byId]="false">
-        </cd-copy-2-clipboard-button>
-        <cd-help-text>
-          <span i18n>This field displays the token needed to import the multisite configuration into a secondary cluster. Copy this token securely and use it on the secondary cluster to replicate the current multisite setup. Ensure that the token is handled securely to prevent unauthorized access.</span>
-        </cd-help-text>
-      </div>
-    </div>
-    <hr *ngIf="realms.length > 1">
+  @for (realminfo of realms; track realminfo; let i = $index) {
+  <div class="form-item">
+    <cds-text-label
+      [labelInputID]="'wizard-export-realm-' + i"
+      i18n
+      helperText="Name of the realm that will be involved in replication."
+      i18n-helperText
+    >
+      Realm Name
+      <input
+        cdsText
+        readonly
+        type="text"
+        [id]="'wizard-export-realm-' + i"
+        [value]="realminfo.realm"
+      />
+    </cds-text-label>
   </div>
+
+  <div class="form-item form-item-append">
+    <cds-text-label
+      [labelInputID]="'wizard-export-token-' + i"
+      i18n
+      helperText="This field displays the token needed to import the multisite configuration into a secondary cluster. Copy this token securely and use it on the secondary cluster to replicate the current multisite setup. Ensure that the token is handled securely to prevent unauthorized access."
+      i18n-helperText
+    >
+      Token
+      <input
+        cdsText
+        readonly
+        type="text"
+        [id]="'wizard-export-token-' + i"
+        [value]="realminfo.token"
+      />
+    </cds-text-label>
+    <cd-copy-2-clipboard-button
+      class="cds-mt-6"
+      [source]="realminfo.token"
+      [byId]="false"
+      size="md"
+    >
+    </cd-copy-2-clipboard-button>
+  </div>
+
+  @if (i < realms.length - 1) {
+  <hr />
+  }
+  }
 </ng-template>
 
 <ng-template #reviewTemplate>


### PR DESCRIPTION

mgr/dashboard: mgr/dashboard: Carbonize Realm Name and Token block in Multi-site Replication Wizard

Fixes: https://tracker.ceph.com/issues/76085

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

PR Description: ## Summary
Carbonize only the **Realm name** and **Token** block shown after **Export Multi-Site token** in the **Set up Multi-site Replication** wizard (`exportTokenTemplate`), aligning it with the existing export modal (`rgw-multisite-export`, #66576).

## What changed
- Replaced Bootstrap-style `form-group`, `cd-help-text`, and plain inputs with:
  - `cds-text-label` + `cdsText` (readonly) for realm and token
  - `helperText` / `i18n-helperText` for helper content
  - `cd-copy-2-clipboard-button` with `size="md"` for token copy
- Scoped styles under `.rgw-multisite-wizard-export-token` for layout consistency
- Added unique input IDs for multiple realms:
  - `wizard-export-realm-*`
  - `wizard-export-token-*`
- Added `<hr>` separator only between multiple realm entries

## Scope
- Changes are limited to `exportTokenTemplate`
- No modifications to other wizard steps or templates

## How to test
1. Navigate to **RGW → Multi-site → Set up Multi-site Replication**
2. Select single-cluster / export-token path
3. Complete the flow until the **Realm name + Token** screen appears
4. Verify:
   - Labels and readonly fields are displayed correctly
   - Helper text is shown properly
   - Copy-to-clipboard button works as expected
   - Layout matches the export modal and is responsive

## Screencast

https://github.com/user-attachments/assets/ac7ac555-9171-425d-a311-98ff738e7478



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
