### PR TITLE
common: add debug level guard to auto-revert high debug levels

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -31,6 +31,16 @@
   in weight by a small fraction (default 0.1). This is tunable via
   `mon_stretch_max_bucket_weight_delta`.
 
+* RADOS: Added a debug-level guard that protects against accidentally leaving
+  debug subsystems at high log levels in production. When `high_debug_level_threshold`
+  is set (default `0` = disabled), any subsystem whose log level sits at or above
+  the threshold for longer than `high_debug_level_reset_timeout` seconds (default
+  `300`) is automatically reverted to the last known safe value, and a
+  `HIGH_DEBUG_LEVEL` health warning surfaces in `ceph health detail` while the
+  level remains elevated. Setting `high_debug_level_reset_timeout` to `0` gives
+  warn-only mode (health warning without auto-revert).
+  Related Tracker: https://tracker.ceph.com/issues/75467
+
 * CephFS: The offline CephFS tools (cephfs-data-scan, cephfs-journal-tool,
   and cephfs-table-tool) now include progress tracking with ETA (Estimated Time of
   Arrival) for long-running operations. Progress updates are displayed automatically

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -139,6 +139,16 @@
   in weight by a small fraction (default 0.1). This is tunable via
   `mon_stretch_max_bucket_weight_delta`.
 
+* RADOS: Added a debug-level guard that protects against accidentally leaving
+  debug subsystems at high log levels in production. When `high_debug_level_threshold`
+  is set (default `0` = disabled), any subsystem whose log level sits at or above
+  the threshold for longer than `high_debug_level_reset_timeout` seconds (default
+  `300`) is automatically reverted to the last known safe value, and a
+  `HIGH_DEBUG_LEVEL` health warning surfaces in `ceph health detail` while the
+  level remains elevated. Setting `high_debug_level_reset_timeout` to `0` gives
+  warn-only mode (health warning without auto-revert).
+  Related Tracker: https://tracker.ceph.com/issues/75467
+
 * CephFS: The offline CephFS tools (cephfs-data-scan, cephfs-journal-tool,
   and cephfs-table-tool) now include progress tracking with ETA (Estimated Time of
   Arrival) for long-running operations. Progress updates are displayed automatically

--- a/qa/suites/rados/singleton/all/debug-level-guard.yaml
+++ b/qa/suites/rados/singleton/all/debug-level-guard.yaml
@@ -1,0 +1,22 @@
+roles:
+- - mon.a
+  - mon.b
+  - mon.c
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+openstack:
+  - volumes: # attached to each instance
+      count: 3
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    log-ignorelist:
+      - Auto-reverted debug_
+      - HIGH_DEBUG_LEVEL
+- workunit:
+    clients:
+      all:
+        - mon/debug_level_guard.sh

--- a/qa/workunits/mon/debug_level_guard.sh
+++ b/qa/workunits/mon/debug_level_guard.sh
@@ -1,0 +1,125 @@
+#!/bin/bash -ex
+#
+# Test the debug level guard: auto-revert of excessively high debug levels.
+#
+
+function expect_false()
+{
+	set -x
+	if "$@"; then return 1; else return 0; fi
+}
+
+function get_daemon_debug() {
+	# $1 = daemon (e.g. osd.0), $2 = subsys (e.g. debug_osd)
+	ceph daemon "$1" config get "$2" | jq -r ".[\"$2\"]" | cut -d/ -f1
+}
+
+function wait_for_revert() {
+	# $1 = daemon, $2 = subsys, $3 = max_wait, $4 = threshold
+	local daemon="$1"
+	local subsys="$2"
+	local max_wait="$3"
+	local threshold="$4"
+	local waited=0
+	while [ $waited -lt "$max_wait" ]; do
+		local level
+		level=$(get_daemon_debug "$daemon" "$subsys")
+		if [ "$level" -lt "$threshold" ]; then
+			return 0
+		fi
+		sleep 1
+		waited=$((waited + 1))
+	done
+	echo "Timed out waiting for $subsys on $daemon to revert below $threshold"
+	return 1
+}
+
+function wait_for_health_warning() {
+	# $1 = health check code, $2 = max_wait
+	local code="$1"
+	local max_wait="$2"
+	local waited=0
+	while [ $waited -lt "$max_wait" ]; do
+		if ceph health detail | grep -q "$code"; then
+			return 0
+		fi
+		sleep 1
+		waited=$((waited + 1))
+	done
+	echo "Timed out waiting for $code in ceph health detail"
+	ceph health detail
+	return 1
+}
+
+function wait_for_health_clear() {
+	# $1 = health check code, $2 = max_wait
+	local code="$1"
+	local max_wait="$2"
+	local waited=0
+	while [ $waited -lt "$max_wait" ]; do
+		if ! ceph health detail | grep -q "$code"; then
+			return 0
+		fi
+		sleep 1
+		waited=$((waited + 1))
+	done
+	echo "Timed out waiting for $code to clear"
+	ceph health detail
+	return 1
+}
+
+# Enable the guard with a short timeout for testing
+ceph config set global high_debug_level_threshold 10
+ceph config set global high_debug_level_reset_timeout 5
+
+# Give daemons time to pick up config
+sleep 2
+
+# Test 1: Set high debug level on osd.0, verify it auto-reverts
+echo "Test 1: auto-revert after timeout"
+ceph tell osd.0 config set debug_osd 20
+sleep 1
+level=$(get_daemon_debug osd.0 debug_osd)
+test "$level" -eq 20
+wait_for_health_warning HIGH_DEBUG_LEVEL 15
+echo "PASS: HIGH_DEBUG_LEVEL warning surfaced"
+wait_for_revert osd.0 debug_osd 10 10
+echo "PASS: debug_osd reverted"
+wait_for_health_clear HIGH_DEBUG_LEVEL 30
+echo "PASS: HIGH_DEBUG_LEVEL warning cleared"
+
+# Test 2: Below threshold is not affected
+echo "Test 2: below threshold not affected"
+ceph tell osd.0 config set debug_osd 5
+sleep 8
+level=$(get_daemon_debug osd.0 debug_osd)
+test "$level" -eq 5
+echo "PASS: below-threshold level preserved"
+
+# Test 3: Manual lower before timeout cancels revert
+echo "Test 3: manual lower cancels revert"
+ceph tell osd.0 config set debug_osd 20
+sleep 2
+ceph tell osd.0 config set debug_osd 3
+sleep 8
+level=$(get_daemon_debug osd.0 debug_osd)
+test "$level" -eq 3
+echo "PASS: manual lower preserved"
+
+# Test 4: Disabled guard (threshold=0) means no revert
+echo "Test 4: disabled guard"
+ceph config set global high_debug_level_threshold 0
+sleep 2
+ceph tell osd.0 config set debug_osd 20
+sleep 8
+level=$(get_daemon_debug osd.0 debug_osd)
+test "$level" -eq 20
+# Clean up
+ceph tell osd.0 config set debug_osd 1
+echo "PASS: guard disabled, no revert"
+
+# Cleanup
+ceph config rm global high_debug_level_threshold
+ceph config rm global high_debug_level_reset_timeout
+
+echo "All debug level guard tests passed"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -56,6 +56,7 @@ set(common_srcs
   ceph_argparse.cc
   ceph_context.cc
   ceph_crypto.cc
+  debug_level_guard.cc
   ceph_frag.cc
   ceph_fs.cc
   ceph_hash.cc

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -942,6 +942,32 @@ void CephContext::reopen_logs()
     _service_thread->reopen_logs();
 }
 
+void CephContext::check_debug_level_guard()
+{
+  auto threshold = _conf.get_val<int64_t>("high_debug_level_threshold");
+  if (threshold <= 0) {
+    return;
+  }
+  auto timeout = _conf.get_val<std::chrono::seconds>("high_debug_level_reset_timeout");
+
+  auto actions = _debug_level_guard.check(_conf->subsys, threshold, timeout);
+
+  for (auto& a : actions) {
+    auto val = std::to_string(a.to_log) + "/" + std::to_string(a.to_gather);
+    _conf.set_val(a.name, val);
+
+    lgeneric_derr(this) << "Auto-reverted " << a.name
+      << " from " << a.from_level
+      << " to " << val
+      << " after " << timeout.count() << "s"
+      << " (high_debug_level_threshold=" << threshold << ")"
+      << dendl;
+  }
+  if (!actions.empty()) {
+    _conf.apply_changes(nullptr);
+  }
+}
+
 void CephContext::join_service_thread()
 {
   std::unique_lock<ceph::spinlock> lg(_service_thread_lock);

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -43,6 +43,7 @@
 #endif
 
 
+#include "common/debug_level_guard.h"
 #include "crush/CrushLocation.h"
 
 #ifdef HAVE_BREAKPAD
@@ -389,6 +390,9 @@ private:
   std::set<std::string> _experimental_features;
 
   ceph::PluginRegistry* _plugin_registry;
+
+  DebugLevelGuard _debug_level_guard;
+
 #ifdef CEPH_DEBUG_MUTEX
   md_config_obs_t *_lockdep_obs;
 #endif
@@ -397,6 +401,11 @@ private:
   ceph::mutex _msgr_hook_lock = ceph::make_mutex("CephContext::msgr_hook");
 public:
   TOPNSPC::crush::CrushLocation crush_location;
+
+  /// Check debug subsystem levels and auto-revert any that have been
+  /// above high_debug_level_threshold for longer than
+  /// high_debug_level_reset_timeout. Called from daemon tick functions.
+  void check_debug_level_guard();
   void modify_msgr_hook(std::function<AdminSocketHook*(void)> create,
 			std::function<void(AdminSocketHook*)> add);
 private:

--- a/src/common/debug_level_guard.cc
+++ b/src/common/debug_level_guard.cc
@@ -1,0 +1,68 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/debug_level_guard.h"
+
+#include <fmt/format.h>
+
+std::vector<DebugLevelGuard::RevertAction>
+DebugLevelGuard::check(
+  const ceph::logging::SubsystemMap& subsys,
+  int threshold,
+  std::chrono::seconds timeout)
+{
+  std::vector<RevertAction> actions;
+
+  if (threshold <= 0) {
+    return actions;
+  }
+
+  auto now = ceph::mono_clock::now();
+  auto num = subsys.get_num();
+
+  for (unsigned i = 0; i < num; ++i) {
+    int log_level = subsys.get_log_level(i);
+    int gather_level = subsys.get_gather_level(i);
+
+    // Only check the log level, not the gather level. High gather
+    // levels are safe because those messages stay in memory for crash
+    // dumps and don't cause the disk I/O floods this guard prevents.
+    if (log_level < threshold) {
+      m_state[i].safe_log = log_level;
+      m_state[i].safe_gather = gather_level;
+      m_state[i].elevated = false;
+    } else if (!m_state[i].elevated) {
+      m_state[i].elevated = true;
+      m_state[i].elevated_since = now;
+    } else {
+      auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+	now - m_state[i].elevated_since);
+      if (timeout.count() > 0 && elapsed >= timeout) {
+	actions.push_back({
+	  i,
+	  // Config option name is "debug_" + subsystem name; this is the
+	  // string the caller passes to set_val() to revert the level.
+	  fmt::format("debug_{}", subsys.get_name(i)),
+	  log_level,
+	  m_state[i].safe_log,
+	  m_state[i].safe_gather
+	});
+	m_state[i].elevated = false;
+      }
+    }
+  }
+
+  return actions;
+}

--- a/src/common/debug_level_guard.h
+++ b/src/common/debug_level_guard.h
@@ -1,0 +1,105 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_DEBUG_LEVEL_GUARD_H
+#define CEPH_DEBUG_LEVEL_GUARD_H
+
+#include <array>
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "common/ceph_time.h"
+#include "common/subsys_types.h"
+#include "log/SubsystemMap.h"
+
+/// Tracks per-subsystem debug levels and identifies subsystems that have
+/// been excessively high for longer than a timeout. Called periodically
+/// from daemon tick functions.
+///
+/// On each check:
+///  - If a subsystem's level is below threshold, its level is recorded
+///    as the "safe" level to revert to.
+///  - If a subsystem's level is at or above threshold and was not
+///    previously elevated, the elevation timestamp is recorded.
+///  - If a subsystem has been elevated longer than the timeout, it is
+///    reported for revert.
+class DebugLevelGuard {
+public:
+  DebugLevelGuard() {
+    // Seed safe levels from compiled defaults. This is only a fallback
+    // for a first-tick race: if a subsystem is already at/above threshold
+    // on the very first check() call, we have no prior observation to
+    // revert to. Under normal operation these get overwritten with the
+    // live user config value on the first check() where the subsystem
+    // is seen below threshold.
+    constexpr auto defaults = ceph_subsys_get_as_array();
+    for (std::size_t i = 0; i < defaults.size(); ++i) {
+      m_state[i].safe_log = defaults[i].log_level;
+      m_state[i].safe_gather = defaults[i].gather_level;
+    }
+  }
+
+  struct RevertAction {
+    unsigned subsys_id;
+    std::string name;      // e.g. "debug_osd"
+    int from_level;        // current log level (the one causing I/O)
+    int to_log;            // safe log level to revert to
+    int to_gather;         // safe gather level to revert to
+  };
+
+  /// Check all subsystems against the threshold and timeout. Returns
+  /// a list of subsystems that should be reverted. Does NOT apply the
+  /// revert — the caller is responsible for that.
+  ///
+  /// After a subsystem is reported for revert, its elevated flag is
+  /// cleared. If the caller does not actually revert the level, it
+  /// will be re-detected on the next call.
+  std::vector<RevertAction> check(
+    const ceph::logging::SubsystemMap& subsys,
+    int threshold,
+    std::chrono::seconds timeout);
+
+  /// Count subsystems with log level at or above threshold.
+  /// Returns {count, max_log_level}. For health metric reporting.
+  static std::pair<uint32_t, uint32_t> count_elevated(
+    const ceph::logging::SubsystemMap& subsys,
+    int threshold)
+  {
+    if (threshold <= 0) return {0, 0};
+    uint32_t count = 0;
+    uint32_t max_level = 0;
+    for (unsigned i = 0; i < subsys.get_num(); ++i) {
+      auto lvl = subsys.get_log_level(i);
+      if (lvl >= threshold) {
+        count++;
+        max_level = std::max(max_level, static_cast<uint32_t>(lvl));
+      }
+    }
+    return {count, max_level};
+  }
+
+private:
+  struct SubsysState {
+    ceph::mono_clock::time_point elevated_since;
+    uint8_t safe_log = 0;
+    uint8_t safe_gather = 0;
+    bool elevated = false;
+  };
+
+  std::array<SubsysState, ceph_subsys_get_num()> m_state;
+};
+
+#endif

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -509,6 +509,36 @@ options:
   daemon_default: 10000
   # default changed by common_preinit()
   with_legacy: true
+- name: high_debug_level_threshold
+  type: int
+  level: advanced
+  desc: Debug log level at or above which a subsystem is considered excessively high
+  long_desc: When any debug_* subsystem has its log level set at or above this
+    threshold, the daemon will issue a health warning and start a timer to
+    automatically revert it to the previous safe level after
+    high_debug_level_reset_timeout seconds. Set to 0 to disable the guard.
+  default: 0
+  min: 0
+  max: 30
+  flags:
+  - runtime
+  see_also:
+  - high_debug_level_reset_timeout
+- name: high_debug_level_reset_timeout
+  type: secs
+  level: advanced
+  desc: Seconds before an excessively high debug level is auto-reverted
+  long_desc: When a debug subsystem exceeds high_debug_level_threshold, the
+    daemon will automatically revert it to the previous level after this many
+    seconds. Set to 0 to disable the auto-revert while keeping the health
+    warning. This protects against accidental high debug levels causing disk
+    I/O floods and CPU overhead in production.
+  default: 300
+  min: 0
+  flags:
+  - runtime
+  see_also:
+  - high_debug_level_threshold
 - name: log_to_file
   type: bool
   level: basic

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/ceph_argparse.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_crypto.cc
+  ${PROJECT_SOURCE_DIR}/src/common/debug_level_guard.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_fs.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_hash.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_time.cc

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -6,6 +6,7 @@ set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/blkdev.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_crypto.cc
+  ${PROJECT_SOURCE_DIR}/src/common/debug_level_guard.cc
   ${PROJECT_SOURCE_DIR}/src/common/Finisher.cc
   ${PROJECT_SOURCE_DIR}/src/common/HeartbeatMap.cc
   ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -121,6 +121,7 @@ OSD::OSD(int id, uint32_t nonce,
       std::ignore = update_heartbeat_peers(
       ).then([this] {
 	update_stats();
+	check_debug_levels();
         mgrc->update_daemon_health(get_health_metrics());
 	tick_timer.arm(
 	  std::chrono::seconds(TICK_INTERVAL));
@@ -1109,6 +1110,32 @@ void OSD::handle_conf_change(
   }
 }
 
+void OSD::check_debug_levels()
+{
+  auto threshold = local_conf().get_val<int64_t>(
+    "high_debug_level_threshold");
+  if (threshold <= 0) {
+    return;
+  }
+  auto timeout = local_conf().get_val<std::chrono::seconds>(
+    "high_debug_level_reset_timeout");
+  auto actions = debug_level_guard.check(
+    local_conf()->subsys, threshold, timeout);
+  for (auto& a : actions) {
+    auto val = std::to_string(a.to_log) + "/" + std::to_string(a.to_gather);
+    LOG_PREFIX(OSD::check_debug_levels);
+    ERROR("Auto-reverted {} from {} to {} after {}s",
+	  a.name, a.from_level, val, timeout.count());
+    gate.dispatch_in_background(
+      "debug_level_revert", *this, [name=a.name, val, FNAME] {
+	return local_conf().set_val(name, val).handle_exception(
+	  [name, val, FNAME](auto ep) {
+	    ERROR("failed to revert {} to {}: {}", name, val, ep);
+	  });
+      });
+  }
+}
+
 void OSD::update_stats()
 {
   gate.dispatch_in_background("statfs", *this, [this] {
@@ -1567,6 +1594,13 @@ vector<DaemonHealthMetric> OSD::get_health_metrics()
     }
     oldest_secs = now - oldest_op->get_started();
     metrics.emplace_back(daemon_metric::SLOW_OPS, slow, oldest_secs);
+  }
+
+  {
+    auto threshold = local_conf().get_val<int64_t>("high_debug_level_threshold");
+    auto [count, max_level] = DebugLevelGuard::count_elevated(
+      local_conf()->subsys, threshold);
+    metrics.emplace_back(daemon_metric::HIGH_DEBUG_LEVEL, count, max_level);
   }
 
   return metrics;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -122,6 +122,7 @@ OSD::OSD(int id, uint32_t nonce,
       std::ignore = update_heartbeat_peers(
       ).then([this] {
 	update_stats();
+	check_debug_levels();
         mgrc->update_daemon_health(get_health_metrics());
 	if (++trim_queue_length_countdown >= TRIM_QLENGTHS_UPDATE_PERIOD) {
 	  trim_queue_length_countdown = 0;
@@ -1113,6 +1114,32 @@ void OSD::handle_conf_change(
   }
 }
 
+void OSD::check_debug_levels()
+{
+  auto threshold = local_conf().get_val<int64_t>(
+    "high_debug_level_threshold");
+  if (threshold <= 0) {
+    return;
+  }
+  auto timeout = local_conf().get_val<std::chrono::seconds>(
+    "high_debug_level_reset_timeout");
+  auto actions = debug_level_guard.check(
+    local_conf()->subsys, threshold, timeout);
+  for (auto& a : actions) {
+    auto val = std::to_string(a.to_log) + "/" + std::to_string(a.to_gather);
+    LOG_PREFIX(OSD::check_debug_levels);
+    ERROR("Auto-reverted {} from {} to {} after {}s",
+	  a.name, a.from_level, val, timeout.count());
+    gate.dispatch_in_background(
+      "debug_level_revert", *this, [name=a.name, val, FNAME] {
+	return local_conf().set_val(name, val).handle_exception(
+	  [name, val, FNAME](auto ep) {
+	    ERROR("failed to revert {} to {}: {}", name, val, ep);
+	  });
+      });
+  }
+}
+
 void OSD::update_stats()
 {
   gate.dispatch_in_background("statfs", *this, [this] {
@@ -1575,6 +1602,13 @@ vector<DaemonHealthMetric> OSD::get_health_metrics()
     }
     oldest_secs = now - oldest_op->get_started();
     metrics.emplace_back(daemon_metric::SLOW_OPS, slow, oldest_secs);
+  }
+
+  {
+    auto threshold = local_conf().get_val<int64_t>("high_debug_level_threshold");
+    auto [count, max_level] = DebugLevelGuard::count_elevated(
+      local_conf()->subsys, threshold);
+    metrics.emplace_back(daemon_metric::HIGH_DEBUG_LEVEL, count, max_level);
   }
 
   return metrics;

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -11,6 +11,7 @@
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/timer.hh>
 
+#include "common/debug_level_guard.h"
 #include "crimson/common/logclient.h"
 #include "crimson/common/type_helpers.h"
 #include "crimson/common/auth_handler.h"
@@ -108,6 +109,7 @@ class OSD final : public crimson::net::Dispatcher,
   // which pgs were scanned for min_lec
   std::vector<pg_t> min_last_epoch_clean_pgs;
   void update_stats();
+  void check_debug_levels();
   seastar::future<MessageURef> get_stats() final;
 
   // AuthHandler methods
@@ -129,6 +131,8 @@ class OSD final : public crimson::net::Dispatcher,
   /// caching the total snap trim queue length across all PGs,
   /// updated periodically by the tick_timer
   uint64_t snap_trim_queue_total = 0;
+
+  DebugLevelGuard debug_level_guard;
 
   seastar::timer<seastar::lowres_clock> stats_timer;
   std::vector<ShardServices::shard_stats_t> shard_stats;

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -11,6 +11,7 @@
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/timer.hh>
 
+#include "common/debug_level_guard.h"
 #include "crimson/common/logclient.h"
 #include "crimson/common/type_helpers.h"
 #include "crimson/common/auth_handler.h"
@@ -110,6 +111,7 @@ class OSD final : public crimson::net::Dispatcher,
   // which pgs were scanned for min_lec
   std::vector<pg_t> min_last_epoch_clean_pgs;
   void update_stats();
+  void check_debug_levels();
   seastar::future<MessageURef> get_stats() final;
 
   // AuthHandler methods
@@ -127,6 +129,7 @@ class OSD final : public crimson::net::Dispatcher,
 
   std::unique_ptr<Heartbeat> heartbeat;
   seastar::timer<seastar::lowres_clock> tick_timer;
+  DebugLevelGuard debug_level_guard;
 
   seastar::timer<seastar::lowres_clock> stats_timer;
   std::vector<ShardServices::shard_stats_t> shard_stats;

--- a/src/mgr/DaemonHealthMetric.h
+++ b/src/mgr/DaemonHealthMetric.h
@@ -12,9 +12,10 @@
 namespace ceph { class Formatter; }
 
 enum class daemon_metric : uint8_t {
-  SLOW_OPS,
-  PENDING_CREATING_PGS,
-  NONE,
+  SLOW_OPS = 0,
+  PENDING_CREATING_PGS = 1,
+  NONE = 2,
+  HIGH_DEBUG_LEVEL = 3,
 };
 
 static inline const char *daemon_metric_name(daemon_metric t) {
@@ -22,6 +23,7 @@ static inline const char *daemon_metric_name(daemon_metric t) {
   case daemon_metric::SLOW_OPS: return "SLOW_OPS";
   case daemon_metric::PENDING_CREATING_PGS: return "PENDING_CREATING_PGS";
   case daemon_metric::NONE: return "NONE";
+  case daemon_metric::HIGH_DEBUG_LEVEL: return "HIGH_DEBUG_LEVEL";
   default: return "???";
   }
 }

--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -93,6 +93,47 @@ class PendingPGs final : public DaemonHealthMetricCollector {
   vector<DaemonKey> osds;
 };
 
+class HighDebugLevel final : public DaemonHealthMetricCollector {
+  bool _is_relevant(daemon_metric type) const override {
+    return type == daemon_metric::HIGH_DEBUG_LEVEL;
+  }
+  health_check_t& _get_check(health_check_map_t& cm) const override {
+    return cm.get_or_add("HIGH_DEBUG_LEVEL", HEALTH_WARN, "", 1);
+  }
+  bool _update(const DaemonKey& daemon,
+               const DaemonHealthMetric& metric) override {
+    // n1 = number of elevated subsystems, n2 = max level
+    auto num_elevated = metric.get_n1();
+    auto max_level = metric.get_n2();
+    value.n1 += num_elevated;
+    value.n2 = std::max(value.n2, max_level);
+    if (num_elevated) {
+      daemons.push_back(daemon);
+      return true;
+    }
+    return false;
+  }
+  void _summarize(health_check_t& check) const override {
+    if (daemons.empty()) {
+      return;
+    }
+    ostringstream ss;
+    if (daemons.size() > 1) {
+      if (daemons.size() > 10) {
+        ss << vector<DaemonKey>(daemons.begin(), daemons.begin()+10) << "...";
+      } else {
+        ss << daemons;
+      }
+    } else {
+      ss << daemons.front();
+    }
+    check.summary =
+      fmt::format("{} subsystems across {} daemon(s) have high debug levels (max {}): {}",
+                  value.n1, daemons.size(), value.n2, ss.str());
+  }
+  vector<DaemonKey> daemons;
+};
+
 } // anonymous namespace
 
 unique_ptr<DaemonHealthMetricCollector>
@@ -103,6 +144,8 @@ DaemonHealthMetricCollector::create(daemon_metric m)
     return std::make_unique<SlowOps>();
   case daemon_metric::PENDING_CREATING_PGS:
     return std::make_unique<PendingPGs>();
+  case daemon_metric::HIGH_DEBUG_LEVEL:
+    return std::make_unique<HighDebugLevel>();
   default:
     return {};
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6118,6 +6118,7 @@ void Monitor::tick()
     paxos->trigger_propose();
   }
 
+  g_ceph_context->check_debug_level_guard();
   mgr_client.update_daemon_health(get_health_metrics());
   new_tick();
 }
@@ -6151,6 +6152,12 @@ vector<DaemonHealthMetric> Monitor::get_health_metrics()
     metrics.emplace_back(daemon_metric::SLOW_OPS, slow, oldest_secs);
   } else {
     metrics.emplace_back(daemon_metric::SLOW_OPS, 0, 0);
+  }
+  {
+    auto threshold = g_conf().get_val<int64_t>("high_debug_level_threshold");
+    auto [count, max_level] = DebugLevelGuard::count_elevated(
+      g_conf()->subsys, threshold);
+    metrics.emplace_back(daemon_metric::HIGH_DEBUG_LEVEL, count, max_level);
   }
   return metrics;
 }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6120,6 +6120,7 @@ void Monitor::tick()
     paxos->trigger_propose();
   }
 
+  g_ceph_context->check_debug_level_guard();
   mgr_client.update_daemon_health(get_health_metrics());
   new_tick();
 }
@@ -6153,6 +6154,12 @@ vector<DaemonHealthMetric> Monitor::get_health_metrics()
     metrics.emplace_back(daemon_metric::SLOW_OPS, slow, oldest_secs);
   } else {
     metrics.emplace_back(daemon_metric::SLOW_OPS, 0, 0);
+  }
+  {
+    auto threshold = g_conf().get_val<int64_t>("high_debug_level_threshold");
+    auto [count, max_level] = DebugLevelGuard::count_elevated(
+      g_conf()->subsys, threshold);
+    metrics.emplace_back(daemon_metric::HIGH_DEBUG_LEVEL, count, max_level);
   }
   return metrics;
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6463,6 +6463,7 @@ void OSD::tick_without_osd_lock()
     maybe_send_beacon();
   }
 
+  cct->check_debug_level_guard();
   mgrc.update_daemon_health(get_health_metrics());
   service.kick_recovery_queue();
   tick_timer_without_osd_lock.add_event_after(get_tick_interval(),
@@ -8032,6 +8033,12 @@ vector<DaemonHealthMetric> OSD::get_health_metrics()
       }
     }
     metrics.emplace_back(daemon_metric::PENDING_CREATING_PGS, n_primaries);
+  }
+  {
+    auto threshold = cct->_conf.get_val<int64_t>("high_debug_level_threshold");
+    auto [count, max_level] = DebugLevelGuard::count_elevated(
+      cct->_conf->subsys, threshold);
+    metrics.emplace_back(daemon_metric::HIGH_DEBUG_LEVEL, count, max_level);
   }
   return metrics;
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6490,6 +6490,7 @@ void OSD::tick_without_osd_lock()
     maybe_send_beacon();
   }
 
+  cct->check_debug_level_guard();
   mgrc.update_daemon_health(get_health_metrics());
   service.kick_recovery_queue();
   tick_timer_without_osd_lock.add_event_after(get_tick_interval(),
@@ -8075,6 +8076,12 @@ vector<DaemonHealthMetric> OSD::get_health_metrics()
       }
     }
     metrics.emplace_back(daemon_metric::PENDING_CREATING_PGS, n_primaries);
+  }
+  {
+    auto threshold = cct->_conf.get_val<int64_t>("high_debug_level_threshold");
+    auto [count, max_level] = DebugLevelGuard::count_elevated(
+      cct->_conf->subsys, threshold);
+    metrics.emplace_back(daemon_metric::HIGH_DEBUG_LEVEL, count, max_level);
   }
   return metrics;
 }

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -447,6 +447,10 @@ add_executable(unittest_ceph_timer test_ceph_timer.cc)
 add_ceph_unittest(unittest_ceph_timer)
 target_link_libraries(unittest_ceph_timer global ceph-common)
 
+add_executable(unittest_debug_level_guard test_debug_level_guard.cc)
+target_link_libraries(unittest_debug_level_guard global ceph-common)
+add_ceph_unittest(unittest_debug_level_guard)
+
 add_executable(unittest_option test_option.cc)
 target_link_libraries(unittest_option ceph-common GTest::Main)
 add_ceph_unittest(unittest_option)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -427,6 +427,10 @@ add_executable(unittest_ceph_timer test_ceph_timer.cc)
 add_ceph_unittest(unittest_ceph_timer)
 target_link_libraries(unittest_ceph_timer global ceph-common)
 
+add_executable(unittest_debug_level_guard test_debug_level_guard.cc)
+target_link_libraries(unittest_debug_level_guard global ceph-common)
+add_ceph_unittest(unittest_debug_level_guard)
+
 add_executable(unittest_option test_option.cc)
 target_link_libraries(unittest_option ceph-common GTest::Main)
 add_ceph_unittest(unittest_option)

--- a/src/test/common/test_debug_level_guard.cc
+++ b/src/test/common/test_debug_level_guard.cc
@@ -1,0 +1,238 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "common/ceph_context.h"
+#include "common/debug_level_guard.h"
+
+using namespace std::literals;
+
+class DebugLevelGuardTest : public ::testing::Test {
+protected:
+  DebugLevelGuard guard;
+  boost::intrusive_ptr<CephContext> cct;
+
+  void SetUp() override {
+    cct.reset(new CephContext(CEPH_ENTITY_TYPE_OSD), false);
+  }
+
+  void set_debug(const std::string& subsys, const std::string& val) {
+    cct->_conf.set_val("debug_" + subsys, val);
+    cct->_conf.apply_changes(nullptr);
+  }
+
+  int get_log_level(unsigned subsys) {
+    return cct->_conf->subsys.get_log_level(subsys);
+  }
+
+  int get_gather_level(unsigned subsys) {
+    return cct->_conf->subsys.get_gather_level(subsys);
+  }
+
+  // Apply revert actions to config (simulates what daemon tick does)
+  void apply_reverts(const std::vector<DebugLevelGuard::RevertAction>& actions) {
+    for (auto& a : actions) {
+      auto val = std::to_string(a.to_log) + "/" + std::to_string(a.to_gather);
+      cct->_conf.set_val(a.name, val);
+    }
+    if (!actions.empty()) {
+      cct->_conf.apply_changes(nullptr);
+    }
+  }
+};
+
+TEST_F(DebugLevelGuardTest, DisabledWhenThresholdZero) {
+  set_debug("osd", "20");
+  auto actions = guard.check(cct->_conf->subsys, 0, 1s);
+  EXPECT_TRUE(actions.empty());
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 20);
+}
+
+TEST_F(DebugLevelGuardTest, BelowThresholdIgnored) {
+  set_debug("osd", "4");
+  auto actions = guard.check(cct->_conf->subsys, 5, 1s);
+  EXPECT_TRUE(actions.empty());
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 4);
+}
+
+TEST_F(DebugLevelGuardTest, AtThresholdDetected) {
+  set_debug("osd", "5");
+  // First check marks as elevated, no revert yet
+  auto actions = guard.check(cct->_conf->subsys, 5, 1s);
+  EXPECT_TRUE(actions.empty());
+  // Second check after timeout should trigger revert
+  std::this_thread::sleep_for(1100ms);
+  actions = guard.check(cct->_conf->subsys, 5, 1s);
+  EXPECT_EQ(actions.size(), 1u);
+}
+
+TEST_F(DebugLevelGuardTest, TimeoutZeroMeansWarnOnly) {
+  set_debug("osd", "20");
+  // First check marks elevated
+  guard.check(cct->_conf->subsys, 10, 0s);
+  // Second check with timeout=0 should NOT revert (warn only)
+  std::this_thread::sleep_for(100ms);
+  auto actions = guard.check(cct->_conf->subsys, 10, 0s);
+  EXPECT_TRUE(actions.empty());
+  // Level should still be 20
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 20);
+}
+
+TEST_F(DebugLevelGuardTest, RevertsAfterTimeout) {
+  set_debug("osd", "3/5");
+
+  // First call records safe levels at 3/5
+  guard.check(cct->_conf->subsys, 10, 1s);
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 3);
+  EXPECT_EQ(get_gather_level(ceph_subsys_osd), 5);
+
+  // Elevate
+  set_debug("osd", "20");
+  // First check marks elevated
+  guard.check(cct->_conf->subsys, 10, 1s);
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 20);
+
+  // Wait for timeout
+  std::this_thread::sleep_for(1100ms);
+
+  auto actions = guard.check(cct->_conf->subsys, 10, 1s);
+  ASSERT_EQ(actions.size(), 1u);
+  EXPECT_EQ(actions[0].name, "debug_osd");
+  EXPECT_EQ(actions[0].from_level, 20);
+  EXPECT_EQ(actions[0].to_log, 3);
+  EXPECT_EQ(actions[0].to_gather, 5);
+
+  // Apply and verify
+  apply_reverts(actions);
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 3);
+  EXPECT_EQ(get_gather_level(ceph_subsys_osd), 5);
+}
+
+TEST_F(DebugLevelGuardTest, RestoresPreviousNotDefault) {
+  // Set a non-default safe level first
+  set_debug("osd", "2/7");
+  guard.check(cct->_conf->subsys, 10, 1s);
+
+  // Elevate
+  set_debug("osd", "20");
+  guard.check(cct->_conf->subsys, 10, 1s);
+
+  // Should trigger revert after timeout
+  std::this_thread::sleep_for(1100ms);
+  auto actions = guard.check(cct->_conf->subsys, 10, 1s);
+  ASSERT_EQ(actions.size(), 1u);
+
+  apply_reverts(actions);
+  // Should restore to 2/7, not compiled default
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 2);
+  EXPECT_EQ(get_gather_level(ceph_subsys_osd), 7);
+}
+
+TEST_F(DebugLevelGuardTest, ManualLowerCancelsRevert) {
+  set_debug("osd", "1");
+  guard.check(cct->_conf->subsys, 10, 2s);
+
+  // Elevate
+  set_debug("osd", "20");
+  guard.check(cct->_conf->subsys, 10, 2s);
+
+  // Manually lower before timeout
+  set_debug("osd", "3");
+  auto actions = guard.check(cct->_conf->subsys, 10, 2s);
+  EXPECT_TRUE(actions.empty());
+
+  // Should stay at 3 even after waiting
+  std::this_thread::sleep_for(2100ms);
+  actions = guard.check(cct->_conf->subsys, 10, 2s);
+  EXPECT_TRUE(actions.empty());
+  EXPECT_EQ(get_log_level(ceph_subsys_osd), 3);
+}
+
+TEST_F(DebugLevelGuardTest, ReElevationResetsTimer) {
+  set_debug("osd", "1");
+  guard.check(cct->_conf->subsys, 10, 2s);
+
+  set_debug("osd", "20");
+  guard.check(cct->_conf->subsys, 10, 2s);
+
+  // Wait 1.5s (less than timeout)
+  std::this_thread::sleep_for(1500ms);
+
+  // Lower then re-elevate — should reset timer
+  set_debug("osd", "3");
+  guard.check(cct->_conf->subsys, 10, 2s);
+  set_debug("osd", "25");
+  guard.check(cct->_conf->subsys, 10, 2s);
+
+  // Wait 1s — not enough since timer was reset
+  std::this_thread::sleep_for(1000ms);
+  auto actions = guard.check(cct->_conf->subsys, 10, 2s);
+  EXPECT_TRUE(actions.empty());
+
+  // Wait the remaining time
+  std::this_thread::sleep_for(1100ms);
+  actions = guard.check(cct->_conf->subsys, 10, 2s);
+  EXPECT_EQ(actions.size(), 1u);
+}
+
+TEST_F(DebugLevelGuardTest, MultipleSubsystemsIndependent) {
+  set_debug("osd", "1");
+  set_debug("ms", "1");
+  guard.check(cct->_conf->subsys, 10, 1s);
+
+  // Elevate osd first
+  set_debug("osd", "20");
+  guard.check(cct->_conf->subsys, 10, 1s);
+
+  // Wait 0.5s, then elevate ms
+  std::this_thread::sleep_for(500ms);
+  set_debug("ms", "15");
+  guard.check(cct->_conf->subsys, 10, 1s);
+
+  // Wait 0.6s more — osd should trigger (1.1s total), ms should not (0.6s)
+  std::this_thread::sleep_for(600ms);
+  auto actions = guard.check(cct->_conf->subsys, 10, 1s);
+
+  bool osd_found = false;
+  bool ms_found = false;
+  for (auto& a : actions) {
+    if (a.name == "debug_osd") osd_found = true;
+    if (a.name == "debug_ms") ms_found = true;
+  }
+  EXPECT_TRUE(osd_found);
+  EXPECT_FALSE(ms_found);
+
+  // ms should still be elevated
+  EXPECT_EQ(get_log_level(ceph_subsys_ms), 15);
+
+  // Apply osd revert
+  apply_reverts(actions);
+
+  // Wait for ms to timeout too
+  std::this_thread::sleep_for(500ms);
+  actions = guard.check(cct->_conf->subsys, 10, 1s);
+  ms_found = false;
+  for (auto& a : actions) {
+    if (a.name == "debug_ms") ms_found = true;
+  }
+  EXPECT_TRUE(ms_found);
+
+  apply_reverts(actions);
+  EXPECT_EQ(get_log_level(ceph_subsys_ms), 1);
+}


### PR DESCRIPTION
High debug levels (e.g. `debug_osd 20`) set accidentally in production can cause catastrophic disk I/O floods and CPU overhead. This adds a guard that periodically checks subsystem debug levels and auto-reverts any that have been above a threshold for longer than a timeout.

## What it does

- New config: `high_debug_level_threshold` (default `0` = disabled) and `high_debug_level_reset_timeout` (default `300s`, set to `0` for warn-only mode).
- When any subsystem's log level hits the threshold, a `HIGH_DEBUG_LEVEL` mgr health warning surfaces in `ceph health detail`.
- After the timeout, the guard reverts the level to the last known safe value, not the compiled default, so intentional customizations like `debug_osd 1/5` are preserved.
- Only the log level is checked, not the gather level. High gather levels are safe: those messages stay in memory for crash dumps and don't cause disk I/O.
- Manual lower during the countdown cancels the pending revert.
- Called from existing daemon tick paths (classic OSD, Monitor, Crimson OSD), zero hot-path overhead.
- Disabled by default; must be explicitly enabled.

## Example

```
$ ceph config set global high_debug_level_threshold 10
$ ceph config set global high_debug_level_reset_timeout 300
$ ceph tell osd.0 config set debug_osd 20
# within a few seconds:
$ ceph health detail
HEALTH_WARN 1 subsystems across 1 daemon(s) have high debug levels (max 20): osd.0
[WRN] HIGH_DEBUG_LEVEL: 1 subsystems across 1 daemon(s) have high debug levels (max 20): osd.0
# after 300s, in out/osd.0.log:
-1 Auto-reverted debug_osd from 20 to 1/5 after 300s (high_debug_level_threshold=10)
```

## Tests

- 9 GTest cases in `test_debug_level_guard.cc`: threshold disabled/active, warn-only, revert restores previous not default, manual-lower cancels revert, re-elevation resets timer, multiple subsystems tracked independently.
- Integration workunit `qa/workunits/mon/debug_level_guard.sh` + teuthology suite entry under `rados/singleton/all/`, exercises a live cluster, verifies the health warning surfaces and clears.

## Tested on vstart

End-to-end verified on a local vstart cluster (MON=1, MGR=1, OSD=1 and MON=1, MGR=1, OSD=3):
- Elevated `debug_bluestore` from `1/5` to `25/25`; health surfaced `HIGH_DEBUG_LEVEL`; auto-reverted to `1/5` after timeout; health cleared.
- With `reset_timeout=0` the warning persisted and no revert fired, warn-only mode works.
- Manual lower during the countdown preserved the user's new value, confirming manual intent overrides the pending revert.
- Verified both classic OSD and Monitor paths emit the `HIGH_DEBUG_LEVEL` metric through `mgr.server handle_report daemon_health_metrics`.

The two new config options (`high_debug_level_threshold`, `high_debug_level_reset_timeout`) are documented in `PendingReleaseNotes`.

Tracker: https://tracker.ceph.com/issues/75467

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [x] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests
