### PR TITLE
squid: qa/suites: use tagged versions of reef and quincy

### DIFF
--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/quincy/v17.2.8.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/quincy/v17.2.8.yaml
@@ -1,15 +1,15 @@
 meta:
 - desc: |
-   setup ceph/quincy
+   setup ceph/v17.2.8
 
 tasks:
 - install:
-    branch: quincy
+    tag: v17.2.8
     exclude_packages:
       - ceph-volume
 - print: "**** done install task..."
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:quincy
+    image: quay.io/ceph/ceph:v17.2.8
     roleless: true
     cephadm_branch: quincy
     cephadm_git_url: https://github.com/ceph/ceph
@@ -18,7 +18,7 @@ tasks:
         #set config option for which cls modules are allowed to be loaded / used
         osd_class_load_list: "*"
         osd_class_default_list: "*"
-- print: "**** done end installing quincy cephadm ..."
+- print: "**** done end installing v17.2.8 cephadm ..."
 - cephadm.shell:
     host.a:
       - ceph config set mgr mgr/cephadm/use_repo_digest true --force

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/reef/v18.2.8.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/reef/v18.2.8.yaml
@@ -1,15 +1,15 @@
 meta:
 - desc: |
-   setup ceph/reef
+   setup ceph/v18.2.8
 
 tasks:
 - install:
-    branch: reef
+    tag: v18.2.8
     exclude_packages:
       - ceph-volume
 - print: "**** done install task..."
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:reef
+    image: quay.io/ceph/ceph:v18.2.8
     roleless: true
     compiled_cephadm_branch: reef
     conf:
@@ -17,7 +17,7 @@ tasks:
         #set config option for which cls modules are allowed to be loaded / used
         osd_class_load_list: "*"
         osd_class_default_list: "*"
-- print: "**** done end installing reef cephadm ..."
+- print: "**** done end installing v18.2.8 cephadm ..."
 - cephadm.shell:
     host.a:
       - ceph config set mgr mgr/cephadm/use_repo_digest true --force

--- a/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-centos_9.stream-quincy.yaml
+++ b/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-centos_9.stream-quincy.yaml
@@ -3,8 +3,8 @@ os_version: "9.stream"
 
 tasks:
 - cephadm:
-    image: quay.io/ceph/ceph:v17.2.0
-    cephadm_branch: v17.2.0
+    image: quay.io/ceph/ceph:v17.2.8
+    cephadm_branch: v17.2.8
     cephadm_git_url: https://github.com/ceph/ceph
 
 roles:

--- a/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-centos_9.stream-reef.yaml
+++ b/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-centos_9.stream-reef.yaml
@@ -1,0 +1,29 @@
+os_type: centos
+os_version: "9.stream"
+
+tasks:
+- cephadm:
+    image: quay.io/ceph/ceph:v18.2.8
+    compiled_cephadm_branch: reef
+
+roles:
+- - mon.a
+  - mon.c
+  - mgr.y
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - client.0
+  - node-exporter.a
+  - alertmanager.a
+- - mon.b
+  - mgr.x
+  - osd.4
+  - osd.5
+  - osd.6
+  - osd.7
+  - client.1
+  - prometheus.a
+  - grafana.a
+  - node-exporter.b

--- a/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-ubuntu_22.04-quincy.yaml
+++ b/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-ubuntu_22.04-quincy.yaml
@@ -3,8 +3,8 @@ os_version: "22.04"
 
 tasks:
 - cephadm:
-    image: quay.io/ceph/ceph:v17.2.0
-    cephadm_branch: v17.2.0
+    image: quay.io/ceph/ceph:v17.2.8
+    cephadm_branch: v17.2.8
     cephadm_git_url: https://github.com/ceph/ceph
 
 roles:

--- a/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-ubuntu_22.04-reef.yaml
+++ b/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-ubuntu_22.04-reef.yaml
@@ -1,0 +1,29 @@
+os_type: ubuntu
+os_version: "22.04"
+
+tasks:
+- cephadm:
+    image: quay.io/ceph/ceph:v18.2.8
+    compiled_cephadm_branch: reef
+
+roles:
+- - mon.a
+  - mon.c
+  - mgr.y
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - client.0
+  - node-exporter.a
+  - alertmanager.a
+- - mon.b
+  - mgr.x
+  - osd.4
+  - osd.5
+  - osd.6
+  - osd.7
+  - client.1
+  - prometheus.a
+  - grafana.a
+  - node-exporter.b

--- a/qa/suites/upgrade/quincy-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/1-tasks.yaml
@@ -11,7 +11,7 @@ tasks:
 - print: "**** done install task..."
 - print: "**** done start installing quincy cephadm ..."
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:quincy
+    image: quay.io/ceph/ceph:v17.2.8
     cephadm_branch: quincy
     cephadm_git_url: https://github.com/ceph/ceph
     conf:

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -32,7 +32,7 @@ tasks:
       - ceph-volume
 
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:quincy
+    image: quay.io/ceph/ceph:v17.2.8
     cephadm_branch: quincy
     cephadm_git_url: https://github.com/ceph/ceph
     conf:

--- a/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
@@ -11,7 +11,7 @@ tasks:
 - print: "**** done install task..."
 - print: "**** done start installing reef cephadm ..."
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:reef
+    image: quay.io/ceph/ceph:v18.2.8
     compiled_cephadm_branch: reef
     conf:
       osd:

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -32,7 +32,7 @@ tasks:
       - ceph-volume
 
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:reef
+    image: quay.io/ceph/ceph:v18.2.8
     compiled_cephadm_branch: reef
     conf:
       osd:

--- a/qa/suites/upgrade/telemetry-upgrade/quincy-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/quincy-x/1-tasks.yaml
@@ -25,7 +25,7 @@ tasks:
 - print: "**** done install task..."
 - print: "**** done start installing quincy cephadm ..."
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:quincy
+    image: quay.io/ceph/ceph:v17.2.8
     cephadm_branch: quincy
     cephadm_git_url: https://github.com/ceph/ceph
     conf:

--- a/qa/suites/upgrade/telemetry-upgrade/quincy-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/quincy-x/1-tasks.yaml
@@ -17,6 +17,7 @@ overrides:
       - OSD_UPGRADE_FINISHED
       - do not have an application enabled
       - is down
+      - Telemetry requires re-opt-in
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/telemetry-upgrade/reef-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/reef-x/1-tasks.yaml
@@ -17,6 +17,7 @@ overrides:
       - OSD_UPGRADE_FINISHED
       - do not have an application enabled
       - is down
+      - Telemetry requires re-opt-in
 tasks:
 - install:
     branch: reef

--- a/qa/suites/upgrade/telemetry-upgrade/reef-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/reef-x/1-tasks.yaml
@@ -26,7 +26,7 @@ tasks:
 - print: "**** done install task..."
 - print: "**** done start installing reef cephadm ..."
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:reef
+    image: quay.io/ceph/ceph:v18.2.8
     compiled_cephadm_branch: reef
     conf:
       osd:

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -10,7 +10,7 @@ FSID='00000000-0000-0000-0000-0000deadbeef'
 
 # images that are used
 IMAGE_MAIN=${IMAGE_MAIN:-'quay.ceph.io/ceph-ci/ceph:main'}
-IMAGE_QUINCY=${IMAGE_QUINCY:-'quay.ceph.io/ceph-ci/ceph:quincy'}
+IMAGE_QUINCY=${IMAGE_QUINCY:-'quay.io/ceph/ceph:v17.2.8'}
 IMAGE_REEF=${IMAGE_REEF:-'quay.ceph.io/ceph-ci/ceph:reef'}
 IMAGE_SQUID=${IMAGE_SQUID:-'quay.ceph.io/ceph-ci/ceph:squid'}
 IMAGE_DEFAULT=${IMAGE_SQUID}

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -11,7 +11,7 @@ FSID='00000000-0000-0000-0000-0000deadbeef'
 # images that are used
 IMAGE_MAIN=${IMAGE_MAIN:-'quay.ceph.io/ceph-ci/ceph:main'}
 IMAGE_QUINCY=${IMAGE_QUINCY:-'quay.io/ceph/ceph:v17.2.8'}
-IMAGE_REEF=${IMAGE_REEF:-'quay.ceph.io/ceph-ci/ceph:reef'}
+IMAGE_REEF=${IMAGE_REEF:-'quay.io/ceph/ceph:v18.2.8'}
 IMAGE_SQUID=${IMAGE_SQUID:-'quay.ceph.io/ceph-ci/ceph:squid'}
 IMAGE_DEFAULT=${IMAGE_SQUID}
 


### PR DESCRIPTION
We not longer have containers for these HEAD of these branches with the
lab relocation.

This is a direct commit to the squid branch since we got rid of the
reef and quincy upgrade paths for main/umbrella.

Fixes: https://tracker.ceph.com/issues/76028
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
