### PR TITLE
cephadm: add --mon-net arg for bootstrap to select IP from CIDR network

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -54,6 +54,7 @@ Synopsis
 
 | **cephadm** **bootstrap** [-h] [--config CONFIG] [--mon-id MON_ID]
 |                           [--mon-addrv MON_ADDRV] [--mon-ip MON_IP]
+|                           [--mon-net MON_NET]
 |                           [--mgr-id MGR_ID] [--fsid FSID]
 |                           [--log-to-file] [--single-host-defaults]
 |                           [--output-dir OUTPUT_DIR]
@@ -223,6 +224,7 @@ Arguments:
 * [--config CONFIG, -c CONFIG]    ceph conf file to incorporate
 * [--mon-id MON_ID]               mon id (default: local hostname)
 * [--mon-addrv MON_ADDRV]         mon IPs (e.g., [v2:localipaddr:3300,v1:localipaddr:6789])
+* [--mon-net MON_NET]             mon network in CIDR notation (e.g., 192.168.1.0/24)
 * [--mon-ip MON_IP]               mon IP
 * [--mgr-id MGR_ID]               mgr id (default: randomly generated)
 * [--fsid FSID]                   cluster FSID

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2081,6 +2081,18 @@ def get_image_info_from_inspect(out, image):
 ##################################
 
 
+def _check_mon_ip_vs_public_network(mon_ip: str, public_network: str) -> None:
+    if not ip_in_subnets(mon_ip, public_network):
+        raise Error(f'The provided --mon-ip {mon_ip} does not belong to any public_network(s) {public_network}')
+
+
+def _check_mon_addrv_vs_public_network(mon_addrv: str, public_network: str) -> None:
+    addrv_args = parse_mon_addrv(mon_addrv)
+    for addrv in addrv_args:
+        if not ip_in_subnets(addrv.ip, public_network):
+            raise Error(f'The provided --mon-addrv {addrv.ip} ip does not belong to any public_network(s) {public_network}')
+
+
 def get_public_net_from_cfg(ctx: CephadmContext) -> Optional[str]:
     """Get mon public network from configuration file."""
     cp = read_config(ctx.config)
@@ -2109,18 +2121,91 @@ def get_public_net_from_cfg(ctx: CephadmContext) -> Optional[str]:
     if not valid_public_net:
         raise Error(f'None of the public CIDR network(s) {configured_subnets} (from -c conf file) is configured locally.')
 
-    # Ensure public_network is compatible with the provided mon-ip (or mon-addrv)
+    # Ensure public_network is compatible with the provided mon address (--mon-ip, --mon-addrv, or --mon-net)
     if ctx.mon_ip:
-        if not ip_in_subnets(ctx.mon_ip, public_network):
-            raise Error(f'The provided --mon-ip {ctx.mon_ip} does not belong to any public_network(s) {public_network}')
+        _check_mon_ip_vs_public_network(ctx.mon_ip, public_network)
     elif ctx.mon_addrv:
-        addrv_args = parse_mon_addrv(ctx.mon_addrv)
-        for addrv in addrv_args:
-            if not ip_in_subnets(addrv.ip, public_network):
-                raise Error(f'The provided --mon-addrv {addrv.ip} ip does not belong to any public_network(s) {public_network}')
+        _check_mon_addrv_vs_public_network(ctx.mon_addrv, public_network)
 
     logger.debug(f'Using mon public network from configuration file {public_network}')
     return public_network
+
+
+def _parse_network(
+    net_str: str
+) -> Optional[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]:
+    """
+    Parse a CIDR string into a network object.
+
+    :param net_str: CIDR network string (e.g., '192.168.1.0/24' or 'fd00::/64')
+    :return: IPv4Network or IPv6Network on success, None if the string is not a valid CIDR
+    """
+    try:
+        return ipaddress.ip_network(net_str)
+    except ValueError:
+        return None
+
+
+def _parse_ip(
+    ip_str: str
+) -> Optional[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]:
+    """
+    Parse an IP address string into an address object.
+
+    :param ip_str: IP address string (e.g., '192.168.1.1' or 'fd00::1')
+    :return: IPv4Address or IPv6Address on success, None if the string is not a valid IP address
+    """
+    try:
+        return ipaddress.ip_address(ip_str)
+    except ValueError:
+        return None
+
+
+def select_ip_from_network(ctx: CephadmContext, network: str) -> str:
+    """
+    Given a CIDR network, select an appropriate IP from local interfaces
+    in that network. Supports both IPv4 and IPv6 networks.
+
+    :param ctx: CephadmContext
+    :param network: CIDR network string (e.g., '192.168.1.0/24' for IPv4 or 'fd00::/64' for IPv6)
+    :return: Selected IP address string (IPv4 unchanged, IPv6 wrapped in brackets)
+    :raises Error: if no suitable IP found in the network or invalid CIDR format
+    """
+    net = _parse_network(network)
+    if net is None:
+        raise Error(f'Invalid network CIDR {network}')
+
+    # local_networks = {'192.168.100.0/24': {'ens3': {'192.168.100.100'}}, 'fe80::/64': {'ens3': {'fe80::5054:ff:fe83:9e8f'}}}
+    local_networks = list_networks(ctx)
+    candidates = []
+    for local_net, ifaces in local_networks.items():
+        local_net_obj = _parse_network(local_net)
+        if local_net_obj is None:
+            logger.debug(f'Skipping invalid local network {local_net}')
+            continue
+        if local_net_obj.version != net.version:
+            logger.debug(f'Skipping local network {local_net} due to IP version mismatch with requested network {network}')
+            continue
+        if not local_net_obj.overlaps(net):
+            logger.debug(f'Skipping local network {local_net} as it does not overlap with requested network {network}')
+            continue
+        for _, ips in ifaces.items():
+            for ip in ips:
+                ip_obj = _parse_ip(ip)
+                if ip_obj is None:
+                    logger.debug(f'Skipping invalid IP address {ip} on local network {local_net}')
+                    continue
+                if ip_obj in net:
+                    candidates.append(ip)
+
+    if not candidates:
+        raise Error(f'No local IP found in network {network}. Local networks: {list(local_networks.keys())}')
+
+    candidates = sorted(set(candidates), key=ipaddress.ip_address)
+    selected_ip = wrap_ipv6(candidates[0]) if is_ipv6(candidates[0]) else candidates[0]
+
+    logger.info(f'Selected IP {selected_ip} from network {network}')
+    return selected_ip
 
 
 def infer_mon_network(ctx: CephadmContext, mon_eps: List[EndPoint]) -> Optional[str]:
@@ -2167,8 +2252,12 @@ def prepare_mon_addresses(ctx: CephadmContext) -> Tuple[str, bool, Optional[str]
         ipv6 = ctx.mon_addrv.count('[') > 1
         addrv_args = parse_mon_addrv(ctx.mon_addrv)
         mon_addrv = ctx.mon_addrv
-    else:
-        raise Error('must specify --mon-ip or --mon-addrv')
+    elif ctx.mon_net:
+        selected_ip = select_ip_from_network(ctx, ctx.mon_net)
+        ctx.mon_ip = selected_ip
+        ipv6 = is_ipv6(selected_ip)
+        addrv_args = parse_mon_ip(selected_ip)
+        mon_addrv = build_addrv_params(addrv_args)
 
     if addrv_args:
         for end_point in addrv_args:
@@ -5294,13 +5383,16 @@ def _get_parser():
         '--mon-id',
         required=False,
         help='mon id (default: local hostname)')
-    group = parser_bootstrap.add_mutually_exclusive_group()
+    group = parser_bootstrap.add_mutually_exclusive_group(required=True)
     group.add_argument(
         '--mon-addrv',
         help='mon IPs (e.g., [v2:localipaddr:3300,v1:localipaddr:6789])')
     group.add_argument(
         '--mon-ip',
         help='mon IP')
+    group.add_argument(
+        '--mon-net',
+        help='mon network CIDR (e.g., 192.168.1.0/24) - will select first available IP from network')
     parser_bootstrap.add_argument(
         '--mgr-id',
         required=False,

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1774,10 +1774,10 @@ class TestBootstrap(object):
         funkypatch.patch('cephadmlib.systemd.call')
 
         cmd = self._get_cmd()
-        with bootstrap_test_ctx(cmd) as ctx:
-            msg = r'must specify --mon-ip or --mon-addrv'
-            with pytest.raises(_cephadm.Error, match=msg):
-                _cephadm.command_bootstrap(ctx)
+        with pytest.raises(SystemExit) as exc_info:
+            with bootstrap_test_ctx(cmd):
+                pass
+        assert exc_info.value.code == 2
 
     def test_skip_mon_network(self, cephadm_fs, funkypatch):
         funkypatch.patch('cephadmlib.systemd.call')
@@ -1958,6 +1958,248 @@ class TestBootstrap(object):
         with bootstrap_test_ctx(cmd, hostname=hostname) as ctx:
             retval = _cephadm.command_bootstrap(ctx)
             assert retval == 0
+
+    @pytest.mark.parametrize('mon_net, list_networks, result',
+        [
+            # IPv4 - valid CIDR networks
+            (
+                '192.168.1.0/24',
+                {'192.168.1.0/24': {'eth0': ['192.168.1.1']}},
+                True,
+            ),
+            (
+                '192.168.1.0/25',
+                {'192.168.1.0/24': {'eth0': ['192.168.1.1']}},
+                True,
+            ),
+            (
+                '192.168.0.0/16',
+                {'192.168.1.0/24': {'eth0': ['192.168.1.1']}},
+                True,
+            ),
+            # IPv4 - invalid or no-match cases
+            (
+                '10.0.0.0/8',
+                {'192.168.1.0/24': {'eth0': ['192.168.1.1']}},
+                False,
+            ),
+            (
+                '192.168.2.0/24',
+                {'192.168.1.0/24': {'eth0': ['192.168.1.1']}},
+                False,
+            ),
+            # IPv6 - valid CIDR networks
+            (
+                'fd00::/64',
+                {'fd00::/64': {'eth0': ['fd00::1']}},
+                True,
+            ),
+            (
+                'fd00::/63',
+                {'fd00::/64': {'eth0': ['fd00::1']}},
+                True,
+            ),
+            (
+                'fd00::/48',
+                {'fd00::/64': {'eth0': ['fd00::1']}},
+                True,
+            ),
+            (
+                'fe80::/10',
+                {'fe80::/10': {'eth0': ['fe80::1']}},
+                True,
+            ),
+            # IPv6 - invalid or no-match cases
+            (
+                'fd01::/64',
+                {'fd00::/64': {'eth0': ['fd00::1']}},
+                False,
+            ),
+            (
+                '::ffff:0:0/96',
+                {'192.168.1.0/24': {'eth0': ['192.168.1.1']}},
+                False,
+            ),
+        ])
+    def test_mon_net(self, mon_net, list_networks, result, cephadm_fs, funkypatch):
+        funkypatch.patch('cephadmlib.systemd.call')
+
+        cmd = self._get_cmd('--mon-net', mon_net)
+        if not result:
+            with bootstrap_test_ctx(cmd, list_networks=list_networks) as ctx:
+                msg = r'No local IP found in network'
+                with pytest.raises(_cephadm.Error, match=msg):
+                    _cephadm.command_bootstrap(ctx)
+        else:
+            with bootstrap_test_ctx(cmd, list_networks=list_networks) as ctx:
+                retval = _cephadm.command_bootstrap(ctx)
+                assert retval == 0
+
+    @pytest.mark.parametrize('invalid_cidr',
+        [
+            'invalid-cidr',           # No slashes, random text
+            '192.168.1.0/33',         # Invalid prefix length (> 32 for IPv4)
+            '192.168.1.0/256',        # Completely invalid prefix
+            '192.168.1.0/-1',         # Negative prefix
+            '256.256.256.256/24',     # Invalid IPv4 octets
+            '192.168.1/24',           # Incomplete IPv4
+            'fd00::/129',             # Invalid prefix length (> 128 for IPv6)
+            'gggg::/64',              # Invalid hex in IPv6
+            '192.168.1.0/',           # Missing prefix length
+            '/24',                    # Missing IP address
+            'not.a.network/24',       # Invalid format entirely
+            '192.168.1.0/24/32',      # Too many slashes
+        ])
+    def test_mon_net_invalid_cidr(self, invalid_cidr, cephadm_fs, funkypatch):
+        """Test --mon-net with various invalid CIDR formats"""
+        funkypatch.patch('cephadmlib.systemd.call')
+
+        cmd = self._get_cmd('--mon-net', invalid_cidr)
+        with bootstrap_test_ctx(cmd) as ctx:
+            msg = r'Invalid network CIDR'
+            with pytest.raises(_cephadm.Error, match=msg):
+                _cephadm.command_bootstrap(ctx)
+
+    def test_mon_net_mutually_exclusive_with_mon_ip(self, cephadm_fs, funkypatch):
+        """Test that --mon-net and --mon-ip are mutually exclusive"""
+        funkypatch.patch('cephadmlib.systemd.call')
+
+        cmd = self._get_cmd('--mon-net', '192.168.1.0/24', '--mon-ip', '192.168.1.1')
+        with pytest.raises(SystemExit):
+            with bootstrap_test_ctx(cmd) as ctx:
+                _cephadm.command_bootstrap(ctx)
+
+    def test_mon_net_mutually_exclusive_with_mon_addrv(self, cephadm_fs, funkypatch):
+        """Test that --mon-net and --mon-addrv are mutually exclusive"""
+        funkypatch.patch('cephadmlib.systemd.call')
+
+        cmd = self._get_cmd('--mon-net', '192.168.1.0/24', '--mon-addrv', '[192.168.1.1:1234]')
+        with pytest.raises(SystemExit):
+            with bootstrap_test_ctx(cmd) as ctx:
+                _cephadm.command_bootstrap(ctx)
+
+    def test_mon_net_with_public_network_overlap(self, cephadm_fs, funkypatch):
+        """Test --mon-net validation with overlapping public_network config"""
+        funkypatch.patch('cephadmlib.systemd.call')
+        
+        # Create a config file with public_network
+        conf_content = """[global]
+public_network = 192.168.1.0/24
+"""
+        cephadm_fs.create_file('ceph.conf', contents=conf_content)
+        
+        cmd = self._get_cmd(
+            '--mon-net', '192.168.1.0/24',
+            '--config', 'ceph.conf'
+        )
+        # Should succeed because --mon-net overlaps with public_network
+        with bootstrap_test_ctx(cmd, list_networks={'192.168.1.0/24': {'eth0': ['192.168.1.1']}}) as ctx:
+            retval = _cephadm.command_bootstrap(ctx)
+            assert retval == 0
+
+    def test_mon_net_with_public_network_no_overlap(self, cephadm_fs, funkypatch):
+        """Test --mon-net validation fails when not overlapping with public_network"""
+        funkypatch.patch('cephadmlib.systemd.call')
+        
+        # Create a config file with public_network in different subnet
+        conf_content = """[global]
+public_network = 10.0.0.0/24
+"""
+        cephadm_fs.create_file('ceph.conf', contents=conf_content)
+        
+        cmd = self._get_cmd(
+            '--mon-net', '192.168.1.0/24',
+            '--config', 'ceph.conf'
+        )
+        # Should fail because the IP selected from --mon-net does not belong to public_network
+        # Note: list_networks must include the public_network from config, or validation fails earlier
+        with bootstrap_test_ctx(cmd, list_networks={'10.0.0.0/24': {'eth1': ['10.0.0.1']}, '192.168.1.0/24': {'eth0': ['192.168.1.1']}}) as ctx:
+            msg = r'does not belong to any public_network'
+            with pytest.raises(_cephadm.Error, match=msg):
+                _cephadm.command_bootstrap(ctx)
+
+    def test_mon_net_with_public_network_partial_overlap(self, cephadm_fs, funkypatch):
+        """Test --mon-net validation succeeds with partial overlap of public_network"""
+        funkypatch.patch('cephadmlib.systemd.call')
+        
+        # Create a config with public_network, user uses --mon-net that overlaps part of it
+        conf_content = """[global]
+public_network = 192.168.0.0/16
+"""
+        cephadm_fs.create_file('ceph.conf', contents=conf_content)
+        
+        cmd = self._get_cmd(
+            '--mon-net', '192.168.1.0/24',
+            '--config', 'ceph.conf'
+        )
+        # Should succeed because 192.168.1.0/24 overlaps with 192.168.0.0/16
+        # Note: list_networks must include the public_network from config for local validation
+        with bootstrap_test_ctx(cmd, list_networks={'192.168.0.0/16': {'eth0': ['192.168.1.1']}, '192.168.1.0/24': {'eth0': ['192.168.1.1']}}) as ctx:
+            retval = _cephadm.command_bootstrap(ctx)
+            assert retval == 0
+
+    def test_mon_net_with_multiple_public_networks(self, cephadm_fs, funkypatch):
+        """Test --mon-net with multiple public_network entries"""
+        funkypatch.patch('cephadmlib.systemd.call')
+        
+        # Create config with multiple public networks
+        conf_content = """[global]
+public_network = 10.0.0.0/24, 192.168.1.0/24, 172.16.0.0/16
+"""
+        cephadm_fs.create_file('ceph.conf', contents=conf_content)
+        
+        cmd = self._get_cmd(
+            '--mon-net', '192.168.1.0/25',
+            '--config', 'ceph.conf'
+        )
+        # Should succeed because --mon-net overlaps with one of the public networks
+        with bootstrap_test_ctx(cmd, list_networks={'192.168.1.0/24': {'eth0': ['192.168.1.1']}}) as ctx:
+            retval = _cephadm.command_bootstrap(ctx)
+            assert retval == 0
+
+    def test_mon_net_ipv6_with_ipv4_public_network(self, cephadm_fs, funkypatch):
+        """Test --mon-net with IPv6 CIDR fails when public_network is IPv4 only"""
+        funkypatch.patch('cephadmlib.systemd.call')
+
+        conf_content = """[global]
+public_network = 192.168.1.0/24
+"""
+        cephadm_fs.create_file('ceph.conf', contents=conf_content)
+
+        cmd = self._get_cmd(
+            '--mon-net', 'fd00::/64',
+            '--config', 'ceph.conf'
+        )
+        # IPv6 and IPv4 networks never overlap; the selected IP won't belong to the IPv4 public_network
+        local_networks = {
+            'fd00::/64': {'eth0': ['fd00::1']},
+            '192.168.1.0/24': {'eth1': ['192.168.1.1']},
+        }
+        with bootstrap_test_ctx(cmd, list_networks=local_networks) as ctx:
+            with pytest.raises(_cephadm.Error, match=r'does not belong to any public_network'):
+                _cephadm.command_bootstrap(ctx)
+
+    def test_mon_net_ipv4_with_ipv6_public_network(self, cephadm_fs, funkypatch):
+        """Test --mon-net with IPv4 CIDR fails when public_network is IPv6 only"""
+        funkypatch.patch('cephadmlib.systemd.call')
+
+        conf_content = """[global]
+public_network = fd00::/64
+"""
+        cephadm_fs.create_file('ceph.conf', contents=conf_content)
+
+        cmd = self._get_cmd(
+            '--mon-net', '192.168.1.0/24',
+            '--config', 'ceph.conf'
+        )
+        # IPv4 and IPv6 networks never overlap; the selected IP won't belong to the IPv6 public_network
+        local_networks = {
+            '192.168.1.0/24': {'eth0': ['192.168.1.1']},
+            'fd00::/64': {'eth1': ['fd00::1']},
+        }
+        with bootstrap_test_ctx(cmd, list_networks=local_networks) as ctx:
+            with pytest.raises(_cephadm.Error, match=r'does not belong to any public_network'):
+                _cephadm.command_bootstrap(ctx)
 
     @pytest.mark.parametrize('fsid, err',
         [


### PR DESCRIPTION
When bootstrapping a Ceph cluster, users can now specify --mon-net with a CIDR network (e.g., 192.168.1.0/24) instead of providing a specific --mon-ip address. The cephadm bootstrap command will automatically select the first available IP from the specified network and validate it against the configured public_network.

What was changed:
- Added --mon-net argument to bootstrap command parser as mutually exclusive with
  --mon-ip and --mon-addrv
- Implemented select_ip_from_network() function to find a suitable IP within a
  given CIDR network from local network interfaces

Fixes: https://tracker.ceph.com/issues/75390

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
