### PR TITLE
rgw/dedup: add --allow/deny-bucket-list and --allow/deny-storage-clas…

### DIFF
--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -34,6 +34,49 @@ Admin Commands
    Displays dedup throttle setting.
 
 
+Allow/Deny Filtering
+====================
+
+The ``dedup estimate`` and ``dedup exec`` commands support optional allow/deny
+filters for buckets and storage classes. These filters control which buckets
+and which storage classes participate in the dedup process.
+
+Allow and deny lists are **mutually exclusive** for each category:
+
+- **Allow mode** -- everything is excluded except items listed in the file.
+- **Deny mode** -- everything is included except items listed in the file.
+
+The filter files contain one name per line. Blank lines and lines starting
+with ``#`` are ignored. Only whitespace is permitted after the name on the
+same line.
+
+Bucket names are validated against RGW/S3 bucket naming rules (relaxed mode).
+Storage-class names must contain only uppercase letters, digits, and
+underscores (e.g. ``STANDARD``, ``REDUCED_REDUNDANCY``).
+
+.. prompt:: bash #
+
+   radosgw-admin dedup estimate --allow-bucket-list=<path-to-file>
+
+.. prompt:: bash #
+
+   radosgw-admin dedup estimate --deny-bucket-list=<path-to-file>
+
+.. prompt:: bash #
+
+   radosgw-admin dedup estimate --allow-storage-class-list=<path-to-file>
+
+.. prompt:: bash #
+
+   radosgw-admin dedup estimate --deny-storage-class-list=<path-to-file>
+
+Multiple filters can be combined (one per category):
+
+.. prompt:: bash #
+
+   radosgw-admin dedup estimate --allow-bucket-list=<bucket-file> --deny-storage-class-list=<sc-file>
+
+
 Skipped Objects
 ===============
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -238,6 +238,7 @@ if(WITH_RADOSGW_RADOS)
           driver/rados/rgw_dedup_store.cc
           driver/rados/rgw_dedup_utils.cc
           driver/rados/rgw_dedup_cluster.cc
+          driver/rados/rgw_dedup_filter.cc
 	  rgw_coroutine.cc
 	)
 endif()

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -2291,11 +2291,16 @@ namespace rgw::dedup {
     p_worker_stats->ingress_obj++;
     p_worker_stats->ingress_obj_bytes += ondisk_byte_size;
 
-    // We limit dedup to objects from the same storage_class
-    // TBD-Future:
-    // Should we use a skip-list of storage_classes we should skip (like glacier) ?
     const std::string& storage_class =
       rgw_placement_rule::get_canonical_storage_class(entry.meta.storage_class);
+
+    if (!d_filter.storage_class_allowed(storage_class)) {
+      ldpp_dout(dpp, 10) << __func__ << "::skipping object " << entry.key.name
+                         << " with storage_class " << storage_class
+                         << " (filtered)" << dendl;
+      return 0;
+    }
+
     if (storage_class == RGW_STORAGE_CLASS_STANDARD) {
       p_worker_stats->default_storage_class_objs++;
       p_worker_stats->default_storage_class_objs_bytes += ondisk_byte_size;
@@ -2685,6 +2690,11 @@ namespace rgw::dedup {
             goto err;
           }
           ldpp_dout(dpp, 20) <<__func__ << "::bucket=" << bucket << dendl;
+          if (!d_filter.bucket_allowed(bucket.name)) {
+            ldpp_dout(dpp, 10) << __func__ << "::skipping bucket "
+                               << bucket.name << " (filtered)" << dendl;
+            continue;
+          }
           ret = read_bucket_stats(bucket, &d_all_buckets_obj_count,
                                   &d_all_buckets_obj_size);
           if (unlikely(ret != 0)) {
@@ -2754,6 +2764,11 @@ namespace rgw::dedup {
             continue;
           }
           ldpp_dout(dpp, 20) <<__func__ << "::bucket=" << bucket << dendl;
+          if (!d_filter.bucket_allowed(bucket.name)) {
+            ldpp_dout(dpp, 10) << __func__ << "::skipping bucket "
+                               << bucket.name << " (filtered)" << dendl;
+            continue;
+          }
           ret = ingress_bucket_objects_single_shard(disk_arr, bucket, worker_id,
                                                     num_work_shards, p_worker_stats);
           if (unlikely(ret != 0)) {
@@ -3042,6 +3057,13 @@ namespace rgw::dedup {
     ceph_assert(d_ctl.dedup_type == dedup_req_type_t::DEDUP_TYPE_ESTIMATE);
 #endif
     ldpp_dout(dpp, 10) << __func__ << "::" << d_ctl.dedup_type << dendl;
+
+    // load allow/deny filter lists from the control pool
+    ret = cluster::load_dedup_filter(store, dpp, &d_filter);
+    if (ret != 0) {
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to load dedup filter" << dendl;
+      return ret;
+    }
 
     return 0;
   }

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -269,6 +269,7 @@ namespace rgw::dedup {
     uint32_t d_max_obj_size_for_split = (16ULL * 1024 * 1024);
     uint32_t d_head_object_size       = (4ULL * 1024 * 1024);
     control_t d_ctl;
+    dedup_filter_t d_filter;
     uint64_t d_watch_handle = 0;
     DedupWatcher d_watcher_ctx;
 

--- a/src/rgw/driver/rados/rgw_dedup_cluster.cc
+++ b/src/rgw/driver/rados/rgw_dedup_cluster.cc
@@ -37,6 +37,7 @@
 namespace rgw::dedup {
   const char* DEDUP_EPOCH_TOKEN = "EPOCH_TOKEN";
   const char* DEDUP_WATCH_OBJ = "DEDUP_WATCH_OBJ";
+  const char* DEDUP_FILTER_ATTR = "rgw.dedup.attr.filter";
 
   static constexpr unsigned EPOCH_MAX_LOCK_DURATION_SEC = 30;
   struct shard_progress_t;
@@ -1297,7 +1298,8 @@ namespace rgw::dedup {
   // command-line called from radosgw-admin.cc
   int cluster::dedup_restart_scan(rgw::sal::RadosStore *store,
                                   dedup_req_type_t dedup_type,
-                                  const DoutPrefixProvider *dpp)
+                                  const DoutPrefixProvider *dpp,
+                                  const dedup_filter_t& filter)
   {
     ldpp_dout(dpp, 1) << __func__ << "::dedup_type = " << dedup_type << dendl;
 
@@ -1336,6 +1338,32 @@ namespace rgw::dedup {
 #else
     ceph_assert(dedup_type == dedup_req_type_t::DEDUP_TYPE_ESTIMATE);
 #endif
+
+    // store filter lists in the control pool
+    {
+      librados::IoCtx ctl_ioctx;
+      ret = get_control_ioctx(store, dpp, ctl_ioctx);
+      if (ret != 0) {
+        return ret;
+      }
+      bufferlist filter_bl;
+      encode(filter, filter_bl);
+      librados::ObjectWriteOperation op;
+      std::string oid(DEDUP_EPOCH_TOKEN);
+      op.setxattr(DEDUP_FILTER_ATTR, filter_bl);
+      ret = ctl_ioctx.operate(oid, &op);
+      if (ret != 0) {
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to store dedup filter: "
+                          << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
+      ldpp_dout(dpp, 5) << __func__ << "::stored dedup filter: bucket_mode="
+                        << filter.bucket_mode << ", bucket_list_size="
+                        << filter.bucket_list.size() << ", sc_mode="
+                        << filter.storage_class_mode << ", sc_list_size="
+                        << filter.storage_class_list.size() << dendl;
+    }
+
     ret = swap_epoch(store, dpp, &old_epoch, dedup_type, 0, 0);
     if (ret == 0) {
       ldpp_dout(dpp, 10) << __func__ << "::Epoch object was reset" << dendl;
@@ -1344,6 +1372,48 @@ namespace rgw::dedup {
     else {
       return ret;
     }
+  }
+
+  //---------------------------------------------------------------------------
+  int cluster::load_dedup_filter(rgw::sal::RadosStore *store,
+                                 const DoutPrefixProvider *dpp,
+                                 dedup_filter_t *p_filter)
+  {
+    librados::IoCtx ctl_ioctx;
+    int ret = get_control_ioctx(store, dpp, ctl_ioctx);
+    if (ret != 0) {
+      return ret;
+    }
+
+    std::string oid(DEDUP_EPOCH_TOKEN);
+    bufferlist bl;
+    ret = ctl_ioctx.getxattr(oid, DEDUP_FILTER_ATTR, bl);
+    if (ret < 0) {
+      if (ret == -ENODATA || ret == -ENOENT) {
+        *p_filter = dedup_filter_t();
+        return 0;
+      }
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to read dedup filter: "
+                        << cpp_strerror(-ret) << dendl;
+      return ret;
+    }
+
+    auto iter = bl.cbegin();
+    try {
+      decode(*p_filter, iter);
+    } catch (const ceph::buffer::error &e) {
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to decode dedup filter: "
+                        << e.what() << dendl;
+      *p_filter = dedup_filter_t();
+      return -EIO;
+    }
+
+    ldpp_dout(dpp, 5) << __func__ << "::loaded dedup filter: bucket_mode="
+                      << p_filter->bucket_mode << ", bucket_list_size="
+                      << p_filter->bucket_list.size() << ", sc_mode="
+                      << p_filter->storage_class_mode << ", sc_list_size="
+                      << p_filter->storage_class_list.size() << dendl;
+    return 0;
   }
 
   //---------------------------------------------------------------------------

--- a/src/rgw/driver/rados/rgw_dedup_cluster.h
+++ b/src/rgw/driver/rados/rgw_dedup_cluster.h
@@ -15,6 +15,7 @@
 #pragma once
 #include "common/dout.h"
 #include "rgw_dedup_utils.h"
+#include "rgw_dedup_filter.h"
 #include "rgw_dedup_store.h"
 #include <string>
 
@@ -101,7 +102,11 @@ namespace rgw::dedup {
                                urgent_msg_t urgent_msg);
     static int   dedup_restart_scan(rgw::sal::RadosStore *store,
                                     dedup_req_type_t dedup_type,
-                                    const DoutPrefixProvider *dpp);
+                                    const DoutPrefixProvider *dpp,
+                                    const dedup_filter_t& filter = {});
+    static int   load_dedup_filter(rgw::sal::RadosStore *store,
+                                   const DoutPrefixProvider *dpp,
+                                   dedup_filter_t *p_filter /*OUT*/);
 
     //---------------------------------------------------------------------------
     int mark_work_shard_token_completed(rgw::sal::RadosStore *store,

--- a/src/rgw/driver/rados/rgw_dedup_filter.cc
+++ b/src/rgw/driver/rados/rgw_dedup_filter.cc
@@ -1,0 +1,155 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2;
+// vim: ts=8 sw=2 sts=2 expandtab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Author: Gabriel BenHanokh <gbenhano@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw_dedup_filter.h"
+#include "rgw_rest_s3.h"
+
+#include <cctype>
+#include <fstream>
+#include <iostream>
+
+namespace rgw::dedup {
+
+  //---------------------------------------------------------------------------
+  static int valid_bucket_name(const std::string& name)
+  {
+    return valid_s3_bucket_name(name, true /* relaxed */);
+  }
+
+  //---------------------------------------------------------------------------
+  static int valid_storage_class_name(const std::string& name)
+  {
+    if (name.empty() || name.size() > 128) {
+      return -EINVAL;
+    }
+    for (char c : name) {
+      if (!(std::isupper(c) || std::isdigit(c) || c == '_')) {
+        return -EINVAL;
+      }
+    }
+    return 0;
+  }
+
+  //---------------------------------------------------------------------------
+  // Parse a file containing one name per line.  Trailing whitespace after the
+  // name is allowed; any other content on the line is rejected.
+  // @validator is called on each trimmed name; it must return 0 on success.
+  static int parse_name_list_file(
+      const std::string& path,
+      int (*validator)(const std::string&),
+      std::set<std::string>& out)
+  {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+      std::cerr << "ERROR: failed to open file: " << path << std::endl;
+      return -ENOENT;
+    }
+
+    std::string line;
+    int line_num = 0;
+    while (std::getline(f, line)) {
+      line_num++;
+
+      if (line.empty() || line[0] == '#') {
+        continue;
+      }
+
+      auto name_end = line.find_first_of(" \t\r");
+      std::string name = (name_end == std::string::npos)
+                         ? line : line.substr(0, name_end);
+
+      if (name_end != std::string::npos) {
+        auto non_ws = line.find_first_not_of(" \t\r", name_end);
+        if (non_ws != std::string::npos) {
+          std::cerr << "ERROR: " << path << ":" << line_num
+                    << ": unexpected content after name '" << name << "'"
+                    << std::endl;
+          return -EINVAL;
+        }
+      }
+
+      if (name.empty()) {
+        continue;
+      }
+
+      int ret = validator(name);
+      if (ret != 0) {
+        std::cerr << "ERROR: " << path << ":" << line_num
+                  << ": invalid name '" << name << "'" << std::endl;
+        return ret;
+      }
+
+      out.insert(std::move(name));
+    }
+
+    if (out.empty()) {
+      std::cerr << "ERROR: " << path << ": file contains no valid entries"
+                << std::endl;
+      return -EINVAL;
+    }
+
+    return 0;
+  }
+
+  //---------------------------------------------------------------------------
+  dedup_filter_t::dedup_filter_t(const std::string& allow_bucket_file,
+                                 const std::string& deny_bucket_file,
+                                 const std::string& allow_sc_file,
+                                 const std::string& deny_sc_file,
+                                 int& init_result)
+  {
+    init_result = 0;
+
+    if (!allow_bucket_file.empty() && !deny_bucket_file.empty()) {
+      std::cerr << "ERROR: --allow-bucket-list and --deny-bucket-list"
+                   " are mutually exclusive" << std::endl;
+      init_result = -EINVAL;
+      return;
+    }
+    if (!allow_sc_file.empty() && !deny_sc_file.empty()) {
+      std::cerr << "ERROR: --allow-storage-class-list and"
+                   " --deny-storage-class-list are mutually exclusive"
+                << std::endl;
+      init_result = -EINVAL;
+      return;
+    }
+
+    if (!allow_bucket_file.empty()) {
+      init_result = parse_name_list_file(allow_bucket_file,
+                                         valid_bucket_name, bucket_list);
+      if (init_result != 0) return;
+      bucket_mode = filter_mode_t::FILTER_ALLOW;
+    } else if (!deny_bucket_file.empty()) {
+      init_result = parse_name_list_file(deny_bucket_file,
+                                         valid_bucket_name, bucket_list);
+      if (init_result != 0) return;
+      bucket_mode = filter_mode_t::FILTER_DENY;
+    }
+
+    if (!allow_sc_file.empty()) {
+      init_result = parse_name_list_file(allow_sc_file,
+                                         valid_storage_class_name,
+                                         storage_class_list);
+      if (init_result != 0) return;
+      storage_class_mode = filter_mode_t::FILTER_ALLOW;
+    } else if (!deny_sc_file.empty()) {
+      init_result = parse_name_list_file(deny_sc_file,
+                                         valid_storage_class_name,
+                                         storage_class_list);
+      if (init_result != 0) return;
+      storage_class_mode = filter_mode_t::FILTER_DENY;
+    }
+  }
+
+} //namespace rgw::dedup

--- a/src/rgw/driver/rados/rgw_dedup_filter.h
+++ b/src/rgw/driver/rados/rgw_dedup_filter.h
@@ -1,0 +1,104 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2;
+// vim: ts=8 sw=2 sts=2 expandtab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Author: Gabriel BenHanokh <gbenhano@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <set>
+#include <string>
+
+#include "include/encoding.h"
+
+namespace rgw::dedup {
+
+  enum class filter_mode_t : uint8_t {
+    FILTER_NONE  = 0,
+    FILTER_ALLOW = 1,
+    FILTER_DENY  = 2
+  };
+
+  inline std::ostream& operator<<(std::ostream &out, filter_mode_t mode) {
+    switch (mode) {
+      case filter_mode_t::FILTER_NONE:  out << "NONE";  break;
+      case filter_mode_t::FILTER_ALLOW: out << "ALLOW"; break;
+      case filter_mode_t::FILTER_DENY:  out << "DENY";  break;
+    }
+    return out;
+  }
+
+  //---------------------------------------------------------------------------
+  struct dedup_filter_t {
+    filter_mode_t bucket_mode = filter_mode_t::FILTER_NONE;
+    filter_mode_t storage_class_mode = filter_mode_t::FILTER_NONE;
+    std::set<std::string> bucket_list;
+    std::set<std::string> storage_class_list;
+
+    // default ctor -- no filtering (used by decode and by workers)
+    dedup_filter_t() = default;
+
+    // construct from CLI file paths; sets @init_result to 0 on success
+    dedup_filter_t(const std::string& allow_bucket_file,
+                   const std::string& deny_bucket_file,
+                   const std::string& allow_sc_file,
+                   const std::string& deny_sc_file,
+                   int& init_result);
+
+    bool bucket_allowed(const std::string& bucket_name) const {
+      switch (bucket_mode) {
+        case filter_mode_t::FILTER_ALLOW:
+          return bucket_list.count(bucket_name) > 0;
+        case filter_mode_t::FILTER_DENY:
+          return bucket_list.count(bucket_name) == 0;
+        default:
+          return true;
+      }
+    }
+
+    bool storage_class_allowed(const std::string& sc) const {
+      switch (storage_class_mode) {
+        case filter_mode_t::FILTER_ALLOW:
+          return storage_class_list.count(sc) > 0;
+        case filter_mode_t::FILTER_DENY:
+          return storage_class_list.count(sc) == 0;
+        default:
+          return true;
+      }
+    }
+  };
+
+  //---------------------------------------------------------------------------
+  inline void encode(const dedup_filter_t& f, ceph::bufferlist& bl)
+  {
+    ENCODE_START(1, 1, bl);
+    encode(static_cast<uint8_t>(f.bucket_mode), bl);
+    encode(static_cast<uint8_t>(f.storage_class_mode), bl);
+    encode(f.bucket_list, bl);
+    encode(f.storage_class_list, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  //---------------------------------------------------------------------------
+  inline void decode(dedup_filter_t& f, ceph::bufferlist::const_iterator& bl)
+  {
+    DECODE_START(1, bl);
+    uint8_t bm, sm;
+    decode(bm, bl);
+    decode(sm, bl);
+    f.bucket_mode = static_cast<filter_mode_t>(bm);
+    f.storage_class_mode = static_cast<filter_mode_t>(sm);
+    decode(f.bucket_list, bl);
+    decode(f.storage_class_list, bl);
+    DECODE_FINISH(bl);
+  }
+
+} //namespace rgw::dedup

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -82,6 +82,7 @@ extern "C" {
 #include "rgw_account.h"
 #include "rgw_bucket_logging.h"
 #include "rgw_dedup_cluster.h"
+#include "rgw_dedup_filter.h"
 #include "services/svc_sync_modules.h"
 #include "services/svc_cls.h"
 #include "services/svc_bilog_rados.h"
@@ -497,6 +498,11 @@ void usage()
   cout << "   --disable-feature                 disable a zone/zonegroup feature\n";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
+  cout << "\nDedup filter options:\n";
+  cout << "   --allow-bucket-list           path to file listing bucket names to include in dedup (mutually exclusive with --deny-bucket-list)\n";
+  cout << "   --deny-bucket-list            path to file listing bucket names to exclude from dedup (mutually exclusive with --allow-bucket-list)\n";
+  cout << "   --allow-storage-class-list    path to file listing storage classes to include in dedup (mutually exclusive with --deny-storage-class-list)\n";
+  cout << "   --deny-storage-class-list     path to file listing storage classes to exclude from dedup (mutually exclusive with --allow-storage-class-list)\n";
   cout << "\nDedup throttle options:\n";
   cout << "   --max-bucket-index-ops        specify max bucket-index requests per second allowed for an RGW during dedup, 0 means unlimited\n";
   cout << "   --max-metadata-ops            specify max metadata requests per second allowed for an RGW during dedup, 0 means unlimited\n";
@@ -3742,6 +3748,10 @@ int main(int argc, const char **argv)
   bool have_max_read_bytes = false;
   bool have_max_bucket_index_ops = false;
   bool have_max_metadata_ops = false;
+  string allow_bucket_list_file;
+  string deny_bucket_list_file;
+  string allow_storage_class_list_file;
+  string deny_storage_class_list_file;
   int include_all = false;
   int allow_unordered = false;
 
@@ -4080,6 +4090,14 @@ int main(int argc, const char **argv)
 	return EINVAL;
       }
       have_max_metadata_ops = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "--allow-bucket-list", (char*)NULL)) {
+      allow_bucket_list_file = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--deny-bucket-list", (char*)NULL)) {
+      deny_bucket_list_file = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--allow-storage-class-list", (char*)NULL)) {
+      allow_storage_class_list_file = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--deny-storage-class-list", (char*)NULL)) {
+      deny_storage_class_list_file = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--date", "--time", (char*)NULL)) {
       date = val;
       if (end_date.empty())
@@ -9406,7 +9424,15 @@ next:
 #endif
       }
 
-      int ret = cluster::dedup_restart_scan(store, dedup_type, dpp());
+      int ret;
+      dedup_filter_t filter(allow_bucket_list_file, deny_bucket_list_file,
+			    allow_storage_class_list_file,
+			    deny_storage_class_list_file, ret);
+      if (ret != 0) {
+	return -ret;
+      }
+
+      ret = cluster::dedup_restart_scan(store, dedup_type, dpp(), filter);
       if (ret == 0) {
 	std::cout << "Dedup was restarted successfully" << std::endl;
       }

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -358,6 +358,12 @@
   
   <date> := "YYYY-MM-DD[ hh:mm:ss]"
   
+  Dedup filter options:
+     --allow-bucket-list           path to file listing bucket names to include in dedup (mutually exclusive with --deny-bucket-list)
+     --deny-bucket-list            path to file listing bucket names to exclude from dedup (mutually exclusive with --allow-bucket-list)
+     --allow-storage-class-list    path to file listing storage classes to include in dedup (mutually exclusive with --deny-storage-class-list)
+     --deny-storage-class-list     path to file listing storage classes to exclude from dedup (mutually exclusive with --allow-storage-class-list)
+  
   Dedup throttle options:
      --max-bucket-index-ops        specify max bucket-index requests per second allowed for an RGW during dedup, 0 means unlimited
      --max-metadata-ops            specify max metadata requests per second allowed for an RGW during dedup, 0 means unlimited


### PR DESCRIPTION
…s-list to dedup commands





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
