### PR TITLE
squid: test/rgw: remove depracated boto dependency

### DIFF
--- a/src/test/rgw/bucket_notification/api.py
+++ b/src/test/rgw/bucket_notification/api.py
@@ -10,11 +10,245 @@ from urllib import parse as urlparse
 from time import gmtime, strftime
 import boto3
 from botocore.client import Config
+from botocore.exceptions import ClientError
 import os
 import subprocess
 import json
 
 log = logging.getLogger('bucket_notification.tests')
+
+
+# Boto3 compatibility wrapper classes to minimize code changes
+class S3Key:
+    """Wrapper class to provide boto-like interface for S3 objects using boto3"""
+    def __init__(self, bucket, key_name, s3_client):
+        self.bucket = bucket
+        self.name = key_name
+        self.key = key_name
+        self._s3_client = s3_client
+        self._metadata = {}
+        self.etag = None
+        self.version_id = None
+
+    def set_contents_from_string(self, content):
+        """Upload object content"""
+        kwargs = {
+            'Bucket': self.bucket.name,
+            'Key': self.name,
+            'Body': content
+        }
+        if self._metadata:
+            kwargs['Metadata'] = self._metadata
+
+        response = self._s3_client.put_object(**kwargs)
+        self.etag = response['ETag']
+        if 'VersionId' in response:
+            self.version_id = response['VersionId']
+        return response
+
+    def set_metadata(self, key, value):
+        """Set metadata for the object"""
+        self._metadata[key] = value
+
+    def delete(self):
+        """Delete the object"""
+        kwargs = {'Bucket': self.bucket.name, 'Key': self.name}
+        if self.version_id:
+            kwargs['VersionId'] = self.version_id
+        return self._s3_client.delete_object(**kwargs)
+
+
+class S3Bucket:
+    """Wrapper class to provide boto-like interface for S3 buckets using boto3"""
+    def __init__(self, connection, bucket_name):
+        self.connection = connection
+        self.name = bucket_name
+        self._s3_client = connection._s3_client
+        self._s3_resource = connection._s3_resource
+        self._bucket = self._s3_resource.Bucket(bucket_name)
+
+    def new_key(self, key_name):
+        """Create a new key object"""
+        return S3Key(self, key_name, self._s3_client)
+
+    def list(self, prefix=''):
+        """List objects in the bucket"""
+        try:
+            if prefix:
+                objects = self._bucket.objects.filter(Prefix=prefix)
+            else:
+                objects = self._bucket.objects.all()
+
+            # Convert to S3Key objects for compatibility
+            keys = []
+            for obj in objects:
+                key = S3Key(self, obj.key, self._s3_client)
+                key.etag = obj.e_tag
+                if hasattr(obj, 'version_id'):
+                    key.version_id = obj.version_id
+                keys.append(key)
+            return keys
+        except Exception:
+            # Return empty list if bucket is empty or error occurs
+            return []
+
+    def delete_key(self, key_name, version_id=None):
+        """Delete a specific key"""
+        kwargs = {'Bucket': self.name, 'Key': key_name}
+        if version_id:
+            kwargs['VersionId'] = version_id
+        response = self._s3_client.delete_object(**kwargs)
+        # Return a key-like object with version_id for compatibility
+        deleted_key = S3Key(self, key_name, self._s3_client)
+        if 'VersionId' in response:
+            deleted_key.version_id = response['VersionId']
+        if 'DeleteMarker' in response:
+            deleted_key.delete_marker = response['DeleteMarker']
+        return deleted_key
+
+    def copy_key(self, new_key_name, src_bucket_name, src_key_name, src_version_id=None, metadata=None):
+        """Copy a key within or between buckets"""
+        copy_source = {'Bucket': src_bucket_name, 'Key': src_key_name}
+        if src_version_id:
+            copy_source['VersionId'] = src_version_id
+
+        kwargs = {
+            'CopySource': copy_source,
+            'Bucket': self.name,
+            'Key': new_key_name
+        }
+
+        if metadata is not None:
+            kwargs['Metadata'] = metadata
+            kwargs['MetadataDirective'] = 'REPLACE'
+
+        response = self._s3_client.copy_object(**kwargs)
+
+        # Return a key object for compatibility
+        new_key = S3Key(self, new_key_name, self._s3_client)
+        if 'CopyObjectResult' in response and 'ETag' in response['CopyObjectResult']:
+            new_key.etag = response['CopyObjectResult']['ETag']
+        if 'VersionId' in response:
+            new_key.version_id = response['VersionId']
+        return new_key
+
+    def configure_versioning(self, enabled):
+        """Enable or disable versioning on the bucket"""
+        status = 'Enabled' if enabled else 'Suspended'
+        self._s3_client.put_bucket_versioning(
+            Bucket=self.name,
+            VersioningConfiguration={'Status': status}
+        )
+
+    def initiate_multipart_upload(self, key_name, metadata=None):
+        """Initiate a multipart upload"""
+        kwargs = {'Bucket': self.name, 'Key': key_name}
+        if metadata:
+            kwargs['Metadata'] = metadata
+
+        response = self._s3_client.create_multipart_upload(**kwargs)
+        return MultipartUpload(self, key_name, response['UploadId'], self._s3_client)
+
+
+class MultipartUpload:
+    """Wrapper for multipart upload operations"""
+    def __init__(self, bucket, key_name, upload_id, s3_client):
+        self.bucket = bucket
+        self.key_name = key_name
+        self.upload_id = upload_id
+        self._s3_client = s3_client
+        self.parts = []
+
+    def upload_part_from_file(self, fp, part_number, size=None):
+        """Upload a part from a file object"""
+        if size:
+            data = fp.read(size)
+        else:
+            data = fp.read()
+
+        response = self._s3_client.upload_part(
+            Bucket=self.bucket.name,
+            Key=self.key_name,
+            PartNumber=part_number,
+            UploadId=self.upload_id,
+            Body=data
+        )
+
+        self.parts.append({
+            'PartNumber': part_number,
+            'ETag': response['ETag']
+        })
+
+    def complete_upload(self):
+        """Complete the multipart upload"""
+        # Sort parts by part number
+        self.parts.sort(key=lambda x: x['PartNumber'])
+
+        response = self._s3_client.complete_multipart_upload(
+            Bucket=self.bucket.name,
+            Key=self.key_name,
+            UploadId=self.upload_id,
+            MultipartUpload={'Parts': self.parts}
+        )
+        return response
+
+
+class S3Connection:
+    """Wrapper class to provide boto-like S3Connection interface using boto3"""
+    def __init__(self, aws_access_key_id, aws_secret_access_key,
+                 is_secure=True, port=None, host=None, calling_format=None):
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.access_key = aws_access_key_id  # Boto compatibility
+        self.secret_key = aws_secret_access_key  # Boto compatibility
+        self.is_secure = is_secure
+        self.port = port
+        self.host = host
+        self.num_retries = 5  # Default for compatibility
+
+        # Build endpoint URL
+        protocol = 'https' if is_secure else 'http'
+        self.endpoint_url = f'{protocol}://{host}:{port}'
+
+        # Create boto3 client and resource
+        self._s3_client = boto3.client(
+            's3',
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            config=boto3.session.Config(retries={'max_attempts': self.num_retries})
+        )
+
+        self._s3_resource = boto3.resource(
+            's3',
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key
+        )
+
+        # For SSL connections
+        self.secure_conn = self if is_secure else None
+
+    def create_bucket(self, bucket_name, **kwargs):
+        """Create a bucket"""
+        acl = kwargs.get('ACL', 'private')
+        try:
+            self._s3_client.create_bucket(Bucket=bucket_name, ACL=acl)
+        except ClientError as e:
+            # Bucket might already exist
+            if e.response['Error']['Code'] != 'BucketAlreadyOwnedByYou':
+                raise
+        return S3Bucket(self, bucket_name)
+
+    def get_bucket(self, bucket_name):
+        """Get a bucket object"""
+        return S3Bucket(self, bucket_name)
+
+    def delete_bucket(self, bucket_name):
+        """Delete a bucket"""
+        return self._s3_client.delete_bucket(Bucket=bucket_name)
+
+
 
 NO_HTTP_BODY = ''
 

--- a/src/test/rgw/bucket_notification/requirements.txt
+++ b/src/test/rgw/bucket_notification/requirements.txt
@@ -1,5 +1,4 @@
-pynose
-boto >=2.6.0
+nose-py3 >=1.0.0
 boto3 >=1.0.0
 configparser >=5.0.0
 kafka-python >=2.0.0

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -9,8 +9,7 @@ import time
 import os
 import io
 import string
-# XXX this should be converted to use boto3
-import boto
+import sys
 from botocore.exceptions import ClientError
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from random import randint
@@ -18,7 +17,6 @@ import hashlib
 # XXX this should be converted to use pytest
 from nose.plugins.attrib import attr
 import boto3
-from boto.s3.connection import S3Connection
 import datetime
 from cloudevents.http import from_http
 from dateutil import parser
@@ -38,11 +36,14 @@ from .api import PSTopicS3, \
     delete_all_objects, \
     delete_all_topics, \
     put_object_tagging, \
-    admin
+    admin, \
+    S3Connection, \
+    S3Bucket, \
+    S3Key, \
+    MultipartUpload
 
 from nose import SkipTest
-from nose.tools import assert_not_equal, assert_equal, assert_in, assert_true
-import boto.s3.tagging
+from nose.tools import assert_not_equal, assert_equal, assert_in, assert_not_in, assert_true
 
 # configure logging for the tests module
 class LogWrapper:
@@ -507,8 +508,7 @@ def connection():
 
     conn = S3Connection(aws_access_key_id=vstart_access_key,
                   aws_secret_access_key=vstart_secret_key,
-                      is_secure=False, port=port_no, host=hostname, 
-                      calling_format='boto.s3.connection.OrdinaryCallingFormat')
+                      is_secure=False, port=port_no, host=hostname)
 
     return conn
 
@@ -521,8 +521,7 @@ def connection2():
 
     conn = S3Connection(aws_access_key_id=vstart_access_key,
                   aws_secret_access_key=vstart_secret_key,
-                      is_secure=False, port=port_no, host=hostname, 
-                      calling_format='boto.s3.connection.OrdinaryCallingFormat')
+                      is_secure=False, port=port_no, host=hostname)
 
     return conn
 
@@ -545,8 +544,7 @@ def another_user(user=None, tenant=None, account=None):
 
     conn = S3Connection(aws_access_key_id=access_key,
                   aws_secret_access_key=secret_key,
-                      is_secure=False, port=get_config_port(), host=get_config_host(), 
-                      calling_format='boto.s3.connection.OrdinaryCallingFormat')
+                      is_secure=False, port=get_config_port(), host=get_config_host())
     return conn, arn
 
 
@@ -3100,7 +3098,7 @@ def test_ps_s3_versioning_on_master():
     s3_notification_conf.del_config()
     topic_conf.del_config()
     # delete the bucket
-    bucket.delete_key(copy_of_key, version_id=ver3)
+    bucket.delete_key(copy_of_key.name, version_id=ver3)
     bucket.delete_key(key.name, version_id=ver2)
     bucket.delete_key(key.name, version_id=ver1)
     #conn.delete_bucket(bucket_name)
@@ -5798,3 +5796,4 @@ def test_connection_caching():
         stop_kafka_receiver(receiver_1, task_1)
     if receiver_2 is not None:
         stop_kafka_receiver(receiver_2, task_2)
+


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75370

(cherry picked from commit 8e9c77160d5cae2f6bd6d97a2ecdabb9ae9530bd)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
