### PR TITLE
mgr/dashboard : fix-non-versioning-bucket-issue

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -204,7 +204,7 @@ class RgwBucketTest(RgwTestCase):
         self.assertEqual(data['bucket'], 'teuth-test-bucket')
         self.assertEqual(data['owner'], 'admin')
         self.assertEqual(data['placement_rule'], 'default-placement')
-        self.assertEqual(data['versioning'], 'Suspended')
+        self.assertEqual(data['versioning'], 'Off')
 
         # Update bucket: change owner, enable versioning.
         self._put(
@@ -312,7 +312,7 @@ class RgwBucketTest(RgwTestCase):
         # Get the bucket.
         data = _verify_tenant_bucket('teuth-test-bucket', 'testx', 'teuth-test-user')
         self.assertEqual(data['placement_rule'], 'default-placement')
-        self.assertEqual(data['versioning'], 'Suspended')
+        self.assertEqual(data['versioning'], 'Off')
 
         # Update bucket: different user with different tenant, enable versioning.
         self._put(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-bucket-versioning.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-bucket-versioning.ts
@@ -1,4 +1,5 @@
 export enum RgwBucketVersioning {
   ENABLED = 'Enabled',
-  SUSPENDED = 'Suspended'
+  SUSPENDED = 'Suspended',
+  OFF = 'Off'
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -68,6 +68,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
   placementTargets: object[] = [];
   isVersioningAlreadyEnabled = false;
   isMfaDeleteAlreadyEnabled = false;
+  initialVersioningStatus: string | null = null;
   icons = Icons;
   kmsConfigured = false;
   s3Configured = false;
@@ -267,6 +268,9 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
 
         if (data['getBid']) {
           const bidResp = data['getBid'];
+          if (this.editing) {
+            this.initialVersioningStatus = bidResp['versioning'] ?? null;
+          }
           // Get the default values (incl. the values from disabled fields).
           const defaults = _.clone(this.bucketForm.getRawValue());
 
@@ -526,8 +530,14 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
     mfaTokenPinControl.updateValueAndValidity();
   }
 
-  getVersioningStatus() {
-    return this.isVersioningEnabled ? RgwBucketVersioning.ENABLED : RgwBucketVersioning.SUSPENDED;
+  getVersioningStatus(): string {
+    if (this.isVersioningEnabled) {
+      return RgwBucketVersioning.ENABLED;
+    }
+    if (this.editing && this.initialVersioningStatus === RgwBucketVersioning.OFF) {
+      return '';
+    }
+    return RgwBucketVersioning.SUSPENDED;
   }
 
   getMfaDeleteStatus() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -95,7 +95,35 @@ describe('RgwBucketService', () => {
       )
       .subscribe();
     const req = httpTesting.expectOne(
-      `api/rgw/bucket/foo?${RgwHelper.DAEMON_QUERY_PARAM}&bucket_id=bar&uid=baz&versioning_state=Enabled&encryption_state=true&encryption_type=aws%253Akms&key_id=qwerty1&mfa_delete=Enabled&mfa_token_serial=1&mfa_token_pin=223344&lock_mode=GOVERNANCE&lock_retention_period_days=10&tags=null&bucket_policy=null&canned_acl=private&replication=true&lifecycle=null`
+      `api/rgw/bucket/foo?${RgwHelper.DAEMON_QUERY_PARAM}&bucket_id=bar&uid=baz&encryption_state=true&encryption_type=aws%253Akms&key_id=qwerty1&mfa_delete=Enabled&mfa_token_serial=1&mfa_token_pin=223344&lock_mode=GOVERNANCE&lock_retention_period_days=10&tags=null&bucket_policy=null&canned_acl=private&replication=true&lifecycle=null&versioning_state=Enabled`
+    );
+    expect(req.request.method).toBe('PUT');
+  });
+
+  it('should call update without versioning_state when empty', () => {
+    service
+      .update(
+        'foo',
+        'bar',
+        'baz',
+        '',
+        true,
+        'aws:kms',
+        'qwerty1',
+        'Enabled',
+        '1',
+        '223344',
+        'GOVERNANCE',
+        '10',
+        null,
+        null,
+        'private',
+        'true',
+        null
+      )
+      .subscribe();
+    const req = httpTesting.expectOne(
+      `api/rgw/bucket/foo?${RgwHelper.DAEMON_QUERY_PARAM}&bucket_id=bar&uid=baz&encryption_state=true&encryption_type=aws%253Akms&key_id=qwerty1&mfa_delete=Enabled&mfa_token_serial=1&mfa_token_pin=223344&lock_mode=GOVERNANCE&lock_retention_period_days=10&tags=null&bucket_policy=null&canned_acl=private&replication=true&lifecycle=null`
     );
     expect(req.request.method).toBe('PUT');
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -170,10 +170,9 @@ export class RgwBucketService extends ApiClient {
     lifecycle: string
   ) {
     return this.rgwDaemonService.request((params: HttpParams) => {
-      params = params.appendAll({
+      const paramsObject: Record<string, string> = {
         bucket_id: bucketId,
         uid: uid,
-        versioning_state: versioningState,
         encryption_state: String(encryptionState),
         encryption_type: encryptionType,
         key_id: keyId,
@@ -187,7 +186,11 @@ export class RgwBucketService extends ApiClient {
         canned_acl: cannedAcl,
         replication: replication,
         lifecycle: lifecycle
-      });
+      };
+      if (versioningState) {
+        paramsObject['versioning_state'] = versioningState;
+      }
+      params = params.appendAll(paramsObject);
       return this.http.put(`${this.url}/${bucket}`, null, { params: params });
     });
   }

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -599,8 +599,12 @@ class RgwClient(RestClient):
         """
         # pylint: disable=unused-argument
         result = request()
-        if 'Status' not in result:
-            result['Status'] = 'Suspended'
+        if not isinstance(result, dict):
+            result = {}
+        # RGW omits Status when versioning has never been configured (CLI/radosgw-admin
+        # reports "off"). That must not be shown as "Suspended", which means versioning was enabled
+        if not result.get('Status'):
+            result['Status'] = 'Off'
         if 'MfaDelete' not in result:
             result['MfaDelete'] = 'Disabled'
         return result


### PR DESCRIPTION


### PS : 
```
In dashboard for a non version bucket versioning status shows as suspended

Case1: If there is no history of enabling versioning on a bucket its 
versioning status should be "off"

Case2: If there is a history of enabling versioning on a bucket and 
then versioning was suspended. then status should be "Suspended"

Currently there is no differentiation between case1 and case2 
from the dashboard view, this might cause a confusion for a user.
```


### UTC : 

For suspended versioning bucket : 
<img width="3334" height="1546" alt="image" src="https://github.com/user-attachments/assets/64dcdc44-f4aa-4f2d-a044-a645bd2af967" />

```
[ceph: root@ceph-node-00 /]# radosgw-admin bucket stats --bucket abhishek 
{
    "bucket": "abhishek",
    "tenant": "",
    "versioning": "suspended",
    "zonegroup": "14cb64b1-8a52-49d6-8839-891da99c3200",
    "placement_rule": "default-placement",
    "explicit_placement": {
        "data_pool": "",
        "data_extra_pool": "",
        "index_pool": ""
    },
    "id": "e6e3dac4-8f65-4592-b38a-e822573603d4.24668.1",
    "marker": "e6e3dac4-8f65-4592-b38a-e822573603d4.24668.1",
    "index_type": "Normal",
    "index_generation": 0,
    "num_shards": 11,
    "reshard_status": "None",
    "judge_reshard_lock_time": "0.000000",
    "object_lock_enabled": false,
    "mfa_enabled": false,
    "owner": "dashboard",
    "ver": "0#1,1#1,2#1,3#1,4#1,5#1,6#1,7#1,8#1,9#1,10#1",
    "master_ver": "0#0,1#0,2#0,3#0,4#0,5#0,6#0,7#0,8#0,9#0,10#0",
    "mtime": "2026-04-20T06:21:17.594370Z",
    "creation_time": "2026-04-20T06:06:58.573206Z",
    "max_marker": "0#,1#,2#,3#,4#,5#,6#,7#,8#,9#,10#",
    "usage": {},
    "bucket_quota": {
        "enabled": false,
        "check_on_raw": false,
        "max_size": -1,
        "max_size_kb": 0,
        "max_objects": -1
    },
    "read_tracker": 5
}
[ceph: root@ceph-node-00 /]# 

```

For non versioning bucket : 

<img width="3354" height="1560" alt="image" src="https://github.com/user-attachments/assets/ffedaf56-a19b-480c-8306-7d5667042b2b" />

```
[ceph: root@ceph-node-00 /]# radosgw-admin bucket stats --bucket abhishek2
{
    "bucket": "abhishek2",
    "tenant": "",
    "versioning": "off",
    "zonegroup": "14cb64b1-8a52-49d6-8839-891da99c3200",
    "placement_rule": "default-placement",
    "explicit_placement": {
        "data_pool": "",
        "data_extra_pool": "",
        "index_pool": ""
    },
    "id": "e6e3dac4-8f65-4592-b38a-e822573603d4.24668.2",
    "marker": "e6e3dac4-8f65-4592-b38a-e822573603d4.24668.2",
    "index_type": "Normal",
    "index_generation": 0,
    "num_shards": 11,
    "reshard_status": "None",
    "judge_reshard_lock_time": "0.000000",
    "object_lock_enabled": false,
    "mfa_enabled": false,
    "owner": "dashboard",
    "ver": "0#1,1#1,2#1,3#1,4#1,5#1,6#1,7#1,8#1,9#1,10#1",
    "master_ver": "0#0,1#0,2#0,3#0,4#0,5#0,6#0,7#0,8#0,9#0,10#0",
    "mtime": "2026-04-20T06:21:47.876240Z",
    "creation_time": "2026-04-20T06:21:47.749591Z",
    "max_marker": "0#,1#,2#,3#,4#,5#,6#,7#,8#,9#,10#",
    "usage": {},
    "bucket_quota": {
        "enabled": false,
        "check_on_raw": false,
        "max_size": -1,
        "max_size_kb": 0,
        "max_objects": -1
    },
    "read_tracker": 3
}
[ceph: root@ceph-node-00 /]# 

```

For versioning bucket : 
<img width="3354" height="1716" alt="image" src="https://github.com/user-attachments/assets/1687f8f1-20de-4941-96b8-e9c7508d1b45" />
```
[ceph: root@ceph-node-00 /]# radosgw-admin bucket stats --bucket abhishek3
{
    "bucket": "abhishek3",
    "tenant": "",
    "versioning": "enabled",
    "zonegroup": "14cb64b1-8a52-49d6-8839-891da99c3200",
    "placement_rule": "default-placement",
    "explicit_placement": {
        "data_pool": "",
        "data_extra_pool": "",
        "index_pool": ""
    },
    "id": "e6e3dac4-8f65-4592-b38a-e822573603d4.24668.3",
    "marker": "e6e3dac4-8f65-4592-b38a-e822573603d4.24668.3",
    "index_type": "Normal",
    "index_generation": 0,
    "num_shards": 11,
    "reshard_status": "None",
    "judge_reshard_lock_time": "0.000000",
    "object_lock_enabled": false,
    "mfa_enabled": false,
    "owner": "dashboard",
    "ver": "0#1,1#1,2#1,3#1,4#1,5#1,6#1,7#1,8#1,9#1,10#1",
    "master_ver": "0#0,1#0,2#0,3#0,4#0,5#0,6#0,7#0,8#0,9#0,10#0",
    "mtime": "2026-04-20T06:34:40.033053Z",
    "creation_time": "2026-04-20T06:34:30.153218Z",
    "max_marker": "0#,1#,2#,3#,4#,5#,6#,7#,8#,9#,10#",
    "usage": {},
    "bucket_quota": {
        "enabled": false,
        "check_on_raw": false,
        "max_size": -1,
        "max_size_kb": 0,
        "max_objects": -1
    },
    "read_tracker": 4
}
[ceph: root@ceph-node-00 /]# 
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
