### PR TITLE
mgr/dashboard: show rados ns in 'ceph nvmeof top io'

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_top_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_top_cli.py
@@ -216,9 +216,15 @@ else:
                     continue
                 perf_stats.calculate(self.delay)
 
+                if ns.rados_namespace_name:
+                    rbd_image_path = (f"{ns.rbd_pool_name}/{ns.rados_namespace_name}/"
+                                      f"{ns.rbd_image_name}")
+                else:
+                    rbd_image_path = f"{ns.rbd_pool_name}/{ns.rbd_image_name}"
+
                 ns_data.append((
                     ns.nsid,
-                    f"{ns.rbd_pool_name}/{ns.rbd_image_name}",
+                    rbd_image_path,
                     int(perf_stats.total_ops_rate),
                     int(perf_stats.read_ops_rate),
                     f"{self.bytes_to_MB(perf_stats.read_bytes_rate):3.2f}",


### PR DESCRIPTION
In nvmeof_top_cli.py, show RADOS namespace name
in "RBD Image" column.

Example:
Before: “rbd/image10”
After: “rbd/ns2/image10"

```
[root@listener-vallari-cluster-node1 ~]# ceph nvmeof top io 'nqn.2016-06.io.spdk:cnode4.mygroup1'
NSID   RBD Image                                     IOPS      r/s    rMB/s   r_await   rareq-sz      w/s    wMB/s   w_await   wareq-sz   LBGrp   QoS
   1   nvmeof/myimage31                                31       31     0.38      0.80      12.17        0     0.00      0.00       0.00     1      No
   2   nvmeof/myimage32                                31       31     0.38      0.44      12.17        0     0.00      0.00       0.00     2      No
   3   nvmeof/myimage33                                31       31     0.38      0.62      12.17        0     0.00      0.00       0.00     3      No
   4   nvmeof/myimage34                                31       31     0.38      0.50      12.17        0     0.00      0.00       0.00     1      No
   5   nvmeof/myimage35                                31       31     0.38      0.46      12.17        0     0.00      0.00       0.00     2      No
   6   nvmeof/myimage36                                31       31     0.38      2.32      12.17        0     0.00      0.00       0.00     3      No
   7   nvmeof/myimage37                                31       31     0.38      2.04      12.17        0     0.00      0.00       0.00     1      No
   8   nvmeof/myimage38                                31       31     0.38      0.49      12.17        0     0.00      0.00       0.00     2      No
   9   nvmeof/myimage39                                31       31     0.38      0.70      12.17        0     0.00      0.00       0.00     3      No
  10   nvmeof/myimage40                                31       31     0.38      2.17      12.17        0     0.00      0.00       0.00     1      No
  11   nvmeof/rados_ns1/myimage100                     31       31     0.38      0.43      12.17        0     0.00      0.00       0.00     2      No
 ---- 

NSID   RBD Image                                     IOPS      r/s    rMB/s   r_await   rareq-sz      w/s    wMB/s   w_await   wareq-sz   LBGrp   QoS
   1   nvmeof/myimage31                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     1      No
   2   nvmeof/myimage32                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     2      No
   3   nvmeof/myimage33                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     3      No
   4   nvmeof/myimage34                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     1      No
   5   nvmeof/myimage35                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     2      No
   6   nvmeof/myimage36                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     3      No
   7   nvmeof/myimage37                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     1      No
   8   nvmeof/myimage38                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     2      No
   9   nvmeof/myimage39                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     3      No
  10   nvmeof/myimage40                                 0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     1      No
  11   nvmeof/rados_ns1/myimage100                      0        0     0.00      0.00       0.00        0     0.00      0.00       0.00     2      No
 ---- 

^CInterrupted
```


Fixes: https://tracker.ceph.com/issues/76116





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
